### PR TITLE
Fix permissions for product types attribute assign

### DIFF
--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -50,12 +50,7 @@ class ProductAttributeAssign(BaseMutation):
         description = "Assign attributes to a given product type."
         error_type_class = ProductError
         error_type_field = "product_errors"
-
-    @classmethod
-    def check_permissions(cls, context):
-        return context.user.has_perm(
-            ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES
-        )
+        permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
 
     @classmethod
     def get_operations(cls, info, operations: List[ProductAttributeAssignInput]):
@@ -230,12 +225,7 @@ class ProductAttributeUnassign(BaseMutation):
         description = "Un-assign attributes from a given product type."
         error_type_class = ProductError
         error_type_field = "product_errors"
-
-    @classmethod
-    def check_permissions(cls, context):
-        return context.user.has_perm(
-            ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES
-        )
+        permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
 
     @classmethod
     def save_field_values(cls, product_type, field, pks):


### PR DESCRIPTION
I want to merge this change because it allows apps to assign attributes to product types.
As far as I can tell there is no real reason not to allow apps to assign attributes to product types.
 

<!-- Please mention all relevant issue numbers. -->
Fixes #8247 

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
