### PR TITLE
Fix NP Atobarai `PLUGIN_ID`

### DIFF
--- a/saleor/payment/gateways/np_atobarai/plugin.py
+++ b/saleor/payment/gateways/np_atobarai/plugin.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 
 class NPAtobaraiGatewayPlugin(BasePlugin):
-    PLUGIN_ID = "mirumee.payments.np-atobarai"
+    PLUGIN_ID = "saleor.payments.np-atobarai"
     PLUGIN_NAME = GATEWAY_NAME
     CONFIGURATION_PER_CHANNEL = True
     SUPPORTED_CURRENCIES = "JPY"

--- a/saleor/payment/gateways/np_atobarai/tests/test_api.py
+++ b/saleor/payment/gateways/np_atobarai/tests/test_api.py
@@ -7,6 +7,7 @@ import requests
 
 from .... import PaymentError
 from .. import api, get_api_config
+from ..plugin import NPAtobaraiGatewayPlugin
 
 
 @pytest.fixture
@@ -256,7 +257,7 @@ def test_report_fulfillment_already_captured(
 
 @pytest.fixture
 def payment_np(payment_dummy):
-    payment_dummy.gateway = "mirumee.payments.np-atobarai"
+    payment_dummy.gateway = NPAtobaraiGatewayPlugin.PLUGIN_ID
     payment_dummy.save(update_fields=["gateway"])
     return payment_dummy
 


### PR DESCRIPTION
I want to update `PLUGIN_ID` to use new form `saleor.*` instead of `mirumee.*`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
