### PR TITLE
Limit error fields when smtp backend raises an error

### DIFF
--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -2,7 +2,7 @@ import logging
 import operator
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from decimal import Decimal, InvalidOperation
 from email.headerregistry import Address
 from typing import List, Optional
@@ -294,15 +294,16 @@ def validate_default_email_configuration(
     except Exception as e:
         logger.warning("Unable to connect to email backend.", exc_info=e)
         error_msg = (
-            "Unable to connect to email backend. Make sure that you provided "
-            "correct values."
+            f"Unable to connect to email backend. Make sure that you provided "
+            f"correct values. {e}"
         )
+
         raise ValidationError(
             {
                 c: ValidationError(
                     error_msg, code=PluginErrorCode.PLUGIN_MISCONFIGURED.value
                 )
-                for c in configuration.keys()
+                for c in asdict(config).keys()
             }
         )
 

--- a/saleor/plugins/tests/test_email_common.py
+++ b/saleor/plugins/tests/test_email_common.py
@@ -3,7 +3,10 @@ from unittest.mock import patch
 import pytest
 from django.core.exceptions import ValidationError
 
-from saleor.plugins.email_common import validate_default_email_configuration
+from saleor.plugins.email_common import (
+    DEFAULT_EMAIL_CONFIGURATION,
+    validate_default_email_configuration,
+)
 from saleor.plugins.error_codes import PluginErrorCode
 
 
@@ -35,3 +38,24 @@ def test_validate_default_email_configuration_correct_email(
 
     email_configuration["sender_address"] = "this_is@correct.email"
     validate_default_email_configuration(plugin_configuration, email_configuration)
+
+
+@patch("saleor.plugins.email_common.validate_email_config")
+def test_validate_default_email_configuration_backend_raises(
+    validate_email_config_mock, plugin_configuration, email_configuration
+):
+    validate_email_config_mock.side_effect = Exception("[Errno 61] Connection refused")
+    email_configuration["sender_address"] = "this_is@correct.email"
+
+    with pytest.raises(ValidationError) as e:
+        validate_default_email_configuration(plugin_configuration, email_configuration)
+
+    expected_keys = [item["name"] for item in DEFAULT_EMAIL_CONFIGURATION]
+    assert list(e.value.error_dict.keys()) == expected_keys
+
+    for message in e.value.messages:
+        assert message == (
+            "Unable to connect to email backend."
+            " Make sure that you provided correct values."
+            " [Errno 61] Connection refused"
+        )


### PR DESCRIPTION
Port changes #8428 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
