### PR TITLE
Add http.url tag to graphql query spans

### DIFF
--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -250,6 +250,10 @@ class GraphQLView(View):
         with opentracing.global_tracer().start_active_span("graphql_query") as scope:
             span = scope.span
             span.set_tag(opentracing.tags.COMPONENT, "graphql")
+            span.set_tag(
+                opentracing.tags.HTTP_URL,
+                request.build_absolute_uri(request.get_full_path()),
+            )
 
             query, variables, operation_name = self.get_graphql_params(request, data)
 


### PR DESCRIPTION
I want to merge this change because it adds http.url tag to graphql query spans

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
