### PR TITLE
Add cron job that wipes old checkouts

### DIFF
--- a/saleor/checkout/tasks.py
+++ b/saleor/checkout/tasks.py
@@ -1,0 +1,32 @@
+from datetime import timedelta
+
+from celery.utils.log import get_task_logger
+from django.conf import settings
+from django.db.models import Q
+from django.utils import timezone
+
+from ..celeryconf import app
+from .models import Checkout
+
+task_logger = get_task_logger(__name__)
+
+
+@app.task
+def delete_expired_checkouts():
+    now = timezone.now()
+    expired_anonymous_checkouts = (
+        Q(email__isnull=True)
+        & Q(user__isnull=True)
+        & Q(last_change__lt=now - timedelta(**settings.ANONYMOUS_CHECKOUTS_TIMEDELTA))
+    )
+    expired_user_checkout = (Q(email__isnull=False) | Q(user__isnull=False)) & Q(
+        last_change__lt=now - timedelta(**settings.USER_CHECKOUTS_TIMEDELTA)
+    )
+    empty_checkouts = Q(lines__isnull=True) & Q(
+        last_change__lt=now - timedelta(**settings.EMPTY_CHECKOUTS_TIMEDELTA)
+    )
+    count, _ = Checkout.objects.filter(
+        empty_checkouts | expired_anonymous_checkouts | expired_user_checkout
+    ).delete()
+    if count:
+        task_logger.debug("Removed %s checkouts.", count)

