### PR TITLE
Fix zero for subtotal with avatax

### DIFF
--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -389,7 +389,7 @@ class AvataxPlugin(BasePlugin):
             return previous_value
 
         if not _validate_order(order):
-            return zero_taxed_money(order.total.currency)
+            return previous_value
 
         taxes_data = self._get_order_tax_data(order, previous_value)
         return self._calculate_line_total_price(taxes_data, variant.sku, previous_value)
@@ -496,7 +496,7 @@ class AvataxPlugin(BasePlugin):
             return previous_value
 
         if not _validate_order(order):
-            return zero_taxed_money(order.total.currency)
+            return previous_value
         taxes_data = get_order_tax_data(order, self.config, False)
 
         tax_included = (


### PR DESCRIPTION
I want to merge this change because it fixes a zero amount for subtotal and total for order when avatax doesn't  have enough details to fetch taxes

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
