### PR TITLE
Add missing prefetech on products webhooks in 3.0

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -647,8 +647,9 @@ class ProductCreate(ModelMutation):
             instance.collections.set(collections)
 
     @classmethod
-    def post_save_action(cls, info, instance, cleaned_input):
-        info.context.plugins.product_created(instance)
+    def post_save_action(cls, info, instance, _cleaned_input):
+        product = models.Product.objects.prefetched_for_webhook().get(pk=instance.pk)
+        info.context.plugins.product_created(product)
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
@@ -687,8 +688,9 @@ class ProductUpdate(ProductCreate):
             AttributeAssignmentMixin.save(instance, attributes)
 
     @classmethod
-    def post_save_action(cls, info, instance, cleaned_input):
-        info.context.plugins.product_updated(instance)
+    def post_save_action(cls, info, instance, _cleaned_input):
+        product = models.Product.objects.prefetched_for_webhook().get(pk=instance.pk)
+        info.context.plugins.product_updated(product)
 
 
 class ProductDelete(ModelDeleteMutation):
@@ -1324,7 +1326,11 @@ class ProductMediaCreate(BaseMutation):
         data = data.get("input")
         cls.validate_input(data)
         product = cls.get_node_or_error(
-            info, data["product"], field="product", only_type=Product
+            info,
+            data["product"],
+            field="product",
+            only_type=Product,
+            qs=models.Product.objects.prefetched_for_webhook(),
         )
 
         alt = data.get("alt", "")
@@ -1375,7 +1381,9 @@ class ProductMediaUpdate(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         media = cls.get_node_or_error(info, data.get("id"), only_type=ProductMedia)
-        product = media.product
+        product = models.Product.objects.prefetched_for_webhook().get(
+            pk=media.product_id
+        )
         alt = data.get("input").get("alt")
         if alt is not None:
             media.alt = alt
@@ -1409,7 +1417,11 @@ class ProductMediaReorder(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, product_id, media_ids):
         product = cls.get_node_or_error(
-            info, product_id, field="product_id", only_type=Product
+            info,
+            product_id,
+            field="product_id",
+            only_type=Product,
+            qs=models.Product.objects.prefetched_for_webhook(),
         )
         if len(media_ids) != product.media.count():
             raise ValidationError(
@@ -1587,7 +1599,9 @@ class ProductMediaDelete(BaseMutation):
         media_id = media_obj.id
         media_obj.delete()
         media_obj.id = media_id
-        product = media_obj.product
+        product = models.Product.objects.prefetched_for_webhook().get(
+            pk=media_obj.product_id
+        )
         info.context.plugins.product_updated(product)
         product = ChannelContext(node=product, channel_slug=None)
         return ProductMediaDelete(product=product, media=media_obj)


### PR DESCRIPTION
I want to merge this change because coping changes from #8811 to 3.0.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