--- a/saleor/checkout/tests/test_tasks.py
+++ b/saleor/checkout/tests/test_tasks.py
@@ -1,0 +1,242 @@
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from ..models import Checkout
+from ..tasks import delete_expired_checkouts
+
+
+def test_delete_expired_anonymous_checkouts(checkouts_list, variant, customer_user):
+    # given
+    now = timezone.now()
+    checkout_count = Checkout.objects.count()
+
+    expired_anonymous_checkout = checkouts_list[0]
+    expired_anonymous_checkout.email = None
+    expired_anonymous_checkout.user = None
+    expired_anonymous_checkout.created = now - timedelta(days=40)
+    expired_anonymous_checkout.last_change = now - timedelta(days=35)
+    expired_anonymous_checkout.lines.create(
+        checkout=expired_anonymous_checkout, variant=variant, quantity=1
+    )
+
+    not_expired_checkout_1 = checkouts_list[1]
+    not_expired_checkout_1.email = None
+    not_expired_checkout_1.user = None
+    not_expired_checkout_1.created = now - timedelta(days=35)
+    not_expired_checkout_1.last_change = now - timedelta(days=29)
+    not_expired_checkout_1.lines.create(
+        checkout=not_expired_checkout_1, variant=variant, quantity=1
+    )
+
+    not_expired_checkout_2 = checkouts_list[2]
+    not_expired_checkout_2.email = None
+    not_expired_checkout_2.user = customer_user
+    not_expired_checkout_2.created = now - timedelta(days=45)
+    not_expired_checkout_2.last_change = now - timedelta(days=40)
+    not_expired_checkout_2.lines.create(
+        checkout=not_expired_checkout_2, variant=variant, quantity=1
+    )
+
+    not_expired_checkout_3 = checkouts_list[3]
+    not_expired_checkout_3.email = "test@example.com"
+    not_expired_checkout_3.user = None
+    not_expired_checkout_3.created = now - timedelta(days=45)
+    not_expired_checkout_3.last_change = now - timedelta(days=40)
+    not_expired_checkout_3.lines.create(
+        checkout=not_expired_checkout_3, variant=variant, quantity=1
+    )
+
+    empty_checkout = checkouts_list[4]
+    empty_checkout.last_change = now - timedelta(hours=8)
+    assert empty_checkout.lines.count() == 0
+
+    Checkout.objects.bulk_update(
+        [
+            expired_anonymous_checkout,
+            not_expired_checkout_1,
+            not_expired_checkout_2,
+            not_expired_checkout_3,
+        ],
+        ["created", "last_change", "email", "user"],
+    )
+
+    # when
+    delete_expired_checkouts()
+
+    # then
+    assert Checkout.objects.count() == checkout_count - 1
+    with pytest.raises(Checkout.DoesNotExist):
+        expired_anonymous_checkout.refresh_from_db()
+
+
+def test_delete_expired_user_checkouts(checkouts_list, variant, customer_user):
+    # given
+    now = timezone.now()
+    checkout_count = Checkout.objects.count()
+
+    expired_user_checkout_1 = checkouts_list[0]
+    expired_user_checkout_1.email = None
+    expired_user_checkout_1.user = customer_user
+    expired_user_checkout_1.created = now - timedelta(days=100)
+    expired_user_checkout_1.last_change = now - timedelta(days=98)
+    expired_user_checkout_1.lines.create(
+        checkout=expired_user_checkout_1, variant=variant, quantity=1
+    )
+
+    expired_user_checkout_2 = checkouts_list[1]
+    expired_user_checkout_2.email = "test@example.com"
+    expired_user_checkout_2.user = None
+    expired_user_checkout_2.created = now - timedelta(days=100)
+    expired_user_checkout_2.last_change = now - timedelta(days=91)
+    expired_user_checkout_2.lines.create(
+        checkout=expired_user_checkout_2, variant=variant, quantity=1
+    )
+
+    not_expired_checkout_1 = checkouts_list[2]
+    not_expired_checkout_1.email = None
+    not_expired_checkout_1.user = None
+    not_expired_checkout_1.created = now - timedelta(days=35)
+    not_expired_checkout_1.last_change = now - timedelta(days=29)
+    not_expired_checkout_1.lines.create(
+        checkout=not_expired_checkout_1, variant=variant, quantity=1
+    )
+
+    not_expired_checkout_2 = checkouts_list[3]
+    not_expired_checkout_2.email = "test@example.com"
+    not_expired_checkout_2.user = None
+    not_expired_checkout_2.created = now - timedelta(days=100)
+    not_expired_checkout_2.last_change = now - timedelta(days=60)
+    not_expired_checkout_2.lines.create(
+        checkout=not_expired_checkout_2, variant=variant, quantity=1
+    )
+
+    not_expired_checkout_3 = checkouts_list[4]
+    not_expired_checkout_3.email = None
+    not_expired_checkout_3.user = customer_user
+    not_expired_checkout_3.created = now - timedelta(days=100)
+    not_expired_checkout_3.last_change = now - timedelta(days=89)
+    not_expired_checkout_3.lines.create(
+        checkout=not_expired_checkout_3, variant=variant, quantity=1
+    )
+
+    Checkout.objects.bulk_update(
+        [
+            expired_user_checkout_1,
+            expired_user_checkout_2,
+            not_expired_checkout_1,
+            not_expired_checkout_2,
+            not_expired_checkout_3,
+        ],
+        ["created", "last_change", "email", "user"],
+    )
+
+    # when
+    delete_expired_checkouts()
+
+    # then
+    assert Checkout.objects.count() == checkout_count - 2
+    for checkout in [expired_user_checkout_1, expired_user_checkout_2]:
+        with pytest.raises(Checkout.DoesNotExist):
+            checkout.refresh_from_db()
+
+
+def test_delete_empty_checkouts(checkouts_list, customer_user, variant):
+    # given
+    now = timezone.now()
+    checkout_count = Checkout.objects.count()
+
+    empty_checkout_1 = checkouts_list[0]
+    empty_checkout_1.last_change = now - timedelta(hours=8)
+    assert empty_checkout_1.lines.count() == 0
+
+    empty_checkout_2 = checkouts_list[1]
+    empty_checkout_2.email = "test@example.com"
+    empty_checkout_2.user = customer_user
+    empty_checkout_2.last_change = now - timedelta(hours=8)
+    assert empty_checkout_2.lines.count() == 0
+
+    empty_checkout_3 = checkouts_list[2]
+    empty_checkout_3.last_change = now - timedelta(hours=2)
+    assert empty_checkout_3.lines.count() == 0
+
+    not_empty_checkout = checkouts_list[3]
+    not_empty_checkout.last_change = now - timedelta(days=2)
+    not_empty_checkout.lines.create(
+        checkout=not_empty_checkout, variant=variant, quantity=1
+    )
+
+    Checkout.objects.bulk_update(
+        [
+            empty_checkout_1,
+            empty_checkout_2,
+            empty_checkout_3,
+            not_empty_checkout,
+        ],
+        ["last_change", "email", "user"],
+    )
+
+    # when
+    delete_expired_checkouts()
+
+    # then
+    for checkout in [empty_checkout_1, empty_checkout_2]:
+        with pytest.raises(Checkout.DoesNotExist):
+            checkout.refresh_from_db()
+    assert Checkout.objects.count() == checkout_count - 2
+
+
+def test_delete_expired_checkouts(checkouts_list, customer_user, variant):
+    # given
+    now = timezone.now()
+    checkout_count = Checkout.objects.count()
+
+    expired_anonymous_checkout = checkouts_list[0]
+    expired_anonymous_checkout.email = None
+    expired_anonymous_checkout.created = now - timedelta(days=40)
+    expired_anonymous_checkout.last_change = now - timedelta(days=35)
+    expired_anonymous_checkout.lines.create(
+        checkout=expired_anonymous_checkout, variant=variant, quantity=1
+    )
+
+    expired_user_checkout = checkouts_list[2]
+    expired_user_checkout.user = customer_user
+    expired_user_checkout.created = now - timedelta(days=100)
+    expired_user_checkout.last_change = now - timedelta(days=95)
+    expired_user_checkout.lines.create(
+        checkout=expired_user_checkout, variant=variant, quantity=1
+    )
+
+    empty_checkout = checkouts_list[4]
+    empty_checkout.last_change = now - timedelta(hours=8)
+    assert empty_checkout.lines.count() == 0
+
+    Checkout.objects.bulk_update(
+        [
+            expired_anonymous_checkout,
+            expired_user_checkout,
+            empty_checkout,
+        ],
+        ["created", "last_change", "email", "user"],
+    )
+
+    # when
+    delete_expired_checkouts()
+
+    # then
+    assert Checkout.objects.count() == checkout_count - 3
+    for checkout in [expired_anonymous_checkout, expired_user_checkout, empty_checkout]:
+        with pytest.raises(Checkout.DoesNotExist):
+            checkout.refresh_from_db()
+
+
+def test_delete_expired_checkouts_no_checkouts_to_delete(checkout):
+    # given
+    checkout_count = Checkout.objects.count()
+
+    # when
+    delete_expired_checkouts()
+
+    # then
+    assert Checkout.objects.count() == checkout_count

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -11,6 +11,7 @@ import jaeger_client.config
 import pkg_resources
 import sentry_sdk
 import sentry_sdk.utils
