### PR TITLE
Fix invalid token error when using accountDelete after logging out

### DIFF
--- a/saleor/account/notifications.py
+++ b/saleor/account/notifications.py
@@ -5,6 +5,7 @@ from django.contrib.auth.tokens import default_token_generator
 
 from ..core.notifications import get_site_context
 from ..core.notify_events import NotifyEventType
+from ..core.tokens import account_delete_token_generator
 from ..core.utils.url import prepare_url
 from .models import User
 
@@ -108,7 +109,7 @@ def send_account_delete_confirmation_notification(
     redirect_url, user, manager, channel_slug
 ):
     """Trigger sending a account delete notification for the given user."""
-    token = default_token_generator.make_token(user)
+    token = account_delete_token_generator.make_token(user)
     params = urlencode({"token": token})
     delete_url = prepare_url(params, redirect_url)
     payload = {

--- a/saleor/core/tokens.py
+++ b/saleor/core/tokens.py
@@ -1,0 +1,14 @@
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+
+
+class AccountDeleteTokenGenerator(PasswordResetTokenGenerator):
+    def _make_hash_value(self, user, timestamp):
+        # Override this method to remove the user `last_login` value from the hash.
+        # As this token is used for deleting the user, so there is no worry
+        # that the token will be used again.
+        email_field = user.get_email_field_name()
+        email = getattr(user, email_field, "") or ""
+        return f"{user.pk}{user.password}{timestamp}{email}"
+
+
+account_delete_token_generator = AccountDeleteTokenGenerator()

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -2,7 +2,6 @@ import graphene
 import jwt
 from django.conf import settings
 from django.contrib.auth import password_validation
-from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
 
 from ....account import events as account_events
@@ -10,6 +9,7 @@ from ....account import models, notifications, utils
 from ....account.error_codes import AccountErrorCode
 from ....checkout import AddressType
 from ....core.jwt import create_token, jwt_decode
+from ....core.tokens import account_delete_token_generator
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
 from ....settings import JWT_TTL_REQUEST_EMAIL_CHANGE
@@ -257,7 +257,7 @@ class AccountDelete(ModelDeleteMutation):
         cls.clean_instance(info, user)
 
         token = data.pop("token")
-        if not default_token_generator.check_token(user, token):
+        if not account_delete_token_generator.check_token(user, token):
             raise ValidationError(
                 {"token": ValidationError(INVALID_TOKEN, code=AccountErrorCode.INVALID)}
             )

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import re
 import uuid
@@ -13,6 +14,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.test import override_settings
+from django.utils import timezone
 from freezegun import freeze_time
 
 from ....account import events as account_events
@@ -23,6 +25,7 @@ from ....checkout import AddressType
 from ....core.jwt import create_token
 from ....core.notify_events import NotifyEventType
 from ....core.permissions import AccountPermissions, OrderPermissions
+from ....core.tokens import account_delete_token_generator
 from ....core.utils.url import prepare_url
 from ....order import OrderStatus
 from ....order.models import FulfillmentStatus, Order
@@ -1679,18 +1682,15 @@ ACCOUNT_REQUEST_DELETION_MUTATION = """
         accountRequestDeletion(redirectUrl: $redirectUrl, channel: $channel) {
             errors {
                 field
-                message
-            }
-            errors {
                 code
-                field
+                message
             }
         }
     }
 """
 
 
-@patch("saleor.account.notifications.default_token_generator.make_token")
+@patch("saleor.account.notifications.account_delete_token_generator.make_token")
 @patch("saleor.plugins.manager.PluginsManager.notify")
 def test_account_request_deletion(
     mocked_notify, mocked_token, user_api_client, channel_PLN
@@ -1730,7 +1730,7 @@ def test_account_request_deletion_token_validation(
     mocked_notify, user_api_client, channel_PLN
 ):
     user = user_api_client.user
-    token = default_token_generator.make_token(user)
+    token = account_delete_token_generator.make_token(user)
     redirect_url = "https://www.example.com"
     variables = {"redirectUrl": redirect_url, "channel": channel_PLN.slug}
     response = user_api_client.post_graphql(
@@ -1791,7 +1791,10 @@ def test_account_request_deletion_all_storefront_hosts_allowed(
     mocked_notify, user_api_client, settings, channel_PLN
 ):
     user = user_api_client.user
-    token = default_token_generator.make_token(user)
+    user.last_login = timezone.now()
+    user.save(update_fields=["last_login"])
+
+    token = account_delete_token_generator.make_token(user)
     settings.ALLOWED_CLIENT_HOSTS = ["*"]
     redirect_url = "https://www.test.com"
     variables = {"redirectUrl": redirect_url, "channel": channel_PLN.slug}
@@ -1827,7 +1830,7 @@ def test_account_request_deletion_subdomain(
     mocked_notify, user_api_client, settings, channel_PLN
 ):
     user = user_api_client.user
-    token = default_token_generator.make_token(user)
+    token = account_delete_token_generator.make_token(user)
     settings.ALLOWED_CLIENT_HOSTS = [".example.com"]
     redirect_url = "https://sub.example.com"
     variables = {"redirectUrl": redirect_url, "channel": channel_PLN.slug}
@@ -1871,7 +1874,43 @@ ACCOUNT_DELETE_MUTATION = """
 @freeze_time("2018-05-31 12:00:01")
 def test_account_delete(user_api_client):
     user = user_api_client.user
-    token = default_token_generator.make_token(user)
+    user.last_login = timezone.now()
+    user.save(update_fields=["last_login"])
+    token = account_delete_token_generator.make_token(user)
+    variables = {"token": token}
+
+    response = user_api_client.post_graphql(ACCOUNT_DELETE_MUTATION, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["accountDelete"]
+    assert not data["errors"]
+    assert not User.objects.filter(pk=user.id).exists()
+
+
+@freeze_time("2018-05-31 12:00:01")
+def test_account_delete_user_never_log_in(user_api_client):
+    user = user_api_client.user
+    token = account_delete_token_generator.make_token(user)
+    variables = {"token": token}
+
+    response = user_api_client.post_graphql(ACCOUNT_DELETE_MUTATION, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["accountDelete"]
+    assert not data["errors"]
+    assert not User.objects.filter(pk=user.id).exists()
+
+
+@freeze_time("2018-05-31 12:00:01")
+def test_account_delete_log_out_after_deletion_request(user_api_client):
+    user = user_api_client.user
+    user.last_login = timezone.now()
+    user.save(update_fields=["last_login"])
+
+    token = account_delete_token_generator.make_token(user)
+
+    # simulate re-login
+    user.last_login = timezone.now() + datetime.timedelta(hours=1)
+    user.save(update_fields=["last_login"])
+
     variables = {"token": token}
 
     response = user_api_client.post_graphql(ACCOUNT_DELETE_MUTATION, variables)
@@ -1916,7 +1955,7 @@ def test_account_delete_staff_user(staff_api_client):
 def test_account_delete_other_customer_token(user_api_client):
     user = user_api_client.user
     other_user = User.objects.create(email="temp@example.com")
-    token = default_token_generator.make_token(other_user)
+    token = account_delete_token_generator.make_token(other_user)
     variables = {"token": token}
 
     response = user_api_client.post_graphql(ACCOUNT_DELETE_MUTATION, variables)


### PR DESCRIPTION
Port from #8359.

`AccountRequestDeletion` generated token with use of `PasswordResetTokenGenerator`. The `PasswordResetTokenGenerator` creates token based on use `last_login`, `pk`, `password`, `email` and current time value. After re-login, the `last_login` value is changing, so the tokens aren't the same.
`Last login` is used for preventing usage token multiple times. For deleting users we don't need this security, as the user will not exist anymore. So, I created a new token generator `AccountDeleteTokenGenerator` that overrides the method that is responsible for creating hash based on `user` value. I excluded the `last_login ` value from this. 


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
