### PR TITLE
Fix zero for subtotal with avatax 3.1

### DIFF
--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -392,7 +392,7 @@ class AvataxPlugin(BasePlugin):
             return previous_value
 
         if not _validate_order(order):
-            return zero_taxed_money(order.total.currency)
+            return previous_value
 
         taxes_data = self._get_order_tax_data(order, previous_value)
         return self._calculate_line_total_price(
@@ -507,7 +507,7 @@ class AvataxPlugin(BasePlugin):
             return previous_value
 
         if not _validate_order(order):
-            return zero_taxed_money(order.total.currency)
+            return previous_value
         taxes_data = get_order_tax_data(order, self.config, False)
 
         tax_included = (

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -297,8 +297,8 @@ def test_calculate_order_line_total_order_not_valid(
     net = variant.get_price(product, [], channel, channel_listing)
     unit_price = TaxedMoney(net=net, gross=net)
     order_line.unit_price = unit_price
-    total_price = unit_price * order_line.quantity
-    order_line.total_price = total_price
+    expected_total_price = unit_price * order_line.quantity
+    order_line.total_price = expected_total_price
     order_line.save()
 
     total = manager.calculate_order_line_total(
@@ -308,7 +308,54 @@ def test_calculate_order_line_total_order_not_valid(
         product,
     )
     total = quantize_price(total, total.currency)
-    assert total == TaxedMoney(net=Money("0.00", "USD"), gross=Money("0.00", "USD"))
+    assert total == expected_total_price
+
+
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_calculate_order_shipping_order_not_valid(
+    order_line,
+    address,
+    site_settings,
+    monkeypatch,
+    plugin_configuration,
+    shipping_method,
+):
+    # given
+    plugin_configuration()
+    manager = get_plugins_manager()
+
+    site_settings.company_address = address
+    site_settings.save(update_fields=["company_address"])
+
+    variant = order_line.variant
+    product = variant.product
+    product.metadata = {}
+    product.charge_taxes = True
+    product.save()
+    product.product_type.save()
+
+    order = order_line.order
+
+    expected_shipping_price = TaxedMoney(
+        net=Money("10.00", "USD"), gross=Money("10.00", "USD")
+    )
+    order.shipping_address = None
+    order.shipping_method = shipping_method
+    order.save()
+
+    order.shipping_method.channel_listings.filter(channel_id=order.channel_id).update(
+        price_amount=Decimal("10.00")
+    )
+
+    # when
+    shipping_price = manager.calculate_order_shipping(
+        order,
+    )
+
+    # then
+    shipping_price = quantize_price(shipping_price, shipping_price.currency)
+
+    assert shipping_price == expected_shipping_price
 
 
 @pytest.mark.vcr

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -331,8 +331,7 @@ def test_calculate_order_shipping_order_not_valid(
     product = variant.product
     product.metadata = {}
     product.charge_taxes = True
-    product.save()
-    product.product_type.save()
+    product.save(update_fields=["metadata", "charge_taxes"])
 
     order = order_line.order
 


### PR DESCRIPTION
I want to merge this change because it is port of changes from #8608

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
