### PR TITLE
Improve message when the cursor in pagination is invalid

### DIFF
--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -237,8 +237,12 @@ def connection_from_queryset_slice(
 
     requested_count = first or last
     end_margin = requested_count + 1 if requested_count else None
+
     cursor = after or before
-    cursor = from_global_cursor(cursor) if cursor else None
+    try:
+        cursor = from_global_cursor(cursor) if cursor else None
+    except ValueError:
+        raise GraphQLError("Received cursor is invalid.")
 
     sort_by = args.get("sort_by", {})
     sorting_fields = _get_sorting_fields(sort_by, qs)

--- a/saleor/graphql/core/tests/test_pagination.py
+++ b/saleor/graphql/core/tests/test_pagination.py
@@ -218,3 +218,14 @@ def test_pagination_backward_last_page_info(books):
     page_info = content["books"]["pageInfo"]
     assert page_info["hasNextPage"]
     assert page_info["hasPreviousPage"] is False
+
+
+def test_pagination_invalid_cursor(books):
+    cursor = graphene.Node.to_global_id("BookType", -1)
+    variables = {"first": 5, "after": cursor}
+
+    result = schema.execute(QUERY_PAGINATION_TEST, variables=variables)
+
+    assert result.errors
+    assert len(result.errors) == 1
+    assert str(result.errors[0]) == "Received cursor is invalid."


### PR DESCRIPTION
Raise `GraphQL` error when the cursor is invalid.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
