### PR TITLE
Add permission_manage_orders to customer query

### DIFF
--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -7,7 +7,11 @@ from i18naddress import get_validation_rules
 
 from ...account import models
 from ...core.exceptions import PermissionDenied
-from ...core.permissions import AccountPermissions
+from ...core.permissions import (
+    AccountPermissions,
+    OrderPermissions,
+    has_one_of_permissions,
+)
 from ...core.tracing import traced_resolver
 from ...payment import gateway
 from ...payment.utils import fetch_customer_id
@@ -63,7 +67,9 @@ def resolve_user(info, id=None, email=None):
             return models.User.objects.filter(**filter_kwargs).first()
         if requester.has_perm(AccountPermissions.MANAGE_STAFF):
             return models.User.objects.staff().filter(**filter_kwargs).first()
-        if requester.has_perm(AccountPermissions.MANAGE_USERS):
+        if has_one_of_permissions(
+            requester, [AccountPermissions.MANAGE_USERS, OrderPermissions.MANAGE_ORDERS]
+        ):
             return models.User.objects.customers().filter(**filter_kwargs).first()
     return PermissionDenied()
 

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ...core.permissions import AccountPermissions
+from ...core.permissions import AccountPermissions, OrderPermissions
 from ..core.fields import FilterInputConnectionField
 from ..core.types import FilterInputObjectType
 from ..core.utils import from_global_id_or_error
@@ -157,7 +157,9 @@ class AccountQueries(graphene.ObjectType):
             city_area=city_area,
         )
 
