### PR TITLE
Fix - test deployment is not created for PRs to feature branches

### DIFF
--- a/.github/workflows/test-env-cleanup.yml
+++ b/.github/workflows/test-env-cleanup.yml
@@ -4,7 +4,7 @@ name: TEST-ENV-CLEANUP
 on:
   pull_request:
     types: [closed, unlabeled]
-    branches: ["*"]
+    branches: ["**"]
 
 jobs:
   cleanup:

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -4,7 +4,7 @@ name: TEST-ENV-DEPLOYMENT
 on:
   pull_request:
     types: [reopened, synchronize, labeled]
-    branches: ["*"]
+    branches: ["**"]
 
 jobs:
   deploy:


### PR DESCRIPTION
Right now, when PR is not to the main branch, the test deployment is not created.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