+from celery.schedules import crontab
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.utils import get_random_secret_key
 from graphql.utils import schema_printer
@@ -470,6 +471,11 @@ AUTHENTICATION_BACKENDS = [
     "saleor.core.auth_backend.PluginBackend",
 ]
 
+# Expired checkouts settings - defines after what time checkouts will be deleted
+ANONYMOUS_CHECKOUTS_TIMEDELTA = {"days": 30}
+USER_CHECKOUTS_TIMEDELTA = {"days": 90}
+EMPTY_CHECKOUTS_TIMEDELTA = {"hours": 6}
+
 # CELERY SETTINGS
 CELERY_TIMEZONE = TIME_ZONE
 CELERY_BROKER_URL = (
@@ -489,6 +495,10 @@ CELERY_BEAT_SCHEDULE = {
     "deactivate-preorder-for-variants": {
         "task": "saleor.product.tasks.deactivate_preorder_for_variants_task",
         "schedule": timedelta(hours=1),
+    },
+    "delete-expired-checkouts": {
+        "task": "saleor.checkout.tasks.delete_expired_checkouts",
+        "schedule": crontab(hour=0, minute=0),
     },
 }
 


### PR DESCRIPTION
- Delete anonymous checkouts after 30 days.
- Delete user checkouts after 90 days.
- Delete checkouts without lines after 6 hours.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
