### PR TITLE
Implement read replicas in all dataloaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add workaround for failing Avatax when line has price 0 - #8610 by @korycins
 - Add option to set tax code for shipping in Avatax configuration view - #8596 by @korycins
 - Fix Avalara tax fetching from cache - #8647 by @fowczarek
+- Implement database read replicas - #8516, #8751 by @fowczarek
 
 
 ### Breaking

--- a/saleor/graphql/account/dataloaders.py
+++ b/saleor/graphql/account/dataloaders.py
@@ -8,7 +8,7 @@ class AddressByIdLoader(DataLoader):
     context_key = "address_by_id"
 
     def batch_load(self, keys):
-        address_map = Address.objects.in_bulk(keys)
+        address_map = Address.objects.using(self.database_connection_name).in_bulk(keys)
         return [address_map.get(address_id) for address_id in keys]
 
 
@@ -16,7 +16,7 @@ class UserByUserIdLoader(DataLoader):
     context_key = "user_by_id"
 
     def batch_load(self, keys):
-        user_map = User.objects.in_bulk(keys)
+        user_map = User.objects.using(self.database_connection_name).in_bulk(keys)
         return [user_map.get(user_id) for user_id in keys]
 
 
@@ -24,7 +24,9 @@ class CustomerEventsByUserLoader(DataLoader):
     context_key = "customer_events_by_user"
 
     def batch_load(self, keys):
-        events = CustomerEvent.objects.filter(user_id__in=keys)
+        events = CustomerEvent.objects.using(self.database_connection_name).filter(
+            user_id__in=keys
+        )
         events_by_user_map = defaultdict(list)
         for event in events:
             events_by_user_map[event.user_id].append(event)

--- a/saleor/graphql/app/dataloaders.py
+++ b/saleor/graphql/app/dataloaders.py
@@ -6,5 +6,5 @@ class AppByIdLoader(DataLoader):
     context_key = "app_by_id"
 
     def batch_load(self, keys):
-        apps = App.objects.in_bulk(keys)
+        apps = App.objects.using(self.database_connection_name).in_bulk(keys)
         return [apps.get(app_id) for app_id in keys]

--- a/saleor/graphql/channel/dataloaders.py
+++ b/saleor/graphql/channel/dataloaders.py
@@ -15,7 +15,7 @@ class ChannelByIdLoader(DataLoader):
     context_key = "channel_by_id"
 
     def batch_load(self, keys):
-        channels = Channel.objects.in_bulk(keys)
+        channels = Channel.objects.using(self.database_connection_name).in_bulk(keys)
         return [channels.get(channel_id) for channel_id in keys]
 
 
@@ -77,8 +77,14 @@ class ChannelWithHasOrdersByIdLoader(DataLoader):
     context_key = "channel_with_has_orders_by_id"
 
     def batch_load(self, keys):
-        orders = Order.objects.filter(channel=OuterRef("pk"))
-        channels = Channel.objects.annotate(has_orders=Exists(orders)).in_bulk(keys)
+        orders = Order.objects.using(self.database_connection_name).filter(
+            channel=OuterRef("pk")
+        )
+        channels = (
+            Channel.objects.using(self.database_connection_name)
+            .annotate(has_orders=Exists(orders))
+            .in_bulk(keys)
+        )
         return [channels.get(channel_id) for channel_id in keys]
 
 
@@ -86,9 +92,11 @@ class ShippingZonesByChannelIdLoader(DataLoader):
     context_key = "shippingzone_by_channel"
 
     def batch_load(self, keys):
-        zone_and_channel_is_pairs = ShippingZone.objects.filter(
-            channels__id__in=keys
-        ).values_list("pk", "channels__id")
+        zone_and_channel_is_pairs = (
+            ShippingZone.objects.using(self.database_connection_name)
+            .filter(channels__id__in=keys)
+            .values_list("pk", "channels__id")
+        )
         channel_shipping_zone_map = defaultdict(list)
         for zone_id, channel_id in zone_and_channel_is_pairs:
             channel_shipping_zone_map[channel_id].append(zone_id)

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -24,7 +24,11 @@ class CheckoutByTokenLoader(DataLoader):
     context_key = "checkout_by_token"
 
     def batch_load(self, keys):
-        checkouts = Checkout.objects.filter(token__in=keys).in_bulk()
+        checkouts = (
+            Checkout.objects.using(self.database_connection_name)
+            .filter(token__in=keys)
+            .in_bulk()
+        )
         return [checkouts.get(token) for token in keys]
 
 
@@ -110,7 +114,7 @@ class CheckoutByIdLoader(DataLoader):
     context_key = "checkout_by_id"
 
     def batch_load(self, keys):
-        checkouts = Checkout.objects.in_bulk(keys)
+        checkouts = Checkout.objects.using(self.database_connection_name).in_bulk(keys)
         return [checkouts.get(checkout_id) for checkout_id in keys]
 
 
@@ -118,7 +122,9 @@ class CheckoutByUserLoader(DataLoader):
     context_key = "checkout_by_user"
 
     def batch_load(self, keys):
-        checkouts = Checkout.objects.filter(user_id__in=keys, channel__is_active=True)
+        checkouts = Checkout.objects.using(self.database_connection_name).filter(
+            user_id__in=keys, channel__is_active=True
+        )
         checkout_by_user_map = defaultdict(list)
         for checkout in checkouts:
             checkout_by_user_map[checkout.user_id].append(checkout)
