### PR TITLE
[SALEOR-4225] Add PSP_Reference field to the Payment object

### DIFF
--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -729,7 +729,8 @@ def test_payments_query(
 QUERY_PAYMENT_BY_ID = """
     query payment($id: ID!) {
         payment(id: $id) {
-            id
+            id,
+            pspReference
         }
     }
 """
@@ -738,6 +739,8 @@ QUERY_PAYMENT_BY_ID = """
 def test_query_payment(payment_dummy, user_api_client, permission_manage_orders):
     query = QUERY_PAYMENT_BY_ID
     payment = payment_dummy
+    payment.psp_reference = "A psp_reference"
+    payment.save()
     payment_id = graphene.Node.to_global_id("Payment", payment.pk)
     variables = {"id": payment_id}
     response = user_api_client.post_graphql(
@@ -746,6 +749,8 @@ def test_query_payment(payment_dummy, user_api_client, permission_manage_orders)
     content = get_graphql_content(response)
     received_id = content["data"]["payment"]["id"]
     assert received_id == payment_id
+    psp_reference = content["data"]["payment"]["pspReference"]
+    assert psp_reference == "A psp_reference"
 
 
 def test_staff_query_payment_by_invalid_id(

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -108,6 +108,7 @@ class Payment(CountableDjangoObjectType):
             "order",
             "customer_ip_address",
             "payment_method_type",
+            "psp_reference",
         ]
 
     @staticmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3816,6 +3816,7 @@ type Payment implements Node {
   order: Order
   paymentMethodType: String!
   customerIpAddress: String
+  pspReference: String
   chargeStatus: PaymentChargeStatusEnum!
   actions: [OrderAction]!
   total: Money


### PR DESCRIPTION
I want to merge this change because...

I need to add PSP_Reference field to the Payment object.
PSP_Reference field is missed in Payment object but I can see it in payment_payment table in database. It's needed for the payment section on Order Details page.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
