### PR TITLE
Add option to set shipping tax code for Avatax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Batch loads in queries for Apollo Federation - #8362 by @rafalp
 - Change metadata mutations to use token for order and checkout as identifier - #8542 by @IKarbowiak
   - After changes, using the order `id` for changing order metadata is deprecated
+- Add option to set tax code for shipping in Avatax configuration view - #8596 by @korycins
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -34,9 +34,6 @@ CACHE_KEY = "avatax_request_id_"
 TAX_CODES_CACHE_KEY = "avatax_tax_codes_cache_key"
 TIMEOUT = 10  # API HTTP Requests Timeout
 
-# Common carrier code used to identify the line as a shipping service
-COMMON_CARRIER_CODE = "FR020100"
-
 # Common discount code use to apply discount on order
 COMMON_DISCOUNT_VOUCHER_CODE = "OD010000"
 
@@ -57,6 +54,7 @@ class AvataxConfiguration:
     use_sandbox: bool = True
     company_name: str = "DEFAULT"
     autocommit: bool = False
+    shipping_tax_code: str = ""
 
 
 class TransactionType:
@@ -220,6 +218,7 @@ def append_line_to_data(
 def append_shipping_to_data(
     data: List[Dict],
     shipping_method_channel_listings: Optional["ShippingMethodChannelListing"],
+    shipping_tax_code: str,
 ):
     charge_taxes_on_shipping = (
         Site.objects.get_current().settings.charge_taxes_on_shipping
@@ -230,7 +229,7 @@ def append_shipping_to_data(
             data,
             quantity=1,
             amount=shipping_price.amount,
-            tax_code=COMMON_CARRIER_CODE,
+            tax_code=shipping_tax_code,
             item_code="Shipping",
         )
 
@@ -238,6 +237,7 @@ def append_shipping_to_data(
 def get_checkout_lines_data(
     checkout_info: "CheckoutInfo",
     lines_info: Iterable["CheckoutLineInfo"],
+    config: AvataxConfiguration,
     discounts=None,
 ) -> List[Dict[str, Union[str, int, bool, None]]]:
     data: List[Dict[str, Union[str, int, bool, None]]] = []
@@ -264,14 +264,13 @@ def get_checkout_lines_data(
         )
 
     append_shipping_to_data(
-        data,
-        checkout_info.shipping_method_channel_listings,
+        data, checkout_info.shipping_method_channel_listings, config.shipping_tax_code
     )
     return data
 
 
 def get_order_lines_data(
-    order: "Order",
+    order: "Order", config: AvataxConfiguration
 ) -> List[Dict[str, Union[str, int, bool, None]]]:
     data: List[Dict[str, Union[str, int, bool, None]]] = []
     lines = order.lines.prefetch_related(
@@ -320,7 +319,9 @@ def get_order_lines_data(
     shipping_method_channel_listing = ShippingMethodChannelListing.objects.filter(
         shipping_method=order.shipping_method_id, channel=order.channel_id
     ).first()
-    append_shipping_to_data(data, shipping_method_channel_listing)
+    append_shipping_to_data(
+        data, shipping_method_channel_listing, config.shipping_tax_code
+    )
     return data
 
 
@@ -377,7 +378,7 @@ def generate_request_data_from_checkout(
 ):
 
     address = checkout_info.shipping_address or checkout_info.billing_address
-    lines = get_checkout_lines_data(checkout_info, lines_info, discounts)
+    lines = get_checkout_lines_data(checkout_info, lines_info, config, discounts)
 
     currency = checkout_info.checkout.currency
     data = generate_request_data(
@@ -446,7 +447,7 @@ def get_checkout_tax_data(
 
 def get_order_request_data(order: "Order", config: AvataxConfiguration):
     address = order.shipping_address or order.billing_address
-    lines = get_order_lines_data(order)
+    lines = get_order_lines_data(order, config)
     transaction = (
         TransactionType.INVOICE
         if not (order.is_draft() or order.is_unconfirmed())

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -68,6 +68,7 @@ class AvataxPlugin(BasePlugin):
         {"name": "from_country", "value": None},
         {"name": "from_country_area", "value": None},
         {"name": "from_postal_code", "value": None},
+        {"name": "shipping_tax_code", "value": "FR000000"},
     ]
     CONFIG_STRUCTURE = {
         "Username or account": {
@@ -125,6 +126,14 @@ class AvataxPlugin(BasePlugin):
             "help_text": "To calculate taxes we need to provide `ship from` details.",
             "label": "Ship from - postal code",
         },
+        "shipping_tax_code": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": (
+                "Provide Avatax's tax code that will be included in the shipping line "
+                "sent to Avatax."
+            ),
+            "label": "Shipping tax code",
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -146,6 +155,7 @@ class AvataxPlugin(BasePlugin):
             from_country=from_country,
             from_country_area=configuration["from_country_area"],
             from_postal_code=configuration["from_postal_code"],
+            shipping_tax_code=configuration["shipping_tax_code"],
         )
 
     def _skip_plugin(

--- a/saleor/plugins/avatax/tests/cassettes/test_api_post_request_task_creates_order_event.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_api_post_request_task_creates_order_event.yaml
@@ -5,7 +5,7 @@ interactions:
       true, "itemCode": "SKU_AA", "description": "Test product"}, {"quantity": 2,
       "amount": "49.200", "taxCode": "O9999999", "taxIncluded": true, "itemCode":
       "SKU_B", "description": "Test product 2"}, {"quantity": 1, "amount": "10.000",
-      "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping", "description":
+      "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping", "description":
       null}], "code": "a4cbdeba-f310-458f-8202-91118fd3b9fd", "date": "2021-03-02",
       "customerCode": 0, "addresses": {"shipFrom": {"line1": "2000 Main Street", "line2":
       "", "city": "Irvine", "region": "CA", "country": "US", "postalCode": "92614"},

--- a/saleor/plugins/avatax/tests/cassettes/test_api_post_request_task_sends_request.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_api_post_request_task_sends_request.yaml
@@ -5,7 +5,7 @@ interactions:
       true, "itemCode": "SKU_AA", "description": "Test product"}, {"quantity": 2,
       "amount": "49.200", "taxCode": "O9999999", "taxIncluded": true, "itemCode":
       "SKU_B", "description": "Test product 2"}, {"quantity": 1, "amount": "10.000",
-      "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping", "description":
+      "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping", "description":
       null}], "code": "ed3eb46f-cd75-41d8-ba4d-f03394a20f28", "date": "2021-03-02",
       "customerCode": 0, "addresses": {"shipFrom": {"line1": "2000 Main Street", "line2":
       "", "city": "Irvine", "region": "CA", "country": "US", "postalCode": "92614"},

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_total[False-24.39-30.00-True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_total[False-24.39-30.00-True].yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "63a24c15-6d69-4fba-872b-ddb393343dd5", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_total[False-30.00-36.90-False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_total[False-30.00-36.90-False].yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
       false, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": false, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": false, "itemCode": "Shipping",
       "description": null}], "code": "e30b79c9-1489-46d1-8189-f6a474a3b250", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_total[True-12.20-15.00-True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_total[True-12.20-15.00-True].yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "922dc055-1fb9-4ea8-9cdc-6429324f5ff4", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_total[True-15.00-18.45-False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_total[True-15.00-18.45-False].yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       false, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": false, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": false, "itemCode": "Shipping",
       "description": null}], "code": "50ac96cf-063e-45cb-bcf6-60e05735bd87", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_unit_price[False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_unit_price[False].yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "5acf893f-9408-49dd-8a26-116226efc978", "date":
       "2021-03-22", "customerCode": 0, "addresses": {"shipFrom": {"line1": "2000 Main
       Street", "line2": "", "city": "Irvine", "region": "CA", "country": "US", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_unit_price[True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_unit_price[True].yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "44efbd04-db7f-4ea5-a129-5e2f425e7553", "date":
       "2021-03-22", "customerCode": 0, "addresses": {"shipFrom": {"line1": "2000 Main
       Street", "line2": "", "city": "Irvine", "region": "CA", "country": "US", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_shipping.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_shipping.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "60ccf01a-5b39-4efd-93e3-8ae6601b277e", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_subtotal[False-40.65-50.00-True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_subtotal[False-40.65-50.00-True].yaml
@@ -4,7 +4,7 @@ interactions:
       "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 2, "amount":
       "20.00", "taxCode": "O9999999", "taxIncluded": true, "itemCode": "SKU_A", "description":
-      "Test product"}, {"quantity": 1, "amount": "10.000", "taxCode": "FR020100",
+      "Test product"}, {"quantity": 1, "amount": "10.000", "taxCode": "FR000000",
       "taxIncluded": true, "itemCode": "Shipping", "description": null}], "code":
       "8409c0ba-26a3-40cf-af59-3954a3329b17", "date": "2021-03-18", "customerCode":
       0, "addresses": {"shipFrom": {"line1": "T\u0119czowa 7", "line2": "", "city":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_subtotal[False-50.00-61.50-False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_subtotal[False-50.00-61.50-False].yaml
@@ -4,7 +4,7 @@ interactions:
       "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
       false, "itemCode": "123", "description": "Test product"}, {"quantity": 2, "amount":
       "20.00", "taxCode": "O9999999", "taxIncluded": false, "itemCode": "SKU_A", "description":
-      "Test product"}, {"quantity": 1, "amount": "10.000", "taxCode": "FR020100",
+      "Test product"}, {"quantity": 1, "amount": "10.000", "taxCode": "FR000000",
       "taxIncluded": false, "itemCode": "Shipping", "description": null}], "code":
       "a4921208-0d1d-441f-8197-a4645e53f2f0", "date": "2021-03-18", "customerCode":
       0, "addresses": {"shipFrom": {"line1": "T\u0119czowa 7", "line2": "", "city":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_subtotal[True-20.33-25.00-True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_subtotal[True-20.33-25.00-True].yaml
@@ -4,7 +4,7 @@ interactions:
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 2, "amount":
       "10.00", "taxCode": "O9999999", "taxIncluded": true, "itemCode": "SKU_A", "description":
-      "Test product"}, {"quantity": 1, "amount": "10.000", "taxCode": "FR020100",
+      "Test product"}, {"quantity": 1, "amount": "10.000", "taxCode": "FR000000",
       "taxIncluded": true, "itemCode": "Shipping", "description": null}], "code":
       "5cf0cea8-c6c7-4508-ab8c-0b8214d32dbd", "date": "2021-03-18", "customerCode":
       0, "addresses": {"shipFrom": {"line1": "T\u0119czowa 7", "line2": "", "city":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_subtotal[True-25.00-30.75-False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_subtotal[True-25.00-30.75-False].yaml
@@ -4,7 +4,7 @@ interactions:
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       false, "itemCode": "123", "description": "Test product"}, {"quantity": 2, "amount":
       "10.00", "taxCode": "O9999999", "taxIncluded": false, "itemCode": "SKU_A", "description":
-      "Test product"}, {"quantity": 1, "amount": "10.000", "taxCode": "FR020100",
+      "Test product"}, {"quantity": 1, "amount": "10.000", "taxCode": "FR000000",
       "taxIncluded": false, "itemCode": "Shipping", "description": null}], "code":
       "7bfc992a-61aa-4552-9acf-bcaae18a8249", "date": "2021-03-18", "customerCode":
       0, "addresses": {"shipFrom": {"line1": "T\u0119czowa 7", "line2": "", "city":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total[False-33.13-40.98-3.0-True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total[False-33.13-40.98-3.0-True].yaml
@@ -5,7 +5,7 @@ interactions:
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
       "1.99", "taxCode": "PS081282", "taxIncluded": true, "itemCode": "SKU_SINGLE_VARIANT",
       "description": "Test product with single variant"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "a93a16ca-6e4a-4611-9033-84664694e8e4", "date":
       "2021-03-18", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total[False-43.98-53.64-0.0-False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total[False-43.98-53.64-0.0-False].yaml
@@ -5,7 +5,7 @@ interactions:
       false, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
       "1.99", "taxCode": "PS081282", "taxIncluded": false, "itemCode": "SKU_SINGLE_VARIANT",
       "description": "Test product with single variant"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": false, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": false, "itemCode": "Shipping",
       "description": null}], "code": "4a1f2a93-9d62-4ae6-9a3c-9f74f46f452b", "date":
       "2021-03-18", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total[True-23.94-28.98-0.0-True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total[True-23.94-28.98-0.0-True].yaml
@@ -5,7 +5,7 @@ interactions:
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
       "1.99", "taxCode": "PS081282", "taxIncluded": true, "itemCode": "SKU_SINGLE_VARIANT",
       "description": "Test product with single variant"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "6e11a3ea-4e04-4c34-9318-bbe9c96c4292", "date":
       "2021-03-18", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total[True-23.98-30.19-5.0-False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total[True-23.98-30.19-5.0-False].yaml
@@ -5,7 +5,7 @@ interactions:
       false, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
       "1.99", "taxCode": "PS081282", "taxIncluded": false, "itemCode": "SKU_SINGLE_VARIANT",
       "description": "Test product with single variant"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": false, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": false, "itemCode": "Shipping",
       "description": null}], "code": "fb1fed9a-cb9d-46b8-86c3-783ceb06dc1e", "date":
       "2021-03-18", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total_not_charged_product_and_shipping_with_0_price.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total_not_charged_product_and_shipping_with_0_price.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
-      "lines": [{"quantity": 1, "amount": "0.000", "taxCode": "FR020100", "taxIncluded":
+      "lines": [{"quantity": 1, "amount": "0.000", "taxCode": "FR000000", "taxIncluded":
       true, "itemCode": "Shipping", "description": null}], "code": "dd5c408f-b533-494c-b2a1-2985140b71be",
       "date": "2021-06-24", "customerCode": 0, "addresses": {"shipFrom": {"line1":
       "Teczowa 7", "line2": null, "city": "Wroclaw", "region": "", "country": "PL",

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total_uses_default_calculation[False-31.51-38.99-3.0-True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total_uses_default_calculation[False-31.51-38.99-3.0-True].yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "PC040156", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "6a2aca87-d3fa-443c-ad88-0d1dc94aab49", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":
@@ -79,7 +79,7 @@ interactions:
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
       "1.99", "taxCode": "PC040156", "taxIncluded": true, "itemCode": "SKU_SINGLE_VARIANT",
       "description": "Test product with single variant"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "6a2aca87-d3fa-443c-ad88-0d1dc94aab49", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total_uses_default_calculation[False-41.99-51.19-0.0-False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total_uses_default_calculation[False-41.99-51.19-0.0-False].yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "PC040156", "taxIncluded":
       false, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": false, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": false, "itemCode": "Shipping",
       "description": null}], "code": "139b19bd-f79b-4d02-a4dc-6c722644b43a", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":
@@ -79,7 +79,7 @@ interactions:
       false, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
       "1.99", "taxCode": "PC040156", "taxIncluded": false, "itemCode": "SKU_SINGLE_VARIANT",
       "description": "Test product with single variant"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": false, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": false, "itemCode": "Shipping",
       "description": null}], "code": "139b19bd-f79b-4d02-a4dc-6c722644b43a", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total_uses_default_calculation[True-21.99-27.74-5.0-False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total_uses_default_calculation[True-21.99-27.74-5.0-False].yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "PC040156", "taxIncluded":
       false, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": false, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": false, "itemCode": "Shipping",
       "description": null}], "code": "c7a67ebc-615d-41cd-b0d0-6a8b908bb21b", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":
@@ -79,7 +79,7 @@ interactions:
       false, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
       "1.99", "taxCode": "PC040156", "taxIncluded": false, "itemCode": "SKU_SINGLE_VARIANT",
       "description": "Test product with single variant"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": false, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": false, "itemCode": "Shipping",
       "description": null}], "code": "c7a67ebc-615d-41cd-b0d0-6a8b908bb21b", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total_uses_default_calculation[True-22.32-26.99-0.0-True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_total_uses_default_calculation[True-22.32-26.99-0.0-True].yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "PC040156", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "8cf8a592-4d23-4788-8071-901700249a0d", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":
@@ -79,7 +79,7 @@ interactions:
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
       "1.99", "taxCode": "PC040156", "taxIncluded": true, "itemCode": "SKU_SINGLE_VARIANT",
       "description": "Test product with single variant"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "8cf8a592-4d23-4788-8071-901700249a0d", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_total.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_total.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
       "lines": [{"quantity": 3, "amount": "36.900", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "f52d00ae-f27a-46f8-86ab-2593ad4dba0d", "date":
       "2021-04-23", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
       "lines": [{"quantity": 3, "amount": "30.000", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "7e3a27d0-5bcd-4678-b362-33d3b0834d63", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "2000 Main
       Street", "line2": "", "city": "Irvine", "region": "CA", "country": "US", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_shipping.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_shipping.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
       "lines": [{"quantity": 3, "amount": "36.900", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "9bdb1747-a32b-4a69-857a-45e52f5c7022", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_get_checkout_line_tax_rate.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_get_checkout_line_tax_rate.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "09b407bb-1f33-4dc0-8e59-4179d89ec991", "date":
       "2021-03-24", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_get_checkout_line_tax_rate_for_product_type_with_non_taxable_product.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_get_checkout_line_tax_rate_for_product_type_with_non_taxable_product.yaml
@@ -5,7 +5,7 @@ interactions:
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
       "10.00", "taxCode": "NT", "taxIncluded": true, "itemCode": "Product variant
       #1", "description": "Test product with two variants"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "eb1dd476-37a0-43a8-a46c-13f08fd2d5b1", "date":
       "2021-03-25", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_get_checkout_shipping_tax_rate.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_get_checkout_shipping_tax_rate.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "bcb8fe8e-f139-43ab-a6b6-08f1aadb0180", "date":
       "2021-03-25", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_get_order_line_tax_rate.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_get_order_line_tax_rate.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
       "lines": [{"quantity": 3, "amount": "36.900", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "0833da78-cbc6-402a-8d64-79e314ffcfb7", "date":
       "2021-03-25", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_get_order_shipping_tax_rate.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_get_order_shipping_tax_rate.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
       "lines": [{"quantity": 3, "amount": "36.900", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "1b825928-d020-4506-9053-4966ab1534ad", "date":
       "2021-03-25", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_plugin_uses_configuration_from_db.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_plugin_uses_configuration_from_db.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "c1b86a21-352b-43f5-bdc9-4e41c79489cd", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":
@@ -77,7 +77,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "c1b86a21-352b-43f5-bdc9-4e41c79489cd", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":
@@ -151,7 +151,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "c1b86a21-352b-43f5-bdc9-4e41c79489cd", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_preprocess_order_creation.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_preprocess_order_creation.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "e66caffe-1106-41a2-add9-8c8711dd4838", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":
@@ -77,7 +77,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "e66caffe-1106-41a2-add9-8c8711dd4838", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_preprocess_order_creation_no_lines_data.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_preprocess_order_creation_no_lines_data.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "21e5fb21-727d-41a1-b1e7-1db9782fab47", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":
@@ -77,7 +77,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "21e5fb21-727d-41a1-b1e7-1db9782fab47", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "T\u0119czowa
       7", "line2": "", "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode":

--- a/saleor/plugins/avatax/tests/cassettes/test_preprocess_order_creation_wrong_data.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_preprocess_order_creation_wrong_data.yaml
@@ -3,7 +3,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "f8eb86f5-450e-4317-b1a3-e3328459e1f3", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": null, "line2":
       null, "city": null, "region": null, "country": null, "postalCode": null}, "shipTo":
@@ -57,7 +57,7 @@ interactions:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
       "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
       "description": null}], "code": "f8eb86f5-450e-4317-b1a3-e3328459e1f3", "date":
       "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": null, "line2":
       null, "city": null, "region": null, "country": null, "postalCode": null}, "shipTo":

--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -27,6 +27,7 @@ def plugin_configuration(db, channel_USD):
         from_country="PL",
         from_country_area="",
         from_postal_code="53-601",
+        shipping_tax_code="FR000000",
     ):
         channel = channel or channel_USD
         data = {
@@ -44,6 +45,7 @@ def plugin_configuration(db, channel_USD):
                 {"name": "from_country", "value": from_country},
                 {"name": "from_country_area", "value": from_country_area},
                 {"name": "from_postal_code", "value": from_postal_code},
+                {"name": "shipping_tax_code", "value": shipping_tax_code},
             ],
         }
         configuration = PluginConfiguration.objects.create(

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -1527,6 +1527,7 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         from_city="WROCŁAW",
         from_postal_code="53-601",
         from_country="PL",
+        shipping_tax_code="FR00001",
     )
     conf = {data["name"]: data["value"] for data in plugin_conf.configuration}
 
@@ -1580,6 +1581,7 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         "from_postal_code": conf["from_postal_code"],
         "from_country": conf["from_country"],
         "from_country_area": conf["from_country_area"],
+        "shipping_tax_code": conf["shipping_tax_code"],
     }
 
     api_post_request_task_mock.assert_called_once_with(


### PR DESCRIPTION
I want to merge this change because it adds an option to set the default tax code for shipping in Avalara

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
