### PR TITLE
Update settings.py

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -95,8 +95,8 @@ INSTALLED_APPS = [
     'saleor.cart',
     'saleor.checkout',
     'saleor.core',
-    'saleor.order',
     'saleor.product',
+    'saleor.order',
     'saleor.registration',
     'saleor.userprofile',
 


### PR DESCRIPTION
order is coupled with product, it comes natural to put product before order in settings.py, this way we should not have problems with south migrations :/
