### PR TITLE
Fix refund payment when cannot create an order in Stripe

### DIFF
--- a/saleor/payment/gateways/stripe/tests/test_webhooks.py
+++ b/saleor/payment/gateways/stripe/tests/test_webhooks.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from unittest.mock import Mock, patch
 
 import pytest
+from django.core.exceptions import ValidationError
 from stripe.stripe_object import StripeObject
 
 from .....checkout.complete_checkout import complete_checkout
@@ -20,6 +21,7 @@ from ..consts import (
     WEBHOOK_SUCCESS_EVENT,
 )
 from ..webhooks import (
+    _finalize_checkout,
     handle_authorized_payment_intent,
     handle_failed_payment_intent,
     handle_processing_payment_intent,
@@ -69,6 +71,42 @@ def test_handle_successful_payment_intent_for_checkout(
     assert payment.order.checkout_token == str(checkout_with_items.token)
     transaction = payment.transactions.get(kind=TransactionKind.CAPTURE)
     assert transaction.token == payment_intent.id
+
+
+@patch("saleor.payment.gateway.refund")
+@patch("saleor.checkout.complete_checkout._get_order_data")
+def test_handle_successful_payment_intent_for_checkout_order_creation_raises(
+    order_data_mock,
+    refund_mock,
+    payment_stripe_for_checkout,
+    checkout_with_items,
+    stripe_plugin,
+    channel_USD,
+    stripe_payment_intent,
+):
+    order_data_mock.side_effect = ValidationError("Test error")
+    payment = payment_stripe_for_checkout
+    payment.to_confirm = True
+    payment.save()
+    payment.transactions.create(
+        is_success=True,
+        action_required=True,
+        kind=TransactionKind.CAPTURE,
+        amount=payment.total,
+        currency=payment.currency,
+        token="ABC",
+        gateway_response={},
+    )
+    plugin = stripe_plugin()
+
+    with pytest.raises(ValidationError):
+        handle_successful_payment_intent(
+            stripe_payment_intent, plugin.config, channel_USD.slug
+        )
+
+    payment.refresh_from_db()
+    assert not payment.order
+    assert refund_mock.called
 
 
 @patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentMethod.modify")
@@ -232,6 +270,43 @@ def test_handle_authorized_payment_intent_for_checkout(
     assert transaction.token == payment_intent.id
 
 
+@patch("saleor.checkout.complete_checkout._get_order_data")
+@patch("saleor.payment.gateway.void")
+def test_handle_authorized_payment_intent_for_checkout_order_creation_raises(
+    void_mock,
+    order_data_mock,
+    payment_stripe_for_checkout,
+    checkout_with_items,
+    stripe_plugin,
+    channel_USD,
+    stripe_payment_intent,
+):
+    order_data_mock.side_effect = ValidationError("Test error")
+    payment = payment_stripe_for_checkout
+    payment.to_confirm = True
+    payment.save()
+    payment.transactions.create(
+        is_success=True,
+        action_required=True,
+        kind=TransactionKind.ACTION_TO_CONFIRM,
+        amount=payment.total,
+        currency=payment.currency,
+        token="ABC",
+        gateway_response={},
+    )
+    plugin = stripe_plugin()
+
+    with pytest.raises(ValidationError):
+        handle_authorized_payment_intent(
+            stripe_payment_intent, plugin.config, channel_USD.slug
+        )
+
+    payment.refresh_from_db()
+
+    assert not payment.order
+    assert void_mock.called
+
+
 @patch(
     "saleor.payment.gateways.stripe.webhooks.complete_checkout", wraps=complete_checkout
 )
@@ -336,6 +411,41 @@ def test_handle_processing_payment_intent_for_checkout(
     assert payment.order.checkout_token == str(checkout_with_items.token)
     transaction = payment.transactions.get(kind=TransactionKind.PENDING)
     assert transaction.token == payment_intent.id
+
+
+@patch("saleor.checkout.complete_checkout._get_order_data")
+def test_handle_processing_payment_intent_for_checkout_order_creation_raises(
+    order_data_mock,
+    payment_stripe_for_checkout,
+    checkout_with_items,
+    stripe_plugin,
+    channel_USD,
+    stripe_payment_intent,
+):
+    order_data_mock.side_effect = ValidationError("Test error")
+    payment = payment_stripe_for_checkout
+    payment.to_confirm = True
+    payment.save()
+    payment.transactions.create(
+        is_success=True,
+        action_required=True,
+        kind=TransactionKind.ACTION_TO_CONFIRM,
+        amount=payment.total,
+        currency=payment.currency,
+        token="ABC",
+        gateway_response={},
+    )
+    plugin = stripe_plugin()
+
+    stripe_payment_intent["status"] = PROCESSING_STATUS
+    with pytest.raises(ValidationError):
+        handle_processing_payment_intent(
+            stripe_payment_intent, plugin.config, channel_USD.slug
+        )
+
+    payment.refresh_from_db()
+
+    assert not payment.order
 
 
 def test_handle_failed_payment_intent_for_checkout(
@@ -554,3 +664,63 @@ def test_handle_webhook_events(
         endpoint_secret,
         api_key=api_key,
     )
+
+
+@patch("saleor.payment.gateway.refund")
+@patch("saleor.checkout.complete_checkout._get_order_data")
+def test_finalize_checkout_not_created_order_payment_refund(
+    order_data_mock,
+    refund_mock,
+    stripe_plugin,
+    channel_USD,
+    payment_stripe_for_checkout,
+    stripe_payment_intent,
+):
+    order_data_mock.side_effect = ValidationError("Test error")
+    stripe_plugin()
+    checkout = payment_stripe_for_checkout.checkout
+
+    with pytest.raises(ValidationError):
+        _finalize_checkout(
+            checkout,
+            payment_stripe_for_checkout,
+            stripe_payment_intent,
+            TransactionKind.CAPTURE,
+            payment_stripe_for_checkout.total,
+            payment_stripe_for_checkout.currency,
+        )
+
+    payment_stripe_for_checkout.refresh_from_db()
+
+    assert not payment_stripe_for_checkout.order
+    assert refund_mock.called
+
+
+@patch("saleor.payment.gateway.void")
+@patch("saleor.checkout.complete_checkout._get_order_data")
+def test_finalize_checkout_not_created_order_payment_void(
+    order_data_mock,
+    void_mock,
+    stripe_plugin,
+    channel_USD,
+    payment_stripe_for_checkout,
+    stripe_payment_intent,
+):
+    order_data_mock.side_effect = ValidationError("Test error")
+    stripe_plugin()
+    checkout = payment_stripe_for_checkout.checkout
+
+    with pytest.raises(ValidationError):
+        _finalize_checkout(
+            checkout,
+            payment_stripe_for_checkout,
+            stripe_payment_intent,
+            TransactionKind.AUTH,
+            payment_stripe_for_checkout.total,
+            payment_stripe_for_checkout.currency,
+        )
+
+    payment_stripe_for_checkout.refresh_from_db()
+
+    assert not payment_stripe_for_checkout.order
+    assert void_mock.called

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -2,6 +2,7 @@ import logging
 from typing import List, Optional
 
 from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import ValidationError
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse
 from stripe.error import SignatureVerificationError
@@ -150,16 +151,19 @@ def _finalize_checkout(
         checkout, lines, discounts, manager  # type: ignore
     )
 
-    order, _, _ = complete_checkout(
-        manager=manager,
-        checkout_info=checkout_info,
-        lines=lines,
-        payment_data={},
-        store_source=False,
-        discounts=discounts,
-        user=checkout.user or AnonymousUser(),  # type: ignore
-        app=None,
-    )
+    try:
+        order, _, _ = complete_checkout(
+            manager=manager,
+            checkout_info=checkout_info,
+            lines=lines,
+            payment_data={},
+            store_source=False,
+            discounts=discounts,
+            user=checkout.user or AnonymousUser(),  # type: ignore
+            app=None,
+        )
+    except ValidationError:
+        return None
 
 
 def _update_payment_with_new_transaction(

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -162,7 +162,8 @@ def _finalize_checkout(
             user=checkout.user or AnonymousUser(),  # type: ignore
             app=None,
         )
-    except ValidationError:
+    except ValidationError as e:
+        logger.info("Failed to complete checkout %s.", checkout.pk, extra={"error": e})
         return None
 
 

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -279,6 +279,12 @@ def gateway_postprocess(transaction, payment):
         payment.to_confirm = False
         changed_fields.append("to_confirm")
 
+    update_payment_charge_status(payment, transaction, changed_fields)
+
+
+def update_payment_charge_status(payment, transaction, changed_fields=None):
+    changed_fields = changed_fields or []
+
     transaction_kind = transaction.kind
 
     if transaction_kind in {


### PR DESCRIPTION
Fix for zombie payments - Stripe case this time.  We have to update payment status without changing `to_confirm` flag. In case when we have processed payment we need to have payment with `FULLY_CHARGED` before order creation.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
