### PR TITLE
Fix hardcoded values in tests

### DIFF
--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -9,6 +9,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.utils import timezone
 from freezegun import freeze_time
 
+from .... import __version__
 from ....account.notifications import (
     get_default_user_payload,
     send_account_confirmation,
@@ -492,7 +493,7 @@ def test_notify_user(mocked_webhook_trigger, settings, customer_user, channel_US
         "payload": payload,
         "meta": {
             "issued_at": timestamp,
-            "version": "dev",
+            "version": __version__,
             "issuing_principal": {
                 "id": graphene.Node.to_global_id("User", customer_user.id),
                 "type": "user",

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -10,6 +10,7 @@ import graphene
 from django.utils import timezone
 from freezegun import freeze_time
 
+from ... import __version__
 from ...core.utils.json_serializer import CustomJsonEncoder
 from ...discount import DiscountValueType, OrderDiscountType
 from ...graphql.utils import get_user_or_app_from_context
@@ -318,7 +319,7 @@ def test_generate_base_product_variant_payload(product_with_two_variants):
             "meta": {
                 "issuing_principal": {"id": None, "type": None},
                 "issued_at": ANY,
-                "version": "dev",
+                "version": __version__,
             },
         },
         {
@@ -337,7 +338,7 @@ def test_generate_base_product_variant_payload(product_with_two_variants):
             "meta": {
                 "issuing_principal": {"id": None, "type": None},
                 "issued_at": ANY,
-                "version": "dev",
+                "version": __version__,
             },
         },
     ]
@@ -380,7 +381,7 @@ def test_generate_product_variant_payload(
     assert payload["meta"] == {
         "issuing_principal": generate_requestor(staff_user),
         "issued_at": ANY,
-        "version": "dev",
+        "version": __version__,
     }
     assert len(payload.keys()) == len(payload_fields)
 
@@ -502,7 +503,7 @@ def test_generate_invoice_payload(fulfilled_order):
         "meta": {
             "issued_at": timestamp,
             "issuing_principal": {"id": None, "type": None},
-            "version": "dev",
+            "version": __version__,
         },
         "order": {
             "type": "Order",
@@ -705,7 +706,7 @@ def test_generate_customer_payload(customer_user, address_other_country, address
         "meta": {
             "issuing_principal": {"id": None, "type": None},
             "issued_at": timestamp,
-            "version": "dev",
+            "version": __version__,
         },
         "default_shipping_address": {
             "type": "Address",
@@ -908,5 +909,5 @@ def test_generate_meta(app, rf):
     assert generate_meta(requestor_data=generate_requestor(requestor)) == {
         "issuing_principal": {"id": "Sample app objects", "type": "app"},
         "issued_at": timestamp,
-        "version": "dev",
+        "version": __version__,
     }


### PR DESCRIPTION
I want to merge this change because it fixes hardcoded version is webhook meta tests, which results in tests failures for specific release versions.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
