### PR TITLE
Add email validation on checkout mutations

### DIFF
--- a/saleor/checkout/error_codes.py
+++ b/saleor/checkout/error_codes.py
@@ -27,3 +27,4 @@ class CheckoutErrorCode(Enum):
     MISSING_CHANNEL_SLUG = "missing_channel_slug"
     CHANNEL_INACTIVE = "channel_inactive"
     UNAVAILABLE_VARIANT_IN_CHANNEL = "unavailable_variant_in_channel"
+    EMAIL_NOT_SET = "email_not_set"

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -234,6 +234,14 @@ def get_checkout_by_token(token: uuid.UUID, prefetch_lookups: Iterable[str] = []
     return checkout
 
 
+def validate_checkout_email(checkout: models.Checkout):
+    if not checkout.email:
+        raise ValidationError(
+            "Checkout email must be set.",
+            code=CheckoutErrorCode.EMAIL_NOT_SET.value,
+        )
+
+
 class CheckoutLineInput(graphene.InputObjectType):
     quantity = graphene.Int(required=True, description="The number of items purchased.")
     variant_id = graphene.ID(required=True, description="ID of the product variant.")
@@ -1383,6 +1391,8 @@ class CheckoutComplete(BaseMutation):
                     )
                 raise e
 
+            validate_checkout_email(checkout)
+
             manager = info.context.plugins
             lines = fetch_checkout_lines(checkout)
             validate_variants_in_checkout_lines(lines)
@@ -1456,6 +1466,8 @@ class CheckoutAddPromoCode(BaseMutation):
             checkout = cls.get_node_or_error(
                 info, checkout_id or token, only_type=Checkout, field="checkout_id"
             )
+
+        validate_checkout_email(checkout)
 
         manager = info.context.plugins
         discounts = info.context.discounts

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -477,6 +477,24 @@ def test_checkout_complete_gift_card_bought(
     assert Fulfillment.objects.count() == 1
 
 
+def test_checkout_complete_no_checkout_email(
+    user_api_client,
+    checkout_with_gift_card,
+):
+    checkout = checkout_with_gift_card
+    checkout.email = None
+    checkout.save(update_fields=["email"])
+
+    redirect_url = "https://www.example.com"
+    variables = {"token": checkout.token, "redirectUrl": redirect_url}
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["code"] == CheckoutErrorCode.EMAIL_NOT_SET.name
+
+
 def test_checkout_complete_with_variant_without_sku(
     site_settings,
     user_api_client,

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -799,6 +799,19 @@ def test_checkout_add_promo_code_invalidate_shipping_method(
     assert shipping_method_id not in data["checkout"]["availableShippingMethods"]
 
 
+def test_checkout_add_promo_code_no_checkout_email(
+    api_client, checkout_with_item, voucher
+):
+    checkout_with_item.email = None
+    checkout_with_item.save(update_fields=["email"])
+
+    variables = {"token": checkout_with_item.token, "promoCode": voucher.code}
+    data = _mutate_checkout_add_promo_code(api_client, variables)
+
+    assert data["errors"]
+    assert data["errors"][0]["code"] == CheckoutErrorCode.EMAIL_NOT_SET.name
+
+
 MUTATION_CHECKOUT_REMOVE_PROMO_CODE = """
     mutation($token: UUID, $promoCode: String!) {
         checkoutRemovePromoCode(

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import TYPE_CHECKING, List
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -27,6 +27,9 @@ from ..core.validators import validate_one_of_args_is_in_mutation
 from ..meta.mutations import MetadataInput
 from .types import Payment, PaymentInitialized
 from .utils import metadata_contains_empty_key
+
+if TYPE_CHECKING:
+    from ...checkout import models as checkout_models
 
 
 def description(enum):
@@ -188,6 +191,14 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
                 }
             )
 
+    @staticmethod
+    def validate_checkout_email(checkout: "checkout_models.Checkout"):
+        if not checkout.email:
+            raise ValidationError(
+                "Checkout email must be set.",
+                code=PaymentErrorCode.EMAIL_NOT_SET.value,
+            )
+
     @classmethod
     def perform_mutation(cls, _root, info, checkout_id=None, token=None, **data):
         # DEPRECATED
@@ -202,6 +213,8 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
             checkout = cls.get_node_or_error(
                 info, checkout_id or token, only_type=Checkout, field="checkout_id"
             )
+
+        cls.validate_checkout_email(checkout)
 
         data = data["input"]
         gateway = data["gateway"]

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -324,6 +324,37 @@ def test_checkout_add_payment_bad_amount(
     )
 
 
+def test_checkout_add_payment_no_checkout_email(
+    user_api_client, checkout_without_shipping_required, address, customer_user
+):
+    checkout = checkout_without_shipping_required
+    checkout.email = None
+    checkout.save(update_fields=["email"])
+
+    manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.checkout_total(
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
+    )
+    return_url = "https://www.example.com"
+    variables = {
+        "token": checkout.token,
+        "input": {
+            "gateway": DUMMY_GATEWAY,
+            "token": "sample-token",
+            "amount": total.gross.amount,
+            "returnUrl": return_url,
+        },
+    }
+    response = user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutPaymentCreate"]
+
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["code"] == PaymentErrorCode.EMAIL_NOT_SET.name
+
+
 def test_checkout_add_payment_not_supported_gateways(
     user_api_client, checkout_without_shipping_required, address
 ):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1131,6 +1131,7 @@ enum CheckoutErrorCode {
   MISSING_CHANNEL_SLUG
   CHANNEL_INACTIVE
   UNAVAILABLE_VARIANT_IN_CHANNEL
+  EMAIL_NOT_SET
 }
 
 type CheckoutLanguageCodeUpdate {
@@ -4902,6 +4903,7 @@ enum PaymentErrorCode {
   PAYMENT_ERROR
   NOT_SUPPORTED_GATEWAY
   CHANNEL_INACTIVE
+  EMAIL_NOT_SET
 }
 
 input PaymentFilterInput {

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -15,3 +15,4 @@ class PaymentErrorCode(Enum):
     PAYMENT_ERROR = "payment_error"
     NOT_SUPPORTED_GATEWAY = "not_supported_gateway"
     CHANNEL_INACTIVE = "channel_inactive"
+    EMAIL_NOT_SET = "email_not_set"


### PR DESCRIPTION
Do not allow to perform following mutations when checkout email is not set:
- `CheckoutComplete`
- `CheckoutAddPromoCode`
- `CheckoutPaymentCreate`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
