### PR TITLE
Add checkoutLinesDelete mutation, deprecated checkoutLineDelete

### DIFF
--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -18,6 +18,7 @@ from .mutations import (
     CheckoutLanguageCodeUpdate,
     CheckoutLineDelete,
     CheckoutLinesAdd,
+    CheckoutLinesDelete,
     CheckoutLinesUpdate,
     CheckoutRemovePromoCode,
     CheckoutShippingAddressUpdate,
@@ -65,7 +66,13 @@ class CheckoutMutations(graphene.ObjectType):
     checkout_customer_attach = CheckoutCustomerAttach.Field()
     checkout_customer_detach = CheckoutCustomerDetach.Field()
     checkout_email_update = CheckoutEmailUpdate.Field()
-    checkout_line_delete = CheckoutLineDelete.Field()
+    checkout_line_delete = CheckoutLineDelete.Field(
+        deprecation_reason=(
+            "DEPRECATED: Will be removed in Saleor 4.0. "
+            "Use `checkoutLinesDelete` instead."
+        )
+    )
+    checkout_lines_delete = CheckoutLinesDelete.Field()
     checkout_lines_add = CheckoutLinesAdd.Field()
     checkout_lines_update = CheckoutLinesUpdate.Field()
     checkout_remove_promo_code = CheckoutRemovePromoCode.Field()

--- a/saleor/graphql/checkout/tests/test_checkout_digital.py
+++ b/saleor/graphql/checkout/tests/test_checkout_digital.py
@@ -16,7 +16,7 @@ from .test_checkout import (
     MUTATION_UPDATE_SHIPPING_METHOD,
 )
 from .test_checkout_lines import (
-    MUTATION_CHECKOUT_LINES_DELETE,
+    MUTATION_CHECKOUT_LINE_DELETE,
     MUTATION_CHECKOUT_LINES_UPDATE,
 )
 
@@ -211,7 +211,7 @@ def test_checkout_line_delete_remove_shipping_if_removed_product_with_shipping(
     line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
 
     variables = {"token": checkout.token, "lineId": line_id}
-    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_DELETE, variables)
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINE_DELETE, variables)
     content = get_graphql_content(response)
 
     data = content["data"]["checkoutLineDelete"]

