### PR TITLE
Fix failing vatlayer for click and collect

### DIFF
--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -223,8 +223,11 @@ class VatlayerPlugin(BasePlugin):
         shipping_price = getattr(
             checkout_info.delivery_method_info.delivery_method, "price", None
         )
-        if shipping_price is None and checkout_info.shipping_method_channel_listings:
-            shipping_price = checkout_info.shipping_method_channel_listings.price
+        if shipping_price is None:
+            if checkout_info.shipping_method_channel_listings:
+                shipping_price = checkout_info.shipping_method_channel_listings.price
+            else:
+                shipping_price = previous_value
 
         return get_taxed_shipping_price(shipping_price, taxes)
 


### PR DESCRIPTION
When the `checkout_info.shipping_method_channel_listings` was `None`, the `None` value was provided as `shipping_price` to `get_taxed_shipping_price` method. Instead of `None` provide `previous_value`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
