### PR TITLE
Add sale_id and voucher_code to webhook fulfillment lines payload

### DIFF
--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -525,6 +525,8 @@ def generate_fulfillment_lines_payload(fulfillment: Fulfillment):
             )
             if fl.stock
             else None,
+            "sale_id": lambda fl: fl.order_line.sale_id,
+            "voucher_code": lambda fl: fl.order_line.voucher_code,
         },
     )
 

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -123,6 +123,9 @@ def test_generate_order_payload(
 def test_generate_fulfillment_lines_payload(order_with_lines):
     fulfillment = order_with_lines.fulfillments.create(tracking_number="123")
     line = order_with_lines.lines.first()
+    line.sale_id = graphene.Node.to_global_id("Sale", 1)
+    line.voucher_code = "code"
+    line.save()
     stock = line.allocations.get().stock
     warehouse_pk = stock.warehouse.pk
     fulfillment_line = fulfillment.lines.create(
@@ -164,6 +167,8 @@ def test_generate_fulfillment_lines_payload(order_with_lines):
         "warehouse_id": graphene.Node.to_global_id(
             "Warehouse", fulfillment_line.stock.warehouse_id
         ),
+        "sale_id": line.sale_id,
+        "voucher_code": line.voucher_code,
     }
 
 


### PR DESCRIPTION
I want to merge this change because it adds sale_id and voucher_code to the payload of fulfillment line.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
