### PR TITLE
Assign user gift cards and orders when it is possible

### DIFF
--- a/saleor/giftcard/tests/test_utils.py
+++ b/saleor/giftcard/tests/test_utils.py
@@ -16,6 +16,7 @@ from .. import GiftCardEvents, GiftCardLineData, events
 from ..models import GiftCard, GiftCardEvent
 from ..utils import (
     add_gift_card_code_to_checkout,
+    assign_user_gift_cards,
     calculate_expiry_date,
     deactivate_order_gift_cards,
     fulfill_gift_card_lines,
@@ -662,3 +663,51 @@ def test_order_has_gift_card_lines_true(gift_card_shippable_order_line):
 
 def test_order_has_gift_card_lines_false(order):
     assert order_has_gift_card_lines(order) is False
+
+
+def test_assign_user_gift_cards(
+    customer_user,
+    gift_card,
+    gift_card_expiry_date,
+    gift_card_used,
+    gift_card_created_by_staff,
+):
+    # given
+    for card in [
+        gift_card,
+        gift_card_expiry_date,
+        gift_card_created_by_staff,
+        gift_card_used,
+    ]:
+        card.created_by = None
+        card.save(update_fields=["created_by"])
+
+    gift_card_used.used_by = None
+    gift_card_used.save(update_fields=["used_by"])
+
+    # when
+    assign_user_gift_cards(customer_user)
+
+    # then
+    for card in [gift_card, gift_card_expiry_date]:
+        card.refresh_from_db()
+        assert card.created_by == customer_user
+
+    gift_card_used.refresh_from_db()
+    assert gift_card_used.used_by == customer_user
+    assert not gift_card_used.created_by
+
+
+def test_assign_user_gift_cards_no_gift_cards_to_assign(
+    customer_user, gift_card_created_by_staff
+):
+    # given
+    gift_card_created_by_staff.created_by = None
+    gift_card_created_by_staff.save(update_fields=["created_by"])
+
+    # when
+    assign_user_gift_cards(customer_user)
+
+    # then
+    gift_card_created_by_staff.refresh_from_db()
+    assert not gift_card_created_by_staff.created_by

--- a/saleor/giftcard/tests/test_utils.py
+++ b/saleor/giftcard/tests/test_utils.py
@@ -673,14 +673,16 @@ def test_assign_user_gift_cards(
     gift_card_created_by_staff,
 ):
     # given
-    for card in [
-        gift_card,
-        gift_card_expiry_date,
-        gift_card_created_by_staff,
-        gift_card_used,
-    ]:
-        card.created_by = None
-        card.save(update_fields=["created_by"])
+    card_ids = [
+        card.id
+        for card in [
+            gift_card,
+            gift_card_expiry_date,
+            gift_card_created_by_staff,
+            gift_card_used,
+        ]
+    ]
+    GiftCard.objects.filter(id__in=card_ids).update(created_by=None)
 
     gift_card_used.used_by = None
     gift_card_used.save(update_fields=["used_by"])

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -250,3 +250,8 @@ def deactivate_order_gift_cards(
 
 def order_has_gift_card_lines(order):
     return any(order.lines.filter(is_gift_card=True))
+
+
+def assign_user_gift_cards(user):
+    GiftCard.objects.filter(used_by_email=user.email).update(used_by=user)
+    GiftCard.objects.filter(created_by_email=user.email).update(created_by=user)

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -146,9 +146,6 @@ class AccountRegister(ModelMutation):
         else:
             user.save()
 
-        assign_user_gift_cards(user)
-        assign_user_orders(user)
-
         account_events.customer_account_created_event(user=user)
         info.context.plugins.customer_created(customer=user)
 

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -536,6 +536,8 @@ class ConfirmEmailChange(BaseMutation):
             data.get("channel"), error_class=AccountErrorCode
         ).slug
 
+        assign_user_gift_cards(user)
+
         notifications.send_user_change_email_notification(
             old_email, user, info.context.plugins, channel_slug=channel_slug
         )

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -13,7 +13,7 @@ from ....core.tokens import account_delete_token_generator
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
 from ....giftcard.utils import assign_user_gift_cards
-from ....order.utils import assign_user_orders
+from ....order.utils import match_orders_with_new_user
 from ....settings import JWT_TTL_REQUEST_EMAIL_CHANGE
 from ...account.enums import AddressTypeEnum
 from ...account.types import Address, AddressInput, User
@@ -538,7 +538,7 @@ class ConfirmEmailChange(BaseMutation):
         ).slug
 
         assign_user_gift_cards(user)
