### PR TITLE
Add type field to ShippingMethod type.

### DIFF
--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -342,6 +342,7 @@ query OrdersQuery {
                 }
                 shippingMethod{
                     id
+                    type
                 }
             }
         }
@@ -390,6 +391,7 @@ def test_order_query(
     )
     assert expected_price == shipping_price.gross
     assert order_data["shippingTaxRate"] == float(shipping_tax_rate)
+    assert order_data["shippingMethod"]["type"] == order.shipping_method.type.upper()
     assert len(order_data["lines"]) == order.lines.count()
     fulfillment = order.fulfillments.first().fulfillment_order
     fulfillment_order = order_data["fulfillments"][0]["fulfillmentOrder"]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5780,7 +5780,7 @@ type ShippingMethod implements Node & ObjectWithMetadata {
   id: ID!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  type: ShippingMethodTypeEnum @deprecated(reason: "This field will be removed in 4.0.")
+  type: ShippingMethodTypeEnum @deprecated(reason: "This field will be removed in Saleor 4.0.")
   name: String!
   description: JSONString
   maximumDeliveryDays: Int

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5780,6 +5780,7 @@ type ShippingMethod implements Node & ObjectWithMetadata {
   id: ID!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
+  type: ShippingMethodTypeEnum
   name: String!
   description: JSONString
   maximumDeliveryDays: Int

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5780,7 +5780,7 @@ type ShippingMethod implements Node & ObjectWithMetadata {
   id: ID!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  type: ShippingMethodTypeEnum
+  type: ShippingMethodTypeEnum @deprecated(reason: "This field will be removed in 4.0.")
   name: String!
   description: JSONString
   maximumDeliveryDays: Int

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -263,6 +263,7 @@ class ShippingMethod(ChannelContextType):
     id = graphene.ID(
         required=True, description="Unique ID of ShippingMethod available for Order."
     )
+    type = ShippingMethodTypeEnum(description="Type of the shipping method.")
     name = graphene.String(required=True, description="Shipping method name.")
     description = graphene.JSONString(description="Shipping method description (JSON).")
     maximum_delivery_days = graphene.Int(

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -265,7 +265,7 @@ class ShippingMethod(ChannelContextType):
     )
     type = ShippingMethodTypeEnum(
         description="Type of the shipping method.",
-        deprecation_reason="This field will be removed in 4.0.",
+        deprecation_reason="This field will be removed in Saleor 4.0.",
     )
 
     name = graphene.String(required=True, description="Shipping method name.")

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -263,7 +263,11 @@ class ShippingMethod(ChannelContextType):
     id = graphene.ID(
         required=True, description="Unique ID of ShippingMethod available for Order."
     )
-    type = ShippingMethodTypeEnum(description="Type of the shipping method.")
+    type = ShippingMethodTypeEnum(
+        description="Type of the shipping method.",
+        deprecation_reason="This field will be removed in 4.0.",
+    )
+
     name = graphene.String(required=True, description="Shipping method name.")
     description = graphene.JSONString(description="Shipping method description (JSON).")
     maximum_delivery_days = graphene.Int(

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -299,6 +299,10 @@ class ShippingMethod(ChannelContextType):
         )
 
     @staticmethod
+    def resolve_type(root: ChannelContext[models.ShippingMethod], info, **_kwargs):
+        return root.node.type
+
+    @staticmethod
     def resolve_minimum_order_price(
         root: ChannelContext[models.ShippingMethod], info, **_kwargs
     ):


### PR DESCRIPTION
This change fixes incompatibility with storefront.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
