### PR TITLE
Add payload to API query

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2045,6 +2045,7 @@ type EventDelivery implements Node {
   status: EventDeliveryStatusEnum!
   eventType: WebhookEventTypeEnum!
   attempts(sortBy: EventDeliveryAttemptSortingInput, before: String, after: String, first: Int, last: Int): EventDeliveryAttemptCountableConnection
+  payload: String
 }
 
 type EventDeliveryAttempt implements Node {

--- a/saleor/graphql/webhook/dataloaders.py
+++ b/saleor/graphql/webhook/dataloaders.py
@@ -1,0 +1,10 @@
+from ...core.models import EventPayload
+from ..core.dataloaders import DataLoader
+
+
+class PayloadByIdLoader(DataLoader):
+    context_key = "payload_by_id"
+
+    def batch_load(self, keys):
+        payload = EventPayload.objects.in_bulk(keys)
+        return [payload.get(payload_id).payload for payload_id in keys]

--- a/saleor/graphql/webhook/tests/queries/test_event_delivery_query.py
+++ b/saleor/graphql/webhook/tests/queries/test_event_delivery_query.py
@@ -18,6 +18,7 @@ EVENT_DELIVERY_QUERY = """
                status
                eventType
                id
+               payload
                attempts(first: $first){
                 edges{
                   node{
@@ -59,6 +60,7 @@ def test_webhook_delivery_attempt_query(
     assert delivery_response["id"] == delivery_id
     assert delivery_response["status"] == EventDeliveryStatus.PENDING.upper()
     assert delivery_response["eventType"] == WebhookEventType.ANY.upper()
+    assert delivery_response["payload"] == delivery.payload.payload
     assert len(attempts_response) == 1
     assert attempts_response[0]["node"]["response"] == event_attempt.response
     assert attempts_response[0]["node"]["duration"] == event_attempt.duration

--- a/saleor/graphql/webhook/types.py
+++ b/saleor/graphql/webhook/types.py
@@ -11,6 +11,7 @@ from ..webhook.sorters import (
     EventDeliveryAttemptSortingInput,
     EventDeliverySortingInput,
 )
+from .dataloaders import PayloadByIdLoader
 
 
 class WebhookEvent(CountableDjangoObjectType):
@@ -63,6 +64,7 @@ class EventDelivery(CountableDjangoObjectType):
         description="Event delivery attempts.",
     )
     event_type = WebhookEventTypeEnum(description="Webhook event type.", required=True)
+    payload = graphene.String(description="Event payload.")
 
     class Meta:
         description = "Event delivery."
@@ -78,6 +80,12 @@ class EventDelivery(CountableDjangoObjectType):
     @staticmethod
     def resolve_attempts(root: core_models.EventDelivery, *_args, **_kwargs):
         return core_models.EventDeliveryAttempt.objects.filter(delivery=root)
+
+    @staticmethod
+    def resolve_payload(root: core_models.EventDelivery, info):
+        if not root.payload_id:
+            return None
+        return PayloadByIdLoader(info.context).load(root.payload_id)
 
 
 class Webhook(CountableDjangoObjectType):


### PR DESCRIPTION
I want to merge this change because payload needs to be returned in api query

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
