### PR TITLE
Include discounts when resolving checkout shipping methods

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -447,6 +447,7 @@ class Checkout(CountableDjangoObjectType):
             subtotal = manager.calculate_checkout_subtotal(
                 checkout_info, lines, address, discounts
             )
+            subtotal -= checkout_info.checkout.discount
             if not address:
                 return []
             available = get_valid_shipping_methods_for_checkout(


### PR DESCRIPTION
Port changes from https://github.com/saleor/saleor/pull/8750.

When resolving checkout shipping methods we should based on checkout subtotal price after discount.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
