### PR TITLE
checkout_token and checkout metadata on payment webhook level

### DIFF
--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -93,6 +93,8 @@ class PaymentData:
     data: Optional[dict] = None
     graphql_customer_id: Optional[str] = None
     refund_data: Optional[Dict[int, int]] = None
+    checkout_token: Optional[str] = None
+    checkout_metadata: Optional[Dict] = None
     # Optional, lazy-evaluated gateway arguments
     _resolve_lines: InitVar[Callable] = None
 

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -227,6 +227,16 @@ def test_create_payment_information_for_checkout_token_from_order(payment_dummy,
     assert payment_info.checkout_token == order.checkout_token == token
 
 
+def test_create_payment_information_for_empty_payment(payment_dummy):
+    payment_dummy.order = None
+    payment_dummy.checkout = None
+    payment_dummy.save(update_fields=["order", "checkout"])
+
+    payment_info = create_payment_information(payment_dummy)
+    assert payment_info.checkout_token == ""
+    assert payment_info.checkout_metadata is None
+
+
 def test_create_payment_information_for_checkout_metadata(payment_dummy, checkout):
     metadata = {"test_key": "test_val"}
     checkout.metadata = metadata

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -1,3 +1,4 @@
+import uuid
 from decimal import Decimal
 from unittest.mock import Mock, patch
 
@@ -203,6 +204,39 @@ def test_create_payment_information_for_checkout_payment(address, checkout_with_
     assert billing.street_address_1 == address.street_address_1
     assert billing.city == address.city
     assert shipping == billing
+
+
+def test_create_payment_information_for_checkout_token(payment_dummy, checkout):
+    payment_dummy.order = None
+    payment_dummy.checkout = checkout
+    payment_dummy.save(update_fields=["order", "checkout"])
+
+    payment_info = create_payment_information(payment_dummy)
+    assert payment_info.checkout_token == str(checkout.token)
+
+
+def test_create_payment_information_for_checkout_token_from_order(payment_dummy, order):
+    token = str(uuid.uuid4())
+    order.checkout_token = token
+    order.save(update_fields=["checkout_token"])
+    payment_dummy.order = order
+    payment_dummy.checkout = None
+    payment_dummy.save(update_fields=["order", "checkout"])
+
+    payment_info = create_payment_information(payment_dummy)
+    assert payment_info.checkout_token == order.checkout_token == token
+
+
+def test_create_payment_information_for_checkout_metadata(payment_dummy, checkout):
+    metadata = {"test_key": "test_val"}
+    checkout.metadata = metadata
+    checkout.save(update_fields=["metadata"])
+    payment_dummy.order = None
+    payment_dummy.checkout = checkout
+    payment_dummy.save(update_fields=["order", "checkout"])
+
+    payment_info = create_payment_information(payment_dummy)
+    assert payment_info.checkout_metadata == metadata
 
 
 def test_create_payment_information_for_draft_order(draft_order):

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -200,13 +200,24 @@ def create_payment_information(
         shipping = checkout.shipping_address
         email = checkout.get_customer_email()
         user_id = checkout.user_id
-    elif payment.order:
-        billing = payment.order.billing_address
-        shipping = payment.order.shipping_address
-        email = payment.order.user_email
-        user_id = payment.order.user_id
+        checkout_token = str(checkout.token)
+        checkout_metadata = checkout.metadata
+    elif order := payment.order:
+        billing = order.billing_address
+        shipping = order.shipping_address
+        email = order.user_email
+        user_id = order.user_id
+        checkout_token = order.checkout_token
+        checkout_metadata = None
     else:
-        billing, shipping, email, user_id = None, None, payment.billing_email, None
+        billing, shipping, email, user_id, checkout_token, checkout_metadata = (
+            None,
+            None,
+            payment.billing_email,
+            None,
+            "",
+            None,
+        )
 
     billing_address = AddressData(**billing.as_data()) if billing else None
     shipping_address = AddressData(**shipping.as_data()) if shipping else None
@@ -238,6 +249,8 @@ def create_payment_information(
         _resolve_lines=lambda: create_payment_lines_information(
             payment, manager or get_plugins_manager()
         ),
+        checkout_token=checkout_token,
+        checkout_metadata=checkout_metadata,
     )
 
 

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -210,14 +210,12 @@ def create_payment_information(
         checkout_token = order.checkout_token
         checkout_metadata = None
     else:
-        billing, shipping, email, user_id, checkout_token, checkout_metadata = (
-            None,
-            None,
-            payment.billing_email,
-            None,
-            "",
-            None,
-        )
+        billing = None
+        shipping = None
+        email = payment.billing_email
+        user_id = None
+        checkout_token = ""
+        checkout_metadata = None
 
     billing_address = AddressData(**billing.as_data()) if billing else None
     shipping_address = AddressData(**shipping.as_data()) if shipping else None


### PR DESCRIPTION
I want to merge this change because it adds two fields to payment webhook payload:
- checkout token (gained from checkout if available or from order `checkout_token` field)
- checkout metadata

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