@@ -131,11 +137,15 @@ class CheckoutByUserAndChannelLoader(DataLoader):
     def batch_load(self, keys):
         user_ids = [key[0] for key in keys]
         channel_slugs = [key[1] for key in keys]
-        checkouts = Checkout.objects.filter(
-            user_id__in=user_ids,
-            channel__slug__in=channel_slugs,
-            channel__is_active=True,
-        ).annotate(channel_slug=F("channel__slug"))
+        checkouts = (
+            Checkout.objects.using(self.database_connection_name)
+            .filter(
+                user_id__in=user_ids,
+                channel__slug__in=channel_slugs,
+                channel__is_active=True,
+            )
+            .annotate(channel_slug=F("channel__slug"))
+        )
         checkout_by_user_and_channel_map = defaultdict(list)
         for checkout in checkouts:
             key = (checkout.user_id, checkout.channel_slug)
@@ -253,7 +263,9 @@ class CheckoutLineByIdLoader(DataLoader):
     context_key = "checkout_line_by_id"
 
     def batch_load(self, keys):
-        checkout_lines = CheckoutLine.objects.in_bulk(keys)
+        checkout_lines = CheckoutLine.objects.using(
+            self.database_connection_name
+        ).in_bulk(keys)
         return [checkout_lines.get(line_id) for line_id in keys]
 
 
@@ -261,7 +273,9 @@ class CheckoutLinesByCheckoutTokenLoader(DataLoader):
     context_key = "checkoutlines_by_checkout"
 
     def batch_load(self, keys):
-        lines = CheckoutLine.objects.filter(checkout_id__in=keys)
+        lines = CheckoutLine.objects.using(self.database_connection_name).filter(
+            checkout_id__in=keys
+        )
         line_map = defaultdict(list)
         for line in lines.iterator():
             line_map[line.checkout_id].append(line)

--- a/saleor/graphql/giftcard/dataloaders.py
+++ b/saleor/graphql/giftcard/dataloaders.py
@@ -8,7 +8,9 @@ class GiftCardsByUserLoader(DataLoader):
     context_key = "gift_cards_by_user"
 
     def batch_load(self, keys):
-        gift_cards = GiftCard.objects.filter(user_id__in=keys)
+        gift_cards = GiftCard.objects.using(self.database_connection_name).filter(
+            user_id__in=keys
+        )
         gift_cards_by_user_map = defaultdict(list)
         for gift_card in gift_cards:
             gift_cards_by_user_map[gift_card.user_id].append(gift_card)

--- a/saleor/graphql/menu/dataloaders.py
+++ b/saleor/graphql/menu/dataloaders.py
@@ -8,7 +8,7 @@ class MenuByIdLoader(DataLoader):
     context_key = "menu_by_id"
 
     def batch_load(self, keys):
-        menus = Menu.objects.in_bulk(keys)
+        menus = Menu.objects.using(self.database_connection_name).in_bulk(keys)
         return [menus.get(menu_id) for menu_id in keys]
 
 
@@ -16,7 +16,7 @@ class MenuItemByIdLoader(DataLoader):
     context_key = "menuitem_by_id"
 
     def batch_load(self, keys):
-        menu_items = MenuItem.objects.in_bulk(keys)
+        menu_items = MenuItem.objects.using(self.database_connection_name).in_bulk(keys)
         return [menu_items.get(menu_item_id) for menu_item_id in keys]
 
 
@@ -24,7 +24,9 @@ class MenuItemsByParentMenuLoader(DataLoader):
     context_key = "menuitems_by_parent_menu"
 
     def batch_load(self, keys):
-        menu_items = MenuItem.objects.filter(menu_id__in=keys, level=0)
+        menu_items = MenuItem.objects.using(self.database_connection_name).filter(
+            menu_id__in=keys, level=0
+        )
         items_map = defaultdict(list)
         for menu_item in menu_items:
             items_map[menu_item.menu_id].append(menu_item)
@@ -35,7 +37,9 @@ class MenuItemChildrenLoader(DataLoader):
     context_key = "menuitem_children"
 
     def batch_load(self, keys):
-        menu_items = MenuItem.objects.filter(parent_id__in=keys)
+        menu_items = MenuItem.objects.using(self.database_connection_name).filter(
+            parent_id__in=keys
+        )
         items_map = defaultdict(list)
         for menu_item in menu_items:
             items_map[menu_item.parent_id].append(menu_item)

--- a/saleor/graphql/order/dataloaders.py
+++ b/saleor/graphql/order/dataloaders.py
@@ -13,9 +13,11 @@ class OrderLinesByVariantIdAndChannelIdLoader(DataLoader):
     def batch_load(self, keys):
         channel_ids = [key[1] for key in keys]
         variant_ids = [key[0] for key in keys]
-        order_lines = OrderLine.objects.filter(
-            order__channel_id__in=channel_ids, variant_id__in=variant_ids
-        ).annotate(channel_id=F("order__channel_id"))
+        order_lines = (
+            OrderLine.objects.using(self.database_connection_name)
+            .filter(order__channel_id__in=channel_ids, variant_id__in=variant_ids)
+            .annotate(channel_id=F("order__channel_id"))
+        )
 
         order_line_by_variant_and_channel_map = defaultdict(list)
         for order_line in order_lines:
@@ -28,7 +30,7 @@ class OrderByIdLoader(DataLoader):
     context_key = "order_by_id"
 
     def batch_load(self, keys):
