### PR TITLE
Add click and collect and preorder order filters

### DIFF
--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -109,6 +109,15 @@ def filter_channels(qs, _, values):
     return qs
 
 
+def filter_is_click_and_collect(qs, _, values):
+    if values is not None:
+        lookup = Q(collection_point__isnull=False) | Q(
+            collection_point_name__isnull=False
+        )
+        qs = qs.filter(lookup) if values is True else qs.exclude(lookup)
+    return qs
+
+
 class DraftOrderFilter(MetadataFilterBase):
     customer = django_filters.CharFilter(method=filter_customer)
     created = ObjectTypeFilter(input_class=DateRangeInput, method=filter_created_range)
@@ -129,6 +138,9 @@ class OrderFilter(DraftOrderFilter):
     created = ObjectTypeFilter(input_class=DateRangeInput, method=filter_created_range)
     search = django_filters.CharFilter(method=filter_order_search)
     channels = GlobalIDMultipleChoiceFilter(method=filter_channels)
+    is_click_and_collect = django_filters.BooleanFilter(
+        method=filter_is_click_and_collect
+    )
 
     class Meta:
         model = Order

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -1,11 +1,13 @@
 import django_filters
 from django.db.models import Exists, OuterRef, Q, Sum
+from django.utils import timezone
 from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
 from ...account.models import User
 from ...discount.models import OrderDiscount
 from ...order.models import Order, OrderLine
 from ...payment.models import Payment
+from ...product.models import ProductVariant
 from ..core.filters import ListObjectTypeFilter, MetadataFilterBase, ObjectTypeFilter
 from ..core.types.common import DateRangeInput
 from ..core.utils import from_global_id_or_error
@@ -118,6 +120,23 @@ def filter_is_click_and_collect(qs, _, values):
     return qs
 
 
+def filter_is_preorder(qs, _, values):
+    if values is not None:
+        variants = ProductVariant.objects.filter(
+            Q(is_preorder=True)
+            & (
+                Q(preorder_end_date__isnull=True)
+                | Q(preorder_end_date__gte=timezone.now())
+            )
+        ).values("id")
+        lines = OrderLine.objects.filter(
+            Exists(variants.filter(id=OuterRef("variant_id")))
+        )
+        lookup = Exists(lines.filter(order_id=OuterRef("id")))
+        qs = qs.filter(lookup) if values is True else qs.exclude(lookup)
+    return qs
+
+
 class DraftOrderFilter(MetadataFilterBase):
     customer = django_filters.CharFilter(method=filter_customer)
     created = ObjectTypeFilter(input_class=DateRangeInput, method=filter_created_range)
@@ -141,6 +160,7 @@ class OrderFilter(DraftOrderFilter):
     is_click_and_collect = django_filters.BooleanFilter(
         method=filter_is_click_and_collect
     )
+    is_preorder = django_filters.BooleanFilter(method=filter_is_preorder)
 
     class Meta:
         model = Order

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4376,6 +4376,7 @@ input OrderFilterInput {
   search: String
   metadata: [MetadataFilter]
   channels: [ID]
+  isClickAndCollect: Boolean
 }
 
 type OrderFulfill {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4377,6 +4377,7 @@ input OrderFilterInput {
   metadata: [MetadataFilter]
   channels: [ID]
   isClickAndCollect: Boolean
+  isPreorder: Boolean
 }
 
 type OrderFulfill {


### PR DESCRIPTION
Add order filters:
- `isClickAndCollect`
- `isPreorder`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
