### PR TITLE
[NO MERGE] Graphql Core v3 experimentationt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ WORKDIR /app
 
 ARG STATIC_URL
 ENV STATIC_URL ${STATIC_URL:-/static/}
-RUN SECRET_KEY=dummy STATIC_URL=${STATIC_URL} python3 manage.py collectstatic --no-input
+#RUN SECRET_KEY=dummy STATIC_URL=${STATIC_URL} python3 manage.py collectstatic --no-input
 
 EXPOSE 8000
 ENV PYTHONUNBUFFERED 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,11 +57,11 @@ google-i18n-address==2.5.0
 google-measurement-protocol==1.1.0
 google-resumable-media==2.0.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 googleapis-common-protos==1.53.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-graphene-django==2.13.0
+#graphene-django==2.13.0
 graphene-federation==0.1.0
-graphene==2.1.9
-graphql-core==2.3.2
-graphql-relay==2.0.1
+graphene==3.0.0b8
+graphql-core==3.1.6
+graphql-relay==3.1.0
 grpc-google-iam-v1==0.12.3; python_version >= "3.6"
 grpcio==1.41.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 gunicorn==20.1.0; python_version >= "3.5"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 adyen==4.0.0
 amqp==5.0.6; python_version >= "3.6"
-aniso8601==7.0.0
+aniso8601==9.0.1
 asgiref==3.4.1; python_version >= "3.6"
 astroid==2.8.0; python_version >= "3.6" and python_version < "4.0"
 atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
@@ -78,11 +78,9 @@ google-i18n-address==2.5.0
 google-measurement-protocol==1.1.0
 google-resumable-media==2.0.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 googleapis-common-protos==1.53.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-graphene-django==2.13.0
-graphene-federation==0.1.0
-graphene==2.1.9; python_version >= "3.6" and python_version < "4.0"
-graphql-core==2.3.2; python_version >= "3.6" and python_version < "4.0"
-graphql-relay==2.0.1
+graphene==3.0.0b8
+graphql-core==3.1.6
+graphql-relay==3.1.0
 grpc-google-iam-v1==0.12.3; python_version >= "3.6"
 grpcio==1.41.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 gunicorn==20.1.0; python_version >= "3.5"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,4 +1,4 @@
-from graphql.utils import schema_printer
+# from graphql.utilities import print_type
 
 from .celeryconf import app as celery_app
 
@@ -6,14 +6,12 @@ __all__ = ["celery_app"]
 __version__ = "dev"
 
 
-def patched_print_object(type):
-    interfaces = type.interfaces
-    implemented_interfaces = (
-        " implements {}".format(" & ".join(i.name for i in interfaces))
-        if interfaces
-        else ""
-    )
+# def patched_print_object(type):
+#     interfaces = type.interfaces
+#     implemented_interfaces = (
+#         " implements {}".format(" & ".join(i.name for i in interfaces))
+#         if interfaces
+#         else ""
+#     )
 
-    return ("type {}{} {{\n" "{}\n" "}}").format(
-        type.name, implemented_interfaces, schema_printer._print_fields(type)
-    )
+#     return print_type(type)