-        assign_user_orders(user)
+        match_orders_with_new_user(user)
 
         notifications.send_user_change_email_notification(
             old_email, user, info.context.plugins, channel_slug=channel_slug

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -13,6 +13,7 @@ from ....core.tokens import account_delete_token_generator
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
 from ....giftcard.utils import assign_user_gift_cards
+from ....order.utils import assign_user_orders
 from ....settings import JWT_TTL_REQUEST_EMAIL_CHANGE
 from ...account.enums import AddressTypeEnum
 from ...account.types import Address, AddressInput, User
@@ -144,7 +145,10 @@ class AccountRegister(ModelMutation):
             )
         else:
             user.save()
+
         assign_user_gift_cards(user)
+        assign_user_orders(user)
+
         account_events.customer_account_created_event(user=user)
         info.context.plugins.customer_created(customer=user)
 
@@ -537,6 +541,7 @@ class ConfirmEmailChange(BaseMutation):
         ).slug
 
         assign_user_gift_cards(user)
+        assign_user_orders(user)
 
         notifications.send_user_change_email_notification(
             old_email, user, info.context.plugins, channel_slug=channel_slug

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -12,6 +12,7 @@ from ....core.jwt import create_token, jwt_decode
 from ....core.tokens import account_delete_token_generator
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
+from ....giftcard.utils import assign_user_gift_cards
 from ....settings import JWT_TTL_REQUEST_EMAIL_CHANGE
 from ...account.enums import AddressTypeEnum
 from ...account.types import Address, AddressInput, User
@@ -143,6 +144,7 @@ class AccountRegister(ModelMutation):
             )
         else:
             user.save()
+        assign_user_gift_cards(user)
         account_events.customer_account_created_event(user=user)
         info.context.plugins.customer_created(customer=user)
 

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -15,6 +15,7 @@ from ....core.exceptions import PermissionDenied
 from ....core.permissions import AccountPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
+from ....giftcard.utils import assign_user_gift_cards
 from ....graphql.utils import get_user_or_app_from_context
 from ....order.utils import match_orders_with_new_user
 from ...account.i18n import I18nMixin
@@ -228,7 +229,10 @@ class ConfirmAccount(BaseMutation):
 
         user.is_active = True
         user.save(update_fields=["is_active"])
+
         match_orders_with_new_user(user)
+        assign_user_gift_cards(user)
+
         return ConfirmAccount(user=user)
 
 

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -15,6 +15,7 @@ from ....core.exceptions import PermissionDenied
 from ....core.permissions import AccountPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
+from ....giftcard.utils import assign_user_gift_cards
 from ...account.enums import AddressTypeEnum
 from ...account.types import Address, AddressInput, User
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
@@ -111,6 +112,7 @@ class CustomerUpdate(CustomerCreate):
             account_events.assigned_email_to_a_customer_event(
                 staff_user=staff_user, app=app, new_email=new_email
             )
+            assign_user_gift_cards(new_instance)
         if has_new_name:
             account_events.assigned_name_to_a_customer_event(
                 staff_user=staff_user, app=app, new_name=new_fullname
@@ -384,6 +386,16 @@ class StaffUpdate(StaffCreate):
         remove_groups = cleaned_data.get("remove_groups")
         if remove_groups:
             instance.groups.remove(*remove_groups)
+
+    @classmethod
+    def perform_mutation(cls, _root, info, **data):
+        instance = cls.get_instance(info, **data)
+        old_email = instance.email
+        response = super().perform_mutation(_root, info, **data)
+        user = response.user
+        if user.email != old_email:
+            assign_user_gift_cards(user)
+        return response
 
 
 class StaffDelete(StaffDeleteMixin, UserDelete):

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -16,6 +16,7 @@ from ....core.permissions import AccountPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
 from ....giftcard.utils import assign_user_gift_cards
+from ....order.utils import assign_user_orders
 from ...account.enums import AddressTypeEnum
 from ...account.types import Address, AddressInput, User
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
@@ -113,6 +114,7 @@ class CustomerUpdate(CustomerCreate):
                 staff_user=staff_user, app=app, new_email=new_email
             )
             assign_user_gift_cards(new_instance)
+            assign_user_orders(new_instance)
         if has_new_name:
             account_events.assigned_name_to_a_customer_event(
                 staff_user=staff_user, app=app, new_name=new_fullname
@@ -395,6 +397,7 @@ class StaffUpdate(StaffCreate):
         user = response.user
         if user.email != old_email:
             assign_user_gift_cards(user)
+            assign_user_orders(user)
         return response
 
 

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -16,7 +16,7 @@ from ....core.permissions import AccountPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
 from ....giftcard.utils import assign_user_gift_cards
-from ....order.utils import assign_user_orders
+from ....order.utils import match_orders_with_new_user
 from ...account.enums import AddressTypeEnum
 from ...account.types import Address, AddressInput, User
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
@@ -114,7 +114,7 @@ class CustomerUpdate(CustomerCreate):
                 staff_user=staff_user, app=app, new_email=new_email
             )
             assign_user_gift_cards(new_instance)
