### PR TITLE
Fix invalid order status for orders with waiting for approvals fulfillments

### DIFF
--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -263,7 +263,6 @@ def order_awaits_fulfillment_approval(
     _notify_customer=True,
 ):
     order = fulfillments[0].order
-    update_order_status(order)
     events.fulfillment_awaits_approval_event(
         order=order, user=user, app=app, fulfillment_lines=fulfillment_lines
     )

--- a/saleor/order/tests/test_fulfillments_actions.py
+++ b/saleor/order/tests/test_fulfillments_actions.py
@@ -85,6 +85,9 @@ def test_create_fulfillments_require_approval(
     site_settings,
 ):
     order = order_with_lines
+    order_status = order.status
+    assert order_status != OrderStatus.FULFILLED
+
     order_line1, order_line2 = order.lines.all()
     fulfillment_lines_for_warehouses = {
         str(warehouse.pk): [
@@ -114,7 +117,7 @@ def test_create_fulfillments_require_approval(
     assert fulfillment_lines[1].stock == order_line2.variant.stocks.get()
     assert fulfillment_lines[1].quantity == 2
 
-    assert order.status == OrderStatus.FULFILLED
+    assert order.status == order_status
     assert order.fulfillments.get() == fulfillment
 
     order_line1, order_line2 = order.lines.all()
@@ -149,6 +152,9 @@ def test_create_fulfillments_require_approval_as_app(
     site_settings,
 ):
     order = order_with_lines
+    order_status = order.status
+    assert order_status != OrderStatus.FULFILLED
+
     order_line1, order_line2 = order.lines.all()
     fulfillment_lines_for_warehouses = {
         str(warehouse.pk): [
@@ -178,7 +184,7 @@ def test_create_fulfillments_require_approval_as_app(
     assert fulfillment_lines[1].stock == order_line2.variant.stocks.get()
     assert fulfillment_lines[1].quantity == 2
 
-    assert order.status == OrderStatus.FULFILLED
+    assert order.status == order_status
     assert order.fulfillments.get() == fulfillment
 
     order_line1, order_line2 = order.lines.all()

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -419,6 +419,17 @@ def test_update_order_status_partially_returned(fulfilled_order):
     assert fulfilled_order.status == OrderStatus.PARTIALLY_RETURNED
 
 
+def test_update_order_status_waiting_for_approval(fulfilled_order):
+    fulfilled_order.fulfillments.create(status=FulfillmentStatus.WAITING_FOR_APPROVAL)
+    fulfilled_order.status = OrderStatus.FULFILLED
+    fulfilled_order.save()
+
+    update_order_status(fulfilled_order)
+
+    fulfilled_order.refresh_from_db()
+    assert fulfilled_order.status == OrderStatus.PARTIALLY_FULFILLED
+
+
 def test_validate_fulfillment_tracking_number_as_url(fulfilled_order):
     fulfillment = fulfilled_order.fulfillments.first()
     assert not fulfillment.is_tracking_number_url

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -290,6 +290,11 @@ def update_order_status(order):
         quantity_returned,
     ) = _calculate_quantity_including_returns(order)
 
+    # check if order contains any fulfillments that awaiting approval
+    awaiting_approval = order.fulfillments.filter(
+        status=FulfillmentStatus.WAITING_FOR_APPROVAL
+    ).exists()
+
     # total_quantity == 0 means that all products have been replaced, we don't change
     # the order status in that case
     if total_quantity == 0:
@@ -300,7 +305,7 @@ def update_order_status(order):
         status = OrderStatus.PARTIALLY_RETURNED
     elif quantity_returned == total_quantity:
         status = OrderStatus.RETURNED
-    elif quantity_fulfilled < total_quantity:
+    elif quantity_fulfilled < total_quantity or awaiting_approval:
         status = OrderStatus.PARTIALLY_FULFILLED
     else:
         status = OrderStatus.FULFILLED

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3702,19 +3702,23 @@ def fulfillment(fulfilled_order):
 
 @pytest.fixture
 def fulfillment_awaiting_approval(fulfilled_order):
-    order_line = fulfilled_order.lines.first()
-    order_line.quantity_fulfilled = 0
-    order_line.save(update_fields=["quantity_fulfilled"])
-
     fulfillment = fulfilled_order.fulfillments.first()
     fulfillment.status = FulfillmentStatus.WAITING_FOR_APPROVAL
     fulfillment.save(update_fields=["status"])
 
+    quantity = 1
     fulfillment_lines_to_update = []
+    order_lines_to_update = []
     for f_line in fulfillment.lines.all():
-        f_line.quantity = 1
+        f_line.quantity = quantity
         fulfillment_lines_to_update.append(f_line)
+
+        order_line = f_line.order_line
+        order_line.quantity_fulfilled = quantity
+        order_lines_to_update.append(order_line)
+
     FulfillmentLine.objects.bulk_update(fulfillment_lines_to_update, ["quantity"])
+    OrderLine.objects.bulk_update(order_lines_to_update, ["quantity_fulfilled"])
 
     return fulfillment
 


### PR DESCRIPTION
- Do not change order `status` after creating waiting for approval fulfillment
- When updating order status check if any fulfillment awaiting approval

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