-        orders = Order.objects.in_bulk(keys)
+        orders = Order.objects.using(self.database_connection_name).in_bulk(keys)
         return [orders.get(order_id) for order_id in keys]
 
 
@@ -36,7 +38,9 @@ class OrdersByUserLoader(DataLoader):
     context_key = "order_by_user"
 
     def batch_load(self, keys):
-        orders = Order.objects.filter(user_id__in=keys)
+        orders = Order.objects.using(self.database_connection_name).filter(
+            user_id__in=keys
+        )
         orders_by_user_map = defaultdict(list)
         for order in orders:
             orders_by_user_map[order.user_id].append(order)
@@ -47,7 +51,9 @@ class OrderLineByIdLoader(DataLoader):
     context_key = "orderline_by_id"
 
     def batch_load(self, keys):
-        order_lines = OrderLine.objects.in_bulk(keys)
+        order_lines = OrderLine.objects.using(self.database_connection_name).in_bulk(
+            keys
+        )
         return [order_lines.get(line_id) for line_id in keys]
 
 
@@ -55,7 +61,11 @@ class OrderLinesByOrderIdLoader(DataLoader):
     context_key = "orderlines_by_order"
 
     def batch_load(self, keys):
-        lines = OrderLine.objects.filter(order_id__in=keys).order_by("pk")
+        lines = (
+            OrderLine.objects.using(self.database_connection_name)
+            .filter(order_id__in=keys)
+            .order_by("pk")
+        )
         line_map = defaultdict(list)
         for line in lines.iterator():
             line_map[line.order_id].append(line)
@@ -66,7 +76,11 @@ class OrderEventsByOrderIdLoader(DataLoader):
     context_key = "orderevents_by_order"
 
     def batch_load(self, keys):
-        events = OrderEvent.objects.filter(order_id__in=keys).order_by("pk")
+        events = (
+            OrderEvent.objects.using(self.database_connection_name)
+            .filter(order_id__in=keys)
+            .order_by("pk")
+        )
         events_map = defaultdict(list)
         for event in events.iterator():
             events_map[event.order_id].append(event)
@@ -77,7 +91,9 @@ class AllocationsByOrderLineIdLoader(DataLoader):
     context_key = "allocations_by_orderline_id"
 
     def batch_load(self, keys):
-        allocations = Allocation.objects.filter(order_line__pk__in=keys)
+        allocations = Allocation.objects.using(self.database_connection_name).filter(
+            order_line__pk__in=keys
+        )
         order_lines_to_allocations = defaultdict(list)
 
         for allocation in allocations:
@@ -90,7 +106,11 @@ class FulfillmentsByOrderIdLoader(DataLoader):
     context_key = "fulfillments_by_order"
 
     def batch_load(self, keys):
-        fulfillments = Fulfillment.objects.filter(order_id__in=keys).order_by("pk")
+        fulfillments = (
+            Fulfillment.objects.using(self.database_connection_name)
+            .filter(order_id__in=keys)
+            .order_by("pk")
+        )
         fulfillments_map = defaultdict(list)
         for fulfillment in fulfillments.iterator():
             fulfillments_map[fulfillment.order_id].append(fulfillment)
@@ -101,5 +121,7 @@ class FulfillmentLinesByIdLoader(DataLoader):
     context_key = "fulfillment_lines_by_id"
 
     def batch_load(self, keys):
-        fulfillment_lines = FulfillmentLine.objects.in_bulk(keys)
+        fulfillment_lines = FulfillmentLine.objects.using(
+            self.database_connection_name
+        ).in_bulk(keys)
         return [fulfillment_lines.get(line_id) for line_id in keys]

--- a/saleor/graphql/page/dataloaders.py
+++ b/saleor/graphql/page/dataloaders.py
@@ -18,7 +18,7 @@ class PageByIdLoader(DataLoader):
     context_key = "page_by_id"
 
     def batch_load(self, keys):
-        pages = Page.objects.in_bulk(keys)
+        pages = Page.objects.using(self.database_connection_name).in_bulk(keys)
         return [pages.get(page_id) for page_id in keys]
 
 
@@ -26,7 +26,7 @@ class PageTypeByIdLoader(DataLoader):
     context_key = "page_type_by_id"
 
     def batch_load(self, keys):
-        page_types = PageType.objects.in_bulk(keys)
+        page_types = PageType.objects.using(self.database_connection_name).in_bulk(keys)
         return [page_types.get(page_type_id) for page_type_id in keys]
 
 
@@ -36,7 +36,9 @@ class PagesByPageTypeIdLoader(DataLoader):
     context_key = "pages_by_pagetype"
 
     def batch_load(self, keys):
-        pages = Page.objects.filter(page_type_id__in=keys)
+        pages = Page.objects.using(self.database_connection_name).filter(
+            page_type_id__in=keys
+        )
 
         pagetype_to_pages = defaultdict(list)
         for page in pages:
@@ -53,9 +55,11 @@ class PageAttributesByPageTypeIdLoader(DataLoader):
     def batch_load(self, keys):
         requestor = get_user_or_app_from_context(self.context)
         if requestor.is_active and requestor.has_perm(PagePermissions.MANAGE_PAGES):
-            qs = AttributePage.objects.all()
+            qs = AttributePage.using(self.database_connection_name).objects.all()
         else:
