### PR TITLE
Refactor checkout lines add and update mutation

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -196,13 +196,23 @@ def get_delivery_method_info(
     raise NotImplementedError()
 
 
-def fetch_checkout_lines(checkout: "Checkout") -> Iterable[CheckoutLineInfo]:
+def fetch_checkout_lines(
+    checkout: "Checkout", prefetch_variant_attributes=False
+) -> Iterable[CheckoutLineInfo]:
     """Fetch checkout lines as CheckoutLineInfo objects."""
-    lines = checkout.lines.prefetch_related(
+    prefetched_fields = [
         "variant__product__collections",
         "variant__channel_listings__channel",
         "variant__product__product_type",
-    )
+    ]
+    if prefetch_variant_attributes:
+        prefetched_fields.extend(
+            [
+                "variant__attributes__assignment__attribute",
+                "variant__attributes__values",
+            ]
+        )
+    lines = checkout.lines.prefetch_related(*prefetched_fields)
     lines_info = []
 
     for line in lines:

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -253,7 +253,7 @@ def fetch_checkout_info(
     # Ugly hack to disable fetching shipping methods if they aren't needed
     # Preventing multiple redundant and potentially costful API calls in
     # checkout lines add/update/delete mutations
-    fetch_shipping_methods: bool = True,
+    fetch_delivery_methods: bool = True,
 ) -> CheckoutInfo:
     """Fetch checkout as CheckoutInfo object."""
     checkout_info = CheckoutInfo(
@@ -268,13 +268,12 @@ def fetch_checkout_info(
         valid_pick_up_points=[],
     )
 
-    valid_pick_up_points = get_valid_collection_points_for_checkout_info(
-        checkout.shipping_address, lines, checkout_info
-    )
-    checkout_info.valid_pick_up_points = valid_pick_up_points
-
-    if fetch_shipping_methods:
+    if fetch_delivery_methods:
         populate_checkout_info_shippings(checkout_info, lines, discounts, manager)
+        valid_pick_up_points = get_valid_collection_points_for_checkout_info(
+            checkout.shipping_address, lines, checkout_info
+        )
+        checkout_info.valid_pick_up_points = valid_pick_up_points
 
     return checkout_info
 

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -616,15 +616,14 @@ class CheckoutLinesAdd(BaseMutation):
         variants = cls.get_nodes_or_error(variant_ids, "variant_id", ProductVariant)
         input_quantities = group_quantity_by_variants(lines)
 
+        lines = fetch_checkout_lines(checkout)
         checkout_info = fetch_checkout_info(
             checkout,
-            [],
+            lines,
             discounts,
             manager,
             fetch_shipping_methods=False,
         )
-
-        lines = fetch_checkout_lines(checkout)
         lines = cls.clean_input(
             info,
             checkout,

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -622,7 +622,7 @@ class CheckoutLinesAdd(BaseMutation):
             lines,
             discounts,
             manager,
-            fetch_shipping_methods=False,
+            fetch_delivery_methods=False,
         )
         lines = cls.clean_input(
             info,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -520,16 +520,17 @@ class WebhookPlugin(BasePlugin):
         apps = App.objects.for_event_type(
             WebhookEventType.SHIPPING_LIST_METHODS_FOR_CHECKOUT
         ).prefetch_related("webhooks")
-        payload = generate_checkout_payload(checkout, self.requestor)
-        for app in apps:
-            response_data = trigger_webhook_sync(
-                event_type=WebhookEventType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
-                data=payload,
-                app=app,
-            )
-            if response_data:
-                shipping_methods = parse_list_shipping_methods_response(
-                    response_data, app
+        if apps:
+            payload = generate_checkout_payload(checkout, self.requestor)
+            for app in apps:
+                response_data = trigger_webhook_sync(
+                    event_type=WebhookEventType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
+                    data=payload,
+                    app=app,
                 )
-                methods.extend(shipping_methods)
+                if response_data:
+                    shipping_methods = parse_list_shipping_methods_response(
+                        response_data, app
+                    )
+                    methods.extend(shipping_methods)
         return methods

--- a/saleor/webhook/serializers.py
+++ b/saleor/webhook/serializers.py
@@ -18,7 +18,7 @@ def serialize_checkout_lines(checkout: "Checkout") -> List[dict]:
     data = []
     channel = checkout.channel
     currency = channel.currency_code
-    for line_info in fetch_checkout_lines(checkout):
+    for line_info in fetch_checkout_lines(checkout, prefetch_variant_attributes=True):
         variant = line_info.variant
         channel_listing = line_info.channel_listing
         collections = line_info.collections


### PR DESCRIPTION
I want to merge this change because refactoring checkout lines add and update mutation.

Changes:
1. Add missing prefetch on `serialize_checkout_lines` 
2. Turn off checkout payload generation when not necessary
~~3. Remove duplicated function call in mutation~~
4. Change from `fetch_shipping_method` in `fetch_checkout_info` to `fetch_delivery_methods`

Test executed before merge #8744.
I execute a test on Checkout with 4 lines and call `CheckoutLinesUpdate` witch modify 3 lines. 
webhook - (Shipping methods for checkout listed) 
DB queries  with webhook ON:
Before: 168
After: 121

DB queries  with webhook OFF:
Before: 168
After: 70

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
