### PR TITLE
Fix Avalara tax fetching from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - After changes, using the order `id` for changing order metadata is deprecated
 - Add workaround for failing Avatax when line has price 0 - #8610 by @korycins
 - Add option to set tax code for shipping in Avatax configuration view - #8596 by @korycins
+- Fix Avalara tax fetching from cache - #8647 by @fowczarek
 
 
 ### Breaking

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -169,20 +169,12 @@ def _validate_checkout(
     )
 
 
-def _retrieve_from_cache(token):
-    taxes_cache_key = CACHE_KEY + token
-    cached_data = cache.get(taxes_cache_key)
-    return cached_data
-
-
-def taxes_need_new_fetch(data: Dict[str, Any], taxes_token: str) -> bool:
+def taxes_need_new_fetch(data: Dict[str, Any], cached_data) -> bool:
     """Check if Avatax's taxes data need to be refetched.
 
     The response from Avatax is stored in a cache. If an object doesn't exist in cache
     or something has changed, taxes need to be refetched.
     """
-    cached_data = _retrieve_from_cache(taxes_token)
-
     if not cached_data:
         return True
 
@@ -437,11 +429,11 @@ def get_cached_response_or_fetch(
     Return cached response if requests data are the same. Fetch new data in other cases.
     """
     data_cache_key = CACHE_KEY + token_in_cache
-    if taxes_need_new_fetch(data, token_in_cache) or force_refresh:
+    cached_data = cache.get(data_cache_key)
+    if taxes_need_new_fetch(data, cached_data) or force_refresh:
         response = _fetch_new_taxes_data(data, data_cache_key, config)
     else:
-        _, response = cache.get(data_cache_key)
-
+        _, response = cached_data
     return response
 
 

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -812,10 +812,7 @@ def test_get_cached_tax_codes_or_fetch_wrong_response(monkeypatch):
     assert len(tax_codes) == 0
 
 
-def test_checkout_needs_new_fetch(
-    monkeypatch, checkout_with_item, address, shipping_method
-):
-    monkeypatch.setattr("saleor.plugins.avatax.cache.get", lambda x: None)
+def test_checkout_needs_new_fetch(checkout_with_item, address, shipping_method):
     checkout_with_item.shipping_address = address
     checkout_with_item.shipping_method = shipping_method
     config = AvataxConfiguration(
@@ -831,12 +828,10 @@ def test_checkout_needs_new_fetch(
     lines = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_data = generate_request_data_from_checkout(checkout_info, lines, config)
-    assert taxes_need_new_fetch(checkout_data, str(checkout_with_item.token))
+    assert taxes_need_new_fetch(checkout_data, None)
 
 
-def test_taxes_need_new_fetch_uses_cached_data(
-    monkeypatch, checkout_with_item, address
-):
+def test_taxes_need_new_fetch_uses_cached_data(checkout_with_item, address):
 
     checkout_with_item.shipping_address = address
     config = AvataxConfiguration(
@@ -852,10 +847,7 @@ def test_taxes_need_new_fetch_uses_cached_data(
     lines = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_data = generate_request_data_from_checkout(checkout_info, lines, config)
-    monkeypatch.setattr(
-        "saleor.plugins.avatax.cache.get", lambda x: [checkout_data, None]
-    )
-    assert not taxes_need_new_fetch(checkout_data, str(checkout_with_item.token))
+    assert not taxes_need_new_fetch(checkout_data, (checkout_data, None))
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
I want to merge this change because of fixing Avalara tax fetching from the cache.
In Sentry I found that situation that first fetch from cache return data and the second one doesn't return any data.

https://sentry.io/organizations/saleor/issues/2802187910/?project=5543592&referrer=slack
![image](https://user-images.githubusercontent.com/43955230/143208295-dcfcddc4-8868-410b-a2e8-b7b5b5942e12.png)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
