### PR TITLE
add-webhook-meta

### DIFF
--- a/saleor/core/middleware.py
+++ b/saleor/core/middleware.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from typing import TYPE_CHECKING, Union
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -10,9 +11,15 @@ from django.utils.translation import get_language
 
 from ..discount.utils import fetch_discounts
 from ..graphql.utils import get_user_or_app_from_context
-from ..plugins.manager import get_plugins_manager
+from ..plugins.manager import PluginsManager, get_plugins_manager
 from . import analytics
 from .jwt import JWT_REFRESH_TOKEN_COOKIE_NAME, jwt_decode_with_exception_handler
+
+if TYPE_CHECKING:
+    from ..account.models import User
+    from ..app.models import App
+
+Requestor = Union["User", "App"]
 
 logger = logging.getLogger(__name__)
 
@@ -82,10 +89,10 @@ def site(get_response):
 def plugins(get_response):
     """Assign plugins manager."""
 
-    def _get_manager(requestor):
-        return get_plugins_manager()
+    def _get_manager(requestor: Requestor) -> PluginsManager:
+        return get_plugins_manager(requestor)
 
-    def _get_requestor(request):
+    def _get_requestor(request) -> Requestor:
         return get_user_or_app_from_context(request)
 
     def _plugins_middleware(request):

--- a/saleor/core/tests/test_middleware.py
+++ b/saleor/core/tests/test_middleware.py
@@ -78,3 +78,40 @@ def test_jwt_refresh_token_middleware_samesite_none(rf, customer_user, settings)
     response = handler.get_response(request)
     cookie = response.cookies.get(JWT_REFRESH_TOKEN_COOKIE_NAME)
     assert cookie["samesite"] == "None"
+
+
+def test_plugins_middleware_loads_requestor_in_plugin(rf, customer_user, settings):
+    settings.MIDDLEWARE = [
+        "saleor.core.middleware.plugins",
+    ]
+    settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.ActivePlugin"]
+    request = rf.request()
+    request.user = customer_user
+    request.app = None
+
+    handler = BaseHandler()
+    handler.load_middleware()
+    handler.get_response(request)
+    plugin = request.plugins.all_plugins.pop()
+
+    assert isinstance(plugin.requestor, type(customer_user))
+    assert plugin.requestor.id == customer_user.id
+
+
+def test_plugins_middleware_requestor_in_plugin_when_no_app_and_user_in_req_is_none(
+    rf, settings
+):
+    settings.MIDDLEWARE = [
+        "saleor.core.middleware.plugins",
+    ]
+    settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.ActivePlugin"]
+    request = rf.request()
+    request.user = None
+    request.app = None
+
+    handler = BaseHandler()
+    handler.load_middleware()
+    handler.get_response(request)
+    plugin = request.plugins.all_plugins.pop()
+
+    assert not plugin.requestor

