### PR TITLE
Change gift card display_code field to last_4

### DIFF
--- a/.github/workflows/test-env-cleanup.yml
+++ b/.github/workflows/test-env-cleanup.yml
@@ -4,7 +4,7 @@ name: TEST-ENV-CLEANUP
 on:
   pull_request:
     types: [closed, unlabeled]
-    branches: ["*"]
+    branches: ["**"]
 
 jobs:
   cleanup:

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -4,7 +4,7 @@ name: TEST-ENV-DEPLOYMENT
 on:
   pull_request:
     types: [reopened, synchronize, labeled]
-    branches: ["*"]
+    branches: ["**"]
 
 jobs:
   deploy:

--- a/saleor/giftcard/models.py
+++ b/saleor/giftcard/models.py
@@ -109,7 +109,7 @@ class GiftCard(ModelWithMetadata):
 
     @property
     def display_code(self):
-        return "****%s" % self.code[-4:]
+        return self.code[-4:]
 
 
 class GiftCardEvent(models.Model):

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_promo_codes.py
@@ -21,7 +21,7 @@ MUTATION_CHECKOUT_ADD_PROMO_CODE = """
                 }
                 giftCards {
                     id
-                    displayCode
+                    last4
                 }
                 totalPrice {
                     gross {
@@ -91,7 +91,7 @@ MUTATION_CHECKOUT_REMOVE_PROMO_CODE = """
                 voucherCode
                 giftCards {
                     id
-                    displayCode
+                    last4
                 }
             }
         }

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_promo_codes.py
@@ -21,7 +21,7 @@ MUTATION_CHECKOUT_ADD_PROMO_CODE = """
                 }
                 giftCards {
                     id
-                    last4
+                    last4CodeChars
                 }
                 totalPrice {
                     gross {
@@ -91,7 +91,7 @@ MUTATION_CHECKOUT_REMOVE_PROMO_CODE = """
                 voucherCode
                 giftCards {
                     id
-                    last4
+                    last4CodeChars
                 }
             }
         }

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -177,7 +177,7 @@ query getCheckout($token: UUID!) {
   checkout(token: $token) {
     token
     giftCards {
-      displayCode
+      last4
       currentBalance {
         amount
       }
@@ -195,7 +195,7 @@ def test_checkout_get_gift_card_code(user_api_client, checkout_with_gift_card):
     )
     content = get_graphql_content(response)
     data = content["data"]["checkout"]["giftCards"][0]
-    assert data["displayCode"] == gift_card.display_code
+    assert data["last4"] == gift_card.display_code
     assert data["currentBalance"]["amount"] == gift_card.current_balance.amount
 
 
@@ -212,9 +212,9 @@ def test_checkout_get_gift_card_codes(
     )
     content = get_graphql_content(response)
     data = content["data"]["checkout"]["giftCards"]
-    assert data[0]["displayCode"] == gift_card_first.display_code
+    assert data[0]["last4"] == gift_card_first.display_code
     assert data[0]["currentBalance"]["amount"] == gift_card_first.current_balance.amount
-    assert data[1]["displayCode"] == gift_card_last.display_code
+    assert data[1]["last4"] == gift_card_last.display_code
     assert data[1]["currentBalance"]["amount"] == gift_card_last.current_balance.amount
 
 
@@ -243,7 +243,7 @@ MUTATION_CHECKOUT_ADD_PROMO_CODE = """
                 voucherCode
                 giftCards {
                     id
-                    displayCode
+                    last4
                 }
                 totalPrice {
                     gross {
@@ -584,7 +584,7 @@ def test_checkout_add_gift_card_code(api_client, checkout_with_item, gift_card):
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_item.token)
     assert data["checkout"]["giftCards"][0]["id"] == gift_card_id
-    assert data["checkout"]["giftCards"][0]["displayCode"] == gift_card.display_code
+    assert data["checkout"]["giftCards"][0]["last4"] == gift_card.display_code
 
 
 def test_checkout_add_many_gift_card_code(
@@ -660,9 +660,7 @@ def test_checkout_add_used_gift_card_code(
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_item.token)
     assert data["checkout"]["giftCards"][0]["id"] == gift_card_id
-    assert (
-        data["checkout"]["giftCards"][0]["displayCode"] == gift_card_used.display_code
-    )
+    assert data["checkout"]["giftCards"][0]["last4"] == gift_card_used.display_code
 
 
 def test_checkout_add_used_gift_card_code_invalid_user(
@@ -760,7 +758,7 @@ def test_checkout_add_same_gift_card_code(api_client, checkout_with_gift_card):
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_gift_card.token)
     assert data["checkout"]["giftCards"][0]["id"] == gift_card_id
-    assert data["checkout"]["giftCards"][0]["displayCode"] == gift_card.display_code
+    assert data["checkout"]["giftCards"][0]["last4"] == gift_card.display_code
     assert len(data["checkout"]["giftCards"]) == gift_card_count
 
 
@@ -859,7 +857,7 @@ MUTATION_CHECKOUT_REMOVE_PROMO_CODE = """
                 voucherCode
                 giftCards {
                     id
-                    displayCode
+                    last4
                 }
             }
         }

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -177,7 +177,7 @@ query getCheckout($token: UUID!) {
   checkout(token: $token) {
     token
     giftCards {
-      last4
+      last4CodeChars
       currentBalance {
         amount
       }
@@ -195,7 +195,7 @@ def test_checkout_get_gift_card_code(user_api_client, checkout_with_gift_card):
     )
     content = get_graphql_content(response)
     data = content["data"]["checkout"]["giftCards"][0]
-    assert data["last4"] == gift_card.display_code
+    assert data["last4CodeChars"] == gift_card.display_code
     assert data["currentBalance"]["amount"] == gift_card.current_balance.amount
 
 
@@ -212,9 +212,9 @@ def test_checkout_get_gift_card_codes(
     )
     content = get_graphql_content(response)
     data = content["data"]["checkout"]["giftCards"]
-    assert data[0]["last4"] == gift_card_first.display_code
+    assert data[0]["last4CodeChars"] == gift_card_first.display_code
     assert data[0]["currentBalance"]["amount"] == gift_card_first.current_balance.amount
-    assert data[1]["last4"] == gift_card_last.display_code
+    assert data[1]["last4CodeChars"] == gift_card_last.display_code
     assert data[1]["currentBalance"]["amount"] == gift_card_last.current_balance.amount
 
 
@@ -243,7 +243,7 @@ MUTATION_CHECKOUT_ADD_PROMO_CODE = """
                 voucherCode
                 giftCards {
                     id
-                    last4
+                    last4CodeChars
                 }
                 totalPrice {
                     gross {
@@ -584,7 +584,7 @@ def test_checkout_add_gift_card_code(api_client, checkout_with_item, gift_card):
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_item.token)
     assert data["checkout"]["giftCards"][0]["id"] == gift_card_id
-    assert data["checkout"]["giftCards"][0]["last4"] == gift_card.display_code
+    assert data["checkout"]["giftCards"][0]["last4CodeChars"] == gift_card.display_code
 
 
 def test_checkout_add_many_gift_card_code(
@@ -660,7 +660,10 @@ def test_checkout_add_used_gift_card_code(
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_item.token)
     assert data["checkout"]["giftCards"][0]["id"] == gift_card_id
-    assert data["checkout"]["giftCards"][0]["last4"] == gift_card_used.display_code
+    assert (
+        data["checkout"]["giftCards"][0]["last4CodeChars"]
+        == gift_card_used.display_code
+    )
 
 
 def test_checkout_add_used_gift_card_code_invalid_user(
@@ -758,7 +761,7 @@ def test_checkout_add_same_gift_card_code(api_client, checkout_with_gift_card):
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_gift_card.token)
     assert data["checkout"]["giftCards"][0]["id"] == gift_card_id
-    assert data["checkout"]["giftCards"][0]["last4"] == gift_card.display_code
+    assert data["checkout"]["giftCards"][0]["last4CodeChars"] == gift_card.display_code
     assert len(data["checkout"]["giftCards"]) == gift_card_count
 
 
@@ -857,7 +860,7 @@ MUTATION_CHECKOUT_REMOVE_PROMO_CODE = """
                 voucherCode
                 giftCards {
                     id
-                    last4
+                    last4CodeChars
                 }
             }
         }

