### PR TITLE
Add tax rate to tax dataclasses

### DIFF
--- a/saleor/core/taxes.py
+++ b/saleor/core/taxes.py
@@ -64,6 +64,7 @@ class TaxType:
 class TaxLineData:
     id: int
     currency: str
+    tax_rate: Decimal
     unit_net_amount: Decimal
     unit_gross_amount: Decimal
     total_gross_amount: Decimal
@@ -79,4 +80,5 @@ class TaxData:
     subtotal_gross_amount: Decimal
     shipping_price_gross_amount: Decimal
     shipping_price_net_amount: Decimal
+    shipping_tax_rate: Decimal
     lines: List[TaxLineData]

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -33,7 +33,7 @@ def sample_tax_data() -> TaxData:
             unit_gross_amount=unit_gross,
             total_net_amount=unit * 3,
             total_gross_amount=unit_gross * 3,
-            tax_rate=Decimal("23.00"),
+            tax_rate=Decimal("0.23"),
         )
         for i in range(8)
     ]
@@ -50,7 +50,7 @@ def sample_tax_data() -> TaxData:
         subtotal_gross_amount=subtotal_gross,
         shipping_price_net_amount=shipping,
         shipping_price_gross_amount=shipping_gross,
-        shipping_tax_rate=Decimal("23.00"),
+        shipping_tax_rate=Decimal("0.23"),
         total_net_amount=subtotal + shipping,
         total_gross_amount=subtotal_gross + shipping_gross,
         lines=lines,

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -33,6 +33,7 @@ def sample_tax_data() -> TaxData:
             unit_gross_amount=unit_gross,
             total_net_amount=unit * 3,
             total_gross_amount=unit_gross * 3,
+            tax_rate=Decimal("23.00"),
         )
         for i in range(8)
     ]
@@ -49,6 +50,7 @@ def sample_tax_data() -> TaxData:
         subtotal_gross_amount=subtotal_gross,
         shipping_price_net_amount=shipping,
         shipping_price_gross_amount=shipping_gross,
+        shipping_tax_rate=Decimal("23.00"),
         total_net_amount=subtotal + shipping,
         total_gross_amount=subtotal_gross + shipping_gross,
         lines=lines,

--- a/saleor/plugins/webhook/conftest.py
+++ b/saleor/plugins/webhook/conftest.py
@@ -14,6 +14,7 @@ def tax_line_data_response():
         "unit_gross_amount": 12.34,
         "total_gross_amount": 12.34,
         "total_net_amount": 12.34,
+        "tax_rate": 23.00,
     }
 
 
@@ -27,6 +28,7 @@ def tax_data_response(tax_line_data_response):
         "subtotal_gross_amount": 12.34,
         "shipping_price_gross_amount": 12.34,
         "shipping_price_net_amount": 12.34,
+        "shipping_tax_rate": 23.00,
         "lines": [tax_line_data_response] * 5,
     }
 

--- a/saleor/plugins/webhook/conftest.py
+++ b/saleor/plugins/webhook/conftest.py
@@ -14,7 +14,7 @@ def tax_line_data_response():
         "unit_gross_amount": 12.34,
         "total_gross_amount": 12.34,
         "total_net_amount": 12.34,
-        "tax_rate": 23.00,
+        "tax_rate": 0.23,
     }
 
 
@@ -28,7 +28,7 @@ def tax_data_response(tax_line_data_response):
         "subtotal_gross_amount": 12.34,
         "shipping_price_gross_amount": 12.34,
         "shipping_price_net_amount": 12.34,
-        "shipping_tax_rate": 23.00,
+        "shipping_tax_rate": 0.23,
         "lines": [tax_line_data_response] * 5,
     }
 

--- a/saleor/plugins/webhook/utils.py
+++ b/saleor/plugins/webhook/utils.py
@@ -119,6 +119,7 @@ def _unsafe_parse_tax_line_data(
     unit_gross_amount = decimal.Decimal(tax_line_data_response["unit_gross_amount"])
     total_gross_amount = decimal.Decimal(tax_line_data_response["total_gross_amount"])
     total_net_amount = decimal.Decimal(tax_line_data_response["total_net_amount"])
+    tax_rate = decimal.Decimal(tax_line_data_response["tax_rate"])
 
     return TaxLineData(
         id=id,
@@ -127,6 +128,7 @@ def _unsafe_parse_tax_line_data(
         unit_gross_amount=unit_gross_amount,
         total_gross_amount=total_gross_amount,
         total_net_amount=total_net_amount,
+        tax_rate=tax_rate,
     )
 
 
@@ -148,6 +150,7 @@ def _unsafe_parse_tax_data(
     shipping_price_net_amount = decimal.Decimal(
         tax_data_response["shipping_price_net_amount"]
     )
+    shipping_tax_rate = decimal.Decimal(tax_data_response["shipping_tax_rate"])
     lines = [_unsafe_parse_tax_line_data(line) for line in tax_data_response["lines"]]
 
     return TaxData(
@@ -158,6 +161,7 @@ def _unsafe_parse_tax_data(
         subtotal_gross_amount=subtotal_gross_amount,
         shipping_price_gross_amount=shipping_price_gross_amount,
         shipping_price_net_amount=shipping_price_net_amount,
+        shipping_tax_rate=shipping_tax_rate,
         lines=lines,
     )
 


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

Extend TaxData and TaxLineData (SALEOR-4584)

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
