### PR TITLE
Use frozen order data to return shipping method

### DIFF
--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -477,9 +477,7 @@ def test_order_query_external_shipping_method(
     permission_manage_orders,
     order_with_lines,
 ):
-    external_shipping_method_id = graphene.Node.to_global_id(
-        "app", "1:external123"
-    )
+    external_shipping_method_id = graphene.Node.to_global_id("app", "1:external123")
 
     # given
     order = order_with_lines

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -501,7 +501,9 @@ def test_order_query_external_shipping_method(
     order_data = content["data"]["orders"]["edges"][0]["node"]
     assert order_data["shippingMethod"]["id"] == external_shipping_method_id
     assert order_data["shippingMethod"]["name"] == order.shipping_method_name
-    assert order_data["shippingMethod"]["price"]["amount"] == float(order.shipping_price_gross.amount)
+    assert order_data["shippingMethod"]["price"]["amount"] == float(
+        order.shipping_price_gross.amount
+    )
 
 
 def test_order_discounts_query(

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -352,6 +352,12 @@ query OrdersQuery {
                 }
                 shippingMethod{
                     id
+                    name
+                    price {
+                        amount
+                        currency
+                    }
+
                 }
                 deliveryMethod {
                     __typename
@@ -494,6 +500,8 @@ def test_order_query_external_shipping_method(
     # then
     order_data = content["data"]["orders"]["edges"][0]["node"]
     assert order_data["shippingMethod"]["id"] == external_shipping_method_id
+    assert order_data["shippingMethod"]["name"] == order.shipping_method_name
+    assert order_data["shippingMethod"]["price"]["amount"] == float(order.shipping_price_gross.amount)
 
 
 def test_order_discounts_query(

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -17,6 +17,7 @@ from prices import Money, TaxedMoney
 
 from ....account.models import CustomerEvent
 from ....checkout import AddressType
+from ....checkout.utils import PRIVATE_META_APP_SHIPPING_ID
 from ....core.anonymize import obfuscate_email
 from ....core.notify_events import NotifyEventType
 from ....core.prices import quantize_price
@@ -469,6 +470,32 @@ def test_order_query_shipping_method_channel_listing_does_not_exist(
     assert order_data["shippingMethod"]["id"] == graphene.Node.to_global_id(
         "ShippingMethod", order.shipping_method.id
     )
+
+
+def test_order_query_external_shipping_method(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+):
+    external_shipping_method_id = graphene.Node.to_global_id(
+        "app", "1:external123"
+    )
+
+    # given
+    order = order_with_lines
+    order.shipping_method = None
+    order.private_metadata = {PRIVATE_META_APP_SHIPPING_ID: external_shipping_method_id}
+    order.save()
+
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    content = get_graphql_content(response)
+
+    # then
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+    assert order_data["shippingMethod"]["id"] == external_shipping_method_id
 
 
 def test_order_discounts_query(

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -20,7 +20,7 @@ from ...core.permissions import (
     ProductPermissions,
     has_one_of_permissions,
 )
-from ...core.taxes import display_gross_prices
+from ...core.taxes import display_gross_prices, include_taxes_in_prices
 from ...core.tracing import traced_resolver
 from ...discount import OrderDiscountType
 from ...graphql.checkout.types import DeliveryMethod
@@ -1047,10 +1047,12 @@ class Order(CountableDjangoObjectType):
         external_app_shipping_id = get_external_shipping_id(root)
 
         if external_app_shipping_id:
+            keep_gross = include_taxes_in_prices()
+            price = root.shipping_price_gross if keep_gross else root.shipping_price_net
             method = ShippingMethodData(
                 id=external_app_shipping_id,
                 name=root.shipping_method_name,
-                price=root.shipping_price,
+                price=price,
             )
             return ChannelContext(node=method, channel_slug=root.channel.slug)
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -20,7 +20,7 @@ from ...core.permissions import (
     ProductPermissions,
     has_one_of_permissions,
 )
-from ...core.taxes import display_gross_prices, include_taxes_in_prices
+from ...core.taxes import display_gross_prices
 from ...core.tracing import traced_resolver
 from ...discount import OrderDiscountType
 from ...graphql.checkout.types import DeliveryMethod
@@ -1047,7 +1047,7 @@ class Order(CountableDjangoObjectType):
         external_app_shipping_id = get_external_shipping_id(root)
 
         if external_app_shipping_id:
-            keep_gross = include_taxes_in_prices()
+            keep_gross = info.context.site.settings.include_taxes_in_prices
             price = root.shipping_price_gross if keep_gross else root.shipping_price_net
             method = ShippingMethodData(
                 id=external_app_shipping_id,

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -156,7 +156,11 @@ class ShippingMethod(ChannelContextTypeWithMetadataForObjectType):
                 info.context
             )
             .load((root.node.id, root.channel_slug))
-            .then(lambda channel_listing: channel_listing.price)
+            .then(
+                lambda channel_listing: channel_listing.price
+                if channel_listing
+                else None
+            )
         )
 
     @staticmethod

--- a/saleor/shipping/interface.py
+++ b/saleor/shipping/interface.py
@@ -16,8 +16,8 @@ class ShippingMethodData:
     """Dataclass for storing information about a shipping method."""
 
     id: str
-    name: str
     price: Optional[Money]
+    name: Optional[str] = None
     description: Optional[str] = None
     type: Optional[str] = None
     maximum_order_price: Optional[Money] = None


### PR DESCRIPTION
This PR uses `order.shipping_method_name` and `order.shipping_price` fields to resolve the shipping method.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
