### PR TITLE
Use sale price when adding variant to order

### DIFF
--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -778,7 +778,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             raise ValidationError(error)
 
     @staticmethod
-    def add_lines_to_order(order, lines_to_add, user, app, manager):
+    def add_lines_to_order(order, lines_to_add, user, app, manager, discounts):
         try:
             return [
                 add_variant_to_order(
@@ -788,6 +788,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
                     user,
                     app,
                     manager,
+                    discounts=discounts,
                     allocate_stock=order.is_unconfirmed(),
                 )
                 for quantity, variant in lines_to_add
@@ -813,6 +814,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             info.context.user,
             info.context.app,
             info.context.plugins,
+            info.context.discounts,
         )
 
         # Create the products added event

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -3549,6 +3549,17 @@ ORDER_LINES_CREATE_MUTATION = """
                 id
                 quantity
                 productSku
+                id
+                unitPrice {
+                    gross {
+                        amount
+                        currency
+                    }
+                    net {
+                        amount
+                        currency
+                    }
+                }
             }
             order {
                 total {
@@ -3687,6 +3698,63 @@ def test_order_lines_create_with_existing_variant(
     assert data["orderLines"][0]["quantity"] == old_quantity + quantity
     assert_proper_webhook_called_once(
         order, status, draft_order_updated_webhook_mock, order_updated_webhook_mock
+    )
+
+
+@pytest.mark.parametrize("status", (OrderStatus.DRAFT, OrderStatus.UNCONFIRMED))
+@patch("saleor.plugins.manager.PluginsManager.draft_order_updated")
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+def test_order_lines_create_variant_on_sale(
+    order_updated_webhook_mock,
+    draft_order_updated_webhook_mock,
+    status,
+    order_with_lines,
+    permission_manage_orders,
+    staff_api_client,
+    variant_with_many_stocks,
+    sale,
+):
+    # given
+    query = ORDER_LINES_CREATE_MUTATION
+
+    order = order_with_lines
+    order.status = status
+    order.save(update_fields=["status"])
+
+    variant = variant_with_many_stocks
+    sale.variants.add(variant)
+
+    quantity = 1
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    variables = {"orderId": order_id, "variantId": variant_id, "quantity": quantity}
+
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    assert_proper_webhook_called_once(
+        order, status, draft_order_updated_webhook_mock, order_updated_webhook_mock
+    )
+    assert OrderEvent.objects.count() == 1
+    assert OrderEvent.objects.last().type == order_events.OrderEvents.ADDED_PRODUCTS
+    content = get_graphql_content(response)
+    data = content["data"]["orderLinesCreate"]
+    line_data = data["orderLines"][0]
+    assert line_data["productSku"] == variant.sku
+    assert line_data["quantity"] == quantity
+    assert line_data["quantity"] == quantity
+    variant_channel_listing = variant.channel_listings.get(channel=order.channel)
+    sale_channel_listing = sale.channel_listings.first()
+    assert (
+        line_data["unitPrice"]["gross"]["amount"]
+        == variant_channel_listing.price_amount - sale_channel_listing.discount_value
+    )
+    assert (
+        line_data["unitPrice"]["net"]["amount"]
+        == variant_channel_listing.price_amount - sale_channel_listing.discount_value
     )
 
 


### PR DESCRIPTION
Previously when a line was added to the draft order, sales were not included.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
