### PR TITLE
Separate sync and async webhooks

### DIFF
--- a/saleor/app/models.py
+++ b/saleor/app/models.py
@@ -6,14 +6,16 @@ from oauthlib.common import generate_token
 
 from ..core.models import Job, ModelWithMetadata
 from ..core.permissions import AppPermission
-from ..webhook.event_types import WebhookEventType
+from ..webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .types import AppExtensionTarget, AppExtensionType, AppExtensionView, AppType
 
 
 class AppQueryset(models.QuerySet):
     def for_event_type(self, event_type: str):
         permissions = {}
-        required_permission = WebhookEventType.PERMISSIONS.get(event_type)
+        required_permission = WebhookEventAsyncType.PERMISSIONS.get(
+            event_type, WebhookEventSyncType.PERMISSIONS.get(event_type)
+        )
         if required_permission:
             app_label, codename = required_permission.value.split(".")
             permissions["permissions__content_type__app_label"] = app_label

--- a/saleor/app/tests/test_models.py
+++ b/saleor/app/tests/test_models.py
@@ -1,31 +1,33 @@
 from ...app.models import App
-from ...webhook.event_types import WebhookEventType
+from ...webhook.event_types import WebhookEventSyncType
 
 
 def test_qs_for_event_type(payment_app):
-    qs = App.objects.for_event_type(WebhookEventType.PAYMENT_AUTHORIZE)
+    qs = App.objects.for_event_type(WebhookEventSyncType.PAYMENT_AUTHORIZE)
     assert len(qs) == 1
     assert qs[0] == payment_app
 
 
 def test_qs_for_event_type_no_payment_permissions(payment_app):
     payment_app.permissions.first().delete()
-    qs = App.objects.for_event_type(WebhookEventType.PAYMENT_AUTHORIZE)
+    qs = App.objects.for_event_type(WebhookEventSyncType.PAYMENT_AUTHORIZE)
     assert len(qs) == 0
 
 
 def test_qs_for_event_type_inactive_app(payment_app):
     payment_app.is_active = False
     payment_app.save()
-    qs = App.objects.for_event_type(WebhookEventType.PAYMENT_AUTHORIZE)
+    qs = App.objects.for_event_type(WebhookEventSyncType.PAYMENT_AUTHORIZE)
     assert len(qs) == 0
 
 
 def test_qs_for_event_type_no_webhook_event(payment_app):
     webhook = payment_app.webhooks.first()
-    event = webhook.events.filter(event_type=WebhookEventType.PAYMENT_AUTHORIZE).first()
+    event = webhook.events.filter(
+        event_type=WebhookEventSyncType.PAYMENT_AUTHORIZE
+    ).first()
     event.delete()
-    qs = App.objects.for_event_type(WebhookEventType.PAYMENT_AUTHORIZE)
+    qs = App.objects.for_event_type(WebhookEventSyncType.PAYMENT_AUTHORIZE)
     assert len(qs) == 0
 
 
@@ -33,5 +35,5 @@ def test_qs_for_event_type_inactive_webhook(payment_app):
     webhook = payment_app.webhooks.first()
     webhook.is_active = False
     webhook.save()
-    qs = App.objects.for_event_type(WebhookEventType.PAYMENT_AUTHORIZE)
+    qs = App.objects.for_event_type(WebhookEventSyncType.PAYMENT_AUTHORIZE)
     assert len(qs) == 0

--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -13,7 +13,7 @@ from ....attribute.utils import associate_attribute_values_to_instance
 from ....page.error_codes import PageErrorCode
 from ....page.models import Page, PageType
 from ....tests.utils import dummy_editorjs
-from ....webhook.event_types import WebhookEventType
+from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.payloads import generate_page_payload
 from ...tests.utils import get_graphql_content, get_graphql_content_from_response
 
@@ -384,7 +384,7 @@ def test_page_create_trigger_page_webhook(
     expected_data = generate_page_payload(page, staff_api_client.user)
 
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PAGE_CREATED, expected_data
+        WebhookEventAsyncType.PAGE_CREATED, expected_data
     )
 
 
@@ -1253,7 +1253,7 @@ def test_page_delete_trigger_webhook(
     expected_data = generate_page_payload(page, staff_api_client.user)
 
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PAGE_DELETED, expected_data
+        WebhookEventAsyncType.PAGE_DELETED, expected_data
     )
 
 
@@ -1434,7 +1434,7 @@ def test_update_page_trigger_webhook(
     expected_data = generate_page_payload(page, staff_api_client.user)
 
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PAGE_UPDATED, expected_data
+        WebhookEventAsyncType.PAGE_UPDATED, expected_data
     )
 
 

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -46,7 +46,7 @@ from ....product.utils.availability import get_variant_availability
 from ....product.utils.costs import get_product_costs_data
 from ....tests.utils import dummy_editorjs, flush_post_commit_hooks
 from ....warehouse.models import Allocation, Stock, Warehouse
