### PR TITLE
Cleanup federation tests

### DIFF
--- a/saleor/graphql/account/tests/benchmark/test_permission_group.py
+++ b/saleor/graphql/account/tests/benchmark/test_permission_group.py
@@ -313,9 +313,6 @@ def test_permission_group_query(
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
 def test_groups_for_federation_query_count(
-    address,
-    customer_user,
-    customer_user2,
     api_client,
     django_assert_num_queries,
     count_queries,

--- a/saleor/graphql/page/tests/benchmark/test_page_type.py
+++ b/saleor/graphql/page/tests/benchmark/test_page_type.py
@@ -148,7 +148,7 @@ def test_query_page_types(
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-def test_query_page_types_for_federation(
+def test_page_types_for_federation_query_count(
     api_client,
     django_assert_num_queries,
     count_queries,

--- a/saleor/graphql/page/tests/test_page_type_query.py
+++ b/saleor/graphql/page/tests/test_page_type_query.py
@@ -201,7 +201,7 @@ def test_page_type_query_no_pages(
     assert available_attributes[0]["node"]["slug"] == author_page_attribute.slug
 
 
-def test_page_types_for_federation_query_count(api_client, page_type):
+def test_query_page_types_for_federation(api_client, page_type):
     page_type_id = graphene.Node.to_global_id("PageType", page_type.pk)
     variables = {
         "representations": [


### PR DESCRIPTION
Few tiny cleanups for 3.1 federation tests: remove unused fixtures, switch back test names.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
