### PR TITLE
Add sender_address field in validate email raising error

### DIFF
--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -15,7 +15,7 @@ from babel.numbers import format_currency
 from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.core.mail.backends.smtp import EmailBackend
-from django.core.validators import validate_email
+from django.core.validators import EmailValidator
 from django_prices.utils.locale import get_locale_data
 
 from ..product.product_images import get_thumbnail_size
@@ -281,7 +281,13 @@ def validate_default_email_configuration(
             }
         )
 
-    validate_email(config.sender_address)
+    EmailValidator(
+        message={
+            "sender_address": ValidationError(
+                "Invalid email", code=PluginErrorCode.INVALID.value
+            )
+        }
+    )(config.sender_address)
 
     try:
         validate_email_config(config)

--- a/saleor/plugins/tests/test_email_common.py
+++ b/saleor/plugins/tests/test_email_common.py
@@ -4,6 +4,7 @@ import pytest
 from django.core.exceptions import ValidationError
 
 from saleor.plugins.email_common import validate_default_email_configuration
+from saleor.plugins.error_codes import PluginErrorCode
 
 
 @pytest.mark.parametrize(
@@ -20,8 +21,11 @@ def test_validate_default_email_configuration_bad_email(
 ):
     email_configuration["sender_address"] = email
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as e:
         validate_default_email_configuration(plugin_configuration, email_configuration)
+
+    assert "sender_address" in e.value.args[0]
+    assert e.value.args[0]["sender_address"].code == PluginErrorCode.INVALID.value
 
 
 @patch("saleor.plugins.email_common.validate_email_config")


### PR DESCRIPTION
Proper field has been added to the `ValidationError` because we didn't have field information. 
Before:
```
{"errors": [{"code": "INVALID", "field": null, "__typename": "PluginError"}]
```
After:
```
{"errors": [{"code": "INVALID", "field": "senderAddress", "__typename": "PluginError"}]
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
