### PR TITLE
Improve product_variant filters performance

### DIFF
--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -43,7 +43,7 @@ from ..core.filters import (
 from ..core.types import ChannelFilterInputObjectType, FilterInputObjectType
 from ..core.types.common import IntRangeInput, PriceRangeInput
 from ..utils import resolve_global_ids_to_primary_keys
-from ..utils.filters import filter_fields_containing_value, filter_range_field
+from ..utils.filters import filter_range_field
 from ..warehouse import types as warehouse_types
 from . import types as product_types
 from .enums import (
@@ -661,15 +661,21 @@ class ProductFilter(MetadataFilterBase):
 
 
 class ProductVariantFilter(MetadataFilterBase):
-    search = django_filters.CharFilter(
-        method=filter_fields_containing_value("name", "product__name", "sku")
-    )
+    search = django_filters.CharFilter(method="product_variant_filter_search")
     sku = ListObjectTypeFilter(input_class=graphene.String, method=filter_sku_list)
     is_preorder = django_filters.BooleanFilter(method=filter_is_preorder)
 
     class Meta:
         model = ProductVariant
         fields = ["search", "sku"]
+
+    def product_variant_filter_search(self, queryset, _name, value):
+        if not value:
+            return queryset
+        qs = Q(name__ilike=value) | Q(sku__ilike=value)
+        products = Product.objects.filter(name__ilike=value).values("pk")
+        qs |= Q(Exists(products.filter(variants=OuterRef("pk"))))
+        return queryset.filter(qs)
 
 
 class CollectionFilter(MetadataFilterBase):


### PR DESCRIPTION
I want to merge this change because it port changes from 3.0 to 3.1

https://github.com/saleor/saleor/pull/8334

\* Improve product_variant filters performance.

* Drop unused gin index

Co-authored-by: Tomasz Szymanski <lime129@gmail.com>


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