-    @permission_required(AccountPermissions.MANAGE_USERS)
+    @one_of_permissions_required(
+        [OrderPermissions.MANAGE_ORDERS, AccountPermissions.MANAGE_USERS]
+    )
     def resolve_customers(self, info, **kwargs):
         return resolve_customers(info, **kwargs)
 

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -181,7 +181,11 @@ class AccountQueries(graphene.ObjectType):
         return resolve_staff_users(info, **kwargs)
 
     @one_of_permissions_required(
-        [AccountPermissions.MANAGE_STAFF, AccountPermissions.MANAGE_USERS]
+        [
+            AccountPermissions.MANAGE_STAFF,
+            AccountPermissions.MANAGE_USERS,
+            OrderPermissions.MANAGE_ORDERS,
+        ]
     )
     def resolve_user(self, info, id=None, email=None):
         validate_one_of_args_is_in_query("id", id, "email", email)

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -4447,6 +4447,24 @@ def test_query_customers_search_without_duplications(
     assert len(users) == 1
 
 
+def test_query_customers_with_permission_manage_orders(
+    query_customer_with_filter,
+    customer_user,
+    staff_api_client,
+    permission_manage_orders,
+):
+    variables = {"filter": {}}
+
+    response = staff_api_client.post_graphql(
+        query_customer_with_filter,
+        variables,
+        permissions=[permission_manage_orders],
+    )
+    content = get_graphql_content(response)
+    users = content["data"]["customers"]["totalCount"]
+    assert users == 1
+
+
 QUERY_CUSTOMERS_WITH_SORT = """
     query ($sort_by: UserSortingInput!) {
         customers(first:5, sortBy: $sort_by) {

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -246,7 +246,10 @@ def test_query_customer_user(
 
 
 def test_query_customer_user_with_orders(
-    staff_api_client, customer_user, order_list, permission_manage_users
+    staff_api_client,
+    customer_user,
+    order_list,
+    permission_manage_users,
 ):
     # given
     query = FULL_USER_QUERY
@@ -4419,6 +4422,7 @@ def test_query_customers_search_without_duplications(
     query_customer_with_filter,
     staff_api_client,
     permission_manage_users,
+    permission_manage_orders,
 ):
     customer = User.objects.create(email="david@example.com")
     customer.addresses.create(first_name="David")
@@ -4427,6 +4431,16 @@ def test_query_customers_search_without_duplications(
     variables = {"filter": {"search": "David"}}
     response = staff_api_client.post_graphql(
         query_customer_with_filter, variables, permissions=[permission_manage_users]
+    )
+    content = get_graphql_content(response)
+    users = content["data"]["customers"]["edges"]
+    assert len(users) == 1
+
+    response = staff_api_client.post_graphql(
+        query_customer_with_filter,
+        variables,
+        permissions=[permission_manage_orders],
+        check_no_permissions=False,
     )
     content = get_graphql_content(response)
     users = content["data"]["customers"]["edges"]

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -11,7 +11,7 @@ from graphene.utils.str_converters import to_camel_case
 
 from ...account import events as account_events
 from ...account.error_codes import AccountErrorCode
-from ...core.permissions import AccountPermissions
+from ...core.permissions import AccountPermissions, has_one_of_permissions
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
@@ -463,7 +463,7 @@ def look_for_permission_in_users_with_manage_staff(
 
 
 def requestor_has_access(
-    requestor: Union["User", "App"], owner: Optional["User"], perm
+    requestor: Union["User", "App"], owner: Optional["User"], *perms
 ):
     """Check if requestor can access data.
 
@@ -473,4 +473,4 @@ def requestor_has_access(
         perm: permission which give the access to the data
 
     """
-    return requestor == owner or requestor.has_perm(perm)
+    return requestor == owner or has_one_of_permissions(requestor, perms)

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -470,7 +470,9 @@ def requestor_has_access(
     Args:
         requestor: requestor user or app
         owner: data owner
-        perm: permission which give the access to the data
+        perms: permissions which can give the access to the data.
+               Requestor needs to have at least one of given permissions
+               to get access to protected resource.
 
     """
     return requestor == owner or has_one_of_permissions(requestor, perms)

--- a/saleor/graphql/app/tests/queries/test_app.py
+++ b/saleor/graphql/app/tests/queries/test_app.py
@@ -142,10 +142,15 @@ def test_app_without_id_as_staff(
 
 
 def test_own_app_without_id(
-    app_api_client, app, permission_manage_orders, order_with_lines, webhook
+    app_api_client,
+    app,
+    permission_manage_orders,
+    order_with_lines,
+    webhook,
+    permission_manage_apps,
 ):
     response = app_api_client.post_graphql(
-        QUERY_APP,
+        QUERY_APP, permissions=[permission_manage_apps]
     )
     content = get_graphql_content(response)
 

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -9,6 +9,7 @@ from ..core.connection import CountableDjangoObjectType
 from ..core.federation import resolve_federation_references
 from ..core.types import Permission
 from ..core.types.common import Job
+from ..decorators import permission_required
 from ..meta.types import ObjectWithMetadata
 from ..utils import format_permissions_for_display, get_user_or_app_from_context
 from ..webhook.types import Webhook
@@ -110,14 +111,17 @@ class App(CountableDjangoObjectType):
         return format_permissions_for_display(permissions)
 
     @staticmethod
+    @permission_required(AppPermission.MANAGE_APPS)
     def resolve_tokens(root: models.App, _info, **_kwargs):
         return root.tokens.all()  # type: ignore
 
     @staticmethod
+    @permission_required(AppPermission.MANAGE_APPS)
     def resolve_webhooks(root: models.App, _info):
         return root.webhooks.all()
 
     @staticmethod
+    @permission_required(AppPermission.MANAGE_APPS)
     def resolve_access_token(root: models.App, info):
         return resolve_access_token(info, root)
 

--- a/saleor/graphql/csv/tests/mutations/test_export_products.py
+++ b/saleor/graphql/csv/tests/mutations/test_export_products.py
@@ -37,6 +37,28 @@ EXPORT_PRODUCTS_MUTATION = """
     }
 """
 
+EXPORT_PRODUCTS_BY_APP_MUTATION = """
+    mutation ExportProducts($input: ExportProductsInput!){
+        exportProducts(input: $input){
+            exportFile {
+                id
+                status
+                createdAt
+                updatedAt
+                url
+                app {
+                    name
+                }
+            }
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
 
 @pytest.mark.parametrize(
     "input, called_data",
@@ -104,9 +126,8 @@ def test_export_products_mutation_by_app(
     product_list,
     permission_manage_products,
     permission_manage_apps,
-    permission_manage_staff,
 ):
-    query = EXPORT_PRODUCTS_MUTATION
+    query = EXPORT_PRODUCTS_BY_APP_MUTATION
     app = app_api_client.app
     variables = {
         "input": {
@@ -122,7 +143,6 @@ def test_export_products_mutation_by_app(
         permissions=[
             permission_manage_products,
             permission_manage_apps,
-            permission_manage_staff,
         ],
     )
     content = get_graphql_content(response)
@@ -136,7 +156,6 @@ def test_export_products_mutation_by_app(
     assert not data["errors"]
     assert data["exportFile"]["id"]
     assert export_file_data["createdAt"]
-    assert export_file_data["user"] is None
     assert export_file_data["app"]["name"] == app.name
     assert ExportEvent.objects.filter(
         user=None, app=app, type=ExportEvents.EXPORT_PENDING

--- a/saleor/graphql/csv/tests/queries/test_export_file.py
+++ b/saleor/graphql/csv/tests/queries/test_export_file.py
@@ -33,6 +33,29 @@ EXPORT_FILE_QUERY = """
     }
 """
 
+EXPORT_FILE_BY_APP_QUERY = """
+    query($id: ID!){
+        exportFile(id: $id){
+            id
+            status
+            createdAt
+            updatedAt
+            url
+            app{
+                name
+            }
+            events{
+                date
+                type
+                message
+                app{
+                    name
+                }
+            }
+        }
+    }
+"""
+
 
 def test_query_export_file(
     staff_api_client,
@@ -76,11 +99,10 @@ def test_query_export_file_by_app(
     user_export_file,
     permission_manage_products,
     permission_manage_apps,
-    permission_manage_staff,
     user_export_event,
 ):
     # given
-    query = EXPORT_FILE_QUERY
+    query = EXPORT_FILE_BY_APP_QUERY
     variables = {"id": graphene.Node.to_global_id("ExportFile", user_export_file.pk)}
 
     # when
@@ -90,7 +112,6 @@ def test_query_export_file_by_app(
         permissions=[
             permission_manage_products,
             permission_manage_apps,
-            permission_manage_staff,
         ],
     )
 
@@ -103,13 +124,11 @@ def test_query_export_file_by_app(
     assert data["updatedAt"]
     assert data["app"] is None
     assert not data["url"]
-    assert data["user"]["email"] == user_export_file.user.email
     assert len(data["events"]) == 1
     event = data["events"][0]
     assert event["date"]
     assert event["message"] == user_export_event.parameters.get("message")
     assert event["type"] == ExportEvents.EXPORT_FAILED.upper()
-    assert event["user"]["email"] == user_export_event.user.email
     assert event["app"] is None
 
 
@@ -123,7 +142,7 @@ def test_query_export_file_export_file_with_app(
     app_export_event,
 ):
     # given
-    query = EXPORT_FILE_QUERY
+    query = EXPORT_FILE_BY_APP_QUERY
     variables = {"id": graphene.Node.to_global_id("ExportFile", app_export_file.pk)}
 
     # when
@@ -132,7 +151,6 @@ def test_query_export_file_export_file_with_app(
         variables=variables,
         permissions=[
             permission_manage_products,
-            permission_manage_staff,
             permission_manage_apps,
         ],
     )
@@ -146,13 +164,11 @@ def test_query_export_file_export_file_with_app(
     assert data["updatedAt"]
     assert data["app"]["name"] == app.name
     assert not data["url"]
-    assert data["user"] is None
     assert len(data["events"]) == 1
     event = data["events"][0]
     assert event["date"]
     assert event["message"] == app_export_event.parameters.get("message")
     assert event["type"] == ExportEvents.EXPORT_FAILED.upper()
-    assert event["user"] is None
     assert event["app"]["name"] == app.name
 
 
@@ -165,7 +181,7 @@ def test_query_export_file_as_app(
     user_export_event,
 ):
     # given
-    query = EXPORT_FILE_QUERY
+    query = EXPORT_FILE_BY_APP_QUERY
     variables = {"id": graphene.Node.to_global_id("ExportFile", user_export_file.pk)}
 
     # when
@@ -174,7 +190,6 @@ def test_query_export_file_as_app(
         variables=variables,
         permissions=[
             permission_manage_products,
-            permission_manage_staff,
             permission_manage_apps,
         ],
     )
@@ -188,13 +203,11 @@ def test_query_export_file_as_app(
     assert data["updatedAt"]
     assert data["app"] is None
     assert not data["url"]
-    assert data["user"]["email"] == user_export_file.user.email
     assert len(data["events"]) == 1
     event = data["events"][0]
     assert event["date"]
     assert event["message"] == user_export_event.parameters.get("message")
     assert event["type"] == ExportEvents.EXPORT_FAILED.upper()
-    assert event["user"]["email"] == user_export_event.user.email
     assert event["app"] is None
 
 

--- a/saleor/graphql/csv/types.py
+++ b/saleor/graphql/csv/types.py
@@ -85,7 +85,7 @@ class ExportFile(CountableDjangoObjectType):
     @staticmethod
     def resolve_app(root: models.ExportFile, info):
         requestor = get_user_or_app_from_context(info.context)
-        if requestor_has_access(requestor, root.user, AccountPermissions.MANAGE_STAFF):
+        if requestor_has_access(requestor, root.user, AppPermission.MANAGE_APPS):
             return (
                 AppByIdLoader(info.context).load(root.app_id) if root.app_id else None
             )

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -212,9 +212,7 @@ class OrderEvent(CountableDjangoObjectType):
     @staticmethod
     def resolve_app(root: models.OrderEvent, info):
         requestor = get_user_or_app_from_context(info.context)
-        if requestor_has_access(
-            requestor, root.user, AppPermission.MANAGE_APPS
-        ) | requestor_has_access(requestor, root.user, OrderPermissions.MANAGE_ORDERS):
+        if requestor_has_access(requestor, root.user, AppPermission.MANAGE_APPS):
             return (
                 AppByIdLoader(info.context).load(root.app_id) if root.app_id else None
             )
@@ -1032,9 +1030,7 @@ class Order(CountableDjangoObjectType):
     def resolve_user(root: models.Order, info):
         def _resolve_user(user):
             requester = get_user_or_app_from_context(info.context)
-            if requestor_has_access(
-                requester, user, AccountPermissions.MANAGE_USERS
-            ) | requestor_has_access(requester, user, OrderPermissions.MANAGE_ORDERS):
+            if requestor_has_access(requester, user, AccountPermissions.MANAGE_USERS):
                 return user
             raise PermissionDenied()
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -212,7 +212,12 @@ class OrderEvent(CountableDjangoObjectType):
     @staticmethod
     def resolve_app(root: models.OrderEvent, info):
         requestor = get_user_or_app_from_context(info.context)
-        if requestor_has_access(requestor, root.user, AppPermission.MANAGE_APPS):
+        if requestor_has_access(
+            requestor,
+            root.user,
+            AppPermission.MANAGE_APPS,
+            OrderPermissions.MANAGE_ORDERS,
+        ):
             return (
                 AppByIdLoader(info.context).load(root.app_id) if root.app_id else None
             )
@@ -1030,7 +1035,12 @@ class Order(CountableDjangoObjectType):
     def resolve_user(root: models.Order, info):
         def _resolve_user(user):
             requester = get_user_or_app_from_context(info.context)
-            if requestor_has_access(requester, user, AccountPermissions.MANAGE_USERS):
+            if requestor_has_access(
+                requester,
+                user,
+                AccountPermissions.MANAGE_USERS,
+                OrderPermissions.MANAGE_ORDERS,
+            ):
                 return user
             raise PermissionDenied()
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -212,7 +212,9 @@ class OrderEvent(CountableDjangoObjectType):
     @staticmethod
     def resolve_app(root: models.OrderEvent, info):
         requestor = get_user_or_app_from_context(info.context)
-        if requestor_has_access(requestor, root.user, AppPermission.MANAGE_APPS):
+        if requestor_has_access(
+            requestor, root.user, AppPermission.MANAGE_APPS
+        ) | requestor_has_access(requestor, root.user, OrderPermissions.MANAGE_ORDERS):
             return (
                 AppByIdLoader(info.context).load(root.app_id) if root.app_id else None
             )
@@ -1030,7 +1032,9 @@ class Order(CountableDjangoObjectType):
     def resolve_user(root: models.Order, info):
         def _resolve_user(user):
             requester = get_user_or_app_from_context(info.context)
-            if requestor_has_access(requester, user, AccountPermissions.MANAGE_USERS):
+            if requestor_has_access(
+                requester, user, AccountPermissions.MANAGE_USERS
+            ) | requestor_has_access(requester, user, OrderPermissions.MANAGE_ORDERS):
                 return user
             raise PermissionDenied()
 


### PR DESCRIPTION
I want to merge this change because it adds `permission_manage_orders` to the `customer` query. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
