### PR TITLE
Add dataloader invalidation for saleChannelListingUpdate mutation

### DIFF
--- a/saleor/graphql/discount/mutations.py
+++ b/saleor/graphql/discount/mutations.py
@@ -24,6 +24,7 @@ from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.scalars import PositiveDecimal
 from ..core.types.common import DiscountError
 from ..core.validators import validate_end_is_after_start, validate_price_precision
+from ..discount.dataloaders import SaleChannelListingBySaleIdLoader
 from ..product.types import Category, Collection, Product, ProductVariant
 from .enums import DiscountValueTypeEnum, VoucherTypeEnum
 from .types import Sale, Voucher
@@ -854,6 +855,10 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
             raise ValidationError(errors)
 
         cls.save(info, sale, cleaned_input)
+
+        # Invalidate dataloader for channel listings
+        SaleChannelListingBySaleIdLoader(info.context).clear(sale.id)
+
         return SaleChannelListingUpdate(
             sale=ChannelContext(node=sale, channel_slug=None)
         )


### PR DESCRIPTION
Port https://github.com/saleor/saleor/pull/8499 to 3.1.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
