### PR TITLE
Fix for hiding payment secrets

### DIFF
--- a/saleor/payment/gateways/braintree/plugin.py
+++ b/saleor/payment/gateways/braintree/plugin.py
@@ -132,6 +132,14 @@ class BraintreeGatewayPlugin(BasePlugin):
             )
 
     @classmethod
+    def _hide_secret_configuration_fields(cls, configuration):
+        secret_fields = ["Public API key", "Secret API key", "Merchant ID"]
+        for field in configuration:
+            # We don't want to share our secret data
+            if field.get("name") in secret_fields and field.get("value"):
+                field["value"] = "*" * 10
+
+    @classmethod
     def _get_default_configuration(cls):
         defaults = {
             "name": cls.PLUGIN_NAME,

--- a/saleor/payment/gateways/razorpay/plugin.py
+++ b/saleor/payment/gateways/razorpay/plugin.py
@@ -89,6 +89,14 @@ class RazorpayGatewayPlugin(BasePlugin):
             )
 
     @classmethod
+    def _hide_secret_configuration_fields(cls, configuration):
+        secret_fields = ["Public API key", "Secret API key"]
+        for field in configuration:
+            # We don't want to share our secret data
+            if field.get("name") in secret_fields and field.get("value"):
+                field["value"] = "*" * 10
+
+    @classmethod
     def _get_default_configuration(cls):
         defaults = {
             "name": cls.PLUGIN_NAME,

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -91,6 +91,14 @@ class StripeGatewayPlugin(BasePlugin):
             )
 
     @classmethod
+    def _hide_secret_configuration_fields(cls, configuration):
+        secret_fields = ["Public API key", "Secret API key"]
+        for field in configuration:
+            # We don't want to share our secret data
+            if field.get("name") in secret_fields and field.get("value"):
+                field["value"] = "*" * 10
+
+    @classmethod
     def _get_default_configuration(cls):
         defaults = {
             "name": cls.PLUGIN_NAME,

--- a/tests/gateway/stripe/test_stripe.py
+++ b/tests/gateway/stripe/test_stripe.py
@@ -4,6 +4,7 @@ from math import isclose
 
 import pytest
 
+from saleor.extensions.manager import get_extensions_manager
 from saleor.payment import ChargeStatus
 from saleor.payment.gateways.stripe import (
     TransactionKind,
@@ -352,3 +353,28 @@ def test_get_client(gateway_config):
 
 def test_get_client_token():
     assert get_client_token() is None
+
+
+def test_get_plugin_configuration_hides_all_stripe_secrets(settings):
+    settings.PLUGINS = ["saleor.payment.gateways.stripe.plugin.StripeGatewayPlugin"]
+    manager = get_extensions_manager()
+    manager.get_plugin_configuration("Stripe")
+    manager.save_plugin_configuration(
+        "Stripe",
+        {
+            "configuration": [
+                {"name": "Public API key", "value": "123"},
+                {"name": "Secret API key", "value": "456"},
+            ]
+        },
+    )
+    plugin_configuration = manager.get_plugin_configuration("Stripe")
+    configuration = plugin_configuration.configuration
+    public_api_key = [
+        field for field in configuration if field["name"] == "Public API key"
+    ][0]
+    secret_api_key = [
+        field for field in configuration if field["name"] == "Secret API key"
+    ][0]
+    assert public_api_key["value"] == "*" * 10
+    assert secret_api_key["value"] == "*" * 10

--- a/tests/gateway/test_braintree.py
+++ b/tests/gateway/test_braintree.py
@@ -7,6 +7,7 @@ from braintree.errors import Errors
 from braintree.validation_error import ValidationError
 from django.core.exceptions import ImproperlyConfigured
 
+from saleor.extensions.manager import get_extensions_manager
 from saleor.payment.gateways.braintree import (
     TransactionKind,
     authorize,
@@ -439,3 +440,35 @@ def test_list_customer_sources(sandbox_braintree_gateway_config):
     )
     sources = list_client_sources(sandbox_braintree_gateway_config, CUSTOMER_ID)
     assert sources == [expected_customer_source]
+
+
+def test_get_plugin_configuration_hides_all_braintree_secrets(settings):
+    settings.PLUGINS = [
+        "saleor.payment.gateways.braintree.plugin.BraintreeGatewayPlugin"
+    ]
+    manager = get_extensions_manager()
+    manager.get_plugin_configuration("Braintree")
+    manager.save_plugin_configuration(
+        "Braintree",
+        {
+            "configuration": [
+                {"name": "Public API key", "value": "123"},
+                {"name": "Merchant ID", "value": "456"},
+                {"name": "Secret API key", "value": "456"},
+            ]
+        },
+    )
+    plugin_configuration = manager.get_plugin_configuration("Braintree")
+    configuration = plugin_configuration.configuration
+    public_api_key = [
+        field for field in configuration if field["name"] == "Public API key"
+    ][0]
+    secret_api_key = [
+        field for field in configuration if field["name"] == "Secret API key"
+    ][0]
+    merchant_id = [field for field in configuration if field["name"] == "Merchant ID"][
+        0
+    ]
+    assert public_api_key["value"] == "*" * 10
+    assert secret_api_key["value"] == "*" * 10
+    assert merchant_id["value"] == "*" * 10

--- a/tests/gateway/test_razorpay.py
+++ b/tests/gateway/test_razorpay.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 from razorpay.errors import BadRequestError, ServerError
 
+from saleor.extensions.manager import get_extensions_manager
 from saleor.payment import ChargeStatus, TransactionKind
 from saleor.payment.gateways.razorpay import (
     capture,
@@ -313,3 +314,28 @@ def test_refund_invalid_data(
 
     # Ensure the HTTP error was logged
     assert mocked_logger.call_count == 1
+
+
+def test_get_plugin_configuration_hides_all_razor_secrets(settings):
+    settings.PLUGINS = ["saleor.payment.gateways.razorpay.plugin.RazorpayGatewayPlugin"]
+    manager = get_extensions_manager()
+    manager.get_plugin_configuration("Razorpay")
+    manager.save_plugin_configuration(
+        "Razorpay",
+        {
+            "configuration": [
+                {"name": "Public API key", "value": "123"},
+                {"name": "Secret API key", "value": "456"},
+            ]
+        },
+    )
+    plugin_configuration = manager.get_plugin_configuration("Razorpay")
+    configuration = plugin_configuration.configuration
+    public_api_key = [
+        field for field in configuration if field["name"] == "Public API key"
+    ][0]
+    secret_api_key = [
+        field for field in configuration if field["name"] == "Secret API key"
+    ][0]
+    assert public_api_key["value"] == "*" * 10
+    assert secret_api_key["value"] == "*" * 10


### PR DESCRIPTION
All payment's secrets fields should be converted to `*` characters.