### PR TITLE
Fix None checkers for quantity available resolver

### DIFF
--- a/saleor/graphql/product/tests/test_variant_availability.py
+++ b/saleor/graphql/product/tests/test_variant_availability.py
@@ -285,3 +285,21 @@ def test_variant_quantity_available_preorder_without_threshold(
     variant_data = content["data"]["productVariant"]
     assert variant_data["deprecatedByCountry"] == settings.MAX_CHECKOUT_LINE_QUANTITY
     assert variant_data["byAddress"] == settings.MAX_CHECKOUT_LINE_QUANTITY
+
+
+@override_settings(MAX_CHECKOUT_LINE_QUANTITY=15)
+def test_variant_quantity_available_preorder_without_channel(
+    api_client,
+    preorder_variant_global_threshold,
+    channel_USD,
+):
+    variant = preorder_variant_global_threshold
+    variant.channel_listings.all().delete()
+    variables = {
+        "id": graphene.Node.to_global_id("ProductVariant", variant.pk),
+        "country": COUNTRY_CODE,
+        "channel": channel_USD.slug,
+    }
+    response = api_client.post_graphql(QUERY_VARIANT_AVAILABILITY, variables)
+    content = get_graphql_content(response)
+    assert not content["data"]["productVariant"]

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -341,7 +341,10 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
             ).load((variant.id, str(root.channel_slug)))
 
             def calculate_available_per_channel(channel_listing):
-                if channel_listing.preorder_quantity_threshold is not None:
+                if (
+                    channel_listing
+                    and channel_listing.preorder_quantity_threshold is not None
+                ):
                     return min(
                         channel_listing.preorder_quantity_threshold
                         - channel_listing.preorder_quantity_allocated,
@@ -353,6 +356,8 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
                     ).load(variant.id)
 
                     def calculate_available_global(variant_channel_listings):
+                        if not variant_channel_listings:
+                            return settings.MAX_CHECKOUT_LINE_QUANTITY
                         global_sold_units = sum(
                             channel_listing.preorder_quantity_allocated
                             for channel_listing in variant_channel_listings


### PR DESCRIPTION
I want to merge this change because it fixes `None` checkers in `quantity_available` resolver for preorder product variant.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
