### PR TITLE
Order filtering breaks when provided with non-numeric ID

### DIFF
--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -31,7 +31,10 @@ def get_payment_id_from_query(value):
 def get_order_id_from_query(value):
     if value.startswith("#"):
         value = value[1:]
-    return value if value.isnumeric() else None
+    try:
+        return int(value)
+    except ValueError:
+        return None
 
 
 def filter_order_by_payment(qs, payment_id):

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -6528,6 +6528,27 @@ def test_orders_query_with_filter_search_by_product_sku_with_multiple_identic_sk
     assert content["data"]["orders"]["totalCount"] == 3
 
 
+@pytest.mark.parametrize(
+    "orders_filter",
+    [
+        {"search": "5430⑨0"},
+        {"search": "132935808982933ⅱ"},
+    ],
+)
+def test_orders_query_with_filter_search_by_invalid_id(
+    orders_query_with_filter,
+    staff_api_client,
+    permission_manage_orders,
+    orders_filter,
+):
+    variables = {"filter": orders_filter}
+    response = staff_api_client.post_graphql(
+        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["orders"]["totalCount"] == 0
+
+
 def test_order_query_with_filter_search_by_product_sku_order_line(
     orders_query_with_filter, staff_api_client, permission_manage_orders, order_line
 ):


### PR DESCRIPTION
I want to merge this change because it fixes the case in 3.0 when the user provides an order filter with an invalid value. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