--- a/saleor/graphql/checkout/tests/test_checkout_lines.py
+++ b/saleor/graphql/checkout/tests/test_checkout_lines.py
@@ -1041,7 +1041,7 @@ def test_checkout_lines_update_with_chosen_shipping(
     assert calculate_checkout_quantity(lines) == 1
 
 
-MUTATION_CHECKOUT_LINES_DELETE = """
+MUTATION_CHECKOUT_LINE_DELETE = """
     mutation checkoutLineDelete($token: UUID, $lineId: ID!) {
         checkoutLineDelete(token: $token, lineId: $lineId) {
             checkout {
@@ -1082,7 +1082,7 @@ def test_checkout_line_delete(
     line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
 
     variables = {"token": checkout.token, "lineId": line_id}
-    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_DELETE, variables)
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINE_DELETE, variables)
     content = get_graphql_content(response)
 
     data = content["data"]["checkoutLineDelete"]
@@ -1095,3 +1095,97 @@ def test_checkout_line_delete(
     manager = get_plugins_manager()
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+
+
+MUTATION_CHECKOUT_LINES_DELETE = """
+    mutation checkoutLinesDelete($token: UUID!, $linesIds: [ID]!) {
+        checkoutLinesDelete(token: $token, linesIds: $linesIds) {
+            checkout {
+                token
+                lines {
+                    id
+                    quantity
+                    variant {
+                        id
+                    }
+                }
+            }
+            errors {
+                  message
+                  code
+                  field
+                  lines
+            }
+        }
+    }
+"""
+
+
+@mock.patch(
+    "saleor.graphql.checkout.mutations.update_checkout_shipping_method_if_invalid",
+    wraps=update_checkout_shipping_method_if_invalid,
+)
+def test_checkout_lines_delete(
+    mocked_update_shipping_method, user_api_client, checkout_with_items
+):
+    checkout = checkout_with_items
+    checkout_lines_count = checkout.lines.count()
+    line = checkout.lines.first()
+    second_line = checkout.lines.last()
+
+    first_line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
+    second_line_id = graphene.Node.to_global_id("CheckoutLine", second_line.pk)
+    lines_list = [first_line_id, second_line_id]
+
+    variables = {"token": checkout.token, "linesIds": lines_list}
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_DELETE, variables)
+    content = get_graphql_content(response)
+
+    data = content["data"]["checkoutLinesDelete"]
+    assert not data["errors"]
+    checkout.refresh_from_db()
+    lines = fetch_checkout_lines(checkout)
+    assert checkout.lines.count() + len(lines_list) == checkout_lines_count
+    remaining_lines = data["checkout"]["lines"]
+    lines_ids = [line["id"] for line in remaining_lines]
+    assert lines_list not in lines_ids
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+
+
+def test_checkout_lines_delete_invalid_checkout_token(
+    user_api_client, checkout_with_items
+):
+    checkout = checkout_with_items
+    line = checkout.lines.first()
+    second_line = checkout.lines.last()
+
+    first_line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
+    second_line_id = graphene.Node.to_global_id("CheckoutLine", second_line.pk)
+    lines_list = [first_line_id, second_line_id]
+
+    variables = {
+        "token": "bd159cc8-9dd6-4529-a6f6-8a5dee169806",
+        "linesIds": lines_list,
+    }
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_DELETE, variables)
+    content = get_graphql_content(response)
+    errors = content["data"]["checkoutLinesDelete"]["errors"][0]
+    assert errors["code"] == CheckoutErrorCode.NOT_FOUND.name
+
+
+def tests_checkout_lines_delete_invalid_lines_ids(user_api_client, checkout_with_items):
+    checkout = checkout_with_items
+    line = checkout.lines.first()
+
+    first_line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
+    lines_list = [first_line_id, "Q2hlY2tvdXRMaW5lOjE8"]
+
+    variables = {"token": checkout.token, "linesIds": lines_list}
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_DELETE, variables)
+    content = get_graphql_content(response)
+    errors = content["data"]["checkoutLinesDelete"]["errors"][0]
+    assert errors["code"] == CheckoutErrorCode.INVALID.name
+    assert errors["lines"] == lines_list[1:]
+    assert errors["field"] == "lineId"

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -15,7 +15,7 @@ from ....plugins.manager import get_plugins_manager
 from ....warehouse.models import Stock
 from ...tests.utils import get_graphql_content
 from .test_checkout import MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE
-from .test_checkout_lines import MUTATION_CHECKOUT_LINES_DELETE
+from .test_checkout_lines import MUTATION_CHECKOUT_LINE_DELETE
 
 
 def test_checkout_lines_delete_with_not_applicable_voucher(
@@ -42,7 +42,7 @@ def test_checkout_lines_delete_with_not_applicable_voucher(
 
     line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
     variables = {"token": checkout_with_item.token, "lineId": line_id}
-    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_DELETE, variables)
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINE_DELETE, variables)
     content = get_graphql_content(response)
 
     data = content["data"]["checkoutLineDelete"]

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -137,6 +137,11 @@ class CheckoutError(Error):
         description="List of varint IDs which causes the error.",
         required=False,
     )
+    lines = graphene.List(
+        graphene.NonNull(graphene.ID),
+        description="List of line Ids which cause the error.",
+        required=False,
+    )
     address_type = AddressTypeEnum(
         description="A type of address that causes the error.", required=False
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1108,6 +1108,7 @@ type CheckoutError {
   message: String
   code: CheckoutErrorCode!
   variants: [ID!]
+  lines: [ID!]
   addressType: AddressTypeEnum
 }
 
@@ -1178,6 +1179,11 @@ input CheckoutLineInput {
 type CheckoutLinesAdd {
   checkout: Checkout
   checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
+  errors: [CheckoutError!]!
+}
+
+type CheckoutLinesDelete {
+  checkout: Checkout
   errors: [CheckoutError!]!
 }
 
@@ -3914,7 +3920,8 @@ type Mutation {
   checkoutCustomerAttach(checkoutId: ID, customerId: ID, token: UUID): CheckoutCustomerAttach
   checkoutCustomerDetach(checkoutId: ID, token: UUID): CheckoutCustomerDetach
   checkoutEmailUpdate(checkoutId: ID, email: String!, token: UUID): CheckoutEmailUpdate
-  checkoutLineDelete(checkoutId: ID, lineId: ID, token: UUID): CheckoutLineDelete
+  checkoutLineDelete(checkoutId: ID, lineId: ID, token: UUID): CheckoutLineDelete @deprecated(reason: "DEPRECATED: Will be removed in Saleor 4.0. Use `checkoutLinesDelete` instead.")
+  checkoutLinesDelete(linesIds: [ID]!, token: UUID!): CheckoutLinesDelete
   checkoutLinesAdd(checkoutId: ID, lines: [CheckoutLineInput]!, token: UUID): CheckoutLinesAdd
   checkoutLinesUpdate(checkoutId: ID, lines: [CheckoutLineInput]!, token: UUID): CheckoutLinesUpdate
   checkoutRemovePromoCode(checkoutId: ID, promoCode: String, promoCodeId: ID, token: UUID): CheckoutRemovePromoCode


### PR DESCRIPTION
I want to merge this change because its port changes from 3.0 to 3.1 

https://github.com/saleor/saleor/pull/8343

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
