### PR TITLE
Fix draft order finalize with not excluded shipping method

### DIFF
--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -54,9 +54,12 @@ def validate_shipping_method(order: "Order", errors: T_ERRORS, manager: PluginsM
         method.price = method.channel_listings.get(  # type: ignore
             channel=order.channel
         ).price
-        if manager.excluded_shipping_methods_for_order(
+        excluded_shipping_methods = manager.excluded_shipping_methods_for_order(
             order, [convert_shipping_method_model_to_dataclass(method)]
-        ):
+        )
+        if method.id in [
+            shipping_method.id for shipping_method in excluded_shipping_methods
+        ]:
             error = ValidationError(
                 "Shipping method cannot be used with this order.",
                 code=OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.value,


### PR DESCRIPTION
This fix provides a fix for an edge case where a plugin would return a non-empty response regardless of whether provided shipping method should be excluded or not.
=
# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
