### PR TITLE
Improvements to partial payments

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -574,6 +574,9 @@ def _complete_checkout_payment(
     if not payment:
         return {}, False
 
+    if not payment.to_confirm and payment.charge_status != ChargeStatus.NOT_CHARGED:
+        return {}, False
+
     if user.is_authenticated:
         customer_id = fetch_customer_id(user=user, gateway=payment.gateway)
 

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -413,7 +413,7 @@ def _create_order(
         if payment.charge_status == ChargeStatus.NOT_CHARGED:
             payment.is_active = False
 
-    Payment.objects.bulk_update(payments, fields=["order", "is_active"])
+    Payment.objects.bulk_update(payments, fields=["order", "is_active", "modified"])
 
     # copy metadata from the checkout into the new order
     order.metadata = checkout.metadata

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -946,6 +946,7 @@ def test_create_order_deactivates_unused_payments(
         }
     )
     payments_count = Payment.objects.count()
+
     # when
     order = _create_order(
         checkout_info=checkout_info,
@@ -959,6 +960,7 @@ def test_create_order_deactivates_unused_payments(
         app=None,
         manager=manager,
     )
+
     # then
     assert order.payments.count() == payments_count
     unused_payment.refresh_from_db()

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -12,6 +12,7 @@ from ...core.taxes import zero_money, zero_taxed_money
 from ...order import OrderEvents
 from ...order.models import OrderEvent
 from ...order.notifications import get_default_order_payload
+from ...payment.models import Payment
 from ...plugins.manager import get_plugins_manager
 from ...product.models import ProductTranslation, ProductVariantTranslation
 from ...tests.utils import flush_post_commit_hooks
@@ -923,3 +924,42 @@ def test_create_order_use_translations(
 
     assert order_line.translated_product_name == translated_product_name
     assert order_line.translated_variant_name == translated_variant_name
+
+
+def test_create_order_deactivates_unused_payments(
+    checkout_with_item, address, customer_user, payment_kwargs
+):
+    # given
+    checkout_with_item.shipping_address = address
+    checkout_with_item.save()
+    manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
+
+    unused_payment = Payment.objects.create(
+        **{
+            **payment_kwargs,
+            **{
+                "checkout": checkout_with_item,
+                "order": None,
+            },
+        }
+    )
+    payments_count = Payment.objects.count()
+    # when
+    order = _create_order(
+        checkout_info=checkout_info,
+        order_data=_prepare_order_data(
+            manager=manager,
+            checkout_info=checkout_info,
+            lines=lines,
+            discounts=None,
+        ),
+        user=customer_user,
+        app=None,
+        manager=manager,
+    )
+    # then
+    assert order.payments.count() == payments_count
+    unused_payment.refresh_from_db()
+    assert not unused_payment.is_active

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -957,13 +957,6 @@ def test_checkout_complete_with_payment_id_of_a_charged_payment(
     checkout.billing_address = address
     checkout.save()
 
-    # manager = get_plugins_manager()
-    # lines = fetch_checkout_lines(checkout)
-    # checkout_info = fetch_checkout_info(checkout, lines, [], manager)
-    # total = calculations.calculate_checkout_total_with_gift_cards(
-    #     manager, checkout_info, lines, address
-    # )
-
     payment = payment_dummy_fully_charged
     payment.order = None
     payment.checkout = checkout

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -943,6 +943,53 @@ def test_checkout_complete_with_payment_id(
     assert new_orders_count == orders_count + 1
 
 
+def test_checkout_complete_with_payment_id_of_a_charged_payment(
+    user_api_client,
+    checkout_with_item,
+    address,
+    shipping_method,
+    payment_dummy_fully_charged,
+):
+    # given
+    checkout = checkout_with_item
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    # manager = get_plugins_manager()
+    # lines = fetch_checkout_lines(checkout)
+    # checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    # total = calculations.calculate_checkout_total_with_gift_cards(
+    #     manager, checkout_info, lines, address
+    # )
+
+    payment = payment_dummy_fully_charged
+    payment.order = None
+    payment.checkout = checkout
+    payment.save()
+
+    # when
+    variables = {
+        "token": checkout.token,
+        "redirectUrl": "https://www.example.com",
+        "paymentId": graphene.Node.to_global_id("Payment", payment.pk),
+    }
+    orders_count = Order.objects.count()
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+    assert not data["confirmationNeeded"]
+    new_orders_count = Order.objects.count()
+    assert new_orders_count == orders_count + 1
+
+    payment.refresh_from_db()
+    assert payment.total == payment.captured_amount
+
+
 def test_checkout_complete_multiple_payments_not_covering_checkout(
     user_api_client, checkout_with_item, address, shipping_method, payment_kwargs
 ):

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -511,14 +511,14 @@ class OrderCapture(BaseMutation):
         payments = get_authorized_payments(order)
         clean_order_capture(order, payments, amount)
         manager = info.context.plugins
-        failed_events = capture_payments(
+        payment_errors = capture_payments(
             order,
             info.context.user,
             info.context.app,
             manager,
         )
-        if failed_events:
-            messages = [e.parameters["message"] for e in failed_events]
+        if payment_errors:
+            messages = [e.message for e in payment_errors]
             raise ValidationError(
                 " ".join(messages),
                 code=OrderErrorCode.PAYMENT_ERROR.value,
@@ -549,14 +549,14 @@ class OrderVoid(BaseMutation):
         payments = [p for p in get_active_payments(order)]
         clean_void_payments(payments)
         manager = info.context.plugins
-        failed_events = void_payments(
+        payment_errors = void_payments(
             order,
             info.context.user,
             info.context.app,
             manager,
         )
-        if failed_events:
-            messages = [e.parameters["message"] for e in failed_events]
+        if payment_errors:
+            messages = [e.message for e in payment_errors]
             raise ValidationError(
                 " ".join(messages),
                 code=OrderErrorCode.PAYMENT_ERROR.value,

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -14,6 +14,7 @@ from ...checkout.utils import (
 )
 from ...core import analytics
 from ...core.permissions import OrderPermissions
+from ...core.taxes import zero_money
 from ...core.transactions import transaction_with_commit_on_errors
 from ...core.utils import get_client_ip
 from ...core.utils.url import validate_storefront_url
@@ -105,7 +106,12 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
                 }
             )
 
-        remaining = checkout_total.gross - get_covered_balance(checkout)
+        # for non-partial payments, already covered balance will be released
+        covered_amount = zero_money(checkout.currency)
+        if partial:
+            covered_amount = get_covered_balance(checkout)
+
+        remaining = checkout_total.gross - covered_amount
         if amount > remaining.amount:
             raise ValidationError(
                 {


### PR DESCRIPTION
I want to merge this change because they have been flagged in testing.

Changes that are introduced:
- `NOT_CHARGED` payments are deactivated on order creation
- validating amount of a non-partial payment does not take into account the amount covered by existing payments
- use PaymentErrors to transmit information about failed payments (SALEOR-4756)
- prevent calling `manager.process_payment` on an already completed payment

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
