### PR TITLE
Don't create and process payment when checkout total is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Set OrderFulfillStockInput fields as required - #6196 by @IKarbowiak
 - Fix attribute filtering by categories and collections - #6214 by @fowczarek
 - Fix is_visible when publication_date==today - #6225 by @korycins
+- Don't create and process payment when checkout total is 0 - #6211 by @IKarbowiak
+
 ## 2.10.2
 
 - Add command to change currencies in the database - #5906 by @d-wysocki

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -432,9 +432,8 @@ def complete_checkout(
             gateway.payment_refund_or_void(payment)
             raise ValidationError(f"Insufficient product stock: {e.item}", code=e.code)
 
-        # if there is no payment and no errors occurred it means that total value is 0
-        # and is paid from definition
-        if not payment:
+        # if the order total value is 0 it is paid from the definition
+        if order.total.net.amount == 0:
             mark_order_as_paid(order, user)
 
     return order, action_required, action_data

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -310,6 +310,44 @@ def test_checkout_complete_checkout_total_not_0_no_payment(
 
 
 @pytest.mark.integration
+def test_checkout_complete_checkout_total_0_no_payment_shipping_not_added(
+    user_api_client,
+    checkout_with_shipping_required,
+    payment_dummy,
+    address,
+    shipping_method,
+):
+    checkout = checkout_with_shipping_required
+    checkout.billing_address = address
+    checkout.store_value_in_metadata(items={"accepted": "true"})
+    checkout.store_value_in_private_metadata(items={"accepted": "false"})
+    checkout.save()
+
+    checkout_line = checkout.lines.first()
+    checkout_line_variant = checkout_line.variant
+
+    checkout_line_variant.price = Money(0, "USD")
+    checkout_line_variant.save(update_fields=["price_amount"])
+
+    total = calculations.calculate_checkout_total_with_gift_cards(checkout=checkout)
+    assert not checkout.payments.all()
+    assert total.gross.amount == 0
+    assert total.net.amount == 0
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variables = {"checkoutId": checkout_id, "redirectUrl": "https://www.example.com"}
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    errors = data["checkoutErrors"]
+    assert not data["order"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == CheckoutErrorCode.SHIPPING_METHOD_NOT_SET.name
+    assert errors[0]["field"] == "shippingMethod"
+
+
+@pytest.mark.integration
 def test_checkout_with_voucher_complete(
     user_api_client,
     checkout_with_voucher_percentage,

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import graphene
 import pytest
+from prices import Money
 
 from ....checkout import calculations
 from ....checkout.error_codes import CheckoutErrorCode
@@ -22,7 +23,8 @@ MUTATION_CHECKOUT_COMPLETE = """
         checkoutComplete(checkoutId: $checkoutId, redirectUrl: $redirectUrl) {
             order {
                 id,
-                token
+                token,
+                isPaid
             },
             checkoutErrors {
                 field,
@@ -148,6 +150,163 @@ def test_checkout_complete(
     assert not Checkout.objects.filter(
         pk=checkout.pk
     ).exists(), "Checkout should have been deleted"
+
+
+@pytest.mark.integration
+def test_checkout_complete_checkout_total_is_0_no_payment(
+    user_api_client,
+    checkout_without_shipping_required,
+    payment_dummy,
+    address,
+    shipping_method,
+):
+    checkout = checkout_without_shipping_required
+    checkout.billing_address = address
+    checkout.store_value_in_metadata(items={"accepted": "true"})
+    checkout.store_value_in_private_metadata(items={"accepted": "false"})
+    checkout.save()
+
+    checkout_line = checkout.lines.first()
+    checkout_line_quantity = checkout_line.quantity
+    checkout_line_variant = checkout_line.variant
+
+    checkout_line_variant.price = Money(0, "USD")
+    checkout_line_variant.save(update_fields=["price_amount"])
+
+    total = calculations.calculate_checkout_total_with_gift_cards(checkout=checkout)
+    assert not checkout.payments.all()
+    assert total.gross.amount == 0
+    assert total.net.amount == 0
+
+    orders_count = Order.objects.count()
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variables = {"checkoutId": checkout_id, "redirectUrl": "https://www.example.com"}
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["checkoutErrors"]
+
+    order_token = data["order"]["token"]
+    assert Order.objects.count() == orders_count + 1
+    order = Order.objects.first()
+    assert order.token == order_token
+    assert order.total.gross == total.gross
+    assert order.metadata == checkout.metadata
+    assert order.private_metadata == checkout.private_metadata
+
+    order_line = order.lines.first()
+    assert checkout_line_quantity == order_line.quantity
+    assert checkout_line_variant == order_line.variant
+    assert order.shipping_address is None
+    assert order.shipping_method is None
+    assert order.payments.exists()
+    order_payment = order.payments.first()
+    assert order_payment.transactions.count() == 0
+    assert order
+    assert data["order"]["isPaid"] is True
+
+    assert not Checkout.objects.filter(
+        pk=checkout.pk
+    ).exists(), "Checkout should have been deleted"
+
+
+@pytest.mark.integration
+def test_checkout_complete_checkout_total_equal_discount_no_payment(
+    user_api_client,
+    checkout_without_shipping_required,
+    payment_dummy,
+    address,
+    shipping_method,
+    gift_card,
+):
+    checkout = checkout_without_shipping_required
+    checkout.gift_cards.add(gift_card)
+    checkout.billing_address = address
+    checkout.store_value_in_metadata(items={"accepted": "true"})
+    checkout.store_value_in_private_metadata(items={"accepted": "false"})
+    checkout.save()
+
+    checkout_line = checkout.lines.first()
+    checkout_line_quantity = checkout_line.quantity
+    checkout_line_variant = checkout_line.variant
+
+    checkout_line_variant.price = gift_card.current_balance
+    checkout_line_variant.save(update_fields=["price_amount"])
+
+    total = calculations.calculate_checkout_total_with_gift_cards(checkout=checkout)
+    assert not checkout.payments.all()
+    assert total.gross.amount == 0
+    assert total.net.amount == 0
+
+    orders_count = Order.objects.count()
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variables = {"checkoutId": checkout_id, "redirectUrl": "https://www.example.com"}
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["checkoutErrors"]
+
+    order_token = data["order"]["token"]
+    assert Order.objects.count() == orders_count + 1
+    order = Order.objects.first()
+    assert order.token == order_token
+    assert order.total.gross == total.gross
+    assert order.metadata == checkout.metadata
+    assert order.private_metadata == checkout.private_metadata
+
+    order_line = order.lines.first()
+    assert checkout_line_quantity == order_line.quantity
+    assert checkout_line_variant == order_line.variant
+    assert order.shipping_address is None
+    assert order.shipping_method is None
+    assert order.payments.exists()
+    order_payment = order.payments.first()
+    assert order_payment.transactions.count() == 0
+    assert order
+    assert data["order"]["isPaid"] is True
+
+    assert not Checkout.objects.filter(
+        pk=checkout.pk
+    ).exists(), "Checkout should have been deleted"
+
+
+@pytest.mark.integration
+def test_checkout_complete_checkout_total_not_0_no_payment(
+    user_api_client,
+    checkout_without_shipping_required,
+    payment_dummy,
+    address,
+    shipping_method,
+):
+    checkout = checkout_without_shipping_required
+    checkout.billing_address = address
+    checkout.store_value_in_metadata(items={"accepted": "true"})
+    checkout.store_value_in_private_metadata(items={"accepted": "false"})
+    checkout.save()
+
+    checkout_line = checkout.lines.first()
+    checkout_line_variant = checkout_line.variant
+
+    checkout_line_variant.save(update_fields=["price_amount"])
+
+    total = calculations.calculate_checkout_total_with_gift_cards(checkout=checkout)
+    assert not checkout.payments.all()
+    assert total.gross.amount != 0
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variables = {"checkoutId": checkout_id, "redirectUrl": "https://www.example.com"}
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    errors = data["checkoutErrors"]
+    assert not data["order"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == CheckoutErrorCode.CHECKOUT_NOT_FULLY_PAID.name
+
+    assert Checkout.objects.filter(pk=checkout.pk).exists()
 
 
 @pytest.mark.integration

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -170,18 +170,20 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
 
         cancel_active_payments(checkout)
 
-        payment = create_payment(
-            gateway=gateway,
-            payment_token=data.get("token", ""),
-            total=amount,
-            currency=settings.DEFAULT_CURRENCY,
-            email=checkout.email,
-            extra_data=extra_data,
-            # FIXME this is not a customer IP address. It is a client storefront ip
-            customer_ip_address=get_client_ip(info.context),
-            checkout=checkout,
-            return_url=data.get("return_url"),
-        )
+        payment = None
+        if amount != 0:
+            payment = create_payment(
+                gateway=gateway,
+                payment_token=data.get("token", ""),
+                total=amount,
+                currency=settings.DEFAULT_CURRENCY,
+                email=checkout.email,
+                extra_data=extra_data,
+                # FIXME this is not a customer IP address. It is a client storefront ip
+                customer_ip_address=get_client_ip(info.context),
+                checkout=checkout,
+                return_url=data.get("return_url"),
+            )
         return CheckoutPaymentCreate(payment=payment, checkout=checkout)
 
 

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -441,6 +441,50 @@ def test_create_payment_for_checkout_with_0_total_payment_not_created(
     assert checkout.payments.all().count() == payments_count
 
 
+def test_create_payment_for_checkout_with_0_total_shipping_not_set(
+    checkout_with_shipping_required, user_api_client, address
+):
+    # given
+    checkout = checkout_with_shipping_required
+    address.street_address_1 = "spanish-inqusition"
+    address.save()
+    checkout.billing_address = address
+    checkout.save()
+
+    variant = checkout.lines.first().variant
+    variant.price = Money(0, "USD")
+    variant.save(update_fields=["price_amount"])
+
+    total = calculations.checkout_total(checkout=checkout, lines=list(checkout))
+
+    assert total.gross.amount == 0
+    assert total.net.amount == 0
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variables = {
+        "checkoutId": checkout_id,
+        "input": {
+            "gateway": DUMMY_GATEWAY,
+            "token": "sample-token",
+            "amount": total.gross.amount,
+        },
+    }
+
+    # when
+    response = user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["checkoutPaymentCreate"]
+    errors = data["paymentErrors"]
+
+    assert not data["payment"]
+    assert len(errors) == 1
+    assert errors[0]["code"]
+    assert errors[0]["code"] == "SHIPPING_METHOD_NOT_SET"
+    assert errors[0]["field"] == "shippingMethod"
+
+
 def test_create_payment_for_checkout_with_digital_product_with_0_price(
     checkout_with_digital_item, user_api_client, address
 ):

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import graphene
 import pytest
+from prices import Money
 
 from ....checkout import calculations
 from ....payment.error_codes import PaymentErrorCode
@@ -355,14 +356,19 @@ def test_use_checkout_billing_address_as_payment_billing(
 
 
 def test_create_payment_for_checkout_with_active_payments(
-    checkout_with_payments, user_api_client, address
+    checkout_without_shipping_required, user_api_client, address
 ):
     # given
-    checkout = checkout_with_payments
+    # checkout = checkout_with_payments
+    checkout = checkout_without_shipping_required
     address.street_address_1 = "spanish-inqusition"
     address.save()
     checkout.billing_address = address
     checkout.save()
+
+    Payment.objects.create(
+        gateway="mirumee.payments.dummy", is_active=True, checkout=checkout
+    )
 
     total = calculations.checkout_total(checkout=checkout, lines=list(checkout))
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
@@ -395,6 +401,191 @@ def test_create_payment_for_checkout_with_active_payments(
     active_payments = checkout.payments.all().filter(is_active=True)
     assert active_payments.count() == 1
     assert active_payments.first().pk not in previous_active_payments_ids
+
+
+def test_create_payment_for_checkout_with_0_total_payment_not_created(
+    checkout, user_api_client, address
+):
+    # given
+    address.street_address_1 = "spanish-inqusition"
+    address.save()
+    checkout.billing_address = address
+    checkout.save()
+
+    total = calculations.checkout_total(checkout=checkout, lines=list(checkout))
+
+    assert total.gross.amount == 0
+    assert total.net.amount == 0
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variables = {
+        "checkoutId": checkout_id,
+        "input": {
+            "gateway": DUMMY_GATEWAY,
+            "token": "sample-token",
+            "amount": total.gross.amount,
+        },
+    }
+
+    payments_count = checkout.payments.count()
+
+    # when
+    response = user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["checkoutPaymentCreate"]
+
+    assert not data["paymentErrors"]
+    checkout.refresh_from_db()
+    assert checkout.payments.all().count() == payments_count
+
+
+def test_create_payment_for_checkout_with_digital_product_with_0_price(
+    checkout_with_digital_item, user_api_client, address
+):
+    # given
+    checkout = checkout_with_digital_item
+    address.street_address_1 = "spanish-inqusition"
+    address.save()
+    checkout.billing_address = address
+    checkout.save()
+
+    variant = checkout.lines.first().variant
+    variant.price = Money(0, "USD")
+    variant.save(update_fields=["price_amount"])
+
+    Payment.objects.create(
+        gateway="mirumee.payments.dummy", is_active=True, checkout=checkout
+    )
+
+    total = calculations.checkout_total(checkout=checkout, lines=list(checkout))
+
+    assert total.gross.amount == 0
+    assert total.net.amount == 0
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variables = {
+        "checkoutId": checkout_id,
+        "input": {
+            "gateway": DUMMY_GATEWAY,
+            "token": "sample-token",
+            "amount": total.gross.amount,
+        },
+    }
+
+    payments_count = checkout.payments.count()
+
+    # when
+    response = user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["checkoutPaymentCreate"]
+
+    assert not data["paymentErrors"]
+    checkout.refresh_from_db()
+    assert checkout.payments.all().count() == payments_count
+
+
+def test_create_payment_for_checkout_with_product_with_0_price_and_required_shipping(
+    checkout_with_shipping_required, user_api_client, address, other_shipping_method
+):
+    # given
+    checkout = checkout_with_shipping_required
+    address.street_address_1 = "spanish-inqusition"
+    address.save(update_fields=["street_address_1"])
+
+    checkout.billing_address = address
+    checkout.shipping_address = address
+    checkout.shipping_method = other_shipping_method
+    checkout.save(
+        update_fields=["shipping_method", "billing_address", "shipping_address"]
+    )
+
+    variant = checkout.lines.first().variant
+    variant.price = Money(0, "USD")
+    variant.save(update_fields=["price_amount"])
+
+    Payment.objects.create(
+        gateway="mirumee.payments.dummy", is_active=True, checkout=checkout
+    )
+
+    total = calculations.checkout_total(checkout=checkout, lines=list(checkout))
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variables = {
+        "checkoutId": checkout_id,
+        "input": {
+            "gateway": DUMMY_GATEWAY,
+            "token": "sample-token",
+            "amount": total.gross.amount,
+        },
+    }
+
+    payments_count = checkout.payments.count()
+
+    # when
+    response = user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["checkoutPaymentCreate"]
+
+    assert not data["paymentErrors"]
+    checkout.refresh_from_db()
+    assert checkout.payments.all().count() == payments_count + 1
+
+
+def test_create_payment_for_checkout_with_digital_product_with_discount_equal_to_price(
+    checkout_with_digital_item, user_api_client, address, gift_card
+):
+    # given
+    assert not gift_card.last_used_on
+
+    checkout = checkout_with_digital_item
+    checkout.gift_cards.add(gift_card)
+
+    address.street_address_1 = "spanish-inqusition"
+    address.save()
+    checkout.billing_address = address
+    checkout.save()
+
+    variant = checkout.lines.first().variant
+    variant.price = gift_card.current_balance
+    variant.save(update_fields=["price_amount"])
+
+    Payment.objects.create(
+        gateway="mirumee.payments.dummy", is_active=True, checkout=checkout
+    )
+
+    total = calculations.calculate_checkout_total_with_gift_cards(checkout=checkout)
+
+    assert total.gross.amount == 0
+    assert total.net.amount == 0
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variables = {
+        "checkoutId": checkout_id,
+        "input": {
+            "gateway": DUMMY_GATEWAY,
+            "token": "sample-token",
+            "amount": total.gross.amount,
+        },
+    }
+
+    payments_count = checkout.payments.count()
+
+    # when
+    response = user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["checkoutPaymentCreate"]
+
+    assert not data["paymentErrors"]
+    checkout.refresh_from_db()
+    assert checkout.payments.all().count() == payments_count
 
 
 CAPTURE_QUERY = """

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1394,7 +1394,7 @@ def order_with_lines(order, product_type, category, shipping_zone, warehouse):
         visible_in_listings=True,
     )
     variant = ProductVariant.objects.create(
-        product=product, sku="SKU_B", cost_price=Money(2, "USD"), price_amount=20
+        product=product, sku="SKU_C", cost_price=Money(2, "USD"), price_amount=20
     )
     stock = Stock.objects.create(
         product_variant=variant, warehouse=warehouse, quantity=2


### PR DESCRIPTION
Right now, when the checkout total is 0, the payment is processed. We are sending requests to gateways with 0 amount. Instead of that, when the checkout total is 0, payment will be not created and any request won't be sent to the gateway, order automatically will be marked as paid.

[SALEOR-1241](https://app.clickup.com/t/2549495/SALEOR-1241)

⚠️ 
The frontend part should be finished before merging.

<!-- Please mention all relevant issue numbers  -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
