### PR TITLE
Let me urlencode ":" so I can run with Google Cloud SQL

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -72,6 +72,10 @@ DATABASES = {
     )
 }
 
+DATABASES["default"]["HOST"] = (
+    DATABASES["default"]["HOST"].replace("%3a", ":").replace("%3A", ":")
+)
+
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 TIME_ZONE = "UTC"


### PR DESCRIPTION
I want to merge this change because...

I can't use `DATABASE_URL` to connect to cloud SQL. Took this approach from https://github.com/CAVaccineInventory/vial/commit/316cd096b2fa1156d86c89be5ef118ab67b79415

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier.  -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