-            qs = AttributePage.objects.filter(attribute__visible_in_storefront=True)
+            qs = AttributePage.using(self.database_connection_name).objects.filter(
+                attribute__visible_in_storefront=True
+            )
 
         page_type_attribute_pairs = qs.filter(page_type_id__in=keys).values_list(
             "page_type_id", "attribute_id"
@@ -90,9 +94,11 @@ class AttributePagesByPageTypeIdLoader(DataLoader):
     def batch_load(self, keys):
         requestor = get_user_or_app_from_context(self.context)
         if requestor.is_active and requestor.has_perm(PagePermissions.MANAGE_PAGES):
-            qs = AttributePage.objects.all()
+            qs = AttributePage.objects.using(self.database_connection_name).all()
         else:
-            qs = AttributePage.objects.filter(attribute__visible_in_storefront=True)
+            qs = AttributePage.objects.using(self.database_connection_name).filter(
+                attribute__visible_in_storefront=True
+            )
         attribute_pages = qs.filter(page_type_id__in=keys)
         pagetype_to_attributepages = defaultdict(list)
         for attribute_page in attribute_pages:
@@ -108,11 +114,13 @@ class AssignedPageAttributesByPageIdLoader(DataLoader):
     def batch_load(self, keys):
         requestor = get_user_or_app_from_context(self.context)
         if requestor.is_active and requestor.has_perm(PagePermissions.MANAGE_PAGES):
-            qs = AssignedPageAttribute.objects.all()
+            qs = AssignedPageAttribute.objects.using(
+                self.database_connection_name
+            ).all()
         else:
-            qs = AssignedPageAttribute.objects.filter(
-                assignment__attribute__visible_in_storefront=True
-            )
+            qs = AssignedPageAttribute.objects.using(
+                self.database_connection_name
+            ).filter(assignment__attribute__visible_in_storefront=True)
         assigned_page_attributes = qs.filter(page_id__in=keys)
         page_to_assignedattributes = defaultdict(list)
         for assigned_page_attribute in assigned_page_attributes:
@@ -126,9 +134,9 @@ class AttributeValuesByAssignedPageAttributeIdLoader(DataLoader):
     context_key = "attributevalues_by_assigned_pageattribute"
 
     def batch_load(self, keys):
-        attribute_values = AssignedPageAttributeValue.objects.filter(
-            assignment_id__in=keys
-        )
+        attribute_values = AssignedPageAttributeValue.objects.using(
+            self.database_connection_name
+        ).filter(assignment_id__in=keys)
         value_ids = [a.value_id for a in attribute_values]
 
         def map_assignment_to_values(values):

--- a/saleor/graphql/page/dataloaders.py
+++ b/saleor/graphql/page/dataloaders.py
@@ -55,9 +55,9 @@ class PageAttributesByPageTypeIdLoader(DataLoader):
     def batch_load(self, keys):
         requestor = get_user_or_app_from_context(self.context)
         if requestor.is_active and requestor.has_perm(PagePermissions.MANAGE_PAGES):
-            qs = AttributePage.using(self.database_connection_name).objects.all()
+            qs = AttributePage.objects.using(self.database_connection_name).all()
         else:
-            qs = AttributePage.using(self.database_connection_name).objects.filter(
+            qs = AttributePage.objects.using(self.database_connection_name).filter(
                 attribute__visible_in_storefront=True
             )
 

--- a/saleor/graphql/product/dataloaders/attributes.py
+++ b/saleor/graphql/product/dataloaders/attributes.py
@@ -30,9 +30,11 @@ class BaseProductAttributesByProductTypeIdLoader(DataLoader):
         if requestor.is_active and requestor.has_perm(
             ProductPermissions.MANAGE_PRODUCTS
         ):
-            qs = self.model_name.objects.all()
+            qs = self.model_name.objects.using(self.database_connection_name).all()
         else:
-            qs = self.model_name.objects.filter(attribute__visible_in_storefront=True)
+            qs = self.model_name.objects.using(self.database_connection_name).filter(
+                attribute__visible_in_storefront=True
+            )
         product_type_attribute_pairs = qs.filter(product_type_id__in=keys).values_list(
             "product_type_id", "attribute_id"
         )
@@ -86,9 +88,11 @@ class AttributeProductsByProductTypeIdLoader(DataLoader):
         if requestor.is_active and requestor.has_perm(
             ProductPermissions.MANAGE_PRODUCTS
         ):
-            qs = AttributeProduct.objects.all()
+            qs = AttributeProduct.objects.using(self.database_connection_name).all()
         else:
-            qs = AttributeProduct.objects.filter(attribute__visible_in_storefront=True)
+            qs = AttributeProduct.objects.using(self.database_connection_name).filter(
+                attribute__visible_in_storefront=True
+            )
         attribute_products = qs.filter(product_type_id__in=keys)
         producttype_to_attributeproducts = defaultdict(list)
         for attribute_product in attribute_products:
@@ -106,9 +110,11 @@ class AttributeVariantsByProductTypeIdLoader(DataLoader):
         if requestor.is_active and requestor.has_perm(
             ProductPermissions.MANAGE_PRODUCTS
         ):
-            qs = AttributeVariant.objects.all()
+            qs = AttributeVariant.objects.using(self.database_connection_name).all()
         else:
-            qs = AttributeVariant.objects.filter(attribute__visible_in_storefront=True)
+            qs = AttributeVariant.objects.using(self.database_connection_name).filter(
+                attribute__visible_in_storefront=True
+            )
         attribute_variants = qs.filter(product_type_id__in=keys)
         producttype_to_attributevariants = defaultdict(list)
         for attribute_variant in attribute_variants:
@@ -126,11 +132,13 @@ class AssignedProductAttributesByProductIdLoader(DataLoader):
         if requestor.is_active and requestor.has_perm(
             ProductPermissions.MANAGE_PRODUCTS
         ):
-            qs = AssignedProductAttribute.objects.all()
+            qs = AssignedProductAttribute.objects.using(
+                self.database_connection_name
+            ).all()
         else:
-            qs = AssignedProductAttribute.objects.filter(
-                assignment__attribute__visible_in_storefront=True
-            )
+            qs = AssignedProductAttribute.objects.using(
+                self.database_connection_name
+            ).filter(assignment__attribute__visible_in_storefront=True)
         assigned_product_attributes = qs.filter(product_id__in=keys)
         product_to_assignedproductattributes = defaultdict(list)
         for assigned_product_attribute in assigned_product_attributes:
@@ -148,11 +156,13 @@ class AssignedVariantAttributesByProductVariantId(DataLoader):
         if requestor.is_active and requestor.has_perm(
             ProductPermissions.MANAGE_PRODUCTS
         ):
-            qs = AssignedVariantAttribute.objects.all()
+            qs = AssignedVariantAttribute.objects.using(
+                self.database_connection_name
+            ).all()
         else:
-            qs = AssignedVariantAttribute.objects.filter(
-                assignment__attribute__visible_in_storefront=True
-            )
+            qs = AssignedVariantAttribute.objects.using(
+                self.database_connection_name
+            ).filter(assignment__attribute__visible_in_storefront=True)
         assigned_variant_attributes = qs.filter(variant_id__in=keys).select_related(
             "assignment__attribute"
         )
@@ -168,9 +178,9 @@ class AttributeValuesByAssignedProductAttributeIdLoader(DataLoader):
     context_key = "attributevalues_by_assignedproductattribute"
 
     def batch_load(self, keys):
-        attribute_values = AssignedProductAttributeValue.objects.filter(
-            assignment_id__in=keys
-        )
+        attribute_values = AssignedProductAttributeValue.objects.using(
+            self.database_connection_name
+        ).filter(assignment_id__in=keys)
         value_ids = [a.value_id for a in attribute_values]
 
         def map_assignment_to_values(values):
@@ -193,9 +203,9 @@ class AttributeValuesByAssignedVariantAttributeIdLoader(DataLoader):
     context_key = "attributevalues_by_assignedvariantattribute"
 
     def batch_load(self, keys):
-        attribute_values = AssignedVariantAttributeValue.objects.filter(
-            assignment_id__in=keys
-        )
+        attribute_values = AssignedVariantAttributeValue.objects.using(
+            self.database_connection_name
+        ).filter(assignment_id__in=keys)
         value_ids = [a.value_id for a in attribute_values]
 
         def map_assignment_to_values(values):

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -27,7 +27,7 @@ class CategoryByIdLoader(DataLoader):
     context_key = "category_by_id"
 
     def batch_load(self, keys):
-        categories = Category.objects.in_bulk(keys)
+        categories = Category.objects.using(self.database_connection_name).in_bulk(keys)
         return [categories.get(category_id) for category_id in keys]
 
 
@@ -56,7 +56,9 @@ class ProductChannelListingByIdLoader(DataLoader[int, ProductChannelListing]):
     context_key = "productchannelisting_by_id"
 
     def batch_load(self, keys):
-        product_channel_listings = ProductChannelListing.objects.in_bulk(keys)
+        product_channel_listings = ProductChannelListing.objects.using(
+            self.database_connection_name
+        ).in_bulk(keys)
         return [product_channel_listings.get(key) for key in keys]
 
 
@@ -64,9 +66,9 @@ class ProductChannelListingByProductIdLoader(DataLoader[int, ProductChannelListi
     context_key = "productchannelisting_by_product"
 
     def batch_load(self, keys):
-        product_channel_listings = ProductChannelListing.objects.filter(
-            product_id__in=keys
-        )
+        product_channel_listings = ProductChannelListing.objects.using(
+            self.database_connection_name
+        ).filter(product_id__in=keys)
         product_id_variant_channel_listings_map = defaultdict(list)
         for product_channel_listing in product_channel_listings:
             product_id_variant_channel_listings_map[
@@ -111,9 +113,9 @@ class ProductChannelListingByProductIdAndChannelSlugLoader(
     def batch_load_channel(
         self, channel_slug: str, products_ids: Iterable[int]
     ) -> Iterable[Tuple[int, Optional[ProductChannelListing]]]:
-        product_channel_listings = ProductChannelListing.objects.filter(
-            channel__slug=channel_slug, product_id__in=products_ids
-        )
+        product_channel_listings = ProductChannelListing.objects.using(
+            self.database_connection_name
+        ).filter(channel__slug=channel_slug, product_id__in=products_ids)
 
         product_channel_listings_map: Dict[int, ProductChannelListing] = {}
         for product_channel_listing in product_channel_listings.iterator():
@@ -131,7 +133,9 @@ class ProductTypeByIdLoader(DataLoader):
     context_key = "product_type_by_id"
 
     def batch_load(self, keys):
-        product_types = ProductType.objects.in_bulk(keys)
+        product_types = ProductType.objects.using(
+            self.database_connection_name
+        ).in_bulk(keys)
         return [product_types.get(product_type_id) for product_type_id in keys]
 
 
@@ -139,7 +143,9 @@ class MediaByProductIdLoader(DataLoader):
     context_key = "media_by_product"
 
     def batch_load(self, keys):
-        media = ProductMedia.objects.filter(product_id__in=keys)
+        media = ProductMedia.objects.using(self.database_connection_name).filter(
+            product_id__in=keys
+        )
         media_map = defaultdict(list)
         for media_obj in media:
             media_map[media_obj.product_id].append(media_obj)
@@ -150,7 +156,7 @@ class ImagesByProductIdLoader(DataLoader):
     context_key = "images_by_product"
 
     def batch_load(self, keys):
-        images = ProductMedia.objects.filter(
+        images = ProductMedia.objects.using(self.database_connection_name).filter(
             product_id__in=keys, type=ProductMediaTypes.IMAGE
         )
         images_map = defaultdict(list)
@@ -173,7 +179,9 @@ class ProductVariantsByProductIdLoader(DataLoader):
     context_key = "productvariants_by_product"
 
     def batch_load(self, keys):
-        variants = ProductVariant.objects.filter(product_id__in=keys)
+        variants = ProductVariant.objects.using(self.database_connection_name).filter(
+            product_id__in=keys
+        )
         variant_map = defaultdict(list)
         variant_loader = ProductVariantByIdLoader(self.context)
         for variant in variants.iterator():
@@ -189,8 +197,10 @@ class ProductVariantsByProductIdAndChannel(DataLoader):
         product_ids, channel_slugs = zip(*keys)
         variants_filter = self.get_variants_filter(product_ids, channel_slugs)
 
-        variants = ProductVariant.objects.filter(**variants_filter).annotate(
-            channel_slug=F("channel_listings__channel__slug")
+        variants = (
+            ProductVariant.objects.using(self.database_connection_name)
+            .filter(**variants_filter)
+            .annotate(channel_slug=F("channel_listings__channel__slug"))
         )
         variant_map = defaultdict(list)
         for variant in variants.iterator():
@@ -226,7 +236,9 @@ class ProductVariantChannelListingByIdLoader(DataLoader):
     context_key = "productvariantchannelisting_by_id"
 
     def batch_load(self, keys):
-        variants = ProductVariantChannelListing.objects.in_bulk(keys)
+        variants = ProductVariantChannelListing.objects.using(
+            self.database_connection_name
+        ).in_bulk(keys)
         return [variants.get(key) for key in keys]
 
 
@@ -234,9 +246,9 @@ class VariantChannelListingByVariantIdLoader(DataLoader):
     context_key = "productvariantchannelisting_by_productvariant"
 
     def batch_load(self, keys):
-        variant_channel_listings = ProductVariantChannelListing.objects.filter(
-            variant_id__in=keys
-        )
+        variant_channel_listings = ProductVariantChannelListing.objects.using(
+            self.database_connection_name
+        ).filter(variant_id__in=keys)
         variant_id_variant_channel_listings_map = defaultdict(list)
         for variant_channel_listing in variant_channel_listings:
             variant_id_variant_channel_listings_map[
@@ -285,7 +297,9 @@ class VariantChannelListingByVariantIdAndChannelLoader(
             "variant_id__in": variant_ids,
             "price_amount__isnull": False,
         }
-        variant_channel_listings = ProductVariantChannelListing.objects.filter(**filter)
+        variant_channel_listings = ProductVariantChannelListing.objects.using(
+            self.database_connection_name
+        ).filter(**filter)
 
         variant_channel_listings_map: Dict[int, ProductVariantChannelListing] = {}
         for variant_channel_listing in variant_channel_listings.iterator():
@@ -348,11 +362,15 @@ class VariantsChannelListingByProductIdAndChannelSlugLoader(
     def batch_load_channel(
         self, channel_slug: str, products_ids: Iterable[int]
     ) -> Iterable[Tuple[int, Optional[List[ProductVariantChannelListing]]]]:
-        variants_channel_listings = ProductVariantChannelListing.objects.filter(
-            channel__slug=channel_slug,
-            variant__product_id__in=products_ids,
-            price_amount__isnull=False,
-        ).annotate(product_id=F("variant__product_id"))
+        variants_channel_listings = (
+            ProductVariantChannelListing.objects.using(self.database_connection_name)
+            .filter(
+                channel__slug=channel_slug,
+                variant__product_id__in=products_ids,
+                price_amount__isnull=False,
+            )
+            .annotate(product_id=F("variant__product_id"))
+        )
 
         variants_channel_listings_map: Dict[
             int, List[ProductVariantChannelListing]
@@ -372,7 +390,9 @@ class ProductMediaByIdLoader(DataLoader):
     context_key = "product_media_by_id"
 
     def batch_load(self, keys):
-        product_media = ProductMedia.objects.in_bulk(keys)
+        product_media = ProductMedia.objects.using(
+            self.database_connection_name
+        ).in_bulk(keys)
         return [product_media.get(product_media_id) for product_media_id in keys]
 
 
@@ -380,7 +400,11 @@ class ProductImageByIdLoader(DataLoader):
     context_key = "product_image_by_id"
 
     def batch_load(self, keys):
-        images = ProductMedia.objects.filter(type=ProductMediaTypes.IMAGE).in_bulk(keys)
+        images = (
+            ProductMedia.objects.using(self.database_connection_name)
+            .filter(type=ProductMediaTypes.IMAGE)
+            .in_bulk(keys)
+        )
         return [images.get(product_image_id) for product_image_id in keys]
 
 
@@ -388,7 +412,7 @@ class ProductImageByProductIdLoader(DataLoader):
     context_key = "product_image_by_product_id"
 
     def batch_load(self, keys):
-        medias = ProductMedia.objects.filter(
+        medias = ProductMedia.objects.using(self.database_connection_name).filter(
             type=ProductMediaTypes.IMAGE, product_id__in=keys
         )
         product_id_medias_map = defaultdict(list)
@@ -401,8 +425,10 @@ class MediaByProductVariantIdLoader(DataLoader):
     context_key = "media_by_product_variant"
 
     def batch_load(self, keys):
-        variant_media = VariantMedia.objects.filter(variant_id__in=keys).values_list(
-            "variant_id", "media_id"
+        variant_media = (
+            VariantMedia.objects.using(self.database_connection_name)
+            .filter(variant_id__in=keys)
+            .values_list("variant_id", "media_id")
         )
 
         variant_media_pairs = defaultdict(list)
@@ -427,9 +453,11 @@ class ImagesByProductVariantIdLoader(DataLoader):
     context_key = "images_by_product_variant"
 
     def batch_load(self, keys):
-        variant_media = VariantMedia.objects.filter(
-            variant_id__in=keys, media__type=ProductMediaTypes.IMAGE
-        ).values_list("variant_id", "media_id")
+        variant_media = (
+            VariantMedia.objects.using(self.database_connection_name)
+            .filter(variant_id__in=keys, media__type=ProductMediaTypes.IMAGE)
+            .values_list("variant_id", "media_id")
+        )
 
         variant_media_pairs = defaultdict(list)
         for variant_id, media_id in variant_media:
@@ -453,8 +481,10 @@ class CollectionByIdLoader(DataLoader):
     context_key = "collection_by_id"
 
     def batch_load(self, keys):
-        collections = Collection.objects.using(self.database_connection_name).in_bulk(
-            keys
+        collections = (
+            Collection.objects.using(self.database_connection_name)
+            .using(self.database_connection_name)
+            .in_bulk(keys)
         )
         return [collections.get(collection_id) for collection_id in keys]
 
@@ -465,6 +495,7 @@ class CollectionsByProductIdLoader(DataLoader):
     def batch_load(self, keys):
         product_collection_pairs = list(
             CollectionProduct.objects.using(self.database_connection_name)
+            .using(self.database_connection_name)
             .filter(product_id__in=keys)
             .order_by("id")
             .values_list("product_id", "collection_id")
@@ -506,9 +537,11 @@ class ProductTypeByProductIdLoader(DataLoader):
     def batch_load(self, keys):
         def with_products(products):
             product_ids = {p.id for p in products}
-            product_types_map = ProductType.objects.filter(
-                products__in=product_ids
-            ).in_bulk()
+            product_types_map = (
+                ProductType.objects.using(self.database_connection_name)
+                .filter(products__in=product_ids)
+                .in_bulk()
+            )
             return [product_types_map[product.product_type_id] for product in products]
 
         return ProductByIdLoader(self.context).load_many(keys).then(with_products)
@@ -531,7 +564,9 @@ class CollectionChannelListingByIdLoader(DataLoader):
     context_key = "collectionchannelisting_by_id"
 
     def batch_load(self, keys):
-        collections = CollectionChannelListing.objects.in_bulk(keys)
+        collections = CollectionChannelListing.objects.using(
+            self.database_connection_name
+        ).in_bulk(keys)
         return [collections.get(key) for key in keys]
 
 
@@ -539,9 +574,9 @@ class CollectionChannelListingByCollectionIdLoader(DataLoader):
     context_key = "collectionchannelisting_by_collection"
 
     def batch_load(self, keys):
-        collections_channel_listings = CollectionChannelListing.objects.filter(
-            collection_id__in=keys
-        )
+        collections_channel_listings = CollectionChannelListing.objects.using(
+            self.database_connection_name
+        ).filter(collection_id__in=keys)
         collection_id_collection_channel_listings_map = defaultdict(list)
         for collection_channel_listing in collections_channel_listings:
             collection_id_collection_channel_listings_map[
@@ -559,9 +594,11 @@ class CollectionChannelListingByCollectionIdAndChannelSlugLoader(DataLoader):
     def batch_load(self, keys):
         collection_ids = [key[0] for key in keys]
         channel_slugs = [key[1] for key in keys]
-        collections_channel_listings = CollectionChannelListing.objects.filter(
-            collection_id__in=collection_ids, channel__slug__in=channel_slugs
-        ).annotate(channel_slug=F("channel__slug"))
+        collections_channel_listings = (
+            CollectionChannelListing.objects.using(self.database_connection_name)
+            .filter(collection_id__in=collection_ids, channel__slug__in=channel_slugs)
+            .annotate(channel_slug=F("channel__slug"))
+        )
         collections_channel_listings_by_collection_and_channel_map = {}
         for collections_channel_listing in collections_channel_listings:
             key = (
@@ -581,7 +618,9 @@ class CategoryChildrenByCategoryIdLoader(DataLoader):
     context_key = "categorychildren_by_category"
 
     def batch_load(self, keys):
-        categories = Category.objects.filter(parent__isnull=False)
+        categories = Category.objects.using(self.database_connection_name).filter(
+            parent__isnull=False
+        )
         parent_to_children_mapping = defaultdict(list)
         for category in categories:
             parent_to_children_mapping[category.parent_id].append(category)

--- a/saleor/graphql/shipping/dataloaders.py
+++ b/saleor/graphql/shipping/dataloaders.py
@@ -16,7 +16,9 @@ class ShippingMethodByIdLoader(DataLoader):
     context_key = "shippingmethod_by_id"
 
     def batch_load(self, keys):
-        shipping_methods = ShippingMethod.objects.in_bulk(keys)
+        shipping_methods = ShippingMethod.objects.using(
+            self.database_connection_name
+        ).in_bulk(keys)
         return [shipping_methods.get(shipping_method_id) for shipping_method_id in keys]
 
 
@@ -24,7 +26,9 @@ class ShippingZoneByIdLoader(DataLoader):
     context_key = "shippingzone_by_id"
 
     def batch_load(self, keys):
-        shipping_zones = ShippingZone.objects.in_bulk(keys)
+        shipping_zones = ShippingZone.objects.using(
+            self.database_connection_name
+        ).in_bulk(keys)
         return [shipping_zones.get(shipping_zone_id) for shipping_zone_id in keys]
 
 
@@ -32,7 +36,9 @@ class ShippingMethodsByShippingZoneIdLoader(DataLoader):
     context_key = "shippingmethod_by_shippingzone"
 
     def batch_load(self, keys):
-        shipping_methods = ShippingMethod.objects.filter(shipping_zone_id__in=keys)
+        shipping_methods = ShippingMethod.objects.using(
+            self.database_connection_name
+        ).filter(shipping_zone_id__in=keys)
         shipping_methods_by_shipping_zone_map = defaultdict(list)
         for shipping_method in shipping_methods:
             shipping_methods_by_shipping_zone_map[
@@ -48,9 +54,11 @@ class PostalCodeRulesByShippingMethodIdLoader(DataLoader):
     context_key = "postal_code_rules_by_shipping_method"
 
     def batch_load(self, keys):
-        postal_code_rules = ShippingMethodPostalCodeRule.objects.filter(
-            shipping_method_id__in=keys
-        ).order_by("id")
+        postal_code_rules = (
+            ShippingMethodPostalCodeRule.objects.using(self.database_connection_name)
+            .filter(shipping_method_id__in=keys)
+            .order_by("id")
+        )
 
         postal_code_rules_map = defaultdict(list)
         for postal_code in postal_code_rules:
@@ -65,9 +73,11 @@ class ShippingMethodsByShippingZoneIdAndChannelSlugLoader(DataLoader):
     context_key = "shippingmethod_by_shippingzone_and_channel"
 
     def batch_load(self, keys):
-        shipping_methods = ShippingMethod.objects.filter(
-            shipping_zone_id__in=keys
-        ).annotate(channel_slug=F("channel_listings__channel__slug"))
+        shipping_methods = (
+            ShippingMethod.objects.using(self.database_connection_name)
+            .filter(shipping_zone_id__in=keys)
+            .annotate(channel_slug=F("channel_listings__channel__slug"))
+        )
 
         shipping_methods_by_shipping_zone_and_channel_map = defaultdict(list)
         for shipping_method in shipping_methods:
@@ -85,9 +95,9 @@ class ShippingMethodChannelListingByShippingMethodIdLoader(DataLoader):
     context_key = "shippingmethodchannellisting_by_shippingmethod"
 
     def batch_load(self, keys):
-        shipping_method_channel_listings = ShippingMethodChannelListing.objects.filter(
-            shipping_method_id__in=keys
-        )
+        shipping_method_channel_listings = ShippingMethodChannelListing.objects.using(
+            self.database_connection_name
+        ).filter(shipping_method_id__in=keys)
         shipping_method_channel_listings_by_shipping_method_map = defaultdict(list)
         for shipping_method_channel_listing in shipping_method_channel_listings:
             shipping_method_channel_listings_by_shipping_method_map[
@@ -107,9 +117,14 @@ class ShippingMethodChannelListingByShippingMethodIdAndChannelSlugLoader(DataLoa
     def batch_load(self, keys):
         shipping_method_ids = [key[0] for key in keys]
         channel_slugs = [key[1] for key in keys]
-        shipping_method_channel_listings = ShippingMethodChannelListing.objects.filter(
-            shipping_method_id__in=shipping_method_ids, channel__slug__in=channel_slugs
-        ).annotate(channel_slug=F("channel__slug"))
+        shipping_method_channel_listings = (
+            ShippingMethodChannelListing.objects.using(self.database_connection_name)
+            .filter(
+                shipping_method_id__in=shipping_method_ids,
+                channel__slug__in=channel_slugs,
+            )
+            .annotate(channel_slug=F("channel__slug"))
+        )
         shipping_method_channel_listings_by_shipping_method_and_channel_map = {}
         for shipping_method_channel_listing in shipping_method_channel_listings:
             key = (
@@ -131,9 +146,11 @@ class ChannelsByShippingZoneIdLoader(DataLoader):
     def batch_load(self, keys):
         from ..channel.dataloaders import ChannelByIdLoader
 
-        channel_and_zone_is_pairs = Channel.objects.filter(
-            shipping_zones__id__in=keys
-        ).values_list("pk", "shipping_zones__id")
+        channel_and_zone_is_pairs = (
+            Channel.objects.using(self.database_connection_name)
+            .filter(shipping_zones__id__in=keys)
+            .values_list("pk", "shipping_zones__id")
+        )
         shipping_zone_channel_map = defaultdict(list)
         for channel_id, zone_id in channel_and_zone_is_pairs:
             shipping_zone_channel_map[zone_id].append(channel_id)


### PR DESCRIPTION
I want to merge this change because implementing read replicas in all dataloaders.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
