### PR TITLE
Fix bug with voucher usage when preprocess_order_creation breaks

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -19,9 +19,8 @@ from ..discount import DiscountInfo, DiscountValueType, OrderDiscountType
 from ..discount.models import NotApplicable
 from ..discount.utils import (
     add_voucher_usage_by_customer,
-    decrease_voucher_usage,
     increase_voucher_usage,
-    remove_voucher_usage_by_customer,
+    release_voucher_usage,
 )
 from ..giftcard.models import GiftCard
 from ..giftcard.utils import fulfill_non_shippable_gift_cards
@@ -52,10 +51,11 @@ if TYPE_CHECKING:
     from .fetch import CheckoutInfo, CheckoutLineInfo
 
 
-def _get_voucher_data_for_order(checkout_info: "CheckoutInfo") -> dict:
+def _process_voucher_data_for_order(checkout_info: "CheckoutInfo") -> dict:
     """Fetch, process and return voucher/discount data from checkout.
 
     Careful! It should be called inside a transaction.
+    If voucher has a usage limit, it will be increased!
 
     :raises NotApplicable: When the voucher is not applicable in the current checkout.
     """
@@ -341,8 +341,7 @@ def _prepare_order_data(
     # validate checkout gift cards
     _validate_gift_cards(checkout)
 
-    # Get voucher data (last) as they require a transaction
-    order_data.update(_get_voucher_data_for_order(checkout_info))
+    order_data.update(_process_voucher_data_for_order(checkout_info))
 
     order_data["total_price_left"] = (
         manager.calculate_checkout_subtotal(checkout_info, lines, address, discounts)
@@ -350,7 +349,12 @@ def _prepare_order_data(
         - checkout.discount
     ).gross
 
-    manager.preprocess_order_creation(checkout_info, discounts, lines)
+    try:
+        manager.preprocess_order_creation(checkout_info, discounts, lines)
+    except TaxError:
+        release_voucher_usage(order_data)
+        raise
+
     return order_data
 
 
@@ -522,14 +526,6 @@ def _prepare_checkout(
     if to_update:
         to_update.append("last_change")
         checkout.save(update_fields=to_update)
-
-
-def release_voucher_usage(order_data: dict):
-    voucher = order_data.get("voucher")
-    if voucher and voucher.usage_limit:
-        decrease_voucher_usage(voucher)
-        if "user_email" in order_data:
-            remove_voucher_usage_by_customer(voucher, order_data["user_email"])
 
 
 def _get_order_data(

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -52,6 +52,14 @@ def remove_voucher_usage_by_customer(voucher: "Voucher", customer_email: str) ->
         voucher_customer.delete()
 
 
+def release_voucher_usage(order_data: dict):
+    voucher = order_data.get("voucher")
+    if voucher and voucher.usage_limit:
+        decrease_voucher_usage(voucher)
+        if "user_email" in order_data:
+            remove_voucher_usage_by_customer(voucher, order_data["user_email"])
+
+
 def get_product_discount_on_sale(
     product: "Product",
     product_collections: Set[int],


### PR DESCRIPTION
I want to merge this change because it ports changes from https://github.com/saleor/saleor/pull/8796 to 3.1

fixes a bug with voucher used count if preprocess_order_creation hook fails.
The used count was increased but it wasn't released in case of the error - user could have used a voucher, hook failed, the voucher was now used and user coudn't use it again in checkoutCompelete (it was lost).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
