### PR TITLE
Add missing validation on token refresh mutation

### DIFF
--- a/saleor/graphql/account/mutations/authentication.py
+++ b/saleor/graphql/account/mutations/authentication.py
@@ -185,7 +185,7 @@ class RefreshToken(BaseMutation):
         if not refresh_token:
             raise ValidationError(
                 {
-                    "refreshToken": ValidationError(
+                    "refresh_token": ValidationError(
                         "Missing refreshToken",
                         code=AccountErrorCode.JWT_MISSING_TOKEN.value,
                     )
@@ -195,7 +195,7 @@ class RefreshToken(BaseMutation):
         if payload["type"] != JWT_REFRESH_TYPE:
             raise ValidationError(
                 {
-                    "refreshToken": ValidationError(
+                    "refresh_token": ValidationError(
                         "Incorrect refreshToken",
                         code=AccountErrorCode.JWT_INVALID_TOKEN.value,
                     )
@@ -205,11 +205,21 @@ class RefreshToken(BaseMutation):
 
     @classmethod
     def clean_csrf_token(cls, csrf_token, payload):
+        if not csrf_token:
+            msg = "CSRF token is required when refreshToken is provided by the cookie"
+            raise ValidationError(
+                {
+                    "csrf_token": ValidationError(
+                        msg,
+                        code=AccountErrorCode.REQUIRED.value,
+                    )
+                }
+            )
         is_valid = _compare_masked_tokens(csrf_token, payload["csrfToken"])
         if not is_valid:
             raise ValidationError(
                 {
-                    "csrfToken": ValidationError(
+                    "csrf_token": ValidationError(
                         "Invalid csrf token",
                         code=AccountErrorCode.JWT_INVALID_CSRF_TOKEN.value,
                     )
@@ -221,7 +231,7 @@ class RefreshToken(BaseMutation):
         try:
             user = get_user(payload)
         except ValidationError as e:
-            raise ValidationError({"refreshToken": e})
+            raise ValidationError({"refresh_token": e})
         return user
 
     @classmethod


### PR DESCRIPTION
I want to merge this change because coping changes from #8288 to 3.0.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
