### PR TITLE
Fix translation queries for shipping methods

### DIFF
--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1438,6 +1438,9 @@ query getCheckout($token: UUID!) {
             price {
                 amount
             }
+            translation (languageCode: PL) {
+                name
+            }
         }
     }
 }
@@ -1595,9 +1598,8 @@ def test_checkout_available_shipping_methods_with_price_displayed(
     apply_taxes_to_shipping_mock.assert_called_once_with(
         shipping_price, mock.ANY, checkout_with_item.channel.slug
     )
-    assert data["availableShippingMethods"] == [
-        {"name": "DHL", "price": {"amount": expected_price}}
-    ]
+    assert data["availableShippingMethods"][0]["name"] == "DHL"
+    assert data["availableShippingMethods"][0]["price"]["amount"] == expected_price
 
 
 def test_checkout_no_available_shipping_methods_without_address(

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -42,6 +42,7 @@ from ....plugins.manager import PluginsManager, get_plugins_manager
 from ....plugins.tests.sample_plugins import ActiveDummyPaymentGateway
 from ....product.models import ProductChannelListing, ProductVariant
 from ....shipping import models as shipping_models
+from ....shipping.models import ShippingMethodTranslation
 from ....shipping.utils import convert_to_shipping_method_data
 from ....warehouse.models import PreorderReservation, Reservation, Stock
 from ...tests.utils import assert_no_permission, get_graphql_content
@@ -1587,6 +1588,10 @@ def test_checkout_available_shipping_methods_with_price_displayed(
     site_settings.save()
     checkout_with_item.shipping_address = address
     checkout_with_item.save()
+    translated_name = "Dostawa ekspresowa"
+    ShippingMethodTranslation.objects.create(
+        language_code="pl", shipping_method=shipping_method, name=translated_name
+    )
 
     query = GET_CHECKOUT_AVAILABLE_SHIPPING_METHODS
 
@@ -1600,6 +1605,7 @@ def test_checkout_available_shipping_methods_with_price_displayed(
     )
     assert data["availableShippingMethods"][0]["name"] == "DHL"
     assert data["availableShippingMethods"][0]["price"]["amount"] == expected_price
+    assert data["availableShippingMethods"][0]["translation"]["name"] == translated_name
 
 
 def test_checkout_no_available_shipping_methods_without_address(

--- a/saleor/graphql/checkout/tests/test_checkout_filters.py
+++ b/saleor/graphql/checkout/tests/test_checkout_filters.py
@@ -347,7 +347,6 @@ def test_checkouts_query_with_filter_search(
     response = staff_api_client.post_graphql(checkout_query_with_filter, variables)
     content = get_graphql_content(response)
 
-    print(content)
     assert content["data"]["checkouts"]["totalCount"] == count
 
 

--- a/saleor/graphql/translations/dataloaders.py
+++ b/saleor/graphql/translations/dataloaders.py
@@ -20,7 +20,7 @@ class BaseTranslationByIdAndLanguageCodeLoader(DataLoader):
         if not self.relation_name:
             raise ValueError("Provide a relation_name for this dataloader.")
 
-        ids = set([key[0] for key in keys])
+        ids = set([str(key[0]) for key in keys])
         language_codes = set([key[1] for key in keys])
 
         filters = {
@@ -34,9 +34,9 @@ class BaseTranslationByIdAndLanguageCodeLoader(DataLoader):
         )
         for translation in translations:
             language_code = translation.language_code
-            id = getattr(translation, self.relation_name)
+            id = str(getattr(translation, self.relation_name))
             translation_by_language_code_by_id[language_code][id] = translation
-        return [translation_by_language_code_by_id[key[1]][key[0]] for key in keys]
+        return [translation_by_language_code_by_id[key[1]][str(key[0])] for key in keys]
 
 
 class AttributeTranslationByIdAndLanguageCodeLoader(

--- a/saleor/graphql/translations/resolvers.py
+++ b/saleor/graphql/translations/resolvers.py
@@ -3,6 +3,7 @@ from ...discount import models as discount_models
 from ...menu import models as menu_models
 from ...page import models as page_models
 from ...product import models as product_models
+from ...shipping import interface as shipping_interface
 from ...shipping import models as shipping_models
 from ...site import models as site_models
 from . import dataloaders
@@ -28,6 +29,9 @@ TYPE_TO_TRANSLATION_LOADER_MAP = {
     shipping_models.ShippingMethod: (
         dataloaders.ShippingMethodTranslationByIdAndLanguageCodeLoader
     ),
+    shipping_interface.ShippingMethodData: (
+        dataloaders.ShippingMethodTranslationByIdAndLanguageCodeLoader
+    ),
     site_models.SiteSettings: (
         dataloaders.SiteSettingsTranslationByIdAndLanguageCodeLoader
     ),
@@ -40,7 +44,7 @@ def resolve_translation(instance, info, language_code):
 
     loader = TYPE_TO_TRANSLATION_LOADER_MAP.get(type(instance))
     if loader:
-        return loader(info.context).load((instance.pk, language_code))
+        return loader(info.context).load((instance.id, language_code))
     raise TypeError(f"No dataloader found to {type(instance)}")
 
 


### PR DESCRIPTION
I want to merge this change because there's an error when querying a translation:

```
---------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------
ERROR    saleor.graphql.errors.unhandled:views.py:381 A query failed unexpectedly
Traceback (most recent call last):
  File "/saleor/venv/lib/python3.9/site-packages/promise/promise.py", line 489, in _resolve_from_executor
    executor(resolve, reject)
  File "/saleor/venv/lib/python3.9/site-packages/promise/promise.py", line 756, in executor
    return resolve(f(*args, **kwargs))
  File "/saleor/venv/lib/python3.9/site-packages/graphql/execution/middleware.py", line 75, in make_it_promise
    return next(*args, **kwargs)
  File "/saleor/saleor/graphql/channel/types.py", line 40, in resolve_translation
    return resolve_translation(root.node, info, language_code)
  File "/saleor/saleor/graphql/translations/resolvers.py", line 44, in resolve_translation
    raise TypeError(f"No dataloader found to {type(instance)}")
TypeError: No dataloader found to <class 'saleor.shipping.interface.ShippingMethodData'>
```

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
