### PR TITLE
Publish main branch to GHCR instead of Docker Hub (#8322)

### DIFF
--- a/.github/workflows/publish-containers.rst
+++ b/.github/workflows/publish-containers.rst
@@ -4,20 +4,18 @@ Tagging Process
 +-----------------------------------+-----------------------------------------------------------------------+
 | Git Ref                           | Container Tags                                                        |
 +===================================+=======================================================================+
-| ``refs/tags/1.0.0``               | ghcr.io/mirumee/saleor:1.0.0                                          |
-|                                   | ghcr.io/mirumee/saleor:latest                                         |
+| ``refs/tags/1.0.0``               | ghcr.io/saleor/saleor:1.0.0                                           |
+|                                   | ghcr.io/saleor/saleor:latest                                          |
 +-----------------------------------+-----------------------------------------------------------------------+
-| ``refs/tags/1.0.0a1``             | ghcr.io/mirumee/saleor:1.0.0a1                                        |
-|                                   | ghcr.io/mirumee/saleor:snapshot                                       |
+| ``refs/tags/1.0.0a1``             | ghcr.io/saleor/saleor:1.0.0a1                                         |
+|                                   | ghcr.io/saleor/saleor:snapshot                                        |
 +-----------------------------------+-----------------------------------------------------------------------+
-| ``refs/tags/1.0.0rc1``            | ghcr.io/mirumee/saleor:1.0.0rc1                                       |
-|                                   | ghcr.io/mirumee/saleor:snapshot                                       |
+| ``refs/tags/1.0.0rc1``            | ghcr.io/saleor/saleor:1.0.0rc1                                        |
+|                                   | ghcr.io/saleor/saleor:snapshot                                        |
 +-----------------------------------+-----------------------------------------------------------------------+
-| ``refs/heads/master``             | docker.io/mirumee/saleor:master                                       |
-|                                   | docker.io/mirumee/saleor:sha-8ccaf90855b4a4251659c382a86e7e58f173c4e3 |
+| ``refs/heads/main``               | ghcr.io/saleor/saleor:unstable-main                                   |
 +-----------------------------------+-----------------------------------------------------------------------+
-| ``refs/heads/preview/my-feature`` | docker.io/mirumee/saleor:my-feature                                   |
-|                                   | docker.io/mirumee/saleor:sha-d122141d318518e216fc0e5b657259de317318c5 |
+| ``refs/heads/preview/my-feature`` | ghcr.io/saleor/saleor:unstable-my-feature                             |
 +-----------------------------------+-----------------------------------------------------------------------+
 
 
@@ -39,7 +37,7 @@ When the image is built, the following instructions will be provided to the belo
 +-----------------------------------+--------------------------------------------------------+
 | ``refs/tags/1.0.0a1``             | 1.0.0a1                                                |
 +-----------------------------------+--------------------------------------------------------+
-| ``refs/heads/master``             | heads/master-0-g8ccaf9                                 |
+| ``refs/heads/main``               | heads/main-0-g8ccaf9                                   |
 +-----------------------------------+--------------------------------------------------------+
 | ``refs/heads/preview/my-feature`` | heads/preview/my-feature-0-gd12214                     |
 +-----------------------------------+--------------------------------------------------------+

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -70,13 +70,10 @@ jobs:
           # Version name is the branch name
           # Slashes are substitued by dashes
           CLEAN_BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)
-          SHA=${GITHUB_SHA}
 
-          # Target Docker Hub with the SHA value
-          # and branch name
+          # Target GHCR with the branch name as the tag, e.g. unstable-main
           TAGS=$"\
-          ${{ steps.image.outputs.image_name }}:${CLEAN_BRANCH_NAME},\
-          ${{ steps.image.outputs.image_name }}:sha-${SHA}\
+          ghcr.io/${{ steps.image.outputs.image_name }}:unstable-${CLEAN_BRANCH_NAME}
           "
 
           # Set version name for open-containers version label as:
@@ -106,15 +103,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Login to DockerHub
-        if: ${{ startsWith(github.ref, 'refs/heads/') }}
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Login to GitHub Container Registry
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,10 +59,10 @@ LABEL org.opencontainers.image.title="mirumee/saleor"                           
 A modular, high performance, headless e-commerce platform built with Python, \
 GraphQL, Django, and ReactJS."                                                         \
       org.opencontainers.image.url="https://saleor.io/"                                \
-      org.opencontainers.image.source="https://github.com/mirumee/saleor"              \
+      org.opencontainers.image.source="https://github.com/saleor/saleor"               \
       org.opencontainers.image.revision="$COMMIT_ID"                                   \
       org.opencontainers.image.version="$PROJECT_VERSION"                              \
-      org.opencontainers.image.authors="Mirumee Software (https://mirumee.com)"        \
+      org.opencontainers.image.authors="Saleor Commerce (https://saleor.io)"           \
       org.opencontainers.image.licenses="BSD 3"
 
 CMD ["gunicorn", "--bind", ":8000", "--workers", "4", "--worker-class", "uvicorn.workers.UvicornWorker", "saleor.asgi:application"]


### PR DESCRIPTION
Cherry-pick of #8322 onto 3.0 branch.
---

Changes:
- Replace publishing of the main from Docker Hub to GHCR as `unstable-main` tag.
- Drop `sha-<commit-hash>` in favor of using the image hash instead.
- Update image labels to new repository


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
