### PR TITLE
Fix queries that not require channel

### DIFF
--- a/saleor/graphql/channel/utils.py
+++ b/saleor/graphql/channel/utils.py
@@ -1,8 +1,17 @@
+from django.utils.functional import SimpleLazyObject
 from graphql.error import GraphQLError
 
 from ...channel.exceptions import ChannelNotDefined, NoDefaultChannel
 from ...channel.models import Channel
 from ...channel.utils import get_default_channel
+
+
+def get_default_channel_slug_or_graphql_error() -> SimpleLazyObject:
+    """Return a default channel slug in lazy way or a GraphQL error.
+
+    Utility to get the default channel in GraphQL query resolvers.
+    """
+    return SimpleLazyObject(lambda: get_default_channel_or_graphql_error().slug)
 
 
 def get_default_channel_or_graphql_error() -> Channel:

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -2,7 +2,7 @@ import graphene
 
 from ...core.permissions import ProductPermissions
 from ..channel import ChannelContext
-from ..channel.utils import get_default_channel_or_graphql_error
+from ..channel.utils import get_default_channel_slug_or_graphql_error
 from ..core.enums import ReportingPeriod
 from ..core.fields import (
     ChannelContextFilterConnectionField,
@@ -304,7 +304,7 @@ class ProductQueries(graphene.ObjectType):
     def resolve_product(self, info, id=None, slug=None, channel=None, **_kwargs):
         validate_one_of_args_is_in_query("id", id, "slug", slug)
         if channel is None:
-            channel = get_default_channel_or_graphql_error().slug
+            channel = get_default_channel_slug_or_graphql_error()
         if id:
             _, id = graphene.Node.from_global_id(id)
             product = resolve_product_by_id(info, id, channel_slug=channel)
@@ -316,7 +316,7 @@ class ProductQueries(graphene.ObjectType):
 
     def resolve_products(self, info, channel=None, **kwargs):
         if channel is None:
-            channel = get_default_channel_or_graphql_error().slug
+            channel = get_default_channel_slug_or_graphql_error()
         return resolve_products(info, channel_slug=channel, **kwargs)
 
     def resolve_product_type(self, info, id, **_kwargs):
@@ -327,20 +327,20 @@ class ProductQueries(graphene.ObjectType):
 
     def resolve_product_variant(self, info, id, channel=None, **_kwargs):
         if channel is None:
-            channel = get_default_channel_or_graphql_error().slug
+            channel = get_default_channel_slug_or_graphql_error()
         _, id = graphene.Node.from_global_id(id)
         variant = resolve_variant_by_id(info, id, channel_slug=channel)
         return ChannelContext(node=variant, channel_slug=channel) if variant else None
 
     def resolve_product_variants(self, info, ids=None, channel=None, **_kwargs):
         if channel is None:
-            channel = get_default_channel_or_graphql_error().slug
+            channel = get_default_channel_slug_or_graphql_error()
         return resolve_product_variants(info, ids=ids, channel_slug=channel)
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_report_product_sales(self, *_args, period, channel=None, **_kwargs):
         if channel is None:
-            channel = get_default_channel_or_graphql_error().slug
+            channel = get_default_channel_slug_or_graphql_error()
         return resolve_report_product_sales(period, channel_slug=channel)
 
 

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -76,7 +76,7 @@ def test_product_details(product, api_client, count_queries, channel_USD):
             category {
               id
               name
-              products(first: 4) {
+              products(first: 4, channel: $channel) {
                 edges {
                   node {
                     ...BasicProductFields

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -289,7 +289,7 @@ def test_product_query_by_id_not_available_as_customer(
 
 
 def test_product_query_by_id_weight_returned_in_default_unit(
-    user_api_client, product, site_settings
+    user_api_client, product, site_settings, channel_USD
 ):
     # given
     product.weight = Weight(kg=10)
@@ -298,7 +298,10 @@ def test_product_query_by_id_weight_returned_in_default_unit(
     site_settings.default_weight_unit = WeightUnits.POUND
     site_settings.save(update_fields=["default_weight_unit"])
 
-    variables = {"id": graphene.Node.to_global_id("Product", product.pk)}
+    variables = {
+        "id": graphene.Node.to_global_id("Product", product.pk),
+        "channel": channel_USD.slug,
+    }
 
     # when
     response = user_api_client.post_graphql(QUERY_PRODUCT, variables=variables)
@@ -312,7 +315,9 @@ def test_product_query_by_id_weight_returned_in_default_unit(
     assert product_data["weight"]["unit"] == WeightUnits.POUND.upper()
 
 
-def test_product_query_by_id_weight_is_rounded(user_api_client, product, site_settings):
+def test_product_query_by_id_weight_is_rounded(
+    user_api_client, product, site_settings, channel_USD
+):
     # given
     product.weight = Weight(kg=1.83456)
     product.save(update_fields=["weight"])
@@ -320,7 +325,10 @@ def test_product_query_by_id_weight_is_rounded(user_api_client, product, site_se
     site_settings.default_weight_unit = WeightUnits.KILOGRAM
     site_settings.save(update_fields=["default_weight_unit"])
 
-    variables = {"id": graphene.Node.to_global_id("Product", product.pk)}
+    variables = {
+        "id": graphene.Node.to_global_id("Product", product.pk),
+        "channel": channel_USD.slug,
+    }
 
     # when
     response = user_api_client.post_graphql(QUERY_PRODUCT, variables=variables)
@@ -834,7 +842,7 @@ def test_fetch_product_from_category_query(
     query = """
     query {
         category(id: "%(category_id)s") {
-            products(first: 20) {
+            products(first: 20, channel: "%(channel_slug)s") {
                 edges {
                     node {
                         id
@@ -888,6 +896,7 @@ def test_fetch_product_from_category_query(
     }
     """ % {
         "category_id": graphene.Node.to_global_id("Category", category.id),
+        "channel_slug": channel_USD.slug,
     }
     staff_api_client.user.user_permissions.add(permission_manage_products)
     response = staff_api_client.post_graphql(query)

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -27,7 +27,7 @@ from ....warehouse.availability import (
 from ...account.enums import CountryCodeEnum
 from ...channel import ChannelContext, ChannelQsContext
 from ...channel.types import ChannelContextType, ChannelContextTypeWithMetadata
-from ...channel.utils import get_default_channel_or_graphql_error
+from ...channel.utils import get_default_channel_slug_or_graphql_error
 from ...core.connection import CountableDjangoObjectType
 from ...core.enums import ReportingPeriod, TaxRateType
 from ...core.fields import (
@@ -693,7 +693,7 @@ class ProductType(CountableDjangoObjectType):
     def resolve_products(root: models.ProductType, info, channel=None, **_kwargs):
         user = info.context.user
         if channel is None:
-            channel = get_default_channel_or_graphql_error().slug
+            channel = get_default_channel_slug_or_graphql_error()
         qs = root.products.visible_to_user(user, channel)
         return ChannelQsContext(qs=qs, channel_slug=channel)
 
@@ -766,7 +766,7 @@ class Collection(CountableDjangoObjectType):
     def resolve_products(root: models.Collection, info, channel=None, **kwargs):
         user = info.context.user
         if channel is None:
-            channel = get_default_channel_or_graphql_error().slug
+            channel = get_default_channel_slug_or_graphql_error()
         qs = root.products.collection_sorted(user, channel)
         return ChannelQsContext(qs=qs, channel_slug=channel)
 
@@ -863,7 +863,7 @@ class Category(CountableDjangoObjectType):
     def resolve_products(root: models.Category, _info, channel=None, **_kwargs):
         tree = root.get_descendants(include_self=True)
         if channel is None:
-            channel = get_default_channel_or_graphql_error().slug
+            channel = get_default_channel_slug_or_graphql_error()
         qs = models.Product.objects.published(channel)
         qs = qs.filter(category__in=tree).distinct()
         return ChannelQsContext(qs=qs, channel_slug=channel)

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -125,7 +125,7 @@ class ProductsQueryset(models.QuerySet):
         return self.filter(
             Q(channel_listing__publication_date__lte=today)
             | Q(channel_listing__publication_date__isnull=True),
-            channel_listing__channel__slug=channel_slug,
+            channel_listing__channel__slug=str(channel_slug),
             channel_listing__is_published=True,
         )
 


### PR DESCRIPTION
For example. 
As admin with "Manage products" permission, I should be able to query all fields that not related to channel, without passing it query. 

This query should work even if we have multiple channels. 
```
{
  products(first:100){
    edges{
      node{
        name
      }
    }
  }
}
```
Before this query work only if we have only one channel.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
