### PR TITLE
Change metadata mutations to use token for order and checkout as identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,8 @@ All notable, unreleased changes to this project will be documented in this file.
   - drop `channel` field from filters and sorters
 - Drop top-level `checkoutLine` query from the schema with related resolver, use `checkout` query instead - #7623 by @dexon44
 - Make SKU an optional field on `ProductVariant` - #7633 by @rafalp
+- Change metadata mutations to use token for order and checkout as identifier - #8426 by @IKarbowiak
+  - After changes, using the order `id` for changing order metadata is deprecated
 
 ### Other
 

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import List
 
 import graphene
@@ -58,13 +59,7 @@ class BaseMetadataMutation(BaseMutation):
         try:
             type_name, _ = from_global_id_or_error(object_id)
             if type_name == "Order":
-                raise ValidationError(
-                    {
-                        "id": ValidationError(
-                            "Use token for changing order metadata.", code="invalid"
-                        )
-                    }
-                )
+                warnings.warn("DEPRECATED. Use token for changing order metadata.")
             # ShippingMethod type isn't model-based class
             if type_name == "ShippingMethod":
                 qs = shipping_models.ShippingMethod.objects

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -4,11 +4,13 @@ import graphene
 from django.core.exceptions import ValidationError
 from graphql.error.base import GraphQLError
 
+from ...checkout import models as checkout_models
 from ...core import models
 from ...core.error_codes import MetadataErrorCode
 from ...core.exceptions import PermissionDenied
 from ...discount import models as discount_models
 from ...menu import models as menu_models
+from ...order import models as order_models
 from ...product import models as product_models
 from ...shipping import models as shipping_models
 from ..channel import ChannelContext
@@ -52,7 +54,38 @@ class BaseMetadataMutation(BaseMutation):
     def get_instance(cls, info, **data):
         object_id = data.get("id")
         qs = data.get("qs", None)
-        return cls.get_node_or_error(info, object_id, qs=qs)
+
+        try:
+            type_name, _ = from_global_id_or_error(object_id)
+            if type_name == "Order":
+                raise ValidationError(
+                    {
+                        "id": ValidationError(
+                            "Use token for changing order metadata.", code="invalid"
+                        )
+                    }
+                )
+            # ShippingMethod type isn't model-based class
+            if type_name == "ShippingMethod":
+                qs = shipping_models.ShippingMethod.objects
+            return cls.get_node_or_error(info, object_id, qs=qs)
+        except GraphQLError as e:
+            if instance := cls.get_instance_by_token(object_id, qs):
+                return instance
+            raise ValidationError({"id": ValidationError(str(e), code="graphql_error")})
+
+    @classmethod
+    def get_instance_by_token(cls, object_id, qs):
+        if not qs:
+            if order := order_models.Order.objects.filter(token=object_id).first():
+                return order
+            if checkout := checkout_models.Checkout.objects.filter(
+                token=object_id
+            ).first():
+                return checkout
+            return None
+        if qs and "token" in [field.name for field in qs.model._meta.get_fields()]:
+            return qs.filter(token=object_id).first()
 
     @classmethod
     def validate_model_is_model_with_metadata(cls, model, object_id):
@@ -79,16 +112,10 @@ class BaseMetadataMutation(BaseMutation):
             )
 
     @classmethod
-    def get_model_for_type_name(cls, info, type_name):
-        graphene_type = info.schema.get_type(type_name).graphene_type
-        return graphene_type._meta.model
-
-    @classmethod
-    def get_permissions(cls, info, **data):
-        object_id = data.get("id")
-        if not object_id:
+    def get_permissions(cls, info, type_name, object_pk, **data):
+        if object_pk is None:
             return []
-        type_name, object_pk = from_global_id_or_error(object_id)
+        object_id = data.get("id")
         model = cls.get_model_for_type_name(info, type_name)
         cls.validate_model_is_model_with_metadata(model, object_id)
         permission = cls._meta.permission_map.get(type_name)
@@ -101,9 +128,17 @@ class BaseMetadataMutation(BaseMutation):
         )
 
     @classmethod
+    def get_model_for_type_name(cls, info, type_name):
+        if type_name == "ShippingMethod":
+            return shipping_models.ShippingMethod
+        graphene_type = info.schema.get_type(type_name).graphene_type
+        return graphene_type._meta.model
+
+    @classmethod
     def mutate(cls, root, info, **data):
