### PR TITLE
Fix for refund payment if order_created raises an error

### DIFF
--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -260,6 +260,7 @@ class AdyenGatewayPlugin(BasePlugin):
                 return handle_additional_actions(
                     request,
                     self.adyen.checkout.payments_details,
+                    self.channel.slug,  # type: ignore
                 )
         return HttpResponseNotFound()
 

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_additional_actions.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_additional_actions.py
@@ -15,12 +15,14 @@ ERROR_MSG_MISSING_CHECKOUT = (
 )
 
 
+@mock.patch("saleor.payment.gateways.adyen.webhooks.payment_refund_or_void")
 @mock.patch("saleor.payment.gateways.adyen.webhooks.api_call")
 def test_handle_additional_actions_post(
-    api_call_mock, payment_adyen_for_checkout, adyen_plugin
+    api_call_mock, _, payment_adyen_for_checkout, adyen_plugin
 ):
     # given
-    adyen_plugin()
+    plugin = adyen_plugin()
+    channel_slug = plugin.channel.slug
     payment_adyen_for_checkout.to_confirm = True
     payment_adyen_for_checkout.extra_data = json.dumps(
         [{"payment_data": "test_data", "parameters": ["payload"]}]
@@ -45,7 +47,9 @@ def test_handle_additional_actions_post(
     api_call_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(
+        request_mock, payment_details_mock, channel_slug
+    )
 
     # then
     payment_adyen_for_checkout.refresh_from_db()
@@ -67,7 +71,8 @@ def test_handle_additional_actions_order_already_created(
     api_call_mock, payment_adyen_for_order, adyen_plugin, order
 ):
     # given
-    adyen_plugin()
+    plugin = adyen_plugin()
+    channel_slug = plugin.channel.slug
     payment_adyen_for_order.to_confirm = True
     payment_adyen_for_order.extra_data = json.dumps(
         [{"payment_data": "test_data", "parameters": ["payload"]}]
@@ -89,7 +94,9 @@ def test_handle_additional_actions_order_already_created(
     api_call_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(
+        request_mock, payment_details_mock, channel_slug
+    )
 
     # then
     payment_adyen_for_order.refresh_from_db()
@@ -115,7 +122,8 @@ def test_handle_additional_actions_handles_return_urls(
     api_call_mock, custom_url, payment_adyen_for_checkout, adyen_plugin
 ):
     # given
-    adyen_plugin()
+    plugin = adyen_plugin()
+    channel_slug = plugin.channel.slug
     payment_adyen_for_checkout.return_url = custom_url
     payment_adyen_for_checkout.to_confirm = True
     payment_adyen_for_checkout.extra_data = json.dumps(
@@ -140,7 +148,9 @@ def test_handle_additional_actions_handles_return_urls(
     api_call_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(
+        request_mock, payment_details_mock, channel_slug
+    )
 
     # then
     payment_adyen_for_checkout.refresh_from_db()
@@ -152,7 +162,8 @@ def test_handle_additional_actions_get(
     api_call_mock, payment_adyen_for_checkout, adyen_plugin
 ):
     # given
-    adyen_plugin()
+    plugin = adyen_plugin()
+    channel_slug = plugin.channel.slug
     payment_adyen_for_checkout.to_confirm = True
     payment_adyen_for_checkout.extra_data = json.dumps(
         {"payment_data": "test_data", "parameters": ["payload"]}
@@ -180,7 +191,9 @@ def test_handle_additional_actions_get(
     api_call_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(
+        request_mock, payment_details_mock, channel_slug
+    )
 
     # then
     payment_adyen_for_checkout.refresh_from_db()
@@ -225,7 +238,7 @@ def test_handle_additional_actions_more_action_required(payment_adyen_for_checko
     payment_details_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(request_mock, payment_details_mock, "channel")
 
     # then
     assert response.status_code == 302
@@ -267,7 +280,7 @@ def test_handle_additional_actions_payment_does_not_exist(payment_adyen_for_chec
     payment_adyen_for_checkout.delete()
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(request_mock, payment_details_mock, "channel")
 
     # then
     assert response.status_code == 404
@@ -298,7 +311,7 @@ def test_handle_additional_actions_payment_lack_of_return_url(
     }
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(request_mock, payment_details_mock, "channel")
 
     # then
     assert response.status_code == 404
@@ -326,7 +339,7 @@ def test_handle_additional_actions_no_payment_id_in_get(payment_adyen_for_checko
     payment_details_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(request_mock, payment_details_mock, "channel")
 
     # then
     assert response.status_code == 404
@@ -354,7 +367,7 @@ def test_handle_additional_actions_checkout_not_related_to_payment(
     payment_details_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(request_mock, payment_details_mock, "channel")
 
     # then
     assert response.status_code == 404
@@ -384,7 +397,7 @@ def test_handle_additional_actions_payment_does_not_have_checkout(
     payment_details_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(request_mock, payment_details_mock, "channel")
 
     # then
     assert response.status_code == 404
@@ -421,7 +434,7 @@ def test_handle_additional_actions_api_call_error(
     payment_details_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(request_mock, payment_details_mock, "channel")
 
     # then
     assert response.status_code == 400
@@ -450,7 +463,7 @@ def test_handle_additional_actions_payment_not_active(payment_adyen_for_checkout
     payment_details_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(request_mock, payment_details_mock, "channel")
 
     # then
     assert response.status_code == 404
@@ -481,7 +494,7 @@ def test_handle_additional_actions_payment_with_no_adyen_gateway(
     payment_details_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(request_mock, payment_details_mock, "channel")
 
     # then
     assert response.status_code == 404
@@ -512,7 +525,7 @@ def test_handle_additional_actions_lack_of_parameter_in_request(
     api_call_mock.return_value.message = message
 
     # when
-    response = handle_additional_actions(request_mock, payment_details_mock)
+    response = handle_additional_actions(request_mock, payment_details_mock, "channel")
 
     # then
     payment_adyen_for_checkout.refresh_from_db()

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
@@ -35,13 +35,13 @@ def test_handle_api_response_auto_capture_order_created_can_refund(
     assert payment_adyen_for_checkout.order
     assert payment_adyen_for_checkout.can_refund()
     assert not payment_adyen_for_checkout.can_void()
-    assert refund_mock.call_count == 0
-    assert void_mock.call_count == 0
+    assert not refund_mock.called
+    assert not void_mock.called
 
 
 @patch("saleor.payment.gateway.refund")
 @patch("saleor.payment.gateway.void")
-def test_handle_api_response_wo_auto_capture_order_created_can_void(
+def test_handle_api_response_auto_capture_false_order_created_can_void(
     void_mock, refund_mock, payment_adyen_for_checkout, adyen_plugin
 ):
     payment_adyen_for_checkout.to_confirm = True
@@ -67,14 +67,14 @@ def test_handle_api_response_wo_auto_capture_order_created_can_void(
     assert payment_adyen_for_checkout.order
     assert payment_adyen_for_checkout.can_void()
     assert not payment_adyen_for_checkout.can_refund()
-    assert refund_mock.call_count == 0
-    assert void_mock.call_count == 0
+    assert not refund_mock.called
+    assert not void_mock.called
 
 
 @patch("saleor.payment.gateway.void")
 @patch("saleor.payment.gateway.refund")
 @patch("saleor.checkout.complete_checkout._get_order_data")
-def test_handle_api_response_wo_auto_capture_cannot_create_order_void_payment(
+def test_handle_api_response_auto_capture_false_cannot_create_order_void_payment(
     order_data_mock, refund_mock, void_mock, payment_adyen_for_checkout, adyen_plugin
 ):
     order_data_mock.side_effect = ValidationError("Test error")
@@ -101,7 +101,7 @@ def test_handle_api_response_wo_auto_capture_cannot_create_order_void_payment(
     assert not payment_adyen_for_checkout.order
 
     assert not payment_adyen_for_checkout.can_refund()
-    assert refund_mock.call_count == 0
+    assert not refund_mock.called
 
     assert payment_adyen_for_checkout.can_void()
     assert void_mock.call_count == 2
@@ -140,4 +140,4 @@ def test_handle_api_response_auto_capture_cannot_create_order_refund_payment(
     assert refund_mock.call_count == 2
 
     assert not payment_adyen_for_checkout.can_void()
-    assert void_mock.call_count == 0
+    assert not void_mock.called

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
@@ -1,0 +1,143 @@
+from unittest.mock import patch
+
+from Adyen.client import AdyenResult
+from django.core.exceptions import ValidationError
+
+from ......payment import ChargeStatus
+from ......payment.gateways.adyen.webhooks import handle_api_response
+
+
+@patch("saleor.payment.gateway.refund")
+@patch("saleor.payment.gateway.void")
+def test_handle_api_response_auto_capture_order_created_can_refund(
+    void_mock, refund_mock, payment_adyen_for_checkout, adyen_plugin
+):
+    payment_adyen_for_checkout.to_confirm = True
+    payment_adyen_for_checkout.save(update_fields=["to_confirm"])
+
+    plugin = adyen_plugin(adyen_auto_capture=True)
+
+    adyen_response = AdyenResult(
+        {
+            "additionalData": {"paymentMethod": "visa"},
+            "pspReference": "882635241694695D",
+            "resultCode": "Authorised",
+            "amount": {"currency": "USD", "value": 4211},
+            "merchantReference": "UGF5bWVudDoxMDU=",
+        }
+    )
+
+    handle_api_response(payment_adyen_for_checkout, adyen_response, plugin.channel.slug)
+
+    payment_adyen_for_checkout.refresh_from_db()
+
+    assert payment_adyen_for_checkout.charge_status == ChargeStatus.FULLY_CHARGED
+    assert payment_adyen_for_checkout.order
+    assert payment_adyen_for_checkout.can_refund()
+    assert not payment_adyen_for_checkout.can_void()
+    assert refund_mock.call_count == 0
+    assert void_mock.call_count == 0
+
+
+@patch("saleor.payment.gateway.refund")
+@patch("saleor.payment.gateway.void")
+def test_handle_api_response_wo_auto_capture_order_created_can_void(
+    void_mock, refund_mock, payment_adyen_for_checkout, adyen_plugin
+):
+    payment_adyen_for_checkout.to_confirm = True
+    payment_adyen_for_checkout.save(update_fields=["to_confirm"])
+
+    plugin = adyen_plugin()
+
+    adyen_response = AdyenResult(
+        {
+            "additionalData": {"paymentMethod": "visa"},
+            "pspReference": "882635241694695D",
+            "resultCode": "Authorised",
+            "amount": {"currency": "USD", "value": 4211},
+            "merchantReference": "UGF5bWVudDoxMDU=",
+        }
+    )
+
+    handle_api_response(payment_adyen_for_checkout, adyen_response, plugin.channel.slug)
+
+    payment_adyen_for_checkout.refresh_from_db()
+
+    assert payment_adyen_for_checkout.charge_status == ChargeStatus.NOT_CHARGED
+    assert payment_adyen_for_checkout.order
+    assert payment_adyen_for_checkout.can_void()
+    assert not payment_adyen_for_checkout.can_refund()
+    assert refund_mock.call_count == 0
+    assert void_mock.call_count == 0
+
+
+@patch("saleor.payment.gateway.void")
+@patch("saleor.payment.gateway.refund")
+@patch("saleor.checkout.complete_checkout._get_order_data")
+def test_handle_api_response_wo_auto_capture_cannot_create_order_void_payment(
+    order_data_mock, refund_mock, void_mock, payment_adyen_for_checkout, adyen_plugin
+):
+    order_data_mock.side_effect = ValidationError("Test error")
+    payment_adyen_for_checkout.to_confirm = True
+    payment_adyen_for_checkout.save(update_fields=["to_confirm"])
+
+    plugin = adyen_plugin()
+
+    adyen_response = AdyenResult(
+        {
+            "additionalData": {"paymentMethod": "visa"},
+            "pspReference": "882635241694695D",
+            "resultCode": "Authorised",
+            "amount": {"currency": "USD", "value": 4211},
+            "merchantReference": "UGF5bWVudDoxMDU=",
+        }
+    )
+
+    handle_api_response(payment_adyen_for_checkout, adyen_response, plugin.channel.slug)
+
+    payment_adyen_for_checkout.refresh_from_db()
+
+    assert payment_adyen_for_checkout.charge_status == ChargeStatus.NOT_CHARGED
+    assert not payment_adyen_for_checkout.order
+
+    assert not payment_adyen_for_checkout.can_refund()
+    assert refund_mock.call_count == 0
+
+    assert payment_adyen_for_checkout.can_void()
+    assert void_mock.call_count == 2
+
+
+@patch("saleor.payment.gateway.void")
+@patch("saleor.payment.gateway.refund")
+@patch("saleor.checkout.complete_checkout._get_order_data")
+def test_handle_api_response_auto_capture_cannot_create_order_refund_payment(
+    order_data_mock, refund_mock, void_mock, payment_adyen_for_checkout, adyen_plugin
+):
+    order_data_mock.side_effect = ValidationError("Test error")
+    payment_adyen_for_checkout.to_confirm = True
+    payment_adyen_for_checkout.save(update_fields=["to_confirm"])
+
+    plugin = adyen_plugin(adyen_auto_capture=True)
+
+    adyen_response = AdyenResult(
+        {
+            "additionalData": {"paymentMethod": "visa"},
+            "pspReference": "882635241694695D",
+            "resultCode": "Authorised",
+            "amount": {"currency": "USD", "value": 4211},
+            "merchantReference": "UGF5bWVudDoxMDU=",
+        }
+    )
+
+    handle_api_response(payment_adyen_for_checkout, adyen_response, plugin.channel.slug)
+
+    payment_adyen_for_checkout.refresh_from_db()
+
+    assert payment_adyen_for_checkout.charge_status == ChargeStatus.FULLY_CHARGED
+    assert not payment_adyen_for_checkout.order
+
+    assert payment_adyen_for_checkout.can_refund()
+    assert refund_mock.call_count == 2
+
+    assert not payment_adyen_for_checkout.can_void()
+    assert void_mock.call_count == 0

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
@@ -1,9 +1,11 @@
 import logging
 from decimal import Decimal
 from unittest import mock
+from unittest.mock import patch
 
 import graphene
 import pytest
+from django.core.exceptions import ValidationError
 
 from ......checkout import calculations
 from ......checkout.fetch import fetch_checkout_info, fetch_checkout_lines
@@ -12,6 +14,7 @@ from ......plugins.manager import get_plugins_manager
 from ..... import ChargeStatus, TransactionKind
 from .....utils import price_to_minor_unit
 from ...webhooks import (
+    confirm_payment_and_set_back_to_confirm,
     create_new_transaction,
     handle_authorization,
     handle_cancel_or_refund,
@@ -19,6 +22,7 @@ from ...webhooks import (
     handle_capture,
     handle_failed_capture,
     handle_failed_refund,
+    handle_not_created_order,
     handle_pending,
     handle_refund,
     handle_reversed_refund,
@@ -989,3 +993,201 @@ def test_handle_cancel_or_refund_action_cancel_invalid_payment_id(
     handle_cancel_or_refund(notification, config)
 
     assert f"Unable to decode the payment ID {invalid_reference}." in caplog.text
+
+
+def test_handle_not_created_order_order_created(
+    checkout_ready_to_complete, payment_adyen_for_checkout, adyen_plugin, notification
+):
+    payment_adyen_for_checkout.charge_status = ChargeStatus.FULLY_CHARGED
+    payment_adyen_for_checkout.save(update_fields=["charge_status"])
+
+    adyen_plugin()
+    handle_not_created_order(
+        notification(),
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        TransactionKind.CAPTURE,
+        get_plugins_manager(),
+    )
+
+    payment_adyen_for_checkout.refresh_from_db()
+
+    assert payment_adyen_for_checkout.order
+
+
+@patch("saleor.payment.gateway.refund")
+@patch("saleor.checkout.complete_checkout._get_order_data")
+def test_handle_not_created_order_refund_when_create_order_raises(
+    order_data_mock, refund_mock, payment_adyen_for_checkout, adyen_plugin, notification
+):
+    order_data_mock.side_effect = ValidationError("Test error")
+
+    payment_adyen_for_checkout.charge_status = ChargeStatus.FULLY_CHARGED
+    payment_adyen_for_checkout.save(update_fields=["charge_status"])
+
+    adyen_plugin()
+    handle_not_created_order(
+        notification(),
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        TransactionKind.CAPTURE,
+        get_plugins_manager(),
+    )
+
+    assert payment_adyen_for_checkout.can_refund()
+    assert refund_mock.call_count == 2
+
+
+@patch("saleor.payment.gateway.void")
+@patch("saleor.checkout.complete_checkout._get_order_data")
+def test_handle_not_created_order_void_when_create_order_raises(
+    order_data_mock, void_mock, payment_adyen_for_checkout, adyen_plugin, notification
+):
+    order_data_mock.side_effect = ValidationError("Test error")
+
+    payment_adyen_for_checkout.charge_status = ChargeStatus.NOT_CHARGED
+    payment_adyen_for_checkout.save(update_fields=["charge_status"])
+
+    adyen_plugin()
+    handle_not_created_order(
+        notification(),
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        TransactionKind.CAPTURE,
+        get_plugins_manager(),
+    )
+
+    assert payment_adyen_for_checkout.can_void()
+    assert void_mock.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "charge_status",
+    [
+        ChargeStatus.PARTIALLY_REFUNDED,
+        ChargeStatus.REFUSED,
+        ChargeStatus.FULLY_REFUNDED,
+        ChargeStatus.CANCELLED,
+    ],
+)
+def test_handle_not_created_order_return_none(
+    charge_status, payment_adyen_for_checkout, adyen_plugin, notification
+):
+    payment_adyen_for_checkout.charge_status = charge_status
+    payment_adyen_for_checkout.save(update_fields=["charge_status"])
+
+    assert not handle_not_created_order(
+        notification(),
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        TransactionKind.CAPTURE,
+        get_plugins_manager(),
+    )
+
+
+def test_handle_not_created_order_create_new_success_transaction(
+    payment_adyen_for_checkout, adyen_plugin, notification
+):
+    payment_adyen_for_checkout.charge_status = ChargeStatus.NOT_CHARGED
+    payment_adyen_for_checkout.save(update_fields=["charge_status"])
+    payment_adyen_for_checkout.transactions.all().delete()
+
+    adyen_plugin()
+    handle_not_created_order(
+        notification(),
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        TransactionKind.CAPTURE,
+        get_plugins_manager(),
+    )
+
+    payment_adyen_for_checkout.refresh_from_db()
+    assert payment_adyen_for_checkout.order
+
+    all_payment_transactions = payment_adyen_for_checkout.transactions.all()
+    assert len(all_payment_transactions) == 2
+    assert all_payment_transactions[0].kind == TransactionKind.ACTION_TO_CONFIRM
+    assert all_payment_transactions[1].kind == TransactionKind.AUTH
+
+
+@patch("saleor.payment.gateway.refund")
+@patch("saleor.checkout.complete_checkout._get_order_data")
+def test_handle_not_created_order_success_transaction_create_order_raises_and_refund(
+    order_data_mock, refund_mock, payment_adyen_for_checkout, adyen_plugin, notification
+):
+    order_data_mock.side_effect = ValidationError("Test error")
+
+    payment_adyen_for_checkout.charge_status = ChargeStatus.FULLY_CHARGED
+    payment_adyen_for_checkout.save(update_fields=["charge_status"])
+    payment_adyen_for_checkout.transactions.all().delete()
+
+    adyen_plugin()
+    handle_not_created_order(
+        notification(),
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        TransactionKind.CAPTURE,
+        get_plugins_manager(),
+    )
+
+    payment_adyen_for_checkout.refresh_from_db()
+    assert not payment_adyen_for_checkout.order
+
+    all_payment_transactions = payment_adyen_for_checkout.transactions.all()
+    assert len(all_payment_transactions) == 2
+    assert all_payment_transactions[0].kind == TransactionKind.ACTION_TO_CONFIRM
+    assert all_payment_transactions[1].kind == TransactionKind.AUTH
+
+    assert payment_adyen_for_checkout.can_refund()
+    assert refund_mock.call_count == 2
+
+
+@patch("saleor.payment.gateway.void")
+@patch("saleor.checkout.complete_checkout._get_order_data")
+def test_handle_not_created_order_success_transaction_create_order_raises_and_void(
+    order_data_mock, void_mock, payment_adyen_for_checkout, adyen_plugin, notification
+):
+    order_data_mock.side_effect = ValidationError("Test error")
+
+    payment_adyen_for_checkout.charge_status = ChargeStatus.NOT_CHARGED
+    payment_adyen_for_checkout.save(update_fields=["charge_status"])
+    payment_adyen_for_checkout.transactions.all().delete()
+
+    adyen_plugin()
+    handle_not_created_order(
+        notification(),
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        TransactionKind.CAPTURE,
+        get_plugins_manager(),
+    )
+
+    payment_adyen_for_checkout.refresh_from_db()
+    assert not payment_adyen_for_checkout.order
+
+    all_payment_transactions = payment_adyen_for_checkout.transactions.all()
+    assert len(all_payment_transactions) == 2
+    assert all_payment_transactions[0].kind == TransactionKind.ACTION_TO_CONFIRM
+    assert all_payment_transactions[1].kind == TransactionKind.AUTH
+
+    assert payment_adyen_for_checkout.can_void()
+    assert void_mock.call_count == 2
+
+
+def test_confirm_payment_and_set_back_to_confirm(
+    payment_adyen_for_checkout, adyen_plugin, notification
+):
+    plugin = adyen_plugin()
+    payment_adyen_for_checkout.to_confirm = True
+    payment_adyen_for_checkout.save(update_fields=["to_confirm"])
+    create_new_transaction(
+        notification(), payment_adyen_for_checkout, TransactionKind.ACTION_TO_CONFIRM
+    )
+
+    confirm_payment_and_set_back_to_confirm(
+        payment_adyen_for_checkout, get_plugins_manager(), plugin.channel.slug
+    )
+
+    payment_adyen_for_checkout.refresh_from_db()
+
+    assert payment_adyen_for_checkout.to_confirm

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -205,20 +205,6 @@ def handle_not_created_order(notification, payment, checkout, kind, manager):
 
     # Only when we confirm that notification is success we will create the order
     if transaction.is_success and checkout:  # type: ignore
-        # The ugly workaround for refund payments when something will crash in
-        # `create_order` function before processing a payment.
-        # At this moment we have a payment processed on Adyen side but we have to do
-        # something more on Saleor side (ACTION_TO_CONFIRM), it's create an order in
-        # this case, so before try to create the order we have to confirm the payment
-        # and force change the flag to_confirm to True again.
-        #
-        # This is because we have to handle 2 flows:
-        # 1. Having confirmed payment to refund easily when we can't create an order.
-        # 2. Do not process payment again when `complete_checkout` logic will execute
-        #    in `create_order` without errors. We just receive a processed transaction
-        #    then.
-        #
-        # This fix is related to SALEOR-4777. PR #8471
         confirm_payment_and_set_back_to_confirm(payment, manager, checkout.channel.slug)
         payment.refresh_from_db()  # refresh charge_status
         order = create_order(payment, checkout, manager)
@@ -849,20 +835,6 @@ def handle_api_response(payment: Payment, response: Adyen.Adyen, channel_slug: s
     if is_success and not action_required and not payment.order:
         manager = get_plugins_manager()
 
-        # The ugly workaround for refund payments when something will crash in
-        # `create_order` function before processing a payment.
-        # At this moment we have a payment processed on Adyen side but we have to do
-        # something more on Saleor side (ACTION_TO_CONFIRM), it's create an order in
-        # this case, so before try to create the order we have to confirm the payment
-        # and force change the flag to_confirm to True again.
-        #
-        # This is because we have to handle 2 flows:
-        # 1. Having confirmed payment to refund easily when we can't create an order.
-        # 2. Do not process payment again when `complete_checkout` logic will execute
-        #    in `create_order` without errors. We just receive a processed transaction
-        #    then.
-        #
-        # This fix is related to SALEOR-4777. PR #8471
         confirm_payment_and_set_back_to_confirm(payment, manager, channel_slug)
         payment.refresh_from_db()  # refresh charge_status
 
@@ -870,6 +842,20 @@ def handle_api_response(payment: Payment, response: Adyen.Adyen, channel_slug: s
 
 
 def confirm_payment_and_set_back_to_confirm(payment, manager, channel_slug):
+    # The workaround for refund payments when something will crash in
+    # `create_order` function before processing a payment.
+    # At this moment we have a payment processed on Adyen side but we have to do
+    # something more on Saleor side (ACTION_TO_CONFIRM), it's create an order in
+    # this case, so before try to create the order we have to confirm the payment
+    # and force change the flag to_confirm to True again.
+    #
+    # This is because we have to handle 2 flows:
+    # 1. Having confirmed payment to refund easily when we can't create an order.
+    # 2. Do not process payment again when `complete_checkout` logic will execute
+    #    in `create_order` without errors. We just receive a processed transaction
+    #    then.
+    #
+    # This fix is related to SALEOR-4777. PR #8471
     gateway.confirm(payment, manager, channel_slug)
     payment.to_confirm = True
     payment.save(update_fields=["to_confirm"])

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -39,7 +39,7 @@ from ....order.actions import (
 from ....order.events import external_notification_event
 from ....payment.models import Payment, Transaction
 from ....plugins.manager import get_plugins_manager
-from ... import ChargeStatus, PaymentError, TransactionKind
+from ... import ChargeStatus, PaymentError, TransactionKind, gateway
 from ...gateway import payment_refund_or_void
 from ...interface import GatewayConfig, GatewayResponse
 from ...utils import (
@@ -683,8 +683,7 @@ def handle_webhook(request: WSGIRequest, gateway_config: "GatewayConfig"):
 
 @transaction_with_commit_on_errors()
 def handle_additional_actions(
-    request: WSGIRequest,
-    payment_details: Callable,
+    request: WSGIRequest, payment_details: Callable, channel_slug: str
 ):
     payment_id = request.GET.get("payment")
     checkout_pk = request.GET.get("checkout")
@@ -739,7 +738,7 @@ def handle_additional_actions(
         result = api_call(request_data, payment_details)
     except PaymentError as e:
         return HttpResponseBadRequest(str(e))
-    handle_api_response(payment, result)
+    handle_api_response(payment, result, channel_slug)
     redirect_url = prepare_redirect_url(payment_id, checkout_pk, result, return_url)
     parsed = urlparse(return_url)
     redirect_class = HttpResponseRedirect
@@ -791,10 +790,7 @@ def prepare_redirect_url(
     return prepare_url(urlencode(params), return_url)
 
 
-def handle_api_response(
-    payment: Payment,
-    response: Adyen.Adyen,
-):
+def handle_api_response(payment: Payment, response: Adyen.Adyen, channel_slug: str):
     checkout = get_checkout(payment)
     payment_data = create_payment_information(
         payment=payment,
@@ -835,4 +831,25 @@ def handle_api_response(
         gateway_response=gateway_response,
     )
     if is_success and not action_required and not payment.order:
-        create_order(payment, checkout, get_plugins_manager())
+        manager = get_plugins_manager()
+
+        # The ugly workaround for refund payments when something will crash in
+        # `create_order` function before processing a payment.
+        # At this moment we have a payment processed on Adyen side but we have to do
+        # something more on Saleor side (ACTION_TO_CONFIRM), it's create an order in
+        # this case, so before try to create the order we have to confirm the payment
+        # and force change the flag to_confirm to True again.
+        #
+        # This is because we have to handle 2 flows:
+        # 1. Having confirmed payment to refund easily when we can't create an order.
+        # 2. Do not process payment again when `complete_checkout` logic will execute
+        #    in `create_order` without errors. We just receive a processed transaction
+        #    then.
+        #
+        # This fix is related to SALEOR-4777.
+        gateway.confirm(payment, manager, channel_slug)
+        payment.to_confirm = True
+        payment.save(update_fields=["to_confirm"])
+        payment.refresh_from_db()  # refresh charge_status
+
+        create_order(payment, checkout, manager)


### PR DESCRIPTION
The workaround for refund payments when something will crash in `create_order` function before processing a payment. At this moment we have a payment processed on Adyen side but we have to do something more on Saleor side (ACTION_TO_CONFIRM), it's create an order in this case, so before try to create the order we have to confirm the payment and force change the flag to_confirm to True again.
 This is because we have to handle 2 flows:

1. Having confirmed payment to refund easily when we can't create an order.
2. Do not process payment again when `complete_checkout` logic will execute in `create_order` without errors. We just receive a processed transaction then.

Above message is also included as a comment to the implementation 😢 

For now it's one and only solution without refactoring entire Adyen interface. 
In addition the `channel_slug` is passing to `saleor.payment.gateways.adyen.webhooks.handle_additional_actions` because we have to know on which channel we have to call payment confirmation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
