### PR TITLE
Remove repeated shipping API calls from checkout lines mutations

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -272,7 +272,7 @@ def populate_checkout_info_shippings(
     lines: Iterable[CheckoutLineInfo],
     discounts: Iterable["DiscountInfo"],
     manager: "PluginsManager",
-) -> CheckoutInfo:
+):
     from .utils import get_external_shipping_id
 
     checkout = checkout_info.checkout

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -304,11 +304,14 @@ def populate_checkout_info_shippings(
 
     if not delivery_method:
         external_shipping_method_id = get_external_shipping_id(checkout)
-        external_shipping_methods_map = {
-            external_shipping_method.id: external_shipping_method
-            for external_shipping_method in external_shipping_methods
-        }
-        delivery_method = external_shipping_methods_map.get(external_shipping_method_id)
+        if external_shipping_method_id:
+            external_shipping_methods_map = {
+                external_shipping_method.id: external_shipping_method
+                for external_shipping_method in external_shipping_methods
+            }
+            delivery_method = external_shipping_methods_map.get(
+                external_shipping_method_id
+            )
 
     if delivery_method:
         delivery_method_info = get_delivery_method_info(

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -241,7 +241,7 @@ def fetch_checkout_info(
     manager: "PluginsManager",
     *,
     # Ugly hax to opt out from pulling shipping methods if they aren't needed
-    include_shipping_methods: bool = True,
+    fetch_shipping_methods: bool = True,
 ) -> CheckoutInfo:
     """Fetch checkout as CheckoutInfo object."""
     checkout_info = CheckoutInfo(
@@ -261,7 +261,7 @@ def fetch_checkout_info(
     )
     checkout_info.valid_pick_up_points = valid_pick_up_points
 
-    if include_shipping_methods:
+    if fetch_shipping_methods:
         populate_checkout_info_shippings(checkout_info, lines, discounts, manager)
 
     return checkout_info

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -240,7 +240,9 @@ def fetch_checkout_info(
     discounts: Iterable["DiscountInfo"],
     manager: "PluginsManager",
     *,
-    # Ugly hax to opt out from pulling shipping methods if they aren't needed
+    # Ugly hack to disable fetching shipping methods if they aren't needed
+    # Preventing multiple redundant and potentially costful API calls in
+    # checkout lines add/update/delete mutations
     fetch_shipping_methods: bool = True,
 ) -> CheckoutInfo:
     """Fetch checkout as CheckoutInfo object."""

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -280,8 +280,10 @@ def populate_checkout_info_shippings(
     shipping_address = checkout_info.shipping_address
     shipping_method = checkout.shipping_method
 
-    external_shipping_methods = get_valid_external_shipping_method_list_for_checkout_info(
-        checkout_info, shipping_address, lines, discounts, manager
+    external_shipping_methods = (
+        get_valid_external_shipping_method_list_for_checkout_info(
+            checkout_info, shipping_address, lines, discounts, manager
+        )
     )
 
     shipping_channel_listings = None
@@ -312,9 +314,7 @@ def populate_checkout_info_shippings(
         )
         checkout_info.delivery_method_info = delivery_method_info
 
-    valid_shipping_methods: List[
-        "ShippingMethodData"
-    ] = list(
+    valid_shipping_methods: List["ShippingMethodData"] = list(
         itertools.chain(
             get_valid_local_shipping_method_list_for_checkout_info(
                 checkout_info, shipping_address, lines, discounts, manager

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -19,6 +19,7 @@ from ...checkout.fetch import (
     fetch_checkout_lines,
     get_valid_collection_points_for_checkout_info,
     get_valid_shipping_method_list_for_checkout_info,
+    populate_checkout_info_shippings,
 )
 from ...checkout.utils import (
     add_promo_code_to_checkout,
@@ -583,11 +584,7 @@ class CheckoutLinesAdd(BaseMutation):
             )
 
         lines = fetch_checkout_lines(checkout)
-        checkout_info.valid_shipping_methods = (
-            get_valid_shipping_method_list_for_checkout_info(
-                checkout_info, checkout_info.shipping_address, lines, discounts, manager
-            )
-        )
+        populate_checkout_info_shippings(checkout_info, lines, discounts, manager)
         checkout_info.valid_pick_up_points = (
             get_valid_collection_points_for_checkout_info(
                 checkout_info.shipping_address, lines, checkout_info
@@ -619,7 +616,13 @@ class CheckoutLinesAdd(BaseMutation):
         variants = cls.get_nodes_or_error(variant_ids, "variant_id", ProductVariant)
         input_quantities = group_quantity_by_variants(lines)
 
-        checkout_info = fetch_checkout_info(checkout, [], discounts, manager)
+        checkout_info = fetch_checkout_info(
+            checkout,
+            [],
+            discounts,
+            manager,
+            include_shipping_methods=False,
+        )
 
         lines = fetch_checkout_lines(checkout)
         lines = cls.clean_input(
@@ -632,17 +635,6 @@ class CheckoutLinesAdd(BaseMutation):
             manager,
             discounts,
             replace,
-        )
-
-        checkout_info.valid_shipping_methods = (
-            get_valid_shipping_method_list_for_checkout_info(
-                checkout_info, checkout_info.shipping_address, lines, discounts, manager
-            )
-        )
-        checkout_info.valid_pick_up_points = (
-            get_valid_collection_points_for_checkout_info(
-                checkout_info.shipping_address, lines, checkout_info
-            )
         )
 
         update_checkout_shipping_method_if_invalid(checkout_info, lines)

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -621,7 +621,7 @@ class CheckoutLinesAdd(BaseMutation):
             [],
             discounts,
             manager,
-            include_shipping_methods=False,
+            fetch_shipping_methods=False,
         )
 
         lines = fetch_checkout_lines(checkout)

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -706,11 +706,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-<<<<<<< HEAD
-    with django_assert_num_queries(60):
-=======
-    with django_assert_num_queries(56):
->>>>>>> 95bb73108... Remove repeated shipping API calls from checkout lines mutations
+    with django_assert_num_queries(57):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "token": checkout.token,
@@ -724,11 +720,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-<<<<<<< HEAD
-    with django_assert_num_queries(60):
-=======
-    with django_assert_num_queries(56):
->>>>>>> 95bb73108... Remove repeated shipping API calls from checkout lines mutations
+    with django_assert_num_queries(57):
         variables = {
             "token": checkout.token,
             "lines": [],
@@ -970,11 +962,7 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
-<<<<<<< HEAD
-    with django_assert_num_queries(59):
-=======
-    with django_assert_num_queries(55):
->>>>>>> 95bb73108... Remove repeated shipping API calls from checkout lines mutations
+    with django_assert_num_queries(56):
         variables = {
             "checkoutId": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -987,11 +975,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-<<<<<<< HEAD
-    with django_assert_num_queries(59):
-=======
-    with django_assert_num_queries(55):
->>>>>>> 95bb73108... Remove repeated shipping API calls from checkout lines mutations
+    with django_assert_num_queries(56):
         variables = {
             "checkoutId": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -769,7 +769,9 @@ MUTATION_CHECKOUT_LINES_ADD = (
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
+@patch("saleor.plugins.manager.PluginsManager.list_shipping_methods_for_checkout")
 def test_add_checkout_lines(
+    list_shipping_methods_for_checkout,
     api_client,
     checkout_with_single_item,
     stock,
@@ -821,6 +823,7 @@ def test_add_checkout_lines(
         api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
     )
     assert not response["data"]["checkoutLinesAdd"]["errors"]
+    assert list_shipping_methods_for_checkout.call_count == 1
 
 
 @pytest.mark.django_db

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -706,7 +706,11 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
+<<<<<<< HEAD
     with django_assert_num_queries(60):
+=======
+    with django_assert_num_queries(56):
+>>>>>>> 95bb73108... Remove repeated shipping API calls from checkout lines mutations
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "token": checkout.token,
@@ -720,7 +724,11 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
+<<<<<<< HEAD
     with django_assert_num_queries(60):
+=======
+    with django_assert_num_queries(56):
+>>>>>>> 95bb73108... Remove repeated shipping API calls from checkout lines mutations
         variables = {
             "token": checkout.token,
             "lines": [],
@@ -859,7 +867,11 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
+<<<<<<< HEAD
     with django_assert_num_queries(59):
+=======
+    with django_assert_num_queries(55):
+>>>>>>> 95bb73108... Remove repeated shipping API calls from checkout lines mutations
         variables = {
             "checkoutId": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -872,7 +884,11 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
+<<<<<<< HEAD
     with django_assert_num_queries(59):
+=======
+    with django_assert_num_queries(55):
+>>>>>>> 95bb73108... Remove repeated shipping API calls from checkout lines mutations
         variables = {
             "checkoutId": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,


### PR DESCRIPTION
Reduces number of shipping API calls performed by Checkout Lines mutations from 4 to 1 by removing redundant API calls from `fetch_checkout_info`.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