-from ....webhook.event_types import WebhookEventType
+from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.payloads import generate_product_deleted_payload
 from ...core.enums import AttributeErrorCode, ReportingPeriod
 from ...tests.utils import (
@@ -7236,7 +7236,7 @@ def test_delete_product_trigger_webhook(
     )
 
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PRODUCT_DELETED, expected_data
+        WebhookEventAsyncType.PRODUCT_DELETED, expected_data
     )
     mocked_recalculate_orders_task.assert_not_called()
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5900,7 +5900,7 @@ input PublishableChannelListingInput {
 
 type Query {
   webhook(id: ID!): Webhook
-  webhookEvents: [WebhookEvent] @deprecated(reason: "This field will be removed in Saleor 4.0.")
+  webhookEvents: [WebhookEvent] @deprecated(reason: "This field will be removed in Saleor 4.0. Use `WebhookEventTypeAsyncEnum` and `WebhookEventTypeSyncEnum` to get available event types.")
   webhookSamplePayload(eventType: WebhookSampleEventTypeEnum!): JSONString
   warehouse(id: ID!): Warehouse
   warehouses(filter: WarehouseFilterInput, sortBy: WarehouseSortingInput, before: String, after: String, first: Int, last: Int): WarehouseCountableConnection

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5900,7 +5900,7 @@ input PublishableChannelListingInput {
 
 type Query {
   webhook(id: ID!): Webhook
-  webhookEvents: [WebhookEvent]
+  webhookEvents: [WebhookEvent] @deprecated(reason: "This field will be removed in Saleor 4.0.")
   webhookSamplePayload(eventType: WebhookSampleEventTypeEnum!): JSONString
   warehouse(id: ID!): Warehouse
   warehouses(filter: WarehouseFilterInput, sortBy: WarehouseSortingInput, before: String, after: String, first: Int, last: Int): WarehouseCountableConnection
@@ -7276,8 +7276,8 @@ input WebhookCreateInput {
   name: String
   targetUrl: String
   events: [WebhookEventTypeEnum]
-  asyncEvents: [WebhookEventTypeAsync!]
-  syncEvents: [WebhookEventTypeSync!]
+  asyncEvents: [WebhookEventTypeAsyncEnum!]
+  syncEvents: [WebhookEventTypeSyncEnum!]
   app: ID
   isActive: Boolean
   secretKey: String
@@ -7309,16 +7309,16 @@ type WebhookEvent {
 }
 
 type WebhookEventAsync {
-  eventType: WebhookEventTypeAsync!
+  eventType: WebhookEventTypeAsyncEnum!
   name: String!
 }
 
 type WebhookEventSync {
-  eventType: WebhookEventTypeSync!
+  eventType: WebhookEventTypeSyncEnum!
   name: String!
 }
 
-enum WebhookEventTypeAsync {
+enum WebhookEventTypeAsyncEnum {
   ANY_EVENTS
   ORDER_CREATED
   ORDER_CONFIRMED
@@ -7404,7 +7404,7 @@ enum WebhookEventTypeEnum {
   TRANSLATION_UPDATED
 }
 
-enum WebhookEventTypeSync {
+enum WebhookEventTypeSyncEnum {
   PAYMENT_AUTHORIZE
   PAYMENT_CAPTURE
   PAYMENT_CONFIRM
@@ -7449,14 +7449,6 @@ enum WebhookSampleEventTypeEnum {
   PAGE_CREATED
   PAGE_UPDATED
   PAGE_DELETED
-  PAYMENT_AUTHORIZE
-  PAYMENT_CAPTURE
-  PAYMENT_CONFIRM
-  PAYMENT_LIST_GATEWAYS
-  PAYMENT_PROCESS
-  PAYMENT_REFUND
-  PAYMENT_VOID
-  SHIPPING_LIST_METHODS_FOR_CHECKOUT
   TRANSLATION_CREATED
   TRANSLATION_UPDATED
 }
@@ -7471,8 +7463,8 @@ input WebhookUpdateInput {
   name: String
   targetUrl: String
   events: [WebhookEventTypeEnum]
-  asyncEvents: [WebhookEventTypeAsync!]
-  syncEvents: [WebhookEventTypeSync!]
+  asyncEvents: [WebhookEventTypeAsyncEnum!]
+  syncEvents: [WebhookEventTypeSyncEnum!]
   app: ID
   isActive: Boolean
   secretKey: String

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7260,7 +7260,9 @@ type Webhook implements Node {
   isActive: Boolean!
   secretKey: String
   id: ID!
-  events: [WebhookEvent!]!
+  events: [WebhookEvent!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `asyncEvents` or `syncEvents` instead.")
+  syncEvents: [WebhookEventSync!]!
+  asyncEvents: [WebhookEventAsync!]!
   app: App!
 }
 
@@ -7274,6 +7276,8 @@ input WebhookCreateInput {
   name: String
   targetUrl: String
   events: [WebhookEventTypeEnum]
+  asyncEvents: [WebhookEventTypeAsync!]
+  syncEvents: [WebhookEventTypeSync!]
   app: ID
   isActive: Boolean
   secretKey: String
@@ -7302,6 +7306,55 @@ enum WebhookErrorCode {
 type WebhookEvent {
   eventType: WebhookEventTypeEnum!
   name: String!
+}
+
+type WebhookEventAsync {
+  eventType: WebhookEventTypeAsync!
+  name: String!
+}
+
+type WebhookEventSync {
+  eventType: WebhookEventTypeSync!
+  name: String!
+}
+
+enum WebhookEventTypeAsync {
+  ANY_EVENTS
+  ORDER_CREATED
+  ORDER_CONFIRMED
+  ORDER_FULLY_PAID
+  ORDER_UPDATED
+  ORDER_CANCELLED
+  ORDER_FULFILLED
+  DRAFT_ORDER_CREATED
+  DRAFT_ORDER_UPDATED
+  DRAFT_ORDER_DELETED
+  SALE_CREATED
+  SALE_UPDATED
+  SALE_DELETED
+  INVOICE_REQUESTED
+  INVOICE_DELETED
+  INVOICE_SENT
+  CUSTOMER_CREATED
+  CUSTOMER_UPDATED
+  PRODUCT_CREATED
+  PRODUCT_UPDATED
+  PRODUCT_DELETED
+  PRODUCT_VARIANT_CREATED
+  PRODUCT_VARIANT_UPDATED
+  PRODUCT_VARIANT_DELETED
+  PRODUCT_VARIANT_OUT_OF_STOCK
+  PRODUCT_VARIANT_BACK_IN_STOCK
+  CHECKOUT_CREATED
+  CHECKOUT_UPDATED
+  FULFILLMENT_CREATED
+  FULFILLMENT_CANCELED
+  NOTIFY_USER
+  PAGE_CREATED
+  PAGE_UPDATED
+  PAGE_DELETED
+  TRANSLATION_CREATED
+  TRANSLATION_UPDATED
 }
 
 enum WebhookEventTypeEnum {
@@ -7349,6 +7402,17 @@ enum WebhookEventTypeEnum {
   SHIPPING_LIST_METHODS_FOR_CHECKOUT
   TRANSLATION_CREATED
   TRANSLATION_UPDATED
+}
+
+enum WebhookEventTypeSync {
+  PAYMENT_AUTHORIZE
+  PAYMENT_CAPTURE
+  PAYMENT_CONFIRM
+  PAYMENT_LIST_GATEWAYS
+  PAYMENT_PROCESS
+  PAYMENT_REFUND
+  PAYMENT_VOID
+  SHIPPING_LIST_METHODS_FOR_CHECKOUT
 }
 
 enum WebhookSampleEventTypeEnum {
@@ -7407,6 +7471,8 @@ input WebhookUpdateInput {
   name: String
   targetUrl: String
   events: [WebhookEventTypeEnum]
+  asyncEvents: [WebhookEventTypeAsync!]
+  syncEvents: [WebhookEventTypeSync!]
   app: ID
   isActive: Boolean
   secretKey: String

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import Permission
 from freezegun import freeze_time
 
 from ....tests.utils import dummy_editorjs
-from ....webhook.event_types import WebhookEventType
+from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.payloads import generate_translation_payload
 from ...core.enums import LanguageCodeEnum
 from ...tests.utils import assert_no_permission, get_graphql_content
@@ -848,7 +848,7 @@ def test_product_create_translation(
     translation = product.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_CREATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_CREATED, expected_payload
     )
 
 
@@ -949,7 +949,7 @@ def test_product_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 
@@ -999,7 +999,7 @@ def test_product_variant_create_translation(
     translation = variant.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_with(
-        WebhookEventType.TRANSLATION_CREATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_CREATED, expected_payload
     )
 
 
@@ -1049,7 +1049,7 @@ def test_product_variant_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 
@@ -1097,7 +1097,7 @@ def test_collection_create_translation(
     translation = published_collection.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_CREATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_CREATED, expected_payload
     )
 
 
@@ -1185,7 +1185,7 @@ def test_collection_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 
@@ -1233,7 +1233,7 @@ def test_category_create_translation(
     translation = category.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_CREATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_CREATED, expected_payload
     )
 
 
@@ -1319,7 +1319,7 @@ def test_category_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 
@@ -1366,7 +1366,7 @@ def test_voucher_create_translation(
     translation = voucher.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_CREATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_CREATED, expected_payload
     )
 
 
@@ -1414,7 +1414,7 @@ def test_voucher_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 
@@ -1461,7 +1461,7 @@ def test_sale_create_translation(
     translation = sale.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_CREATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_CREATED, expected_payload
     )
 
 
@@ -1510,7 +1510,7 @@ def test_sale_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 
@@ -1558,7 +1558,7 @@ def test_page_create_translation(
     translation = page.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_CREATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_CREATED, expected_payload
     )
 
 
@@ -1640,7 +1640,7 @@ def test_page_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 
@@ -1689,7 +1689,7 @@ def test_attribute_create_translation(
     translation = color_attribute.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_CREATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_CREATED, expected_payload
     )
 
 
@@ -1738,7 +1738,7 @@ def test_attribute_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 
@@ -1789,7 +1789,7 @@ def test_attribute_value_create_translation(
     translation = pink_attribute_value.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_CREATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_CREATED, expected_payload
     )
 
 
@@ -1840,7 +1840,7 @@ def test_attribute_value_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 
@@ -1899,7 +1899,7 @@ def test_shipping_method_create_translation(
     translation = shipping_method.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_CREATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_CREATED, expected_payload
     )
 
 
@@ -1974,7 +1974,7 @@ def test_shipping_method_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 
@@ -2026,7 +2026,7 @@ def test_menu_item_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 
@@ -2084,7 +2084,7 @@ def test_shop_create_translation(
     translation = site_settings.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_CREATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_CREATED, expected_payload
     )
 
 
@@ -2130,7 +2130,7 @@ def test_shop_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.TRANSLATION_UPDATED, expected_payload
+        WebhookEventAsyncType.TRANSLATION_UPDATED, expected_payload
     )
 
 

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -78,6 +78,28 @@ WebhookEventTypeEnum = graphene.Enum(
     [(str_to_enum(e_type[0]), e_type[0]) for e_type in WebhookEventType.CHOICES],
     description=description,
 )
+
+WebhookEventTypeSync = graphene.Enum(
+    "WebhookEventTypeSync",
+    [
+        (str_to_enum(e_type[0]), e_type[0])
+        for e_type in WebhookEventType.CHOICES
+        if e_type[0] in WebhookEventType.SYNC_EVENTS
+    ],
+    description=description,
+)
+
+WebhookEventTypeAsync = graphene.Enum(
+    "WebhookEventTypeAsync",
+    [
+        (str_to_enum(e_type[0]), e_type[0])
+        for e_type in WebhookEventType.CHOICES
+        if not e_type[0] in WebhookEventType.SYNC_EVENTS
+    ],
+    description=description,
+)
+
+
 WebhookSampleEventTypeEnum = graphene.Enum(
     "WebhookSampleEventTypeEnum",
     [

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -1,74 +1,75 @@
 import graphene
 
-from ...webhook.event_types import WebhookEventType
+from ...webhook.deprecated_event_types import WebhookEventType
+from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..core.utils import str_to_enum
 
 
 def description(enum):
     if enum is None:
         return "Enum determining type of webhook."
-    elif enum == WebhookEventTypeEnum.CHECKOUT_CREATED:
+    elif enum == WebhookEventTypeAsyncEnum.CHECKOUT_CREATED:
         return "A new checkout is created."
-    elif enum == WebhookEventTypeEnum.CHECKOUT_UPDATED:
+    elif enum == WebhookEventTypeAsyncEnum.CHECKOUT_UPDATED:
         return (
             "A checkout is updated. "
             "It also triggers all updates related to the checkout."
         )
-    elif enum == WebhookEventTypeEnum.CUSTOMER_CREATED:
+    elif enum == WebhookEventTypeAsyncEnum.CUSTOMER_CREATED:
         return "A new customer account is created."
-    elif enum == WebhookEventTypeEnum.CUSTOMER_UPDATED:
+    elif enum == WebhookEventTypeAsyncEnum.CUSTOMER_UPDATED:
         return "A customer account is updated."
-    elif enum == WebhookEventTypeEnum.NOTIFY_USER:
+    elif enum == WebhookEventTypeAsyncEnum.NOTIFY_USER:
         return "User notification triggered."
-    elif enum == WebhookEventTypeEnum.ORDER_CREATED:
+    elif enum == WebhookEventTypeAsyncEnum.ORDER_CREATED:
         return "A new order is placed."
-    elif enum == WebhookEventTypeEnum.ORDER_CONFIRMED:
+    elif enum == WebhookEventTypeAsyncEnum.ORDER_CONFIRMED:
         return (
             "An order is confirmed (status change unconfirmed -> unfulfilled) "
             "by a staff user using the OrderConfirm mutation. "
             "It also triggers when the user completes the checkout and the shop "
             "setting `automatically_confirm_all_new_orders` is enabled."
         )
-    elif enum == WebhookEventTypeEnum.ORDER_FULLY_PAID:
+    elif enum == WebhookEventTypeAsyncEnum.ORDER_FULLY_PAID:
         return "Payment is made and an order is fully paid."
-    elif enum == WebhookEventTypeEnum.ORDER_UPDATED:
+    elif enum == WebhookEventTypeAsyncEnum.ORDER_UPDATED:
         return (
             "An order is updated; triggered for all changes related to an order; "
             "covers all other order webhooks, except for ORDER_CREATED."
         )
-    elif enum == WebhookEventTypeEnum.ORDER_CANCELLED:
+    elif enum == WebhookEventTypeAsyncEnum.ORDER_CANCELLED:
         return "An order is cancelled."
-    elif enum == WebhookEventTypeEnum.ORDER_FULFILLED:
+    elif enum == WebhookEventTypeAsyncEnum.ORDER_FULFILLED:
         return "An order is fulfilled."
-    elif enum == WebhookEventTypeEnum.FULFILLMENT_CREATED:
+    elif enum == WebhookEventTypeAsyncEnum.FULFILLMENT_CREATED:
         return "A new fulfillment is created."
-    elif enum == WebhookEventTypeEnum.FULFILLMENT_CANCELED:
+    elif enum == WebhookEventTypeAsyncEnum.FULFILLMENT_CANCELED:
         return "A fulfillment is cancelled."
-    elif enum == WebhookEventTypeEnum.PAGE_CREATED:
+    elif enum == WebhookEventTypeAsyncEnum.PAGE_CREATED:
         return "A new page is created."
-    elif enum == WebhookEventTypeEnum.PAGE_UPDATED:
+    elif enum == WebhookEventTypeAsyncEnum.PAGE_UPDATED:
         return "A page is updated."
-    elif enum == WebhookEventTypeEnum.PAGE_DELETED:
+    elif enum == WebhookEventTypeAsyncEnum.PAGE_DELETED:
         return "A page is deleted."
-    elif enum == WebhookEventTypeEnum.PRODUCT_CREATED:
+    elif enum == WebhookEventTypeAsyncEnum.PRODUCT_CREATED:
         return "A new product is created."
-    elif enum == WebhookEventTypeEnum.PRODUCT_UPDATED:
+    elif enum == WebhookEventTypeAsyncEnum.PRODUCT_UPDATED:
         return "A product is updated."
-    elif enum == WebhookEventTypeEnum.PRODUCT_DELETED:
+    elif enum == WebhookEventTypeAsyncEnum.PRODUCT_DELETED:
         return "A product is deleted."
-    elif enum == WebhookEventTypeEnum.PRODUCT_VARIANT_CREATED:
+    elif enum == WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_CREATED:
         return "A new product variant is created."
-    elif enum == WebhookEventTypeEnum.PRODUCT_VARIANT_UPDATED:
+    elif enum == WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_UPDATED:
         return "A product variant is updated."
-    elif enum == WebhookEventTypeEnum.PRODUCT_VARIANT_DELETED:
+    elif enum == WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_DELETED:
         return "A product variant is deleted."
-    elif enum == WebhookEventTypeEnum.INVOICE_REQUESTED:
+    elif enum == WebhookEventTypeAsyncEnum.INVOICE_REQUESTED:
         return "An invoice for order requested."
-    elif enum == WebhookEventTypeEnum.INVOICE_DELETED:
+    elif enum == WebhookEventTypeAsyncEnum.INVOICE_DELETED:
         return "An invoice is deleted."
-    elif enum == WebhookEventTypeEnum.INVOICE_SENT:
+    elif enum == WebhookEventTypeAsyncEnum.INVOICE_SENT:
         return "Invoice has been sent."
-    elif enum == WebhookEventTypeEnum.ANY_EVENTS:
+    elif enum == WebhookEventTypeAsyncEnum.ANY_EVENTS:
         return "All the events."
     return None
 
@@ -79,32 +80,24 @@ WebhookEventTypeEnum = graphene.Enum(
     description=description,
 )
 
-WebhookEventTypeSync = graphene.Enum(
-    "WebhookEventTypeSync",
-    [
-        (str_to_enum(e_type[0]), e_type[0])
-        for e_type in WebhookEventType.CHOICES
-        if e_type[0] in WebhookEventType.SYNC_EVENTS
-    ],
+
+WebhookEventTypeAsyncEnum = graphene.Enum(
+    "WebhookEventTypeAsyncEnum",
+    [(str_to_enum(e_type[0]), e_type[0]) for e_type in WebhookEventAsyncType.CHOICES],
     description=description,
 )
 
-WebhookEventTypeAsync = graphene.Enum(
-    "WebhookEventTypeAsync",
-    [
-        (str_to_enum(e_type[0]), e_type[0])
-        for e_type in WebhookEventType.CHOICES
-        if not e_type[0] in WebhookEventType.SYNC_EVENTS
-    ],
+WebhookEventTypeSyncEnum = graphene.Enum(
+    "WebhookEventTypeSyncEnum",
+    [(str_to_enum(e_type[0]), e_type[0]) for e_type in WebhookEventSyncType.CHOICES],
     description=description,
 )
-
 
 WebhookSampleEventTypeEnum = graphene.Enum(
     "WebhookSampleEventTypeEnum",
     [
         (str_to_enum(e_type[0]), e_type[0])
-        for e_type in WebhookEventType.CHOICES
-        if e_type[0] != WebhookEventType.ANY
+        for e_type in WebhookEventAsyncType.CHOICES
+        if e_type[0] != WebhookEventAsyncType.ANY
     ],
 )

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -74,6 +74,7 @@ def description(enum):
     return None
 
 
+# deprecated, use WebhookEventTypeAsyncEnum or WebhookEventTypeSyncEnum
 WebhookEventTypeEnum = graphene.Enum(
     "WebhookEventTypeEnum",
     [(str_to_enum(e_type[0]), e_type[0]) for e_type in WebhookEventType.CHOICES],

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -21,11 +21,11 @@ class WebhookCreateInput(graphene.InputObjectType):
         ),
     )
     async_events = graphene.List(
-        graphene.NonNull(enums.WebhookEventTypeAsync),
+        graphene.NonNull(enums.WebhookEventTypeAsyncEnum),
         description="The asynchronous events that webhook wants to subscribe.",
     )
     sync_events = graphene.List(
-        graphene.NonNull(enums.WebhookEventTypeSync),
+        graphene.NonNull(enums.WebhookEventTypeSyncEnum),
         description="The synchronous events that webhook wants to subscribe.",
     )
     app = graphene.ID(
@@ -129,12 +129,12 @@ class WebhookUpdateInput(graphene.InputObjectType):
         required=False,
     )
     async_events = graphene.List(
-        graphene.NonNull(enums.WebhookEventTypeAsync),
+        graphene.NonNull(enums.WebhookEventTypeAsyncEnum),
         description="The asynchronous events that webhook wants to subscribe.",
         required=False,
     )
     sync_events = graphene.List(
-        graphene.NonNull(enums.WebhookEventTypeSync),
+        graphene.NonNull(enums.WebhookEventTypeSyncEnum),
         description="The synchronous events that webhook wants to subscribe.",
         required=False,
     )

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -4,17 +4,29 @@ from django.core.exceptions import ValidationError
 from ...core.permissions import AppPermission
 from ...webhook import models
 from ...webhook.error_codes import WebhookErrorCode
+from ..core.descriptions import DEPRECATED_IN_3X_INPUT
 from ..core.mutations import ModelDeleteMutation, ModelMutation
 from ..core.types.common import WebhookError
-from .enums import WebhookEventTypeEnum
+from . import enums
 
 
 class WebhookCreateInput(graphene.InputObjectType):
     name = graphene.String(description="The name of the webhook.", required=False)
     target_url = graphene.String(description="The url to receive the payload.")
     events = graphene.List(
-        WebhookEventTypeEnum,
-        description=("The events that webhook wants to subscribe."),
+        enums.WebhookEventTypeEnum,
+        description=(
+            f"The events that webhook wants to subscribe. {DEPRECATED_IN_3X_INPUT} "
+            "Use `asyncEvents` or `syncEvents` instead."
+        ),
+    )
+    async_events = graphene.List(
+        graphene.NonNull(enums.WebhookEventTypeAsync),
+        description="The asynchronous events that webhook wants to subscribe.",
+    )
+    sync_events = graphene.List(
+        graphene.NonNull(enums.WebhookEventTypeSync),
+        description="The synchronous events that webhook wants to subscribe.",
     )
     app = graphene.ID(
         required=False,
@@ -27,6 +39,17 @@ class WebhookCreateInput(graphene.InputObjectType):
         description="The secret key used to create a hash signature with each payload.",
         required=False,
     )
+
+
+def clean_webhook_events(_info, _instance, data):
+    # if `events` field is not empty, use this field. Otherwise get event types
+    # from `async_events` and `sync_events`.
+    events = data.get("events", [])
+    if not events:
+        events += data.pop("async_events", [])
+        events += data.pop("sync_events", [])
+    data["events"] = events
+    return data
 
 
 class WebhookCreate(ModelMutation):
@@ -64,6 +87,7 @@ class WebhookCreate(ModelMutation):
                 "App doesn't exist or is disabled",
                 code=WebhookErrorCode.NOT_FOUND,
             )
+        clean_webhook_events(info, instance, cleaned_data)
         return cleaned_data
 
     @classmethod
@@ -97,8 +121,21 @@ class WebhookUpdateInput(graphene.InputObjectType):
         description="The url to receive the payload.", required=False
     )
     events = graphene.List(
-        WebhookEventTypeEnum,
-        description=("The events that webhook wants to subscribe."),
+        enums.WebhookEventTypeEnum,
+        description=(
+            f"The events that webhook wants to subscribe. {DEPRECATED_IN_3X_INPUT} "
+            "Use `asyncEvents` or `syncEvents` instead."
+        ),
+        required=False,
+    )
+    async_events = graphene.List(
+        graphene.NonNull(enums.WebhookEventTypeAsync),
+        description="The asynchronous events that webhook wants to subscribe.",
+        required=False,
+    )
+    sync_events = graphene.List(
+        graphene.NonNull(enums.WebhookEventTypeSync),
+        description="The synchronous events that webhook wants to subscribe.",
         required=False,
     )
     app = graphene.ID(
@@ -146,6 +183,7 @@ class WebhookUpdate(ModelMutation):
                 "App doesn't exist or is disabled",
                 code=WebhookErrorCode.NOT_FOUND,
             )
+        clean_webhook_events(info, instance, cleaned_data)
         return cleaned_data
 
     @classmethod

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -2,7 +2,8 @@ from ...core.exceptions import PermissionDenied
 from ...core.permissions import AppPermission
 from ...core.tracing import traced_resolver
 from ...webhook import models, payloads
-from ...webhook.event_types import WebhookEventType
+from ...webhook.deprecated_event_types import WebhookEventType
+from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..core.utils import from_global_id_or_error
 from .types import Webhook, WebhookEvent
 
@@ -40,7 +41,9 @@ def resolve_webhook_events():
 @traced_resolver
 def resolve_sample_payload(info, event_name):
     app = info.context.app
-    required_permission = WebhookEventType.PERMISSIONS.get(event_name)
+    required_permission = WebhookEventAsyncType.PERMISSIONS.get(
+        event_name, WebhookEventSyncType.PERMISSIONS.get(event_name)
+    )
     if required_permission:
         if app and app.has_perm(required_permission):
             return payloads.generate_sample_payload(event_name)

--- a/saleor/graphql/webhook/schema.py
+++ b/saleor/graphql/webhook/schema.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ...core.permissions import AppPermission
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..decorators import permission_required
 from .enums import WebhookSampleEventTypeEnum
 from .mutations import WebhookCreate, WebhookDelete, WebhookUpdate
@@ -17,7 +18,9 @@ class WebhookQueries(graphene.ObjectType):
         description="Look up a webhook by ID.",
     )
     webhook_events = graphene.List(
-        WebhookEvent, description="List of all available webhook events."
+        WebhookEvent,
+        description="List of all available webhook events.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD}",
     )
     webhook_sample_payload = graphene.Field(
         graphene.JSONString,

--- a/saleor/graphql/webhook/schema.py
+++ b/saleor/graphql/webhook/schema.py
@@ -20,7 +20,10 @@ class WebhookQueries(graphene.ObjectType):
     webhook_events = graphene.List(
         WebhookEvent,
         description="List of all available webhook events.",
-        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD}",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use `WebhookEventTypeAsyncEnum` and "
+            "`WebhookEventTypeSyncEnum` to get available event types."
+        ),
     )
     webhook_sample_payload = graphene.Field(
         graphene.JSONString,

--- a/saleor/graphql/webhook/tests/deprecated/test_webhook.py
+++ b/saleor/graphql/webhook/tests/deprecated/test_webhook.py
@@ -1,0 +1,255 @@
+import graphene
+
+from .....webhook.models import Webhook
+from ....tests.utils import assert_no_permission, get_graphql_content
+from ...enums import WebhookEventTypeEnum
+
+WEBHOOK_CREATE_BY_APP = """
+    mutation webhookCreate($name: String, $target_url: String,
+            $events: [WebhookEventTypeEnum]){
+      webhookCreate(input:{name: $name, targetUrl:$target_url, events:$events}){
+        errors{
+          field
+          message
+        }
+        webhook{
+          id
+        }
+      }
+    }
+"""
+
+
+def test_webhook_create_by_app(app_api_client, permission_manage_orders):
+    query = WEBHOOK_CREATE_BY_APP
+    variables = {
+        "name": "New integration",
+        "target_url": "https://www.example.com",
+        "events": [
+            WebhookEventTypeEnum.ORDER_CREATED.name,
+            WebhookEventTypeEnum.ORDER_CREATED.name,
+        ],
+    }
+    response = app_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_orders],
+        check_no_permissions=False,
+    )
+    get_graphql_content(response)
+    new_webhook = Webhook.objects.get()
+    assert new_webhook.name == "New integration"
+    assert new_webhook.target_url == "https://www.example.com"
+    events = new_webhook.events.all()
+    assert len(events) == 1
+    assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value
+
+
+def test_webhook_create_inactive_app(app_api_client, app, permission_manage_orders):
+    app.is_active = False
+    app.save()
+    query = WEBHOOK_CREATE_BY_APP
+    variables = {
+        "target_url": "https://www.example.com",
+        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "name": "",
+    }
+
+    response = app_api_client.post_graphql(
+        query, variables=variables, permissions=[permission_manage_orders]
+    )
+    assert_no_permission(response)
+
+
+def test_webhook_create_without_app(app_api_client, app):
+    app_api_client.app = None
+    app_api_client.app_token = None
+    query = WEBHOOK_CREATE_BY_APP
+    variables = {
+        "target_url": "https://www.example.com",
+        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "name": "",
+    }
+    response = app_api_client.post_graphql(query, variables=variables)
+    assert_no_permission(response)
+
+
+def test_webhook_create_app_doesnt_exist(app_api_client, app):
+    app.delete()
+
+    query = WEBHOOK_CREATE_BY_APP
+    variables = {
+        "target_url": "https://www.example.com",
+        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "name": "",
+    }
+    response = app_api_client.post_graphql(query, variables=variables)
+    assert_no_permission(response)
+
+
+WEBHOOK_CREATE_BY_STAFF = """
+    mutation webhookCreate(
+        $target_url: String, $events: [WebhookEventTypeEnum], $app: ID){
+      webhookCreate(input:{
+            targetUrl:$target_url, events:$events, app: $app}){
+        errors{
+          field
+          message
+        }
+        webhook{
+          id
+        }
+      }
+    }
+"""
+
+
+def test_webhook_create_by_staff(
+    staff_api_client,
+    app,
+    permission_manage_apps,
+    permission_manage_orders,
+):
+    query = WEBHOOK_CREATE_BY_STAFF
+    app.permissions.add(permission_manage_orders)
+    app_id = graphene.Node.to_global_id("App", app.pk)
+    variables = {
+        "target_url": "https://www.example.com",
+        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "app": app_id,
+    }
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
+    response = staff_api_client.post_graphql(query, variables=variables)
+    get_graphql_content(response)
+    new_webhook = Webhook.objects.get()
+    assert new_webhook.target_url == "https://www.example.com"
+    assert new_webhook.app == app
+    events = new_webhook.events.all()
+    assert len(events) == 1
+    assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value
+
+
+def test_webhook_create_by_staff_with_inactive_app(staff_api_client, app):
+    app.is_active = False
+    query = WEBHOOK_CREATE_BY_STAFF
+    app_id = graphene.Node.to_global_id("App", app.pk)
+    variables = {
+        "target_url": "https://www.example.com",
+        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "app": app_id,
+    }
+    response = staff_api_client.post_graphql(query, variables=variables)
+    assert_no_permission(response)
+    assert Webhook.objects.count() == 0
+
+
+def test_webhook_create_by_staff_without_permission(staff_api_client, app):
+    query = WEBHOOK_CREATE_BY_STAFF
+    app_id = graphene.Node.to_global_id("App", app.pk)
+    variables = {
+        "target_url": "https://www.example.com",
+        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "app": app_id,
+    }
+    response = staff_api_client.post_graphql(query, variables=variables)
+    assert_no_permission(response)
+    assert Webhook.objects.count() == 0
+
+
+WEBHOOK_UPDATE = """
+    mutation webhookUpdate(
+        $id: ID!, $events: [WebhookEventTypeEnum], $is_active: Boolean){
+      webhookUpdate(id: $id, input:{events: $events, isActive: $is_active}){
+        errors{
+          field
+          message
+        }
+        webhook{
+          events{
+            eventType
+          }
+          isActive
+        }
+      }
+    }
+"""
+
+
+def test_webhook_update_not_allowed_by_app(app_api_client, app, webhook):
+    query = WEBHOOK_UPDATE
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {
+        "id": webhook_id,
+        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "is_active": False,
+    }
+    response = app_api_client.post_graphql(query, variables=variables)
+    assert_no_permission(response)
+
+
+def test_webhook_update_by_staff(
+    staff_api_client, app, webhook, permission_manage_apps
+):
+    query = WEBHOOK_UPDATE
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {
+        "id": webhook_id,
+        "events": [
+            WebhookEventTypeEnum.CUSTOMER_CREATED.name,
+            WebhookEventTypeEnum.CUSTOMER_CREATED.name,
+        ],
+        "is_active": False,
+    }
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
+    response = staff_api_client.post_graphql(query, variables=variables)
+    get_graphql_content(response)
+    webhook.refresh_from_db()
+    assert webhook.is_active is False
+    events = webhook.events.all()
+    assert len(events) == 1
+    assert events[0].event_type == WebhookEventTypeEnum.CUSTOMER_CREATED.value
+
+
+def test_webhook_update_by_staff_without_permission(staff_api_client, app, webhook):
+    query = WEBHOOK_UPDATE
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {
+        "id": webhook_id,
+        "events": [
+            WebhookEventTypeEnum.ORDER_CREATED.name,
+            WebhookEventTypeEnum.CUSTOMER_CREATED.name,
+        ],
+        "is_active": False,
+    }
+    response = staff_api_client.post_graphql(query, variables=variables)
+    assert_no_permission(response)
+
+
+QUERY_WEBHOOK = """
+    query webhook($id: ID!){
+      webhook(id: $id){
+        id
+        isActive
+        events{
+          eventType
+        }
+      }
+    }
+"""
+
+
+def test_query_webhook_by_staff(staff_api_client, webhook, permission_manage_apps):
+    query = QUERY_WEBHOOK
+
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {"id": webhook_id}
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
+    response = staff_api_client.post_graphql(query, variables=variables)
+
+    content = get_graphql_content(response)
+    webhook_response = content["data"]["webhook"]
+    assert webhook_response["id"] == webhook_id
+    assert webhook_response["isActive"] == webhook.is_active
+    events = webhook.events.all()
+    assert len(events) == 1
+    assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value

--- a/saleor/graphql/webhook/tests/deprecated/test_webhook.py
+++ b/saleor/graphql/webhook/tests/deprecated/test_webhook.py
@@ -2,11 +2,11 @@ import graphene
 
 from .....webhook.models import Webhook
 from ....tests.utils import assert_no_permission, get_graphql_content
-from ...enums import WebhookEventTypeEnum
+from ...enums import WebhookEventTypeAsyncEnum
 
 WEBHOOK_CREATE_BY_APP = """
     mutation webhookCreate($name: String, $target_url: String,
-            $events: [WebhookEventTypeEnum]){
+            $events: [WebhookEventTypeAsyncEnum]){
       webhookCreate(input:{name: $name, targetUrl:$target_url, events:$events}){
         errors{
           field
@@ -26,8 +26,8 @@ def test_webhook_create_by_app(app_api_client, permission_manage_orders):
         "name": "New integration",
         "target_url": "https://www.example.com",
         "events": [
-            WebhookEventTypeEnum.ORDER_CREATED.name,
-            WebhookEventTypeEnum.ORDER_CREATED.name,
+            WebhookEventTypeAsyncEnum.ORDER_CREATED.name,
+            WebhookEventTypeAsyncEnum.ORDER_CREATED.name,
         ],
     }
     response = app_api_client.post_graphql(
@@ -42,7 +42,7 @@ def test_webhook_create_by_app(app_api_client, permission_manage_orders):
     assert new_webhook.target_url == "https://www.example.com"
     events = new_webhook.events.all()
     assert len(events) == 1
-    assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value
+    assert events[0].event_type == WebhookEventTypeAsyncEnum.ORDER_CREATED.value
 
 
 def test_webhook_create_inactive_app(app_api_client, app, permission_manage_orders):
@@ -51,7 +51,7 @@ def test_webhook_create_inactive_app(app_api_client, app, permission_manage_orde
     query = WEBHOOK_CREATE_BY_APP
     variables = {
         "target_url": "https://www.example.com",
-        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "events": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
         "name": "",
     }
 
@@ -67,7 +67,7 @@ def test_webhook_create_without_app(app_api_client, app):
     query = WEBHOOK_CREATE_BY_APP
     variables = {
         "target_url": "https://www.example.com",
-        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "events": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
         "name": "",
     }
     response = app_api_client.post_graphql(query, variables=variables)
@@ -80,7 +80,7 @@ def test_webhook_create_app_doesnt_exist(app_api_client, app):
     query = WEBHOOK_CREATE_BY_APP
     variables = {
         "target_url": "https://www.example.com",
-        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "events": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
         "name": "",
     }
     response = app_api_client.post_graphql(query, variables=variables)
@@ -89,7 +89,7 @@ def test_webhook_create_app_doesnt_exist(app_api_client, app):
 
 WEBHOOK_CREATE_BY_STAFF = """
     mutation webhookCreate(
-        $target_url: String, $events: [WebhookEventTypeEnum], $app: ID){
+        $target_url: String, $events: [WebhookEventTypeAsyncEnum], $app: ID){
       webhookCreate(input:{
             targetUrl:$target_url, events:$events, app: $app}){
         errors{
@@ -115,7 +115,7 @@ def test_webhook_create_by_staff(
     app_id = graphene.Node.to_global_id("App", app.pk)
     variables = {
         "target_url": "https://www.example.com",
-        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "events": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
         "app": app_id,
     }
     staff_api_client.user.user_permissions.add(permission_manage_apps)
@@ -126,7 +126,7 @@ def test_webhook_create_by_staff(
     assert new_webhook.app == app
     events = new_webhook.events.all()
     assert len(events) == 1
-    assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value
+    assert events[0].event_type == WebhookEventTypeAsyncEnum.ORDER_CREATED.value
 
 
 def test_webhook_create_by_staff_with_inactive_app(staff_api_client, app):
@@ -135,7 +135,7 @@ def test_webhook_create_by_staff_with_inactive_app(staff_api_client, app):
     app_id = graphene.Node.to_global_id("App", app.pk)
     variables = {
         "target_url": "https://www.example.com",
-        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "events": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
         "app": app_id,
     }
     response = staff_api_client.post_graphql(query, variables=variables)
@@ -148,7 +148,7 @@ def test_webhook_create_by_staff_without_permission(staff_api_client, app):
     app_id = graphene.Node.to_global_id("App", app.pk)
     variables = {
         "target_url": "https://www.example.com",
-        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "events": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
         "app": app_id,
     }
     response = staff_api_client.post_graphql(query, variables=variables)
@@ -158,7 +158,7 @@ def test_webhook_create_by_staff_without_permission(staff_api_client, app):
 
 WEBHOOK_UPDATE = """
     mutation webhookUpdate(
-        $id: ID!, $events: [WebhookEventTypeEnum], $is_active: Boolean){
+        $id: ID!, $events: [WebhookEventTypeAsyncEnum], $is_active: Boolean){
       webhookUpdate(id: $id, input:{events: $events, isActive: $is_active}){
         errors{
           field
@@ -180,7 +180,7 @@ def test_webhook_update_not_allowed_by_app(app_api_client, app, webhook):
     webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
     variables = {
         "id": webhook_id,
-        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "events": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
         "is_active": False,
     }
     response = app_api_client.post_graphql(query, variables=variables)
@@ -195,8 +195,8 @@ def test_webhook_update_by_staff(
     variables = {
         "id": webhook_id,
         "events": [
-            WebhookEventTypeEnum.CUSTOMER_CREATED.name,
-            WebhookEventTypeEnum.CUSTOMER_CREATED.name,
+            WebhookEventTypeAsyncEnum.CUSTOMER_CREATED.name,
+            WebhookEventTypeAsyncEnum.CUSTOMER_CREATED.name,
         ],
         "is_active": False,
     }
@@ -207,7 +207,7 @@ def test_webhook_update_by_staff(
     assert webhook.is_active is False
     events = webhook.events.all()
     assert len(events) == 1
-    assert events[0].event_type == WebhookEventTypeEnum.CUSTOMER_CREATED.value
+    assert events[0].event_type == WebhookEventTypeAsyncEnum.CUSTOMER_CREATED.value
 
 
 def test_webhook_update_by_staff_without_permission(staff_api_client, app, webhook):
@@ -216,8 +216,8 @@ def test_webhook_update_by_staff_without_permission(staff_api_client, app, webho
     variables = {
         "id": webhook_id,
         "events": [
-            WebhookEventTypeEnum.ORDER_CREATED.name,
-            WebhookEventTypeEnum.CUSTOMER_CREATED.name,
+            WebhookEventTypeAsyncEnum.ORDER_CREATED.name,
+            WebhookEventTypeAsyncEnum.CUSTOMER_CREATED.name,
         ],
         "is_active": False,
     }
@@ -252,4 +252,4 @@ def test_query_webhook_by_staff(staff_api_client, webhook, permission_manage_app
     assert webhook_response["isActive"] == webhook.is_active
     events = webhook.events.all()
     assert len(events) == 1
-    assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value
+    assert events[0].event_type == WebhookEventTypeAsyncEnum.ORDER_CREATED.value

--- a/saleor/graphql/webhook/tests/test_webhook.py
+++ b/saleor/graphql/webhook/tests/test_webhook.py
@@ -4,7 +4,6 @@ import graphene
 import pytest
 
 from ....app.models import App
-from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.models import Webhook
 from ...tests.utils import (
     assert_no_permission,
@@ -454,33 +453,6 @@ def test_webhook_with_invalid_object_type(
     response = staff_api_client.post_graphql(QUERY_WEBHOOK, variables)
     content = get_graphql_content(response)
     assert content["data"]["webhook"] is None
-
-
-WEBHOOK_EVENTS_QUERY = """
-{
-  webhookEvents {
-    eventType
-    name
-  }
-}
-"""
-
-
-def test_query_webhook_events(staff_api_client, permission_manage_apps):
-    query = WEBHOOK_EVENTS_QUERY
-    staff_api_client.user.user_permissions.add(permission_manage_apps)
-    response = staff_api_client.post_graphql(query)
-    content = get_graphql_content(response)
-    webhook_events = content["data"]["webhookEvents"]
-
-    assert len(webhook_events) == len(WebhookEventAsyncType.CHOICES)
-
-
-def test_query_webhook_events_without_permissions(staff_api_client):
-
-    query = WEBHOOK_EVENTS_QUERY
-    response = staff_api_client.post_graphql(query)
-    assert_no_permission(response)
 
 
 SAMPLE_PAYLOAD_QUERY = """

--- a/saleor/graphql/webhook/tests/test_webhook.py
+++ b/saleor/graphql/webhook/tests/test_webhook.py
@@ -4,7 +4,7 @@ import graphene
 import pytest
 
 from ....app.models import App
-from ....webhook.event_types import WebhookEventType
+from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.models import Webhook
 from ...tests.utils import (
     assert_no_permission,
@@ -12,9 +12,8 @@ from ...tests.utils import (
     get_graphql_content_from_response,
 )
 from ..enums import (
-    WebhookEventTypeAsync,
-    WebhookEventTypeEnum,
-    WebhookEventTypeSync,
+    WebhookEventTypeAsyncEnum,
+    WebhookEventTypeSyncEnum,
     WebhookSampleEventTypeEnum,
 )
 
@@ -40,8 +39,8 @@ def test_webhook_create_by_app(app_api_client, permission_manage_orders):
             "name": "New integration",
             "targetUrl": "https://www.example.com",
             "asyncEvents": [
-                WebhookEventTypeEnum.ORDER_CREATED.name,
-                WebhookEventTypeEnum.ORDER_CREATED.name,
+                WebhookEventTypeAsyncEnum.ORDER_CREATED.name,
+                WebhookEventTypeAsyncEnum.ORDER_CREATED.name,
             ],
         }
     }
@@ -57,7 +56,7 @@ def test_webhook_create_by_app(app_api_client, permission_manage_orders):
     assert new_webhook.target_url == "https://www.example.com"
     events = new_webhook.events.all()
     assert len(events) == 1
-    assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value
+    assert events[0].event_type == WebhookEventTypeAsyncEnum.ORDER_CREATED.value
 
 
 def test_webhook_create_inactive_app(app_api_client, app, permission_manage_orders):
@@ -67,7 +66,7 @@ def test_webhook_create_inactive_app(app_api_client, app, permission_manage_orde
     variables = {
         "input": {
             "targetUrl": "https://www.example.com",
-            "asyncEvents": [WebhookEventTypeEnum.ORDER_CREATED.name],
+            "asyncEvents": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
             "name": "",
         }
     }
@@ -85,7 +84,7 @@ def test_webhook_create_without_app(app_api_client, app):
     variables = {
         "input": {
             "targetUrl": "https://www.example.com",
-            "asyncEvents": [WebhookEventTypeEnum.ORDER_CREATED.name],
+            "asyncEvents": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
             "name": "",
         }
     }
@@ -100,7 +99,7 @@ def test_webhook_create_app_doesnt_exist(app_api_client, app):
     variables = {
         "input": {
             "targetUrl": "https://www.example.com",
-            "asyncEvents": [WebhookEventTypeEnum.ORDER_CREATED.name],
+            "asyncEvents": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
             "name": "",
         }
     }
@@ -120,8 +119,8 @@ def test_webhook_create_by_staff(
     variables = {
         "input": {
             "targetUrl": "https://www.example.com",
-            "asyncEvents": [WebhookEventTypeEnum.ORDER_CREATED.name],
-            "syncEvents": [WebhookEventTypeEnum.PAYMENT_LIST_GATEWAYS.name],
+            "asyncEvents": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
+            "syncEvents": [WebhookEventTypeSyncEnum.PAYMENT_LIST_GATEWAYS.name],
             "app": app_id,
         }
     }
@@ -135,8 +134,8 @@ def test_webhook_create_by_staff(
     assert len(events) == 2
 
     created_event_types = [events[0].event_type, events[1].event_type]
-    assert WebhookEventTypeEnum.ORDER_CREATED.value in created_event_types
-    assert WebhookEventTypeEnum.PAYMENT_LIST_GATEWAYS.value in created_event_types
+    assert WebhookEventTypeAsyncEnum.ORDER_CREATED.value in created_event_types
+    assert WebhookEventTypeSyncEnum.PAYMENT_LIST_GATEWAYS.value in created_event_types
 
 
 def test_webhook_create_by_staff_with_inactive_app(staff_api_client, app):
@@ -146,7 +145,7 @@ def test_webhook_create_by_staff_with_inactive_app(staff_api_client, app):
     variables = {
         "input": {
             "targetUrl": "https://www.example.com",
-            "asyncEvents": [WebhookEventTypeEnum.ORDER_CREATED.name],
+            "asyncEvents": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
             "app": app_id,
         }
     }
@@ -161,7 +160,7 @@ def test_webhook_create_by_staff_without_permission(staff_api_client, app):
     variables = {
         "input": {
             "targetUrl": "https://www.example.com",
-            "asyncEvents": [WebhookEventTypeEnum.ORDER_CREATED.name],
+            "asyncEvents": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
             "app": app_id,
         }
     }
@@ -269,7 +268,7 @@ def test_webhook_update_not_allowed_by_app(app_api_client, app, webhook):
     variables = {
         "id": webhook_id,
         "input": {
-            "asyncEvents": [WebhookEventTypeEnum.ORDER_CREATED.name],
+            "asyncEvents": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
             "isActive": False,
         },
     }
@@ -286,8 +285,8 @@ def test_webhook_update_by_staff(
         "id": webhook_id,
         "input": {
             "asyncEvents": [
-                WebhookEventTypeEnum.CUSTOMER_CREATED.name,
-                WebhookEventTypeEnum.CUSTOMER_CREATED.name,
+                WebhookEventTypeAsyncEnum.CUSTOMER_CREATED.name,
+                WebhookEventTypeAsyncEnum.CUSTOMER_CREATED.name,
             ],
             "isActive": False,
         },
@@ -299,7 +298,7 @@ def test_webhook_update_by_staff(
     assert webhook.is_active is False
     events = webhook.events.all()
     assert len(events) == 1
-    assert events[0].event_type == WebhookEventTypeEnum.CUSTOMER_CREATED.value
+    assert events[0].event_type == WebhookEventTypeAsyncEnum.CUSTOMER_CREATED.value
 
 
 def test_webhook_update_by_staff_without_permission(staff_api_client, app, webhook):
@@ -309,8 +308,8 @@ def test_webhook_update_by_staff_without_permission(staff_api_client, app, webho
         "id": webhook_id,
         "input": {
             "asyncEvents": [
-                WebhookEventTypeEnum.ORDER_CREATED.name,
-                WebhookEventTypeEnum.CUSTOMER_CREATED.name,
+                WebhookEventTypeAsyncEnum.ORDER_CREATED.name,
+                WebhookEventTypeAsyncEnum.CUSTOMER_CREATED.name,
             ],
             "isActive": False,
         },
@@ -349,7 +348,7 @@ def test_query_webhook_by_staff(staff_api_client, webhook, permission_manage_app
     assert webhook_response["isActive"] == webhook.is_active
     events = webhook.events.all()
     assert len(events) == 1
-    assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value
+    assert events[0].event_type == WebhookEventTypeAsyncEnum.ORDER_CREATED.value
 
 
 def test_query_webhook_by_staff_without_permission(staff_api_client, webhook):
@@ -373,7 +372,7 @@ def test_query_webhook_by_app(app_api_client, webhook):
     assert webhook_response["isActive"] == webhook.is_active
     events = webhook.events.all()
     assert len(events) == 1
-    assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value
+    assert events[0].event_type == WebhookEventTypeAsyncEnum.ORDER_CREATED.value
 
 
 def test_query_webhook_by_app_without_permission(app_api_client):
@@ -397,8 +396,10 @@ def test_query_webhook_sync_and_async_events(
 ):
     # given
     webhook.events.all().delete()
-    webhook.events.create(event_type=WebhookEventTypeAsync.ORDER_CREATED.value)
-    webhook.events.create(event_type=WebhookEventTypeSync.PAYMENT_LIST_GATEWAYS.value)
+    webhook.events.create(event_type=WebhookEventTypeAsyncEnum.ORDER_CREATED.value)
+    webhook.events.create(
+        event_type=WebhookEventTypeSyncEnum.PAYMENT_LIST_GATEWAYS.value
+    )
     webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
     variables = {"id": webhook_id}
     staff_api_client.user.user_permissions.add(permission_manage_apps)
@@ -412,11 +413,11 @@ def test_query_webhook_sync_and_async_events(
 
     assert (
         webhook_response["asyncEvents"][0]["eventType"]
-        == WebhookEventTypeAsync.ORDER_CREATED.name
+        == WebhookEventTypeAsyncEnum.ORDER_CREATED.name
     )
     assert (
         webhook_response["syncEvents"][0]["eventType"]
-        == WebhookEventTypeSync.PAYMENT_LIST_GATEWAYS.name
+        == WebhookEventTypeSyncEnum.PAYMENT_LIST_GATEWAYS.name
     )
 
 
@@ -472,7 +473,7 @@ def test_query_webhook_events(staff_api_client, permission_manage_apps):
     content = get_graphql_content(response)
     webhook_events = content["data"]["webhookEvents"]
 
-    assert len(webhook_events) == len(WebhookEventType.CHOICES)
+    assert len(webhook_events) == len(WebhookEventAsyncType.CHOICES)
 
 
 def test_query_webhook_events_without_permissions(staff_api_client):

--- a/saleor/graphql/webhook/types.py
+++ b/saleor/graphql/webhook/types.py
@@ -3,12 +3,13 @@ import graphene
 from ...webhook import models
 from ...webhook.event_types import WebhookEventType
 from ..core.connection import CountableDjangoObjectType
-from .enums import WebhookEventTypeEnum
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
+from . import enums
 
 
 class WebhookEvent(CountableDjangoObjectType):
     name = graphene.String(description="Display name of the event.", required=True)
-    event_type = WebhookEventTypeEnum(
+    event_type = enums.WebhookEventTypeEnum(
         description="Internal name of the event type.", required=True
     )
 
@@ -22,11 +23,56 @@ class WebhookEvent(CountableDjangoObjectType):
         return WebhookEventType.DISPLAY_LABELS.get(root.event_type) or root.event_type
 
 
+class WebhookEventAsync(CountableDjangoObjectType):
+    name = graphene.String(description="Display name of the event.", required=True)
+    event_type = enums.WebhookEventTypeAsync(
+        description="Internal name of the event type.", required=True
+    )
+
+    class Meta:
+        model = models.WebhookEvent
+        description = "Asynchronous webhook event."
+        only_fields = ["event_type"]
+
+    @staticmethod
+    def resolve_name(root: models.WebhookEvent, *_args, **_kwargs):
+        return WebhookEventType.DISPLAY_LABELS.get(root.event_type) or root.event_type
+
+
+class WebhookEventSync(CountableDjangoObjectType):
+    name = graphene.String(description="Display name of the event.", required=True)
+    event_type = enums.WebhookEventTypeSync(
+        description="Internal name of the event type.", required=True
+    )
+
+    class Meta:
+        model = models.WebhookEvent
+        description = "Synchronous webhook event."
+        only_fields = ["event_type"]
+
+    @staticmethod
+    def resolve_name(root: models.WebhookEvent, *_args, **_kwargs):
+        return WebhookEventType.DISPLAY_LABELS.get(root.event_type) or root.event_type
+
+
 class Webhook(CountableDjangoObjectType):
     name = graphene.String(required=True)
     events = graphene.List(
         graphene.NonNull(WebhookEvent),
         description="List of webhook events.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use `asyncEvents` or `syncEvents` instead."
+        ),
+        required=True,
+    )
+    sync_events = graphene.List(
+        graphene.NonNull(WebhookEventSync),
+        description="List of synchronous webhook events.",
+        required=True,
+    )
+    async_events = graphene.List(
+        graphene.NonNull(WebhookEventAsync),
+        description="List of asynchronous webhook events.",
         required=True,
     )
     app = graphene.Field("saleor.graphql.app.types.App", required=True)
@@ -41,6 +87,14 @@ class Webhook(CountableDjangoObjectType):
             "secret_key",
             "name",
         ]
+
+    @staticmethod
+    def resolve_async_events(root: models.Webhook, *_args, **_kwargs):
+        return root.events.exclude(event_type__in=WebhookEventType.SYNC_EVENTS)
+
+    @staticmethod
+    def resolve_sync_events(root: models.Webhook, *_args, **_kwargs):
+        return root.events.filter(event_type__in=WebhookEventType.SYNC_EVENTS)
 
     @staticmethod
     def resolve_events(root: models.Webhook, *_args, **_kwargs):

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -6,7 +6,7 @@ from ...app.models import App
 from ...core.notify_events import NotifyEventType
 from ...core.utils.json_serializer import CustomJsonEncoder
 from ...payment import PaymentError, TransactionKind
-from ...webhook.event_types import WebhookEventType
+from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...webhook.payloads import (
     generate_checkout_payload,
     generate_customer_payload,
@@ -74,25 +74,33 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.ORDER_CREATED, order_data)
+        trigger_webhooks_for_event.delay(
+            WebhookEventAsyncType.ORDER_CREATED, order_data
+        )
 
     def order_confirmed(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
         order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.ORDER_CONFIRMED, order_data)
+        trigger_webhooks_for_event.delay(
+            WebhookEventAsyncType.ORDER_CONFIRMED, order_data
+        )
 
     def order_fully_paid(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
         order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.ORDER_FULLY_PAID, order_data)
+        trigger_webhooks_for_event.delay(
+            WebhookEventAsyncType.ORDER_FULLY_PAID, order_data
+        )
 
     def order_updated(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
         order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.ORDER_UPDATED, order_data)
+        trigger_webhooks_for_event.delay(
+            WebhookEventAsyncType.ORDER_UPDATED, order_data
+        )
 
     def sale_created(
         self, sale: "Sale", current_catalogue: "NodeCatalogueInfo", previous_value: Any
@@ -105,7 +113,7 @@ class WebhookPlugin(BasePlugin):
             current_catalogue=current_catalogue,
             requestor=self.requestor,
         )
-        trigger_webhooks_for_event.delay(WebhookEventType.SALE_CREATED, sale_data)
+        trigger_webhooks_for_event.delay(WebhookEventAsyncType.SALE_CREATED, sale_data)
 
     def sale_updated(
         self,
@@ -119,7 +127,7 @@ class WebhookPlugin(BasePlugin):
         sale_data = generate_sale_payload(
             sale, previous_catalogue, current_catalogue, self.requestor
         )
-        trigger_webhooks_for_event.delay(WebhookEventType.SALE_UPDATED, sale_data)
+        trigger_webhooks_for_event.delay(WebhookEventAsyncType.SALE_UPDATED, sale_data)
 
     def sale_deleted(
         self, sale: "Sale", previous_catalogue: "NodeCatalogueInfo", previous_value: Any
@@ -129,7 +137,7 @@ class WebhookPlugin(BasePlugin):
         sale_data = generate_sale_payload(
             sale, previous_catalogue=previous_catalogue, requestor=self.requestor
         )
-        trigger_webhooks_for_event.delay(WebhookEventType.SALE_DELETED, sale_data)
+        trigger_webhooks_for_event.delay(WebhookEventAsyncType.SALE_DELETED, sale_data)
 
     def invoice_request(
         self,
@@ -142,39 +150,47 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         invoice_data = generate_invoice_payload(invoice, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.INVOICE_REQUESTED, invoice_data
+            WebhookEventAsyncType.INVOICE_REQUESTED, invoice_data
         )
 
     def invoice_delete(self, invoice: "Invoice", previous_value: Any):
         if not self.active:
             return previous_value
         invoice_data = generate_invoice_payload(invoice, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.INVOICE_DELETED, invoice_data)
+        trigger_webhooks_for_event.delay(
+            WebhookEventAsyncType.INVOICE_DELETED, invoice_data
+        )
 
     def invoice_sent(self, invoice: "Invoice", email: str, previous_value: Any) -> Any:
         if not self.active:
             return previous_value
         invoice_data = generate_invoice_payload(invoice, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.INVOICE_SENT, invoice_data)
+        trigger_webhooks_for_event.delay(
+            WebhookEventAsyncType.INVOICE_SENT, invoice_data
+        )
 
     def order_cancelled(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
         order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.ORDER_CANCELLED, order_data)
+        trigger_webhooks_for_event.delay(
+            WebhookEventAsyncType.ORDER_CANCELLED, order_data
+        )
 
     def order_fulfilled(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
         order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.ORDER_FULFILLED, order_data)
+        trigger_webhooks_for_event.delay(
+            WebhookEventAsyncType.ORDER_FULFILLED, order_data
+        )
 
     def draft_order_created(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
         order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.DRAFT_ORDER_CREATED, order_data
+            WebhookEventAsyncType.DRAFT_ORDER_CREATED, order_data
         )
 
     def draft_order_updated(self, order: "Order", previous_value: Any) -> Any:
@@ -182,7 +198,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.DRAFT_ORDER_UPDATED, order_data
+            WebhookEventAsyncType.DRAFT_ORDER_UPDATED, order_data
         )
 
     def draft_order_deleted(self, order: "Order", previous_value: Any) -> Any:
@@ -190,7 +206,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.DRAFT_ORDER_DELETED, order_data
+            WebhookEventAsyncType.DRAFT_ORDER_DELETED, order_data
         )
 
     def fulfillment_created(self, fulfillment: "Fulfillment", previous_value):
@@ -198,7 +214,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.FULFILLMENT_CREATED, fulfillment_data
+            WebhookEventAsyncType.FULFILLMENT_CREATED, fulfillment_data
         )
 
     def fulfillment_canceled(self, fulfillment: "Fulfillment", previous_value):
@@ -206,7 +222,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.FULFILLMENT_CANCELED, fulfillment_data
+            WebhookEventAsyncType.FULFILLMENT_CANCELED, fulfillment_data
         )
 
     def customer_created(self, customer: "User", previous_value: Any) -> Any:
@@ -214,7 +230,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         customer_data = generate_customer_payload(customer, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.CUSTOMER_CREATED, customer_data
+            WebhookEventAsyncType.CUSTOMER_CREATED, customer_data
         )
 
     def customer_updated(self, customer: "User", previous_value: Any) -> Any:
@@ -222,20 +238,24 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         customer_data = generate_customer_payload(customer, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.CUSTOMER_UPDATED, customer_data
+            WebhookEventAsyncType.CUSTOMER_UPDATED, customer_data
         )
 
     def product_created(self, product: "Product", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
         product_data = generate_product_payload(product, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.PRODUCT_CREATED, product_data)
+        trigger_webhooks_for_event.delay(
+            WebhookEventAsyncType.PRODUCT_CREATED, product_data
+        )
 
     def product_updated(self, product: "Product", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
         product_data = generate_product_payload(product, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.PRODUCT_UPDATED, product_data)
+        trigger_webhooks_for_event.delay(
+            WebhookEventAsyncType.PRODUCT_UPDATED, product_data
+        )
 
     def product_deleted(
         self, product: "Product", variants: List[int], previous_value: Any
@@ -245,7 +265,9 @@ class WebhookPlugin(BasePlugin):
         product_data = generate_product_deleted_payload(
             product, variants, self.requestor
         )
-        trigger_webhooks_for_event.delay(WebhookEventType.PRODUCT_DELETED, product_data)
+        trigger_webhooks_for_event.delay(
+            WebhookEventAsyncType.PRODUCT_DELETED, product_data
+        )
 
     def product_variant_created(
         self, product_variant: "ProductVariant", previous_value: Any
@@ -257,7 +279,7 @@ class WebhookPlugin(BasePlugin):
             [product_variant], self.requestor
         )
         trigger_webhooks_for_event.delay(
-            WebhookEventType.PRODUCT_VARIANT_CREATED, product_variant_data
+            WebhookEventAsyncType.PRODUCT_VARIANT_CREATED, product_variant_data
         )
 
     def product_variant_updated(
@@ -269,7 +291,7 @@ class WebhookPlugin(BasePlugin):
             [product_variant], self.requestor
         )
         trigger_webhooks_for_event.delay(
-            WebhookEventType.PRODUCT_VARIANT_UPDATED, product_variant_data
+            WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED, product_variant_data
         )
 
     def product_variant_deleted(
@@ -281,7 +303,7 @@ class WebhookPlugin(BasePlugin):
             [product_variant], self.requestor
         )
         trigger_webhooks_for_event.delay(
-            WebhookEventType.PRODUCT_VARIANT_DELETED, product_variant_data
+            WebhookEventAsyncType.PRODUCT_VARIANT_DELETED, product_variant_data
         )
 
     def product_variant_out_of_stock(self, stock: "Stock", previous_value: Any) -> Any:
@@ -289,7 +311,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         product_variant_data = generate_product_variant_with_stock_payload([stock])
         trigger_webhooks_for_event.delay(
-            WebhookEventType.PRODUCT_VARIANT_OUT_OF_STOCK, product_variant_data
+            WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK, product_variant_data
         )
 
     def product_variant_back_in_stock(self, stock: "Stock", previous_value: Any) -> Any:
@@ -299,7 +321,7 @@ class WebhookPlugin(BasePlugin):
             [stock], self.requestor
         )
         trigger_webhooks_for_event.delay(
-            WebhookEventType.PRODUCT_VARIANT_BACK_IN_STOCK, product_variant_data
+            WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK, product_variant_data
         )
 
     def checkout_created(self, checkout: "Checkout", previous_value: Any) -> Any:
@@ -307,7 +329,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         checkout_data = generate_checkout_payload(checkout, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.CHECKOUT_CREATED, checkout_data
+            WebhookEventAsyncType.CHECKOUT_CREATED, checkout_data
         )
 
     def checkout_updated(self, checkout: "Checkout", previous_value: Any) -> Any:
@@ -315,7 +337,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         checkout_data = generate_checkout_payload(checkout, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.CHECKOUT_UPDATED, checkout_data
+            WebhookEventAsyncType.CHECKOUT_UPDATED, checkout_data
         )
 
     def notify(
@@ -324,7 +346,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
 
-        notify_user_event = WebhookEventType.NOTIFY_USER
+        notify_user_event = WebhookEventAsyncType.NOTIFY_USER
         data = {
             "notify_event": event,
             "payload": payload,
@@ -344,26 +366,26 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         page_data = generate_page_payload(page, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.PAGE_CREATED, page_data)
+        trigger_webhooks_for_event.delay(WebhookEventAsyncType.PAGE_CREATED, page_data)
 
     def page_updated(self, page: "Page", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
         page_data = generate_page_payload(page, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.PAGE_UPDATED, page_data)
+        trigger_webhooks_for_event.delay(WebhookEventAsyncType.PAGE_UPDATED, page_data)
 
     def page_deleted(self, page: "Page", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
         page_data = generate_page_payload(page, self.requestor)
-        trigger_webhooks_for_event.delay(WebhookEventType.PAGE_DELETED, page_data)
+        trigger_webhooks_for_event.delay(WebhookEventAsyncType.PAGE_DELETED, page_data)
 
     def translation_created(self, translation: "Translation", previous_value: Any):
         if not self.active:
             return previous_value
         translation_data = generate_translation_payload(translation, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.TRANSLATION_CREATED, translation_data
+            WebhookEventAsyncType.TRANSLATION_CREATED, translation_data
         )
 
     def translation_updated(self, translation: "Translation", previous_value: Any):
@@ -371,7 +393,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         translation_data = generate_translation_payload(translation, self.requestor)
         trigger_webhooks_for_event.delay(
-            WebhookEventType.TRANSLATION_UPDATED, translation_data
+            WebhookEventAsyncType.TRANSLATION_UPDATED, translation_data
         )
 
     def __run_payment_webhook(
@@ -430,11 +452,11 @@ class WebhookPlugin(BasePlugin):
     ) -> List["PaymentGateway"]:
         gateways = []
         apps = App.objects.for_event_type(
-            WebhookEventType.PAYMENT_LIST_GATEWAYS
+            WebhookEventSyncType.PAYMENT_LIST_GATEWAYS
         ).prefetch_related("webhooks")
         for app in apps:
             response_data = trigger_webhook_sync(
-                event_type=WebhookEventType.PAYMENT_LIST_GATEWAYS,
+                event_type=WebhookEventSyncType.PAYMENT_LIST_GATEWAYS,
                 data=generate_list_gateways_payload(currency, checkout),
                 app=app,
             )
@@ -451,7 +473,7 @@ class WebhookPlugin(BasePlugin):
         self, payment_information: "PaymentData", previous_value, **kwargs
     ) -> "GatewayResponse":
         return self.__run_payment_webhook(
-            WebhookEventType.PAYMENT_AUTHORIZE,
+            WebhookEventSyncType.PAYMENT_AUTHORIZE,
             TransactionKind.AUTH,
             payment_information,
             previous_value,
@@ -462,7 +484,7 @@ class WebhookPlugin(BasePlugin):
         self, payment_information: "PaymentData", previous_value, **kwargs
     ) -> "GatewayResponse":
         return self.__run_payment_webhook(
-            WebhookEventType.PAYMENT_CAPTURE,
+            WebhookEventSyncType.PAYMENT_CAPTURE,
             TransactionKind.CAPTURE,
             payment_information,
             previous_value,
@@ -473,7 +495,7 @@ class WebhookPlugin(BasePlugin):
         self, payment_information: "PaymentData", previous_value, **kwargs
     ) -> "GatewayResponse":
         return self.__run_payment_webhook(
-            WebhookEventType.PAYMENT_REFUND,
+            WebhookEventSyncType.PAYMENT_REFUND,
             TransactionKind.REFUND,
             payment_information,
             previous_value,
@@ -484,7 +506,7 @@ class WebhookPlugin(BasePlugin):
         self, payment_information: "PaymentData", previous_value, **kwargs
     ) -> "GatewayResponse":
         return self.__run_payment_webhook(
-            WebhookEventType.PAYMENT_VOID,
+            WebhookEventSyncType.PAYMENT_VOID,
             TransactionKind.VOID,
             payment_information,
             previous_value,
@@ -495,7 +517,7 @@ class WebhookPlugin(BasePlugin):
         self, payment_information: "PaymentData", previous_value, **kwargs
     ) -> "GatewayResponse":
         return self.__run_payment_webhook(
-            WebhookEventType.PAYMENT_CONFIRM,
+            WebhookEventSyncType.PAYMENT_CONFIRM,
             TransactionKind.CONFIRM,
             payment_information,
             previous_value,
@@ -506,7 +528,7 @@ class WebhookPlugin(BasePlugin):
         self, payment_information: "PaymentData", previous_value, **kwargs
     ) -> "GatewayResponse":
         return self.__run_payment_webhook(
-            WebhookEventType.PAYMENT_PROCESS,
+            WebhookEventSyncType.PAYMENT_PROCESS,
             TransactionKind.CAPTURE,
             payment_information,
             previous_value,
@@ -518,13 +540,13 @@ class WebhookPlugin(BasePlugin):
     ) -> List["ShippingMethodData"]:
         methods = []
         apps = App.objects.for_event_type(
-            WebhookEventType.SHIPPING_LIST_METHODS_FOR_CHECKOUT
+            WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT
         ).prefetch_related("webhooks")
         if apps:
             payload = generate_checkout_payload(checkout, self.requestor)
             for app in apps:
                 response_data = trigger_webhook_sync(
-                    event_type=WebhookEventType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
+                    event_type=WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
                     data=payload,
                     app=app,
                 )

--- a/saleor/plugins/webhook/tests/test_payment_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook.py
@@ -168,7 +168,7 @@ def test_get_payment_gateways(
     webhook.events.bulk_create(
         [
             WebhookEvent(event_type=event_type, webhook=webhook)
-            for event_type in WebhookEventAsyncType.PAYMENT_EVENTS
+            for event_type in WebhookEventSyncType.PAYMENT_EVENTS
         ]
     )
 

--- a/saleor/plugins/webhook/tests/test_payment_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from ....app.models import App
 from ....payment import PaymentError, TransactionKind
 from ....payment.utils import create_payment_information
-from ....webhook.event_types import WebhookEventType
+from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....webhook.models import Webhook, WebhookEvent
 from ...manager import get_plugins_manager
 from ..tasks import (
@@ -50,7 +50,7 @@ WebhookTestData = namedtuple("WebhookTestData", "secret, event_type, data, messa
 @pytest.fixture
 def webhook_data():
     secret = "secret"
-    event_type = WebhookEventType.ANY
+    event_type = WebhookEventAsyncType.ANY
     data = json.dumps({"key": "value"})
     message = data.encode("utf-8")
     return WebhookTestData(secret, event_type, data, message)
@@ -59,13 +59,13 @@ def webhook_data():
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
 def test_trigger_webhook_sync(mock_request, payment_app):
     data = {"key": "value"}
-    trigger_webhook_sync(WebhookEventType.PAYMENT_CAPTURE, data, payment_app)
+    trigger_webhook_sync(WebhookEventSyncType.PAYMENT_CAPTURE, data, payment_app)
     webhook = payment_app.webhooks.first()
     mock_request.assert_called_once_with(
         payment_app.name,
         webhook.target_url,
         webhook.secret_key,
-        WebhookEventType.PAYMENT_CAPTURE,
+        WebhookEventSyncType.PAYMENT_CAPTURE,
         data,
     )
 
@@ -81,15 +81,15 @@ def test_trigger_webhook_sync_use_first_webhook(mock_request, payment_app):
         name="payment-webhook-2",
         target_url="https://dont-use-this-gateway.com/api/",
     )
-    webhook_2.events.create(event_type=WebhookEventType.PAYMENT_CAPTURE)
+    webhook_2.events.create(event_type=WebhookEventSyncType.PAYMENT_CAPTURE)
 
     data = {"key": "value"}
-    trigger_webhook_sync(WebhookEventType.PAYMENT_CAPTURE, data, payment_app)
+    trigger_webhook_sync(WebhookEventSyncType.PAYMENT_CAPTURE, data, payment_app)
     mock_request.assert_called_once_with(
         payment_app.name,
         webhook_1.target_url,
         webhook_1.secret_key,
-        WebhookEventType.PAYMENT_CAPTURE,
+        WebhookEventSyncType.PAYMENT_CAPTURE,
         data,
     )
 
@@ -98,7 +98,7 @@ def test_trigger_webhook_sync_no_webhook_available():
     app = App.objects.create(name="Dummy app", is_active=True)
     # should raise an error for app with no payment webhooks
     with pytest.raises(PaymentError):
-        trigger_webhook_sync(WebhookEventType.PAYMENT_REFUND, {}, app)
+        trigger_webhook_sync(WebhookEventSyncType.PAYMENT_REFUND, {}, app)
 
 
 @pytest.mark.parametrize(
@@ -168,7 +168,7 @@ def test_get_payment_gateways(
     webhook.events.bulk_create(
         [
             WebhookEvent(event_type=event_type, webhook=webhook)
-            for event_type in WebhookEventType.PAYMENT_EVENTS
+            for event_type in WebhookEventAsyncType.PAYMENT_EVENTS
         ]
     )
 
@@ -271,7 +271,7 @@ def test_run_payment_webhook_invalid_app(payment_invalid_app, webhook_plugin):
     payment_information = create_payment_information(payment_invalid_app, "token")
     with pytest.raises(PaymentError):
         plugin._WebhookPlugin__run_payment_webhook(
-            WebhookEventType.PAYMENT_AUTHORIZE,
+            WebhookEventSyncType.PAYMENT_AUTHORIZE,
             TransactionKind.AUTH,
             payment_information,
             None,
@@ -284,7 +284,7 @@ def test_run_payment_webhook_no_payment_app_data(payment, webhook_plugin):
     payment_information.gateway = "dummy"
     with pytest.raises(PaymentError):
         plugin._WebhookPlugin__run_payment_webhook(
-            WebhookEventType.PAYMENT_AUTHORIZE,
+            WebhookEventSyncType.PAYMENT_AUTHORIZE,
             TransactionKind.AUTH,
             payment_information,
             None,
@@ -297,7 +297,7 @@ def test_run_payment_webhook_inactive_plugin(payment, webhook_plugin):
     payment_information = create_payment_information(payment, "token")
     dummy_previous_value = {"key": "dummy"}
     response = plugin._WebhookPlugin__run_payment_webhook(
-        WebhookEventType.PAYMENT_AUTHORIZE,
+        WebhookEventSyncType.PAYMENT_AUTHORIZE,
         TransactionKind.AUTH,
         payment_information,
         dummy_previous_value,
@@ -313,7 +313,7 @@ def test_run_payment_webhook_no_response(mock_send_request, payment, webhook_plu
     payment_information = create_payment_information(payment, "token")
     with pytest.raises(PaymentError):
         plugin._WebhookPlugin__run_payment_webhook(
-            WebhookEventType.PAYMENT_AUTHORIZE,
+            WebhookEventSyncType.PAYMENT_AUTHORIZE,
             TransactionKind.AUTH,
             payment_information,
             {},
@@ -327,7 +327,7 @@ def test_run_payment_webhook_empty_response(mock_send_request, payment, webhook_
     plugin = webhook_plugin()
     payment_information = create_payment_information(payment, "token")
     response = plugin._WebhookPlugin__run_payment_webhook(
-        WebhookEventType.PAYMENT_AUTHORIZE,
+        WebhookEventSyncType.PAYMENT_AUTHORIZE,
         TransactionKind.AUTH,
         payment_information,
         {},

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -3,7 +3,7 @@ from unittest import mock
 import graphene
 import pytest
 
-from ....webhook.event_types import WebhookEventType
+from ....webhook.event_types import WebhookEventSyncType
 from ...manager import get_plugins_manager
 from ..tasks import trigger_webhook_sync
 from ..utils import parse_list_shipping_methods_response
@@ -28,14 +28,14 @@ def webhook_plugin(plugin_manager):
 def test_trigger_webhook_sync(mock_request, shipping_app):
     data = {"key": "value"}
     trigger_webhook_sync(
-        WebhookEventType.SHIPPING_LIST_METHODS_FOR_CHECKOUT, data, shipping_app
+        WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT, data, shipping_app
     )
     webhook = shipping_app.webhooks.first()
     mock_request.assert_called_once_with(
         shipping_app.name,
         webhook.target_url,
         webhook.secret_key,
-        WebhookEventType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
+        WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
         data,
     )
 

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -21,7 +21,7 @@ from ....core.utils.json_serializer import CustomJsonEncoder
 from ....core.utils.url import prepare_url
 from ....discount.utils import fetch_catalogue_info
 from ....graphql.discount.mutations import convert_catalogue_info_to_global_ids
-from ....webhook.event_types import WebhookEventType
+from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.payloads import (
     generate_checkout_payload,
     generate_customer_payload,
@@ -44,14 +44,14 @@ third_url = "http://www.example.com/third/"
 @pytest.mark.parametrize(
     "event_name, total_webhook_calls, expected_target_urls",
     [
-        (WebhookEventType.PRODUCT_CREATED, 1, {first_url}),
-        (WebhookEventType.ORDER_FULLY_PAID, 2, {first_url, third_url}),
-        (WebhookEventType.ORDER_FULFILLED, 1, {third_url}),
-        (WebhookEventType.ORDER_CANCELLED, 1, {third_url}),
-        (WebhookEventType.ORDER_CONFIRMED, 1, {third_url}),
-        (WebhookEventType.ORDER_UPDATED, 1, {third_url}),
-        (WebhookEventType.ORDER_CREATED, 1, {third_url}),
-        (WebhookEventType.CUSTOMER_CREATED, 0, set()),
+        (WebhookEventAsyncType.PRODUCT_CREATED, 1, {first_url}),
+        (WebhookEventAsyncType.ORDER_FULLY_PAID, 2, {first_url, third_url}),
+        (WebhookEventAsyncType.ORDER_FULFILLED, 1, {third_url}),
+        (WebhookEventAsyncType.ORDER_CANCELLED, 1, {third_url}),
+        (WebhookEventAsyncType.ORDER_CONFIRMED, 1, {third_url}),
+        (WebhookEventAsyncType.ORDER_UPDATED, 1, {third_url}),
+        (WebhookEventAsyncType.ORDER_CREATED, 1, {third_url}),
+        (WebhookEventAsyncType.CUSTOMER_CREATED, 0, set()),
     ],
 )
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request.delay")
@@ -71,25 +71,25 @@ def test_trigger_webhooks_for_event_calls_expected_events(
     app.permissions.add(permission_manage_orders)
     app.permissions.add(permission_manage_products)
     webhook = app.webhooks.create(target_url="http://www.example.com/first/")
-    webhook.events.create(event_type=WebhookEventType.CUSTOMER_CREATED)
-    webhook.events.create(event_type=WebhookEventType.PRODUCT_CREATED)
-    webhook.events.create(event_type=WebhookEventType.ORDER_FULLY_PAID)
+    webhook.events.create(event_type=WebhookEventAsyncType.CUSTOMER_CREATED)
+    webhook.events.create(event_type=WebhookEventAsyncType.PRODUCT_CREATED)
+    webhook.events.create(event_type=WebhookEventAsyncType.ORDER_FULLY_PAID)
 
     app_without_permissions = App.objects.create()
 
     second_webhook = app_without_permissions.webhooks.create(
         target_url="http://www.example.com/wrong"
     )
-    second_webhook.events.create(event_type=WebhookEventType.ANY)
-    second_webhook.events.create(event_type=WebhookEventType.PRODUCT_CREATED)
-    second_webhook.events.create(event_type=WebhookEventType.CUSTOMER_CREATED)
+    second_webhook.events.create(event_type=WebhookEventAsyncType.ANY)
+    second_webhook.events.create(event_type=WebhookEventAsyncType.PRODUCT_CREATED)
+    second_webhook.events.create(event_type=WebhookEventAsyncType.CUSTOMER_CREATED)
 
     app_with_partial_permissions = App.objects.create()
     app_with_partial_permissions.permissions.add(permission_manage_orders)
     third_webhook = app_with_partial_permissions.webhooks.create(
         target_url="http://www.example.com/third/"
     )
-    third_webhook.events.create(event_type=WebhookEventType.ANY)
+    third_webhook.events.create(event_type=WebhookEventAsyncType.ANY)
 
     trigger_webhooks_for_event(event_name, data="")
     assert mock_request.call_count == total_webhook_calls
@@ -107,7 +107,7 @@ def test_order_created(mocked_webhook_trigger, settings, order_with_lines):
 
     expected_data = generate_order_payload(order_with_lines)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.ORDER_CREATED, expected_data
+        WebhookEventAsyncType.ORDER_CREATED, expected_data
     )
 
 
@@ -120,7 +120,7 @@ def test_order_confirmed(mocked_webhook_trigger, settings, order_with_lines):
 
     expected_data = generate_order_payload(order_with_lines)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.ORDER_CONFIRMED, expected_data
+        WebhookEventAsyncType.ORDER_CONFIRMED, expected_data
     )
 
 
@@ -133,7 +133,7 @@ def test_draft_order_created(mocked_webhook_trigger, settings, order_with_lines)
 
     expected_data = generate_order_payload(order_with_lines)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.DRAFT_ORDER_CREATED, expected_data
+        WebhookEventAsyncType.DRAFT_ORDER_CREATED, expected_data
     )
 
 
@@ -146,7 +146,7 @@ def test_draft_order_deleted(mocked_webhook_trigger, settings, order_with_lines)
 
     expected_data = generate_order_payload(order_with_lines)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.DRAFT_ORDER_DELETED, expected_data
+        WebhookEventAsyncType.DRAFT_ORDER_DELETED, expected_data
     )
 
 
@@ -159,7 +159,7 @@ def test_draft_order_updated(mocked_webhook_trigger, settings, order_with_lines)
 
     expected_data = generate_order_payload(order_with_lines)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.DRAFT_ORDER_UPDATED, expected_data
+        WebhookEventAsyncType.DRAFT_ORDER_UPDATED, expected_data
     )
 
 
@@ -172,7 +172,7 @@ def test_customer_created(mocked_webhook_trigger, settings, customer_user):
 
     expected_data = generate_customer_payload(customer_user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.CUSTOMER_CREATED, expected_data
+        WebhookEventAsyncType.CUSTOMER_CREATED, expected_data
     )
 
 
@@ -185,7 +185,7 @@ def test_customer_updated(mocked_webhook_trigger, settings, customer_user):
 
     expected_data = generate_customer_payload(customer_user)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.CUSTOMER_UPDATED, expected_data
+        WebhookEventAsyncType.CUSTOMER_UPDATED, expected_data
     )
 
 
@@ -198,7 +198,7 @@ def test_order_fully_paid(mocked_webhook_trigger, settings, order_with_lines):
 
     expected_data = generate_order_payload(order_with_lines)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.ORDER_FULLY_PAID, expected_data
+        WebhookEventAsyncType.ORDER_FULLY_PAID, expected_data
     )
 
 
@@ -211,7 +211,7 @@ def test_product_created(mocked_webhook_trigger, settings, product):
 
     expected_data = generate_product_payload(product)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PRODUCT_CREATED, expected_data
+        WebhookEventAsyncType.PRODUCT_CREATED, expected_data
     )
 
 
@@ -224,7 +224,7 @@ def test_product_updated(mocked_webhook_trigger, settings, product):
 
     expected_data = generate_product_payload(product)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PRODUCT_UPDATED, expected_data
+        WebhookEventAsyncType.PRODUCT_UPDATED, expected_data
     )
 
 
@@ -252,7 +252,7 @@ def test_product_deleted(mocked_webhook_trigger, settings, product):
     assert variant_global_ids == expected_data_dict["variants"]
 
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PRODUCT_DELETED, expected_data
+        WebhookEventAsyncType.PRODUCT_DELETED, expected_data
     )
 
 
@@ -265,7 +265,7 @@ def test_product_variant_created(mocked_webhook_trigger, settings, variant):
 
     expected_data = generate_product_variant_payload([variant])
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PRODUCT_VARIANT_CREATED, expected_data
+        WebhookEventAsyncType.PRODUCT_VARIANT_CREATED, expected_data
     )
 
 
@@ -278,7 +278,7 @@ def test_product_variant_updated(mocked_webhook_trigger, settings, variant):
 
     expected_data = generate_product_variant_payload([variant])
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PRODUCT_VARIANT_UPDATED, expected_data
+        WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED, expected_data
     )
 
 
@@ -291,7 +291,7 @@ def test_product_variant_deleted(mocked_webhook_trigger, settings, variant):
 
     expected_data = generate_product_variant_payload([variant])
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PRODUCT_VARIANT_DELETED, expected_data
+        WebhookEventAsyncType.PRODUCT_VARIANT_DELETED, expected_data
     )
 
 
@@ -308,7 +308,7 @@ def test_product_variant_out_of_stock(
         [variant_with_many_stocks.stocks.first()]
     )
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PRODUCT_VARIANT_OUT_OF_STOCK, expected_data
+        WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK, expected_data
     )
 
 
@@ -325,7 +325,7 @@ def test_product_variant_back_in_stock(
         [variant_with_many_stocks.stocks.first()]
     )
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PRODUCT_VARIANT_BACK_IN_STOCK, expected_data
+        WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK, expected_data
     )
 
 
@@ -338,7 +338,7 @@ def test_order_updated(mocked_webhook_trigger, settings, order_with_lines):
 
     expected_data = generate_order_payload(order_with_lines)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.ORDER_UPDATED, expected_data
+        WebhookEventAsyncType.ORDER_UPDATED, expected_data
     )
 
 
@@ -351,7 +351,7 @@ def test_order_cancelled(mocked_webhook_trigger, settings, order_with_lines):
 
     expected_data = generate_order_payload(order_with_lines)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.ORDER_CANCELLED, expected_data
+        WebhookEventAsyncType.ORDER_CANCELLED, expected_data
     )
 
 
@@ -364,7 +364,7 @@ def test_checkout_created(mocked_webhook_trigger, settings, checkout_with_items)
 
     expected_data = generate_checkout_payload(checkout_with_items)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.CHECKOUT_CREATED, expected_data
+        WebhookEventAsyncType.CHECKOUT_CREATED, expected_data
     )
 
 
@@ -377,7 +377,7 @@ def test_checkout_updated(mocked_webhook_trigger, settings, checkout_with_items)
 
     expected_data = generate_checkout_payload(checkout_with_items)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.CHECKOUT_UPDATED, expected_data
+        WebhookEventAsyncType.CHECKOUT_UPDATED, expected_data
     )
 
 
@@ -390,7 +390,7 @@ def test_page_created(mocked_webhook_trigger, settings, page):
 
     expected_data = generate_page_payload(page)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PAGE_CREATED, expected_data
+        WebhookEventAsyncType.PAGE_CREATED, expected_data
     )
 
 
@@ -403,7 +403,7 @@ def test_page_updated(mocked_webhook_trigger, settings, page):
 
     expected_data = generate_page_payload(page)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PAGE_UPDATED, expected_data
+        WebhookEventAsyncType.PAGE_UPDATED, expected_data
     )
 
 
@@ -420,7 +420,7 @@ def test_page_deleted(mocked_webhook_trigger, settings, page):
     expected_data = generate_page_payload(page)
 
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.PAGE_DELETED, expected_data
+        WebhookEventAsyncType.PAGE_DELETED, expected_data
     )
 
 
@@ -433,7 +433,7 @@ def test_invoice_request(mocked_webhook_trigger, settings, fulfilled_order):
     manager.invoice_request(fulfilled_order, invoice, invoice.number)
     expected_data = generate_invoice_payload(invoice)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.INVOICE_REQUESTED, expected_data
+        WebhookEventAsyncType.INVOICE_REQUESTED, expected_data
     )
 
 
@@ -446,7 +446,7 @@ def test_invoice_delete(mocked_webhook_trigger, settings, fulfilled_order):
     manager.invoice_delete(invoice)
     expected_data = generate_invoice_payload(invoice)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.INVOICE_DELETED, expected_data
+        WebhookEventAsyncType.INVOICE_DELETED, expected_data
     )
 
 
@@ -459,7 +459,7 @@ def test_invoice_sent(mocked_webhook_trigger, settings, fulfilled_order):
     manager.invoice_sent(invoice, fulfilled_order.user.email)
     expected_data = generate_invoice_payload(invoice)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.INVOICE_SENT, expected_data
+        WebhookEventAsyncType.INVOICE_SENT, expected_data
     )
 
 
@@ -501,7 +501,8 @@ def test_notify_user(mocked_webhook_trigger, settings, customer_user, channel_US
         },
     }
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.NOTIFY_USER, json.dumps(expected_data, cls=CustomJsonEncoder)
+        WebhookEventAsyncType.NOTIFY_USER,
+        json.dumps(expected_data, cls=CustomJsonEncoder),
     )
 
 
@@ -516,7 +517,7 @@ def test_sale_created(mocked_webhook_trigger, settings, sale):
     manager.sale_created(sale, current_catalogue=sale_catalogue_info)
     expected_data = generate_sale_payload(sale, current_catalogue=sale_catalogue_info)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.SALE_CREATED, expected_data
+        WebhookEventAsyncType.SALE_CREATED, expected_data
     )
 
 
@@ -544,7 +545,7 @@ def test_sale_updated(mocked_webhook_trigger, settings, sale, product_list):
         previous_catalogue=previous_sale_catalogue_info,
     )
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.SALE_UPDATED, expected_data
+        WebhookEventAsyncType.SALE_UPDATED, expected_data
     )
 
 
@@ -559,5 +560,5 @@ def test_sale_deleted(mocked_webhook_trigger, settings, sale):
     manager.sale_deleted(sale, previous_catalogue=sale_catalogue_info)
     expected_data = generate_sale_payload(sale, previous_catalogue=sale_catalogue_info)
     mocked_webhook_trigger.assert_called_once_with(
-        WebhookEventType.SALE_DELETED, expected_data
+        WebhookEventAsyncType.SALE_DELETED, expected_data
     )

--- a/saleor/plugins/webhook/tests/test_webhook_protocols.py
+++ b/saleor/plugins/webhook/tests/test_webhook_protocols.py
@@ -7,7 +7,7 @@ from django.core.serializers import serialize
 from google.cloud.pubsub_v1 import PublisherClient
 from kombu.asynchronous.aws.sqs.connection import AsyncSQSConnection
 
-from ....webhook.event_types import WebhookEventType
+from ....webhook.event_types import WebhookEventAsyncType
 from ...webhook import signature_for_payload
 from ...webhook.tasks import trigger_webhooks_for_event
 
@@ -47,7 +47,7 @@ def test_trigger_webhooks_with_aws_sqs(
 
     expected_data = serialize("json", [order_with_lines])
 
-    trigger_webhooks_for_event(WebhookEventType.ORDER_CREATED, expected_data)
+    trigger_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED, expected_data)
 
     mocked_client_constructor.assert_called_once_with(
         "sqs",
@@ -100,7 +100,7 @@ def test_trigger_webhooks_with_aws_sqs_and_secret_key(
         expected_data.encode("utf-8"), webhook.secret_key
     )
 
-    trigger_webhooks_for_event(WebhookEventType.ORDER_CREATED, expected_data)
+    trigger_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED, expected_data)
 
     mocked_client_constructor.assert_called_once_with(
         "sqs",
@@ -138,12 +138,12 @@ def test_trigger_webhooks_with_google_pub_sub(
 
     expected_data = serialize("json", [order_with_lines])
 
-    trigger_webhooks_for_event(WebhookEventType.ORDER_CREATED, expected_data)
+    trigger_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED, expected_data)
     mocked_publisher.publish.assert_called_once_with(
         "projects/saleor/topics/test",
         expected_data.encode("utf-8"),
         saleorDomain="mirumee.com",
-        eventType=WebhookEventType.ORDER_CREATED,
+        eventType=WebhookEventAsyncType.ORDER_CREATED,
         signature="",
     )
 
@@ -170,12 +170,12 @@ def test_trigger_webhooks_with_google_pub_sub_and_secret_key(
     expected_signature = signature_for_payload(
         expected_data.encode("utf-8"), webhook.secret_key
     )
-    trigger_webhooks_for_event(WebhookEventType.ORDER_CREATED, expected_data)
+    trigger_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED, expected_data)
     mocked_publisher.publish.assert_called_once_with(
         "projects/saleor/topics/test",
         expected_data.encode("utf-8"),
         saleorDomain="mirumee.com",
-        eventType=WebhookEventType.ORDER_CREATED,
+        eventType=WebhookEventAsyncType.ORDER_CREATED,
         signature=expected_signature,
     )
 
@@ -196,7 +196,7 @@ def test_trigger_webhooks_with_http(
 
     expected_data = serialize("json", [order_with_lines])
 
-    trigger_webhooks_for_event(WebhookEventType.ORDER_CREATED, expected_data)
+    trigger_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED, expected_data)
 
     expected_headers = {
         "Content-Type": "application/json",
@@ -228,7 +228,7 @@ def test_trigger_webhooks_with_http_and_secret_key(
     webhook.save()
 
     expected_data = serialize("json", [order_with_lines])
-    trigger_webhooks_for_event(WebhookEventType.ORDER_CREATED, expected_data)
+    trigger_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED, expected_data)
 
     expected_signature = signature_for_payload(
         expected_data.encode("utf-8"), webhook.secret_key

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -120,7 +120,7 @@ from ..warehouse.models import (
     Stock,
     Warehouse,
 )
-from ..webhook.event_types import WebhookEventType
+from ..webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..webhook.models import Webhook, WebhookEvent
 from ..wishlist.models import Wishlist
 from .utils import dummy_editorjs
@@ -4862,7 +4862,7 @@ def payment_app(db, permission_manage_payments):
     webhook.events.bulk_create(
         [
             WebhookEvent(event_type=event_type, webhook=webhook)
-            for event_type in WebhookEventType.PAYMENT_EVENTS
+            for event_type in WebhookEventAsyncType.PAYMENT_EVENTS
         ]
     )
     return app
@@ -4883,8 +4883,8 @@ def shipping_app(db, permission_manage_shipping):
         [
             WebhookEvent(event_type=event_type, webhook=webhook)
             for event_type in [
-                WebhookEventType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
-                WebhookEventType.FULFILLMENT_CREATED,
+                WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
+                WebhookEventAsyncType.FULFILLMENT_CREATED,
             ]
         ]
     )
@@ -4915,7 +4915,7 @@ def webhook(app):
     webhook = Webhook.objects.create(
         name="Simple webhook", app=app, target_url="http://www.example.com/test"
     )
-    webhook.events.create(event_type=WebhookEventType.ORDER_CREATED)
+    webhook.events.create(event_type=WebhookEventAsyncType.ORDER_CREATED)
     return webhook
 
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4862,7 +4862,7 @@ def payment_app(db, permission_manage_payments):
     webhook.events.bulk_create(
         [
             WebhookEvent(event_type=event_type, webhook=webhook)
-            for event_type in WebhookEventAsyncType.PAYMENT_EVENTS
+            for event_type in WebhookEventSyncType.PAYMENT_EVENTS
         ]
     )
     return app

--- a/saleor/webhook/deprecated_event_types.py
+++ b/saleor/webhook/deprecated_event_types.py
@@ -11,7 +11,7 @@ from ..core.permissions import (
 )
 
 
-class WebhookEventAsyncType:
+class WebhookEventType:
     ANY = "any_events"
     ORDER_CREATED = "order_created"
     ORDER_CONFIRMED = "order_confirmed"
@@ -58,6 +58,16 @@ class WebhookEventAsyncType:
     PAGE_UPDATED = "page_updated"
     PAGE_DELETED = "page_deleted"
 
+    PAYMENT_LIST_GATEWAYS = "payment_list_gateways"
+    PAYMENT_AUTHORIZE = "payment_authorize"
+    PAYMENT_CAPTURE = "payment_capture"
+    PAYMENT_REFUND = "payment_refund"
+    PAYMENT_VOID = "payment_void"
+    PAYMENT_CONFIRM = "payment_confirm"
+    PAYMENT_PROCESS = "payment_process"
+
+    SHIPPING_LIST_METHODS_FOR_CHECKOUT = "shipping_list_methods_for_checkout"
+
     TRANSLATION_CREATED = "translation_created"
     TRANSLATION_UPDATED = "translation_updated"
 
@@ -96,6 +106,14 @@ class WebhookEventAsyncType:
         PAGE_CREATED: "Page Created",
         PAGE_UPDATED: "Page Updated",
         PAGE_DELETED: "Page Deleted",
+        PAYMENT_AUTHORIZE: "Authorize payment",
+        PAYMENT_CAPTURE: "Capture payment",
+        PAYMENT_CONFIRM: "Confirm payment",
+        PAYMENT_LIST_GATEWAYS: "List payment gateways",
+        PAYMENT_PROCESS: "Process payment",
+        PAYMENT_REFUND: "Refund payment",
+        PAYMENT_VOID: "Void payment",
+        SHIPPING_LIST_METHODS_FOR_CHECKOUT: "Shipping list methods for checkout",
         TRANSLATION_CREATED: "Create translation",
         TRANSLATION_UPDATED: "Update translation",
     }
@@ -135,11 +153,32 @@ class WebhookEventAsyncType:
         (PAGE_CREATED, DISPLAY_LABELS[PAGE_CREATED]),
         (PAGE_UPDATED, DISPLAY_LABELS[PAGE_UPDATED]),
         (PAGE_DELETED, DISPLAY_LABELS[PAGE_DELETED]),
+        (PAYMENT_AUTHORIZE, DISPLAY_LABELS[PAYMENT_AUTHORIZE]),
+        (PAYMENT_CAPTURE, DISPLAY_LABELS[PAYMENT_CAPTURE]),
+        (PAYMENT_CONFIRM, DISPLAY_LABELS[PAYMENT_CONFIRM]),
+        (PAYMENT_LIST_GATEWAYS, DISPLAY_LABELS[PAYMENT_LIST_GATEWAYS]),
+        (PAYMENT_PROCESS, DISPLAY_LABELS[PAYMENT_PROCESS]),
+        (PAYMENT_REFUND, DISPLAY_LABELS[PAYMENT_REFUND]),
+        (PAYMENT_VOID, DISPLAY_LABELS[PAYMENT_VOID]),
+        (
+            SHIPPING_LIST_METHODS_FOR_CHECKOUT,
+            DISPLAY_LABELS[SHIPPING_LIST_METHODS_FOR_CHECKOUT],
+        ),
         (TRANSLATION_CREATED, DISPLAY_LABELS[TRANSLATION_CREATED]),
         (TRANSLATION_UPDATED, DISPLAY_LABELS[TRANSLATION_UPDATED]),
     ]
 
-    ALL = [event[0] for event in CHOICES]
+    PAYMENT_EVENTS = [
+        PAYMENT_AUTHORIZE,
+        PAYMENT_CAPTURE,
+        PAYMENT_CONFIRM,
+        PAYMENT_LIST_GATEWAYS,
+        PAYMENT_PROCESS,
+        PAYMENT_REFUND,
+        PAYMENT_VOID,
+    ]
+
+    SYNC_EVENTS = [SHIPPING_LIST_METHODS_FOR_CHECKOUT] + PAYMENT_EVENTS
 
     PERMISSIONS = {
         ORDER_CREATED: OrderPermissions.MANAGE_ORDERS,
@@ -175,60 +214,6 @@ class WebhookEventAsyncType:
         PAGE_CREATED: PagePermissions.MANAGE_PAGES,
         PAGE_UPDATED: PagePermissions.MANAGE_PAGES,
         PAGE_DELETED: PagePermissions.MANAGE_PAGES,
-        TRANSLATION_CREATED: SitePermissions.MANAGE_TRANSLATIONS,
-        TRANSLATION_UPDATED: SitePermissions.MANAGE_TRANSLATIONS,
-    }
-
-
-class WebhookEventSyncType:
-    PAYMENT_LIST_GATEWAYS = "payment_list_gateways"
-    PAYMENT_AUTHORIZE = "payment_authorize"
-    PAYMENT_CAPTURE = "payment_capture"
-    PAYMENT_REFUND = "payment_refund"
-    PAYMENT_VOID = "payment_void"
-    PAYMENT_CONFIRM = "payment_confirm"
-    PAYMENT_PROCESS = "payment_process"
-
-    SHIPPING_LIST_METHODS_FOR_CHECKOUT = "shipping_list_methods_for_checkout"
-
-    DISPLAY_LABELS = {
-        PAYMENT_AUTHORIZE: "Authorize payment",
-        PAYMENT_CAPTURE: "Capture payment",
-        PAYMENT_CONFIRM: "Confirm payment",
-        PAYMENT_LIST_GATEWAYS: "List payment gateways",
-        PAYMENT_PROCESS: "Process payment",
-        PAYMENT_REFUND: "Refund payment",
-        PAYMENT_VOID: "Void payment",
-        SHIPPING_LIST_METHODS_FOR_CHECKOUT: "Shipping list methods for checkout",
-    }
-
-    CHOICES = [
-        (PAYMENT_AUTHORIZE, DISPLAY_LABELS[PAYMENT_AUTHORIZE]),
-        (PAYMENT_CAPTURE, DISPLAY_LABELS[PAYMENT_CAPTURE]),
-        (PAYMENT_CONFIRM, DISPLAY_LABELS[PAYMENT_CONFIRM]),
-        (PAYMENT_LIST_GATEWAYS, DISPLAY_LABELS[PAYMENT_LIST_GATEWAYS]),
-        (PAYMENT_PROCESS, DISPLAY_LABELS[PAYMENT_PROCESS]),
-        (PAYMENT_REFUND, DISPLAY_LABELS[PAYMENT_REFUND]),
-        (PAYMENT_VOID, DISPLAY_LABELS[PAYMENT_VOID]),
-        (
-            SHIPPING_LIST_METHODS_FOR_CHECKOUT,
-            DISPLAY_LABELS[SHIPPING_LIST_METHODS_FOR_CHECKOUT],
-        ),
-    ]
-
-    ALL = [event[0] for event in CHOICES]
-
-    PAYMENT_EVENTS = [
-        PAYMENT_AUTHORIZE,
-        PAYMENT_CAPTURE,
-        PAYMENT_CONFIRM,
-        PAYMENT_LIST_GATEWAYS,
-        PAYMENT_PROCESS,
-        PAYMENT_REFUND,
-        PAYMENT_VOID,
-    ]
-
-    PERMISSIONS = {
         PAYMENT_AUTHORIZE: PaymentPermissions.HANDLE_PAYMENTS,
         PAYMENT_CAPTURE: PaymentPermissions.HANDLE_PAYMENTS,
         PAYMENT_CONFIRM: PaymentPermissions.HANDLE_PAYMENTS,
@@ -237,4 +222,6 @@ class WebhookEventSyncType:
         PAYMENT_REFUND: PaymentPermissions.HANDLE_PAYMENTS,
         PAYMENT_VOID: PaymentPermissions.HANDLE_PAYMENTS,
         SHIPPING_LIST_METHODS_FOR_CHECKOUT: ShippingPermissions.MANAGE_SHIPPING,
+        TRANSLATION_CREATED: SitePermissions.MANAGE_TRANSLATIONS,
+        TRANSLATION_UPDATED: SitePermissions.MANAGE_TRANSLATIONS,
     }

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -178,6 +178,8 @@ class WebhookEventType:
         PAYMENT_VOID,
     ]
 
+    SYNC_EVENTS = [SHIPPING_LIST_METHODS_FOR_CHECKOUT] + PAYMENT_EVENTS
+
     PERMISSIONS = {
         ORDER_CREATED: OrderPermissions.MANAGE_ORDERS,
         ORDER_CONFIRMED: OrderPermissions.MANAGE_ORDERS,

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -30,7 +30,7 @@ from ..plugins.webhook.utils import from_payment_app_id
 from ..product import ProductMediaTypes
 from ..product.models import Product
 from ..warehouse.models import Stock, Warehouse
-from .event_types import WebhookEventType
+from .event_types import WebhookEventAsyncType
 from .payload_serializers import PayloadSerializer
 from .serializers import (
     serialize_checkout_lines,
@@ -838,19 +838,19 @@ def _generate_sample_order_payload(event_name):
         "fulfillments",
     )
     order = None
-    if event_name == WebhookEventType.ORDER_CREATED:
+    if event_name == WebhookEventAsyncType.ORDER_CREATED:
         order = _get_sample_object(order_qs.filter(status=OrderStatus.UNFULFILLED))
-    elif event_name == WebhookEventType.ORDER_FULLY_PAID:
+    elif event_name == WebhookEventAsyncType.ORDER_FULLY_PAID:
         order = _get_sample_object(
             order_qs.filter(payments__charge_status=ChargeStatus.FULLY_CHARGED)
         )
-    elif event_name == WebhookEventType.ORDER_FULFILLED:
+    elif event_name == WebhookEventAsyncType.ORDER_FULFILLED:
         order = _get_sample_object(
             order_qs.filter(fulfillments__status=FulfillmentStatus.FULFILLED)
         )
     elif event_name in [
-        WebhookEventType.ORDER_CANCELLED,
-        WebhookEventType.ORDER_UPDATED,
+        WebhookEventAsyncType.ORDER_CANCELLED,
+        WebhookEventAsyncType.ORDER_UPDATED,
     ]:
         order = _get_sample_object(order_qs.filter(status=OrderStatus.CANCELED))
     if order:
@@ -860,20 +860,23 @@ def _generate_sample_order_payload(event_name):
 
 def generate_sample_payload(event_name: str) -> Optional[dict]:
     checkout_events = [
-        WebhookEventType.CHECKOUT_UPDATED,
-        WebhookEventType.CHECKOUT_CREATED,
+        WebhookEventAsyncType.CHECKOUT_UPDATED,
+        WebhookEventAsyncType.CHECKOUT_CREATED,
     ]
     pages_events = [
-        WebhookEventType.PAGE_CREATED,
-        WebhookEventType.PAGE_DELETED,
-        WebhookEventType.PAGE_UPDATED,
+        WebhookEventAsyncType.PAGE_CREATED,
+        WebhookEventAsyncType.PAGE_DELETED,
+        WebhookEventAsyncType.PAGE_UPDATED,
     ]
-    user_events = [WebhookEventType.CUSTOMER_CREATED, WebhookEventType.CUSTOMER_UPDATED]
+    user_events = [
+        WebhookEventAsyncType.CUSTOMER_CREATED,
+        WebhookEventAsyncType.CUSTOMER_UPDATED,
+    ]
 
     if event_name in user_events:
         user = generate_fake_user()
         payload = generate_customer_payload(user)
-    elif event_name == WebhookEventType.PRODUCT_CREATED:
+    elif event_name == WebhookEventAsyncType.PRODUCT_CREATED:
         product = _get_sample_object(
             Product.objects.prefetch_related("category", "collections", "variants")
         )
@@ -890,7 +893,7 @@ def generate_sample_payload(event_name: str) -> Optional[dict]:
         page = _get_sample_object(Page.objects.all())
         if page:
             payload = generate_page_payload(page)
-    elif event_name == WebhookEventType.FULFILLMENT_CREATED:
+    elif event_name == WebhookEventAsyncType.FULFILLMENT_CREATED:
         fulfillment = _get_sample_object(
             Fulfillment.objects.prefetch_related("lines__order_line__variant")
         )

--- a/saleor/webhook/tests/test_webhook_sample_payloads.py
+++ b/saleor/webhook/tests/test_webhook_sample_payloads.py
@@ -8,7 +8,7 @@ import pytest
 from freezegun import freeze_time
 
 from ...order import OrderStatus
-from ..event_types import WebhookEventType
+from ..event_types import WebhookEventAsyncType
 from ..payloads import (
     generate_checkout_payload,
     generate_fulfillment_payload,
@@ -33,11 +33,11 @@ def _remove_anonymized_order_data(order_data: dict) -> dict:
 @pytest.mark.parametrize(
     "event_name, order_status",
     [
-        (WebhookEventType.ORDER_CREATED, OrderStatus.UNFULFILLED),
-        (WebhookEventType.ORDER_UPDATED, OrderStatus.CANCELED),
-        (WebhookEventType.ORDER_CANCELLED, OrderStatus.CANCELED),
-        (WebhookEventType.ORDER_FULFILLED, OrderStatus.FULFILLED),
-        (WebhookEventType.ORDER_FULLY_PAID, OrderStatus.FULFILLED),
+        (WebhookEventAsyncType.ORDER_CREATED, OrderStatus.UNFULFILLED),
+        (WebhookEventAsyncType.ORDER_UPDATED, OrderStatus.CANCELED),
+        (WebhookEventAsyncType.ORDER_CANCELLED, OrderStatus.CANCELED),
+        (WebhookEventAsyncType.ORDER_FULFILLED, OrderStatus.FULFILLED),
+        (WebhookEventAsyncType.ORDER_FULLY_PAID, OrderStatus.FULFILLED),
     ],
 )
 def test_generate_sample_payload_order(
@@ -72,7 +72,7 @@ def test_generate_sample_payload_order(
 @freeze_time("1914-06-28 10:50", ignore=["faker"])
 def test_generate_sample_payload_fulfillment_created(fulfillment):
     sample_fulfillment_payload = generate_sample_payload(
-        WebhookEventType.FULFILLMENT_CREATED
+        WebhookEventAsyncType.FULFILLMENT_CREATED
     )[0]
     fulfillment_payload = json.loads(generate_fulfillment_payload(fulfillment))[0]
     order = fulfillment.order
@@ -108,16 +108,16 @@ def test_generate_sample_payload_fulfillment_created(fulfillment):
 @pytest.mark.parametrize(
     "event_name",
     [
-        WebhookEventType.ORDER_CREATED,
-        WebhookEventType.ORDER_UPDATED,
-        WebhookEventType.ORDER_CANCELLED,
-        WebhookEventType.ORDER_FULFILLED,
-        WebhookEventType.ORDER_FULLY_PAID,
-        WebhookEventType.DRAFT_ORDER_CREATED,
-        WebhookEventType.DRAFT_ORDER_UPDATED,
-        WebhookEventType.DRAFT_ORDER_DELETED,
-        WebhookEventType.PRODUCT_CREATED,
-        WebhookEventType.PRODUCT_UPDATED,
+        WebhookEventAsyncType.ORDER_CREATED,
+        WebhookEventAsyncType.ORDER_UPDATED,
+        WebhookEventAsyncType.ORDER_CANCELLED,
+        WebhookEventAsyncType.ORDER_FULFILLED,
+        WebhookEventAsyncType.ORDER_FULLY_PAID,
+        WebhookEventAsyncType.DRAFT_ORDER_CREATED,
+        WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
+        WebhookEventAsyncType.DRAFT_ORDER_DELETED,
+        WebhookEventAsyncType.PRODUCT_CREATED,
+        WebhookEventAsyncType.PRODUCT_UPDATED,
         "Non_existing_event",
         None,
         "",
@@ -128,7 +128,7 @@ def test_generate_sample_payload_empty_response_(event_name):
 
 
 def test_generate_sample_customer_payload(customer_user):
-    payload = generate_sample_payload(WebhookEventType.CUSTOMER_CREATED)
+    payload = generate_sample_payload(WebhookEventAsyncType.CUSTOMER_CREATED)
     assert payload
     # Assert that the payload was generated from the fake user
     assert payload[0]["email"] != customer_user.email
@@ -136,7 +136,7 @@ def test_generate_sample_customer_payload(customer_user):
 
 @freeze_time("1914-06-28 10:50")
 def test_generate_sample_product_payload(variant):
-    payload = generate_sample_payload(WebhookEventType.PRODUCT_CREATED)
+    payload = generate_sample_payload(WebhookEventAsyncType.PRODUCT_CREATED)
     product = variant.product
     product.refresh_from_db()
     assert payload == json.loads(generate_product_payload(variant.product))
@@ -164,7 +164,7 @@ def test_generate_sample_checkout_payload(user_checkouts):
         "saleor.webhook.payloads._get_sample_object", return_value=user_checkouts
     ):
         checkout = user_checkouts
-        payload = generate_sample_payload(WebhookEventType.CHECKOUT_UPDATED)
+        payload = generate_sample_payload(WebhookEventAsyncType.CHECKOUT_UPDATED)
         checkout_payload = json.loads(generate_checkout_payload(checkout))
         # Check anonymized data differ
         assert checkout.token != payload[0]["token"]


### PR DESCRIPTION
Split sync and async webhooks in the schema.
- Deprecated `webhookEvents` since the query is not used in the dashboard, and all event types can be obtained from `WebhookEventTypeAsyncEnum` and `WebhookEventTypeSyncEnum`.
- Splitted internal WebhookEventType class into from `WebhookEventAsyncType` and `WebhookEventSyncType`.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
