### PR TITLE
checkout_token and checkout metadata on payment webhook level

### DIFF
--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -89,6 +89,8 @@ class PaymentData:
     reuse_source: bool = False  # Note: this field will be removed in 4.0.
     data: Optional[dict] = None
     graphql_customer_id: Optional[str] = None
+    checkout_token: Optional[str] = None
+    checkout_metadata: Optional[Dict] = None
     store_payment_method: StorePaymentMethodEnum = StorePaymentMethodEnum.NONE
     payment_metadata: Dict[str, str] = field(default_factory=dict)
     psp_reference: Optional[str] = None

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -1,3 +1,4 @@
+import uuid
 from decimal import Decimal
 from unittest.mock import Mock, patch
 
@@ -213,6 +214,49 @@ def test_create_payment_information_for_checkout_payment(address, checkout_with_
     assert billing.street_address_1 == address.street_address_1
     assert billing.city == address.city
     assert shipping == billing
+
+
+def test_create_payment_information_for_checkout_token(payment_dummy, checkout):
+    payment_dummy.order = None
+    payment_dummy.checkout = checkout
+    payment_dummy.save(update_fields=["order", "checkout"])
+
+    payment_info = create_payment_information(payment_dummy)
+    assert payment_info.checkout_token == str(checkout.token)
+
+
+def test_create_payment_information_for_checkout_token_from_order(payment_dummy, order):
+    token = str(uuid.uuid4())
+    order.checkout_token = token
+    order.save(update_fields=["checkout_token"])
+    payment_dummy.order = order
+    payment_dummy.checkout = None
+    payment_dummy.save(update_fields=["order", "checkout"])
+
+    payment_info = create_payment_information(payment_dummy)
+    assert payment_info.checkout_token == order.checkout_token == token
+
+
+def test_create_payment_information_for_empty_payment(payment_dummy):
+    payment_dummy.order = None
+    payment_dummy.checkout = None
+    payment_dummy.save(update_fields=["order", "checkout"])
+
+    payment_info = create_payment_information(payment_dummy)
+    assert payment_info.checkout_token == ""
+    assert payment_info.checkout_metadata is None
+
+
+def test_create_payment_information_for_checkout_metadata(payment_dummy, checkout):
+    metadata = {"test_key": "test_val"}
+    checkout.metadata = metadata
+    checkout.save(update_fields=["metadata"])
+    payment_dummy.order = None
+    payment_dummy.checkout = checkout
+    payment_dummy.save(update_fields=["order", "checkout"])
+
+    payment_info = create_payment_information(payment_dummy)
+    assert payment_info.checkout_metadata == metadata
 
 
 def test_create_payment_information_for_draft_order(draft_order):


### PR DESCRIPTION
I want to merge this change because it ports https://github.com/saleor/saleor/pull/8761 to 3.1

It adds two fields to payment webhook payload:
- checkout token (gained from checkout if available or from order checkout_token field)
- checkout metadata

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