--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -344,6 +344,7 @@ def test_page_create_mutation(staff_api_client, permission_manage_pages, page_ty
     assert tag_value_slug in values
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_page_create_trigger_page_webhook(
     mocked_webhook_trigger,
@@ -380,7 +381,7 @@ def test_page_create_trigger_page_webhook(
     assert data["page"]["isPublished"] == page_is_published
     assert data["page"]["pageType"]["id"] == page_type_id
     page = Page.objects.first()
-    expected_data = generate_page_payload(page)
+    expected_data = generate_page_payload(page, staff_api_client.user)
 
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.PAGE_CREATED, expected_data
@@ -1233,6 +1234,7 @@ def test_page_delete_mutation(staff_api_client, page, permission_manage_pages):
         page.refresh_from_db()
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_page_delete_trigger_webhook(
     mocked_webhook_trigger, staff_api_client, page, permission_manage_pages, settings
@@ -1248,7 +1250,7 @@ def test_page_delete_trigger_webhook(
     with pytest.raises(page._meta.model.DoesNotExist):
         page.refresh_from_db()
 
-    expected_data = generate_page_payload(page)
+    expected_data = generate_page_payload(page, staff_api_client.user)
 
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.PAGE_DELETED, expected_data
@@ -1429,7 +1431,7 @@ def test_update_page_trigger_webhook(
     assert data["page"]["title"] == page_title
     assert data["page"]["slug"] == new_slug
     page.publication_date = date(2020, 3, 18)
-    expected_data = generate_page_payload(page)
+    expected_data = generate_page_payload(page, staff_api_client.user)
 
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.PAGE_UPDATED, expected_data

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -974,6 +974,7 @@ class ProductVariantCreate(ModelMutation):
             if new_variant
             else info.context.plugins.product_variant_updated
         )
+
         transaction.on_commit(lambda: event_to_call(instance))
 
     @classmethod

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -974,7 +974,6 @@ class ProductVariantCreate(ModelMutation):
             if new_variant
             else info.context.plugins.product_variant_updated
         )
-
         transaction.on_commit(lambda: event_to_call(instance))
 
     @classmethod

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -7204,6 +7204,7 @@ def test_delete_product_with_image(
     mocked_recalculate_orders_task.assert_not_called()
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
 def test_delete_product_trigger_webhook(
@@ -7230,7 +7231,9 @@ def test_delete_product_trigger_webhook(
         product.refresh_from_db()
     assert node_id == data["product"]["id"]
 
-    expected_data = generate_product_deleted_payload(product, variants_id)
+    expected_data = generate_product_deleted_payload(
+        product, variants_id, staff_api_client.user
+    )
 
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.PRODUCT_DELETED, expected_data

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import graphene
 import pytest
 from django.contrib.auth.models import Permission
+from freezegun import freeze_time
 
 from ....tests.utils import dummy_editorjs
 from ....webhook.event_types import WebhookEventType
@@ -822,6 +823,7 @@ PRODUCT_TRANSLATE_MUTATION = """
 """
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_create_translation(
     mocked_webhook_trigger,
@@ -844,7 +846,7 @@ def test_product_create_translation(
     assert data["product"]["translation"]["language"]["code"] == "PL"
 
     translation = product.translations.first()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_CREATED, expected_payload
     )
@@ -920,6 +922,7 @@ def test_product_create_translation_by_translatable_content_id(
     assert data["product"]["translation"]["language"]["code"] == "PL"
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_update_translation(
     mocked_webhook_trigger,
@@ -944,7 +947,7 @@ def test_product_update_translation(
     assert data["product"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )
@@ -970,6 +973,7 @@ mutation productVariantTranslate(
 """
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_variant_create_translation(
     mocked_webhook_trigger,
@@ -993,7 +997,7 @@ def test_product_variant_create_translation(
     assert data["productVariant"]["translation"]["language"]["code"] == "PL"
 
     translation = variant.translations.first()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_with(
         WebhookEventType.TRANSLATION_CREATED, expected_payload
     )
@@ -1018,6 +1022,7 @@ def test_product_variant_create_translation_by_translatable_content_id(
     assert data["productVariant"]["translation"]["language"]["code"] == "PL"
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_variant_update_translation(
     mocked_webhook_trigger,
@@ -1042,7 +1047,7 @@ def test_product_variant_update_translation(
     assert data["productVariant"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )
@@ -1067,6 +1072,7 @@ mutation collectionTranslate($collectionId: ID!, $input: TranslationInput!) {
 """
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_collection_create_translation(
     mocked_webhook_trigger,
@@ -1089,7 +1095,7 @@ def test_collection_create_translation(
     assert data["collection"]["translation"]["language"]["code"] == "PL"
 
     translation = published_collection.translations.first()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_CREATED, expected_payload
     )
@@ -1150,6 +1156,7 @@ def test_collection_create_translation_for_description_name_as_null(
     assert data["collection"]["translation"]["language"]["code"] == "PL"
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_collection_update_translation(
     mocked_webhook_trigger,
@@ -1176,7 +1183,7 @@ def test_collection_update_translation(
     assert data["collection"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )
@@ -1201,6 +1208,7 @@ mutation categoryTranslate($categoryId: ID!, $input: TranslationInput!) {
 """
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_category_create_translation(
     mocked_webhook_trigger,
@@ -1223,7 +1231,7 @@ def test_category_create_translation(
     assert data["category"]["translation"]["language"]["code"] == "PL"
 
     translation = category.translations.first()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_CREATED, expected_payload
     )
@@ -1284,6 +1292,7 @@ def test_category_create_translation_for_description_name_as_null(
     assert data["category"]["translation"]["language"]["code"] == "PL"
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_category_update_translation(
     mocked_webhook_trigger,
@@ -1308,7 +1317,7 @@ def test_category_update_translation(
     assert data["category"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )
@@ -1332,6 +1341,7 @@ VOUCHER_TRANSLATE_MUTATION = """
 """
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_voucher_create_translation(
     mocked_webhook_trigger,
@@ -1354,7 +1364,7 @@ def test_voucher_create_translation(
     assert data["voucher"]["translation"]["language"]["code"] == "PL"
 
     translation = voucher.translations.first()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_CREATED, expected_payload
     )
@@ -1378,6 +1388,7 @@ def test_voucher_create_translation_by_translatable_content_id(
     assert data["voucher"]["translation"]["language"]["code"] == "PL"
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_voucher_update_translation(
     mocked_webhook_trigger,
@@ -1401,7 +1412,7 @@ def test_voucher_update_translation(
     assert data["voucher"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )
@@ -1425,6 +1436,7 @@ SALE_TRANSLATION_MUTATION = """
 """
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_sale_create_translation(
     mocked_webhook_trigger,
@@ -1447,7 +1459,7 @@ def test_sale_create_translation(
     assert data["sale"]["translation"]["language"]["code"] == "PL"
 
     translation = sale.translations.first()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_CREATED, expected_payload
     )
@@ -1471,6 +1483,7 @@ def test_sale_create_translation_by_translatable_content_id(
     assert data["sale"]["translation"]["language"]["code"] == "PL"
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_sale_update_translation(
     mocked_webhook_trigger,
@@ -1495,7 +1508,7 @@ def test_sale_update_translation(
     assert data["sale"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )
@@ -1520,6 +1533,7 @@ mutation pageTranslate($pageId: ID!, $input: PageTranslationInput!) {
 """
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_page_create_translation(
     mocked_webhook_trigger,
@@ -1542,7 +1556,7 @@ def test_page_create_translation(
     assert data["page"]["translation"]["language"]["code"] == "PL"
 
     translation = page.translations.first()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_CREATED, expected_payload
     )
@@ -1600,6 +1614,7 @@ def test_page_create_translation_by_translatable_content_id(
     assert data["page"]["translation"]["language"]["code"] == "PL"
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_page_update_translation(
     mocked_webhook_trigger,
@@ -1623,7 +1638,7 @@ def test_page_update_translation(
     assert data["page"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )
@@ -1649,6 +1664,7 @@ ATTRIBUTE_TRANSLATE_MUTATION = """
 """
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_attribute_create_translation(
     mocked_webhook_trigger,
@@ -1671,7 +1687,7 @@ def test_attribute_create_translation(
     assert data["attribute"]["translation"]["language"]["code"] == "PL"
 
     translation = color_attribute.translations.first()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_CREATED, expected_payload
     )
@@ -1695,6 +1711,7 @@ def test_attribute_create_translation_by_translatable_content_id(
     assert data["attribute"]["translation"]["language"]["code"] == "PL"
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_attribute_update_translation(
     mocked_webhook_trigger,
@@ -1719,7 +1736,7 @@ def test_attribute_update_translation(
     assert data["attribute"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )
@@ -1745,6 +1762,7 @@ ATTRIBUTE_VALUE_TRANSLATE_MUTATION = """
 """
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_attribute_value_create_translation(
     mocked_webhook_trigger,
@@ -1769,7 +1787,7 @@ def test_attribute_value_create_translation(
     assert data["attributeValue"]["translation"]["language"]["code"] == "PL"
 
     translation = pink_attribute_value.translations.first()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_CREATED, expected_payload
     )
@@ -1791,6 +1809,7 @@ def test_attribute_value_create_translation_by_translatable_content_id(
     assert data["attributeValue"]["translation"]["language"]["code"] == "PL"
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_attribute_value_update_translation(
     mocked_webhook_trigger,
@@ -1819,7 +1838,7 @@ def test_attribute_value_update_translation(
     assert data["attributeValue"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )
@@ -1848,6 +1867,7 @@ SHIPPING_PRICE_TRANSLATE = """
 """
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_shipping_method_create_translation(
     mocked_webhook_trigger,
@@ -1877,7 +1897,7 @@ def test_shipping_method_create_translation(
     assert data["shippingMethod"]["translation"]["language"]["code"] == "PL"
 
     translation = shipping_method.translations.first()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_CREATED, expected_payload
     )
@@ -1908,6 +1928,7 @@ def test_shipping_method_create_translation_by_translatable_content_id(
     assert data["shippingMethod"]["translation"]["language"]["code"] == "PL"
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_shipping_method_update_translation(
     mocked_webhook_trigger,
@@ -1951,7 +1972,7 @@ def test_shipping_method_update_translation(
     assert data["shippingMethod"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )
@@ -1976,6 +1997,7 @@ MENU_ITEM_TRANSLATE = """
 """
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_menu_item_update_translation(
     mocked_webhook_trigger,
@@ -2002,7 +2024,7 @@ def test_menu_item_update_translation(
     assert data["menuItem"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )
@@ -2024,6 +2046,7 @@ def test_menu_item_create_translation_by_translatable_content_id(
     assert data["menuItem"]["translation"]["language"]["code"] == "PL"
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_shop_create_translation(
     mocked_webhook_trigger,
@@ -2059,12 +2082,13 @@ def test_shop_create_translation(
     assert data["shop"]["translation"]["language"]["code"] == "PL"
 
     translation = site_settings.translations.first()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_CREATED, expected_payload
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_shop_update_translation(
     mocked_webhook_trigger,
@@ -2104,7 +2128,7 @@ def test_shop_update_translation(
     assert data["shop"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation)
+    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.TRANSLATION_UPDATED, expected_payload
     )

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -91,11 +91,13 @@ class BasePlugin:
         *,
         configuration: PluginConfigurationType,
         active: bool,
-        channel: Optional["Channel"] = None
+        channel: Optional["Channel"] = None,
+        requestor=None
     ):
         self.configuration = self.get_plugin_configuration(configuration)
         self.active = active
         self.channel = channel
+        self.requestor = requestor
 
     def __str__(self):
         return self.PLUGIN_NAME

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 
 PluginConfigurationType = List[dict]
 NoneType = type(None)
+RequestorOrLazyObject = Union[SimpleLazyObject, "Requestor"]
 
 
 class ConfigurationTypeField:
@@ -99,7 +100,7 @@ class BasePlugin:
         self.configuration = self.get_plugin_configuration(configuration)
         self.active = active
         self.channel = channel
-        self.requestor = (
+        self.requestor: Optional[RequestorOrLazyObject] = (
             SimpleLazyObject(requestor_getter) if requestor_getter else requestor_getter
         )
 

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from ..account.models import Address, User
     from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
     from ..checkout.models import Checkout
+    from ..core.middleware import Requestor
     from ..discount.models import Sale
     from ..invoice.models import Invoice
     from ..order.models import Fulfillment, Order, OrderLine
@@ -1125,6 +1126,6 @@ class PluginsManager(PaymentInterface):
         )
 
 
-def get_plugins_manager(requestor=None) -> PluginsManager:
+def get_plugins_manager(requestor: Optional["Requestor"] = None) -> PluginsManager:
     with opentracing.global_tracer().start_active_span("get_plugins_manager"):
         return PluginsManager(settings.PLUGINS, requestor)

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -241,7 +241,10 @@ class WebhookPlugin(BasePlugin):
     ) -> Any:
         if not self.active:
             return previous_value
-        product_variant_data = generate_product_variant_payload([product_variant])
+
+        product_variant_data = generate_product_variant_payload(
+            [product_variant], self.requestor
+        )
         trigger_webhooks_for_event.delay(
             WebhookEventType.PRODUCT_VARIANT_CREATED, product_variant_data
         )
@@ -251,7 +254,9 @@ class WebhookPlugin(BasePlugin):
     ) -> Any:
         if not self.active:
             return previous_value
-        product_variant_data = generate_product_variant_payload([product_variant])
+        product_variant_data = generate_product_variant_payload(
+            [product_variant], self.requestor
+        )
         trigger_webhooks_for_event.delay(
             WebhookEventType.PRODUCT_VARIANT_UPDATED, product_variant_data
         )
@@ -261,7 +266,9 @@ class WebhookPlugin(BasePlugin):
     ) -> Any:
         if not self.active:
             return previous_value
-        product_variant_data = generate_product_variant_payload([product_variant])
+        product_variant_data = generate_product_variant_payload(
+            [product_variant], self.requestor
+        )
         trigger_webhooks_for_event.delay(
             WebhookEventType.PRODUCT_VARIANT_DELETED, product_variant_data
         )
@@ -277,7 +284,9 @@ class WebhookPlugin(BasePlugin):
     def product_variant_back_in_stock(self, stock: "Stock", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        product_variant_data = generate_product_variant_with_stock_payload([stock])
+        product_variant_data = generate_product_variant_with_stock_payload(
+            [stock], self.requestor
+        )
         trigger_webhooks_for_event.delay(
             WebhookEventType.PRODUCT_VARIANT_BACK_IN_STOCK, product_variant_data
         )

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -71,25 +71,25 @@ class WebhookPlugin(BasePlugin):
     def order_created(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order)
+        order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(WebhookEventType.ORDER_CREATED, order_data)
 
     def order_confirmed(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order)
+        order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(WebhookEventType.ORDER_CONFIRMED, order_data)
 
     def order_fully_paid(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order)
+        order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(WebhookEventType.ORDER_FULLY_PAID, order_data)
 
     def order_updated(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order)
+        order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(WebhookEventType.ORDER_UPDATED, order_data)
 
     def sale_created(
@@ -98,7 +98,10 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         sale_data = generate_sale_payload(
-            sale, previous_catalogue=None, current_catalogue=current_catalogue
+            sale,
+            previous_catalogue=None,
+            current_catalogue=current_catalogue,
+            requestor=self.requestor,
         )
         trigger_webhooks_for_event.delay(WebhookEventType.SALE_CREATED, sale_data)
 
@@ -111,7 +114,9 @@ class WebhookPlugin(BasePlugin):
     ) -> Any:
         if not self.active:
             return previous_value
-        sale_data = generate_sale_payload(sale, previous_catalogue, current_catalogue)
+        sale_data = generate_sale_payload(
+            sale, previous_catalogue, current_catalogue, self.requestor
+        )
         trigger_webhooks_for_event.delay(WebhookEventType.SALE_UPDATED, sale_data)
 
     def sale_deleted(
@@ -119,7 +124,9 @@ class WebhookPlugin(BasePlugin):
     ) -> Any:
         if not self.active:
             return previous_value
-        sale_data = generate_sale_payload(sale, previous_catalogue=previous_catalogue)
+        sale_data = generate_sale_payload(
+            sale, previous_catalogue=previous_catalogue, requestor=self.requestor
+        )
         trigger_webhooks_for_event.delay(WebhookEventType.SALE_DELETED, sale_data)
 
     def invoice_request(
@@ -151,19 +158,19 @@ class WebhookPlugin(BasePlugin):
     def order_cancelled(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order)
+        order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(WebhookEventType.ORDER_CANCELLED, order_data)
 
     def order_fulfilled(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order)
+        order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(WebhookEventType.ORDER_FULFILLED, order_data)
 
     def draft_order_created(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order)
+        order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(
             WebhookEventType.DRAFT_ORDER_CREATED, order_data
         )
@@ -171,7 +178,7 @@ class WebhookPlugin(BasePlugin):
     def draft_order_updated(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order)
+        order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(
             WebhookEventType.DRAFT_ORDER_UPDATED, order_data
         )
@@ -179,7 +186,7 @@ class WebhookPlugin(BasePlugin):
     def draft_order_deleted(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order)
+        order_data = generate_order_payload(order, self.requestor)
         trigger_webhooks_for_event.delay(
             WebhookEventType.DRAFT_ORDER_DELETED, order_data
         )
@@ -219,13 +226,13 @@ class WebhookPlugin(BasePlugin):
     def product_created(self, product: "Product", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        product_data = generate_product_payload(product)
+        product_data = generate_product_payload(product, self.requestor)
         trigger_webhooks_for_event.delay(WebhookEventType.PRODUCT_CREATED, product_data)
 
     def product_updated(self, product: "Product", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        product_data = generate_product_payload(product)
+        product_data = generate_product_payload(product, self.requestor)
         trigger_webhooks_for_event.delay(WebhookEventType.PRODUCT_UPDATED, product_data)
 
     def product_deleted(
@@ -233,7 +240,9 @@ class WebhookPlugin(BasePlugin):
     ) -> Any:
         if not self.active:
             return previous_value
-        product_data = generate_product_deleted_payload(product, variants)
+        product_data = generate_product_deleted_payload(
+            product, variants, self.requestor
+        )
         trigger_webhooks_for_event.delay(WebhookEventType.PRODUCT_DELETED, product_data)
 
     def product_variant_created(

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -95,6 +95,7 @@ def test_trigger_webhooks_for_event_calls_expected_events(
     assert target_url_calls == expected_target_urls
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_order_created(mocked_webhook_trigger, settings, order_with_lines):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -107,6 +108,7 @@ def test_order_created(mocked_webhook_trigger, settings, order_with_lines):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_order_confirmed(mocked_webhook_trigger, settings, order_with_lines):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -119,6 +121,7 @@ def test_order_confirmed(mocked_webhook_trigger, settings, order_with_lines):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_draft_order_created(mocked_webhook_trigger, settings, order_with_lines):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -131,6 +134,7 @@ def test_draft_order_created(mocked_webhook_trigger, settings, order_with_lines)
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_draft_order_deleted(mocked_webhook_trigger, settings, order_with_lines):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -143,6 +147,7 @@ def test_draft_order_deleted(mocked_webhook_trigger, settings, order_with_lines)
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_draft_order_updated(mocked_webhook_trigger, settings, order_with_lines):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -179,6 +184,7 @@ def test_customer_updated(mocked_webhook_trigger, settings, customer_user):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_order_fully_paid(mocked_webhook_trigger, settings, order_with_lines):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -191,6 +197,7 @@ def test_order_fully_paid(mocked_webhook_trigger, settings, order_with_lines):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_created(mocked_webhook_trigger, settings, product):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -203,6 +210,7 @@ def test_product_created(mocked_webhook_trigger, settings, product):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_updated(mocked_webhook_trigger, settings, product):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -215,6 +223,7 @@ def test_product_updated(mocked_webhook_trigger, settings, product):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_deleted(mocked_webhook_trigger, settings, product):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -242,6 +251,7 @@ def test_product_deleted(mocked_webhook_trigger, settings, product):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_variant_created(mocked_webhook_trigger, settings, variant):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -254,6 +264,7 @@ def test_product_variant_created(mocked_webhook_trigger, settings, variant):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_variant_updated(mocked_webhook_trigger, settings, variant):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -266,6 +277,7 @@ def test_product_variant_updated(mocked_webhook_trigger, settings, variant):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_variant_deleted(mocked_webhook_trigger, settings, variant):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -278,6 +290,7 @@ def test_product_variant_deleted(mocked_webhook_trigger, settings, variant):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_variant_out_of_stock(
     mocked_webhook_trigger, settings, variant_with_many_stocks
@@ -294,6 +307,7 @@ def test_product_variant_out_of_stock(
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_product_variant_back_in_stock(
     mocked_webhook_trigger, settings, variant_with_many_stocks
@@ -310,6 +324,7 @@ def test_product_variant_back_in_stock(
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_order_updated(mocked_webhook_trigger, settings, order_with_lines):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -322,6 +337,7 @@ def test_order_updated(mocked_webhook_trigger, settings, order_with_lines):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_order_cancelled(mocked_webhook_trigger, settings, order_with_lines):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -465,6 +481,7 @@ def test_notify_user(mocked_webhook_trigger, settings, customer_user, channel_US
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_sale_created(mocked_webhook_trigger, settings, sale):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -479,6 +496,7 @@ def test_sale_created(mocked_webhook_trigger, settings, sale):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_sale_updated(mocked_webhook_trigger, settings, sale, product_list):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
@@ -506,6 +524,7 @@ def test_sale_updated(mocked_webhook_trigger, settings, sale, product_list):
     )
 
 
+@freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
 def test_sale_deleted(mocked_webhook_trigger, settings, sale):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -861,6 +861,6 @@ def test_generate_meta(app, rf):
     request.user = None
     requestor = get_user_or_app_from_context(request)
 
-    assert generate_meta(issuing_principal=generate_requestor(requestor)) == {
+    assert generate_meta(requestor_data=generate_requestor(requestor)) == {
         "issuing_principal": {"id": "Sample app objects", "type": "app"}
     }

--- a/saleor/webhook/tests/test_webhook_sample_payloads.py
+++ b/saleor/webhook/tests/test_webhook_sample_payloads.py
@@ -2,8 +2,10 @@ import copy
 import json
 from unittest import mock
 
+import freezegun
 import graphene
 import pytest
+from freezegun import freeze_time
 
 from ...order import OrderStatus
 from ..event_types import WebhookEventType
@@ -27,6 +29,7 @@ def _remove_anonymized_order_data(order_data: dict) -> dict:
     return order_data
 
 
+@freezegun.freeze_time("1914-06-28 10:50", ignore=["faker"])
 @pytest.mark.parametrize(
     "event_name, order_status",
     [
@@ -44,7 +47,6 @@ def test_generate_sample_payload_order(
     order.status = order_status
     order.save()
     order_id = graphene.Node.to_global_id("Order", order.id)
-
     payload = generate_sample_payload(event_name)
     order_payload = json.loads(generate_order_payload(order))
     # Check anonymized data differ
@@ -131,6 +133,7 @@ def test_generate_sample_customer_payload(customer_user):
     assert payload[0]["email"] != customer_user.email
 
 
+@freeze_time("1914-06-28 10:50")
 def test_generate_sample_product_payload(variant):
     payload = generate_sample_payload(WebhookEventType.PRODUCT_CREATED)
     product = variant.product

--- a/saleor/webhook/tests/test_webhook_sample_payloads.py
+++ b/saleor/webhook/tests/test_webhook_sample_payloads.py
@@ -69,6 +69,7 @@ def test_generate_sample_payload_order(
     assert payload == order_payload
 
 
+@freeze_time("1914-06-28 10:50", ignore=["faker"])
 def test_generate_sample_payload_fulfillment_created(fulfillment):
     sample_fulfillment_payload = generate_sample_payload(
         WebhookEventType.FULFILLMENT_CREATED
@@ -153,6 +154,7 @@ def _remove_anonymized_checkout_data(checkout_data: dict) -> dict:
     return checkout_data
 
 
+@freeze_time("1914-06-28 10:50", ignore=["faker"])
 @pytest.mark.parametrize(
     "user_checkouts", ["regular", "click_and_collect"], indirect=True
 )


### PR DESCRIPTION
I want to merge this change because this change enables to develop additional logic from saleor-app perspective, in particular, ignoring webhooks triggered by the app itself (thundering herd problem). This PR adds metadata to each of webhook payloads, so it is possible to determine, who triggered the webhook, when, and which API version were used. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
