### PR TITLE
Fix flaky `create_refund_data` test

### DIFF
--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -80,7 +80,7 @@ def test_create_refund_data_fulfillment_lines(
     fulfilled_order, refund_shipping_costs, shipping_line_quantity
 ):
     # given
-    fulfillment_lines = fulfilled_order.fulfillments.first().lines.all()
+    fulfillment_lines = list(fulfilled_order.fulfillments.first().lines.all())
     order_refund_lines = []
     fulfillment_refund_lines = [
         FulfillmentLineData(


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
