### PR TITLE
Script for cleaning checkout_tokens of cancelled orders.

### DIFF
--- a/saleor/core/management/commands/fix_checkouts.py
+++ b/saleor/core/management/commands/fix_checkouts.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+
+from ....order import OrderStatus
+from ....order.models import Order
+
+
+class Command(BaseCommand):
+    help = (
+        "Find all orders in cancelled state. "
+        "Changed their checkout_token to empty string (like DB default)."
+    )
+
+    def handle(self, *args, **options):
+        Order.objects.filter(status=OrderStatus.CANCELED).update(checkout_token="")


### PR DESCRIPTION
I *do not* want to merge this change.

Review appreciated but it's a single script we need to run once on particular instance, will be closed after it's used.

Script filters all orders with status canceled and set checkout_token to "" (empty string).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