-            assign_user_orders(new_instance)
+            match_orders_with_new_user(new_instance)
         if has_new_name:
             account_events.assigned_name_to_a_customer_event(
                 staff_user=staff_user, app=app, new_name=new_fullname
@@ -397,7 +397,7 @@ class StaffUpdate(StaffCreate):
         user = response.user
         if user.email != old_email:
             assign_user_gift_cards(user)
-            assign_user_orders(user)
+            match_orders_with_new_user(user)
         return response
 
 

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -5062,7 +5062,10 @@ mutation emailUpdate($token: String!, $channel: String) {
 """
 
 
-def test_email_update(user_api_client, customer_user, channel_PLN):
+@patch("saleor.graphql.account.mutations.account.assign_user_gift_cards")
+def test_email_update(
+    assign_gift_cards_mock, user_api_client, customer_user, channel_PLN
+):
     new_email = "new_email@example.com"
     payload = {
         "old_email": customer_user.email,
@@ -5077,6 +5080,7 @@ def test_email_update(user_api_client, customer_user, channel_PLN):
     content = get_graphql_content(response)
     data = content["data"]["confirmEmailChange"]
     assert data["user"]["email"] == new_email
+    assign_gift_cards_mock.assert_called_once_with(customer_user)
 
 
 def test_email_update_to_existing_email(user_api_client, customer_user, staff_user):

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -1068,6 +1068,7 @@ def test_customer_register(
     channel_PLN,
     gift_card,
     gift_card_expiry_date,
+    order,
 ):
     mocked_generator.return_value = "token"
     email = "customer@example.com"
@@ -1078,6 +1079,10 @@ def test_customer_register(
 
     gift_card_expiry_date.used_by_email = email
     gift_card_expiry_date.save(update_fields=["used_by_email"])
+
+    order.user = None
+    order.user_email = email
+    order.save(update_fields=["user_email", "user"])
 
     redirect_url = "http://localhost:3000"
     variables = {
@@ -1137,6 +1142,9 @@ def test_customer_register(
 
     gift_card_expiry_date.refresh_from_db()
     assert gift_card_expiry_date.used_by == new_user
+
+    order.refresh_from_db()
+    assert order.user == new_user
 
 
 @override_settings(ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL=False)
@@ -1574,12 +1582,13 @@ def test_customer_update_generates_event_when_changing_email_by_app(
     assert email_changed_event.parameters == {"message": "mirumee@example.com"}
 
 
-def test_customer_update_assign_gift_cards(
+def test_customer_update_assign_gift_cards_and_orders(
     staff_api_client,
     staff_user,
     customer_user,
     address,
     gift_card,
+    order,
     permission_manage_users,
 ):
     # given
@@ -1595,6 +1604,10 @@ def test_customer_update_assign_gift_cards(
     gift_card.created_by = None
     gift_card.created_by_email = new_email
     gift_card.save(update_fields=["created_by", "created_by_email"])
+
+    order.user = None
+    order.user_email = new_email
+    order.save(update_fields=["user_email", "user"])
 
     variables = {
         "id": user_id,
@@ -1615,6 +1628,8 @@ def test_customer_update_assign_gift_cards(
     customer_user.refresh_from_db()
     assert gift_card.created_by == customer_user
     assert gift_card.created_by_email == customer_user.email
+    order.refresh_from_db()
+    assert order.user == customer_user
 
 
 ACCOUNT_UPDATE_QUERY = """
@@ -2895,8 +2910,8 @@ def test_staff_update_deactivate_with_manage_staff_all_perms_manageable(
     assert staff_user1.is_active is False
 
 
-def test_staff_update_update_email_and_assign_gift_cards(
-    staff_api_client, permission_manage_staff, gift_card, media_root
+def test_staff_update_update_email_assign_gift_cards_and_orders(
+    staff_api_client, permission_manage_staff, gift_card, order
 ):
     # given
     query = STAFF_UPDATE_MUTATIONS
@@ -2907,6 +2922,10 @@ def test_staff_update_update_email_and_assign_gift_cards(
     gift_card.created_by = None
     gift_card.created_by_email = new_email
     gift_card.save(update_fields=["created_by", "created_by_email"])
+
+    order.user = None
+    order.user_email = new_email
+    order.save(update_fields=["user_email", "user"])
 
     id = graphene.Node.to_global_id("User", staff_user.id)
     variables = {"id": id, "input": {"email": new_email}}
@@ -2926,6 +2945,8 @@ def test_staff_update_update_email_and_assign_gift_cards(
     staff_user.refresh_from_db()
     assert gift_card.created_by == staff_user
     assert gift_card.created_by_email == staff_user.email
+    order.refresh_from_db()
+    assert order.user == staff_user
 
 
 STAFF_DELETE_MUTATION = """
@@ -5138,9 +5159,14 @@ mutation emailUpdate($token: String!, $channel: String) {
 """
 
 
+@patch("saleor.graphql.account.mutations.account.assign_user_orders")
 @patch("saleor.graphql.account.mutations.account.assign_user_gift_cards")
 def test_email_update(
-    assign_gift_cards_mock, user_api_client, customer_user, channel_PLN
+    assign_gift_cards_mock,
+    assign_orders_mock,
+    user_api_client,
+    customer_user,
+    channel_PLN,
 ):
     new_email = "new_email@example.com"
     payload = {
@@ -5157,6 +5183,7 @@ def test_email_update(
     data = content["data"]["confirmEmailChange"]
     assert data["user"]["email"] == new_email
     assign_gift_cards_mock.assert_called_once_with(customer_user)
+    assign_orders_mock.assert_called_once_with(customer_user)
 
 
 def test_email_update_to_existing_email(user_api_client, customer_user, staff_user):

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -1066,23 +1066,10 @@ def test_customer_register(
     mocked_generator,
     api_client,
     channel_PLN,
-    gift_card,
-    gift_card_expiry_date,
     order,
 ):
     mocked_generator.return_value = "token"
     email = "customer@example.com"
-
-    gift_card.created_by = None
-    gift_card.created_by_email = email
-    gift_card.save(update_fields=["created_by_email", "created_by"])
-
-    gift_card_expiry_date.used_by_email = email
-    gift_card_expiry_date.save(update_fields=["used_by_email"])
-
-    order.user = None
-    order.user_email = email
-    order.save(update_fields=["user_email", "user"])
 
     redirect_url = "http://localhost:3000"
     variables = {
@@ -1136,15 +1123,6 @@ def test_customer_register(
     customer_creation_event = account_events.CustomerEvent.objects.get()
     assert customer_creation_event.type == account_events.CustomerEvents.ACCOUNT_CREATED
     assert customer_creation_event.user == new_user
-
-    gift_card.refresh_from_db()
-    assert gift_card.created_by == new_user
-
-    gift_card_expiry_date.refresh_from_db()
-    assert gift_card_expiry_date.used_by == new_user
-
-    order.refresh_from_db()
-    assert order.user == new_user
 
 
 @override_settings(ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL=False)

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -14,6 +14,7 @@ from ..models import Order, OrderEvent
 from ..utils import (
     add_gift_cards_to_order,
     add_variant_to_order,
+    assign_user_orders,
     change_order_line_quantity,
     get_valid_shipping_methods_for_order,
     match_orders_with_new_user,
@@ -390,3 +391,21 @@ def test_add_gift_cards_to_order_no_checkout_user(
         },
         "order_id": order.id,
     }
+
+
+def test_assign_user_orders(order_list, staff_user):
+    # given
+    for order in order_list[:2]:
+        order.user = None
+        order.user_email = staff_user.email
+        order.save(update_fields=["user", "user_email"])
+
+    # when
+    assign_user_orders(staff_user)
+
+    # then
+    for order in order_list[:2]:
+        order.refresh_from_db()
+        assert order.user == staff_user
+
+    assert order_list[-1].user != staff_user

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -462,7 +462,11 @@ def set_gift_card_user(
 ):
     """Set user when the gift card is used for the first time."""
     if gift_card.used_by_email is None:
-        gift_card.used_by = used_by_user
+        gift_card.used_by = (
+            used_by_user
+            if used_by_user
+            else User.objects.filter(email=used_by_email).first()
+        )
         gift_card.used_by_email = used_by_email
 
 

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -938,3 +938,7 @@ def remove_discount_from_order_line(
             "tax_rate",
         ]
     )
+
+
+def assign_user_orders(user):
+    Order.objects.filter(user_email=user.email).update(user=user)

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -938,7 +938,3 @@ def remove_discount_from_order_line(
             "tax_rate",
         ]
     )
-
-
-def assign_user_orders(user):
-    Order.objects.filter(user_email=user.email).update(user=user)


### PR DESCRIPTION
Try to find the corresponding user when `used_by_email` is set.

Assign gift cards and orders when an email is changed in:
- `ConfirmEmailChange`
- `AccountRegister`
- `StaffUpdate`
- `CustomerUpdate`


<!-- Please mention all relevant issue numbers.  -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