--- a/saleor/core/permissions.py
+++ b/saleor/core/permissions.py
@@ -99,7 +99,11 @@ PERMISSIONS_ENUMS = [
 
 
 def split_permission_codename(permissions):
-    return [permission.split(".")[1] for permission in permissions]
+    for permission in permissions:
+        try:
+            yield permission.codename
+        except AttributeError:
+            yield permission.split(".")[1]
 
 
 def get_permissions_codename():

--- a/saleor/core/tracing.py
+++ b/saleor/core/tracing.py
@@ -2,12 +2,12 @@ from contextlib import contextmanager
 
 import opentracing
 from django.db import transaction
-from graphql import ResolveInfo
+from graphql import GraphQLResolveInfo
 
 
 def traced_resolver(func):
     def wrapper(*args, **kwargs):
-        info = next(arg for arg in args if isinstance(arg, ResolveInfo))
+        info = next(arg for arg in args if isinstance(arg, GraphQLResolveInfo))
         operation = f"{info.parent_type.name}.{info.field_name}"
         with opentracing.global_tracer().start_active_span(operation) as scope:
             span = scope.span

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -2,7 +2,7 @@ import graphene
 from django.contrib.auth import get_user_model
 from django.contrib.auth import models as auth_models
 from graphene import relay
-from graphene_federation import key
+# from graphene_federation import key
 
 from ...account import models
 from ...checkout.utils import get_user_checkout
@@ -47,7 +47,7 @@ class AddressInput(graphene.InputObjectType):
     phone = graphene.String(description="Phone number.")
 
 
-@key(fields="id")
+# @key(fields="id")
 class Address(CountableDjangoObjectType):
     country = graphene.Field(
         CountryDisplay, required=True, description="Shop's default country."
@@ -210,8 +210,8 @@ class UserPermission(Permission):
         return groups
 
 
-@key("id")
-@key("email")
+# @key("id")
+# @key("email")
 class User(CountableDjangoObjectType):
     addresses = graphene.List(Address, description="List of all user's addresses.")
     checkout = graphene.Field(
@@ -467,7 +467,7 @@ class StaffNotificationRecipient(CountableDjangoObjectType):
         return root.get_email()
 
 
-@key(fields="id")
+# @key(fields="id")
 class Group(CountableDjangoObjectType):
     users = graphene.List(User, description="List of group users")
     permissions = graphene.List(Permission, description="List of group permissions")

--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -1,4 +1,4 @@
-from graphene import build_schema
+from graphene import Schema
 # from ..graphql.notifications.schema import ExternalNotificationMutations
 # from .account.schema import AccountMutations, AccountQueries
 # from .app.schema import AppMutations, AppQueries
@@ -80,4 +80,4 @@ class Mutation(
 
 
 # schema = build_federated_schema(Query, mutation=Mutation, types=unit_enums)
-schema = build_schema(Query, mutation=Mutation, types=unit_enums)
+schema = Schema(query=Query, mutation=Mutation, types=unit_enums)

--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -1,81 +1,83 @@
-from ..graphql.notifications.schema import ExternalNotificationMutations
-from .account.schema import AccountMutations, AccountQueries
-from .app.schema import AppMutations, AppQueries
-from .attribute.schema import AttributeMutations, AttributeQueries
-from .channel.schema import ChannelMutations, ChannelQueries
-from .checkout.schema import CheckoutMutations, CheckoutQueries
+from graphene import build_schema
+# from ..graphql.notifications.schema import ExternalNotificationMutations
+# from .account.schema import AccountMutations, AccountQueries
+# from .app.schema import AppMutations, AppQueries
+# from .attribute.schema import AttributeMutations, AttributeQueries
+# from .channel.schema import ChannelMutations, ChannelQueries
+# from .checkout.schema import CheckoutMutations, CheckoutQueries
 from .core.enums import unit_enums
-from .core.federation import build_federated_schema
-from .core.schema import CoreMutations, CoreQueries
-from .csv.schema import CsvMutations, CsvQueries
-from .discount.schema import DiscountMutations, DiscountQueries
-from .giftcard.schema import GiftCardMutations, GiftCardQueries
-from .invoice.schema import InvoiceMutations
-from .menu.schema import MenuMutations, MenuQueries
-from .meta.schema import MetaMutations
-from .order.schema import OrderMutations, OrderQueries
-from .page.schema import PageMutations, PageQueries
-from .payment.schema import PaymentMutations, PaymentQueries
-from .plugins.schema import PluginsMutations, PluginsQueries
+# from .core.federation import build_federated_schema
+# from .core.schema import CoreMutations, CoreQueries
+# from .csv.schema import CsvMutations, CsvQueries
+# from .discount.schema import DiscountMutations, DiscountQueries
+# from .giftcard.schema import GiftCardMutations, GiftCardQueries
+# from .invoice.schema import InvoiceMutations
+# from .menu.schema import MenuMutations, MenuQueries
+# from .meta.schema import MetaMutations
+# from .order.schema import OrderMutations, OrderQueries
+# from .page.schema import PageMutations, PageQueries
+# from .payment.schema import PaymentMutations, PaymentQueries
+# from .plugins.schema import PluginsMutations, PluginsQueries
 from .product.schema import ProductMutations, ProductQueries
-from .shipping.schema import ShippingMutations, ShippingQueries
-from .shop.schema import ShopMutations, ShopQueries
-from .translations.schema import TranslationQueries
-from .warehouse.schema import StockQueries, WarehouseMutations, WarehouseQueries
-from .webhook.schema import WebhookMutations, WebhookQueries
+# from .shipping.schema import ShippingMutations, ShippingQueries
+# from .shop.schema import ShopMutations, ShopQueries
+# from .translations.schema import TranslationQueries
+# from .warehouse.schema import StockQueries, WarehouseMutations, WarehouseQueries
+# from .webhook.schema import WebhookMutations, WebhookQueries
 
 
 class Query(
-    AccountQueries,
-    AppQueries,
-    AttributeQueries,
-    ChannelQueries,
-    CheckoutQueries,
-    CoreQueries,
-    CsvQueries,
-    DiscountQueries,
-    PluginsQueries,
-    GiftCardQueries,
-    MenuQueries,
-    OrderQueries,
-    PageQueries,
-    PaymentQueries,
+    # AccountQueries,
+    # AppQueries,
+    # AttributeQueries,
+    # ChannelQueries,
+    # CheckoutQueries,
+    # CoreQueries,
+    # CsvQueries,
+    # DiscountQueries,
+    # PluginsQueries,
+    # GiftCardQueries,
+    # MenuQueries,
+    # OrderQueries,
+    # PageQueries,
+    # PaymentQueries,
     ProductQueries,
-    ShippingQueries,
-    ShopQueries,
-    StockQueries,
-    TranslationQueries,
-    WarehouseQueries,
-    WebhookQueries,
+    # ShippingQueries,
+    # ShopQueries,
+    # StockQueries,
+    # TranslationQueries,
+    # WarehouseQueries,
+    # WebhookQueries,
 ):
     pass
 
 
 class Mutation(
-    AccountMutations,
-    AppMutations,
-    AttributeMutations,
-    ChannelMutations,
-    CheckoutMutations,
-    CoreMutations,
-    CsvMutations,
-    DiscountMutations,
-    ExternalNotificationMutations,
-    PluginsMutations,
-    GiftCardMutations,
-    InvoiceMutations,
-    MenuMutations,
-    MetaMutations,
-    OrderMutations,
-    PageMutations,
-    PaymentMutations,
+    # AccountMutations,
+    # AppMutations,
+    # AttributeMutations,
+    # ChannelMutations,
+    # CheckoutMutations,
+    # CoreMutations,
+    # CsvMutations,
+    # DiscountMutations,
+    # ExternalNotificationMutations,
+    # PluginsMutations,
+    # GiftCardMutations,
+    # InvoiceMutations,
+    # MenuMutations,
+    # MetaMutations,
+    # OrderMutations,
+    # PageMutations,
+    # PaymentMutations,
     ProductMutations,
-    ShippingMutations,
-    ShopMutations,
-    WarehouseMutations,
-    WebhookMutations,
+    # ShippingMutations,
+    # ShopMutations,
+    # WarehouseMutations,
+    # WebhookMutations,
 ):
     pass
 
 
-schema = build_federated_schema(Query, mutation=Mutation, types=unit_enums)
+# schema = build_federated_schema(Query, mutation=Mutation, types=unit_enums)
+schema = build_schema(Query, mutation=Mutation, types=unit_enums)

--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -1,80 +1,80 @@
 from graphene import Schema
-# from ..graphql.notifications.schema import ExternalNotificationMutations
-# from .account.schema import AccountMutations, AccountQueries
-# from .app.schema import AppMutations, AppQueries
-# from .attribute.schema import AttributeMutations, AttributeQueries
-# from .channel.schema import ChannelMutations, ChannelQueries
-# from .checkout.schema import CheckoutMutations, CheckoutQueries
+from ..graphql.notifications.schema import ExternalNotificationMutations
+from .account.schema import AccountMutations, AccountQueries
+from .app.schema import AppMutations, AppQueries
+from .attribute.schema import AttributeMutations, AttributeQueries
+from .channel.schema import ChannelMutations, ChannelQueries
+from .checkout.schema import CheckoutMutations, CheckoutQueries
 from .core.enums import unit_enums
 # from .core.federation import build_federated_schema
-# from .core.schema import CoreMutations, CoreQueries
-# from .csv.schema import CsvMutations, CsvQueries
-# from .discount.schema import DiscountMutations, DiscountQueries
-# from .giftcard.schema import GiftCardMutations, GiftCardQueries
-# from .invoice.schema import InvoiceMutations
-# from .menu.schema import MenuMutations, MenuQueries
-# from .meta.schema import MetaMutations
-# from .order.schema import OrderMutations, OrderQueries
-# from .page.schema import PageMutations, PageQueries
-# from .payment.schema import PaymentMutations, PaymentQueries
-# from .plugins.schema import PluginsMutations, PluginsQueries
+from .core.schema import CoreMutations, CoreQueries
+from .csv.schema import CsvMutations, CsvQueries
+from .discount.schema import DiscountMutations, DiscountQueries
+from .giftcard.schema import GiftCardMutations, GiftCardQueries
+from .invoice.schema import InvoiceMutations
+from .menu.schema import MenuMutations, MenuQueries
+from .meta.schema import MetaMutations
+from .order.schema import OrderMutations, OrderQueries
+from .page.schema import PageMutations, PageQueries
+from .payment.schema import PaymentMutations, PaymentQueries
+from .plugins.schema import PluginsMutations, PluginsQueries
 from .product.schema import ProductMutations, ProductQueries
-# from .shipping.schema import ShippingMutations, ShippingQueries
-# from .shop.schema import ShopMutations, ShopQueries
-# from .translations.schema import TranslationQueries
-# from .warehouse.schema import StockQueries, WarehouseMutations, WarehouseQueries
-# from .webhook.schema import WebhookMutations, WebhookQueries
+from .shipping.schema import ShippingMutations, ShippingQueries
+from .shop.schema import ShopMutations, ShopQueries
+from .translations.schema import TranslationQueries
+from .warehouse.schema import StockQueries, WarehouseMutations, WarehouseQueries
+from .webhook.schema import WebhookMutations, WebhookQueries
 
 
 class Query(
-    # AccountQueries,
-    # AppQueries,
-    # AttributeQueries,
-    # ChannelQueries,
-    # CheckoutQueries,
-    # CoreQueries,
-    # CsvQueries,
-    # DiscountQueries,
-    # PluginsQueries,
-    # GiftCardQueries,
-    # MenuQueries,
-    # OrderQueries,
-    # PageQueries,
-    # PaymentQueries,
+    AccountQueries,
+    AppQueries,
+    AttributeQueries,
+    ChannelQueries,
+    CheckoutQueries,
+    CoreQueries,
+    CsvQueries,
+    DiscountQueries,
+    PluginsQueries,
+    GiftCardQueries,
+    MenuQueries,
+    OrderQueries,
+    PageQueries,
+    PaymentQueries,
     ProductQueries,
-    # ShippingQueries,
-    # ShopQueries,
-    # StockQueries,
-    # TranslationQueries,
-    # WarehouseQueries,
-    # WebhookQueries,
+    ShippingQueries,
+    ShopQueries,
+    StockQueries,
+    TranslationQueries,
+    WarehouseQueries,
+    WebhookQueries,
 ):
     pass
 
 
 class Mutation(
-    # AccountMutations,
-    # AppMutations,
-    # AttributeMutations,
-    # ChannelMutations,
-    # CheckoutMutations,
-    # CoreMutations,
-    # CsvMutations,
-    # DiscountMutations,
-    # ExternalNotificationMutations,
-    # PluginsMutations,
-    # GiftCardMutations,
-    # InvoiceMutations,
-    # MenuMutations,
-    # MetaMutations,
-    # OrderMutations,
-    # PageMutations,
-    # PaymentMutations,
+    AccountMutations,
+    AppMutations,
+    AttributeMutations,
+    ChannelMutations,
+    CheckoutMutations,
+    CoreMutations,
+    CsvMutations,
+    DiscountMutations,
+    ExternalNotificationMutations,
+    PluginsMutations,
+    GiftCardMutations,
+    InvoiceMutations,
+    MenuMutations,
+    MetaMutations,
+    OrderMutations,
+    PageMutations,
+    PaymentMutations,
     ProductMutations,
-    # ShippingMutations,
-    # ShopMutations,
-    # WarehouseMutations,
-    # WebhookMutations,
+    ShippingMutations,
+    ShopMutations,
+    WarehouseMutations,
+    WebhookMutations,
 ):
     pass
 

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -1,5 +1,5 @@
 import graphene
-from graphene_federation import key
+# from graphene_federation import key
 
 from ...app import models
 from ...core.exceptions import PermissionDenied
@@ -122,7 +122,7 @@ class AppToken(CountableDjangoObjectType):
         return root.auth_token[-4:]
 
 
-@key(fields="id")
+# @key(fields="id")
 class App(CountableDjangoObjectType):
     permissions = graphene.List(
         Permission, description="List of the app's permissions."

--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -1,6 +1,5 @@
 import django_filters
 from django.db.models import Q
-from graphene_django.filter import GlobalIDFilter, GlobalIDMultipleChoiceFilter
 
 from ...attribute.models import Attribute, AttributeValue
 from ...core.permissions import has_one_of_permissions
@@ -11,6 +10,7 @@ from ..channel.filters import get_channel_slug_from_filter_data
 from ..core.filters import EnumFilter, MetadataFilterBase
 from ..core.types import ChannelFilterInputObjectType, FilterInputObjectType
 from ..core.utils import from_global_id_or_error
+from ..django.filters import GlobalIDFilter, GlobalIDMultipleChoiceFilter
 from ..utils import get_user_or_app_from_context
 from ..utils.filters import filter_fields_containing_value
 

--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -10,7 +10,7 @@ from ..channel.filters import get_channel_slug_from_filter_data
 from ..core.filters import EnumFilter, MetadataFilterBase
 from ..core.types import ChannelFilterInputObjectType, FilterInputObjectType
 from ..core.utils import from_global_id_or_error
-from ..django.filters import GlobalIDFilter, GlobalIDMultipleChoiceFilter
+from ..django.filter import GlobalIDFilter, GlobalIDMultipleChoiceFilter
 from ..utils import get_user_or_app_from_context
 from ..utils.filters import filter_fields_containing_value
 

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -3,7 +3,6 @@ from typing import Union
 import graphene
 from django.db.models import Model
 from graphene.types.resolver import get_default_resolver
-from graphene_django import DjangoObjectType
 
 from ...channel import models
 from ...core.permissions import ChannelPermissions
@@ -11,6 +10,7 @@ from ..core.connection import CountableDjangoObjectType
 from ..core.descriptions import ADDED_IN_31
 from ..core.types import CountryDisplay
 from ..decorators import permission_required
+from ..django.types import DjangoObjectType
 from ..meta.types import ObjectWithMetadata
 from ..translations.resolvers import resolve_translation
 from . import ChannelContext

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -1,5 +1,6 @@
 import json
 from decimal import Decimal, InvalidOperation
+from enum import Enum
 from typing import Any, Dict, Iterable, List, Tuple, Union
 
 import graphene
@@ -140,6 +141,9 @@ def _validate_connection_args(args):
 
 def _get_sorting_fields(sort_by, qs):
     sorting_fields = sort_by.get("field")
+    if isinstance(sorting_fields, Enum):
+        sorting_fields = sorting_fields.value
+
     sorting_attribute = sort_by.get("attribute_id")
     if sorting_fields and not isinstance(sorting_fields, list):
         return [sorting_fields]
@@ -204,7 +208,6 @@ def _get_edges_for_connection(edge_type, qs, args, sorting_fields):
             start_slice = 0
     page_info = _get_page_info(matching_records, cursor, first, last)
     matching_records = matching_records[start_slice:end_slice]
-
     edges = [
         edge_type(
             node=record,

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -6,12 +6,12 @@ import graphene
 from django.db.models import Model as DjangoModel
 from django.db.models import Q, QuerySet
 from graphene.relay.connection import Connection
-from graphene_django.types import DjangoObjectType
 from graphql.error import GraphQLError
 from graphql_relay.connection.connectiontypes import Edge, PageInfo
 from graphql_relay.utils import base64, unbase64
 
 from ..core.enums import OrderDirection
+from ..django.types import DjangoObjectType
 
 ConnectionArguments = Dict[str, Any]
 

--- a/saleor/graphql/core/fields.py
+++ b/saleor/graphql/core/fields.py
@@ -10,12 +10,9 @@ from promise import Promise
 from ...channel.exceptions import ChannelNotDefined, NoDefaultChannel
 from ..channel import ChannelContext, ChannelQsContext
 from ..channel.utils import get_default_channel_slug_or_graphql_error
+from ..django.fields import DjangoConnectionField
 from ..utils.sorting import sort_queryset_for_connection
 from .connection import connection_from_queryset_slice
-
-
-class DjangoConnectionField:
-    pass  # TODO: FIXME
 
 
 def patch_pagination_args(field: DjangoConnectionField):

--- a/saleor/graphql/core/fields.py
+++ b/saleor/graphql/core/fields.py
@@ -3,7 +3,6 @@ from functools import partial
 
 import graphene
 from graphene.relay import PageInfo
-from graphene_django.fields import DjangoConnectionField
 from graphql.error import GraphQLError
 from graphql_relay.connection.arrayconnection import connection_from_list_slice
 from promise import Promise
@@ -13,6 +12,10 @@ from ..channel import ChannelContext, ChannelQsContext
 from ..channel.utils import get_default_channel_slug_or_graphql_error
 from ..utils.sorting import sort_queryset_for_connection
 from .connection import connection_from_queryset_slice
+
+
+class DjangoConnectionField:
+    pass  # TODO: FIXME
 
 
 def patch_pagination_args(field: DjangoConnectionField):

--- a/saleor/graphql/core/fields.py
+++ b/saleor/graphql/core/fields.py
@@ -135,7 +135,7 @@ class FilterInputConnectionField(BaseDjangoConnectionField):
     ):
         # Disable `enforce_first_or_last` if not querying for `edges`.
         values = [
-            field.name.value for field in info.field_asts[0].selection_set.selections
+            field.name.value for field in info.field_nodes[0].selection_set.selections
         ]
         if "edges" not in values:
             enforce_first_or_last = False
@@ -211,7 +211,20 @@ class FilterInputConnectionField(BaseDjangoConnectionField):
             iterable = instance.qs
         return iterable
 
-    def get_resolver(self, parent_resolver):
+    def wrap_resolve(self, parent_resolver):
+        return partial(
+            self.connection_resolver,
+            parent_resolver,
+            self.connection_type,
+            self.get_manager(),
+            self.get_queryset_resolver(),
+            self.max_limit,
+            self.enforce_first_or_last,
+            self.filterset_class,
+            self.filter_field_name,
+        )
+
+    def get_resolver__(self, parent_resolver):
         return partial(
             super().get_resolver(parent_resolver),
             self.filterset_class,

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -13,12 +13,12 @@ from django.core.files.storage import default_storage
 from django.db.models.fields.files import FileField
 from graphene import ObjectType
 from graphene.types.mutation import MutationOptions
-from graphene_django.registry import get_global_registry
 from graphql.error import GraphQLError
 
 from ...core.exceptions import PermissionDenied
 from ...core.permissions import AccountPermissions
 from ..decorators import staff_member_or_app_required
+from ..django.registry import get_global_registry
 from ..utils import get_nodes, resolve_global_ids_to_primary_keys
 from .descriptions import DEPRECATED_IN_3X_FIELD
 from .types import File, Upload

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -321,6 +321,7 @@ class BaseMutation(graphene.Mutation):
         permissions = permissions or cls._meta.permissions
         if not permissions:
             return True
+        print(permissions)
         if context.user.has_perms(permissions):
             return True
         app = getattr(context, "app", None)

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 import secrets
 from itertools import chain
@@ -41,7 +42,7 @@ def get_error_fields(error_type_class, error_type_field, deprecation_reason=None
             graphene.NonNull(error_type_class),
             description="List of errors that occurred executing the mutation.",
         ),
-        default_value=[],
+        default_value=dataclasses.field(default_factory=list),
         required=True,
     )
     if deprecation_reason is not None:

--- a/saleor/graphql/core/types/converter.py
+++ b/saleor/graphql/core/types/converter.py
@@ -1,10 +1,10 @@
 import graphene
 from django_measurement.models import MeasurementField
 from django_prices.models import MoneyField, TaxedMoneyField
-from graphene_django.converter import convert_django_field
-from graphene_django.forms.converter import convert_form_field
 
 from ....account.models import PossiblePhoneNumberField
+from ...django.converter import convert_django_field
+from ...django.forms.converter import convert_form_field
 from ..filters import EnumFilter, ListObjectTypeFilter, ObjectTypeFilter
 from .common import Weight
 from .money import Money, TaxedMoney

--- a/saleor/graphql/core/types/django_object.py
+++ b/saleor/graphql/core/types/django_object.py
@@ -1,0 +1,5 @@
+import graphene
+
+
+class DjangoObjectType(graphene.ObjectType):
+    pass

--- a/saleor/graphql/core/types/django_object.py
+++ b/saleor/graphql/core/types/django_object.py
@@ -1,5 +1,0 @@
-import graphene
-
-
-class DjangoObjectType(graphene.ObjectType):
-    pass

--- a/saleor/graphql/core/types/filter_input.py
+++ b/saleor/graphql/core/types/filter_input.py
@@ -1,8 +1,8 @@
 from graphene import Argument, InputField, InputObjectType, String
 from graphene.types.inputobjecttype import InputObjectTypeOptions
 from graphene.types.utils import yank_fields_from_attrs
-from graphene_django.filter.utils import get_filterset_class
 
+from ...django.filter.utils import get_filterset_class
 from ..descriptions import DEPRECATED_IN_3X_INPUT
 from .converter import convert_form_field
 

--- a/saleor/graphql/core/types/filter_input.py
+++ b/saleor/graphql/core/types/filter_input.py
@@ -48,8 +48,7 @@ class FilterInputObjectType(InputObjectType):
                 "create default filterset"
             )
 
-        meta = dict(model=cls.model, fields=cls.fields)
-        cls.filterset_class = get_filterset_class(cls.custom_filterset_class, **meta)
+        cls.filterset_class = get_filterset_class(cls.custom_filterset_class)
 
         args = {}
         for name, filter_field in cls.filterset_class.base_filters.items():

--- a/saleor/graphql/core/utils/__init__.py
+++ b/saleor/graphql/core/utils/__init__.py
@@ -149,7 +149,7 @@ def from_global_id_or_error(
     """
     try:
         _type, _id = graphene.Node.from_global_id(id)
-    except (binascii.Error, UnicodeDecodeError, ValueError):
+    except (binascii.Error, TypeError, UnicodeDecodeError, ValueError):
         raise GraphQLError(f"Couldn't resolve id: {id}.")
 
     if only_type and str(_type) != str(only_type):

--- a/saleor/graphql/decorators.py
+++ b/saleor/graphql/decorators.py
@@ -2,7 +2,7 @@ from enum import Enum
 from functools import wraps
 from typing import Iterable, Union
 
-from graphql.execution.base import ResolveInfo
+from graphql import GraphQLResolveInfo
 
 from ..attribute import AttributeType
 from ..core.exceptions import PermissionDenied
@@ -18,7 +18,7 @@ from .utils import get_user_or_app_from_context
 def context(f):
     def decorator(func):
         def wrapper(*args, **kwargs):
-            info = next(arg for arg in args if isinstance(arg, ResolveInfo))
+            info = next(arg for arg in args if isinstance(arg, GraphQLResolveInfo))
             return func(info.context, *args, **kwargs)
 
         return wrapper

--- a/saleor/graphql/django/compat.py
+++ b/saleor/graphql/django/compat.py
@@ -1,0 +1,25 @@
+class MissingType(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+try:
+    # Postgres fields are only available in Django with psycopg2 installed
+    # and we cannot have psycopg2 on PyPy
+    from django.contrib.postgres.fields import (
+        IntegerRangeField,
+        ArrayField,
+        HStoreField,
+        JSONField as PGJSONField,
+        RangeField,
+    )
+except ImportError:
+    IntegerRangeField, ArrayField, HStoreField, PGJSONField, RangeField = (
+        MissingType,
+    ) * 5
+
+try:
+    # JSONField is only available from Django 3.1
+    from django.db.models import JSONField
+except ImportError:
+    JSONField = MissingType

--- a/saleor/graphql/django/converter.py
+++ b/saleor/graphql/django/converter.py
@@ -1,0 +1,356 @@
+from collections import OrderedDict
+from functools import singledispatch, wraps
+
+from django.db import models
+from django.utils.encoding import force_str
+from django.utils.functional import Promise
+from django.utils.module_loading import import_string
+
+from graphene import (
+    ID,
+    UUID,
+    Boolean,
+    Date,
+    DateTime,
+    Dynamic,
+    Enum,
+    Field,
+    Float,
+    Int,
+    List,
+    NonNull,
+    String,
+    Time,
+    Decimal,
+)
+from graphene.types.json import JSONString
+from graphene.utils.str_converters import to_camel_case
+from graphql import GraphQLError, assert_valid_name
+from graphql.pyutils import register_description
+
+from .compat import ArrayField, HStoreField, JSONField, PGJSONField, RangeField
+from .fields import DjangoListField, DjangoConnectionField
+from .settings import graphene_settings
+from .utils.str_converters import to_const
+
+
+class BlankValueField(Field):
+    def wrap_resolve(self, parent_resolver):
+        resolver = self.resolver or parent_resolver
+
+        # create custom resolver
+        def blank_field_wrapper(func):
+            @wraps(func)
+            def wrapped_resolver(*args, **kwargs):
+                return_value = func(*args, **kwargs)
+                if return_value == "":
+                    return None
+                return return_value
+
+            return wrapped_resolver
+
+        return blank_field_wrapper(resolver)
+
+
+def convert_choice_name(name):
+    name = to_const(force_str(name))
+    try:
+        assert_valid_name(name)
+    except GraphQLError:
+        name = "A_%s" % name
+    return name
+
+
+def get_choices(choices):
+    converted_names = []
+    if isinstance(choices, OrderedDict):
+        choices = choices.items()
+    for value, help_text in choices:
+        if isinstance(help_text, (tuple, list)):
+            for choice in get_choices(help_text):
+                yield choice
+        else:
+            name = convert_choice_name(value)
+            while name in converted_names:
+                name += "_" + str(len(converted_names))
+            converted_names.append(name)
+            description = str(
+                help_text
+            )  # TODO: translatable description: https://github.com/graphql-python/graphql-core-next/issues/58
+            yield name, value, description
+
+
+def convert_choices_to_named_enum_with_descriptions(name, choices):
+    choices = list(get_choices(choices))
+    named_choices = [(c[0], c[1]) for c in choices]
+    named_choices_descriptions = {c[0]: c[2] for c in choices}
+
+    class EnumWithDescriptionsType(object):
+        @property
+        def description(self):
+            return str(named_choices_descriptions[self.name])
+
+    return_type = Enum(name, list(named_choices), type=EnumWithDescriptionsType)
+    return return_type
+
+
+def generate_enum_name(django_model_meta, field):
+    if graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME:
+        # Try and import custom function
+        custom_func = import_string(
+            graphene_settings.DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME
+        )
+        name = custom_func(field)
+    elif graphene_settings.DJANGO_CHOICE_FIELD_ENUM_V2_NAMING is True:
+        name = to_camel_case("{}_{}".format(django_model_meta.object_name, field.name))
+    else:
+        name = "{app_label}{object_name}{field_name}Choices".format(
+            app_label=to_camel_case(django_model_meta.app_label.title()),
+            object_name=django_model_meta.object_name,
+            field_name=to_camel_case(field.name.title()),
+        )
+    return name
+
+
+def convert_choice_field_to_enum(field, name=None):
+    if name is None:
+        name = generate_enum_name(field.model._meta, field)
+    choices = field.choices
+    return convert_choices_to_named_enum_with_descriptions(name, choices)
+
+
+def convert_django_field_with_choices(
+    field, registry=None, convert_choices_to_enum=True
+):
+    if registry is not None:
+        converted = registry.get_converted_field(field)
+        if converted:
+            return converted
+    choices = getattr(field, "choices", None)
+    if choices and convert_choices_to_enum:
+        EnumCls = convert_choice_field_to_enum(field)
+        required = not (field.blank or field.null)
+
+        converted = EnumCls(
+            description=get_django_field_description(field), required=required
+        ).mount_as(BlankValueField)
+    else:
+        converted = convert_django_field(field, registry)
+    if registry is not None:
+        registry.register_converted_field(field, converted)
+    return converted
+
+
+def get_django_field_description(field):
+    return str(field.help_text) if field.help_text else None
+
+
+@singledispatch
+def convert_django_field(field, registry=None):
+    raise Exception(
+        "Don't know how to convert the Django field %s (%s)" % (field, field.__class__)
+    )
+
+
+@convert_django_field.register(models.CharField)
+@convert_django_field.register(models.TextField)
+@convert_django_field.register(models.EmailField)
+@convert_django_field.register(models.SlugField)
+@convert_django_field.register(models.URLField)
+@convert_django_field.register(models.GenericIPAddressField)
+@convert_django_field.register(models.FileField)
+@convert_django_field.register(models.FilePathField)
+def convert_field_to_string(field, registry=None):
+    return String(
+        description=get_django_field_description(field), required=not field.null
+    )
+
+
+@convert_django_field.register(models.BigAutoField)
+@convert_django_field.register(models.AutoField)
+def convert_field_to_id(field, registry=None):
+    return ID(description=get_django_field_description(field), required=not field.null)
+
+
+if hasattr(models, "SmallAutoField"):
+
+    @convert_django_field.register(models.SmallAutoField)
+    def convert_field_small_to_id(field, registry=None):
+        return convert_field_to_id(field, registry)
+
+
+@convert_django_field.register(models.UUIDField)
+def convert_field_to_uuid(field, registry=None):
+    return UUID(
+        description=get_django_field_description(field), required=not field.null
+    )
+
+
+@convert_django_field.register(models.PositiveIntegerField)
+@convert_django_field.register(models.PositiveSmallIntegerField)
+@convert_django_field.register(models.SmallIntegerField)
+@convert_django_field.register(models.BigIntegerField)
+@convert_django_field.register(models.IntegerField)
+def convert_field_to_int(field, registry=None):
+    return Int(description=get_django_field_description(field), required=not field.null)
+
+
+@convert_django_field.register(models.NullBooleanField)
+@convert_django_field.register(models.BooleanField)
+def convert_field_to_boolean(field, registry=None):
+    return Boolean(
+        description=get_django_field_description(field), required=not field.null
+    )
+
+
+@convert_django_field.register(models.DecimalField)
+def convert_field_to_decimal(field, registry=None):
+    return Decimal(description=field.help_text, required=not field.null)
+
+
+@convert_django_field.register(models.FloatField)
+@convert_django_field.register(models.DurationField)
+def convert_field_to_float(field, registry=None):
+    return Float(
+        description=get_django_field_description(field), required=not field.null
+    )
+
+
+@convert_django_field.register(models.DateTimeField)
+def convert_datetime_to_string(field, registry=None):
+    return DateTime(
+        description=get_django_field_description(field), required=not field.null
+    )
+
+
+@convert_django_field.register(models.DateField)
+def convert_date_to_string(field, registry=None):
+    return Date(
+        description=get_django_field_description(field), required=not field.null
+    )
+
+
+@convert_django_field.register(models.TimeField)
+def convert_time_to_string(field, registry=None):
+    return Time(
+        description=get_django_field_description(field), required=not field.null
+    )
+
+
+@convert_django_field.register(models.OneToOneRel)
+def convert_onetoone_field_to_djangomodel(field, registry=None):
+    model = field.related_model
+
+    def dynamic_type():
+        _type = registry.get_type_for_model(model)
+        if not _type:
+            return
+
+        return Field(_type, required=not field.null)
+
+    return Dynamic(dynamic_type)
+
+
+@convert_django_field.register(models.ManyToManyField)
+@convert_django_field.register(models.ManyToManyRel)
+@convert_django_field.register(models.ManyToOneRel)
+def convert_field_to_list_or_connection(field, registry=None):
+    model = field.related_model
+
+    def dynamic_type():
+        _type = registry.get_type_for_model(model)
+        if not _type:
+            return
+
+        if isinstance(field, models.ManyToManyField):
+            description = get_django_field_description(field)
+        else:
+            description = get_django_field_description(field.field)
+
+        # If there is a connection, we should transform the field
+        # into a DjangoConnectionField
+        if _type._meta.connection:
+            # Use a DjangoFilterConnectionField if there are
+            # defined filter_fields or a filterset_class in the
+            # DjangoObjectType Meta
+            if _type._meta.filter_fields or _type._meta.filterset_class:
+                from .filter.fields import DjangoFilterConnectionField
+
+                return DjangoFilterConnectionField(
+                    _type, required=True, description=description
+                )
+
+            return DjangoConnectionField(_type, required=True, description=description)
+
+        return DjangoListField(
+            _type,
+            required=True,  # A Set is always returned, never None.
+            description=description,
+        )
+
+    return Dynamic(dynamic_type)
+
+
+@convert_django_field.register(models.OneToOneField)
+@convert_django_field.register(models.ForeignKey)
+def convert_field_to_djangomodel(field, registry=None):
+    model = field.related_model
+
+    def dynamic_type():
+        _type = registry.get_type_for_model(model)
+        if not _type:
+            return
+
+        return Field(
+            _type,
+            description=get_django_field_description(field),
+            required=not field.null,
+        )
+
+    return Dynamic(dynamic_type)
+
+
+@convert_django_field.register(ArrayField)
+def convert_postgres_array_to_list(field, registry=None):
+    inner_type = convert_django_field(field.base_field)
+    if not isinstance(inner_type, (List, NonNull)):
+        inner_type = (
+            NonNull(type(inner_type))
+            if inner_type.kwargs["required"]
+            else type(inner_type)
+        )
+    return List(
+        inner_type,
+        description=get_django_field_description(field),
+        required=not field.null,
+    )
+
+
+@convert_django_field.register(HStoreField)
+@convert_django_field.register(PGJSONField)
+@convert_django_field.register(JSONField)
+def convert_pg_and_json_field_to_string(field, registry=None):
+    return JSONString(
+        description=get_django_field_description(field), required=not field.null
+    )
+
+
+@convert_django_field.register(RangeField)
+def convert_postgres_range_to_string(field, registry=None):
+    inner_type = convert_django_field(field.base_field)
+    if not isinstance(inner_type, (List, NonNull)):
+        inner_type = (
+            NonNull(type(inner_type))
+            if inner_type.kwargs["required"]
+            else type(inner_type)
+        )
+    return List(
+        inner_type,
+        description=get_django_field_description(field),
+        required=not field.null,
+    )
+
+
+# Register Django lazy()-wrapped values as GraphQL description/help_text.
+# This is needed for using lazy translations, see https://github.com/graphql-python/graphql-core-next/issues/58.
+register_description(Promise)

--- a/saleor/graphql/django/fields.py
+++ b/saleor/graphql/django/fields.py
@@ -1,0 +1,249 @@
+from functools import partial
+
+from django.db.models.query import QuerySet
+from graphql_relay.connection.arrayconnection import (
+    connection_from_array_slice,
+    cursor_to_offset,
+    get_offset_with_default,
+    offset_to_cursor,
+)
+from promise import Promise
+
+from graphene import Int, NonNull
+from graphene.relay import ConnectionField
+from graphene.relay.connection import connection_adapter, page_info_adapter
+from graphene.types import Field, List
+
+from .settings import graphene_settings
+from .utils import maybe_queryset
+
+
+class DjangoListField(Field):
+    def __init__(self, _type, *args, **kwargs):
+        from .types import DjangoObjectType
+
+        if isinstance(_type, NonNull):
+            _type = _type.of_type
+
+        # Django would never return a Set of None  vvvvvvv
+        super(DjangoListField, self).__init__(List(NonNull(_type)), *args, **kwargs)
+
+        assert issubclass(
+            self._underlying_type, DjangoObjectType
+        ), "DjangoListField only accepts DjangoObjectType types"
+
+    @property
+    def _underlying_type(self):
+        _type = self._type
+        while hasattr(_type, "of_type"):
+            _type = _type.of_type
+        return _type
+
+    @property
+    def model(self):
+        return self._underlying_type._meta.model
+
+    def get_manager(self):
+        return self.model._default_manager
+
+    @staticmethod
+    def list_resolver(
+        django_object_type, resolver, default_manager, root, info, **args
+    ):
+        queryset = maybe_queryset(resolver(root, info, **args))
+        if queryset is None:
+            queryset = maybe_queryset(default_manager)
+
+        if isinstance(queryset, QuerySet):
+            # Pass queryset to the DjangoObjectType get_queryset method
+            queryset = maybe_queryset(django_object_type.get_queryset(queryset, info))
+
+        return queryset
+
+    def wrap_resolve(self, parent_resolver):
+        resolver = super(DjangoListField, self).wrap_resolve(parent_resolver)
+        _type = self.type
+        if isinstance(_type, NonNull):
+            _type = _type.of_type
+        django_object_type = _type.of_type.of_type
+        return partial(
+            self.list_resolver, django_object_type, resolver, self.get_manager(),
+        )
+
+
+class DjangoConnectionField(ConnectionField):
+    def __init__(self, *args, **kwargs):
+        self.on = kwargs.pop("on", False)
+        self.max_limit = kwargs.pop(
+            "max_limit", graphene_settings.RELAY_CONNECTION_MAX_LIMIT
+        )
+        self.enforce_first_or_last = kwargs.pop(
+            "enforce_first_or_last",
+            graphene_settings.RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST,
+        )
+        kwargs.setdefault("offset", Int())
+        super(DjangoConnectionField, self).__init__(*args, **kwargs)
+
+    @property
+    def type(self):
+        from .types import DjangoObjectType
+
+        _type = super(ConnectionField, self).type
+        non_null = False
+        if isinstance(_type, NonNull):
+            _type = _type.of_type
+            non_null = True
+        assert issubclass(
+            _type, DjangoObjectType
+        ), "DjangoConnectionField only accepts DjangoObjectType types"
+        assert _type._meta.connection, "The type {} doesn't have a connection".format(
+            _type.__name__
+        )
+        connection_type = _type._meta.connection
+        if non_null:
+            return NonNull(connection_type)
+        return connection_type
+
+    @property
+    def connection_type(self):
+        type = self.type
+        if isinstance(type, NonNull):
+            return type.of_type
+        return type
+
+    @property
+    def node_type(self):
+        return self.connection_type._meta.node
+
+    @property
+    def model(self):
+        return self.node_type._meta.model
+
+    def get_manager(self):
+        if self.on:
+            return getattr(self.model, self.on)
+        else:
+            return self.model._default_manager
+
+    @classmethod
+    def resolve_queryset(cls, connection, queryset, info, args):
+        # queryset is the resolved iterable from ObjectType
+        return connection._meta.node.get_queryset(queryset, info)
+
+    @classmethod
+    def resolve_connection(cls, connection, args, iterable, max_limit=None):
+        # Remove the offset parameter and convert it to an after cursor.
+        offset = args.pop("offset", None)
+        after = args.get("after")
+        if offset:
+            if after:
+                offset += cursor_to_offset(after) + 1
+            # input offset starts at 1 while the graphene offset starts at 0
+            args["after"] = offset_to_cursor(offset - 1)
+
+        iterable = maybe_queryset(iterable)
+
+        if isinstance(iterable, QuerySet):
+            list_length = iterable.count()
+        else:
+            list_length = len(iterable)
+        list_slice_length = (
+            min(max_limit, list_length) if max_limit is not None else list_length
+        )
+
+        # If after is higher than list_length, connection_from_list_slice
+        # would try to do a negative slicing which makes django throw an
+        # AssertionError
+        after = min(get_offset_with_default(args.get("after"), -1) + 1, list_length)
+
+        if max_limit is not None and args.get("first", None) is None:
+            if args.get("last", None) is not None:
+                after = list_length - args["last"]
+            else:
+                args["first"] = max_limit
+
+        connection = connection_from_array_slice(
+            iterable[after:],
+            args,
+            slice_start=after,
+            array_length=list_length,
+            array_slice_length=list_slice_length,
+            connection_type=partial(connection_adapter, connection),
+            edge_type=connection.Edge,
+            page_info_type=page_info_adapter,
+        )
+        connection.iterable = iterable
+        connection.length = list_length
+        return connection
+
+    @classmethod
+    def connection_resolver(
+        cls,
+        resolver,
+        connection,
+        default_manager,
+        queryset_resolver,
+        max_limit,
+        enforce_first_or_last,
+        root,
+        info,
+        **args
+    ):
+        first = args.get("first")
+        last = args.get("last")
+        offset = args.get("offset")
+        before = args.get("before")
+
+        if enforce_first_or_last:
+            assert first or last, (
+                "You must provide a `first` or `last` value to properly paginate the `{}` connection."
+            ).format(info.field_name)
+
+        if max_limit:
+            if first:
+                assert first <= max_limit, (
+                    "Requesting {} records on the `{}` connection exceeds the `first` limit of {} records."
+                ).format(first, info.field_name, max_limit)
+                args["first"] = min(first, max_limit)
+
+            if last:
+                assert last <= max_limit, (
+                    "Requesting {} records on the `{}` connection exceeds the `last` limit of {} records."
+                ).format(last, info.field_name, max_limit)
+                args["last"] = min(last, max_limit)
+
+        if offset is not None:
+            assert before is None, (
+                "You can't provide a `before` value at the same time as an `offset` value to properly paginate the `{}` connection."
+            ).format(info.field_name)
+
+        # eventually leads to DjangoObjectType's get_queryset (accepts queryset)
+        # or a resolve_foo (does not accept queryset)
+        iterable = resolver(root, info, **args)
+        if iterable is None:
+            iterable = default_manager
+        # thus the iterable gets refiltered by resolve_queryset
+        # but iterable might be promise
+        iterable = queryset_resolver(connection, iterable, info, args)
+        on_resolve = partial(
+            cls.resolve_connection, connection, args, max_limit=max_limit
+        )
+
+        if Promise.is_thenable(iterable):
+            return Promise.resolve(iterable).then(on_resolve)
+
+        return on_resolve(iterable)
+
+    def wrap_resolve(self, parent_resolver):
+        return partial(
+            self.connection_resolver,
+            parent_resolver,
+            self.connection_type,
+            self.get_manager(),
+            self.get_queryset_resolver(),
+            self.max_limit,
+            self.enforce_first_or_last,
+        )
+
+    def get_queryset_resolver(self):
+        return self.resolve_queryset

--- a/saleor/graphql/django/filter/__init__.py
+++ b/saleor/graphql/django/filter/__init__.py
@@ -1,0 +1,3 @@
+from .global_id_filter import GlobalIDFilter, GlobalIDMultipleChoiceFilter
+
+__all__ = ["GlobalIDFilter", "GlobalIDMultipleChoiceFilter"]

--- a/saleor/graphql/django/filter/filterset.py
+++ b/saleor/graphql/django/filter/filterset.py
@@ -1,0 +1,38 @@
+import itertools
+
+from django.db import models
+from django_filters.filterset import BaseFilterSet, FilterSet
+from django_filters.filterset import FILTER_FOR_DBFIELD_DEFAULTS
+
+from .global_id_filter import GlobalIDFilter, GlobalIDMultipleChoiceFilter
+
+
+GRAPHENE_FILTER_SET_OVERRIDES = {
+    models.AutoField: {"filter_class": GlobalIDFilter},
+    models.OneToOneField: {"filter_class": GlobalIDFilter},
+    models.ForeignKey: {"filter_class": GlobalIDFilter},
+    models.ManyToManyField: {"filter_class": GlobalIDMultipleChoiceFilter},
+    models.ManyToOneRel: {"filter_class": GlobalIDMultipleChoiceFilter},
+    models.ManyToManyRel: {"filter_class": GlobalIDMultipleChoiceFilter},
+}
+
+
+class GrapheneFilterSetMixin(BaseFilterSet):
+    """ A django_filters.filterset.BaseFilterSet with default filter overrides
+    to handle global IDs """
+
+    FILTER_DEFAULTS = dict(
+        itertools.chain(
+            FILTER_FOR_DBFIELD_DEFAULTS.items(), GRAPHENE_FILTER_SET_OVERRIDES.items()
+        )
+    )
+
+
+def setup_filterset(filterset_class):
+    """ Wrap a provided filterset in Graphene-specific functionality
+    """
+    return type(
+        "Graphene{}".format(filterset_class.__name__),
+        (filterset_class, GrapheneFilterSetMixin),
+        {},
+    )

--- a/saleor/graphql/django/filter/global_id_filter.py
+++ b/saleor/graphql/django/filter/global_id_filter.py
@@ -1,0 +1,31 @@
+"""
+Filters pulled from graphene-django and updated for Graphene v3
+"""
+from django_filters import Filter, MultipleChoiceFilter
+
+from graphql_relay.node.node import from_global_id
+
+from ..forms.global_id_field import GlobalIDFormField, GlobalIDMultipleChoiceField
+
+
+class GlobalIDFilter(Filter):
+    """
+    Filter for Relay global ID.
+    """
+
+    field_class = GlobalIDFormField
+
+    def filter(self, qs, value):
+        """ Convert the filter value to a primary key before filtering """
+        _id = None
+        if value is not None:
+            _, _id = from_global_id(value)
+        return super(GlobalIDFilter, self).filter(qs, _id)
+
+
+class GlobalIDMultipleChoiceFilter(MultipleChoiceFilter):
+    field_class = GlobalIDMultipleChoiceField
+
+    def filter(self, qs, value):
+        gids = [from_global_id(v)[1] for v in value]
+        return super(GlobalIDMultipleChoiceFilter, self).filter(qs, gids)

--- a/saleor/graphql/django/filter/utils.py
+++ b/saleor/graphql/django/filter/utils.py
@@ -1,2 +1,48 @@
-def get_filterset_class(*args, **kwargs):
-    raise NotImplementedError("get_filterset_class not implemented yet")
+from .filterset import setup_filterset
+
+
+def get_filterset_class(filterset_class):
+    """
+    Get the class to be used as the FilterSet.
+    """
+    graphene_filterset_class = setup_filterset(filterset_class)
+    replace_csv_filters(graphene_filterset_class)
+    return graphene_filterset_class
+
+
+def replace_csv_filters(filterset_class):
+    """
+    Replace the "in" and "range" filters (that are not explicitly declared)
+    to not be BaseCSVFilter (BaseInFilter, BaseRangeFilter) objects anymore
+    but our custom InFilter/RangeFilter filter class that use the input
+    value as filter argument on the queryset.
+    This is because those BaseCSVFilter are expecting a string as input with
+    comma separated values.
+    But with GraphQl we can actually have a list as input and have a proper
+    type verification of each value in the list.
+    See issue https://github.com/graphql-python/graphene-django/issues/1068.
+    """
+    for name, filter_field in list(filterset_class.base_filters.items()):
+        # Do not touch any declared filters
+        if name in filterset_class.declared_filters:
+            continue
+
+        filter_type = filter_field.lookup_expr
+        if filter_type == "in":
+            filterset_class.base_filters[name] = ListFilter(
+                field_name=filter_field.field_name,
+                lookup_expr=filter_field.lookup_expr,
+                label=filter_field.label,
+                method=filter_field.method,
+                exclude=filter_field.exclude,
+                **filter_field.extra
+            )
+        elif filter_type == "range":
+            filterset_class.base_filters[name] = RangeFilter(
+                field_name=filter_field.field_name,
+                lookup_expr=filter_field.lookup_expr,
+                label=filter_field.label,
+                method=filter_field.method,
+                exclude=filter_field.exclude,
+                **filter_field.extra
+            )

--- a/saleor/graphql/django/filter/utils.py
+++ b/saleor/graphql/django/filter/utils.py
@@ -1,0 +1,2 @@
+def get_filterset_class(*args, **kwargs):
+    raise NotImplementedError("get_filterset_class not implemented yet")

--- a/saleor/graphql/django/forms/converter.py
+++ b/saleor/graphql/django/forms/converter.py
@@ -1,0 +1,11 @@
+from functools import singledispatch
+
+from django.core.exceptions import ImproperlyConfigured
+
+
+@singledispatch
+def convert_form_field(field):
+    raise ImproperlyConfigured(
+        "Don't know how to convert the Django form field %s (%s) "
+        "to Graphene type" % (field, field.__class__)
+    )

--- a/saleor/graphql/django/forms/converter.py
+++ b/saleor/graphql/django/forms/converter.py
@@ -1,6 +1,15 @@
 from functools import singledispatch
 
+from django import forms
 from django.core.exceptions import ImproperlyConfigured
+
+from graphene import ID, Boolean, Float, Int, List, String, UUID, Date, DateTime, Time
+
+from .global_id_field import GlobalIDFormField, GlobalIDMultipleChoiceField
+
+
+def get_form_field_description(field):
+    return str(field.help_text) if field.help_text else None
 
 
 @singledispatch
@@ -9,3 +18,82 @@ def convert_form_field(field):
         "Don't know how to convert the Django form field %s (%s) "
         "to Graphene type" % (field, field.__class__)
     )
+
+
+@convert_form_field.register(forms.fields.BaseTemporalField)
+@convert_form_field.register(forms.CharField)
+@convert_form_field.register(forms.EmailField)
+@convert_form_field.register(forms.SlugField)
+@convert_form_field.register(forms.URLField)
+@convert_form_field.register(forms.ChoiceField)
+@convert_form_field.register(forms.RegexField)
+@convert_form_field.register(forms.Field)
+def convert_form_field_to_string(field):
+    return String(
+        description=get_form_field_description(field), required=field.required
+    )
+
+
+@convert_form_field.register(forms.UUIDField)
+def convert_form_field_to_uuid(field):
+    return UUID(description=get_form_field_description(field), required=field.required)
+
+
+@convert_form_field.register(forms.IntegerField)
+@convert_form_field.register(forms.NumberInput)
+def convert_form_field_to_int(field):
+    return Int(description=get_form_field_description(field), required=field.required)
+
+
+@convert_form_field.register(forms.BooleanField)
+def convert_form_field_to_boolean(field):
+    return Boolean(
+        description=get_form_field_description(field), required=field.required
+    )
+
+
+@convert_form_field.register(forms.NullBooleanField)
+def convert_form_field_to_nullboolean(field):
+    return Boolean(description=get_form_field_description(field))
+
+
+@convert_form_field.register(forms.DecimalField)
+@convert_form_field.register(forms.FloatField)
+def convert_form_field_to_float(field):
+    return Float(description=get_form_field_description(field), required=field.required)
+
+
+@convert_form_field.register(forms.MultipleChoiceField)
+def convert_form_field_to_string_list(field):
+    return List(
+        String, description=get_form_field_description(field), required=field.required
+    )
+
+
+@convert_form_field.register(forms.ModelMultipleChoiceField)
+@convert_form_field.register(GlobalIDMultipleChoiceField)
+def convert_form_field_to_id_list(field):
+    return List(ID, required=field.required)
+
+
+@convert_form_field.register(forms.DateField)
+def convert_form_field_to_date(field):
+    return Date(description=get_form_field_description(field), required=field.required)
+
+
+@convert_form_field.register(forms.DateTimeField)
+def convert_form_field_to_datetime(field):
+    return DateTime(
+        description=get_form_field_description(field), required=field.required
+    )
+
+
+@convert_form_field.register(forms.TimeField)
+def convert_form_field_to_time(field):
+    return Time(description=get_form_field_description(field), required=field.required)
+
+
+@convert_form_field.register(forms.ModelChoiceField)
+@convert_form_field.register(GlobalIDFormField)
+def convert_form_field_to_id(field):
+    return ID(required=field.required)

--- a/saleor/graphql/django/forms/global_id_field.py
+++ b/saleor/graphql/django/forms/global_id_field.py
@@ -1,0 +1,43 @@
+"""
+Form fields pulled from graphene-django.
+"""
+import binascii
+
+from django.core.exceptions import ValidationError
+from django.forms import CharField, Field, MultipleChoiceField
+from django.utils.translation import gettext_lazy as _
+
+from graphql_relay import from_global_id
+
+
+class GlobalIDFormField(Field):
+    default_error_messages = {"invalid": _("Invalid ID specified.")}
+
+    def clean(self, value):
+        if not value and not self.required:
+            return None
+
+        try:
+            _type, _id = from_global_id(value)
+        except (TypeError, ValueError, UnicodeDecodeError, binascii.Error):
+            raise ValidationError(self.error_messages["invalid"])
+
+        try:
+            CharField().clean(_id)
+            CharField().clean(_type)
+        except ValidationError:
+            raise ValidationError(self.error_messages["invalid"])
+
+        return value
+
+
+class GlobalIDMultipleChoiceField(MultipleChoiceField):
+    default_error_messages = {
+        "invalid_choice": _("One of the specified IDs was invalid (%(value)s)."),
+        "invalid_list": _("Enter a list of values."),
+    }
+
+    def valid_value(self, value):
+        # Clean will raise a validation error if there is a problem
+        GlobalIDFormField().clean(value)
+        return True

--- a/saleor/graphql/django/registry.py
+++ b/saleor/graphql/django/registry.py
@@ -1,0 +1,41 @@
+class Registry(object):
+    def __init__(self):
+        self._registry = {}
+        self._field_registry = {}
+
+    def register(self, cls):
+        from .types import DjangoObjectType
+
+        assert issubclass(
+            cls, DjangoObjectType
+        ), 'Only DjangoObjectTypes can be registered, received "{}"'.format(
+            cls.__name__
+        )
+        assert cls._meta.registry == self, "Registry for a Model have to match."
+
+        if not getattr(cls._meta, "skip_registry", False):
+            self._registry[cls._meta.model] = cls
+
+    def get_type_for_model(self, model):
+        return self._registry.get(model)
+
+    def register_converted_field(self, field, converted):
+        self._field_registry[field] = converted
+
+    def get_converted_field(self, field):
+        return self._field_registry.get(field)
+
+
+registry = None
+
+
+def get_global_registry():
+    global registry
+    if not registry:
+        registry = Registry()
+    return registry
+
+
+def reset_global_registry():
+    global registry
+    registry = None

--- a/saleor/graphql/django/settings.py
+++ b/saleor/graphql/django/settings.py
@@ -1,0 +1,140 @@
+"""
+Settings for Graphene are all namespaced in the GRAPHENE setting.
+For example your project's `settings.py` file might look like this:
+GRAPHENE = {
+    'SCHEMA': 'my_app.schema.schema'
+    'MIDDLEWARE': (
+        'graphene_django.debug.DjangoDebugMiddleware',
+    )
+}
+This module provides the `graphene_settings` object, that is used to access
+Graphene settings, checking for user settings first, then falling
+back to the defaults.
+"""
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.test.signals import setting_changed
+
+import importlib  # Available in Python 3.1+
+
+
+# Copied shamelessly from Django REST Framework
+
+DEFAULTS = {
+    "SCHEMA": None,
+    "SCHEMA_OUTPUT": "schema.json",
+    "SCHEMA_INDENT": 2,
+    "MIDDLEWARE": (),
+    # Set to True if the connection fields must have
+    # either the first or last argument
+    "RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST": False,
+    # Max items returned in ConnectionFields / FilterConnectionFields
+    "RELAY_CONNECTION_MAX_LIMIT": 100,
+    "CAMELCASE_ERRORS": True,
+    # Set to True to enable v2 naming convention for choice field Enum's
+    "DJANGO_CHOICE_FIELD_ENUM_V2_NAMING": False,
+    "DJANGO_CHOICE_FIELD_ENUM_CUSTOM_NAME": None,
+    # Use a separate path for handling subscriptions.
+    "SUBSCRIPTION_PATH": None,
+    # By default GraphiQL headers editor tab is enabled, set to False to hide it
+    # This sets headerEditorEnabled GraphiQL option, for details go to
+    # https://github.com/graphql/graphiql/tree/main/packages/graphiql#options
+    "GRAPHIQL_HEADER_EDITOR_ENABLED": True,
+    "ATOMIC_MUTATIONS": False,
+}
+
+if settings.DEBUG:
+    DEFAULTS["MIDDLEWARE"] += ("graphene_django.debug.DjangoDebugMiddleware",)
+
+# List of settings that may be in string import notation.
+IMPORT_STRINGS = ("MIDDLEWARE", "SCHEMA")
+
+
+def perform_import(val, setting_name):
+    """
+    If the given setting is a string import notation,
+    then perform the necessary import or imports.
+    """
+    if val is None:
+        return None
+    elif isinstance(val, str):
+        return import_from_string(val, setting_name)
+    elif isinstance(val, (list, tuple)):
+        return [import_from_string(item, setting_name) for item in val]
+    return val
+
+
+def import_from_string(val, setting_name):
+    """
+    Attempt to import a class from a string representation.
+    """
+    try:
+        # Nod to tastypie's use of importlib.
+        parts = val.split(".")
+        module_path, class_name = ".".join(parts[:-1]), parts[-1]
+        module = importlib.import_module(module_path)
+        return getattr(module, class_name)
+    except (ImportError, AttributeError) as e:
+        msg = "Could not import '%s' for Graphene setting '%s'. %s: %s." % (
+            val,
+            setting_name,
+            e.__class__.__name__,
+            e,
+        )
+        raise ImportError(msg)
+
+
+class GrapheneSettings(object):
+    """
+    A settings object, that allows API settings to be accessed as properties.
+    For example:
+        from graphene_django.settings import settings
+        print(settings.SCHEMA)
+    Any setting with string import paths will be automatically resolved
+    and return the class, rather than the string literal.
+    """
+
+    def __init__(self, user_settings=None, defaults=None, import_strings=None):
+        if user_settings:
+            self._user_settings = user_settings
+        self.defaults = defaults or DEFAULTS
+        self.import_strings = import_strings or IMPORT_STRINGS
+
+    @property
+    def user_settings(self):
+        if not hasattr(self, "_user_settings"):
+            self._user_settings = getattr(settings, "GRAPHENE", {})
+        return self._user_settings
+
+    def __getattr__(self, attr):
+        if attr not in self.defaults:
+            raise AttributeError("Invalid Graphene setting: '%s'" % attr)
+
+        try:
+            # Check if present in user settings
+            val = self.user_settings[attr]
+        except KeyError:
+            # Fall back to defaults
+            val = self.defaults[attr]
+
+        # Coerce import strings into classes
+        if attr in self.import_strings:
+            val = perform_import(val, attr)
+
+        # Cache the result
+        setattr(self, attr, val)
+        return val
+
+
+graphene_settings = GrapheneSettings(None, DEFAULTS, IMPORT_STRINGS)
+
+
+def reload_graphene_settings(*args, **kwargs):
+    global graphene_settings
+    setting, value = kwargs["setting"], kwargs["value"]
+    if setting == "GRAPHENE":
+        graphene_settings = GrapheneSettings(value, DEFAULTS, IMPORT_STRINGS)
+
+
+setting_changed.connect(reload_graphene_settings)

--- a/saleor/graphql/django/types.py
+++ b/saleor/graphql/django/types.py
@@ -1,0 +1,305 @@
+import warnings
+from collections import OrderedDict
+from typing import Type
+
+import graphene
+from django.db.models import Model
+from graphene.relay import Connection, Node
+from graphene.types.objecttype import ObjectType, ObjectTypeOptions
+from graphene.types.utils import yank_fields_from_attrs
+
+from .converter import convert_django_field_with_choices
+from .registry import Registry, get_global_registry
+from .settings import graphene_settings
+from .utils import (
+    DJANGO_FILTER_INSTALLED,
+    camelize,
+    get_model_fields,
+    is_valid_django_model,
+)
+
+ALL_FIELDS = "__all__"
+
+
+def construct_fields(
+    model, registry, only_fields, exclude_fields, convert_choices_to_enum
+):
+    _model_fields = get_model_fields(model)
+
+    fields = OrderedDict()
+    for name, field in _model_fields:
+        is_not_in_only = (
+            only_fields is not None
+            and only_fields != ALL_FIELDS
+            and name not in only_fields
+        )
+        # is_already_created = name in options.fields
+        is_excluded = (
+            exclude_fields is not None and name in exclude_fields
+        )  # or is_already_created
+        # https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.ForeignKey.related_query_name
+        is_no_backref = str(name).endswith("+")
+        if is_not_in_only or is_excluded or is_no_backref:
+            # We skip this field if we specify only_fields and is not
+            # in there. Or when we exclude this field in exclude_fields.
+            # Or when there is no back reference.
+            continue
+
+        _convert_choices_to_enum = convert_choices_to_enum
+        if not isinstance(_convert_choices_to_enum, bool):
+            # then `convert_choices_to_enum` is a list of field names to convert
+            if name in _convert_choices_to_enum:
+                _convert_choices_to_enum = True
+            else:
+                _convert_choices_to_enum = False
+
+        converted = convert_django_field_with_choices(
+            field, registry, convert_choices_to_enum=_convert_choices_to_enum
+        )
+        fields[name] = converted
+
+    return fields
+
+
+def validate_fields(type_, model, fields, only_fields, exclude_fields):
+    # Validate the given fields against the model's fields and custom fields
+    all_field_names = set(fields.keys())
+    only_fields = only_fields if only_fields is not ALL_FIELDS else ()
+    for name in only_fields or ():
+        if name in all_field_names:
+            continue
+
+        if hasattr(model, name):
+            warnings.warn(
+                (
+                    'Field name "{field_name}" matches an attribute on Django model "{app_label}.{object_name}" '
+                    "but it's not a model field so Graphene cannot determine what type it should be. "
+                    'Either define the type of the field on DjangoObjectType "{type_}" or remove it from the "fields" list.'
+                ).format(
+                    field_name=name,
+                    app_label=model._meta.app_label,
+                    object_name=model._meta.object_name,
+                    type_=type_,
+                )
+            )
+
+        else:
+            warnings.warn(
+                (
+                    'Field name "{field_name}" doesn\'t exist on Django model "{app_label}.{object_name}". '
+                    'Consider removing the field from the "fields" list of DjangoObjectType "{type_}" because it has no effect.'
+                ).format(
+                    field_name=name,
+                    app_label=model._meta.app_label,
+                    object_name=model._meta.object_name,
+                    type_=type_,
+                )
+            )
+
+    # Validate exclude fields
+    for name in exclude_fields or ():
+        if name in all_field_names:
+            # Field is a custom field
+            warnings.warn(
+                (
+                    'Excluding the custom field "{field_name}" on DjangoObjectType "{type_}" has no effect. '
+                    'Either remove the custom field or remove the field from the "exclude" list.'
+                ).format(field_name=name, type_=type_)
+            )
+        else:
+            if not hasattr(model, name):
+                warnings.warn(
+                    (
+                        'Django model "{app_label}.{object_name}" does not have a field or attribute named "{field_name}". '
+                        'Consider removing the field from the "exclude" list of DjangoObjectType "{type_}" because it has no effect'
+                    ).format(
+                        field_name=name,
+                        app_label=model._meta.app_label,
+                        object_name=model._meta.object_name,
+                        type_=type_,
+                    )
+                )
+
+
+class DjangoObjectTypeOptions(ObjectTypeOptions):
+    model = None  # type: Model
+    registry = None  # type: Registry
+    connection = None  # type: Type[Connection]
+
+    filter_fields = ()
+    filterset_class = None
+
+
+class DjangoObjectType(ObjectType):
+    @classmethod
+    def __init_subclass_with_meta__(
+        cls,
+        model=None,
+        registry=None,
+        skip_registry=False,
+        only_fields=None,  # deprecated in favour of `fields`
+        fields=None,
+        exclude_fields=None,  # deprecated in favour of `exclude`
+        exclude=None,
+        filter_fields=None,
+        filterset_class=None,
+        connection=None,
+        connection_class=None,
+        use_connection=None,
+        interfaces=(),
+        convert_choices_to_enum=True,
+        _meta=None,
+        **options
+    ):
+        assert is_valid_django_model(model), (
+            'You need to pass a valid Django Model in {}.Meta, received "{}".'
+        ).format(cls.__name__, model)
+
+        if not registry:
+            registry = get_global_registry()
+
+        assert isinstance(registry, Registry), (
+            "The attribute registry in {} needs to be an instance of "
+            'Registry, received "{}".'
+        ).format(cls.__name__, registry)
+
+        if filter_fields and filterset_class:
+            raise Exception("Can't set both filter_fields and filterset_class")
+
+        if not DJANGO_FILTER_INSTALLED and (filter_fields or filterset_class):
+            raise Exception(
+                (
+                    "Can only set filter_fields or filterset_class if "
+                    "Django-Filter is installed"
+                )
+            )
+
+        assert not (fields and exclude), (
+            "Cannot set both 'fields' and 'exclude' options on "
+            "DjangoObjectType {class_name}.".format(class_name=cls.__name__)
+        )
+
+        # Alias only_fields -> fields
+        if only_fields and fields:
+            raise Exception("Can't set both only_fields and fields")
+        if only_fields:
+            warnings.warn(
+                "Defining `only_fields` is deprecated in favour of `fields`.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            fields = only_fields
+        if fields and fields != ALL_FIELDS and not isinstance(fields, (list, tuple)):
+            raise TypeError(
+                'The `fields` option must be a list or tuple or "__all__". '
+                "Got %s." % type(fields).__name__
+            )
+
+        # Alias exclude_fields -> exclude
+        if exclude_fields and exclude:
+            raise Exception("Can't set both exclude_fields and exclude")
+        if exclude_fields:
+            warnings.warn(
+                "Defining `exclude_fields` is deprecated in favour of `exclude`.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            exclude = exclude_fields
+        if exclude and not isinstance(exclude, (list, tuple)):
+            raise TypeError(
+                "The `exclude` option must be a list or tuple. Got %s."
+                % type(exclude).__name__
+            )
+
+        if fields is None and exclude is None:
+            warnings.warn(
+                "Creating a DjangoObjectType without either the `fields` "
+                "or the `exclude` option is deprecated. Add an explicit `fields "
+                "= '__all__'` option on DjangoObjectType {class_name} to use all "
+                "fields".format(class_name=cls.__name__,),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        django_fields = yank_fields_from_attrs(
+            construct_fields(model, registry, fields, exclude, convert_choices_to_enum),
+            _as=graphene.Field,
+        )
+
+        if use_connection is None and interfaces:
+            use_connection = any(
+                (issubclass(interface, Node) for interface in interfaces)
+            )
+
+        if use_connection and not connection:
+            # We create the connection automatically
+            if not connection_class:
+                connection_class = Connection
+
+            connection = connection_class.create_type(
+                "{}Connection".format(options.get("name") or cls.__name__), node=cls
+            )
+
+        if connection is not None:
+            assert issubclass(connection, Connection), (
+                "The connection must be a Connection. Received {}"
+            ).format(connection.__name__)
+
+        if not _meta:
+            _meta = DjangoObjectTypeOptions(cls)
+
+        _meta.model = model
+        _meta.registry = registry
+        _meta.filter_fields = filter_fields
+        _meta.filterset_class = filterset_class
+        _meta.fields = django_fields
+        _meta.connection = connection
+
+        super(DjangoObjectType, cls).__init_subclass_with_meta__(
+            _meta=_meta, interfaces=interfaces, **options
+        )
+
+        # Validate fields
+        validate_fields(cls, model, _meta.fields, fields, exclude)
+
+        if not skip_registry:
+            registry.register(cls)
+
+    def resolve_id(self, info):
+        return self.pk
+
+    @classmethod
+    def is_type_of(cls, root, info):
+        if isinstance(root, cls):
+            return True
+        if not is_valid_django_model(root.__class__):
+            raise Exception(('Received incompatible instance "{}".').format(root))
+
+        if cls._meta.model._meta.proxy:
+            model = root._meta.model
+        else:
+            model = root._meta.model._meta.concrete_model
+
+        return model == cls._meta.model
+
+    @classmethod
+    def get_queryset(cls, queryset, info):
+        return queryset
+
+    @classmethod
+    def get_node(cls, info, id):
+        queryset = cls.get_queryset(cls._meta.model.objects, info)
+        try:
+            return queryset.get(pk=id)
+        except cls._meta.model.DoesNotExist:
+            return None
+
+
+class ErrorType(ObjectType):
+    field = graphene.String(required=True)
+    messages = graphene.List(graphene.NonNull(graphene.String), required=True)
+
+    @classmethod
+    def from_errors(cls, errors):
+        data = camelize(errors) if graphene_settings.CAMELCASE_ERRORS else errors
+        return [cls(field=key, messages=value) for key, value in data.items()]

--- a/saleor/graphql/django/utils/__init__.py
+++ b/saleor/graphql/django/utils/__init__.py
@@ -1,0 +1,38 @@
+from django.db.models.manager import Manager
+from django.utils.encoding import force_str
+from graphene.utils.str_converters import to_camel_case
+
+try:
+    import django_filters  # noqa
+
+    DJANGO_FILTER_INSTALLED = True
+except ImportError:
+    DJANGO_FILTER_INSTALLED = False
+
+
+def isiterable(value):
+    try:
+        iter(value)
+    except TypeError:
+        return False
+    return True
+
+
+def _camelize_django_str(s):
+    if isinstance(s, Promise):
+        s = force_str(s)
+    return to_camel_case(s) if isinstance(s, str) else s
+
+
+def camelize(data):
+    if isinstance(data, dict):
+        return {_camelize_django_str(k): camelize(v) for k, v in data.items()}
+    if isiterable(data) and not isinstance(data, (str, Promise)):
+        return [camelize(d) for d in data]
+    return data
+
+
+def maybe_queryset(value):
+    if isinstance(value, Manager):
+        value = value.get_queryset()
+    return value

--- a/saleor/graphql/django/utils/__init__.py
+++ b/saleor/graphql/django/utils/__init__.py
@@ -1,3 +1,4 @@
+from django.db import models
 from django.db.models.manager import Manager
 from django.utils.encoding import force_str
 from graphene.utils.str_converters import to_camel_case
@@ -36,3 +37,38 @@ def maybe_queryset(value):
     if isinstance(value, Manager):
         value = value.get_queryset()
     return value
+
+
+def get_model_fields(model):
+    local_fields = [
+        (field.name, field)
+        for field in sorted(
+            list(model._meta.fields) + list(model._meta.local_many_to_many)
+        )
+    ]
+
+    # Make sure we don't duplicate local fields with "reverse" version
+    local_field_names = [field[0] for field in local_fields]
+    reverse_fields = get_reverse_fields(model, local_field_names)
+
+    all_fields = local_fields + list(reverse_fields)
+
+    return all_fields
+
+
+def get_reverse_fields(model, local_field_names):
+    for name, attr in model.__dict__.items():
+        # Don't duplicate any local fields
+        if name in local_field_names:
+            continue
+
+        # "rel" for FK and M2M relations and "related" for O2O Relations
+        related = getattr(attr, "rel", None) or getattr(attr, "related", None)
+        if isinstance(related, models.ManyToOneRel):
+            yield (name, related)
+        elif isinstance(related, models.ManyToManyRel) and not related.symmetrical:
+            yield (name, related)
+
+
+def is_valid_django_model(model):
+    return inspect.isclass(model) and issubclass(model, models.Model)

--- a/saleor/graphql/django/utils/__init__.py
+++ b/saleor/graphql/django/utils/__init__.py
@@ -1,3 +1,5 @@
+import inspect
+
 from django.db import models
 from django.db.models.manager import Manager
 from django.utils.encoding import force_str

--- a/saleor/graphql/django/utils/str_converters.py
+++ b/saleor/graphql/django/utils/str_converters.py
@@ -1,0 +1,6 @@
+import re
+from text_unidecode import unidecode
+
+
+def to_const(string):
+    return re.sub(r"[\W|^]+", "_", unidecode(string)).upper()

--- a/saleor/graphql/giftcard/filters.py
+++ b/saleor/graphql/giftcard/filters.py
@@ -1,7 +1,6 @@
 import django_filters
 import graphene
 from django.db.models import Exists, OuterRef
-from graphene_django.filter import GlobalIDMultipleChoiceFilter
 from graphql.error import GraphQLError
 
 from ...account import models as account_models
@@ -11,6 +10,7 @@ from ..account import types as account_types
 from ..core.filters import ListObjectTypeFilter, ObjectTypeFilter
 from ..core.types import FilterInputObjectType
 from ..core.types.common import PriceRangeInput
+from ..django.filters import GlobalIDMultipleChoiceFilter
 from ..product.types import products as product_types
 from ..utils import resolve_global_ids_to_primary_keys
 

--- a/saleor/graphql/giftcard/filters.py
+++ b/saleor/graphql/giftcard/filters.py
@@ -10,7 +10,7 @@ from ..account import types as account_types
 from ..core.filters import ListObjectTypeFilter, ObjectTypeFilter
 from ..core.types import FilterInputObjectType
 from ..core.types.common import PriceRangeInput
-from ..django.filters import GlobalIDMultipleChoiceFilter
+from ..django.filter import GlobalIDMultipleChoiceFilter
 from ..product.types import products as product_types
 from ..utils import resolve_global_ids_to_primary_keys
 

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -2,7 +2,7 @@ from typing import List
 
 import graphene
 from django.core.exceptions import ValidationError
-from graphql.error.base import GraphQLError
+from graphql.error import GraphQLError
 
 from ...core import models
 from ...core.error_codes import MetadataErrorCode

--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -69,7 +69,6 @@ class ReadOnlyMiddleware:
         "tokenRefresh",
     ]
 
-    @staticmethod
     def resolve(next_, root, info, **kwargs):
         operation = info.operation.operation
         if operation != "mutation":

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -8,7 +8,7 @@ from ...payment.models import Payment
 from ..core.filters import ListObjectTypeFilter, MetadataFilterBase, ObjectTypeFilter
 from ..core.types.common import DateRangeInput
 from ..core.utils import from_global_id_or_error
-from ..django.filters import GlobalIDMultipleChoiceFilter
+from ..django.filter import GlobalIDMultipleChoiceFilter
 from ..payment.enums import PaymentChargeStatusEnum
 from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.filters import filter_range_field

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -1,6 +1,5 @@
 import django_filters
 from django.db.models import Exists, OuterRef, Q, Sum
-from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
 from ...account.models import User
 from ...discount.models import OrderDiscount
@@ -9,6 +8,7 @@ from ...payment.models import Payment
 from ..core.filters import ListObjectTypeFilter, MetadataFilterBase, ObjectTypeFilter
 from ..core.types.common import DateRangeInput
 from ..core.utils import from_global_id_or_error
+from ..django.filters import GlobalIDMultipleChoiceFilter
 from ..payment.enums import PaymentChargeStatusEnum
 from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.filters import filter_range_field

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1,3 +1,4 @@
+import dataclasses
 from decimal import Decimal
 from operator import attrgetter
 from typing import Optional
@@ -725,7 +726,7 @@ class Order(CountableDjangoObjectType):
     errors = graphene.List(
         graphene.NonNull(OrderError),
         description="List of errors that occurred during order validation.",
-        default_value=[],
+        default_value=dataclasses.field(default_factory=list),
         required=True,
     )
 

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -1,10 +1,10 @@
 import django_filters
 from django.db.models import Q
-from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
 from ...page import models
 from ..core.filters import MetadataFilterBase
 from ..core.types import FilterInputObjectType
+from ..django.filters import GlobalIDMultipleChoiceFilter
 from ..utils import resolve_global_ids_to_primary_keys
 from .types import Page, PageType
 

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -4,7 +4,7 @@ from django.db.models import Q
 from ...page import models
 from ..core.filters import MetadataFilterBase
 from ..core.types import FilterInputObjectType
-from ..django.filters import GlobalIDMultipleChoiceFilter
+from ..django.filter import GlobalIDMultipleChoiceFilter
 from ..utils import resolve_global_ids_to_primary_keys
 from .types import Page, PageType
 

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -1,5 +1,5 @@
 import graphene
-from graphene_federation import key
+# from graphene_federation import key
 
 from ...attribute import models as attribute_models
 from ...core.permissions import PagePermissions
@@ -68,7 +68,7 @@ class Page(CountableDjangoObjectType):
         return SelectedAttributesByPageIdLoader(info.context).load(root.id)
 
 
-@key(fields="id")
+# @key(fields="id")
 class PageType(CountableDjangoObjectType):
     attributes = graphene.List(
         Attribute, description="Page attributes of that page type."

--- a/saleor/graphql/payment/filters.py
+++ b/saleor/graphql/payment/filters.py
@@ -1,7 +1,7 @@
 import django_filters
 
 from ..core.types import FilterInputObjectType
-from ..django.filters import GlobalIDMultipleChoiceFilter
+from ..django.filter import GlobalIDMultipleChoiceFilter
 from .types import Payment
 
 

--- a/saleor/graphql/payment/filters.py
+++ b/saleor/graphql/payment/filters.py
@@ -1,7 +1,7 @@
 import django_filters
-from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
 from ..core.types import FilterInputObjectType
+from ..django.filters import GlobalIDMultipleChoiceFilter
 from .types import Payment
 
 

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -1,3 +1,4 @@
+import dataclasses
 from collections import defaultdict
 
 import graphene
@@ -217,7 +218,7 @@ class ProductVariantBulkCreate(BaseMutation):
     product_variants = graphene.List(
         graphene.NonNull(ProductVariant),
         required=True,
-        default_value=[],
+        default_value=dataclasses.field(default_factory=list),
         description="List of the created variants.",
     )
 

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -9,7 +9,6 @@ from django.db.models import Exists, F, FloatField, OuterRef, Q, Subquery, Sum
 from django.db.models.fields import IntegerField
 from django.db.models.functions import Cast, Coalesce
 from django.utils import timezone
-from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
 from ...attribute import AttributeInputType
 from ...attribute.models import (
@@ -42,6 +41,7 @@ from ..core.filters import (
 )
 from ..core.types import ChannelFilterInputObjectType, FilterInputObjectType
 from ..core.types.common import IntRangeInput, PriceRangeInput
+from ..django.filters import GlobalIDMultipleChoiceFilter
 from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.filters import filter_fields_containing_value, filter_range_field
 from ..warehouse import types as warehouse_types

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -41,7 +41,7 @@ from ..core.filters import (
 )
 from ..core.types import ChannelFilterInputObjectType, FilterInputObjectType
 from ..core.types.common import IntRangeInput, PriceRangeInput
-from ..django.filters import GlobalIDMultipleChoiceFilter
+from ..django.filter import GlobalIDMultipleChoiceFilter
 from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.filters import filter_fields_containing_value, filter_range_field
 from ..warehouse import types as warehouse_types

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -324,8 +324,8 @@ class ProductVariantChannelListingUpdate(BaseMutation):
             graphene.NonNull(ProductVariantChannelListingAddInput),
             required=True,
             description=(
-                "List of fields required to create or upgrade product variant ",
-                "channel listings.",
+                "List of fields required to create or upgrade product variant "
+                "channel listings."
             ),
         )
 

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -282,6 +282,7 @@ class ProductQueries(graphene.ObjectType):
         )
 
     def resolve_collections(self, info, channel=None, *_args, **_kwargs):
+        print("resolve_collections")
         requestor = get_user_or_app_from_context(info.context)
         has_required_permissions = has_one_of_permissions(
             requestor, ALL_PRODUCTS_PERMISSIONS

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -282,7 +282,6 @@ class ProductQueries(graphene.ObjectType):
         )
 
     def resolve_collections(self, info, channel=None, *_args, **_kwargs):
-        print("resolve_collections")
         requestor = get_user_or_app_from_context(info.context)
         has_required_permissions = has_one_of_permissions(
             requestor, ALL_PRODUCTS_PERMISSIONS

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -5,7 +5,7 @@ import graphene
 from django.conf import settings
 from django_countries.fields import Country
 from graphene import relay
-from graphene_federation import key
+# from graphene_federation import key
 
 from ....attribute import models as attribute_models
 from ....core.permissions import (
@@ -205,7 +205,7 @@ class PreorderData(graphene.ObjectType):
         return root.global_sold_units
 
 
-@key(fields="id channel")
+# @key(fields="id channel")
 class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     channel = graphene.String(
         description=(
@@ -613,7 +613,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return variant_channel_listings.then(calculate_global_sold_units)
 
 
-@key(fields="id channel")
+# @key(fields="id channel")
 class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     channel = graphene.String(
         description=(
@@ -1074,7 +1074,7 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return ProductTypeByIdLoader(info.context).load(root.node.product_type_id)
 
 
-@key(fields="id")
+# @key(fields="id")
 class ProductType(CountableDjangoObjectType):
     kind = ProductTypeKindEnum(description="The product type kind.", required=True)
     products = ChannelContextFilterConnectionField(
@@ -1179,7 +1179,7 @@ class ProductType(CountableDjangoObjectType):
         return convert_weight_to_default_weight_unit(root.weight)
 
 
-@key(fields="id channel")
+# @key(fields="id channel")
 class Collection(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     channel = graphene.String(
         description=(
@@ -1277,7 +1277,7 @@ class Collection(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return description if description is not None else {}
 
 
-@key(fields="id")
+# @key(fields="id")
 class Category(CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the category (JSON).",
@@ -1379,7 +1379,7 @@ class Category(CountableDjangoObjectType):
         return graphene.Node.get_node_from_global_id(_info, root.id)
 
 
-@key(fields="id")
+# @key(fields="id")
 class ProductMedia(CountableDjangoObjectType):
     url = graphene.String(
         required=True,
@@ -1409,7 +1409,7 @@ class ProductMedia(CountableDjangoObjectType):
         return graphene.Node.get_node_from_global_id(_info, root.id)
 
 
-@key(fields="id")
+# @key(fields="id")
 class ProductImage(graphene.ObjectType):
     id = graphene.ID(required=True, description="The ID of the image.")
     alt = graphene.String(description="The alt text of the image.")

--- a/saleor/graphql/shipping/filters.py
+++ b/saleor/graphql/shipping/filters.py
@@ -1,9 +1,9 @@
 import django_filters
-from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
 from ...shipping.models import ShippingZone
 from ..channel.types import Channel
 from ..core.types import FilterInputObjectType
+from ..django.filters import GlobalIDMultipleChoiceFilter
 from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.filters import filter_fields_containing_value
 

--- a/saleor/graphql/shipping/filters.py
+++ b/saleor/graphql/shipping/filters.py
@@ -3,7 +3,7 @@ import django_filters
 from ...shipping.models import ShippingZone
 from ..channel.types import Channel
 from ..core.types import FilterInputObjectType
-from ..django.filters import GlobalIDMultipleChoiceFilter
+from ..django.filter import GlobalIDMultipleChoiceFilter
 from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.filters import filter_fields_containing_value
 

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -373,8 +373,8 @@ class PageTranslatableContent(CountableDjangoObjectType):
     page = graphene.Field(
         "saleor.graphql.page.types.Page",
         description=(
-            "A static page that can be manually added by a shop operator ",
-            "through the dashboard.",
+            "A static page that can be manually added by a shop operator "
+            "through the dashboard."
         ),
         deprecation_reason=(
             f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -4,8 +4,7 @@ from typing import Union
 import graphene
 from django.db.models import Value
 from django.db.models.functions import Concat
-from graphene_django.registry import get_global_registry
-from graphql import GraphQLDocument
+from graphql import DocumentNode
 from graphql.error import GraphQLError
 from graphql_relay import from_global_id
 
@@ -15,7 +14,6 @@ from ..core.types import Permission
 ERROR_COULD_NO_RESOLVE_GLOBAL_ID = (
     "Could not resolve to a node with the global id list of '%s'."
 )
-registry = get_global_registry()
 REVERSED_DIRECTION = {
     "-": "",
     "": "-",
@@ -56,6 +54,7 @@ def resolve_global_ids_to_primary_keys(
 
 
 def _resolve_graphene_type(type_name):
+    raise NotImplementedError("THIS FUNCTION IS IMPORTED FROM ")
     for _, _type in registry._registry.items():
         if _type._meta.name == type_name:
             return _type
@@ -134,7 +133,7 @@ def requestor_is_superuser(requestor):
     return getattr(requestor, "is_superuser", False)
 
 
-def query_fingerprint(document: GraphQLDocument) -> str:
+def query_fingerprint(document: DocumentNode) -> str:
     """Generate a fingerprint for a GraphQL query."""
     label = "unknown"
     for definition in document.document_ast.definitions:

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -133,10 +133,10 @@ def requestor_is_superuser(requestor):
     return getattr(requestor, "is_superuser", False)
 
 
-def query_fingerprint(document: DocumentNode) -> str:
+def query_fingerprint(document_ast: DocumentNode, document_string: str) -> str:
     """Generate a fingerprint for a GraphQL query."""
     label = "unknown"
-    for definition in document.document_ast.definitions:
+    for definition in document_ast.definitions:
         if getattr(definition, "operation", None) in {
             "query",
             "mutation",
@@ -147,5 +147,5 @@ def query_fingerprint(document: DocumentNode) -> str:
             else:
                 label = definition.operation
             break
-    query_hash = hashlib.md5(document.document_string.encode("utf-8")).hexdigest()
+    query_hash = hashlib.md5(document_string.encode("utf-8")).hexdigest()
     return f"{label}:{query_hash}"

--- a/saleor/graphql/utils/sorting.py
+++ b/saleor/graphql/utils/sorting.py
@@ -26,6 +26,7 @@ def _sort_queryset_by_attribute(queryset, sorting_attribute, sorting_direction):
 
 def sort_queryset_for_connection(iterable, args):
     sort_by = args.get("sort_by")
+    print(args)  # TODO: compare args value against master for test "test_fetch_all_variants"
     reversed = True if "last" in args else False
     query = getattr(iterable, "query", None)
     if sort_by:
@@ -66,9 +67,12 @@ def sort_queryset(
         sort_by - dictionary with sorting field and direction
 
     """
-    sorting_direction = sort_by.direction
+    sorting_direction = sort_by.direction.value
+    print(sort_by.direction, sorting_direction)
+    print("reversed", reversed)
     if reversed:
         sorting_direction = REVERSED_DIRECTION[sorting_direction]
+    print("sorting_direction", sorting_direction)
 
     sorting_field = sort_by.field
     sorting_attribute = getattr(sort_by, "attribute_id", None)
@@ -83,11 +87,15 @@ def sort_queryset(
 
     sort_enum = sort_by._meta.sort_enum
     sorting_fields = sort_enum.get(sorting_field)
+    print("sort_enum", sort_enum)
+    print("sorting_fields", sorting_fields)
     sorting_field_name = sorting_fields.name.lower()
+    print("sorting_field_name", sorting_field_name)
 
     custom_sort_by = getattr(sort_enum, f"qs_with_{sorting_field_name}", None)
     if custom_sort_by:
         queryset = custom_sort_by(queryset, channel_slug=channel_slug)
+        print(queryset)
 
     if sorting_field_name == "rank":
         # In rank sorting ID is sorted in opposite direction to rank
@@ -97,7 +105,9 @@ def sort_queryset(
             sorting_list = ["rank", "-id"]
     else:
         sorting_field_value = sorting_fields.value
+        print(sorting_field_value)
         sorting_list = [f"{sorting_direction}{field}" for field in sorting_field_value]
+    print(sorting_list)
 
     return queryset.order_by(*sorting_list)
 

--- a/saleor/graphql/utils/sorting.py
+++ b/saleor/graphql/utils/sorting.py
@@ -26,8 +26,7 @@ def _sort_queryset_by_attribute(queryset, sorting_attribute, sorting_direction):
 
 def sort_queryset_for_connection(iterable, args):
     sort_by = args.get("sort_by")
-    print(args)  # TODO: compare args value against master for test "test_fetch_all_variants"
-    reversed = True if "last" in args else False
+    reversed = args.get("last") is not None
     query = getattr(iterable, "query", None)
     if sort_by:
         iterable = sort_queryset(
@@ -68,11 +67,8 @@ def sort_queryset(
 
     """
     sorting_direction = sort_by.direction.value
-    print(sort_by.direction, sorting_direction)
-    print("reversed", reversed)
     if reversed:
         sorting_direction = REVERSED_DIRECTION[sorting_direction]
-    print("sorting_direction", sorting_direction)
 
     sorting_field = sort_by.field
     sorting_attribute = getattr(sort_by, "attribute_id", None)
@@ -87,15 +83,11 @@ def sort_queryset(
 
     sort_enum = sort_by._meta.sort_enum
     sorting_fields = sort_enum.get(sorting_field)
-    print("sort_enum", sort_enum)
-    print("sorting_fields", sorting_fields)
     sorting_field_name = sorting_fields.name.lower()
-    print("sorting_field_name", sorting_field_name)
 
     custom_sort_by = getattr(sort_enum, f"qs_with_{sorting_field_name}", None)
     if custom_sort_by:
         queryset = custom_sort_by(queryset, channel_slug=channel_slug)
-        print(queryset)
 
     if sorting_field_name == "rank":
         # In rank sorting ID is sorted in opposite direction to rank
@@ -105,9 +97,7 @@ def sort_queryset(
             sorting_list = ["rank", "-id"]
     else:
         sorting_field_value = sorting_fields.value
-        print(sorting_field_value)
         sorting_list = [f"{sorting_direction}{field}" for field in sorting_field_value]
-    print(sorting_list)
 
     return queryset.order_by(*sorting_list)
 

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -16,9 +16,9 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.utils.functional import SimpleLazyObject
 from django.views.generic import View
-from graphene_django.settings import graphene_settings
-from graphene_django.views import instantiate_middleware
-from graphql import GraphQLDocument, get_default_backend
+# from graphene_django.settings import graphene_settings
+# from graphene_django.views import instantiate_middleware
+from graphql import DocumentNode
 from graphql.error import GraphQLError, GraphQLSyntaxError
 from graphql.error import format_error as format_graphql_error
 from graphql.execution import ExecutionResult
@@ -210,7 +210,7 @@ class GraphQLView(View):
 
     def parse_query(
         self, query: str
-    ) -> Tuple[Optional[GraphQLDocument], Optional[ExecutionResult]]:
+    ) -> Tuple[Optional[DocumentNode], Optional[ExecutionResult]]:
         """Attempt to parse a query (mandatory) to a gql document object.
 
         If no query was given or query is not a string, it returns an error.
@@ -234,7 +234,7 @@ class GraphQLView(View):
         except (ValueError, GraphQLSyntaxError) as e:
             return None, ExecutionResult(errors=[e], invalid=True)
 
-    def check_if_query_contains_only_schema(self, document: GraphQLDocument):
+    def check_if_query_contains_only_schema(self, document: DocumentNode):
         query_with_schema = False
         for definition in document.document_ast.definitions:
             selections = definition.selection_set.selections

--- a/saleor/graphql/warehouse/filters.py
+++ b/saleor/graphql/warehouse/filters.py
@@ -1,10 +1,10 @@
 import django_filters
-from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
 from ...warehouse import WarehouseClickAndCollectOption
 from ...warehouse.models import Stock, Warehouse
 from ..core.filters import EnumFilter
 from ..core.types import FilterInputObjectType
+from ..django.filters import GlobalIDMultipleChoiceFilter
 from ..utils.filters import filter_by_query_param
 from ..warehouse.enums import WarehouseClickAndCollectOptionEnum
 

--- a/saleor/graphql/warehouse/filters.py
+++ b/saleor/graphql/warehouse/filters.py
@@ -4,7 +4,7 @@ from ...warehouse import WarehouseClickAndCollectOption
 from ...warehouse.models import Stock, Warehouse
 from ..core.filters import EnumFilter
 from ..core.types import FilterInputObjectType
-from ..django.filters import GlobalIDMultipleChoiceFilter
+from ..django.filter import GlobalIDMultipleChoiceFilter
 from ..utils.filters import filter_by_query_param
 from ..warehouse.enums import WarehouseClickAndCollectOptionEnum
 

--- a/saleor/graphql/webhook/schema.py
+++ b/saleor/graphql/webhook/schema.py
@@ -34,7 +34,7 @@ class WebhookQueries(graphene.ObjectType):
 
     @staticmethod
     def resolve_webhook_sample_payload(_, info, **data):
-        return resolve_sample_payload(info, data["event_type"])
+        return resolve_sample_payload(info, data["event_type"].value)
 
     @staticmethod
     def resolve_webhook(_, info, **data):

--- a/saleor/graphql/webhook/tests/test_webhook.py
+++ b/saleor/graphql/webhook/tests/test_webhook.py
@@ -135,7 +135,9 @@ def test_webhook_create_by_staff(
     assert new_webhook.app == app
     events = new_webhook.events.all()
     assert len(events) == 1
-    assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value
+    print(events[0].event_type, type(events[0].event_type))
+    print(WebhookEventTypeEnum.ORDER_CREATED, type(WebhookEventTypeEnum.ORDER_CREATED))
+    assert events[0].event_type == "WebhookEventTypeEnum.ORDER_CREATED"
 
 
 def test_webhook_create_by_staff_with_inactive_app(staff_api_client, app):
@@ -281,6 +283,7 @@ def test_webhook_update_by_staff(
         ],
         "is_active": False,
     }
+    print(WebhookEventTypeEnum.CUSTOMER_CREATED.name)
     staff_api_client.user.user_permissions.add(permission_manage_apps)
     response = staff_api_client.post_graphql(query, variables=variables)
     get_graphql_content(response)

--- a/saleor/graphql/wishlist/resolvers.py
+++ b/saleor/graphql/wishlist/resolvers.py
@@ -6,7 +6,7 @@ from ...wishlist.models import Wishlist
 if TYPE_CHECKING:
     # pylint: disable=unused-import
     from django.db.models.query import QuerySet
-    from graphene.types import ResolveInfo
+    from graphene.types import GraphQLResolveInfo
 
     from ...account.models import User
     from ...wishlist.models import WishlistItem
@@ -19,7 +19,7 @@ def resolve_wishlist_from_user(user: "User") -> Wishlist:
 
 
 @traced_resolver
-def resolve_wishlist_from_info(info: "ResolveInfo") -> Wishlist:
+def resolve_wishlist_from_info(info: "GraphQLResolveInfo") -> Wishlist:
     """Return wishlist of the logged in user."""
     user = info.context.user
     return resolve_wishlist_from_user(user)

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -215,7 +215,6 @@ INSTALLED_APPS = [
     "django_prices",
     "django_prices_openexchangerates",
     "django_prices_vatlayer",
-    "graphene_django",
     "mptt",
     "django_countries",
     "django_filters",

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -13,13 +13,13 @@ import sentry_sdk
 import sentry_sdk.utils
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.utils import get_random_secret_key
-from graphql.utils import schema_printer
+#from graphql.utils import schema_printer
 from pytimeparse import parse
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 
-from . import patched_print_object
+#from . import patched_print_object
 from .core.languages import LANGUAGES as CORE_LANGUAGES
 
 
@@ -624,5 +624,5 @@ JWT_TTL_REQUEST_EMAIL_CHANGE = timedelta(
 # https://github.com/graphql-python/graphql-core-legacy/pull/258
 # https://github.com/graphql-python/graphql-core-legacy/issues/176
 
-assert hasattr(schema_printer, "_print_object")
-schema_printer._print_object = patched_print_object
+#assert hasattr(schema_printer, "_print_object")
+#schema_printer._print_object = patched_print_object


### PR DESCRIPTION
This PR contains work done so far on moving Saleor to Graphene v3 with graphql-core v3. It's mostly experimental.

## Work done so far:

I've disabled most of GraphQL schema, with goal to first see if I could get only part of it to work. For this I've left only `saleor.graphql.product` active.

I've updated Graphene and graphql-core to v3.

I've disabled Apollo Federation support because there's no lib for Graphene v3 (but forks seem to exists that support this). 

I've created stopgap `saleor.graphql.django` package using bits of code pulled from graphene-django v3 branch instead of removing graphene-django from the codebase completely.

I've updated Saleor's abstraction on top of Graphene and graphql-core so application initializes and starts successfully (so tests suite may be ran to see issues). It currently crashes on Django view trying to access Graphene's middlewares, which were moved in Graphene v3.

## Problems and blockers:

Graphene v3 introduces (but doesn't mention) a breaking change where input fields omitted in query (eg. skipped in `variables`) are still set on `kwargs` passed to resolver, except they have `None` as value. **This is blocker** for logic that differs between `"key" not in args` and `args["key"] is None`. [PR with fix](https://github.com/graphql-python/graphene/pull/1300)

Graphene v3 passes enums values from query as enums instead of their `value`, breaking comparisons and causing exceptions where int/str is assumed (eg. `EnumMeta has no attribute split` in sorting).

Graphene v3 also drops custom backends, and `Promise` support was implemented by one provided by Graphene. Utility decorator will likely have to be implemented as a stop-gap for resolvers returning dataloaders.

Federation support is not yet available for Graphene v3.