### PR TITLE
Fix product variant channel list mutation declaration

### DIFF
--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -324,8 +324,8 @@ class ProductVariantChannelListingUpdate(BaseMutation):
             graphene.NonNull(ProductVariantChannelListingAddInput),
             required=True,
             description=(
-                "List of fields required to create or upgrade product variant ",
-                "channel listings.",
+                "List of fields required to create or upgrade product variant "
+                "channel listings."
             ),
         )
 


### PR DESCRIPTION
There's an input type in our GraphQL API which uses incorrect syntax for splitting long string, defining it as tuple instead.

This isn't a problem currently but graphql-core v3 runs type checks, and they throw very non-descriptive error from internals for this type, preventing Saleor from initializing correctly.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
