### PR TITLE
Fix payment status for iDEAL payments

### DIFF
--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -544,8 +544,13 @@ class AdyenGatewayPlugin(BasePlugin):
             return self._process_additional_action(payment_information, kind)
 
         result_code = transaction.gateway_response.get("resultCode", "").strip().lower()
+        payment_method = (
+            transaction.gateway_response.get("paymentMethod", "").strip().lower()
+        )
         if result_code and result_code in PENDING_STATUSES:
             kind = TransactionKind.PENDING
+        elif result_code == AUTH_STATUS and payment_method == "ideal":
+            kind = TransactionKind.CAPTURE
 
         # We already have the ACTION_TO_CONFIRM transaction, it means that
         # payment was processed asynchronous and no additional action is required


### PR DESCRIPTION
I want to merge this change because iDEAL payments [do not support separate captures](https://docs.adyen.com/payment-methods/ideal):
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/2566928/144471548-3f4c7edf-3c59-4b20-8774-81779861a796.png">

In Adyen, they always end up at SentForSettle/Settled status regardless of the Saleor plugin configuration:
<img width="1149" alt="image" src="https://user-images.githubusercontent.com/2566928/144471448-265f8d26-9840-4023-9701-9dfb9c713ba0.png">

I am using a plugin configuration that does not assume that payments are automatically captured:
<img width="564" alt="image" src="https://user-images.githubusercontent.com/2566928/144471828-3d07e514-f4f9-4785-98d2-10f162ea0184.png">

This results in the payment being "unpaid" in Saleor but "paid" in Adyen.

This is the difference between orders before/after the fix:
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/2566928/144471361-c2984c36-926b-4034-8bf8-4088f978dcb4.png">

CC: @korycins 

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
