### PR TITLE
Webhooks improvements for partial payments

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -26,6 +26,7 @@ from ..giftcard.utils import (
     add_gift_card_code_to_checkout,
     remove_gift_card_code_from_checkout,
 )
+from ..payment import ChargeStatus
 from ..payment.models import Payment
 from ..payment.tasks import refund_or_void_inactive_payment
 from ..plugins.manager import PluginsManager
@@ -654,7 +655,10 @@ def is_fully_covered(
     """
     checkout = checkout_info.checkout
     total_covered = get_covered_balance(checkout).amount
-    if current_payment and current_payment.not_charged:
+    if current_payment and current_payment.charge_status in (
+        ChargeStatus.NOT_CHARGED,
+        ChargeStatus.PENDING,
+    ):
         total_covered += current_payment.total
 
     address = checkout_info.shipping_address or checkout_info.billing_address

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -88,7 +88,7 @@ def order_created(
             app=app,
             payment_actions=[
                 OrderPaymentAction(
-                    amount=payment.captured_amount,
+                    amount=payment.total,
                     payment=payment,
                 )
                 for payment in authorized_payments

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
@@ -63,7 +63,7 @@ def test_handle_api_response_auto_capture_false_order_created_can_void(
 
     payment_adyen_for_checkout.refresh_from_db()
 
-    assert payment_adyen_for_checkout.charge_status == ChargeStatus.NOT_CHARGED
+    assert payment_adyen_for_checkout.charge_status == ChargeStatus.AUTHORIZED
     assert payment_adyen_for_checkout.order
     assert payment_adyen_for_checkout.can_void()
     assert not payment_adyen_for_checkout.can_refund()
@@ -97,14 +97,14 @@ def test_handle_api_response_auto_capture_false_cannot_create_order_void_payment
 
     payment_adyen_for_checkout.refresh_from_db()
 
-    assert payment_adyen_for_checkout.charge_status == ChargeStatus.NOT_CHARGED
+    assert payment_adyen_for_checkout.charge_status == ChargeStatus.AUTHORIZED
     assert not payment_adyen_for_checkout.order
 
     assert not payment_adyen_for_checkout.can_refund()
     assert not refund_mock.called
 
     assert payment_adyen_for_checkout.can_void()
-    assert void_mock.call_count == 2
+    assert void_mock.call_count == 1
 
 
 @patch("saleor.payment.gateway.void")
@@ -137,7 +137,7 @@ def test_handle_api_response_auto_capture_cannot_create_order_refund_payment(
     assert not payment_adyen_for_checkout.order
 
     assert payment_adyen_for_checkout.can_refund()
-    assert refund_mock.call_count == 2
+    assert refund_mock.call_count == 1
 
     assert not payment_adyen_for_checkout.can_void()
     assert not void_mock.called

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -854,6 +854,7 @@ def handle_api_response(payment: Payment, response: Adyen.Adyen, channel_slug: s
         payment_information=payment_data,
         gateway_response=gateway_response,
     )
+    # TODO: check payment.complete order
     if is_success and not action_required and not payment.order:
         manager = get_plugins_manager()
 

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -208,7 +208,6 @@ def handle_not_created_order(notification, payment, checkout, kind, manager):
     ):  # type: ignore
 
         confirm_payment_and_set_back_to_confirm(payment, manager, checkout.channel.slug)
-        payment.refresh_from_db()  # refresh charge_status
         order = create_order(payment, checkout, manager)
         return order
     return None
@@ -854,14 +853,13 @@ def handle_api_response(payment: Payment, response: Adyen.Adyen, channel_slug: s
         payment_information=payment_data,
         gateway_response=gateway_response,
     )
-    # TODO: check payment.complete order
     if is_success and not action_required and not payment.order:
         manager = get_plugins_manager()
 
         confirm_payment_and_set_back_to_confirm(payment, manager, channel_slug)
-        payment.refresh_from_db()  # refresh charge_status
 
-        create_order(payment, checkout, manager)
+        if payment.can_create_order():
+            create_order(payment, checkout, manager)
 
 
 def confirm_payment_and_set_back_to_confirm(payment, manager, channel_slug):
@@ -882,3 +880,4 @@ def confirm_payment_and_set_back_to_confirm(payment, manager, channel_slug):
     gateway.confirm(payment, manager, channel_slug)
     payment.to_confirm = True
     payment.save(update_fields=["to_confirm"])
+    payment.refresh_from_db()  # refresh charge_status

--- a/saleor/payment/gateways/stripe/tests/test_webhooks.py
+++ b/saleor/payment/gateways/stripe/tests/test_webhooks.py
@@ -1,11 +1,13 @@
 import json
 from decimal import Decimal
+from unittest import mock
 from unittest.mock import Mock, patch
 
 import pytest
 from stripe.stripe_object import StripeObject
 
 from .....checkout.complete_checkout import complete_checkout
+from .....plugins.manager import get_plugins_manager
 from .... import ChargeStatus, TransactionKind
 from ....utils import price_to_minor_unit
 from ..consts import (
@@ -60,7 +62,9 @@ def test_handle_successful_payment_intent_for_checkout(
     payment_intent["currency"] = payment.currency
     payment_intent["status"] = SUCCESS_STATUS
 
-    handle_successful_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_successful_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     payment.refresh_from_db()
 
@@ -106,7 +110,9 @@ def test_handle_successful_payment_intent_with_future_usage(
     payment_intent["currency"] = payment.currency
     payment_intent["status"] = SUCCESS_STATUS
 
-    handle_successful_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_successful_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     mocked_payment_method_modify.assert_called_once_with(
         "payment_method_id",
@@ -119,7 +125,10 @@ def test_handle_successful_payment_intent_with_future_usage(
     "saleor.payment.gateways.stripe.webhooks.complete_checkout", wraps=complete_checkout
 )
 def test_handle_successful_payment_intent_for_order(
-    wrapped_checkout_complete, payment_stripe_for_order, stripe_plugin, channel_USD
+    wrapped_checkout_complete,
+    payment_stripe_for_order,
+    stripe_plugin,
+    channel_USD,
 ):
 
     payment = payment_stripe_for_order
@@ -128,7 +137,9 @@ def test_handle_successful_payment_intent_for_order(
     payment_intent["amount"] = payment.total
     payment_intent["currency"] = payment.currency
     payment_intent["capture_method"] = "automatic"
-    handle_successful_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_successful_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     assert wrapped_checkout_complete.called is False
 
@@ -137,7 +148,10 @@ def test_handle_successful_payment_intent_for_order(
     "saleor.payment.gateways.stripe.webhooks.complete_checkout", wraps=complete_checkout
 )
 def test_handle_successful_payment_intent_for_order_with_auth_payment(
-    wrapped_checkout_complete, payment_stripe_for_order, stripe_plugin, channel_USD
+    wrapped_checkout_complete,
+    payment_stripe_for_order,
+    stripe_plugin,
+    channel_USD,
 ):
     payment = payment_stripe_for_order
 
@@ -151,7 +165,9 @@ def test_handle_successful_payment_intent_for_order_with_auth_payment(
     payment_intent["setup_future_usage"] = None
     payment_intent["status"] = SUCCESS_STATUS
 
-    handle_successful_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_successful_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     payment.refresh_from_db()
 
@@ -166,7 +182,10 @@ def test_handle_successful_payment_intent_for_order_with_auth_payment(
     "saleor.payment.gateways.stripe.webhooks.complete_checkout", wraps=complete_checkout
 )
 def test_handle_successful_payment_intent_for_order_with_pending_payment(
-    wrapped_checkout_complete, payment_stripe_for_order, stripe_plugin, channel_USD
+    wrapped_checkout_complete,
+    payment_stripe_for_order,
+    stripe_plugin,
+    channel_USD,
 ):
     payment = payment_stripe_for_order
     transaction = payment.transactions.first()
@@ -183,7 +202,9 @@ def test_handle_successful_payment_intent_for_order_with_pending_payment(
     payment_intent["setup_future_usage"] = None
     payment_intent["status"] = SUCCESS_STATUS
 
-    handle_successful_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_successful_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     payment.refresh_from_db()
 
@@ -221,7 +242,9 @@ def test_handle_authorized_payment_intent_for_checkout(
     payment_intent["amount"] = price_to_minor_unit(payment.total, payment.currency)
     payment_intent["currency"] = payment.currency
     payment_intent["status"] = AUTHORIZED_STATUS
-    handle_authorized_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_authorized_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     payment.refresh_from_db()
 
@@ -250,7 +273,9 @@ def test_handle_authorized_payment_intent_for_order(
     payment_intent["amount"] = payment.total
     payment_intent["currency"] = payment.currency
     payment_intent["status"] = AUTHORIZED_STATUS
-    handle_authorized_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_authorized_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     assert wrapped_checkout_complete.called is False
 
@@ -273,7 +298,9 @@ def test_handle_authorized_payment_intent_for_processing_order_payment(
     payment_intent["amount"] = payment.total
     payment_intent["currency"] = payment.currency
     payment_intent["status"] = AUTHORIZED_STATUS
-    handle_authorized_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_authorized_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     assert wrapped_checkout_complete.called is False
 
@@ -295,7 +322,9 @@ def test_handle_processing_payment_intent_for_order(
     payment_intent["amount"] = payment.total
     payment_intent["currency"] = payment.currency
     payment_intent["status"] = PROCESSING_STATUS
-    handle_processing_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_processing_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     assert wrapped_checkout_complete.called is False
 
@@ -327,7 +356,9 @@ def test_handle_processing_payment_intent_for_checkout(
     payment_intent["amount"] = price_to_minor_unit(payment.total, payment.currency)
     payment_intent["currency"] = payment.currency
     payment_intent["status"] = PROCESSING_STATUS
-    handle_processing_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_processing_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     payment.refresh_from_db()
 
@@ -360,7 +391,9 @@ def test_handle_failed_payment_intent_for_checkout(
     payment_intent["currency"] = payment.currency
     payment_intent["status"] = FAILED_STATUSES[0]
 
-    handle_failed_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_failed_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     payment.refresh_from_db()
 
@@ -391,7 +424,9 @@ def test_handle_failed_payment_intent_for_order(
     payment_intent["currency"] = payment.currency
     payment_intent["status"] = FAILED_STATUSES[0]
 
-    handle_failed_payment_intent(payment_intent, plugin.config, channel_USD.slug)
+    handle_failed_payment_intent(
+        payment_intent, plugin.config, channel_USD.slug, get_plugins_manager()
+    )
 
     payment.refresh_from_db()
 
@@ -425,7 +460,7 @@ def test_handle_fully_refund(stripe_plugin, payment_stripe_for_order, channel_US
     charge["refunds"] = StripeObject()
     charge["refunds"]["data"] = [refund]
 
-    handle_refund(charge, plugin.config, channel_USD.slug)
+    handle_refund(charge, plugin.config, channel_USD.slug, get_plugins_manager())
 
     payment.refresh_from_db()
 
@@ -459,7 +494,7 @@ def test_handle_partial_refund(stripe_plugin, payment_stripe_for_order, channel_
     charge["refunds"] = StripeObject()
     charge["refunds"]["data"] = [refund]
 
-    handle_refund(charge, plugin.config, channel_USD.slug)
+    handle_refund(charge, plugin.config, channel_USD.slug, get_plugins_manager())
 
     payment.refresh_from_db()
 
@@ -498,7 +533,7 @@ def test_handle_refund_already_processed(
     charge["refunds"] = StripeObject()
     charge["refunds"]["data"] = [refund]
 
-    handle_refund(charge, plugin.config, channel_USD.slug)
+    handle_refund(charge, plugin.config, channel_USD.slug, get_plugins_manager())
 
     payment.refresh_from_db()
 
@@ -528,6 +563,7 @@ def test_handle_webhook_events(
     request = rf.post(
         path="/webhooks/", data=dummy_payload, content_type="application/json"
     )
+    request.plugins = get_plugins_manager()
 
     stripe_signature = "1234"
     request.META["HTTP_STRIPE_SIGNATURE"] = stripe_signature
@@ -543,7 +579,7 @@ def test_handle_webhook_events(
     with patch(f"saleor.payment.gateways.stripe.webhooks.{fun_to_mock}") as mocked_fun:
         plugin.webhook(request, "/webhooks/", None)
         mocked_fun.assert_called_once_with(
-            event.data.object, plugin.config, channel_USD.slug
+            event.data.object, plugin.config, channel_USD.slug, request.plugins
         )
 
     api_key = plugin.config.connection_params["secret_api_key"]
@@ -586,19 +622,13 @@ def test_process_payment_with_checkout_creates_order(
 
     _process_payment_with_checkout(
         payment,
-        payment_intent,
-        TransactionKind.ACTION_TO_CONFIRM,
-        payment.total,
-        channel_USD.slug,
+        mock.ANY,
     )
 
     mock_finalize_checkout.assert_called_once_with(
         payment.checkout,
         payment,
-        payment_intent,
-        TransactionKind.ACTION_TO_CONFIRM,
-        payment.total,
-        channel_USD.slug,
+        mock.ANY,
     )
 
 
@@ -631,10 +661,7 @@ def test_process_payment_with_checkout_does_not_create_order(
 
     _process_payment_with_checkout(
         payment,
-        payment_intent,
-        TransactionKind.ACTION_TO_CONFIRM,
-        payment.total,
-        channel_USD.slug,
+        get_plugins_manager(),
     )
 
     mock_finalize_checkout.assert_not_called()

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -158,6 +158,7 @@ def _create_transaction_if_not_exists(
         token=transaction_id,
         kind=kind,
         is_success=True,
+        action_required=False,
     ).exists():
         return None
 

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -15,7 +15,7 @@ from ....discount.utils import fetch_active_discounts
 from ....order import events
 from ....order.actions import order_captured, order_voided
 from ....order.interface import OrderPaymentAction
-from ....plugins.manager import get_plugins_manager
+from ....plugins.manager import PluginsManager
 from ... import ChargeStatus, TransactionKind
 from ...interface import GatewayConfig, GatewayResponse
 from ...models import Payment
@@ -81,7 +81,12 @@ def handle_webhook(
             "Processing new Stripe webhook",
             extra={"event_type": event.type, "event_id": event.id},
         )
-        webhook_handlers[event.type](event.data.object, gateway_config, channel_slug)
+        webhook_handlers[event.type](
+            event.data.object,
+            gateway_config,
+            channel_slug,
+            request.plugins,  # type: ignore
+        )
     else:
         logger.warning(
             "Received unhandled webhook events", extra={"event_type": event.type}
@@ -101,44 +106,11 @@ def _get_payment(payment_intent_id: str) -> Optional[Payment]:
     )
 
 
-def _get_checkout(payment_id: int) -> Optional[Checkout]:
-    return (
-        Checkout.objects.prefetch_related("payments")
-        .select_for_update(of=("self",))
-        .filter(payments__id=payment_id, payments__is_active=True)
-        .first()
-    )
-
-
 def _finalize_checkout(
     checkout: Checkout,
     payment: Payment,
-    payment_intent: StripeObject,
-    kind: str,
-    amount: str,
-    currency: str,
+    manager: PluginsManager,
 ):
-    gateway_response = GatewayResponse(
-        kind=kind,
-        action_required=False,
-        transaction_id=payment_intent.id,
-        is_success=True,
-        amount=price_from_minor_unit(amount, currency),
-        currency=payment_intent.currency,
-        error=None,
-        raw_response=payment_intent.last_response,
-        psp_reference=payment_intent.id,
-    )
-
-    create_transaction(
-        payment,
-        kind=kind,
-        payment_information=None,  # type: ignore
-        action_required=False,
-        gateway_response=gateway_response,
-    )
-
-    manager = get_plugins_manager()
     discounts = fetch_active_discounts()
     lines = fetch_checkout_lines(checkout)  # type: ignore
     checkout_info = fetch_checkout_info(
@@ -158,6 +130,27 @@ def _finalize_checkout(
     )
 
 
+def _get_checkout(payment_id: int) -> Optional[Checkout]:
+    return (
+        Checkout.objects.prefetch_related("payments")
+        .select_for_update(of=("self",))
+        .filter(payments__id=payment_id, payments__is_active=True)
+        .first()
+    )
+
+
+def _get_transaction_id_by_kind(
+    payment: Payment,
+    stripe_object: StripeObject,
+    kind: str,
+):
+    # stripe_object is Refund type
+    if kind == TransactionKind.REFUND:
+        return stripe_object.id
+    # stripe_object is a PaymentIntent type
+    return stripe_object.id
+
+
 def _update_payment_with_new_transaction(
     payment: Payment, stripe_object: StripeObject, kind: str, amount: str, currency: str
 ):
@@ -172,75 +165,81 @@ def _update_payment_with_new_transaction(
         raw_response=stripe_object.last_response,
         psp_reference=stripe_object.id,
     )
-    transaction = create_transaction(
-        payment,
-        kind=kind,
-        payment_information=None,  # type: ignore
-        action_required=False,
-        gateway_response=gateway_response,
-    )
-    gateway_postprocess(transaction, payment)
 
-    return transaction
+    transaction_id = _get_transaction_id_by_kind(
+        payment,
+        stripe_object,
+        kind,
+    )
+    if not payment.transactions.filter(token=transaction_id, kind=kind).exists():
+        transaction = create_transaction(
+            payment,
+            kind=kind,
+            payment_information=None,  # type: ignore
+            action_required=False,
+            gateway_response=gateway_response,
+        )
+        gateway_postprocess(transaction, payment)
+        return transaction
 
 
 def _process_payment_with_checkout(
     payment: Payment,
-    payment_intent: StripeObject,
-    kind: str,
-    amount: str,
-    currency: str,
+    manager: PluginsManager,
 ):
     checkout = _get_checkout(payment.id)
 
     if checkout and payment.can_create_order():
-        _finalize_checkout(checkout, payment, payment_intent, kind, amount, currency)
+        _finalize_checkout(checkout, payment, manager)
 
 
 def handle_authorized_payment_intent(
-    payment_intent: StripeObject, gateway_config: "GatewayConfig", _channel_slug: str
+    payment_intent: StripeObject,
+    gateway_config: "GatewayConfig",
+    _channel_slug: str,
+    manager: "PluginsManager",
 ):
     payment = _get_payment(payment_intent.id)
-
     if not payment:
         logger.warning(
             "Payment for PaymentIntent was not found",
             extra={"payment_intent": payment_intent.id},
         )
         return
+
+    _update_payment_with_new_transaction(
+        payment,
+        payment_intent,
+        TransactionKind.AUTH,
+        payment_intent.amount,
+        payment_intent.currency,
+    )
+
     if payment.order_id:
-        if payment.charge_status == ChargeStatus.PENDING:
-            _update_payment_with_new_transaction(
-                payment,
-                payment_intent,
-                TransactionKind.AUTH,
-                payment_intent.amount,
-                payment_intent.currency,
-            )
         # Order already created
         return
 
     if payment.checkout_id:
         _process_payment_with_checkout(
             payment,
-            payment_intent,
-            kind=TransactionKind.AUTH,
-            amount=payment_intent.amount,
-            currency=payment_intent.currency,
+            manager,
         )
 
 
 def handle_failed_payment_intent(
-    payment_intent: StripeObject, gateway_config: "GatewayConfig", _channel_slug: str
+    payment_intent: StripeObject,
+    gateway_config: "GatewayConfig",
+    _channel_slug: str,
+    manager: "PluginsManager",
 ):
     payment = _get_payment(payment_intent.id)
-
     if not payment:
         logger.warning(
             "Payment for PaymentIntent was not found",
             extra={"payment_intent": payment_intent.id},
         )
         return
+
     transaction = _update_payment_with_new_transaction(
         payment,
         payment_intent,
@@ -248,22 +247,34 @@ def handle_failed_payment_intent(
         payment_intent.amount,
         payment_intent.currency,
     )
+
     if payment.order:
         actions = [OrderPaymentAction(payment, transaction.amount)]
-        order_voided(payment.order, None, None, actions, get_plugins_manager())
+        order_voided(payment.order, None, None, actions, manager)
 
 
 def handle_processing_payment_intent(
-    payment_intent: StripeObject, gateway_config: "GatewayConfig", _channel_slug: str
+    payment_intent: StripeObject,
+    gateway_config: "GatewayConfig",
+    _channel_slug: str,
+    manager: "PluginsManager",
 ):
     payment = _get_payment(payment_intent.id)
-
     if not payment:
         logger.warning(
             "Payment for PaymentIntent was not found",
             extra={"payment_intent": payment_intent.id},
         )
         return
+
+    _update_payment_with_new_transaction(
+        payment,
+        payment_intent,
+        TransactionKind.PENDING,
+        payment_intent.amount,
+        payment_intent.currency,
+    )
+
     if payment.order_id:
         # Order already created
         return
@@ -271,18 +282,17 @@ def handle_processing_payment_intent(
     if payment.checkout_id:
         _process_payment_with_checkout(
             payment,
-            payment_intent,
-            TransactionKind.PENDING,
-            amount=payment_intent.amount,
-            currency=payment_intent.currency,
+            manager,
         )
 
 
 def handle_successful_payment_intent(
-    payment_intent: StripeObject, gateway_config: "GatewayConfig", channel_slug: str
+    payment_intent: StripeObject,
+    gateway_config: "GatewayConfig",
+    channel_slug: str,
+    manager: "PluginsManager",
 ):
     payment = _get_payment(payment_intent.id)
-
     if not payment:
         logger.warning(
             "Payment for PaymentIntent was not found",
@@ -302,36 +312,37 @@ def handle_successful_payment_intent(
         if changed_fields:
             payment.save(update_fields=changed_fields)
 
+    capture_transaction = _update_payment_with_new_transaction(
+        payment,
+        payment_intent,
+        TransactionKind.CAPTURE,
+        payment_intent.amount_received,
+        payment_intent.currency,
+    )
+
     if payment.order_id:
-        if payment.charge_status in [ChargeStatus.PENDING, ChargeStatus.NOT_CHARGED]:
-            capture_transaction = _update_payment_with_new_transaction(
-                payment,
-                payment_intent,
-                TransactionKind.CAPTURE,
-                payment_intent.amount_received,
-                payment_intent.currency,
-            )
+        if capture_transaction:
             order_captured(
                 payment.order,  # type: ignore
                 None,
                 None,
                 [OrderPaymentAction(payment, capture_transaction.amount)],
-                get_plugins_manager(),
+                manager,
             )
         return
 
     if payment.checkout_id:
         _process_payment_with_checkout(
             payment,
-            payment_intent,
-            TransactionKind.CAPTURE,
-            amount=payment_intent.amount_received,
-            currency=payment_intent.currency,
+            manager,
         )
 
 
 def handle_refund(
-    charge: StripeObject, gateway_config: "GatewayConfig", _channel_slug: str
+    charge: StripeObject,
+    gateway_config: "GatewayConfig",
+    _channel_slug: str,
+    manager: "PluginsManager",
 ):
     payment_intent_id = charge.payment_intent
     payment = _get_payment(payment_intent_id)
@@ -375,4 +386,4 @@ def handle_refund(
                 amount=refund_transaction.amount,
                 payment=payment,
             )
-            get_plugins_manager().order_updated(payment.order)
+            manager.order_updated(payment.order)

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -139,18 +139,6 @@ def _get_checkout(payment_id: int) -> Optional[Checkout]:
     )
 
 
-def _get_transaction_id_by_kind(
-    payment: Payment,
-    stripe_object: StripeObject,
-    kind: str,
-):
-    # stripe_object is Refund type
-    if kind == TransactionKind.REFUND:
-        return stripe_object.id
-    # stripe_object is a PaymentIntent type
-    return stripe_object.id
-
-
 def _update_payment_with_new_transaction(
     payment: Payment, stripe_object: StripeObject, kind: str, amount: str, currency: str
 ):
@@ -166,12 +154,12 @@ def _update_payment_with_new_transaction(
         psp_reference=stripe_object.id,
     )
 
-    transaction_id = _get_transaction_id_by_kind(
-        payment,
-        stripe_object,
-        kind,
-    )
-    if not payment.transactions.filter(token=transaction_id, kind=kind).exists():
+    transaction_id = stripe_object.id
+    if not payment.transactions.filter(
+        token=transaction_id,
+        kind=kind,
+        is_success=True,
+    ).exists():
         transaction = create_transaction(
             payment,
             kind=kind,

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -18,7 +18,7 @@ from ....order.interface import OrderPaymentAction
 from ....plugins.manager import PluginsManager
 from ... import ChargeStatus, TransactionKind
 from ...interface import GatewayConfig, GatewayResponse
-from ...models import Payment
+from ...models import Payment, Transaction
 from ...utils import (
     create_transaction,
     gateway_postprocess,
@@ -100,8 +100,7 @@ def _get_payment(payment_intent_id: str) -> Optional[Payment]:
             "checkout",
         )
         .select_for_update(of=("self",))
-        # TODO: inactive payments should be processed to reflect their state in PSP
-        .filter(transactions__token=payment_intent_id, is_active=True)
+        .filter(transactions__token=payment_intent_id)
         .first()
     )
 
@@ -134,14 +133,14 @@ def _get_checkout(payment_id: int) -> Optional[Checkout]:
     return (
         Checkout.objects.prefetch_related("payments")
         .select_for_update(of=("self",))
-        .filter(payments__id=payment_id, payments__is_active=True)
+        .filter(payments__id=payment_id)
         .first()
     )
 
 
-def _update_payment_with_new_transaction(
+def _create_transaction_if_not_exists(
     payment: Payment, stripe_object: StripeObject, kind: str, amount: str, currency: str
-):
+) -> Optional[Transaction]:
     gateway_response = GatewayResponse(
         kind=kind,
         action_required=False,
@@ -155,20 +154,22 @@ def _update_payment_with_new_transaction(
     )
 
     transaction_id = stripe_object.id
-    if not payment.transactions.filter(
+    if payment.transactions.filter(
         token=transaction_id,
         kind=kind,
         is_success=True,
     ).exists():
-        transaction = create_transaction(
-            payment,
-            kind=kind,
-            payment_information=None,  # type: ignore
-            action_required=False,
-            gateway_response=gateway_response,
-        )
-        gateway_postprocess(transaction, payment)
-        return transaction
+        return None
+
+    transaction = create_transaction(
+        payment,
+        kind=kind,
+        payment_information=None,  # type: ignore
+        action_required=False,
+        gateway_response=gateway_response,
+    )
+    gateway_postprocess(transaction, payment)
+    return transaction
 
 
 def _process_payment_with_checkout(
@@ -195,7 +196,7 @@ def handle_authorized_payment_intent(
         )
         return
 
-    _update_payment_with_new_transaction(
+    _create_transaction_if_not_exists(
         payment,
         payment_intent,
         TransactionKind.AUTH,
@@ -228,7 +229,7 @@ def handle_failed_payment_intent(
         )
         return
 
-    transaction = _update_payment_with_new_transaction(
+    transaction = _create_transaction_if_not_exists(
         payment,
         payment_intent,
         TransactionKind.CANCEL,
@@ -236,7 +237,7 @@ def handle_failed_payment_intent(
         payment_intent.currency,
     )
 
-    if payment.order:
+    if payment.order and transaction:
         actions = [OrderPaymentAction(payment, transaction.amount)]
         order_voided(payment.order, None, None, actions, manager)
 
@@ -255,7 +256,7 @@ def handle_processing_payment_intent(
         )
         return
 
-    _update_payment_with_new_transaction(
+    _create_transaction_if_not_exists(
         payment,
         payment_intent,
         TransactionKind.PENDING,
@@ -300,7 +301,7 @@ def handle_successful_payment_intent(
         if changed_fields:
             payment.save(update_fields=changed_fields)
 
-    capture_transaction = _update_payment_with_new_transaction(
+    capture_transaction = _create_transaction_if_not_exists(
         payment,
         payment_intent,
         TransactionKind.CAPTURE,
@@ -362,11 +363,11 @@ def handle_refund(
         )
         return
 
-    refund_transaction = _update_payment_with_new_transaction(
+    refund_transaction = _create_transaction_if_not_exists(
         payment, refund, TransactionKind.REFUND, refund.amount, refund.currency
     )
     if payment.order:
-        if payment.order and refund_transaction.is_success:
+        if refund_transaction and refund_transaction.is_success:
             events.payment_refunded_event(
                 order=payment.order,
                 user=None,


### PR DESCRIPTION
I want to merge this change because:
- manager from request is being passed onto webhooks (query optimisation)
- fixed order authorize event amount when creating an order (it was captured amount always equal to 0 instead of the authorized amount)
- resolve conflicts with zombie payment solution (changed unit tests)
- count payments with pending status towards order total
- call process_gateway in all payment-related webhooks prior to finalising checkout

Adyen tests:
<img width="822" alt="image" src="https://user-images.githubusercontent.com/2566928/141693900-645996a5-a486-420d-8c35-c501dbdd7004.png">

<img width="1110" alt="image" src="https://user-images.githubusercontent.com/2566928/141693935-4a7067e0-6b9f-419a-95a5-7f62c34857de.png">



<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
