### PR TITLE
Voucher used count breaks on checkout complete

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -50,6 +50,14 @@ def remove_voucher_usage_by_customer(voucher: "Voucher", customer_email: str) ->
         voucher_customer.delete()
 
 
+def release_voucher_usage(order_data: dict):
+    voucher = order_data.get("voucher")
+    if voucher and voucher.usage_limit:
+        decrease_voucher_usage(voucher)
+        if "user_email" in order_data:
+            remove_voucher_usage_by_customer(voucher, order_data["user_email"])
+
+
 def get_product_discount_on_sale(
     product: "Product",
     product_collections: Set[int],

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -11,7 +11,7 @@ from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.models import Checkout
 from ....core.exceptions import InsufficientStock, InsufficientStockData
-from ....core.taxes import zero_money
+from ....core.taxes import TaxError, zero_money
 from ....order import OrderOrigin, OrderStatus
 from ....order.models import Order
 from ....payment import ChargeStatus, PaymentError, TransactionKind
@@ -538,6 +538,51 @@ def test_checkout_with_voucher_complete(
     assert not Checkout.objects.filter(
         pk=checkout.pk
     ).exists(), "Checkout should have been deleted"
+
+
+@patch.object(PluginsManager, "preprocess_order_creation")
+@pytest.mark.integration
+def test_checkout_with_voucher_not_increase_uses_on_preprocess_order_creation_failure(
+    mocked_preprocess_order_creation,
+    user_api_client,
+    checkout_with_voucher_percentage,
+    voucher_percentage,
+    payment_dummy,
+    address,
+    shipping_method,
+):
+    mocked_preprocess_order_creation.side_effect = TaxError("tax error!")
+    voucher_percentage.used = 0
+    voucher_percentage.usage_limit = 1
+    voucher_percentage.save(update_fields=["used", "usage_limit"])
+
+    checkout = checkout_with_voucher_percentage
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    payment = payment_dummy
+    payment.is_active = True
+    payment.order = None
+    payment.checkout = checkout
+    payment.save()
+    assert not payment.transactions.exists()
+
+    variables = {"token": checkout.token, "redirectUrl": "https://www.example.com"}
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+
+    assert data["errors"][0]["code"] == CheckoutErrorCode.TAX_ERROR.name
+
+    voucher_percentage.refresh_from_db()
+    assert voucher_percentage.used == 0
+
+    assert Checkout.objects.filter(
+        pk=checkout.pk
+    ).exists(), "Checkout shouldn't have been deleted"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
I want to merge this change because it fixes a bug with voucher used count if preprocess_order_creation hook fails.
The used count was increased but it wasn't released in case of the error - user could have used a voucher, hook failed, the voucher was now used and user coudn't use it again in checkoutCompelete (it was lost).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