+        type_name, object_pk = cls.get_object_type_name_and_pk(data)
         try:
-            permissions = cls.get_permissions(info, **data)
+            permissions = cls.get_permissions(info, type_name, object_pk, **data)
         except GraphQLError as e:
             error = ValidationError(
                 {"id": ValidationError(str(e), code="graphql_error")}
@@ -116,15 +151,36 @@ class BaseMetadataMutation(BaseMutation):
         try:
             result = super().mutate(root, info, **data)
             if not result.errors:
-                cls.perform_model_extra_actions(root, info, **data)
+                cls.perform_model_extra_actions(root, info, type_name, **data)
         except ValidationError as e:
             return cls.handle_errors(e)
         return result
 
     @classmethod
-    def perform_model_extra_actions(cls, root, info, **data):
+    def get_object_type_name_and_pk(cls, data):
+        object_id = data.get("id")
+        if not object_id:
+            return None, None
+        try:
+            return from_global_id_or_error(object_id)
+        except GraphQLError:
+            if order := order_models.Order.objects.filter(token=object_id).first():
+                return "Order", order.pk
+            if checkout := checkout_models.Checkout.objects.filter(
+                token=object_id
+            ).first():
+                return "Checkout", checkout.pk
+            raise ValidationError(
+                {
+                    "id": ValidationError(
+                        "Couldn't resolve to a node.", code="graphql_error"
+                    )
+                }
+            )
+
+    @classmethod
+    def perform_model_extra_actions(cls, root, info, type_name, **data):
         """Run extra metadata method based on mutating model."""
-        type_name, _ = from_global_id_or_error(data["id"])
         if MODEL_EXTRA_METHODS.get(type_name):
             prefetch_method = MODEL_EXTRA_PREFETCH.get(type_name)
             if prefetch_method:
@@ -162,29 +218,7 @@ class MetadataInput(graphene.InputObjectType):
     value = graphene.String(required=True, description="Value of a metadata item.")
 
 
-class ShippingMethodMetadataMixin:
-    @classmethod
-    def get_instance(cls, info, **data):
-        object_id = data.get("id")
-        qs = data.get("qs", None)
-
-        type_name, _ = from_global_id_or_error(object_id)
-        # ShippingMethod type isn't model-based class
-        if type_name == "ShippingMethod":
-            qs = shipping_models.ShippingMethod.objects
-
-        return cls.get_node_or_error(info, object_id, qs=qs)
-
-    @classmethod
-    def get_model_for_type_name(cls, info, type_name):
-        # ShippingMethod type isn't model-based class
-        if type_name == "ShippingMethod":
-            return shipping_models.ShippingMethod
-        graphene_type = info.schema.get_type(type_name).graphene_type
-        return graphene_type._meta.model
-
-
-class UpdateMetadata(ShippingMethodMetadataMixin, BaseMetadataMutation):
+class UpdateMetadata(BaseMetadataMutation):
     class Meta:
         description = "Updates metadata of an object."
         permission_map = PUBLIC_META_PERMISSION_MAP
@@ -192,7 +226,10 @@ class UpdateMetadata(ShippingMethodMetadataMixin, BaseMetadataMutation):
         error_type_field = "metadata_errors"
 
     class Arguments:
-        id = graphene.ID(description="ID of an object to update.", required=True)
+        id = graphene.ID(
+            description="ID or token (for Order and Checkout) of an object to update.",
+            required=True,
+        )
         input = graphene.List(
             graphene.NonNull(MetadataInput),
             description="Fields required to update the object's metadata.",
@@ -211,7 +248,7 @@ class UpdateMetadata(ShippingMethodMetadataMixin, BaseMetadataMutation):
         return cls.success_response(instance)
 
 
-class DeleteMetadata(ShippingMethodMetadataMixin, BaseMetadataMutation):
+class DeleteMetadata(BaseMetadataMutation):
     class Meta:
         description = "Delete metadata of an object."
         permission_map = PUBLIC_META_PERMISSION_MAP
@@ -219,7 +256,10 @@ class DeleteMetadata(ShippingMethodMetadataMixin, BaseMetadataMutation):
         error_type_field = "metadata_errors"
 
     class Arguments:
-        id = graphene.ID(description="ID of an object to update.", required=True)
+        id = graphene.ID(
+            description="ID or token (for Order and Checkout) of an object to update.",
+            required=True,
+        )
         keys = graphene.List(
             graphene.NonNull(graphene.String),
             description="Metadata keys to delete.",
@@ -237,7 +277,7 @@ class DeleteMetadata(ShippingMethodMetadataMixin, BaseMetadataMutation):
         return cls.success_response(instance)
 
 
-class UpdatePrivateMetadata(ShippingMethodMetadataMixin, BaseMetadataMutation):
+class UpdatePrivateMetadata(BaseMetadataMutation):
     class Meta:
         description = "Updates private metadata of an object."
         permission_map = PRIVATE_META_PERMISSION_MAP
@@ -245,7 +285,10 @@ class UpdatePrivateMetadata(ShippingMethodMetadataMixin, BaseMetadataMutation):
         error_type_field = "metadata_errors"
 
     class Arguments:
-        id = graphene.ID(description="ID of an object to update.", required=True)
+        id = graphene.ID(
+            description="ID or token (for Order and Checkout) of an object to update.",
+            required=True,
+        )
         input = graphene.List(
             graphene.NonNull(MetadataInput),
             description=("Fields required to update the object's metadata."),
@@ -264,7 +307,7 @@ class UpdatePrivateMetadata(ShippingMethodMetadataMixin, BaseMetadataMutation):
         return cls.success_response(instance)
 
 
-class DeletePrivateMetadata(ShippingMethodMetadataMixin, BaseMetadataMutation):
+class DeletePrivateMetadata(BaseMetadataMutation):
     class Meta:
         description = "Delete object's private metadata."
         permission_map = PRIVATE_META_PERMISSION_MAP
@@ -272,7 +315,10 @@ class DeletePrivateMetadata(ShippingMethodMetadataMixin, BaseMetadataMutation):
         error_type_field = "metadata_errors"
 
     class Arguments:
-        id = graphene.ID(description="ID of an object to update.", required=True)
+        id = graphene.ID(
+            description="ID or token (for Order and Checkout) of an object to update.",
+            required=True,
+        )
         keys = graphene.List(
             graphene.NonNull(graphene.String),
             description="Metadata keys to delete.",

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -1,5 +1,6 @@
 import base64
 import uuid
+import warnings
 from unittest.mock import patch
 
 import graphene
@@ -368,21 +369,23 @@ def test_add_metadata_for_checkout_triggers_checkout_updated_hook(
     mock_checkout_updated.assert_called_once_with(checkout)
 
 
-def test_add_public_metadata_for_order_by_id_raising_error(api_client, order):
+def test_add_public_metadata_for_order_by_id(api_client, order):
     # given
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    response = execute_update_public_metadata_for_item(
-        api_client, None, order_id, "Order"
-    )
+    with warnings.catch_warnings(record=True) as warns:
+        response = execute_update_public_metadata_for_item(
+            api_client, None, order_id, "Order"
+        )
+        expected_warning = "DEPRECATED. Use token for changing order metadata."
+
+        assert any([str(warning.message) == expected_warning for warning in warns])
 
     # then
-    data = response["data"]["updateMetadata"]
-    assert not data["item"]
-    assert len(data["errors"]) == 1
-    assert data["errors"][0]["code"] == "INVALID"
-    assert data["errors"][0]["field"] == "id"
+    assert item_contains_proper_public_metadata(
+        response["data"]["updateMetadata"]["item"], order, order_id
+    )
 
 
 def test_add_public_metadata_for_order_by_token(api_client, order):
@@ -400,23 +403,23 @@ def test_add_public_metadata_for_order_by_token(api_client, order):
     )
 
 
-def test_add_public_metadata_for_draft_order_by_id_raising_error(
-    api_client, draft_order
-):
+def test_add_public_metadata_for_draft_order_by_id(api_client, draft_order):
     # given
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    response = execute_update_public_metadata_for_item(
-        api_client, None, draft_order_id, "Order"
-    )
+    with warnings.catch_warnings(record=True) as warns:
+        response = execute_update_public_metadata_for_item(
+            api_client, None, draft_order_id, "Order"
+        )
+        expected_warning = "DEPRECATED. Use token for changing order metadata."
+
+        assert any([str(warning.message) == expected_warning for warning in warns])
 
     # then
-    data = response["data"]["updateMetadata"]
-    assert not data["item"]
-    assert len(data["errors"]) == 1
-    assert data["errors"][0]["code"] == "INVALID"
-    assert data["errors"][0]["field"] == "id"
+    assert item_contains_proper_public_metadata(
+        response["data"]["updateMetadata"]["item"], draft_order, draft_order_id
+    )
 
 
 def test_add_public_metadata_for_draft_order_by_token(api_client, draft_order):
@@ -1148,23 +1151,25 @@ def test_delete_public_metadata_for_checkout_by_token(api_client, checkout):
     )
 
 
-def test_delete_public_metadata_for_order_by_id_raising_error(api_client, order):
+def test_delete_public_metadata_for_order_by_id(api_client, order):
     # given
     order.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
     order.save(update_fields=["metadata"])
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    response = execute_clear_public_metadata_for_item(
-        api_client, None, order_id, "Order"
-    )
+    with warnings.catch_warnings(record=True) as warns:
+        response = execute_clear_public_metadata_for_item(
+            api_client, None, order_id, "Order"
+        )
+        expected_warning = "DEPRECATED. Use token for changing order metadata."
+
+        assert any([str(warning.message) == expected_warning for warning in warns])
 
     # then
-    data = response["data"]["deleteMetadata"]
-    assert not data["item"]
-    assert len(data["errors"]) == 1
-    assert data["errors"][0]["code"] == "INVALID"
-    assert data["errors"][0]["field"] == "id"
+    assert item_without_public_metadata(
+        response["data"]["deleteMetadata"]["item"], order, order_id
+    )
 
 
 def test_delete_public_metadata_for_order_by_token(api_client, order):
@@ -1184,25 +1189,25 @@ def test_delete_public_metadata_for_order_by_token(api_client, order):
     )
 
 
-def test_delete_public_metadata_for_draft_order_by_id_raising_error(
-    api_client, draft_order
-):
+def test_delete_public_metadata_for_draft_order_by_id(api_client, draft_order):
     # given
     draft_order.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
     draft_order.save(update_fields=["metadata"])
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    response = execute_clear_public_metadata_for_item(
-        api_client, None, draft_order_id, "Order"
-    )
+    with warnings.catch_warnings(record=True) as warns:
+        response = execute_clear_public_metadata_for_item(
+            api_client, None, draft_order_id, "Order"
+        )
+        expected_warning = "DEPRECATED. Use token for changing order metadata."
+
+        assert any([str(warning.message) == expected_warning for warning in warns])
 
     # then
-    data = response["data"]["deleteMetadata"]
-    assert not data["item"]
-    assert len(data["errors"]) == 1
-    assert data["errors"][0]["code"] == "INVALID"
-    assert data["errors"][0]["field"] == "id"
+    assert item_without_public_metadata(
+        response["data"]["deleteMetadata"]["item"], draft_order, draft_order_id
+    )
 
 
 def test_delete_public_metadata_for_draft_order_by_token(api_client, draft_order):
@@ -1959,23 +1964,25 @@ def test_add_private_metadata_for_checkout_by_token(
     )
 
 
-def test_add_private_metadata_for_order_by_id_raising_error(
+def test_add_private_metadata_for_order_by_id(
     staff_api_client, order, permission_manage_orders
 ):
     # given
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    response = execute_update_private_metadata_for_item(
-        staff_api_client, permission_manage_orders, order_id, "Order"
-    )
+    with warnings.catch_warnings(record=True) as warns:
+        response = execute_update_private_metadata_for_item(
+            staff_api_client, permission_manage_orders, order_id, "Order"
+        )
+        expected_warning = "DEPRECATED. Use token for changing order metadata."
+
+        assert any([str(warning.message) == expected_warning for warning in warns])
 
     # then
-    data = response["data"]["updatePrivateMetadata"]
-    assert not data["item"]
-    assert len(data["errors"]) == 1
-    assert data["errors"][0]["code"] == "INVALID"
-    assert data["errors"][0]["field"] == "id"
+    assert item_contains_proper_private_metadata(
+        response["data"]["updatePrivateMetadata"]["item"], order, order_id
+    )
 
 
 def test_add_private_metadata_for_order_by_token(
@@ -1995,23 +2002,25 @@ def test_add_private_metadata_for_order_by_token(
     )
 
 
-def test_add_private_metadata_for_draft_order_by_id_raising_error(
+def test_add_private_metadata_for_draft_order_by_id(
     staff_api_client, draft_order, permission_manage_orders
 ):
     # given
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    response = execute_update_private_metadata_for_item(
-        staff_api_client, permission_manage_orders, draft_order_id, "Order"
-    )
+    with warnings.catch_warnings(record=True) as warns:
+        response = execute_update_private_metadata_for_item(
+            staff_api_client, permission_manage_orders, draft_order_id, "Order"
+        )
+        expected_warning = "DEPRECATED. Use token for changing order metadata."
+
+        assert any([str(warning.message) == expected_warning for warning in warns])
 
     # then
-    data = response["data"]["updatePrivateMetadata"]
-    assert not data["item"]
-    assert len(data["errors"]) == 1
-    assert data["errors"][0]["code"] == "INVALID"
-    assert data["errors"][0]["field"] == "id"
+    assert item_contains_proper_private_metadata(
+        response["data"]["updatePrivateMetadata"]["item"], draft_order, draft_order_id
+    )
 
 
 def test_add_private_metadata_for_draft_order_by_token(
@@ -2812,7 +2821,7 @@ def test_delete_private_metadata_for_checkout_by_token(
     )
 
 
-def test_delete_private_metadata_for_order_by_id_raising_error(
+def test_delete_private_metadata_for_order_by_id(
     staff_api_client, order, permission_manage_orders
 ):
     # given
@@ -2821,16 +2830,18 @@ def test_delete_private_metadata_for_order_by_id_raising_error(
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    response = execute_clear_private_metadata_for_item(
-        staff_api_client, permission_manage_orders, order_id, "Order"
-    )
+    with warnings.catch_warnings(record=True) as warns:
+        response = execute_clear_private_metadata_for_item(
+            staff_api_client, permission_manage_orders, order_id, "Order"
+        )
+        expected_warning = "DEPRECATED. Use token for changing order metadata."
+
+        assert any([str(warning.message) == expected_warning for warning in warns])
 
     # then
-    data = response["data"]["deletePrivateMetadata"]
-    assert not data["item"]
-    assert len(data["errors"]) == 1
-    assert data["errors"][0]["code"] == "INVALID"
-    assert data["errors"][0]["field"] == "id"
+    assert item_without_private_metadata(
+        response["data"]["deletePrivateMetadata"]["item"], order, order_id
+    )
 
 
 def test_delete_private_metadata_for_order_by_token(
@@ -2852,7 +2863,7 @@ def test_delete_private_metadata_for_order_by_token(
     )
 
 
-def test_delete_private_metadata_for_draft_order_by_id_raising_error(
+def test_delete_private_metadata_for_draft_order_by_id(
     staff_api_client, draft_order, permission_manage_orders
 ):
     # given
@@ -2861,16 +2872,18 @@ def test_delete_private_metadata_for_draft_order_by_id_raising_error(
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    response = execute_clear_private_metadata_for_item(
-        staff_api_client, permission_manage_orders, draft_order_id, "Order"
-    )
+    with warnings.catch_warnings(record=True) as warns:
+        response = execute_clear_private_metadata_for_item(
+            staff_api_client, permission_manage_orders, draft_order_id, "Order"
+        )
+        expected_warning = "DEPRECATED. Use token for changing order metadata."
+
+        assert any([str(warning.message) == expected_warning for warning in warns])
 
     # then
-    data = response["data"]["deletePrivateMetadata"]
-    assert not data["item"]
-    assert len(data["errors"]) == 1
-    assert data["errors"][0]["code"] == "INVALID"
-    assert data["errors"][0]["field"] == "id"
+    assert item_without_private_metadata(
+        response["data"]["deletePrivateMetadata"]["item"], draft_order, draft_order_id
+    )
 
 
 def test_delete_private_metadata_for_draft_order_by_token(


### PR DESCRIPTION
- Do not allow to change order metadata with use of `id`, require order `token`.
- Allow providing checkout `token` as an identifier. 


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