--- a/saleor/graphql/giftcard/tests/benchmark/test_gift_card_queries.py
+++ b/saleor/graphql/giftcard/tests/benchmark/test_gift_card_queries.py
@@ -50,7 +50,7 @@ FRAGMENT_GIFT_CARD_DETAILS = (
         fragment GiftCardDetails on GiftCard {
             id
             code
-            displayCode
+            last4
             isActive
             expiryDate
             tag

--- a/saleor/graphql/giftcard/tests/benchmark/test_gift_card_queries.py
+++ b/saleor/graphql/giftcard/tests/benchmark/test_gift_card_queries.py
@@ -50,7 +50,7 @@ FRAGMENT_GIFT_CARD_DETAILS = (
         fragment GiftCardDetails on GiftCard {
             id
             code
-            last4
+            last4CodeChars
             isActive
             expiryDate
             tag

--- a/saleor/graphql/giftcard/tests/deprecated/test_gift_card_mutations.py
+++ b/saleor/graphql/giftcard/tests/deprecated/test_gift_card_mutations.py
@@ -16,7 +16,7 @@ CREATE_GIFT_CARD_MUTATION = """
             giftCard {
                 id
                 code
-                displayCode
+                last4
                 isActive
                 startDate
                 endDate
@@ -87,7 +87,7 @@ def test_create_never_expiry_gift_card(
     data = content["data"]["giftCardCreate"]["giftCard"]
 
     assert not errors
-    assert data["displayCode"]
+    assert data["last4"]
     assert data["user"]["email"] == staff_api_client.user.email
     assert data["startDate"] is None
     assert data["endDate"] is None

--- a/saleor/graphql/giftcard/tests/deprecated/test_gift_card_mutations.py
+++ b/saleor/graphql/giftcard/tests/deprecated/test_gift_card_mutations.py
@@ -16,7 +16,7 @@ CREATE_GIFT_CARD_MUTATION = """
             giftCard {
                 id
                 code
-                last4
+                last4CodeChars
                 isActive
                 startDate
                 endDate
@@ -87,7 +87,7 @@ def test_create_never_expiry_gift_card(
     data = content["data"]["giftCardCreate"]["giftCard"]
 
     assert not errors
-    assert data["last4"]
+    assert data["last4CodeChars"]
     assert data["user"]["email"] == staff_api_client.user.email
     assert data["startDate"] is None
     assert data["endDate"] is None

--- a/saleor/graphql/giftcard/tests/deprecated/test_gift_card_query.py
+++ b/saleor/graphql/giftcard/tests/deprecated/test_gift_card_query.py
@@ -9,7 +9,7 @@ QUERY_GIFT_CARD_BY_ID = """
         giftCard(id: $id){
             id
             code
-            displayCode
+            last4
             user {
                 email
             }
@@ -41,7 +41,7 @@ def test_query_gift_card(
     content = get_graphql_content(response)
     data = content["data"]["giftCard"]
     assert data["id"] == gift_card_id
-    assert data["displayCode"] == gift_card.display_code
+    assert data["last4"] == gift_card.display_code
     assert data["user"]["email"] == gift_card.created_by.email
     assert data["endDate"] == end_date.isoformat()
     assert data["startDate"] is None

--- a/saleor/graphql/giftcard/tests/deprecated/test_gift_card_query.py
+++ b/saleor/graphql/giftcard/tests/deprecated/test_gift_card_query.py
@@ -9,7 +9,7 @@ QUERY_GIFT_CARD_BY_ID = """
         giftCard(id: $id){
             id
             code
-            last4
+            last4CodeChars
             user {
                 email
             }
@@ -41,7 +41,7 @@ def test_query_gift_card(
     content = get_graphql_content(response)
     data = content["data"]["giftCard"]
     assert data["id"] == gift_card_id
-    assert data["last4"] == gift_card.display_code
+    assert data["last4CodeChars"] == gift_card.display_code
     assert data["user"]["email"] == gift_card.created_by.email
     assert data["endDate"] == end_date.isoformat()
     assert data["startDate"] is None

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_bulk_create.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_bulk_create.py
@@ -13,7 +13,7 @@ GIFT_CARD_BULK_CREATE_MUTATION = """
             giftCards {
                 id
                 code
-                displayCode
+                last4
                 isActive
                 expiryDate
                 tag

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_bulk_create.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_bulk_create.py
@@ -13,7 +13,7 @@ GIFT_CARD_BULK_CREATE_MUTATION = """
             giftCards {
                 id
                 code
-                last4
+                last4CodeChars
                 isActive
                 expiryDate
                 tag

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
@@ -14,7 +14,7 @@ CREATE_GIFT_CARD_MUTATION = """
             giftCard {
                 id
                 code
-                displayCode
+                last4
                 isActive
                 expiryDate
                 tag
@@ -128,7 +128,7 @@ def test_create_never_expiry_gift_card(
 
     assert not errors
     assert data["code"]
-    assert data["displayCode"]
+    assert data["last4"]
     assert not data["expiryDate"]
     assert data["tag"] == tag
     assert data["createdBy"]["email"] == staff_api_client.user.email
@@ -211,7 +211,7 @@ def test_create_gift_card_by_app(
 
     assert not errors
     assert data["code"]
-    assert data["displayCode"]
+    assert data["last4"]
     assert not data["expiryDate"]
     assert data["tag"] == tag
     assert not data["createdBy"]
@@ -534,7 +534,7 @@ def test_create_gift_card_with_expiry_date(
 
     assert not errors
     assert data["code"]
-    assert data["displayCode"]
+    assert data["last4"]
     assert data["expiryDate"] == date_value.isoformat()
 
     assert len(data["events"]) == 1

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
@@ -14,7 +14,7 @@ CREATE_GIFT_CARD_MUTATION = """
             giftCard {
                 id
                 code
-                last4
+                last4CodeChars
                 isActive
                 expiryDate
                 tag
@@ -128,7 +128,7 @@ def test_create_never_expiry_gift_card(
 
     assert not errors
     assert data["code"]
-    assert data["last4"]
+    assert data["last4CodeChars"]
     assert not data["expiryDate"]
     assert data["tag"] == tag
     assert data["createdBy"]["email"] == staff_api_client.user.email
@@ -211,7 +211,7 @@ def test_create_gift_card_by_app(
 
     assert not errors
     assert data["code"]
-    assert data["last4"]
+    assert data["last4CodeChars"]
     assert not data["expiryDate"]
     assert data["tag"] == tag
     assert not data["createdBy"]
@@ -534,7 +534,7 @@ def test_create_gift_card_with_expiry_date(
 
     assert not errors
     assert data["code"]
-    assert data["last4"]
+    assert data["last4CodeChars"]
     assert data["expiryDate"] == date_value.isoformat()
 
     assert len(data["events"]) == 1

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
@@ -14,7 +14,7 @@ UPDATE_GIFT_CARD_MUTATION = """
         giftCardUpdate(id: $id, input: $input) {
             giftCard {
                 id
-                displayCode
+                last4
                 isActive
                 expiryDate
                 tag
@@ -126,7 +126,7 @@ def test_update_gift_card(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["displayCode"]
+    assert data["last4"]
     assert data["expiryDate"] == date_value.isoformat()
     assert data["tag"] == tag
     assert data["createdBy"]["email"] == gift_card.created_by.email
@@ -241,7 +241,7 @@ def test_update_gift_card_by_app(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["displayCode"]
+    assert data["last4"]
     assert data["expiryDate"] == date_value.isoformat()
     assert data["tag"] == tag
     assert data["createdBy"]["email"] == gift_card.created_by.email
@@ -442,7 +442,7 @@ def test_update_gift_card_change_to_never_expire(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["displayCode"]
+    assert data["last4"]
     assert not data["expiryDate"]
     assert data["tag"] == gift_card.tag
     assert data["createdBy"]["email"] == gift_card.created_by.email
@@ -499,7 +499,7 @@ def test_update_used_gift_card_to_expiry_date(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["displayCode"]
+    assert data["last4"]
     assert data["expiryDate"] == date_value.isoformat()
     assert len(data["events"]) == 1
     event = data["events"][0]
@@ -541,7 +541,7 @@ def test_update_used_gift_card_to_never_expired(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["displayCode"]
+    assert data["last4"]
     assert data["expiryDate"] is None
 
 
@@ -618,7 +618,7 @@ def test_update_gift_card_expired_card(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["displayCode"]
+    assert data["last4"]
     assert not data["expiryDate"]
     assert data["tag"] == gift_card.tag
     assert data["createdBy"]["email"] == gift_card.created_by.email

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
@@ -14,7 +14,7 @@ UPDATE_GIFT_CARD_MUTATION = """
         giftCardUpdate(id: $id, input: $input) {
             giftCard {
                 id
-                last4
+                last4CodeChars
                 isActive
                 expiryDate
                 tag
@@ -126,7 +126,7 @@ def test_update_gift_card(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["last4"]
+    assert data["last4CodeChars"]
     assert data["expiryDate"] == date_value.isoformat()
     assert data["tag"] == tag
     assert data["createdBy"]["email"] == gift_card.created_by.email
@@ -241,7 +241,7 @@ def test_update_gift_card_by_app(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["last4"]
+    assert data["last4CodeChars"]
     assert data["expiryDate"] == date_value.isoformat()
     assert data["tag"] == tag
     assert data["createdBy"]["email"] == gift_card.created_by.email
@@ -442,7 +442,7 @@ def test_update_gift_card_change_to_never_expire(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["last4"]
+    assert data["last4CodeChars"]
     assert not data["expiryDate"]
     assert data["tag"] == gift_card.tag
     assert data["createdBy"]["email"] == gift_card.created_by.email
@@ -499,7 +499,7 @@ def test_update_used_gift_card_to_expiry_date(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["last4"]
+    assert data["last4CodeChars"]
     assert data["expiryDate"] == date_value.isoformat()
     assert len(data["events"]) == 1
     event = data["events"][0]
@@ -541,7 +541,7 @@ def test_update_used_gift_card_to_never_expired(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["last4"]
+    assert data["last4CodeChars"]
     assert data["expiryDate"] is None
 
 
@@ -618,7 +618,7 @@ def test_update_gift_card_expired_card(
     data = content["data"]["giftCardUpdate"]["giftCard"]
 
     assert not errors
-    assert data["last4"]
+    assert data["last4CodeChars"]
     assert not data["expiryDate"]
     assert data["tag"] == gift_card.tag
     assert data["createdBy"]["email"] == gift_card.created_by.email

--- a/saleor/graphql/giftcard/tests/queries/test_gift_card.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_card.py
@@ -19,7 +19,7 @@ QUERY_GIFT_CARD_BY_ID = """
         giftCard(id: $id){
             id
             code
-            displayCode
+            last4
             isActive
             expiryDate
             tag
@@ -81,7 +81,7 @@ def test_query_gift_card_with_permissions(
     data = content["data"]["giftCard"]
     assert data["id"] == gift_card_id
     assert data["code"] == gift_card.code
-    assert data["displayCode"] == gift_card.display_code
+    assert data["last4"] == gift_card.display_code
     assert data["isActive"] == gift_card.is_active
     assert data["expiryDate"] is None
     assert data["tag"] == gift_card.tag
@@ -146,7 +146,7 @@ def test_query_gift_card_by_app(
     data = content["data"]["giftCard"]
     assert data["id"] == gift_card_id
     assert data["code"] == gift_card.code
-    assert data["displayCode"] == gift_card.display_code
+    assert data["last4"] == gift_card.display_code
     assert data["isActive"] == gift_card.is_active
     assert data["expiryDate"] is None
     assert data["tag"] == gift_card.tag
@@ -207,7 +207,7 @@ def test_query_gift_card_with_expiry_date(
     data = content["data"]["giftCard"]
     assert data["id"] == gift_card_id
     assert data["code"] == gift_card_expiry_date.code
-    assert data["displayCode"] == gift_card_expiry_date.display_code
+    assert data["last4"] == gift_card_expiry_date.display_code
     assert data["expiryDate"] == gift_card_expiry_date.expiry_date.isoformat()
 
 

--- a/saleor/graphql/giftcard/tests/queries/test_gift_card.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_card.py
@@ -19,7 +19,7 @@ QUERY_GIFT_CARD_BY_ID = """
         giftCard(id: $id){
             id
             code
-            last4
+            last4CodeChars
             isActive
             expiryDate
             tag
@@ -81,7 +81,7 @@ def test_query_gift_card_with_permissions(
     data = content["data"]["giftCard"]
     assert data["id"] == gift_card_id
     assert data["code"] == gift_card.code
-    assert data["last4"] == gift_card.display_code
+    assert data["last4CodeChars"] == gift_card.display_code
     assert data["isActive"] == gift_card.is_active
     assert data["expiryDate"] is None
     assert data["tag"] == gift_card.tag
@@ -146,7 +146,7 @@ def test_query_gift_card_by_app(
     data = content["data"]["giftCard"]
     assert data["id"] == gift_card_id
     assert data["code"] == gift_card.code
-    assert data["last4"] == gift_card.display_code
+    assert data["last4CodeChars"] == gift_card.display_code
     assert data["isActive"] == gift_card.is_active
     assert data["expiryDate"] is None
     assert data["tag"] == gift_card.tag
@@ -207,7 +207,7 @@ def test_query_gift_card_with_expiry_date(
     data = content["data"]["giftCard"]
     assert data["id"] == gift_card_id
     assert data["code"] == gift_card_expiry_date.code
-    assert data["last4"] == gift_card_expiry_date.display_code
+    assert data["last4CodeChars"] == gift_card_expiry_date.display_code
     assert data["expiryDate"] == gift_card_expiry_date.expiry_date.isoformat()
 
 

--- a/saleor/graphql/giftcard/tests/queries/test_gift_card_filtering.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_card_filtering.py
@@ -10,7 +10,7 @@ QUERY_GIFT_CARDS = """
             edges {
                 node {
                     id
-                    displayCode
+                    last4
                     product {
                         name
                     }

--- a/saleor/graphql/giftcard/tests/queries/test_gift_card_filtering.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_card_filtering.py
@@ -10,7 +10,7 @@ QUERY_GIFT_CARDS = """
             edges {
                 node {
                     id
-                    last4
+                    last4CodeChars
                     product {
                         name
                     }

--- a/saleor/graphql/giftcard/tests/queries/test_gift_card_sorting.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_card_sorting.py
@@ -13,7 +13,7 @@ QUERY_GIFT_CARDS = """
             edges {
                 node {
                     id
-                    displayCode
+                    last4
                 }
             }
             totalCount

--- a/saleor/graphql/giftcard/tests/queries/test_gift_card_sorting.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_card_sorting.py
@@ -13,7 +13,7 @@ QUERY_GIFT_CARDS = """
             edges {
                 node {
                     id
-                    last4
+                    last4CodeChars
                 }
             }
             totalCount

--- a/saleor/graphql/giftcard/tests/queries/test_gift_cards.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_cards.py
@@ -8,7 +8,7 @@ QUERY_GIFT_CARDS = """
             edges {
                 node {
                     id
-                    displayCode
+                    last4
                 }
             }
             totalCount
@@ -37,9 +37,9 @@ def test_query_gift_cards_by_staff(
     data = content["data"]["giftCards"]["edges"]
     assert len(data) == 2
     assert data[0]["node"]["id"] == gift_card_created_by_staff_id
-    assert data[0]["node"]["displayCode"] == gift_card_created_by_staff.display_code
+    assert data[0]["node"]["last4"] == gift_card_created_by_staff.display_code
     assert data[1]["node"]["id"] == gift_card_id
-    assert data[1]["node"]["displayCode"] == gift_card.display_code
+    assert data[1]["node"]["last4"] == gift_card.display_code
 
 
 def test_query_gift_cards_by_app(
@@ -62,9 +62,9 @@ def test_query_gift_cards_by_app(
     data = content["data"]["giftCards"]["edges"]
     assert len(data) == 2
     assert data[0]["node"]["id"] == gift_card_created_by_staff_id
-    assert data[0]["node"]["displayCode"] == gift_card_created_by_staff.display_code
+    assert data[0]["node"]["last4"] == gift_card_created_by_staff.display_code
     assert data[1]["node"]["id"] == gift_card_id
-    assert data[1]["node"]["displayCode"] == gift_card.display_code
+    assert data[1]["node"]["last4"] == gift_card.display_code
 
 
 def test_query_own_gift_cards(
@@ -77,7 +77,7 @@ def test_query_own_gift_cards(
                     edges {
                         node {
                             id
-                            displayCode
+                            last4
                             code
                         }
                     }
@@ -91,6 +91,6 @@ def test_query_own_gift_cards(
     content = get_graphql_content(response)
     data = content["data"]["me"]["giftCards"]
     assert data["edges"][0]["node"]["id"] == gift_card_id
-    assert data["edges"][0]["node"]["displayCode"] == gift_card_used.display_code
+    assert data["edges"][0]["node"]["last4"] == gift_card_used.display_code
     assert data["edges"][0]["node"]["code"] == gift_card_used.code
     assert data["totalCount"] == 1

--- a/saleor/graphql/giftcard/tests/queries/test_gift_cards.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_cards.py
@@ -8,7 +8,7 @@ QUERY_GIFT_CARDS = """
             edges {
                 node {
                     id
-                    last4
+                    last4CodeChars
                 }
             }
             totalCount
@@ -37,9 +37,9 @@ def test_query_gift_cards_by_staff(
     data = content["data"]["giftCards"]["edges"]
     assert len(data) == 2
     assert data[0]["node"]["id"] == gift_card_created_by_staff_id
-    assert data[0]["node"]["last4"] == gift_card_created_by_staff.display_code
+    assert data[0]["node"]["last4CodeChars"] == gift_card_created_by_staff.display_code
     assert data[1]["node"]["id"] == gift_card_id
-    assert data[1]["node"]["last4"] == gift_card.display_code
+    assert data[1]["node"]["last4CodeChars"] == gift_card.display_code
 
 
 def test_query_gift_cards_by_app(
@@ -62,9 +62,9 @@ def test_query_gift_cards_by_app(
     data = content["data"]["giftCards"]["edges"]
     assert len(data) == 2
     assert data[0]["node"]["id"] == gift_card_created_by_staff_id
-    assert data[0]["node"]["last4"] == gift_card_created_by_staff.display_code
+    assert data[0]["node"]["last4CodeChars"] == gift_card_created_by_staff.display_code
     assert data[1]["node"]["id"] == gift_card_id
-    assert data[1]["node"]["last4"] == gift_card.display_code
+    assert data[1]["node"]["last4CodeChars"] == gift_card.display_code
 
 
 def test_query_own_gift_cards(
@@ -77,7 +77,7 @@ def test_query_own_gift_cards(
                     edges {
                         node {
                             id
-                            last4
+                            last4CodeChars
                             code
                         }
                     }
@@ -91,6 +91,6 @@ def test_query_own_gift_cards(
     content = get_graphql_content(response)
     data = content["data"]["me"]["giftCards"]
     assert data["edges"][0]["node"]["id"] == gift_card_id
-    assert data["edges"][0]["node"]["last4"] == gift_card_used.display_code
+    assert data["edges"][0]["node"]["last4CodeChars"] == gift_card_used.display_code
     assert data["edges"][0]["node"]["code"] == gift_card_used.code
     assert data["totalCount"] == 1

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -178,8 +178,8 @@ class GiftCardEvent(CountableDjangoObjectType):
 
 
 class GiftCard(CountableDjangoObjectType):
-    display_code = graphene.String(
-        description="Code in format which allows displaying in a user interface.",
+    last_4 = graphene.String(
+        description="Last 4 characters of gift card code.",
         required=True,
     )
     code = graphene.String(
@@ -269,7 +269,7 @@ class GiftCard(CountableDjangoObjectType):
         model = models.GiftCard
 
     @staticmethod
-    def resolve_display_code(root: models.GiftCard, *_args, **_kwargs):
+    def resolve_last_4(root: models.GiftCard, *_args, **_kwargs):
         return root.display_code
 
     @staticmethod

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -178,7 +178,7 @@ class GiftCardEvent(CountableDjangoObjectType):
 
 
 class GiftCard(CountableDjangoObjectType):
-    last_4 = graphene.String(
+    last_4_code_chars = graphene.String(
         description="Last 4 characters of gift card code.",
         required=True,
     )
@@ -269,7 +269,7 @@ class GiftCard(CountableDjangoObjectType):
         model = models.GiftCard
 
     @staticmethod
-    def resolve_last_4(root: models.GiftCard, *_args, **_kwargs):
+    def resolve_last_4_code_chars(root: models.GiftCard, *_args, **_kwargs):
         return root.display_code
 
     @staticmethod

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -829,7 +829,7 @@ def test_order_query_gift_cards(
     query OrderQuery($id: ID!) {
         order(id: $id) {
             giftCards {
-                displayCode
+                last4
                 currentBalance {
                     amount
                 }
@@ -847,7 +847,7 @@ def test_order_query_gift_cards(
     content = get_graphql_content(response)
     gift_card_data = content["data"]["order"]["giftCards"][0]
 
-    assert gift_card.display_code == gift_card_data["displayCode"]
+    assert gift_card.display_code == gift_card_data["last4"]
     assert (
         gift_card.current_balance.amount == gift_card_data["currentBalance"]["amount"]
     )

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -829,7 +829,7 @@ def test_order_query_gift_cards(
     query OrderQuery($id: ID!) {
         order(id: $id) {
             giftCards {
-                last4
+                last4CodeChars
                 currentBalance {
                     amount
                 }
@@ -847,7 +847,7 @@ def test_order_query_gift_cards(
     content = get_graphql_content(response)
     gift_card_data = content["data"]["order"]["giftCards"][0]
 
-    assert gift_card.display_code == gift_card_data["last4"]
+    assert gift_card.display_code == gift_card_data["last4CodeChars"]
     assert (
         gift_card.current_balance.amount == gift_card_data["currentBalance"]["amount"]
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2327,7 +2327,7 @@ type GiftCard implements Node & ObjectWithMetadata {
   id: ID!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  last4: String!
+  last4CodeChars: String!
   createdBy: User
   usedBy: User
   createdByEmail: String

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2327,7 +2327,7 @@ type GiftCard implements Node & ObjectWithMetadata {
   id: ID!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  displayCode: String!
+  last4: String!
   createdBy: User
   usedBy: User
   createdByEmail: String


### PR DESCRIPTION
Change gift_card `display_code` field to `last_4`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
