### PR TITLE
markdown template tag

### DIFF
--- a/saleor/core/templatetags/markup.py
+++ b/saleor/core/templatetags/markup.py
@@ -1,8 +1,10 @@
 from django import template
+import markdown as markd
+from django.utils.safestring import mark_safe
 register = template.Library()
 
 @register.filter
 def markdown(text):
-    #pretty simple
-    return markdown.markdown(text, safe_mode="remove", output_format="html5")
+    #should use bleach here instad of safe_mode="remove"?
+    return mark_safe(markd.markdown(text, safe_mode="remove", output_format="html5"))
     pass


### PR DESCRIPTION
This is a simple templatetags that should convert unicode from db in pretty written html5 data. I'd put `safe_mode="remove"` with no kw/args to change this behavior (it is trivial), so that every dev that should change this is doing at his own risk and must know how `markdown.markdown` work at least a little, a comment hint about using bleach.
