### PR TITLE
Fix CheckoutLinesUpdate fails to remove lines unavailable for purchase.

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -146,10 +146,11 @@ def add_variants_to_checkout(
     channel_listings_by_product_id = {cl.product_id: cl for cl in channel_listings}
 
     # check if variants are published
-    for variant in variants:
-        product_channel_listing = channel_listings_by_product_id[variant.product_id]
-        if not product_channel_listing or not product_channel_listing.is_published:
-            raise ProductNotPublished()
+    for variant, quantity in zip(variants, quantities):
+        if quantity > 0:
+            product_channel_listing = channel_listings_by_product_id[variant.product_id]
+            if not product_channel_listing or not product_channel_listing.is_published:
+                raise ProductNotPublished()
 
     variant_ids_in_lines = {line.variant_id: line for line in checkout.lines.all()}
     to_create = []

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -124,33 +124,13 @@ def calculate_checkout_quantity(lines: Iterable["CheckoutLineInfo"]):
     return sum([line_info.line.quantity for line_info in lines])
 
 
-def add_variants_to_checkout(
-    checkout, variants, quantities, channel_slug, skip_stock_check=False, replace=False
-):
+def add_variants_to_checkout(checkout, variants, quantities, replace=False):
     """Add variants to checkout.
 
     If a variant is not placed in checkout, a new checkout line will be created.
     If quantity is set to 0, checkout line will be deleted.
     Otherwise, quantity will be added or replaced (if replace argument is True).
     """
-
-    # check quantities
-    country_code = checkout.get_country()
-    if not skip_stock_check:
-        check_stock_quantity_bulk(variants, country_code, quantities, channel_slug)
-
-    channel_listings = product_models.ProductChannelListing.objects.filter(
-        channel_id=checkout.channel.id,
-        product_id__in=[v.product_id for v in variants],
-    )
-    channel_listings_by_product_id = {cl.product_id: cl for cl in channel_listings}
-
-    # check if variants are published
-    for variant, quantity in zip(variants, quantities):
-        if quantity > 0:
-            product_channel_listing = channel_listings_by_product_id[variant.product_id]
-            if not product_channel_listing or not product_channel_listing.is_published:
-                raise ProductNotPublished()
 
     variant_ids_in_lines = {line.variant_id: line for line in checkout.lines.all()}
     to_create = []

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -30,7 +30,7 @@ from ...checkout.utils import (
     validate_variants_in_checkout_lines,
 )
 from ...core import analytics
-from ...core.exceptions import InsufficientStock, PermissionDenied, ProductNotPublished
+from ...core.exceptions import InsufficientStock, PermissionDenied
 from ...core.permissions import AccountPermissions
 from ...core.tracing import traced_atomic_transaction
 from ...core.transactions import transaction_with_commit_on_errors
@@ -55,7 +55,6 @@ from ..product.types import ProductVariant
 from ..shipping.types import ShippingMethod
 from ..utils import get_user_or_app_from_context, resolve_global_ids_to_primary_keys
 from .types import Checkout, CheckoutLine
-from .utils import prepare_insufficient_stock_checkout_validation_error
 
 ERROR_DOES_NOT_SHIP = "This checkout doesn't need shipping"
 
@@ -192,12 +191,34 @@ def validate_variants_available_for_purchase(variants_id: set, channel_id: int):
             graphene.Node.to_global_id("ProductVariant", pk)
             for pk in not_available_variants
         ]
-        error_code = CheckoutErrorCode.PRODUCT_UNAVAILABLE_FOR_PURCHASE
+        error_code = CheckoutErrorCode.PRODUCT_UNAVAILABLE_FOR_PURCHASE.value
         raise ValidationError(
             {
                 "lines": ValidationError(
                     "Cannot add lines for unavailable for purchase variants.",
-                    code=error_code,  # type: ignore
+                    code=error_code,
+                    params={"variants": variant_ids},
+                )
+            }
+        )
+
+
+def validate_variants_are_published(variants_id: set, channel_id: int):
+    published_variants = product_models.ProductChannelListing.objects.filter(
+        channel_id=channel_id, product__variants__id__in=variants_id, is_published=True
+    ).values_list("product__variants__id", flat=True)
+    not_published_variants = variants_id.difference(set(published_variants))
+    if not_published_variants:
+        variant_ids = [
+            graphene.Node.to_global_id("ProductVariant", pk)
+            for pk in not_published_variants
+        ]
+        error_code = CheckoutErrorCode.PRODUCT_NOT_PUBLISHED.value
+        raise ValidationError(
+            {
+                "lines": ValidationError(
+                    "Cannot add lines for unpublished variants.",
+                    code=error_code,
                     params={"variants": variant_ids},
                 )
             }
@@ -295,6 +316,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         validate_variants_available_in_channel(
             variant_db_ids, channel.id, CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL
         )
+        validate_variants_are_published(variant_db_ids, channel.id)
         check_lines_quantity(variants, quantities, country, channel.slug)
         return variants, quantities
 
@@ -359,7 +381,6 @@ class CheckoutCreate(ModelMutation, I18nMixin):
     @classmethod
     @traced_atomic_transaction()
     def save(cls, info, instance: models.Checkout, cleaned_input):
-        channel = cleaned_input["channel"]
         # Create the checkout object
         instance.save()
 
@@ -371,16 +392,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         variants = cleaned_input.get("variants")
         quantities = cleaned_input.get("quantities")
         if variants and quantities:
-            try:
-                add_variants_to_checkout(instance, variants, quantities, channel.slug)
-            except InsufficientStock as exc:
-                error = prepare_insufficient_stock_checkout_validation_error(exc)
-                raise ValidationError({"lines": error})
-            except ProductNotPublished as exc:
-                raise ValidationError(
-                    "Can't create checkout with unpublished product.",
-                    code=exc.code,
-                )
+            add_variants_to_checkout(instance, variants, quantities)
 
         # Save addresses
         shipping_address = cleaned_input.get("shipping_address")
@@ -485,22 +497,17 @@ class CheckoutLinesAdd(BaseMutation):
                 checkout.channel_id,
                 CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL,
             )
