### PR TITLE
fix checkout created event and tests

### DIFF
--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -3,7 +3,6 @@ import logging
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from ...app.models import App
-from ...core.models import EventPayload
 from ...core.notify_events import NotifyEventType
 from ...core.utils.json_serializer import CustomJsonEncoder
 from ...payment import PaymentError, TransactionKind
@@ -271,8 +270,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         checkout_data = generate_checkout_payload(checkout)
-        event_payload = EventPayload.objects.create(payload=checkout_data)
-        trigger_webhooks_async(event_payload, WebhookEventType.CHECKOUT_CREATED)
+        trigger_webhooks_async(checkout_data, WebhookEventType.CHECKOUT_CREATED)
 
     def checkout_updated(self, checkout: "Checkout", previous_value: Any) -> Any:
         if not self.active:

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -346,14 +346,11 @@ def test_checkout_created(mocked_webhook_trigger, settings, checkout_with_items)
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.checkout_created(checkout_with_items)
-
-    event_payload = EventPayload.objects.first()
     expected_data = generate_checkout_payload(checkout_with_items)
 
     mocked_webhook_trigger.assert_called_once_with(
-        event_payload, WebhookEventType.CHECKOUT_CREATED
+        expected_data, WebhookEventType.CHECKOUT_CREATED
     )
-    assert expected_data == event_payload.payload
 
 
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")


### PR DESCRIPTION
I want to merge this change because checkout_created event needs to be fixed

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
