### PR TITLE
Fix method id comparison with types

### DIFF
--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -88,7 +88,7 @@ def clean_order_update_shipping(
     excluded_shipping_methods = manager.excluded_shipping_methods_for_order(
         order, [convert_shipping_method_model_to_dataclass(method)]
     )
-    if method.id in [
+    if str(method.id) in [
         shipping_method.id for shipping_method in excluded_shipping_methods
     ]:
         raise ValidationError(

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -3247,7 +3247,7 @@ def test_draft_order_complete_with_excluded_shipping_method(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     webhook_reason = "archives-are-incomplete"
     mocked_webhook.return_value = [
-        ExcludedShippingMethod(shipping_method.id, webhook_reason)
+        ExcludedShippingMethod(str(shipping_method.id), webhook_reason)
     ]
     order = draft_order
     order.status = OrderStatus.DRAFT
@@ -4773,7 +4773,7 @@ def test_draft_order_update_shipping_with_excluded_method(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     webhook_reason = "archives-are-incomplete"
     mocked_webhook.return_value = [
-        ExcludedShippingMethod(shipping_method.id, webhook_reason)
+        ExcludedShippingMethod(str(shipping_method.id), webhook_reason)
     ]
     order = draft_order
     order.status = OrderStatus.DRAFT
@@ -4844,7 +4844,7 @@ def test_order_update_shipping_with_excluded_method(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     webhook_reason = "archives-are-incomplete"
     mocked_webhook.return_value = [
-        ExcludedShippingMethod(shipping_method.id, webhook_reason)
+        ExcludedShippingMethod(str(shipping_method.id), webhook_reason)
     ]
     order = order_with_lines
     order.status = OrderStatus.DRAFT

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -57,7 +57,7 @@ def validate_shipping_method(order: "Order", errors: T_ERRORS, manager: PluginsM
         excluded_shipping_methods = manager.excluded_shipping_methods_for_order(
             order, [convert_shipping_method_model_to_dataclass(method)]
         )
-        if method.id in [
+        if str(method.id) in [
             shipping_method.id for shipping_method in excluded_shipping_methods
         ]:
             error = ValidationError(


### PR DESCRIPTION
Previous implementation didn't cover types in comparison, resulting in not raising an error.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