+            validate_variants_are_published(
+                variants_ids_to_validate, checkout.channel_id
+            )
 
         if variants and quantities:
-            try:
-                checkout = add_variants_to_checkout(
-                    checkout,
-                    variants,
-                    quantities,
-                    channel_slug,
-                    skip_stock_check=True,  # already checked by validate_checkout_lines
-                    replace=replace,
-                )
-            except ProductNotPublished as exc:
-                raise ValidationError(
-                    "Can't add unpublished product.",
-                    code=exc.code,
-                )
+            checkout = add_variants_to_checkout(
+                checkout,
+                variants,
+                quantities,
+                replace=replace,
+            )
 
         lines = fetch_checkout_lines(checkout)
         checkout_info.valid_shipping_methods = (

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -468,13 +468,23 @@ class CheckoutLinesAdd(BaseMutation):
         cls.validate_checkout_lines(
             variants, quantities, checkout.get_country(), channel_slug, lines=lines
         )
-        variants_db_ids = {variant.id for variant in variants}
-        validate_variants_available_for_purchase(variants_db_ids, checkout.channel_id)
-        validate_variants_available_in_channel(
-            variants_db_ids,
-            checkout.channel_id,
-            CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL,
-        )
+
+        variants_ids_to_validate = {
+            variant.id
+            for variant, quantity in zip(variants, quantities)
+            if quantity != 0
+        }
+
+        # validate variant only when line quantity is bigger than 0
+        if variants_ids_to_validate:
+            validate_variants_available_for_purchase(
+                variants_ids_to_validate, checkout.channel_id
+            )
+            validate_variants_available_in_channel(
+                variants_ids_to_validate,
+                checkout.channel_id,
+                CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL,
+            )
 
         if variants and quantities:
             try:

--- a/saleor/graphql/checkout/tests/test_checkout_lines.py
+++ b/saleor/graphql/checkout/tests/test_checkout_lines.py
@@ -569,6 +569,40 @@ def test_checkout_line_delete_by_zero_quantity(
     "saleor.graphql.checkout.mutations.update_checkout_shipping_method_if_invalid",
     wraps=update_checkout_shipping_method_if_invalid,
 )
+def test_checkout_line_delete_by_zero_quantity_when_variant_unavailable_for_purchase(
+    mocked_update_shipping_method, user_api_client, checkout_with_item
+):
+    checkout = checkout_with_item
+    assert checkout.lines.count() == 1
+    line = checkout.lines.first()
+    variant = line.variant
+    assert line.quantity == 3
+    variant.channel_listings.all().delete()
+    variant.product.channel_listings.all().delete()
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    variables = {
+        "token": checkout.token,
+        "lines": [{"variantId": variant_id, "quantity": 0}],
+    }
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
+    content = get_graphql_content(response)
+
+    data = content["data"]["checkoutLinesUpdate"]
+    assert not data["errors"]
+    checkout.refresh_from_db()
+    assert checkout.lines.count() == 0
+    manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+
+
+@mock.patch(
+    "saleor.graphql.checkout.mutations.update_checkout_shipping_method_if_invalid",
+    wraps=update_checkout_shipping_method_if_invalid,
+)
 def test_checkout_line_update_by_zero_quantity_dont_create_new_lines(
     mocked_update_shipping_method,
     user_api_client,


### PR DESCRIPTION
Allow deleting checkout line with the use of  `CheckoutLinesUpdate` mutation for unavailable for purchase products.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
