### PR TITLE
Add event delivery retry mutation

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1993,7 +1993,6 @@ input EventDeliveryFilterInput {
 
 type EventDeliveryRetry {
   delivery: EventDelivery
-  webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
   errors: [WebhookError!]!
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1991,6 +1991,12 @@ input EventDeliveryFilterInput {
   eventType: WebhookEventTypeEnum
 }
 
+type EventDeliveryRetry {
+  delivery: EventDelivery
+  webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [WebhookError!]!
+}
+
 enum EventDeliverySortField {
   CREATED_AT
 }
@@ -3542,7 +3548,7 @@ type Mutation {
   webhookCreate(input: WebhookCreateInput!): WebhookCreate
   webhookDelete(id: ID!): WebhookDelete
   webhookUpdate(id: ID!, input: WebhookUpdateInput!): WebhookUpdate
-  webhookDeliveryRetry(id: ID!): WebhookDeliveryRetry
+  eventDeliveryRetry(id: ID!): EventDeliveryRetry
   createWarehouse(input: WarehouseCreateInput!): WarehouseCreate
   updateWarehouse(id: ID!, input: WarehouseUpdateInput!): WarehouseUpdate
   deleteWarehouse(id: ID!): WarehouseDelete
@@ -6918,12 +6924,6 @@ type WebhookDelete {
   webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
   errors: [WebhookError!]!
   webhook: Webhook
-}
-
-type WebhookDeliveryRetry {
-  delivery: EventDelivery
-  webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
-  errors: [WebhookError!]!
 }
 
 type WebhookError {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3542,6 +3542,7 @@ type Mutation {
   webhookCreate(input: WebhookCreateInput!): WebhookCreate
   webhookDelete(id: ID!): WebhookDelete
   webhookUpdate(id: ID!, input: WebhookUpdateInput!): WebhookUpdate
+  webhookDeliveryRetry(id: ID!): WebhookDeliveryRetry
   createWarehouse(input: WarehouseCreateInput!): WarehouseCreate
   updateWarehouse(id: ID!, input: WarehouseUpdateInput!): WarehouseUpdate
   deleteWarehouse(id: ID!): WarehouseDelete
@@ -6917,6 +6918,12 @@ type WebhookDelete {
   webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
   errors: [WebhookError!]!
   webhook: Webhook
+}
+
+type WebhookDeliveryRetry {
+  delivery: EventDelivery
+  webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [WebhookError!]!
 }
 
 type WebhookError {

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -2,7 +2,7 @@ import graphene
 from django.core.exceptions import ValidationError
 
 from ...core import EventDeliveryStatus
-from ...core.permissions import AppPermission, OrderPermissions
+from ...core.permissions import AppPermission
 from ...plugins.webhook.tasks import send_webhook_request_async
 from ...plugins.webhook.utils import delivery_update
 from ...webhook import models
@@ -216,9 +216,8 @@ class EventDeliveryRetry(BaseMutation):
 
     class Meta:
         description = "Retries event delivery."
-        permissions = (OrderPermissions.MANAGE_ORDERS,)
+        permissions = (AppPermission.MANAGE_APPS,)
         error_type_class = WebhookError
-        error_type_field = "webhook_errors"
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -206,7 +206,7 @@ class WebhookDelete(ModelDeleteMutation):
         return super().perform_mutation(_root, info, **data)
 
 
-class WebhookDeliveryRetry(BaseMutation):
+class EventDeliveryRetry(BaseMutation):
     delivery = graphene.Field(EventDelivery, description=".")
 
     class Arguments:
@@ -229,4 +229,4 @@ class WebhookDeliveryRetry(BaseMutation):
         )
         delivery_update(delivery, status=EventDeliveryStatus.PENDING)
         send_webhook_request_async.delay(delivery.pk)
-        return WebhookDeliveryRetry(delivery=delivery)
+        return EventDeliveryRetry(delivery=delivery)

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -207,7 +207,7 @@ class WebhookDelete(ModelDeleteMutation):
 
 
 class EventDeliveryRetry(BaseMutation):
-    delivery = graphene.Field(EventDelivery, description=".")
+    delivery = graphene.Field(EventDelivery, description="Event delivery.")
 
     class Arguments:
         id = graphene.ID(

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -1,12 +1,16 @@
 import graphene
 from django.core.exceptions import ValidationError
 
-from ...core.permissions import AppPermission
+from ...core import EventDeliveryStatus
+from ...core.permissions import AppPermission, OrderPermissions
+from ...plugins.webhook.tasks import send_webhook_request_async
+from ...plugins.webhook.utils import delivery_update
 from ...webhook import models
 from ...webhook.error_codes import WebhookErrorCode
-from ..core.mutations import ModelDeleteMutation, ModelMutation
+from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types.common import WebhookError
 from .enums import WebhookEventTypeEnum
+from .types import EventDelivery
 
 
 class WebhookCreateInput(graphene.InputObjectType):
@@ -200,3 +204,29 @@ class WebhookDelete(ModelDeleteMutation):
                 )
 
         return super().perform_mutation(_root, info, **data)
+
+
+class WebhookDeliveryRetry(BaseMutation):
+    delivery = graphene.Field(EventDelivery, description=".")
+
+    class Arguments:
+        id = graphene.ID(
+            required=True, description="ID of the event delivery to retry."
+        )
+
+    class Meta:
+        description = "Retries event delivery."
+        permissions = (OrderPermissions.MANAGE_ORDERS,)
+        error_type_class = WebhookError
+        error_type_field = "webhook_errors"
+
+    @classmethod
+    def perform_mutation(cls, _root, info, **data):
+        delivery = cls.get_node_or_error(
+            info,
+            data["id"],
+            only_type=EventDelivery,
+        )
+        delivery_update(delivery, status=EventDeliveryStatus.PENDING)
+        send_webhook_request_async.delay(delivery.pk)
+        return WebhookDeliveryRetry(delivery=delivery)

--- a/saleor/graphql/webhook/schema.py
+++ b/saleor/graphql/webhook/schema.py
@@ -3,7 +3,7 @@ import graphene
 from ...core.permissions import AppPermission
 from ..decorators import permission_required
 from .enums import WebhookSampleEventTypeEnum
-from .mutations import WebhookCreate, WebhookDelete, WebhookUpdate
+from .mutations import WebhookCreate, WebhookDelete, WebhookDeliveryRetry, WebhookUpdate
 from .resolvers import resolve_sample_payload, resolve_webhook, resolve_webhook_events
 from .types import Webhook, WebhookEvent
 
@@ -50,3 +50,4 @@ class WebhookMutations(graphene.ObjectType):
     webhook_create = WebhookCreate.Field()
     webhook_delete = WebhookDelete.Field()
     webhook_update = WebhookUpdate.Field()
+    webhook_delivery_retry = WebhookDeliveryRetry.Field()

--- a/saleor/graphql/webhook/schema.py
+++ b/saleor/graphql/webhook/schema.py
@@ -3,7 +3,7 @@ import graphene
 from ...core.permissions import AppPermission
 from ..decorators import permission_required
 from .enums import WebhookSampleEventTypeEnum
-from .mutations import WebhookCreate, WebhookDelete, WebhookDeliveryRetry, WebhookUpdate
+from .mutations import EventDeliveryRetry, WebhookCreate, WebhookDelete, WebhookUpdate
 from .resolvers import resolve_sample_payload, resolve_webhook, resolve_webhook_events
 from .types import Webhook, WebhookEvent
 
@@ -50,4 +50,4 @@ class WebhookMutations(graphene.ObjectType):
     webhook_create = WebhookCreate.Field()
     webhook_delete = WebhookDelete.Field()
     webhook_update = WebhookUpdate.Field()
-    webhook_delivery_retry = WebhookDeliveryRetry.Field()
+    event_delivery_retry = EventDeliveryRetry.Field()

--- a/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
+++ b/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
@@ -5,8 +5,8 @@ import graphene
 from saleor.graphql.tests.utils import assert_no_permission, get_graphql_content
 
 WEBHOOK_DELIVERY_RETRY_MUTATION = """
-    mutation webhookDeliveryRetry($id: ID!){
-      webhookDeliveryRetry(id: $id){
+    mutation eventDeliveryRetry($id: ID!){
+      eventDeliveryRetry(id: $id){
         errors{
           field
           message
@@ -39,7 +39,7 @@ def test_delivery_retry_mutation(
 
     # then
     mocked_send_request_async.assert_called_once_with(event_delivery.pk)
-    errors = content["data"]["webhookDeliveryRetry"]["errors"]
+    errors = content["data"]["eventDeliveryRetry"]["errors"]
     assert len(errors) == 0
 
 
@@ -69,7 +69,29 @@ def test_webhook_delivery_retry_wrong_type(
         check_no_permissions=False,
     )
     content = get_graphql_content(response)
-    errors = content["data"]["webhookDeliveryRetry"]["errors"]
+    errors = content["data"]["eventDeliveryRetry"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "id"
+    assert errors[0]["message"] == expected_message
+
+
+def test_delivery_retry_mutation_wrong_id(
+    app_api_client, permission_manage_orders, event_delivery
+):
+    # given
+    query = WEBHOOK_DELIVERY_RETRY_MUTATION
+    variables = {"id": "/w"}
+    expected_message = "Couldn't resolve id: /w."
+    # when
+    response = app_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_orders],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+    # then
+    errors = content["data"]["eventDeliveryRetry"]["errors"]
     assert len(errors) == 1
     assert errors[0]["field"] == "id"
     assert errors[0]["message"] == expected_message

--- a/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
+++ b/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
@@ -1,0 +1,75 @@
+from unittest.mock import patch
+
+import graphene
+
+from saleor.graphql.tests.utils import assert_no_permission, get_graphql_content
+
+WEBHOOK_DELIVERY_RETRY_MUTATION = """
+    mutation webhookDeliveryRetry($id: ID!){
+      webhookDeliveryRetry(id: $id){
+        errors{
+          field
+          message
+        }
+        delivery{
+          id
+        }
+      }
+    }
+"""
+
+
+@patch("saleor.plugins.webhook.tasks.send_webhook_request_async.delay")
+def test_delivery_retry_mutation(
+    mocked_send_request_async, app_api_client, permission_manage_orders, event_delivery
+):
+    # given
+    query = WEBHOOK_DELIVERY_RETRY_MUTATION
+    delivery_id = graphene.Node.to_global_id("EventDelivery", event_delivery.pk)
+    variables = {"id": delivery_id}
+
+    # when
+    response = app_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_orders],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    mocked_send_request_async.assert_called_once_with(event_delivery.pk)
+    errors = content["data"]["webhookDeliveryRetry"]["errors"]
+    assert len(errors) == 0
+
+
+def test_webhook_delivery_retry_without_permission(
+    staff_api_client, app, event_delivery
+):
+    query = WEBHOOK_DELIVERY_RETRY_MUTATION
+    delivery_id = graphene.Node.to_global_id("EventDelivery", event_delivery.pk)
+    variables = {"id": delivery_id}
+    response = staff_api_client.post_graphql(query, variables=variables)
+    assert_no_permission(response)
+
+
+def test_webhook_delivery_retry_wrong_type(
+    staff_api_client, app, event_attempt, permission_manage_orders
+):
+    query = WEBHOOK_DELIVERY_RETRY_MUTATION
+    delivery_wrong_id = graphene.Node.to_global_id(
+        "EventDeliveryAttempt", event_attempt.id
+    )
+    variables = {"id": delivery_wrong_id}
+    expected_message = "Must receive a EventDelivery id."
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_orders],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+    errors = content["data"]["webhookDeliveryRetry"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "id"
+    assert errors[0]["message"] == expected_message

--- a/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
+++ b/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
@@ -21,7 +21,7 @@ WEBHOOK_DELIVERY_RETRY_MUTATION = """
 
 @patch("saleor.plugins.webhook.tasks.send_webhook_request_async.delay")
 def test_delivery_retry_mutation(
-    mocked_send_request_async, app_api_client, permission_manage_orders, event_delivery
+    mocked_send_request_async, app_api_client, permission_manage_apps, event_delivery
 ):
     # given
     query = WEBHOOK_DELIVERY_RETRY_MUTATION
@@ -32,7 +32,7 @@ def test_delivery_retry_mutation(
     response = app_api_client.post_graphql(
         query,
         variables=variables,
-        permissions=[permission_manage_orders],
+        permissions=[permission_manage_apps],
         check_no_permissions=False,
     )
     content = get_graphql_content(response)
@@ -54,7 +54,7 @@ def test_webhook_delivery_retry_without_permission(
 
 
 def test_webhook_delivery_retry_wrong_type(
-    staff_api_client, app, event_attempt, permission_manage_orders
+    staff_api_client, app, event_attempt, permission_manage_apps
 ):
     query = WEBHOOK_DELIVERY_RETRY_MUTATION
     delivery_wrong_id = graphene.Node.to_global_id(
@@ -65,7 +65,7 @@ def test_webhook_delivery_retry_wrong_type(
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
-        permissions=[permission_manage_orders],
+        permissions=[permission_manage_apps],
         check_no_permissions=False,
     )
     content = get_graphql_content(response)
@@ -76,7 +76,7 @@ def test_webhook_delivery_retry_wrong_type(
 
 
 def test_delivery_retry_mutation_wrong_id(
-    app_api_client, permission_manage_orders, event_delivery
+    app_api_client, permission_manage_apps, event_delivery
 ):
     # given
     query = WEBHOOK_DELIVERY_RETRY_MUTATION
@@ -86,7 +86,7 @@ def test_delivery_retry_mutation_wrong_id(
     response = app_api_client.post_graphql(
         query,
         variables=variables,
-        permissions=[permission_manage_orders],
+        permissions=[permission_manage_apps],
         check_no_permissions=False,
     )
     content = get_graphql_content(response)


### PR DESCRIPTION
I want to merge this change because it adds delivery retry mutation for new webhooks flow
Its a new pr cherry-picked from old one #8585 due to github change-detection problems.
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
