### PR TITLE
Fix invalid token error when using accountDelete after logging out

### DIFF
--- a/saleor/account/notifications.py
+++ b/saleor/account/notifications.py
@@ -5,6 +5,7 @@ from django.contrib.auth.tokens import default_token_generator
 
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
+from ..core.tokens import account_delete_token_generator
 from ..core.utils.url import prepare_url
 from .models import User
 
@@ -117,7 +118,7 @@ def send_account_delete_confirmation_notification(
     redirect_url, user, manager, channel_slug
 ):
     """Trigger sending a account delete notification for the given user."""
-    token = default_token_generator.make_token(user)
+    token = account_delete_token_generator.make_token(user)
     params = urlencode({"token": token})
     delete_url = prepare_url(params, redirect_url)
     payload = {

--- a/saleor/core/tokens.py
+++ b/saleor/core/tokens.py
@@ -1,0 +1,14 @@
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+
+
+class AccountDeleteTokenGenerator(PasswordResetTokenGenerator):
+    def _make_hash_value(self, user, timestamp):
+        # Override this method to remove the user `last_login` value from the hash.
+        # As this token is used for deleting the user, so there is no worry
+        # that the token will be used again.
+        email_field = user.get_email_field_name()
+        email = getattr(user, email_field, "") or ""
+        return f"{user.pk}{user.password}{timestamp}{email}"
+
+
+account_delete_token_generator = AccountDeleteTokenGenerator()

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -2,7 +2,6 @@ import graphene
 import jwt
 from django.conf import settings
 from django.contrib.auth import password_validation
-from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
 
 from ....account import events as account_events
@@ -10,6 +9,7 @@ from ....account import models, notifications, utils
 from ....account.error_codes import AccountErrorCode
 from ....checkout import AddressType
 from ....core.jwt import create_token, jwt_decode
+from ....core.tokens import account_delete_token_generator
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
 from ....settings import JWT_TTL_REQUEST_EMAIL_CHANGE
@@ -262,7 +262,7 @@ class AccountDelete(ModelDeleteMutation):
         cls.clean_instance(info, user)
 
         token = data.pop("token")
-        if not default_token_generator.check_token(user, token):
+        if not account_delete_token_generator.check_token(user, token):
             raise ValidationError(
                 {"token": ValidationError(INVALID_TOKEN, code=AccountErrorCode.INVALID)}
             )


### PR DESCRIPTION
`AccountRequestDeletion` generated token with use of `PasswordResetTokenGenerator`. The `PasswordResetTokenGenerator` creates token based on use `last_login`, `pk`, `password`, `email` and current time value. After re-login, the `last_login` value is changing, so the tokens aren't the same.
`Last login` is used for preventing usage token multiple times. For deleting users we don't need this security, as the user will not exist anymore. So, I created a new token generator `AccountDeleteTokenGenerator` that overrides the method that is responsible for creating hash based on `user` value. I excluded the `last_login ` value from this. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
