### PR TITLE
Handle invoice requests in plugins in 3.1

### DIFF
--- a/saleor/graphql/invoice/mutations.py
+++ b/saleor/graphql/invoice/mutations.py
@@ -65,11 +65,20 @@ class InvoiceRequest(ModelMutation):
             order=order,
             number=data.get("number"),
         )
+        import ipdb
+
+        ipdb.set_trace()
+        if not any(
+            hasattr(plugin, "invoice_request")
+            for plugin in info.context.plugins.all_plugins
+        ):
+            print("benc")
+
         invoice = info.context.plugins.invoice_request(
             order=order, invoice=shallow_invoice, number=data.get("number")
         )
 
-        if invoice.status == JobStatus.SUCCESS:
+        if invoice and invoice.status == JobStatus.SUCCESS:
             order_events.invoice_generated_event(
                 order=order,
                 user=info.context.user,

--- a/saleor/graphql/invoice/tests/test_invoice_utils.py
+++ b/saleor/graphql/invoice/tests/test_invoice_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from ....invoice.models import Invoice
 from ....plugins.invoicing.utils import generate_invoice_number
+from ..utils import is_event_active_for_any_plugin
 
 
 @patch("saleor.plugins.invoicing.utils.datetime")
@@ -23,3 +24,33 @@ def test_generate_invoice_number_old_invoice(datetime_mock, order):
 def test_generate_invoice_number_no_existing_invoice(datetime_mock, order):
     datetime_mock.now.return_value = datetime(2020, 7, 23, 12, 59, 59)
     assert generate_invoice_number() == "1/07/2020"
+
+
+class MockInvoicePluginActive:
+    active = True
+
+    @staticmethod
+    def is_event_active(_):
+        return True
+
+
+class MockInvoicePluginInactive:
+    active = False
+
+    @staticmethod
+    def is_event_active(_):
+        return True
+
+
+def test_is_event_active_for_any_plugin_plugin_active():
+    result = is_event_active_for_any_plugin(
+        "event", [MockInvoicePluginActive(), MockInvoicePluginInactive()]
+    )
+    assert result is True
+
+
+def test_is_event_active_for_any_plugin_plugin_inactive():
+    result = is_event_active_for_any_plugin(
+        "event", [MockInvoicePluginInactive(), MockInvoicePluginInactive()]
+    )
+    assert result is False

--- a/saleor/graphql/invoice/utils.py
+++ b/saleor/graphql/invoice/utils.py
@@ -1,0 +1,4 @@
+def is_event_active_for_any_plugin(event: str, plugins_list):
+    return any(
+        [plugin.is_event_active(event) for plugin in plugins_list if plugin.active]
+    )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2611,6 +2611,7 @@ enum InvoiceErrorCode {
   NUMBER_NOT_SET
   NOT_FOUND
   INVALID_STATUS
+  NO_INVOICE_PLUGIN
 }
 
 type InvoiceRequest {

--- a/saleor/invoice/error_codes.py
+++ b/saleor/invoice/error_codes.py
@@ -9,3 +9,4 @@ class InvoiceErrorCode(Enum):
     NUMBER_NOT_SET = "number_not_set"
     NOT_FOUND = "not_found"
     INVALID_STATUS = "invalid_status"
+    NO_INVOICE_PLUGIN = "no_invoice_plugin"

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -358,9 +358,11 @@ class BasePlugin:
     invoice_delete: Callable[["Invoice", Any], Any]
 
     #  Trigger when invoice creation starts.
-    #
+    #  May return Invoice object.
     #  Overwrite to create invoice with proper data, call invoice.update_invoice.
-    invoice_request: Callable[["Order", "Invoice", Union[str, NoneType], Any], Any]
+    invoice_request: Callable[
+        ["Order", "Invoice", Union[str, NoneType], Any], Optional["Invoice"]
+    ]
 
     #  Trigger after invoice is sent.
     invoice_sent: Callable[["Invoice", str, Any], Any]
@@ -665,3 +667,6 @@ class BasePlugin:
             # Let's add a translated descriptions and labels
             self._append_config_structure(configuration)
         return configuration
+
+    def is_event_active(self, event: str, channel=Optional[str]):
+        return hasattr(self, event)

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -26,7 +26,11 @@ from ...webhook.payloads import (
     generate_translation_payload,
 )
 from ..base_plugin import BasePlugin
-from .tasks import trigger_webhook_sync, trigger_webhooks_for_event
+from .tasks import (
+    _get_webhooks_for_event,
+    trigger_webhook_sync,
+    trigger_webhooks_for_event,
+)
 from .utils import (
     from_payment_app_id,
     parse_list_payment_gateways_response,
@@ -556,3 +560,8 @@ class WebhookPlugin(BasePlugin):
                     )
                     methods.extend(shipping_methods)
         return methods
+
+    def is_event_active(self, event: str, channel=Optional[str]):
+        map_event = {"invoice_request": WebhookEventAsyncType.INVOICE_REQUESTED}
+        webhooks = _get_webhooks_for_event(event_type=map_event[event])
+        return any(webhooks)


### PR DESCRIPTION
I want to merge this change because it fixes error when invoice is not returned and adds check if any plugin is set to handle invoice request. If no plugin handling invoice requests is active - raises new NO_INVOICE_PLUGIN error
<!-- Please mention all relevant issue numbers. -->
this is port to 3.1 for pr #8763

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
