### PR TITLE
Set warnings as error in pytest(on CI)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ exclude_lines =
     if TYPE_CHECKING:
 
 [tool:pytest]
-addopts = -n auto --vcr-record-mode=none --ds=saleor.tests.settings
+addopts = -Werror -n auto --vcr-record-mode=none --ds=saleor.tests.settings
 testpaths = saleor
 filterwarnings =
     ignore::DeprecationWarning


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
