### PR TITLE
Fix ability to set password after e.g. user registration

### DIFF
--- a/saleor/registration/forms.py
+++ b/saleor/registration/forms.py
@@ -28,6 +28,22 @@ class LoginForm(AuthenticationForm):
                 self.fields['username'].initial = email
 
 
+class SetOrRemovePasswordForm(SetPasswordForm):
+
+    def __init__(self, *args, **kwargs):
+        super(SetOrRemovePasswordForm, self).__init__(*args, **kwargs)
+        if not 'new_password1' in self.data.keys():
+            self.fields['new_password1'].required = False
+            self.fields['new_password2'].required = False
+
+    def save(self, commit=True):
+        if self.cleaned_data.get('new_password1'):
+            return super(SetOrRemovePasswordForm, self).save(commit)
+        else:
+            self.user.set_unusable_password()
+        return self.user
+
+
 class RequestEmailConfirmationForm(forms.Form):
 
     email = forms.EmailField()

--- a/saleor/registration/models.py
+++ b/saleor/registration/models.py
@@ -62,7 +62,6 @@ class EmailConfirmationRequest(AbstractToken):
 
     def get_authenticated_user(self):
         user, _created = User.objects.get_or_create(email=self.email)
-        EmailConfirmationRequest.objects.filter(email=self.email).delete()
         return authenticate(user=user)
 
     def get_confirmation_url(self):

--- a/saleor/registration/views.py
+++ b/saleor/registration/views.py
@@ -8,7 +8,6 @@ from django.contrib import messages
 from django.contrib.auth import (get_user_model, login as auth_login,
                                  logout as auth_logout)
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.forms import SetPasswordForm
 from django.contrib.auth.views import (login as django_login_view,
                                        password_change)
 from django.core.urlresolvers import reverse
@@ -93,20 +92,23 @@ def request_email_change(request):
 
 
 def confirm_email(request, token):
-    try:
-        email_confirmation_request = EmailConfirmationRequest.objects.get(
-            token=token, valid_until__gte=now())
-        # TODO: cronjob (celery task) to delete stale tokens
-    except EmailConfirmationRequest.DoesNotExist:
-        return TemplateResponse(request, 'registration/invalid_token.html')
-    user = email_confirmation_request.get_authenticated_user()
-    email_confirmation_request.delete()
-    auth_login(request, user)
-    messages.success(request, _('You are now logged in.'))
+    if not request.POST:
+        try:
+            email_confirmation_request = EmailConfirmationRequest.objects.get(
+                token=token, valid_until__gte=now())
+            # TODO: cronjob (celery task) to delete stale tokens
+        except EmailConfirmationRequest.DoesNotExist:
+            return TemplateResponse(request, 'registration/invalid_token.html')
+        user = email_confirmation_request.get_authenticated_user()
+        email_confirmation_request.delete()
+        auth_login(request, user)
+        messages.success(request, _('You are now logged in.'))
 
-    form = SetPasswordForm(user=user, data=request.POST or None)
+    form = forms.SetOrRemovePasswordForm(user=request.user,
+                                         data=request.POST or None)
     if form.is_valid():
         form.save()
+        messages.success(request, _('Password has been successfully changed.'))
         return redirect(settings.LOGIN_REDIRECT_URL)
 
     return TemplateResponse(


### PR DESCRIPTION
User is not able to set his own password after e.g. user registration (request email confirmation). The view `confirm_email` returns error message about invalid token instead of process the form.
