### PR TITLE
Add support for out of order stripe webhooks

### DIFF
--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -237,8 +237,12 @@ def connection_from_queryset_slice(
 
     requested_count = first or last
     end_margin = requested_count + 1 if requested_count else None
+
     cursor = after or before
-    cursor = from_global_cursor(cursor) if cursor else None
+    try:
+        cursor = from_global_cursor(cursor) if cursor else None
+    except ValueError:
+        raise GraphQLError("Received cursor is invalid.")
 
     sort_by = args.get("sort_by", {})
     sorting_fields = _get_sorting_fields(sort_by, qs)

--- a/saleor/graphql/core/tests/test_pagination.py
+++ b/saleor/graphql/core/tests/test_pagination.py
@@ -218,3 +218,14 @@ def test_pagination_backward_last_page_info(books):
     page_info = content["books"]["pageInfo"]
     assert page_info["hasNextPage"]
     assert page_info["hasPreviousPage"] is False
+
+
+def test_pagination_invalid_cursor(books):
+    cursor = graphene.Node.to_global_id("BookType", -1)
+    variables = {"first": 5, "after": cursor}
+
+    result = schema.execute(QUERY_PAGINATION_TEST, variables=variables)
+
+    assert result.errors
+    assert len(result.errors) == 1
+    assert str(result.errors[0]) == "Received cursor is invalid."

--- a/saleor/payment/gateways/adyen/tests/conftest.py
+++ b/saleor/payment/gateways/adyen/tests/conftest.py
@@ -94,32 +94,40 @@ def payment_adyen_for_checkout(checkout_with_items, address, shipping_method):
 
 
 @pytest.fixture
-def payment_adyen_for_order(order_with_lines):
-    payment = create_payment(
-        gateway=AdyenGatewayPlugin.PLUGIN_ID,
-        payment_token="",
-        total=Decimal("80.00"),
-        currency=order_with_lines.currency,
-        email=order_with_lines.user_email,
-        customer_ip_address="",
-        checkout=None,
-        order=order_with_lines,
-        return_url="https://www.example.com",
-    )
+def payment_adyen_for_order_factory(order_with_lines):
+    def factory():
+        payment = create_payment(
+            gateway=AdyenGatewayPlugin.PLUGIN_ID,
+            payment_token="",
+            total=Decimal("80.00"),
+            currency=order_with_lines.currency,
+            email=order_with_lines.user_email,
+            customer_ip_address="",
+            checkout=None,
+            order=order_with_lines,
+            return_url="https://www.example.com",
+        )
 
-    Transaction.objects.create(
-        payment=payment,
-        action_required=False,
-        kind=TransactionKind.AUTH,
-        token="token",
-        is_success=True,
-        amount=order_with_lines.total_gross_amount,
-        currency=order_with_lines.currency,
-        error="",
-        gateway_response={},
-        action_required_data={},
-    )
-    return payment
+        Transaction.objects.create(
+            payment=payment,
+            action_required=False,
+            kind=TransactionKind.AUTH,
+            token="token",
+            is_success=True,
+            amount=order_with_lines.total_gross_amount,
+            currency=order_with_lines.currency,
+            error="",
+            gateway_response={},
+            action_required_data={},
+        )
+        return payment
+
+    return factory
+
+
+@pytest.fixture
+def payment_adyen_for_order(payment_adyen_for_order_factory):
+    return payment_adyen_for_order_factory()
 
 
 @pytest.fixture()

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -35,6 +35,7 @@ from ....order.actions import cancel_order, order_authorized, order_captured
 from ....order.events import external_notification_event
 from ....order.interface import OrderPaymentAction
 from ....order.notifications import send_order_refunded_confirmation
+from ....order.utils import get_active_payments
 from ....payment.models import Payment, Transaction
 from ....plugins.manager import get_plugins_manager
 from ... import ChargeStatus, PaymentError, TransactionKind, gateway
@@ -298,13 +299,14 @@ def handle_cancellation(
 
     reason = notification.get("reason", "-")
     success_msg = f"Adyen: The cancel {transaction_id} request was successful."
-    failed_msg = f"Adyen: The camcel {transaction_id} request failed. Reason: {reason}"
+    failed_msg = f"Adyen: The cancel {transaction_id} request failed. Reason: {reason}"
     create_payment_notification_for_order(
         payment, success_msg, failed_msg, new_transaction.is_success
     )
     if payment.order and new_transaction.is_success:
         manager = get_plugins_manager()
-        cancel_order(payment.order, None, None, manager)
+        if not get_active_payments(payment.order):
+            cancel_order(payment.order, None, None, manager)
 
 
 def handle_cancel_or_refund(


### PR DESCRIPTION
I want to merge this change because webhooks that arrive out of order can currently break the payment charge status.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
