### PR TITLE
Add dataloader invalidation for saleChannelListingUpdate mutation

### DIFF
--- a/saleor/graphql/discount/mutations.py
+++ b/saleor/graphql/discount/mutations.py
@@ -21,6 +21,7 @@ from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.scalars import PositiveDecimal
 from ..core.types.common import DiscountError
 from ..core.validators import validate_end_is_after_start, validate_price_precision
+from ..discount.dataloaders import SaleChannelListingBySaleIdLoader
 from ..product.types import Category, Collection, Product
 from .enums import DiscountValueTypeEnum, VoucherTypeEnum
 from .types import Sale, Voucher
@@ -732,6 +733,10 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
             raise ValidationError(errors)
 
         cls.save(info, sale, cleaned_input)
+
+        # Invalidate dataloader for channel listings
+        SaleChannelListingBySaleIdLoader(info.context).clear(sale.id)
+
         return SaleChannelListingUpdate(
             sale=ChannelContext(node=sale, channel_slug=None)
         )


### PR DESCRIPTION
Add dataloader invalidation to `saleChannelListingUpdate` mutation. This fixes issue with the dataloader returning old data in cases when it is called in mutations that modify the data being resolved by the dataloader e.g. (`channelListings` field is affected here):

```graphql
mutation SaleUpdate(
  $id: ID!
  $saleInput: SaleInput!
  $channelInput: SaleChannelListingInput!
) {
  saleUpdate(id: $id, input: $saleInput) {
    sale {
      channelListings {
        id
      }
    }
  }
  saleChannelListingUpdate(id: $id, input: $channelInput) {
    sale {
      channelListings {
        id
      }
    }
  }
}

```

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
