### PR TITLE
Fix weight serialisation in webhooks

### DIFF
--- a/saleor/core/tests/test_serializer.py
+++ b/saleor/core/tests/test_serializer.py
@@ -23,14 +23,11 @@ def test_custom_json_encoder_dumps_money_objects():
 
 def test_custom_json_encoder_dumps_weight_objects():
     # given
-    weight = 5
-    input = {"weight": Weight(kg=weight)}
+    input = {"weight": Weight(kg=5)}
 
     # when
     serialized_data = json.dumps(input, cls=CustomJsonEncoder)
 
     # then
     data = json.loads(serialized_data)
-    assert data["weight"]["_type"] == "Weight"
-    assert data["weight"]["unit"] == "kg"
-    assert data["weight"]["value"] == weight
+    assert data["weight"] == "5.0:kg"

--- a/saleor/core/tests/test_serializer.py
+++ b/saleor/core/tests/test_serializer.py
@@ -1,0 +1,36 @@
+import json
+
+from measurement.measures import Weight
+
+from ..taxes import zero_money
+from ..utils.json_serializer import CustomJsonEncoder
+
+
+def test_custom_json_encoder_dumps_money_objects():
+    # given
+    currency = "usd"
+    input = {"money": zero_money(currency)}
+
+    # when
+    serialized_data = json.dumps(input, cls=CustomJsonEncoder)
+
+    # then
+    data = json.loads(serialized_data)
+    assert data["money"]["_type"] == "Money"
+    assert data["money"]["amount"] == "0"
+    assert data["money"]["currency"] == currency
+
+
+def test_custom_json_encoder_dumps_weight_objects():
+    # given
+    weight = 5
+    input = {"weight": Weight(kg=weight)}
+
+    # when
+    serialized_data = json.dumps(input, cls=CustomJsonEncoder)
+
+    # then
+    data = json.loads(serialized_data)
+    assert data["weight"]["_type"] == "Weight"
+    assert data["weight"]["unit"] == "kg"
+    assert data["weight"]["value"] == weight

--- a/saleor/core/utils/json_serializer.py
+++ b/saleor/core/utils/json_serializer.py
@@ -1,9 +1,11 @@
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.serializers.json import Serializer as JsonSerializer
 from draftjs_sanitizer import SafeJSONEncoder
+from measurement.measures import Weight
 from prices import Money
 
 MONEY_TYPE = "Money"
+WEIGHT_TYPE = "Weight"
 
 
 class Serializer(JsonSerializer):
@@ -16,6 +18,8 @@ class CustomJsonEncoder(DjangoJSONEncoder):
     def default(self, obj):
         if isinstance(obj, Money):
             return {"_type": MONEY_TYPE, "amount": obj.amount, "currency": obj.currency}
+        if isinstance(obj, Weight):
+            return {"_type": WEIGHT_TYPE, "unit": obj.unit, "value": obj.value}
         return super().default(obj)
 
 

--- a/saleor/core/utils/json_serializer.py
+++ b/saleor/core/utils/json_serializer.py
@@ -18,8 +18,9 @@ class CustomJsonEncoder(DjangoJSONEncoder):
     def default(self, obj):
         if isinstance(obj, Money):
             return {"_type": MONEY_TYPE, "amount": obj.amount, "currency": obj.currency}
+        # Mirror implementation of django_measurement.MeasurementField.value_to_string
         if isinstance(obj, Weight):
-            return {"_type": WEIGHT_TYPE, "unit": obj.unit, "value": obj.value}
+            return "%s:%s" % (obj.value, obj.unit)
         return super().default(obj)
 
 

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import graphene
 import pytest
+from measurement.measures import Weight
 
 from ....app.models import App
 from ....graphql.tests.utils import get_graphql_content
@@ -73,8 +74,8 @@ def available_shipping_methods_factory():
                     id=str(i),
                     price=Decimal("10.0"),
                     name=uuid.uuid4().hex,
-                    maximum_order_weight=Decimal("0"),
-                    minimum_order_weight=Decimal("100"),
+                    maximum_order_weight=Weight(kg=0),
+                    minimum_order_weight=Weight(kg=0),
                     maximum_delivery_days=0,
                     minimum_delivery_days=5,
                 )


### PR DESCRIPTION
I want to merge this change because CustomJSONEncoder couldn't serialise weight objects correctly.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
