### PR TITLE
Change delivery retry mutation flow

### DIFF
--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -1,10 +1,7 @@
 import graphene
 from django.core.exceptions import ValidationError
 
-from ...core import EventDeliveryStatus
 from ...core.permissions import AppPermission
-from ...plugins.webhook.tasks import send_webhook_request_async
-from ...plugins.webhook.utils import delivery_update
 from ...webhook import models
 from ...webhook.error_codes import WebhookErrorCode
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
@@ -226,6 +223,6 @@ class EventDeliveryRetry(BaseMutation):
             data["id"],
             only_type=EventDelivery,
         )
-        delivery_update(delivery, status=EventDeliveryStatus.PENDING)
-        send_webhook_request_async.delay(delivery.pk)
+        manager = info.context.plugins
+        manager.event_delivery_retry(delivery)
         return EventDeliveryRetry(delivery=delivery)

--- a/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
+++ b/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
@@ -19,11 +19,16 @@ WEBHOOK_DELIVERY_RETRY_MUTATION = """
 """
 
 
-@patch("saleor.plugins.webhook.tasks.send_webhook_request_async.delay")
+@patch("saleor.plugins.webhook.plugin.send_webhook_request_async.delay")
 def test_delivery_retry_mutation(
-    mocked_send_request_async, app_api_client, permission_manage_apps, event_delivery
+    mocked_send_request_async,
+    app_api_client,
+    permission_manage_apps,
+    event_delivery,
+    settings,
 ):
     # given
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     query = WEBHOOK_DELIVERY_RETRY_MUTATION
     delivery_id = graphene.Node.to_global_id("EventDelivery", event_delivery.pk)
     variables = {"id": delivery_id}

--- a/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
+++ b/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
@@ -19,7 +19,7 @@ WEBHOOK_DELIVERY_RETRY_MUTATION = """
 """
 
 
-@patch("saleor.plugins.webhook.plugin.send_webhook_request_async.delay")
+@patch("saleor.plugins.manager.PluginsManager.event_delivery_retry")
 def test_delivery_retry_mutation(
     mocked_send_request_async,
     app_api_client,
@@ -43,7 +43,7 @@ def test_delivery_retry_mutation(
     content = get_graphql_content(response)
 
     # then
-    mocked_send_request_async.assert_called_once_with(event_delivery.pk)
+    mocked_send_request_async.assert_called_once_with(event_delivery)
     errors = content["data"]["eventDeliveryRetry"]["errors"]
     assert len(errors) == 0
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse
 from django_countries.fields import Country
 from prices import Money, TaxedMoney
 
+from ..core.models import EventDelivery
 from ..payment.interface import (
     CustomerSource,
     GatewayResponse,
@@ -500,6 +501,9 @@ class BasePlugin:
     #
     #  Overwrite this method if the plugin expects the incoming requests.
     webhook: Callable[[WSGIRequest, str, Any], HttpResponse]
+
+    # Triggers retry mechanism for event delivery
+    event_delivery_retry: Callable[["EventDelivery", Any], EventDelivery]
 
     def token_is_required_as_payment_input(self, previous_value):
         return previous_value

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -22,6 +22,7 @@ from prices import Money, TaxedMoney
 
 from ..channel.models import Channel
 from ..checkout import base_calculations
+from ..core.models import EventDelivery
 from ..core.payments import PaymentInterface
 from ..core.prices import quantize_price
 from ..core.taxes import TaxType, zero_taxed_money
@@ -543,6 +544,12 @@ class PluginsManager(PaymentInterface):
         default_value = None
         return self.__run_method_on_plugins(
             "order_created", default_value, order, channel_slug=order.channel.slug
+        )
+
+    def event_delivery_retry(self, event_delivery: "EventDelivery"):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "event_delivery_retry", default_value, event_delivery
         )
 
     def order_confirmed(self, order: "Order"):

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -245,6 +245,9 @@ class PluginSample(BasePlugin):
     def sample_not_implemented(self, previous_value):
         return NotImplemented
 
+    def event_delivery_retry(self, delivery: "EventDelivery", previous_value: Any):
+        return True
+
 
 class ChannelPluginSample(PluginSample):
     PLUGIN_ID = "channel.plugin.sample"

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1038,3 +1038,10 @@ def test_run_check_payment_balance_not_implemented(channel_USD):
 
     manager = PluginsManager(plugins=plugins)
     assert not manager.check_payment_balance({}, "main")
+
+
+def test_manager_delivery_retry(event_delivery):
+    plugins = ["saleor.plugins.tests.sample_plugins.PluginSample"]
+    manager = PluginsManager(plugins=plugins)
+    delivery_retry = manager.event_delivery_retry(event_delivery=event_delivery)
+    assert delivery_retry

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -565,3 +565,16 @@ def test_sale_deleted(mocked_webhook_trigger, settings, sale):
     mocked_webhook_trigger.assert_called_once_with(
         expected_data, WebhookEventType.SALE_DELETED
     )
+
+
+@mock.patch("saleor.plugins.webhook.plugin.send_webhook_request_async.delay")
+def test_event_delivery_retry(mocked_webhook_send, event_delivery, settings):
+    # given
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    manager = get_plugins_manager()
+
+    # when
+    manager.event_delivery_retry(event_delivery)
+
+    # then
+    mocked_webhook_send.assert_called_once_with(event_delivery.pk)


### PR DESCRIPTION
I want to merge this change because event delivery retry mutation shouldn't call plugin function directly without plugin manager participation

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
