### PR TITLE
Drop support for python 2.6 and add support for python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-- 2.6
 - 2.7
 - 3.2
 - 3.3
+- 3.4
 install:
 - python setup.py install
 script:


### PR DESCRIPTION
The latest version of Django has dropped support for python 2.6, hence we should do the same.
