### PR TITLE
Prevent excluded shipping method being assigned to order

### DIFF
--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from typing import Dict
 
 from django.db.models import F
 from promise import Promise
@@ -183,7 +182,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                     for checkout, channel in zip(checkouts, channels)
                     if checkout.shipping_method_id
                 ]
-                shipping_method_channel_listing = (
+                shipping_method_channel_listings = (
                     ShippingMethodChannelListingByShippingMethodIdAndChannelSlugLoader(
                         self.context
                     ).load_many(shipping_method_ids_channel_slugs)
@@ -202,7 +201,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                         shipping_method.id: shipping_method
                         for shipping_method in shipping_methods
                     }
-                    shipping_method_channel_listing_map: Dict = {
+                    shipping_method_channel_listing_map = {
                         (listing.shipping_method_id, listing.channel_id): listing
                         for listing in channel_listings
                         if listing
@@ -237,7 +236,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                         addresses,
                         users,
                         shipping_methods,
-                        shipping_method_channel_listing,
+                        shipping_method_channel_listings,
                     ]
                 ).then(with_checkout_info)
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2053,7 +2053,7 @@ def test_checkout_billing_address_update(
 
 
 @mock.patch(
-    "saleor.plugins.webhook.plugin.WebhookPlugin.excluded_shipping_methods_for_checkout"
+    "saleor.plugins.manager.PluginsManager.excluded_shipping_methods_for_checkout"
 )
 def test_checkout_shipping_address_update_exclude_shipping_method(
     mocked_webhook,

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -27,6 +27,7 @@ from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types.common import OrderError
 from ...product.types import ProductVariant
+from ...shipping.utils import convert_shipping_method_model_to_dataclass
 from ..types import Order
 from ..utils import (
     prepare_insufficient_stock_order_validation_errors,
@@ -431,6 +432,20 @@ class DraftOrderComplete(BaseMutation):
                 order.shipping_address.delete()
                 order.shipping_address = None
 
+        method = order.shipping_method
+        manager = info.context.plugins
+        method.price = order.shipping_price  # type: ignore
+        if manager.excluded_shipping_methods_for_order(
+            order, [convert_shipping_method_model_to_dataclass(method)]
+        ):
+            raise ValidationError(
+                {
+                    "shipping_method": ValidationError(
+                        "Shipping method cannot be used with this order.",
+                        code=OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.value,
+                    )
+                }
+            )
         order.save()
 
         for line in order.lines.all():

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -334,11 +334,17 @@ class OrderUpdateShipping(EditableOrderValidationMixin, BaseMutation):
                 "postal_code_rules"
             ),
         )
-
-        shipping_price = info.context.plugins.calculate_order_shipping(order)
-        clean_order_update_shipping(order, method, shipping_price, info.context.plugins)
+        shipping_channel_listing = (
+            shipping_models.ShippingMethodChannelListing.objects.filter(
+                shipping_method=method, channel=order.channel
+            ).first()
+        )
+        clean_order_update_shipping(
+            order, method, shipping_channel_listing.price, info.context.plugins
+        )
 
         order.shipping_method = method
+        shipping_price = info.context.plugins.calculate_order_shipping(order)
         order.shipping_price = shipping_price
         order.shipping_tax_rate = info.context.plugins.get_order_shipping_tax_rate(
             order, shipping_price

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -8,7 +8,9 @@ from ....core.exceptions import InsufficientStock
 from ....core.permissions import OrderPermissions
 from ....core.taxes import TaxError, zero_taxed_money
 from ....core.tracing import traced_atomic_transaction
-from ....order import FulfillmentStatus, OrderLineData, OrderStatus, events, models
+from ....order import FulfillmentStatus, OrderLineData, OrderStatus, events
+from ....order import models
+from ....order import models as order_models
 from ....order.actions import (
     cancel_order,
     clean_mark_order_as_paid,
@@ -54,8 +56,8 @@ ORDER_EDITABLE_STATUS = (OrderStatus.DRAFT, OrderStatus.UNCONFIRMED)
 
 
 def clean_order_update_shipping(
-    order: Order,
-    method: ShippingMethod,
+    order: order_models.Order,
+    method: shipping_models.ShippingMethod,
     shipping_price: TaxedMoney,
     manager: PluginsManager,
 ):

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -1,6 +1,7 @@
 import graphene
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from prices import TaxedMoney
 
 from ....account.models import User
 from ....core.exceptions import InsufficientStock
@@ -28,6 +29,7 @@ from ....order.utils import (
     update_order_prices,
 )
 from ....payment import PaymentError, TransactionKind, gateway
+from ....plugins.manager import PluginsManager
 from ....shipping import models as shipping_models
 from ...account.types import AddressInput
 from ...core.mutations import BaseMutation, ModelMutation
@@ -41,6 +43,7 @@ from ...order.mutations.draft_orders import (
 )
 from ...product.types import ProductVariant
 from ...shipping.types import ShippingMethod
+from ...shipping.utils import convert_shipping_method_model_to_dataclass
 from ..types import Order, OrderEvent, OrderLine
 from ..utils import (
     validate_product_is_published_in_channel,
@@ -50,14 +53,19 @@ from ..utils import (
 ORDER_EDITABLE_STATUS = (OrderStatus.DRAFT, OrderStatus.UNCONFIRMED)
 
 
-def clean_order_update_shipping(order, method):
+def clean_order_update_shipping(
+    order: Order,
+    method: ShippingMethod,
+    shipping_price: TaxedMoney,
+    manager: PluginsManager,
+):
     if not order.shipping_address:
         raise ValidationError(
             {
                 "order": ValidationError(
                     "Cannot choose a shipping method for an order without "
                     "the shipping address.",
-                    code=OrderErrorCode.ORDER_NO_SHIPPING_ADDRESS,
+                    code=OrderErrorCode.ORDER_NO_SHIPPING_ADDRESS.value,
                 )
             }
         )
@@ -70,7 +78,20 @@ def clean_order_update_shipping(order, method):
             {
                 "shipping_method": ValidationError(
                     "Shipping method cannot be used with this order.",
-                    code=OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE,
+                    code=OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.value,
+                )
+            }
+        )
+
+    method.price = shipping_price  # type: ignore
+    if manager.excluded_shipping_methods_for_order(
+        order, [convert_shipping_method_model_to_dataclass(method)]
+    ):
+        raise ValidationError(
+            {
+                "shipping_method": ValidationError(
+                    "Shipping method cannot be used with this order.",
+                    code=OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.value,
                 )
             }
         )
@@ -314,10 +335,10 @@ class OrderUpdateShipping(EditableOrderValidationMixin, BaseMutation):
             ),
         )
 
-        clean_order_update_shipping(order, method)
+        shipping_price = info.context.plugins.calculate_order_shipping(order)
+        clean_order_update_shipping(order, method, shipping_price, info.context.plugins)
 
         order.shipping_method = method
-        shipping_price = info.context.plugins.calculate_order_shipping(order)
         order.shipping_price = shipping_price
         order.shipping_tax_rate = info.context.plugins.get_order_shipping_tax_rate(
             order, shipping_price

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -9,7 +9,6 @@ from ....core.permissions import OrderPermissions
 from ....core.taxes import TaxError, zero_taxed_money
 from ....core.tracing import traced_atomic_transaction
 from ....order import FulfillmentStatus, OrderLineData, OrderStatus, events
-from ....order import models
 from ....order import models as order_models
 from ....order.actions import (
     cancel_order,
@@ -201,7 +200,7 @@ class OrderUpdate(DraftOrderCreate):
 
     class Meta:
         description = "Updates an order."
-        model = models.Order
+        model = order_models.Order
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
@@ -297,7 +296,7 @@ class OrderUpdateShipping(EditableOrderValidationMixin, BaseMutation):
             info,
             data.get("id"),
             only_type=Order,
-            qs=models.Order.objects.prefetch_related("lines"),
+            qs=order_models.Order.objects.prefetch_related("lines"),
         )
         cls.validate_order(order)
         data = data.get("input")
@@ -657,7 +656,7 @@ class OrderConfirm(ModelMutation):
 
     class Meta:
         description = "Confirms an unconfirmed order by changing status to unfulfilled."
-        model = models.Order
+        model = order_models.Order
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
@@ -895,7 +894,7 @@ class OrderLineUpdate(EditableOrderValidationMixin, ModelMutation):
 
     class Meta:
         description = "Updates an order line of an order."
-        model = models.OrderLine
+        model = order_models.OrderLine
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"

--- a/saleor/graphql/order/tests/conftest.py
+++ b/saleor/graphql/order/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+from ....plugins.manager import get_plugins_manager
+from ....plugins.webhook.plugin import WebhookPlugin
+
+
+@pytest.fixture
+def webhook_plugin(settings):
+    def factory() -> WebhookPlugin:
+        settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+        manager = get_plugins_manager()
+        return manager.global_plugins[0]
+
+    return factory

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -4752,12 +4752,9 @@ def test_order_update_shipping(
     assert order.shipping_method_name == shipping_method.name
 
 
-@mock.patch(
-    "saleor.plugins.webhook.plugin.WebhookPlugin.excluded_shipping_methods_for_order"
-)
+@mock.patch("saleor.plugins.manager.PluginsManager.excluded_shipping_methods_for_order")
 def test_order_update_shipping_with_excluded_method(
     mocked_webhook,
-    webhook_plugin,
     order_with_lines,
     shipping_method,
     staff_api_client,

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -4782,7 +4782,6 @@ def test_order_update_shipping_with_excluded_method(
         query, variables, permissions=[permission_manage_orders]
     )
     content = get_graphql_content(response)
-    print(content)
     data = content["data"]["orderUpdateShipping"]
     assert data["errors"][0]["field"] == "shippingMethod"
     assert (

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1000,11 +1000,11 @@ class Order(CountableDjangoObjectType):
 
     @staticmethod
     @traced_resolver
-    def resolve_can_finalize(root: models.Order, _info):
+    def resolve_can_finalize(root: models.Order, info):
         if root.status == OrderStatus.DRAFT:
             country = get_order_country(root)
             try:
-                validate_draft_order(root, country)
+                validate_draft_order(root, country, info.context.plugins)
             except ValidationError:
                 return False
         return True
@@ -1089,11 +1089,11 @@ class Order(CountableDjangoObjectType):
         return graphene.Node.to_global_id("Order", root.original_id)
 
     @traced_resolver
-    def resolve_errors(root, _info, **_kwargs):
+    def resolve_errors(root, info, **_kwargs):
         if root.status == OrderStatus.DRAFT:
             country = get_order_country(root)
             try:
-                validate_draft_order(root, country)
+                validate_draft_order(root, country, info.context.plugins)
             except ValidationError as e:
                 return validation_error_to_error_type(e, OrderError)
         return []

--- a/saleor/graphql/shipping/dataloaders.py
+++ b/saleor/graphql/shipping/dataloaders.py
@@ -85,16 +85,16 @@ class ShippingMethodChannelListingByShippingMethodIdLoader(DataLoader):
     context_key = "shippingmethodchannellisting_by_shippingmethod"
 
     def batch_load(self, keys):
-        shipping_method_channel_listing = ShippingMethodChannelListing.objects.filter(
+        shipping_method_channel_listings = ShippingMethodChannelListing.objects.filter(
             shipping_method_id__in=keys
         )
-        shipping_method_channel_listing_by_shipping_method_map = defaultdict(list)
-        for shipping_method_channel_listing in shipping_method_channel_listing:
-            shipping_method_channel_listing_by_shipping_method_map[
+        shipping_method_channel_listings_by_shipping_method_map = defaultdict(list)
+        for shipping_method_channel_listing in shipping_method_channel_listings:
+            shipping_method_channel_listings_by_shipping_method_map[
                 shipping_method_channel_listing.shipping_method_id
             ].append(shipping_method_channel_listing)
         return [
-            shipping_method_channel_listing_by_shipping_method_map.get(
+            shipping_method_channel_listings_by_shipping_method_map.get(
                 shipping_method_id, []
             )
             for shipping_method_id in keys
@@ -107,20 +107,20 @@ class ShippingMethodChannelListingByShippingMethodIdAndChannelSlugLoader(DataLoa
     def batch_load(self, keys):
         shipping_method_ids = [key[0] for key in keys]
         channel_slugs = [key[1] for key in keys]
-        shipping_method_channel_listing = ShippingMethodChannelListing.objects.filter(
+        shipping_method_channel_listings = ShippingMethodChannelListing.objects.filter(
             shipping_method_id__in=shipping_method_ids, channel__slug__in=channel_slugs
         ).annotate(channel_slug=F("channel__slug"))
-        shipping_method_channel_listing_by_shipping_method_and_channel_map = {}
-        for shipping_method_channel_listing in shipping_method_channel_listing:
+        shipping_method_channel_listings_by_shipping_method_and_channel_map = {}
+        for shipping_method_channel_listing in shipping_method_channel_listings:
             key = (
                 shipping_method_channel_listing.shipping_method_id,
                 shipping_method_channel_listing.channel_slug,
             )
-            shipping_method_channel_listing_by_shipping_method_and_channel_map[
+            shipping_method_channel_listings_by_shipping_method_and_channel_map[
                 key
             ] = shipping_method_channel_listing
         return [
-            shipping_method_channel_listing_by_shipping_method_and_channel_map.get(key)
+            shipping_method_channel_listings_by_shipping_method_and_channel_map.get(key)
             for key in keys
         ]
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -405,6 +405,15 @@ def checkout_with_items(checkout, product_list, product):
 
 
 @pytest.fixture
+def checkout_with_items_and_shipping(checkout_with_items, address, shipping_method):
+    checkout_with_items.shipping_address = address
+    checkout_with_items.shipping_method = shipping_method
+    checkout_with_items.billing_address = address
+    checkout_with_items.save()
+    return checkout_with_items
+
+
+@pytest.fixture
 def checkout_with_voucher(checkout, product, voucher):
     variant = product.variants.get()
     checkout_info = fetch_checkout_info(checkout, [], [], get_plugins_manager())

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3039,10 +3039,11 @@ def fulfillment(fulfilled_order):
 
 
 @pytest.fixture
-def draft_order(order_with_lines):
+def draft_order(order_with_lines, shipping_method):
     Allocation.objects.filter(order_line__order=order_with_lines).delete()
     order_with_lines.status = OrderStatus.DRAFT
     order_with_lines.origin = OrderOrigin.DRAFT
+    order_with_lines.shipping_method = shipping_method
     order_with_lines.save(update_fields=["status", "origin"])
     return order_with_lines
 


### PR DESCRIPTION
This task fixes an unwanted behaviour when orderUpdateShipping would allow an excluded shipping method to be assigned to the order.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
