### PR TITLE
Remove successful event deliveries from db

### DIFF
--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -299,8 +299,7 @@ def send_webhook_request_async(self, event_delivery_id):
         response = WebhookResponse(content=str(e), status=EventDeliveryStatus.FAILED)
         attempt_update(attempt, response)
         delivery_update(delivery=delivery, status=EventDeliveryStatus.FAILED)
-    if delivery.status == EventDeliveryStatus.SUCCESS:
-        clear_successful_delivery(delivery)
+    clear_successful_delivery(delivery)
 
 
 def send_webhook_request_sync(app_name, delivery):
@@ -368,8 +367,7 @@ def send_webhook_request_sync(app_name, delivery):
         delivery_update(delivery, EventDeliveryStatus.FAILED)
         raise ValueError("Unknown webhook scheme: %r" % (parts.scheme,))
     delivery_update(delivery, response.status)
-    if delivery.status == EventDeliveryStatus.SUCCESS:
-        clear_successful_delivery(delivery)
+    clear_successful_delivery(delivery)
     return response_data
 
 

--- a/saleor/plugins/webhook/tests/test_payment_webhook_utils.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook_utils.py
@@ -1,8 +1,11 @@
 import pytest
 
+from ....core import EventDeliveryStatus
+from ....core.models import EventDelivery
 from ....payment import TransactionKind
 from ..utils import (
     APP_ID_PREFIX,
+    clear_successful_delivery,
     from_payment_app_id,
     parse_list_payment_gateways_response,
     parse_payment_action_response,
@@ -160,3 +163,25 @@ def test_parse_payment_action_response_parse_amount(
         dummy_webhook_app_payment_data, payment_action_response, TransactionKind.AUTH
     )
     assert gateway_response.amount == dummy_webhook_app_payment_data.amount
+
+
+def test_clear_successful_delivery(event_delivery):
+    # given
+    assert EventDelivery.objects.filter(pk=event_delivery.pk).exists()
+    event_delivery.status = EventDeliveryStatus.SUCCESS
+    event_delivery.save()
+    # when
+    clear_successful_delivery(event_delivery)
+    # then
+    assert not EventDelivery.objects.filter(pk=event_delivery.pk).exists()
+
+
+def test_clear_successful_delivery_on_failed_delivery(event_delivery):
+    # given
+    assert EventDelivery.objects.filter(pk=event_delivery.pk).exists()
+    event_delivery.status = EventDeliveryStatus.FAILED
+    event_delivery.save()
+    # when
+    clear_successful_delivery(event_delivery)
+    # then
+    assert EventDelivery.objects.filter(pk=event_delivery.pk).exists()

--- a/saleor/plugins/webhook/tests/test_payment_webhook_utils.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook_utils.py
@@ -178,7 +178,6 @@ def test_clear_successful_delivery(event_delivery):
 
 def test_clear_successful_delivery_on_failed_delivery(event_delivery):
     # given
-    assert EventDelivery.objects.filter(pk=event_delivery.pk).exists()
     event_delivery.status = EventDeliveryStatus.FAILED
     event_delivery.save()
     # when

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -625,7 +625,7 @@ def test_event_delivery_retry(mocked_webhook_send, event_delivery, settings):
     mocked_webhook_send.assert_called_once_with(event_delivery.pk)
 
 
-WEBHOOK_RESPONSE = WebhookResponse(
+TEST_WEBHOOK_RESPONSE = WebhookResponse(
     content="test_content",
     request_headers={"headers": "test_request"},
     response_headers={"headers": "test_response"},
@@ -637,7 +637,7 @@ WEBHOOK_RESPONSE = WebhookResponse(
 @mock.patch("saleor.plugins.webhook.tasks.clear_successful_delivery")
 @mock.patch(
     "saleor.plugins.webhook.tasks.send_webhook_using_scheme_method",
-    return_value=WEBHOOK_RESPONSE,
+    return_value=TEST_WEBHOOK_RESPONSE,
 )
 def test_send_webhook_request_async(
     mocked_send_response, mocked_clear_delivery, event_delivery
@@ -655,8 +655,10 @@ def test_send_webhook_request_async(
     attempt = EventDeliveryAttempt.objects.filter(delivery=event_delivery).first()
     delivery = EventDelivery.objects.get(id=event_delivery.pk)
     assert attempt.status == EventDeliveryStatus.SUCCESS
-    assert attempt.response == WEBHOOK_RESPONSE.content
-    assert attempt.response_headers == json.dumps(WEBHOOK_RESPONSE.response_headers)
-    assert attempt.request_headers == json.dumps(WEBHOOK_RESPONSE.request_headers)
-    assert attempt.duration == WEBHOOK_RESPONSE.duration
+    assert attempt.response == TEST_WEBHOOK_RESPONSE.content
+    assert attempt.response_headers == json.dumps(
+        TEST_WEBHOOK_RESPONSE.response_headers
+    )
+    assert attempt.request_headers == json.dumps(TEST_WEBHOOK_RESPONSE.request_headers)
+    assert attempt.duration == TEST_WEBHOOK_RESPONSE.duration
     assert delivery.status == EventDeliveryStatus.SUCCESS

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -19,6 +19,7 @@ from ....account.notifications import (
     send_account_confirmation,
 )
 from ....app.models import App
+from ....core import EventDeliveryStatus
 from ....core.models import EventDelivery, EventDeliveryAttempt, EventPayload
 from ....core.notification.utils import get_site_context
 from ....core.notify_events import NotifyEventType
@@ -39,7 +40,11 @@ from ....webhook.payloads import (
     generate_sale_payload,
 )
 from ...manager import get_plugins_manager
-from ...webhook.tasks import send_webhook_request_async, trigger_webhooks_async
+from ...webhook.tasks import (
+    WebhookResponse,
+    send_webhook_request_async,
+    trigger_webhooks_async,
+)
 
 first_url = "http://www.example.com/first/"
 third_url = "http://www.example.com/third/"
@@ -618,3 +623,40 @@ def test_event_delivery_retry(mocked_webhook_send, event_delivery, settings):
 
     # then
     mocked_webhook_send.assert_called_once_with(event_delivery.pk)
+
+
+WEBHOOK_RESPONSE = WebhookResponse(
+    content="test_content",
+    request_headers={"headers": "test_request"},
+    response_headers={"headers": "test_response"},
+    duration=2.0,
+    status=EventDeliveryStatus.SUCCESS,
+)
+
+
+@mock.patch("saleor.plugins.webhook.tasks.clear_successful_delivery")
+@mock.patch(
+    "saleor.plugins.webhook.tasks.send_webhook_using_scheme_method",
+    return_value=WEBHOOK_RESPONSE,
+)
+def test_send_webhook_request_async(
+    mocked_send_response, mocked_clear_delivery, event_delivery
+):
+    send_webhook_request_async(event_delivery.pk)
+
+    mocked_send_response.assert_called_once_with(
+        event_delivery.webhook.target_url,
+        "mirumee.com",
+        event_delivery.webhook.secret_key,
+        event_delivery.event_type,
+        event_delivery.payload.payload,
+    )
+    mocked_clear_delivery.assert_called_once_with(event_delivery)
+    attempt = EventDeliveryAttempt.objects.filter(delivery=event_delivery).first()
+    delivery = EventDelivery.objects.get(id=event_delivery.pk)
+    assert attempt.status == EventDeliveryStatus.SUCCESS
+    assert attempt.response == WEBHOOK_RESPONSE.content
+    assert attempt.response_headers == json.dumps(WEBHOOK_RESPONSE.response_headers)
+    assert attempt.request_headers == json.dumps(WEBHOOK_RESPONSE.request_headers)
+    assert attempt.duration == WEBHOOK_RESPONSE.duration
+    assert delivery.status == EventDeliveryStatus.SUCCESS

--- a/saleor/plugins/webhook/utils.py
+++ b/saleor/plugins/webhook/utils.py
@@ -217,3 +217,8 @@ def attempt_update(
 def delivery_update(delivery: "EventDelivery", status: str):
     delivery.status = status
     delivery.save(update_fields=["status"])
+
+
+def clear_successful_delivery(delivery: "EventDelivery"):
+    if delivery.status == EventDeliveryStatus.SUCCESS:
+        delivery.delete()


### PR DESCRIPTION
I want to merge this change because we want successful event deliveries to be automatically removed from db. Additionally this pr fixes minor bug with wrong attempt status set.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
