### PR TITLE
Remove duplicated attribute fetching in date and data time resolvers

### DIFF
--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -107,15 +107,29 @@ class AttributeValue(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_date_time(root: models.AttributeValue, info, **_kwargs):
-        if root.attribute.input_type == AttributeInputType.DATE_TIME:
-            return root.date_time
-        return None
+        def _resolve_date(attribute):
+            if attribute.input_type == AttributeInputType.DATE_TIME:
+                return root.date_time
+            return None
+
+        return (
+            AttributesByAttributeId(info.context)
+            .load(root.attribute_id)
+            .then(_resolve_date)
+        )
 
     @staticmethod
     def resolve_date(root: models.AttributeValue, info, **_kwargs):
-        if root.attribute.input_type == AttributeInputType.DATE:
-            return root.date_time
-        return None
+        def _resolve_date(attribute):
+            if attribute.input_type == AttributeInputType.DATE:
+                return root.date_time
+            return None
+
+        return (
+            AttributesByAttributeId(info.context)
+            .load(root.attribute_id)
+            .then(_resolve_date)
+        )
 
 
 class AttributeValueCountableConnection(CountableConnection):


### PR DESCRIPTION
I want to merge this change because of removing duplicated attribute fetching in date and data time resolvers.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
