### PR TITLE
environment variable - not an ecological variable

### DIFF
--- a/docs/gettingstarted/installation-linux.rst
+++ b/docs/gettingstarted/installation-linux.rst
@@ -130,7 +130,7 @@ Installation
 
    .. note::
 
-       Database name is extracted from the ``DATABASE_URL`` environmental variable. If absent it defaults to ``saleor``.
+       Database name is extracted from the ``DATABASE_URL`` environment variable. If absent it defaults to ``saleor``.
 
 
 #. Prepare the database:


### PR DESCRIPTION
I want to merge this change because there's a typo.

NyanKiyoshi: "It's an environment variable, it's not an ecological variable."

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
