### PR TITLE
Attach sale discount info to the line when adding variant to order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,10 @@ All notable, unreleased changes to this project will be documented in this file.
   - When any sale or voucher discount was applied, `line.discount_reason` will be fulfilled.
   - New interface for handling more data for prices: `PricesData` and `TaxedPricesData` used in checkout calculations
   and in plugins/pluginManager.
-
+- Attach sale discount info to the line when adding variant to order - #8821 by @IKarbowiak
+  - Rename checkout interfaces: `CheckoutTaxedPricesData` instead of `TaxedPricesData`
+  and `CheckoutPricesData` instead of `PricesData`
+  - New interface for handling more data for prices: `OrderTaxedPricesData` used in plugins/pluginManager.
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki
@@ -277,6 +280,12 @@ All notable, unreleased changes to this project will be documented in this file.
 - Propagate sale and voucher discounts over specific lines - #8793 by @korycins
   - Use a new interface for response received from plugins/pluginManager. Methods `calculate_checkout_line_unit_price`
   and `calculate_checkout_line_total` returns `TaxedPricesData` instead of `TaxedMoney`.
+- Attach sale discount info to the line when adding variant to order - #8821 by @IKarbowiak
+  - Use a new interface for the response received from plugins/pluginManager.
+  Methods `calculate_order_line_unit` and `calculate_order_line_total` returns
+  `OrderTaxedPricesData` instead of `TaxedMoney`.
+  - Rename checkout interfaces: `CheckoutTaxedPricesData` instead of `TaxedPricesData`
+  and `CheckoutPricesData` instead of `PricesData`
 
 ### Other
 

--- a/saleor/checkout/base_calculations.py
+++ b/saleor/checkout/base_calculations.py
@@ -12,8 +12,9 @@ from prices import TaxedMoney
 from ..core.prices import quantize_price
 from ..core.taxes import zero_money, zero_taxed_money
 from ..discount import DiscountInfo
+from ..order.interface import OrderTaxedPricesData
 from .fetch import CheckoutLineInfo
-from .interface import PricesData, TaxedPricesData
+from .interface import CheckoutPricesData, CheckoutTaxedPricesData
 
 if TYPE_CHECKING:
     from ..channel.models import Channel
@@ -25,7 +26,7 @@ def calculate_base_line_unit_price(
     line_info: CheckoutLineInfo,
     channel: "Channel",
     discounts: Optional[Iterable[DiscountInfo]] = None,
-) -> PricesData:
+) -> CheckoutPricesData:
     """Calculate line unit prices including discounts and vouchers.
 
     Returns a three money values. Undiscounted price, price and price with voucher.
@@ -67,7 +68,7 @@ def calculate_base_line_unit_price(
     else:
         price_with_discounts = variant_price
 
-    return PricesData(
+    return CheckoutPricesData(
         undiscounted_price=quantize_price(
             undiscounted_variant_price, undiscounted_variant_price.currency
         ),
@@ -82,7 +83,7 @@ def calculate_base_line_total_price(
     line_info: CheckoutLineInfo,
     channel: "Channel",
     discounts: Optional[Iterable[DiscountInfo]] = None,
-) -> PricesData:
+) -> CheckoutPricesData:
     """Calculate line total prices including discounts and vouchers.
 
     Returns a three money values. Undiscounted price, price and price with voucher.
@@ -107,7 +108,7 @@ def calculate_base_line_total_price(
         # we add -1 as we handle a case when voucher is applied only to single line
         # of the cheapest line
         quantity_without_voucher = line_info.line.quantity - 1
-        prices_data = PricesData(
+        prices_data = CheckoutPricesData(
             price_with_discounts=(
                 prices_data.price_with_sale * quantity_without_voucher
                 + variant_price_with_discounts
@@ -116,7 +117,7 @@ def calculate_base_line_total_price(
             undiscounted_price=prices_data.undiscounted_price * line_info.line.quantity,
         )
     else:
-        prices_data = PricesData(
+        prices_data = CheckoutPricesData(
             price_with_sale=prices_data.price_with_sale * line_info.line.quantity,
             price_with_discounts=prices_data.price_with_discounts
             * line_info.line.quantity,
@@ -174,12 +175,12 @@ def base_checkout_line_total(
     checkout_line_info: "CheckoutLineInfo",
     channel: "Channel",
     discounts: Optional[Iterable[DiscountInfo]] = None,
-) -> TaxedPricesData:
+) -> CheckoutTaxedPricesData:
     """Return the total price of this line."""
     prices_data = calculate_base_line_total_price(
         line_info=checkout_line_info, channel=channel, discounts=discounts
     )
-    return TaxedPricesData(
+    return CheckoutTaxedPricesData(
         price_with_sale=TaxedMoney(
             net=prices_data.price_with_sale, gross=prices_data.price_with_sale
         ),
@@ -192,9 +193,12 @@ def base_checkout_line_total(
     )
 
 
-def base_order_line_total(order_line: "OrderLine"):
-    unit_price = order_line.unit_price * order_line.quantity
-    return quantize_price(unit_price, unit_price.currency)
+def base_order_line_total(order_line: "OrderLine") -> OrderTaxedPricesData:
+    quantity = order_line.quantity
+    return OrderTaxedPricesData(
+        undiscounted_price=order_line.undiscounted_unit_price * quantity,
+        price_with_discounts=order_line.unit_price * quantity,
+    )
 
 
 def base_tax_rate(price: TaxedMoney):
@@ -213,7 +217,7 @@ def base_checkout_line_unit_price(
     prices_data = calculate_base_line_unit_price(
         line_info=checkout_line_info, channel=channel, discounts=discounts
     )
-    return TaxedPricesData(
+    return CheckoutTaxedPricesData(
         price_with_sale=TaxedMoney(
             net=prices_data.price_with_sale, gross=prices_data.price_with_sale
         ),

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Iterable, Optional
 from ..core.prices import quantize_price
 from ..core.taxes import zero_taxed_money
 from ..discount import DiscountInfo
-from .interface import TaxedPricesData
+from .interface import CheckoutTaxedPricesData
 
 if TYPE_CHECKING:
     from prices import TaxedMoney
@@ -98,7 +98,7 @@ def checkout_line_total(
     lines: Iterable["CheckoutLineInfo"],
     checkout_line_info: "CheckoutLineInfo",
     discounts: Iterable[DiscountInfo] = [],
-) -> "TaxedPricesData":
+) -> "CheckoutTaxedPricesData":
     """Return the total price of provided line, taxes included.
 
     It takes in account all plugins.

--- a/saleor/checkout/interface.py
+++ b/saleor/checkout/interface.py
@@ -4,10 +4,10 @@ from prices import Money, TaxedMoney
 
 
 @dataclass
-class TaxedPricesData:
-    """Store a prices data with applied taxes.
+class CheckoutTaxedPricesData:
+    """Store a checkout prices data with applied taxes.
 
-    'price' includes discount from sale if any valid exists.
+    'price_with_sale' includes discount from sale if any valid exists.
     'price_with_discounts' includes voucher discount and sale discount if any valid
     exists.
     'undiscounted_price' is a price without any sale and voucher.
@@ -19,10 +19,10 @@ class TaxedPricesData:
 
 
 @dataclass
-class PricesData:
-    """Store a prices data without applied taxes.
+class CheckoutPricesData:
+    """Store a checkout prices data without applied taxes.
 
-    'price' includes discount from sale if any valid exists.
+    'price_with_sale' includes discount from sale if any valid exists.
     'price_with_discounts' includes voucher discount and sale discount if any valid
     exists.
     'undiscounted_price' is a price without any sale and voucher.

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -617,16 +617,16 @@ def create_order_lines(order, discounts, how_many=10):
     warehouse_iter = itertools.cycle(warehouses)
     for line in lines:
         variant = line.variant
-        unit_price = manager.calculate_order_line_unit(
+        unit_price_data = manager.calculate_order_line_unit(
             order, line, variant, variant.product
         )
-        total_price = manager.calculate_order_line_total(
+        total_price_data = manager.calculate_order_line_total(
             order, line, variant, variant.product
         )
-        line.unit_price = unit_price
-        line.total_price = total_price
-        line.undiscounted_unit_price = unit_price
-        line.undiscounted_total_price = total_price
+        line.unit_price = unit_price_data.price_with_discounts
+        line.total_price = total_price_data.price_with_discounts
+        line.undiscounted_unit_price = unit_price_data.undiscounted_price
+        line.undiscounted_total_price = total_price_data.undiscounted_price
         line.tax_rate = unit_price.tax / unit_price.net
         warehouse = next(warehouse_iter)
         increase_stock(line, warehouse, line.quantity, allocate=True)

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -244,6 +244,7 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
                     info.context.user,
                     info.context.app,
                     info.context.plugins,
+                    info.context.site.settings,
                 )
 
             # New event

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -778,7 +778,9 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             raise ValidationError(error)
 
     @staticmethod
-    def add_lines_to_order(order, lines_to_add, user, app, manager, discounts):
+    def add_lines_to_order(
+        order, lines_to_add, user, app, manager, settings, discounts
+    ):
         try:
             return [
                 add_variant_to_order(
@@ -788,6 +790,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
                     user,
                     app,
                     manager,
+                    settings,
                     discounts=discounts,
                     allocate_stock=order.is_unconfirmed(),
                 )
@@ -814,6 +817,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             info.context.user,
             info.context.app,
             info.context.plugins,
+            info.context.site.settings,
             info.context.discounts,
         )
 

--- a/saleor/graphql/order/tests/test_discount_order.py
+++ b/saleor/graphql/order/tests/test_discount_order.py
@@ -10,6 +10,7 @@ from ....core.prices import quantize_price
 from ....discount import DiscountValueType
 from ....order import OrderEvents, OrderStatus
 from ....order.error_codes import OrderErrorCode
+from ....order.interface import OrderTaxedPricesData
 from ...discount.enums import DiscountValueTypeEnum
 from ...tests.utils import get_graphql_content
 
@@ -708,8 +709,14 @@ def test_delete_discount_from_order_line(
     line_undiscounted_price = line.undiscounted_unit_price
     line_undiscounted_total_price = line.undiscounted_total_price
 
-    mocked_calculate_order_line_unit.return_value = line_undiscounted_price
-    mocked_calculate_order_line_total.return_value = line_undiscounted_total_price
+    mocked_calculate_order_line_unit.return_value = OrderTaxedPricesData(
+        undiscounted_price=line_undiscounted_price,
+        price_with_discounts=line_undiscounted_price,
+    )
+    mocked_calculate_order_line_total.return_value = OrderTaxedPricesData(
+        undiscounted_price=line_undiscounted_total_price,
+        price_with_discounts=line_undiscounted_total_price,
+    )
 
     line.unit_discount_amount = Decimal("2.5")
     line.unit_discount_type = DiscountValueType.FIXED

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -3757,6 +3757,15 @@ def test_order_lines_create_variant_on_sale(
         == variant_channel_listing.price_amount - sale_channel_listing.discount_value
     )
 
+    line = order.lines.get(product_sku=variant.sku)
+    assert line.sale_id == str(sale_channel_listing.id)
+    assert line.unit_discount_amount == sale_channel_listing.discount_value
+    assert line.unit_discount_value == sale_channel_listing.discount_value
+    assert (
+        line.unit_discount_reason
+        == f"Sale: {graphene.Node.to_global_id('Sale', sale_channel_listing.id)}"
+    )
+
 
 @pytest.mark.parametrize("status", (OrderStatus.DRAFT, OrderStatus.UNCONFIRMED))
 @patch("saleor.plugins.manager.PluginsManager.draft_order_updated")

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -3758,12 +3758,12 @@ def test_order_lines_create_variant_on_sale(
     )
 
     line = order.lines.get(product_sku=variant.sku)
-    assert line.sale_id == str(sale_channel_listing.id)
+    assert line.sale_id == graphene.Node.to_global_id("Sale", sale.id)
     assert line.unit_discount_amount == sale_channel_listing.discount_value
     assert line.unit_discount_value == sale_channel_listing.discount_value
     assert (
         line.unit_discount_reason
-        == f"Sale: {graphene.Node.to_global_id('Sale', sale_channel_listing.id)}"
+        == f"Sale: {graphene.Node.to_global_id('Sale', sale.id)}"
     )
 
 

--- a/saleor/order/interface.py
+++ b/saleor/order/interface.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+
+from prices import TaxedMoney
+
+
+@dataclass
+class OrderTaxedPricesData:
+    """Store an order prices data with applied taxes.
+
+    'price_with_discounts' includes voucher discount and sale discount if any valid
+    exists.
+    'undiscounted_price' is a price without any sale and voucher.
+    """
+
+    undiscounted_price: TaxedMoney
+    price_with_discounts: TaxedMoney

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -293,6 +293,7 @@ def test_send_confirmation_emails_without_addresses_for_payment(
         user=info.context.user,
         app=info.context.app,
         manager=info.context.plugins,
+        site_settings=site_settings,
     )
     DigitalContentUrl.objects.create(content=digital_content, line=line)
 
@@ -337,6 +338,7 @@ def test_send_confirmation_emails_without_addresses_for_order(
         user=info.context.user,
         app=info.context.app,
         manager=info.context.plugins,
+        site_settings=site_settings,
     )
     DigitalContentUrl.objects.create(content=digital_content, line=line)
 

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -14,6 +14,7 @@ from ...discount.models import (
     VoucherType,
 )
 from ...discount.utils import validate_voucher_in_order
+from ...order.interface import OrderTaxedPricesData
 from ...payment import ChargeStatus
 from ...payment.models import Payment
 from ...plugins.manager import get_plugins_manager
@@ -76,14 +77,20 @@ def test_order_get_subtotal(order_with_lines):
 
 
 def test_add_variant_to_order_adds_line_for_new_variant(
-    order_with_lines, product, product_translation_fr, settings, info
+    order_with_lines, product, product_translation_fr, settings, info, site_settings
 ):
     order = order_with_lines
     variant = product.variants.get()
     lines_before = order.lines.count()
     settings.LANGUAGE_CODE = "fr"
     add_variant_to_order(
-        order, variant, 1, info.context.user, info.context.app, info.context.plugins
+        order,
+        variant,
+        1,
+        info.context.user,
+        info.context.app,
+        info.context.plugins,
+        site_settings,
     )
 
     line = order.lines.last()
@@ -94,10 +101,62 @@ def test_add_variant_to_order_adds_line_for_new_variant(
     assert line.translated_product_name == str(variant.product.translated)
     assert line.variant_name == str(variant)
     assert line.product_name == str(variant.product)
+    assert not line.unit_discount_amount
+    assert not line.unit_discount_value
+    assert not line.unit_discount_reason
+
+
+def test_add_variant_to_order_adds_line_for_new_variant_on_sale(
+    order_with_lines,
+    product,
+    product_translation_fr,
+    sale,
+    discount_info,
+    settings,
+    info,
+    site_settings,
+):
+    order = order_with_lines
+    variant = product.variants.get()
+    discount_info.variants_ids.add(variant.id)
+    sale.variants.add(variant)
+    lines_before = order.lines.count()
+    settings.LANGUAGE_CODE = "fr"
+
+    add_variant_to_order(
+        order,
+        variant,
+        1,
+        info.context.user,
+        info.context.app,
+        info.context.plugins,
+        site_settings,
+        [discount_info],
+    )
+
+    line = order.lines.last()
+    variant_channel_listing = variant.channel_listings.get(channel=order.channel)
+    sale_channel_listing = sale.channel_listings.first()
+    assert order.lines.count() == lines_before + 1
+    assert line.product_sku == variant.sku
+    assert line.quantity == 1
+    unit_amount = (
+        variant_channel_listing.price_amount - sale_channel_listing.discount_value
+    )
+    assert line.unit_price == TaxedMoney(
+        net=Money(unit_amount, "USD"), gross=Money(unit_amount, "USD")
+    )
+    assert line.translated_product_name == str(variant.product.translated)
+    assert line.variant_name == str(variant)
+    assert line.product_name == str(variant.product)
+
+    assert line.unit_discount_amount == sale_channel_listing.discount_value
+    assert line.unit_discount_value == sale_channel_listing.discount_value
+    assert line.unit_discount_reason
 
 
 def test_add_variant_to_draft_order_adds_line_for_new_variant_with_tax(
-    order_with_lines, product, product_translation_fr, settings, info
+    order_with_lines, product, product_translation_fr, settings, info, site_settings
 ):
     order = order_with_lines
     variant = product.variants.get()
@@ -105,14 +164,22 @@ def test_add_variant_to_draft_order_adds_line_for_new_variant_with_tax(
     settings.LANGUAGE_CODE = "fr"
     unit_price = TaxedMoney(net=Money(8, "USD"), gross=Money(10, "USD"))
     total_price = TaxedMoney(net=Money("30.34", "USD"), gross=Money("36.49", "USD"))
+    unit_price_data = OrderTaxedPricesData(
+        undiscounted_price=unit_price,
+        price_with_discounts=unit_price,
+    )
+    total_price_data = OrderTaxedPricesData(
+        undiscounted_price=total_price,
+        price_with_discounts=total_price,
+    )
     manager = Mock(
-        calculate_order_line_unit=Mock(return_value=unit_price),
-        calculate_order_line_total=Mock(return_value=total_price),
+        calculate_order_line_unit=Mock(return_value=unit_price_data),
+        calculate_order_line_total=Mock(return_value=total_price_data),
         get_order_line_tax_rate=Mock(return_value=0.25),
     )
 
     add_variant_to_order(
-        order, variant, 1, info.context.user, info.context.app, manager
+        order, variant, 1, info.context.user, info.context.app, manager, site_settings
     )
 
     line = order.lines.last()
@@ -127,7 +194,7 @@ def test_add_variant_to_draft_order_adds_line_for_new_variant_with_tax(
 
 
 def test_add_variant_to_draft_order_adds_line_for_variant_with_price_0(
-    order_with_lines, product, product_translation_fr, settings, info
+    order_with_lines, product, product_translation_fr, settings, info, site_settings
 ):
     order = order_with_lines
     variant = product.variants.get()
@@ -138,7 +205,13 @@ def test_add_variant_to_draft_order_adds_line_for_variant_with_price_0(
     lines_before = order.lines.count()
     settings.LANGUAGE_CODE = "fr"
     add_variant_to_order(
-        order, variant, 1, info.context.user, info.context.app, info.context.plugins
+        order,
+        variant,
+        1,
+        info.context.user,
+        info.context.app,
+        info.context.plugins,
+        site_settings,
     )
 
     line = order.lines.last()
@@ -151,7 +224,7 @@ def test_add_variant_to_draft_order_adds_line_for_variant_with_price_0(
 
 
 def test_add_variant_to_order_not_allocates_stock_for_new_variant(
-    order_with_lines, product, info
+    order_with_lines, product, info, site_settings
 ):
     variant = product.variants.get()
     stock = Stock.objects.get(product_variant=variant)
@@ -165,13 +238,16 @@ def test_add_variant_to_order_not_allocates_stock_for_new_variant(
         info.context.user,
         info.context.app,
         info.context.plugins,
+        site_settings,
     )
 
     stock.refresh_from_db()
     assert get_quantity_allocated_for_stock(stock) == stock_before
 
 
-def test_add_variant_to_order_edits_line_for_existing_variant(order_with_lines, info):
+def test_add_variant_to_order_edits_line_for_existing_variant(
+    order_with_lines, info, site_settings
+):
     existing_line = order_with_lines.lines.first()
     variant = existing_line.variant
     lines_before = order_with_lines.lines.count()
@@ -184,6 +260,7 @@ def test_add_variant_to_order_edits_line_for_existing_variant(order_with_lines, 
         info.context.user,
         info.context.app,
         info.context.plugins,
+        site_settings,
     )
 
     existing_line.refresh_from_db()
@@ -193,7 +270,7 @@ def test_add_variant_to_order_edits_line_for_existing_variant(order_with_lines, 
 
 
 def test_add_variant_to_order_not_allocates_stock_for_existing_variant(
-    order_with_lines, info
+    order_with_lines, info, site_settings
 ):
     existing_line = order_with_lines.lines.first()
     variant = existing_line.variant
@@ -209,6 +286,7 @@ def test_add_variant_to_order_not_allocates_stock_for_existing_variant(
         info.context.user,
         info.context.app,
         info.context.plugins,
+        site_settings,
     )
 
     stock.refresh_from_db()
@@ -549,7 +627,16 @@ def test_update_order_prices(
     )
     price_2 = TaxedMoney(net=price_2, gross=price_2)
 
-    mocked_calculate_order_line_unit.side_effect = [price_1, price_2]
+    mocked_calculate_order_line_unit.side_effect = [
+        OrderTaxedPricesData(
+            undiscounted_price=price_1,
+            price_with_discounts=price_1,
+        ),
+        OrderTaxedPricesData(
+            undiscounted_price=price_2,
+            price_with_discounts=price_2,
+        ),
+    ]
 
     shipping_price = order_with_lines.shipping_method.channel_listings.get(
         channel_id=order_with_lines.channel_id
@@ -629,7 +716,7 @@ def test_calculate_order_weight(order_with_lines):
     assert calculated_weight == order_weight
 
 
-def test_order_weight_add_more_variant(order_with_lines, info):
+def test_order_weight_add_more_variant(order_with_lines, info, site_settings):
     variant = order_with_lines.lines.first().variant
     add_variant_to_order(
         order_with_lines,
@@ -638,6 +725,7 @@ def test_order_weight_add_more_variant(order_with_lines, info):
         info.context.user,
         info.context.app,
         info.context.plugins,
+        site_settings,
     )
     order_with_lines.refresh_from_db()
 
@@ -646,7 +734,7 @@ def test_order_weight_add_more_variant(order_with_lines, info):
     )
 
 
-def test_order_weight_add_new_variant(order_with_lines, product, info):
+def test_order_weight_add_new_variant(order_with_lines, product, info, site_settings):
     variant = product.variants.first()
 
     add_variant_to_order(
@@ -656,6 +744,7 @@ def test_order_weight_add_new_variant(order_with_lines, product, info):
         info.context.user,
         info.context.app,
         info.context.plugins,
+        site_settings,
     )
     order_with_lines.refresh_from_db()
 
@@ -682,12 +771,20 @@ def test_order_weight_delete_line(lines_info):
     assert order.weight == _calculate_order_weight_from_lines(order)
 
 
-def test_get_order_weight_non_existing_product(order_with_lines, product, info):
+def test_get_order_weight_non_existing_product(
+    order_with_lines, product, info, site_settings
+):
     # Removing product should not affect order's weight
     order = order_with_lines
     variant = product.variants.first()
     add_variant_to_order(
-        order, variant, 1, info.context.user, info.context.app, info.context.plugins
+        order,
+        variant,
+        1,
+        info.context.user,
+        info.context.app,
+        info.context.plugins,
+        site_settings,
     )
     old_weight = order.get_total_weight()
 

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 from prices import Money, TaxedMoney
 
+from ...order.interface import OrderTaxedPricesData
 from .. import OrderLineData, OrderStatus
 from ..events import OrderEvents
 from ..models import Order, OrderEvent
@@ -217,16 +218,20 @@ def test_get_valid_shipping_methods_for_order_shipping_not_required(
 
 def test_update_taxes_for_order_lines(order_with_lines):
     # given
-    line_with_discount = order_with_lines.lines.first()
-    line_with_discount.unit_discount_amount = Decimal("2.00")
-    line_with_discount.save(update_fields=["unit_discount_amount"])
-
     unit_price = TaxedMoney(net=Money("10.23", "USD"), gross=Money("15.80", "USD"))
     total_price = TaxedMoney(net=Money("30.34", "USD"), gross=Money("36.49", "USD"))
     tax_rate = Decimal("0.23")
+    unit_price_data = OrderTaxedPricesData(
+        undiscounted_price=unit_price,
+        price_with_discounts=unit_price,
+    )
+    total_price_data = OrderTaxedPricesData(
+        undiscounted_price=total_price,
+        price_with_discounts=total_price,
+    )
     manager = Mock(
-        calculate_order_line_unit=Mock(return_value=unit_price),
-        calculate_order_line_total=Mock(return_value=total_price),
+        calculate_order_line_unit=Mock(return_value=unit_price_data),
+        calculate_order_line_total=Mock(return_value=total_price_data),
         get_order_line_tax_rate=Mock(return_value=tax_rate),
     )
 
@@ -240,31 +245,72 @@ def test_update_taxes_for_order_lines(order_with_lines):
         assert line.unit_price == unit_price
         assert line.total_price == total_price
         assert line.tax_rate == tax_rate
-        if line.pk != line_with_discount.pk:
-            assert line.undiscounted_unit_price == unit_price
-            assert line.undiscounted_total_price == total_price
-        else:
-            assert line.undiscounted_unit_price == unit_price + line.unit_discount
-            assert (
-                line.undiscounted_total_price
-                == (unit_price + line.unit_discount) * line.quantity
-            )
+        assert line.undiscounted_unit_price == unit_price
+        assert line.undiscounted_total_price == total_price
 
 
-def test_add_variant_to_order(order, customer_user, variant):
+def test_update_taxes_for_order_lines_discounted_price(order_with_lines):
+    # given
+    unit_discount_amount = Decimal("2.00")
+
+    unit_price = TaxedMoney(net=Money("10.23", "USD"), gross=Money("15.80", "USD"))
+    total_price = TaxedMoney(net=Money("30.34", "USD"), gross=Money("36.49", "USD"))
+    tax_rate = Decimal("0.23")
+    discount = TaxedMoney(
+        net=Money(unit_discount_amount, "USD"), gross=Money(unit_discount_amount, "USD")
+    )
+    unit_price_data = OrderTaxedPricesData(
+        undiscounted_price=unit_price + discount,
+        price_with_discounts=unit_price,
+    )
+    total_price_data = OrderTaxedPricesData(
+        undiscounted_price=total_price + discount,
+        price_with_discounts=total_price,
+    )
+    manager = Mock(
+        calculate_order_line_unit=Mock(return_value=unit_price_data),
+        calculate_order_line_total=Mock(return_value=total_price_data),
+        get_order_line_tax_rate=Mock(return_value=tax_rate),
+    )
+
+    # when
+    update_taxes_for_order_lines(
+        order_with_lines.lines.all(), order_with_lines, manager, True
+    )
+
+    # then
+    for line in order_with_lines.lines.all():
+        assert line.unit_price == unit_price
+        assert line.total_price == total_price
+        assert line.tax_rate == tax_rate
+        assert line.undiscounted_unit_price == unit_price + discount
+        assert line.undiscounted_total_price == total_price + discount
+
+
+def test_add_variant_to_order(order, customer_user, variant, site_settings):
     # given
     unit_price = TaxedMoney(net=Money("10.23", "USD"), gross=Money("15.80", "USD"))
     total_price = TaxedMoney(net=Money("30.34", "USD"), gross=Money("36.49", "USD"))
     tax_rate = Decimal("0.23")
+    unit_price_data = OrderTaxedPricesData(
+        undiscounted_price=unit_price,
+        price_with_discounts=unit_price,
+    )
+    total_price_data = OrderTaxedPricesData(
+        undiscounted_price=total_price,
+        price_with_discounts=total_price,
+    )
     manager = Mock(
-        calculate_order_line_unit=Mock(return_value=unit_price),
-        calculate_order_line_total=Mock(return_value=total_price),
+        calculate_order_line_unit=Mock(return_value=unit_price_data),
+        calculate_order_line_total=Mock(return_value=total_price_data),
         get_order_line_tax_rate=Mock(return_value=tax_rate),
     )
     app = None
 
     # when
-    line = add_variant_to_order(order, variant, 4, customer_user, app, manager)
+    line = add_variant_to_order(
+        order, variant, 4, customer_user, app, manager, site_settings
+    )
 
     # then
     assert line.unit_price == unit_price

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -416,7 +416,9 @@ def add_variant_to_order(
             line.unit_discount_reason = (
                 f"Sale: {graphene.Node.to_global_id('Sale', sale_id)}"
             )
-            line.sale_id = sale_id
+            line.sale_id = (
+                graphene.Node.to_global_id("Sale", sale_id) if sale_id else None
+            )
 
         line.save(
             update_fields=[

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from functools import partial, wraps
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union
 
+import graphene
 from django.conf import settings
 from django.utils import timezone
 from prices import Money, TaxedMoney, fixed_discount, percentage_discount
@@ -13,7 +14,11 @@ from ..core.tracing import traced_atomic_transaction
 from ..core.weight import zero_weight
 from ..discount import DiscountValueType, OrderDiscountType
 from ..discount.models import NotApplicable, OrderDiscount, Voucher, VoucherType
-from ..discount.utils import get_products_voucher_discount, validate_voucher_in_order
+from ..discount.utils import (
+    get_products_voucher_discount,
+    get_sale_id_applied_as_a_discount,
+    validate_voucher_in_order,
+)
 from ..order import FulfillmentStatus, OrderLineData, OrderStatus
 from ..order.models import Order, OrderLine
 from ..product.utils.digital_products import get_default_digital_content_settings
@@ -193,19 +198,15 @@ def update_taxes_for_order_line(
     line_price = line.unit_price.gross if tax_included else line.unit_price.net
     line.unit_price = TaxedMoney(line_price, line_price)
 
-    unit_price = manager.calculate_order_line_unit(order, line, variant, product)
-    total_price = manager.calculate_order_line_total(order, line, variant, product)
-    line.unit_price = unit_price
-    line.total_price = total_price
-    line.undiscounted_unit_price = line.unit_price + line.unit_discount
-    line.undiscounted_total_price = (
-        line.undiscounted_unit_price * line.quantity
-        if line.unit_discount
-        else total_price
-    )
-    if unit_price.tax and unit_price.net:
+    unit_price_data = manager.calculate_order_line_unit(order, line, variant, product)
+    total_price_data = manager.calculate_order_line_total(order, line, variant, product)
+    line.unit_price = unit_price_data.price_with_discounts
+    line.total_price = total_price_data.price_with_discounts
+    line.undiscounted_unit_price = unit_price_data.undiscounted_price
+    line.undiscounted_total_price = total_price_data.undiscounted_price
+    if line.unit_price.tax and line.unit_price.net:
         line.tax_rate = manager.get_order_line_tax_rate(
-            order, product, variant, None, unit_price
+            order, product, variant, None, line.unit_price
         )
 
 
@@ -308,7 +309,15 @@ def update_order_status(order):
 
 @traced_atomic_transaction()
 def add_variant_to_order(
-    order, variant, quantity, user, app, manager, discounts=None, allocate_stock=False
+    order,
+    variant,
+    quantity,
+    user,
+    app,
+    manager,
+    site_settings,
+    discounts=None,
+    allocate_stock=False,
 ):
     """Add total_quantity of variant to order.
 
@@ -333,11 +342,24 @@ def add_variant_to_order(
         product = variant.product
         collections = product.collections.all()
         channel_listing = variant.channel_listings.get(channel=channel)
+
+        # vouchers are not applied for new lines in unconfirmed/draft orders
         unit_price = variant.get_price(
             product, collections, channel, channel_listing, discounts
         )
+        if not discounts:
+            undiscounted_price = unit_price
+        else:
+            undiscounted_price = variant.get_price(
+                product, collections, channel, channel_listing, []
+            )
         unit_price = TaxedMoney(net=unit_price, gross=unit_price)
+        undiscounted_unit_price = TaxedMoney(
+            net=undiscounted_price, gross=undiscounted_price
+        )
         total_price = unit_price * quantity
+        undiscounted_total_price = unit_price * quantity
+
         product_name = str(product)
         variant_name = str(variant)
         translated_product_name = str(product.translated)
@@ -355,18 +377,47 @@ def add_variant_to_order(
             is_shipping_required=variant.is_shipping_required(),
             quantity=quantity,
             unit_price=unit_price,
+            undiscounted_unit_price=undiscounted_unit_price,
             total_price=total_price,
+            undiscounted_total_price=undiscounted_total_price,
             variant=variant,
         )
-        unit_price = manager.calculate_order_line_unit(order, line, variant, product)
-        total_price = manager.calculate_order_line_total(order, line, variant, product)
-        line.unit_price = unit_price
-        line.total_price = total_price
-        line.undiscounted_unit_price = unit_price
-        line.undiscounted_total_price = total_price
+        unit_price_data = manager.calculate_order_line_unit(
+            order, line, variant, product
+        )
+        total_line_price_data = manager.calculate_order_line_total(
+            order, line, variant, product
+        )
+        line.unit_price = unit_price_data.price_with_discounts
+        line.total_price = total_line_price_data.price_with_discounts
+        line.undiscounted_unit_price = unit_price_data.undiscounted_price
+        line.undiscounted_total_price = total_line_price_data.undiscounted_price
         line.tax_rate = manager.get_order_line_tax_rate(
             order, product, variant, None, unit_price
         )
+
+        unit_discount = line.undiscounted_unit_price - line.unit_price
+        if unit_discount.gross:
+            sale_id = get_sale_id_applied_as_a_discount(
+                product=product,
+                price=channel_listing.price,
+                discounts=discounts,
+                collections=collections,
+                channel=channel,
+                variant_id=variant.id,
+            )
+            taxes_included_in_prices = site_settings.include_taxes_in_prices
+            if taxes_included_in_prices:
+                discount_amount = unit_discount.gross
+            else:
+                discount_amount = unit_discount.net
+            line.unit_discount = discount_amount
+            line.unit_discount_value = discount_amount.amount
+            line.unit_discount_reason = (
+                f"Sale: {graphene.Node.to_global_id('Sale', sale_id)}"
+            )
+            line.sale_id = sale_id
+
         line.save(
             update_fields=[
                 "currency",
@@ -379,6 +430,10 @@ def add_variant_to_order(
                 "undiscounted_total_price_gross_amount",
                 "undiscounted_total_price_net_amount",
                 "tax_rate",
+                "unit_discount_amount",
+                "unit_discount_value",
+                "unit_discount_reason",
+                "sale_id",
             ]
         )
 

--- a/saleor/payment/gateways/adyen/tests/utils/test_common.py
+++ b/saleor/payment/gateways/adyen/tests/utils/test_common.py
@@ -19,7 +19,7 @@ from saleor.payment.gateways.adyen.utils.common import (
 from saleor.payment.interface import PaymentMethodInfo
 from saleor.payment.utils import price_from_minor_unit, price_to_minor_unit
 
-from ......checkout.interface import TaxedPricesData
+from ......checkout.interface import CheckoutTaxedPricesData
 from ...utils.common import prepare_address_request_data
 
 
@@ -97,7 +97,7 @@ def test_append_checkout_details_tax_included(
 
     country_code = checkout_ready_to_complete.get_country()
 
-    mocked_calculate_checkout_line_unit_price.return_value = TaxedPricesData(
+    mocked_calculate_checkout_line_unit_price.return_value = CheckoutTaxedPricesData(
         price_with_sale=unit_price,
         undiscounted_price=unit_price,
         price_with_discounts=unit_price,

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -317,6 +317,7 @@ def get_order_lines_data(
         product_type = line.variant.product.product_type
         tax_code = retrieve_tax_code_from_meta(product, default=None)
         tax_code = tax_code or retrieve_tax_code_from_meta(product_type)
+        prices_data = base_calculations.base_order_line_total(line)
 
         # Confirm if line doesn't have included taxes in the price. If not then, we
         # check if the current Saleor config doesn't assume that taxes are included in
@@ -326,21 +327,37 @@ def get_order_lines_data(
         )
         tax_included = line_has_included_taxes or system_tax_included
 
-        amount = line.unit_price_gross_amount * line.quantity
-        append_line_to_data(
-            data=data,
-            quantity=line.quantity,
-            amount=amount,
+        if tax_included:
+            undiscounted_amount = prices_data.undiscounted_price.gross.amount
+            price_with_discounts_amount = prices_data.price_with_discounts.gross.amount
+        else:
+            undiscounted_amount = prices_data.undiscounted_price.net.amount
+            price_with_discounts_amount = prices_data.price_with_discounts.net.amount
+
+        append_line_to_data_kwargs = {
+            "data": data,
+            "quantity": line.quantity,
             # This is a workaround for Avatax and sending a lines with amount 0. Like
             # order lines which are fully discounted for some reason. If we use a
             # standard tax_code, Avatax will raise an exception: "When shipping
             # cross-border into CIF countries, Tax Included is not supported with mixed
             # positive and negative line amounts."
-            tax_code=tax_code if amount else DEFAULT_TAX_CODE,
-            item_code=line.variant.sku,
-            name=line.variant.product.name,
-            tax_included=tax_included,
+            "tax_code": tax_code if undiscounted_amount else DEFAULT_TAX_CODE,
+            "item_code": line.variant.sku,
+            "name": line.variant.product.name,
+            "tax_included": tax_included,
+        }
+        append_line_to_data(
+            **append_line_to_data_kwargs,
+            amount=undiscounted_amount,
         )
+
+        if undiscounted_amount != price_with_discounts_amount:
+            append_line_to_data(
+                **append_line_to_data_kwargs,
+                amount=price_with_discounts_amount,
+                ref1=line.variant.sku,
+            )
 
     discount_amount = get_total_order_discount(order)
     if discount_amount:
@@ -353,6 +370,7 @@ def get_order_lines_data(
             name="Order discount",
             tax_included=True,  # Voucher should be always applied as a gross amount
         )
+
     shipping_method_channel_listing = ShippingMethodChannelListing.objects.filter(
         shipping_method=order.shipping_method_id, channel=order.channel_id
     ).first()

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -14,9 +14,10 @@ from prices import Money, TaxedMoney, TaxedMoneyRange
 
 from ...checkout import base_calculations
 from ...checkout.fetch import fetch_checkout_lines
-from ...checkout.interface import TaxedPricesData
+from ...checkout.interface import CheckoutTaxedPricesData
 from ...core.taxes import TaxError, TaxType, charge_taxes_on_shipping, zero_taxed_money
 from ...discount import DiscountInfo
+from ...order.interface import OrderTaxedPricesData
 from ...product.models import ProductType
 from ..base_plugin import BasePlugin, ConfigurationTypeField
 from ..error_codes import PluginErrorCode
@@ -203,7 +204,7 @@ class AvataxPlugin(BasePlugin):
         )
 
         currency = checkout_info.checkout.currency
-        taxed_total = TaxedPricesData(
+        taxed_total = CheckoutTaxedPricesData(
             price_with_discounts=zero_taxed_money(currency),
             price_with_sale=zero_taxed_money(currency),
             undiscounted_price=zero_taxed_money(currency),
@@ -381,8 +382,8 @@ class AvataxPlugin(BasePlugin):
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-        previous_value: TaxedPricesData,
-    ) -> TaxedPricesData:
+        previous_value: CheckoutTaxedPricesData,
+    ) -> CheckoutTaxedPricesData:
         if self._skip_plugin(previous_value):
             return previous_value
 
@@ -407,8 +408,8 @@ class AvataxPlugin(BasePlugin):
         taxes_data: Dict[str, Any],
         item_code: str,
         tax_included: Callable[[], bool],
-        base_value: TaxedPricesData,
-    ) -> TaxedPricesData:
+        base_value: CheckoutTaxedPricesData,
+    ) -> CheckoutTaxedPricesData:
         if not taxes_data or "error" in taxes_data:
             return base_value
 
@@ -453,7 +454,7 @@ class AvataxPlugin(BasePlugin):
                 )
             else:
                 price_with_discounts = line_price_with_discounts
-            return TaxedPricesData(
+            return CheckoutTaxedPricesData(
                 undiscounted_price=undiscounted_line_price,
                 price_with_sale=price,
                 price_with_discounts=price_with_discounts,
@@ -467,8 +468,8 @@ class AvataxPlugin(BasePlugin):
         order_line: "OrderLine",
         variant: "ProductVariant",
         product: "Product",
-        previous_value: TaxedMoney,
-    ) -> TaxedMoney:
+        previous_value: OrderTaxedPricesData,
+    ) -> OrderTaxedPricesData:
         if self._skip_plugin(previous_value):
             return previous_value
 
@@ -478,35 +479,62 @@ class AvataxPlugin(BasePlugin):
         if not _validate_order(order):
             return previous_value
 
+        tax_included = (
+            lambda: Site.objects.get_current().settings.include_taxes_in_prices
+        )
+
         taxes_data = self._get_order_tax_data(order, previous_value)
         return self._calculate_order_line_total_price(
-            taxes_data, variant.sku, previous_value
+            taxes_data, variant.sku, tax_included, previous_value
         )
 
     @staticmethod
     def _calculate_order_line_total_price(
         taxes_data: Dict[str, Any],
         item_code: str,
+        tax_included: Callable[[], bool],
         base_value: TaxedMoney,
-    ):
+    ) -> OrderTaxedPricesData:
         if not taxes_data or "error" in taxes_data:
             return base_value
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
         currency = taxes_data.get("currencyCode")
+        undiscounted_line_price = None
+        line_price_with_discounts = None
+
         for line in taxes_data.get("lines", []):
-            if line.get("itemCode") == item_code:
-                tax = Decimal(line.get("tax", 0.0))
-                net = Decimal(line["lineAmount"])
-                if currency == "JPY" and tax_included():
-                    line_gross = base_value.gross
-                    line_net = Money(amount=line_gross.amount - tax, currency=currency)
-                else:
-                    line_gross = Money(amount=net + tax, currency=currency)
-                    line_net = Money(amount=net, currency=currency)
-                return TaxedMoney(net=line_net, gross=line_gross)
+            if line.get("itemCode") != item_code:
+                continue
+            is_discount_record = line.get("ref1")
+
+            tax = Decimal(line.get("tax", 0.0))
+            net = Decimal(line["lineAmount"])
+
+            if currency == "JPY" and tax_included():
+                line_gross = base_value.undiscounted_price.gross
+                if is_discount_record:
+                    line_gross = base_value.price_with_discounts.gross
+                line_net = Money(amount=line_gross.amount - tax, currency=currency)
+            else:
+                line_gross = Money(amount=net + tax, currency=currency)
+                line_net = Money(amount=net, currency=currency)
+
+            total = TaxedMoney(net=line_net, gross=line_gross)
+            if is_discount_record:
+                line_price_with_discounts = total
+            else:
+                undiscounted_line_price = total
+
+        if undiscounted_line_price is not None:
+            price_with_discounts = (
+                line_price_with_discounts
+                if line_price_with_discounts is not None
+                else undiscounted_line_price
+            )
+            return OrderTaxedPricesData(
+                undiscounted_price=undiscounted_line_price,
+                price_with_discounts=price_with_discounts,
+            )
 
         return base_value
 
@@ -517,8 +545,8 @@ class AvataxPlugin(BasePlugin):
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-        previous_value: TaxedPricesData,
-    ) -> TaxedPricesData:
+        previous_value: CheckoutTaxedPricesData,
+    ) -> CheckoutTaxedPricesData:
         if self._skip_plugin(previous_value):
             return previous_value
 
@@ -538,7 +566,7 @@ class AvataxPlugin(BasePlugin):
             taxes_data, checkout_line_info.variant.sku, tax_included, previous_value
         )
         quantity = checkout_line_info.line.quantity
-        return TaxedPricesData(
+        return CheckoutTaxedPricesData(
             undiscounted_price=taxed_total_prices_data.undiscounted_price / quantity,
             price_with_sale=taxed_total_prices_data.price_with_sale / quantity,
             price_with_discounts=taxed_total_prices_data.price_with_discounts
@@ -551,43 +579,25 @@ class AvataxPlugin(BasePlugin):
         order_line: "OrderLine",
         variant: "ProductVariant",
         product: "Product",
-        previous_value: TaxedMoney,
-    ) -> TaxedMoney:
+        previous_value: OrderTaxedPricesData,
+    ) -> OrderTaxedPricesData:
         if not variant or (variant and not product.charge_taxes):
             return previous_value
-        taxes_data = self._get_order_tax_data(order, previous_value)
-        return self._calculate_unit_price(
-            taxes_data, order_line, variant.sku, previous_value
-        )
-
-    @staticmethod
-    def _calculate_unit_price(
-        taxes_data: Dict[str, Any],
-        line: Union["CheckoutLine", "OrderLine"],
-        item_code: str,
-        base_value: TaxedMoney,
-    ):
-        if taxes_data is None:
-            return base_value
 
         tax_included = (
             lambda: Site.objects.get_current().settings.include_taxes_in_prices
         )
-        currency = taxes_data.get("currencyCode")
-        for line_data in taxes_data.get("lines", []):
-            if line_data.get("itemCode") == item_code:
-                tax = Decimal(line_data.get("tax", 0.0)) / line.quantity
-                net = Decimal(line_data.get("lineAmount", 0.0)) / line.quantity
 
-                if currency == "JPY" and tax_included():
-                    gross = base_value.gross
-                    net = Money(amount=gross.amount - tax, currency=currency)
-                else:
-                    gross = Money(amount=net + tax, currency=currency)
-                    net = Money(amount=net, currency=currency)
-                return TaxedMoney(net=net, gross=gross)
-
-        return base_value
+        taxes_data = self._get_order_tax_data(order, previous_value)
+        taxed_total_prices_data = self._calculate_order_line_total_price(
+            taxes_data, variant.sku, tax_included, previous_value
+        )
+        quantity = order_line.quantity
+        return OrderTaxedPricesData(
+            undiscounted_price=taxed_total_prices_data.undiscounted_price / quantity,
+            price_with_discounts=taxed_total_prices_data.price_with_discounts
+            / quantity,
+        )
 
     def calculate_order_shipping(
         self, order: "Order", previous_value: TaxedMoney
@@ -701,7 +711,9 @@ class AvataxPlugin(BasePlugin):
 
         return response
 
-    def _get_order_tax_data(self, order: "Order", base_value: Decimal):
+    def _get_order_tax_data(
+        self, order: "Order", base_value: Union[Decimal, OrderTaxedPricesData]
+    ):
         if self._skip_plugin(base_value):
             return None
 

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_total_with_discount.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_total_with_discount.yaml
@@ -6,7 +6,7 @@ interactions:
       "30.000", "taxCode": "O9999999", "taxIncluded": true, "itemCode": "SKU_A", "description":
       "Test product", "ref1": "SKU_A"}, {"quantity": 1, "amount": "10.000", "taxCode":
       "FR000000", "taxIncluded": true, "itemCode": "Shipping", "description": null}],
-      "code": "6ecf08d4-c3d6-43ef-8da4-d68a07fe8318", "date": "2021-12-17", "customerCode":
+      "code": "06e18f75-c275-4495-8126-3a8b639a0d78", "date": "2021-12-17", "customerCode":
       0, "addresses": {"shipFrom": {"line1": "Teczowa 7", "line2": null, "city": "Wroclaw",
       "region": "", "country": "PL", "postalCode": "53-601"}, "shipTo": {"line1":
       "O\u0142awska 10", "line2": "", "city": "WROC\u0141AW", "region": "", "country":
@@ -16,7 +16,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Authorization:
       - Basic Og==
       Connection:
@@ -30,105 +30,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        i/8BAICqqqrq/3SXs7qBqpm5m7me0sE9DgEQEJEQ7h53cVU2d800UzVQFfM0h3y5Ecjcap1+bvy/
-        R1w0EheJxPdzIi4umqJubJ0BiFj29P8UPNmu1Vpr0+36rak7RS55kKUd3KB7325c43ebtsGw6T23
-        G7/rWXcD+sb0pMilaeb4evdk67bed1tFngVkqda12Zh6YzpSVIRlKWTpzE94UiSvuRPMnXlEeY/P
-        FBxI0Y3FPY4hFm5gl5wR3Qulmev5RIqwugfHO75ZcBS9GLqlSJqQr4XvuLzmXsC1LkqQ17XAkYTU
-        2fwg+pQ5Ek2WX9hjxTTLZ6JqvJPhUnRhhCc78FigaEyOJaRYR0JCcHPKEuL9g96L5yW7Bxd8ZY9s
-        nM2AjOhSFil3BDojF+8qEF6/nsg5+BFT/0wRRNbRYUpLFLK60lxtv8ElRcqIXZLwKE59Z6puj5O8
-        zYuHASv1FIozrRgPL7ySNW1VG0VCtBde+TbCbxNfeD3y6JaRBb5mDdj/WYpMiBJq1c8kBwZPeBJV
-        9oTicpivFz7RdUzurx18714z7oFO75yD/CJLvz9I0RO58BgaRSUN8o8zfvDkqTaVqaumenSYSTnc
-        Qzx4n1HKuyfbmZ8Bw6bt9vW+6RV5FAnxkfGiZKFoZRbsZ4nfhgFOwhMnFrSEpus/kS/iTtZUugv+
-        mfU2Jg4jWRIU+YWVp3lE5dJEim5LCTEt8ma3IWzfcuySm5IPQ4Bvvje6mMZujTX7qt3umxr/AwAA
-        VVVV1f/pGsBnDQdVNXdTc70ZeGQCGGRAhEO6+yXjkKBuKm6gAGaqlqqiAW6Qqk50smindNOPUdtP
-        hYWBgYWFhZMuneLAwMHBE3i9TI/nbg0qSP+ibf5AYEk+PAL5W6E8eFjdNeqoBdg93xwTLLTU6lXp
-        V2UgMIdIBfbrP4KHNUZKKdu96g5dqwU4u1jcyCHFwcOafQgcZdruoLQRuAD3PupypwwLBYF7qtG7
-        vH1+U87BEwn8SgqMtXBaKN+Km+i6rQQLCFDkwNut0Cl5gvmOpzLmsHJIERZXKvyy5uTryAgg4xCd
-        Yey9z1RKDVTDC7Fs9uaoj00nkHKYQgzaVGU7x4cyphq5X/7QYeVOOla9bitz6fSkZY3cFdhOlLk6
-        qgTFPhJsU7gSysC0XN3T3WeC5VzJAedyuZ5hH24uEJRp6XkZLr9uf3uMkg9Cvj7utJFS4F91cURQ
-        2IYjLNNDFWLL9NAnGdeUOcRpuU96pu9+7JVKQlBSzWOIEyzeqMxSGoQ4MMC2O9McKbFv/TIcznyy
-        xzm5eayzY/Lhj3cn7fP44XJdckyDhz00e5lOH/lN7J4/4hSiFhZl9xSNpBVEsPhIkSBwryXEVVOS
-        iz7CuH86Jn5OPVjndZ599ptcUROVlGmI41w9+fWI44ldmAvs1xPgoO2klGpvWnVo2s62+h5ib1SN
-        5Og7r6Q5r9VX8n6CvMHi/A6BTFOgSxnJAcP2czhf0AD1wo4JWosWo35JNTKs3EkppcD/AABAVVVV
-        9X+6JshZwUHdwj083G6e5pEBDuBg7uBueUqIg7iphLsEqIsaiIokuENCmrnhp2WHtWVa/igXWYmM
-        jKys7DZtIiQSI4E8Vp+HYzH1FKAH3Sc7EdYiuwTtIgDL2dAIWlOnAN+uXLuSCFo47iHAtyvXHu8E
-        LRwP+02/hczsiUdjrXShiXEemwCVr4LmSp1KMghQb0DbVAqn1BcA8rnpHJ7TgXX9ANFcVQ94v7iY
-        PiGAFBnwgZdMm3txMWjjLMYYaWEnzzQWvkFVsxMa5cAggM4rFmfNi0hijJjl3WIe16smnvxcXEci
-        XQxQSYdaSWOWK7SwpWos6ARCCGD4gPZ1tnppDmo9b7xZz5oVy7Wx7uA2udWm8+wXAjbS4BBOjPmH
-        Fp+ADDuZ3DaSCou6mPFsKAk1/ZgUe/24cbsVZXsKgRptsexK7ERXXtqiyyOx4aPDPHpGozRBORz+
-        kionMgyTXRSd762mklST9NxF4r78t7DV8ddpk5Ue4vvL/AUiF7bD10+sXF8fAtLOVUnGZy6uQgCu
-        fZEj1jrc1KH9wlyJ4PxFFHkFSlNRY7kOXb2dM1pfnthC/b25OUXfP478xzqsfZlL+gEfHebR1mII
-        kBkvnLeSadVAOZPC/09rhKNcsJsWv962ZMi5QvvnsxIutC/jIxP6TBT+g1RGv5PYnjM2ulsi7i1i
-        jPPl/G29jsvXAKmMfiexPQvtEv4HAACqqqqq/9M1gc/qDqpm7rbozcAjA8AhHRYANz8mJKiriZsr
-        gJmqpaqogzsEuNkmfjLWWjvEtEkpF4lEIiuRyO52s/4lsnKyepkez95GENHeBV3XUkpZbVSzbapC
-        YAg2z+S5G4ZIKe0H6FrBcF+5qduiLRuBKVjDLvj+vdAuDASNy8Mt3zHM+IifMs/j4Dwd8KvV86ol
-        RrVVTdvKbWWL4Q3zMyVj5JLSO6QP+PwVeKQdTf0fAjYk3vuUo/GWviO58cHQci0FnoaxD34+XFZF
-        KU+r1fmAoAzHPN8o9u8ptJMf8QNHF95YxDgan4xlF/w04hvDRNVVs1VFLTA5T9X0IjQKCNxC9oOJ
-        79OTYnSDBDKVAjYnDjPFazIjNYaDvwzk2fH7mlQPBAIDJRvd0hQzaPSU+NcSw5AtA7Sx88bwsU7j
-        ddavC9GNzoNeXFlEBpdsyJ67+Qu7YDngvSyhF6AXzQsySu62o8iSwKUz1GPABHLFpT3T3JuXuU0E
-        zTFTAORy6c/QdzMlFxrTvFuhdpc/138dpNRMiBebddlKKfA/Gy8RKnS5UByR7gppS4t0L/oqjbSE
-        yM6PX4avLlghC7VSxUrVAKA+OzuwpIRJCjla50dofFESNFAIsHlBb9eV+hUboXVzyKnYSG0RsjOT
-        zZNhGuDrPk45tYemchbwPRK13EiTr/wGNq/ffnSeOJIr3xzbwwwax+AJArecnH+6Ynem3N1j1Sz7
-        ObXv5pA9A/8DAABVVVXV/+kaIGcFB7XdzW4WHhAJDuBg5uBmcYqTuKmEhyaYixqIiia4QZpt4oe0
-        m7VU2wBcJDISGYlEctMKWVlZIQduqD4HsUxs96azB2tA8TX+IxHv6EYYA0MHgOj/Z17W5MhBp5LI
-        gCNFv0bovv+Dd9A1R2ttVjZ1VhV1a0AFOeKiPvDFM51dG8+2LrNjdazzilOLloX7rKmPVZY3BtA5
-        oRgxCX1pi7Jp87Y4GlhCYpUdOrhewIDQw49LSUkNvn+er1OA4FFRSfpM9KLnpv3TBgrJYdZacuTc
-        8tWhNOB5Oo0aevM3iY+n4Ai+xUm0AZ9Fw3jphw8AbM4v2SFe97m1mc0NRP9g1CTkwgqzcesjhZMb
-        AgBKxjbvW6GfhhlULq4Vyvy3soMBDjzjC+8r9aGuC+23tNI4UAui4mY31B5yMCCYF90e8mLfyFo9
-        PpSZbZtcDz6FJIvpYZEk1Ffo3vMDOvigqJ5xE8hPaICuOtSZN1RnvnheHoqWcRlsGJNuSc8Gm9Kd
-        QDI0GOUgmv+RkDZA05m3pD27g1G5mHlSZIfi3pIin5/7pL9BvO5GEI9WVlOR3l4RiWi5rS6N9oqv
-        E65LWlHJJYh1/ElYFrasS0zX75alCilL0mmKIPc1frHXCF38c7mvQqt5fq+/wC6x1/HnHaOPzxEb
-        klMSIV72XjwFAz4Oga8Y4/wrCbofXCMR2CeRcj4Q2oKo58eML7yv9MX4HwAAqKqqqv5PdzmrOaia
-        ubmZ6c3BIgPAAQw8HMDMTwFxUFcTNxMANVVLVTEHNwgIy028A9ZaS7Mss552zUnkS4REIlvtXk4i
-        Z+TcmHLcTSkR5+/ECXR+PBSNgIhriEx+ugY/mLd5OLx7Eps8SEFZun9vXFZOPxsH8wZdHk7qyuoP
-        5t0aZzdnGEdG+k9H5kGOeB/2FUFDj85hhL8fAT74m0mJ5xi2af5ANuQS6O8fAY48dsEapuCHfcUE
-        +vsXxmC3BT132M5cRtDVSUqpSlU3jSwrwc93jl9LKeXpqOqyPuVY+vM4RkyJRinAL45VkzdFLcAF
-        K+JhbRg7oDfT+hnDAn/it0yujr/u76mR9NaiSFLSK3UIhtLm1MoM8yDAhsQXn7ZovMXPiDTNDHq+
-        tJdhbvRvXZ/lhfzKslsHSQ7XbXlgHPYugmSbELmL0s7VPY+j8clYpuC7pY4UjKo61aXKKzE+6voa
-        Z0FDAQIeYfOjifvXC2OkES/iqxRgt8RhwXhPZsLCEOjniJ6J93tCqdEBASMmG2ktCkEwNSZvgNsI
-        i5arZ12INJEnZVLYOCMlGzbP5+WEj0lnQoMVyQTgKvDOPMKtxcgdxSNo1wAi2VO6MC7DeoUONMcN
-        E3D6friBfhqXQmiMSzu2MPYzrSv5CRwMZzW3PqhCSgH/N+ONQQOtDivK+lSlQov4zL9SXcNW0z4M
-        /6uYyGWuMpVnqgIBEV9ni/8BAICqqqrq/3RNkLOGg6i6mamZ3gzcMxIMwME8wNxveRI31fDUBHNR
-        B1XRBHdI0y28g9+/tWSZVgVIZWXlSyQSuWTaIJETcnJuTHecO0BItP63psoCDkBBSTWvke/g4BiK
-        RCaJiUGB0Auc3vVWgdCLblsYH0nKu9/pPcHFgba1biTBV1+LQ/IBHHwu+GNxE2KaPLjG2kFOP5JU
-        YmHQ6A9tPrStDf0n3yOTKNDq/C/kHH24vp8Evp4TB1BwqyVyKGXygSV+x7Vt+pxA+kTHpqPjDg9m
-        sxyWQCWx5PHbidet+uDBSa5BgQ9CcSvgfv+H6MF1GhF1Yzvd7rsIWGfiQqvExKfI2Wh2CIy5a3Tf
-        9p1RZYlEN9uUYKNt17faWAXkfQ5BB2dZrHDf2MEM+17BerjJb3DwdQIFOdxju8xILujvz+nrEiD0
-        IiQBOsfwCo+njMlPR0TmKLnl1KFREPmiRgs9/a05lkPyc0Y+K4M+0+NjP5/G+Ugc5mN2itfeIGo0
-        Ckq8M0nNwSUq9BZtLCws+OUc2bhu8z7MV0BjdW2k3M5FfoMCTnylu5cqhopvrC91WwEViaS6+UJS
-        ww4KMuVFx53Z41QoWJMPjcbBGjzo5T2gmXoJOdQlrEV+Ka/JtD+9lUrVvoZzlWeV+x38Um8MZJoG
-        ZzgI1n/lVJ8Ep4mfVUb2wqTuZb4IsafsfwRF0c9jlT8pR3kbQTysaZuiLpeIu8mDM9hqNAqEXvgf
-        AACoqqqq/k/XBDmrO6iaubmZ6S3SIh3AAQzcHcItIAAiIQ7iphJuCqmuaiCq6ukGAW66hdeyMWv5
-        ZcusryCVlUgkEvmSTKtKZOXLBzdmx1/MQuyeDt2YHSYyoNW6qaUUkPBxvBOzNQRarqUUEGJMNCwz
-        gYZzQm+QDSjZusCjwRluoB1eHL17myLoZq3KK9B98INY1rsnetBtThWpCvHsbTp+/8ZoI2g4EXeZ
-        mfy4sIiCABsPwZ8wxmHiDPobXSQFbUd08nSY5sDJ+uvwdimmVsAOwdvbFdE/Do+r3AZ8xMZ/zkeH
-        bsyhvjwBzuLFOpuWCB8nco4Ynl/JkHQSSBOHfJ1eKaF1EfTfr0o4nvowYrLBF0Mk9wdMGPONfOot
-        cYjsDehtKaVUlWraVla14EthrG6nidN2o5qq2RZMnl+MYYoRI1ULbrmp26ItGwEumMh1zM5k5x2H
-        GzyFpc+1Wj8VRyotfWNDCJT6FLvwEykMAsYQ097HzOhH2jHZ65TgP2MIuGNik3/qz6uilLvV6tSD
-        SM4h3y7EwzJTIlA5JigmxEozYLVZQoytzubE6COOw4JUWr1BcF3V26ZSRS3gErI3yEtPd3Kg4dPO
-        FQiYMTYKNBwd/o//8JeSQrICuiBhtNxydLRpAQ0fb8euf/kAAUxXGzzA8xxiQtd1z6MqV0q+gGkM
-        2SeuhJ7aQ0/4eKuj/d6ALmSlZPEUP2ANIGYAAKCqqqr6P10D+KxhIGrm5uauNwcPCIAEcPAICHeA
-        BMiAOIibCkRogpmqgapohnsGuOW2+1Nn7c7N2lH0I/GjkUgkojMHopFoibpDO34Klv3XDZaIqFsN
-        23bbbQw0cyw8akjxl4cbVkREdlhvetsOBpdUo+d8O8g/meDwJyw9DKYQxcLhLOP/9M0PA/KMLRwQ
-        UjuwdQx6g8PvnMaJv2GQ5TOkKOCnJRXlaZ+8wKHvHtdkYTCmGjVXIn89wED5+lYnbseXlnpL7f3D
-        YEojb46W822RAvf+A5/GOkvUAzu6urDePFuyTdf3A1mjHRx/++a9T7rzPkspMlELFK5dhvv1a6ev
-        sDznNONuVpmnWyzmOpTHe7KKnRMcQix1ntlHhPcfTyeOI6wOx781h+IjTjjsze88o/vbsJDakWcg
-        eX057I5P12G+q/qVctBbG7aseoOirLIrJXxG8cd0bZryVcUML1WXqkiLneqF6bekn2In5Z+Hun94
-        YxUYZFYRdzu91dT4Mgnc2jbDVskEjpq2cwvrkBTOrprWxlLZ8zTWiVU8M5wxxXOjPlBThwa5yrxo
-        SBGOGqL7x30=
+        H4sIAAAAAAAEA+1aWW/bOBD+K4WfY0OH5etpvTkWwQZxEDst0EWxYCQ6VitLXpJK4y3y3/cbHrKs
+        pGnOIhu0D4UyHI7m4Hz8RPpbK01ao17k4Z/f73tROOzvtOIi4a1Ry+txfzDvR+04wH/d7jBqD/yg
+        1w7Z4LwXDpmX9Act0l6uWL4+hKGgGwz70U4rYYoMBF7gt/2g7fehJhVTpYR0yi55AoFar0hpyjIu
+        D/PLIo05pOdMxYtd4wAZL4Xgeby2krPpHoT8Kl6w/IKf4jW7tynEpVTFkoszyS74zLyH5uUqVesz
+        yev2jeZ7nieFsHJPv9gM1ET8ii9X6riA01AQPC7yOM0Qy2jOMsl3WlkRM5UW+ca84KtCqDS/OLox
+        tCoFopB8IhIuNkbnnOKteSgpPysuZN2uYleTSy5Emrjwjouc0lcbGC+LMletkdfxtuSnnMGWCUIV
+        imVOsed3+kOokmxfx+omk2QvlXHdIMlm7Ko18rudwLfTIGDnGcpatwXhLsviMkO5kCyrz5LPqNIS
+        NakcOi7UWEv1+tgo7HEZi3RFqTVuI9FfankX/KIa0j6KNfROjpAPJEnqMXgoi7n6ygR/72StwO/4
+        QSfsUMELkV6k+ThJBJeSFnOvR10RdgdhGHoDLGouUUld4LqW7p2NVn1t7s/nPFbpJd+7pR/qikgK
+        FQlv2I6TL1maIRSFV//Gr9hylfEO+g3unpcyzbWntKrnqVl5bh0tiwQyntx48cyPRr438gadXjfy
+        ol7wEbacNjpD6DYehP4w0IvmhgGoZ/Ti1uivbxo8+joBvW4QBYMIva8EyyVD2EWus9jAFpp8XC7P
+        uUBcPgWCRZUwsXbrmSYhF/dv4e2szZCqdytRJGWsYP1+Rftx7e3id62ieyqxQgIY67WBiC0tI9rl
+        Qm3puEql8lDxZdU3SpQAklROp7OTCldSaFhMmf559vfY1sC9Jhh2gr6HnP1TMo1wrRGWNCHU3Df9
+        gqfAPVlAuq2wgl+OY9vkBHGyAEYBvDB1b7P4MaCo73udfqgfqeO3fNHSestXqjaKydD8M6ZISLmJ
+        wi68hu3bfIN4P0eD0pZhprkFY/HdAuDdfQErbprz+E54ZFeHeZyVCYGNKU3CFXqytvx92jq7/X7P
+        G/hduL9Z/kfwluJ6YIewGgQ1wKUBbhXuaajTg+uDw5OpSRFtuHzz542lCb9pK6U9zSAw+YoI0nxK
+        M13An0uRSls3/R4tOGZLqsTJ5Gh8TFuyFiZp1fYBkuIBQmR6AcgsRX1DI+tjSSM8cW2g59tK7h7P
+        GhbdAO0/wPadVl7kM7PV1MqoA9qMnJaZa8uN0Foi5kDjMCV0rF4nCDGfusYO6Wz43rCPKEg2pWZw
+        BgGUNiWw8OM2IbtYejcaxcqtU5NSrUoCLahOy3OSkhOtiRHR33+Iolxp4WEO3XGe1CfZoqB8hKjJ
+        O4rSzB2XagGQU2tntEtIza5O9c5JBgMv0gWDsNm51kvXOJoUVKmyvrt34nWULJLaBE2NBxT7WZ4q
+        dE6FV5uy2BH0ojZsVmVDWGL2ZP47kylstE5QAUv9SA8vSeVxkZ8wKWcLUW6wUx5wrFTL0Co+NjPV
+        sK/QHsFzx9ZgaFtBg0Q1vK+bZuNebSamOWSs1CFrppQ2UXaeZrYiiGfKswx74vUnvbgpDLVAsS8W
+        exXgYIh2T0clKccGh5IiLolIEeDUR6mu2BjQihHKG4Qh2F1dV483tm83Xqc4DSIE9qVZUL3Ii3R1
+        IEBMrne+bb3ihjsaLp/mTgMUv+POrNDJXDjswgqJC6kOc1kComN+IHh6sXD8+JKpCuOmbWDBpN02
+        BJIpQ1coWkqYRyGmlFmdlscRnwDe/CI+TyY+3U44JHS6nfg4rvQi7Cfq9OijpwHq5JCW1hu+UrUr
+        7C2xny6hy93s52Ft8ov9vCn2Q2v/NvbjOhcNRMBKLOcVsp+a98/Hflzor4f9GNSq+MoT2Y+Bu8pa
+        g/2Y0Z/GfvAd4tgPfVw6dlN9mjXAyY2/FPvRcGnYz2PdeS3sRxPLx7Gf8PnZDyy+uaMecOoVnb4Y
+        2u8+dAcdH1+qdc6jzw5f+LDH7wxwMdCgO+TKDbZTaVq2c3BKXyAeHbFiOgmJRYMyGKL0vzrrAdms
+        2M72UWcFKA9ri19s502xHVr7t7Ad17Kvm+zUnH82suMifzVcx0BWRU6eSHUM1lXWGlTHjP40qjMg
+        cLqDWzSQ6aWpjsbKp7nzU6jOwfcPenDgZgG6dt9lLss3F361A3/a2Jp36e6U54hfcrrK+5iuIruj
+        0+XMJGNf5Rf2zqf9kU737D0NPYYYhzTGISGePpxOdo/GHyCojv3xvMKRFsvsVhuFbd8j6417AuBO
+        86DXHWI1LzmfFs2Mx/8WX9k7uu+/OxhRxIj8B8H0PLogvEcwdDJaO5RsnIrWRnSFzHHmIBxGQR/3
+        Ha4RbqueG3uO74GmG7ofw0e78aDmkOVyiTtWfWnbyGe1mjaXO/aLfLe6brnfHRCW2dY9A1geSBLW
+        583rnjt3QmoL1B0637nQcDcMUKzdO0B/67cHpEV3Fe5iB+PVjw/wXD+hsz9J2OxS5o7DXY/pHxDQ
+        3cT1p+v/AGjkQVYyIwAA
     headers:
       Connection:
       - keep-alive
       Content-Encoding:
-      - br
+      - gzip
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Dec 2021 13:51:19 GMT
+      - Fri, 17 Dec 2021 15:10:08 GMT
       Location:
-      - /api/v2/companies/242975/transactions/74000017685127
+      - /api/v2/companies/242975/transactions/65000017705397
       ServerDuration:
-      - '00:00:00.1193108'
+      - '00:00:00.1074532'
       Transfer-Encoding:
       - chunked
       Vary:
@@ -140,9 +89,9 @@ interactions:
       strict-transport-security:
       - max-age=31536000; includeSubdomains
       x-avalara-uid:
-      - 4628fd67-3958-4ae1-a930-0b811876abd5
+      - c7699403-93d0-486d-b749-30c326df71e6
       x-correlation-id:
-      - 4628fd67-3958-4ae1-a930-0b811876abd5
+      - c7699403-93d0-486d-b749-30c326df71e6
       x-frame-options:
       - sameorigin
       x-permitted-cross-domain-policies:

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_total_with_discount.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_total_with_discount.yaml
@@ -1,0 +1,155 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
+      "lines": [{"quantity": 3, "amount": "36.000", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 3, "amount":
+      "30.000", "taxCode": "O9999999", "taxIncluded": true, "itemCode": "SKU_A", "description":
+      "Test product", "ref1": "SKU_A"}, {"quantity": 1, "amount": "10.000", "taxCode":
+      "FR000000", "taxIncluded": true, "itemCode": "Shipping", "description": null}],
+      "code": "6ecf08d4-c3d6-43ef-8da4-d68a07fe8318", "date": "2021-12-17", "customerCode":
+      0, "addresses": {"shipFrom": {"line1": "Teczowa 7", "line2": null, "city": "Wroclaw",
+      "region": "", "country": "PL", "postalCode": "53-601"}, "shipTo": {"line1":
+      "O\u0142awska 10", "line2": "", "city": "WROC\u0141AW", "region": "", "country":
+      "PL", "postalCode": "53-105"}}, "commit": false, "currencyCode": "USD", "email":
+      "test@example.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '928'
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: https://rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: !!binary |
+        i/8BAICqqqrq/3SXs7qBqpm5m7me0sE9DgEQEJEQ7h53cVU2d800UzVQFfM0h3y5Ecjcap1+bvy/
+        R1w0EheJxPdzIi4umqJubJ0BiFj29P8UPNmu1Vpr0+36rak7RS55kKUd3KB7325c43ebtsGw6T23
+        G7/rWXcD+sb0pMilaeb4evdk67bed1tFngVkqda12Zh6YzpSVIRlKWTpzE94UiSvuRPMnXlEeY/P
+        FBxI0Y3FPY4hFm5gl5wR3Qulmev5RIqwugfHO75ZcBS9GLqlSJqQr4XvuLzmXsC1LkqQ17XAkYTU
+        2fwg+pQ5Ek2WX9hjxTTLZ6JqvJPhUnRhhCc78FigaEyOJaRYR0JCcHPKEuL9g96L5yW7Bxd8ZY9s
+        nM2AjOhSFil3BDojF+8qEF6/nsg5+BFT/0wRRNbRYUpLFLK60lxtv8ElRcqIXZLwKE59Z6puj5O8
+        zYuHASv1FIozrRgPL7ySNW1VG0VCtBde+TbCbxNfeD3y6JaRBb5mDdj/WYpMiBJq1c8kBwZPeBJV
+        9oTicpivFz7RdUzurx18714z7oFO75yD/CJLvz9I0RO58BgaRSUN8o8zfvDkqTaVqaumenSYSTnc
+        Qzx4n1HKuyfbmZ8Bw6bt9vW+6RV5FAnxkfGiZKFoZRbsZ4nfhgFOwhMnFrSEpus/kS/iTtZUugv+
+        mfU2Jg4jWRIU+YWVp3lE5dJEim5LCTEt8ma3IWzfcuySm5IPQ4Bvvje6mMZujTX7qt3umxr/AwAA
+        VVVV1f/pGsBnDQdVNXdTc70ZeGQCGGRAhEO6+yXjkKBuKm6gAGaqlqqiAW6Qqk50smindNOPUdtP
+        hYWBgYWFhZMuneLAwMHBE3i9TI/nbg0qSP+ibf5AYEk+PAL5W6E8eFjdNeqoBdg93xwTLLTU6lXp
+        V2UgMIdIBfbrP4KHNUZKKdu96g5dqwU4u1jcyCHFwcOafQgcZdruoLQRuAD3PupypwwLBYF7qtG7
+        vH1+U87BEwn8SgqMtXBaKN+Km+i6rQQLCFDkwNut0Cl5gvmOpzLmsHJIERZXKvyy5uTryAgg4xCd
+        Yey9z1RKDVTDC7Fs9uaoj00nkHKYQgzaVGU7x4cyphq5X/7QYeVOOla9bitz6fSkZY3cFdhOlLk6
+        qgTFPhJsU7gSysC0XN3T3WeC5VzJAedyuZ5hH24uEJRp6XkZLr9uf3uMkg9Cvj7utJFS4F91cURQ
+        2IYjLNNDFWLL9NAnGdeUOcRpuU96pu9+7JVKQlBSzWOIEyzeqMxSGoQ4MMC2O9McKbFv/TIcznyy
+        xzm5eayzY/Lhj3cn7fP44XJdckyDhz00e5lOH/lN7J4/4hSiFhZl9xSNpBVEsPhIkSBwryXEVVOS
+        iz7CuH86Jn5OPVjndZ599ptcUROVlGmI41w9+fWI44ldmAvs1xPgoO2klGpvWnVo2s62+h5ib1SN
+        5Og7r6Q5r9VX8n6CvMHi/A6BTFOgSxnJAcP2czhf0AD1wo4JWosWo35JNTKs3EkppcD/AABAVVVV
+        9X+6JshZwUHdwj083G6e5pEBDuBg7uBueUqIg7iphLsEqIsaiIokuENCmrnhp2WHtWVa/igXWYmM
+        jKys7DZtIiQSI4E8Vp+HYzH1FKAH3Sc7EdYiuwTtIgDL2dAIWlOnAN+uXLuSCFo47iHAtyvXHu8E
+        LRwP+02/hczsiUdjrXShiXEemwCVr4LmSp1KMghQb0DbVAqn1BcA8rnpHJ7TgXX9ANFcVQ94v7iY
+        PiGAFBnwgZdMm3txMWjjLMYYaWEnzzQWvkFVsxMa5cAggM4rFmfNi0hijJjl3WIe16smnvxcXEci
+        XQxQSYdaSWOWK7SwpWos6ARCCGD4gPZ1tnppDmo9b7xZz5oVy7Wx7uA2udWm8+wXAjbS4BBOjPmH
+        Fp+ADDuZ3DaSCou6mPFsKAk1/ZgUe/24cbsVZXsKgRptsexK7ERXXtqiyyOx4aPDPHpGozRBORz+
+        kionMgyTXRSd762mklST9NxF4r78t7DV8ddpk5Ue4vvL/AUiF7bD10+sXF8fAtLOVUnGZy6uQgCu
+        fZEj1jrc1KH9wlyJ4PxFFHkFSlNRY7kOXb2dM1pfnthC/b25OUXfP478xzqsfZlL+gEfHebR1mII
+        kBkvnLeSadVAOZPC/09rhKNcsJsWv962ZMi5QvvnsxIutC/jIxP6TBT+g1RGv5PYnjM2ulsi7i1i
+        jPPl/G29jsvXAKmMfiexPQvtEv4HAACqqqqq/9M1gc/qDqpm7rbozcAjA8AhHRYANz8mJKiriZsr
+        gJmqpaqogzsEuNkmfjLWWjvEtEkpF4lEIiuRyO52s/4lsnKyepkez95GENHeBV3XUkpZbVSzbapC
+        YAg2z+S5G4ZIKe0H6FrBcF+5qduiLRuBKVjDLvj+vdAuDASNy8Mt3zHM+IifMs/j4Dwd8KvV86ol
+        RrVVTdvKbWWL4Q3zMyVj5JLSO6QP+PwVeKQdTf0fAjYk3vuUo/GWviO58cHQci0FnoaxD34+XFZF
+        KU+r1fmAoAzHPN8o9u8ptJMf8QNHF95YxDgan4xlF/w04hvDRNVVs1VFLTA5T9X0IjQKCNxC9oOJ
+        79OTYnSDBDKVAjYnDjPFazIjNYaDvwzk2fH7mlQPBAIDJRvd0hQzaPSU+NcSw5AtA7Sx88bwsU7j
+        ddavC9GNzoNeXFlEBpdsyJ67+Qu7YDngvSyhF6AXzQsySu62o8iSwKUz1GPABHLFpT3T3JuXuU0E
+        zTFTAORy6c/QdzMlFxrTvFuhdpc/138dpNRMiBebddlKKfA/Gy8RKnS5UByR7gppS4t0L/oqjbSE
+        yM6PX4avLlghC7VSxUrVAKA+OzuwpIRJCjla50dofFESNFAIsHlBb9eV+hUboXVzyKnYSG0RsjOT
+        zZNhGuDrPk45tYemchbwPRK13EiTr/wGNq/ffnSeOJIr3xzbwwwax+AJArecnH+6Ynem3N1j1Sz7
+        ObXv5pA9A/8DAABVVVXV/+kaIGcFB7XdzW4WHhAJDuBg5uBmcYqTuKmEhyaYixqIiia4QZpt4oe0
+        m7VU2wBcJDISGYlEctMKWVlZIQduqD4HsUxs96azB2tA8TX+IxHv6EYYA0MHgOj/Z17W5MhBp5LI
+        gCNFv0bovv+Dd9A1R2ttVjZ1VhV1a0AFOeKiPvDFM51dG8+2LrNjdazzilOLloX7rKmPVZY3BtA5
+        oRgxCX1pi7Jp87Y4GlhCYpUdOrhewIDQw49LSUkNvn+er1OA4FFRSfpM9KLnpv3TBgrJYdZacuTc
+        8tWhNOB5Oo0aevM3iY+n4Ai+xUm0AZ9Fw3jphw8AbM4v2SFe97m1mc0NRP9g1CTkwgqzcesjhZMb
+        AgBKxjbvW6GfhhlULq4Vyvy3soMBDjzjC+8r9aGuC+23tNI4UAui4mY31B5yMCCYF90e8mLfyFo9
+        PpSZbZtcDz6FJIvpYZEk1Ffo3vMDOvigqJ5xE8hPaICuOtSZN1RnvnheHoqWcRlsGJNuSc8Gm9Kd
+        QDI0GOUgmv+RkDZA05m3pD27g1G5mHlSZIfi3pIin5/7pL9BvO5GEI9WVlOR3l4RiWi5rS6N9oqv
+        E65LWlHJJYh1/ElYFrasS0zX75alCilL0mmKIPc1frHXCF38c7mvQqt5fq+/wC6x1/HnHaOPzxEb
+        klMSIV72XjwFAz4Oga8Y4/wrCbofXCMR2CeRcj4Q2oKo58eML7yv9MX4HwAAqKqqqv5PdzmrOaia
+        ubmZ6c3BIgPAAQw8HMDMTwFxUFcTNxMANVVLVTEHNwgIy028A9ZaS7Mss552zUnkS4REIlvtXk4i
+        Z+TcmHLcTSkR5+/ECXR+PBSNgIhriEx+ugY/mLd5OLx7Eps8SEFZun9vXFZOPxsH8wZdHk7qyuoP
+        5t0aZzdnGEdG+k9H5kGOeB/2FUFDj85hhL8fAT74m0mJ5xi2af5ANuQS6O8fAY48dsEapuCHfcUE
+        +vsXxmC3BT132M5cRtDVSUqpSlU3jSwrwc93jl9LKeXpqOqyPuVY+vM4RkyJRinAL45VkzdFLcAF
+        K+JhbRg7oDfT+hnDAn/it0yujr/u76mR9NaiSFLSK3UIhtLm1MoM8yDAhsQXn7ZovMXPiDTNDHq+
+        tJdhbvRvXZ/lhfzKslsHSQ7XbXlgHPYugmSbELmL0s7VPY+j8clYpuC7pY4UjKo61aXKKzE+6voa
+        Z0FDAQIeYfOjifvXC2OkES/iqxRgt8RhwXhPZsLCEOjniJ6J93tCqdEBASMmG2ktCkEwNSZvgNsI
+        i5arZ12INJEnZVLYOCMlGzbP5+WEj0lnQoMVyQTgKvDOPMKtxcgdxSNo1wAi2VO6MC7DeoUONMcN
+        E3D6friBfhqXQmiMSzu2MPYzrSv5CRwMZzW3PqhCSgH/N+ONQQOtDivK+lSlQov4zL9SXcNW0z4M
+        /6uYyGWuMpVnqgIBEV9ni/8BAICqqqrq/3RNkLOGg6i6mamZ3gzcMxIMwME8wNxveRI31fDUBHNR
+        B1XRBHdI0y28g9+/tWSZVgVIZWXlSyQSuWTaIJETcnJuTHecO0BItP63psoCDkBBSTWvke/g4BiK
+        RCaJiUGB0Auc3vVWgdCLblsYH0nKu9/pPcHFgba1biTBV1+LQ/IBHHwu+GNxE2KaPLjG2kFOP5JU
+        YmHQ6A9tPrStDf0n3yOTKNDq/C/kHH24vp8Evp4TB1BwqyVyKGXygSV+x7Vt+pxA+kTHpqPjDg9m
+        sxyWQCWx5PHbidet+uDBSa5BgQ9CcSvgfv+H6MF1GhF1Yzvd7rsIWGfiQqvExKfI2Wh2CIy5a3Tf
+        9p1RZYlEN9uUYKNt17faWAXkfQ5BB2dZrHDf2MEM+17BerjJb3DwdQIFOdxju8xILujvz+nrEiD0
+        IiQBOsfwCo+njMlPR0TmKLnl1KFREPmiRgs9/a05lkPyc0Y+K4M+0+NjP5/G+Ugc5mN2itfeIGo0
+        Ckq8M0nNwSUq9BZtLCws+OUc2bhu8z7MV0BjdW2k3M5FfoMCTnylu5cqhopvrC91WwEViaS6+UJS
+        ww4KMuVFx53Z41QoWJMPjcbBGjzo5T2gmXoJOdQlrEV+Ka/JtD+9lUrVvoZzlWeV+x38Um8MZJoG
+        ZzgI1n/lVJ8Ep4mfVUb2wqTuZb4IsafsfwRF0c9jlT8pR3kbQTysaZuiLpeIu8mDM9hqNAqEXvgf
+        AACoqqqq/k/XBDmrO6iaubmZ6S3SIh3AAQzcHcItIAAiIQ7iphJuCqmuaiCq6ukGAW66hdeyMWv5
+        ZcusryCVlUgkEvmSTKtKZOXLBzdmx1/MQuyeDt2YHSYyoNW6qaUUkPBxvBOzNQRarqUUEGJMNCwz
+        gYZzQm+QDSjZusCjwRluoB1eHL17myLoZq3KK9B98INY1rsnetBtThWpCvHsbTp+/8ZoI2g4EXeZ
+        mfy4sIiCABsPwZ8wxmHiDPobXSQFbUd08nSY5sDJ+uvwdimmVsAOwdvbFdE/Do+r3AZ8xMZ/zkeH
+        bsyhvjwBzuLFOpuWCB8nco4Ynl/JkHQSSBOHfJ1eKaF1EfTfr0o4nvowYrLBF0Mk9wdMGPONfOot
+        cYjsDehtKaVUlWraVla14EthrG6nidN2o5qq2RZMnl+MYYoRI1ULbrmp26ItGwEumMh1zM5k5x2H
+        GzyFpc+1Wj8VRyotfWNDCJT6FLvwEykMAsYQ097HzOhH2jHZ65TgP2MIuGNik3/qz6uilLvV6tSD
+        SM4h3y7EwzJTIlA5JigmxEozYLVZQoytzubE6COOw4JUWr1BcF3V26ZSRS3gErI3yEtPd3Kg4dPO
+        FQiYMTYKNBwd/o//8JeSQrICuiBhtNxydLRpAQ0fb8euf/kAAUxXGzzA8xxiQtd1z6MqV0q+gGkM
+        2SeuhJ7aQ0/4eKuj/d6ALmSlZPEUP2ANIGYAAKCqqqr6P10D+KxhIGrm5uauNwcPCIAEcPAICHeA
+        BMiAOIibCkRogpmqgapohnsGuOW2+1Nn7c7N2lH0I/GjkUgkojMHopFoibpDO34Klv3XDZaIqFsN
+        23bbbQw0cyw8akjxl4cbVkREdlhvetsOBpdUo+d8O8g/meDwJyw9DKYQxcLhLOP/9M0PA/KMLRwQ
+        UjuwdQx6g8PvnMaJv2GQ5TOkKOCnJRXlaZ+8wKHvHtdkYTCmGjVXIn89wED5+lYnbseXlnpL7f3D
+        YEojb46W822RAvf+A5/GOkvUAzu6urDePFuyTdf3A1mjHRx/++a9T7rzPkspMlELFK5dhvv1a6ev
+        sDznNONuVpmnWyzmOpTHe7KKnRMcQix1ntlHhPcfTyeOI6wOx781h+IjTjjsze88o/vbsJDakWcg
+        eX057I5P12G+q/qVctBbG7aseoOirLIrJXxG8cd0bZryVcUML1WXqkiLneqF6bekn2In5Z+Hun94
+        YxUYZFYRdzu91dT4Mgnc2jbDVskEjpq2cwvrkBTOrprWxlLZ8zTWiVU8M5wxxXOjPlBThwa5yrxo
+        SBGOGqL7x30=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - br
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Dec 2021 13:51:19 GMT
+      Location:
+      - /api/v2/companies/242975/transactions/74000017685127
+      ServerDuration:
+      - '00:00:00.1193108'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - 4628fd67-3958-4ae1-a930-0b811876abd5
+      x-correlation-id:
+      - 4628fd67-3958-4ae1-a930-0b811876abd5
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit.yaml
@@ -4,85 +4,126 @@ interactions:
       "lines": [{"quantity": 3, "amount": "30.000", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 1, "amount":
       "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
-      "description": null}], "code": "7e3a27d0-5bcd-4678-b362-33d3b0834d63", "date":
-      "2021-03-02", "customerCode": 0, "addresses": {"shipFrom": {"line1": "2000 Main
-      Street", "line2": "", "city": "Irvine", "region": "CA", "country": "US", "postalCode":
-      "92614"}, "shipTo": {"line1": "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW",
+      "description": null}], "code": "d1a8b22e-d8b8-46ff-9f87-b4e16de726bc", "date":
+      "2021-12-16", "customerCode": 0, "addresses": {"shipFrom": {"line1": "Teczowa
+      7", "line2": null, "city": "Wroclaw", "region": "", "country": "PL", "postalCode":
+      "53-601"}, "shipTo": {"line1": "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW",
       "region": "", "country": "PL", "postalCode": "53-601"}}, "commit": false, "currencyCode":
       "USD", "email": "test@example.com"}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Authorization:
       - Basic Og==
       Connection:
       - keep-alive
       Content-Length:
-      - '782'
+      - '777'
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.26.0
     method: POST
     uri: https://rest.avatax.com/api/v2/transactions/createoradjust
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEA+1ZW2/byBX+K4aeLWF4EUXqqVo7Loy6lmHJu0CKxWJEji1uKVIdkl67Qf57vzMX
-        ckjbadIk7bZokAfxzJkz5z7fHH+Y5Nlk6THmBXESeIs48k4naZWJyXKyEAH3FxmbzndpNg2jRTzd
-        BZE/DYIs2LE4CLMomBD34cjL50vI8UM/WcxPJxlvSIDPfG/KginzwVY3vGlrUDf8UWQgNM9HYtrw
-        QtSX5WOVpwLUHW/S/ZlWgIS3UooyfTaUu805iOIp3fPyQdzimLPXGNK2bqqDkHc1fxBbfQ7tK5u8
-        eb6rhStfc/4oyqyShs7UwXrBIYkncTg21xWUBoMUaVWmeQFblve8qMXppKhS3uRV2YuX4ljJJi8f
-        rl4sHVsJK2qxlpmQvdB7QfY6Gtbkn6OQtSu34U/rRyFlnlnzrquS3OcsrA5VWzaTJZuxAf1WcMjS
-        RjRVwwvLGISzIAEr0d4pW+1mopzndeoKJNqWP02W8xnljNqFb74rEFVXFIhnvEjbAtGCrzQ7z35F
-        jA6ISKfOddWsFFVlR89wLupU5kdyrFYabv6r43UpHrolpaF8Bt/NFbwBF9VqDQrW1X3zG5fiR0ub
-        +N7Mm8E7YKxk/pCXqyyToq4pk+eMUfaGXhzFERJa1IiiCq7DFIJp7iWBzxbMH6blu/t7kTb5ozh/
-        pRTc/EXxUXxwwNBIceB5ATsanPwH8cQPx0LMUGpQdtfWean0pIS+z3XS2RQ6VBloIntx8JYtlmG4
-        9KPZIvHmYRC+hyzLjaKQqoLjwEtgC/LoFQFsyeg/bSxIhcnyLx9UAwkYC30WJQGbhyF2S17WHPZX
-        JQkdtRfaet0edkLCPo8MQl5lXD7blKY98MnnV/HQe1u47OQoq6xNG0j/rNj90wQw2W9rRRVVZojU
-        YYzOukcMuDTpTMhmwGPjldeXjTh0ldPIFp0krzeb7U3XWHJwmKay+dPdLyvjf3uMT4XL4LG/tVy1
-        OBQgJZUU954uGfzy7S/TkV6EF0KleFylpsqpx9UVmhS6F7ae9xWABaSHrmQ6FR9U9QNtFHVc9obZ
-        WLJO9D8tjojkn3kQapGv6YeT3pUoVLo39DabMqbJmy746QqBFLvN6vzJHsmfLsu0aDPqOTo8mWhQ
-        nX36e8jwgPlJELFkEQzy/wrakl1fVCG8b0SjHjNqcF3vU+1OLT5fXN5stH/oyhX954vcZBQQTdVd
-        mBRF+eblhnZ26fdrK/PaRE0dpAjX/EBxuFlfra7pVlbELO+q3geooLZY5w/onK107zQSv6ppRWS2
-        ENR+E8ez6+1Iol2gKwgN/nRSVuV2mHgIorKoX7ltC1uYPdFIIvBA6xAllbFs5iNI5BL6tltDDyGF
-        FUTbUDlYgWiYxiWQ8K8XiqkJo9S6bY4tNS3k6KbdEZViMllrEn3/UVbtUREvS/CuyszdZIKC+FFH
-        zU7ISr131TZ7dLnm2QoNAdRwzK26Pkmgz+YqYCC+Ubm2bBQu6FxldLdn4jhyFlGNgzZaA2oSd2Xe
-        oG66jtWHxazYIOq0HBFb7F7f/8DrHDImN4iAQX/Eh0Py+roqb3hdb/ey7dI3ry9En8wdJDPZY45Q
-        GkFzC9ggaMigWkS3/E7ho149Zye2WZTTsYM2dildoXyXFyYisGcjigJ34sefVXKTGc0ewX7Yn3ft
-        Bkt0e1o0ST7WXSir0pbQFLUbd5XiiqvBjyNElyUxgJDLSsujzmSXHZwzAkPAXwoJuRHe58cLCXTy
-        8fTD4ICxLmiUX6nMqCG+ocy2Un7c27aF5Eirurks6xbYJBUXUuQPe4uOH3nTtbfNFG1gPZ3eUdZi
-        QSMVspWcxcjAHD+gRod44kHHJ7ZPIR56DH1jxAOJ/2MoB/l0JOCh891e057tDj3QUej5OwMde2oz
-        vG9IG9VC3dJ2eE1KXdziKYGEgC0QQETKkHARE1B+BWZrvt8nzkHSeyyaJ1EQ0kuxh/kW5nxRWfwf
-        5vxHYA6BnDHM8aMknqOPfQ3McVLffQ90RYtkpzZKcOYbwZz3QlbfAuI4mn8S4tB5KM8RvKHnsGkN
-        BhB0Jv9u4I3uVR0e+Up0oxpfJ2w7BDdq8d+FbdBX5/OIxRhahIuX2GbUjr4vtgGQ6nRBb7eHvdEa
-        7bKDs74/tEHdX7wNbYAuTUt2RjsjpZye/wrQsbjmSjwKml69z49zVAdhVppEbEX69+o3frIwNDOT
-        oOUAy6CmgMP49dPt+uxq9RMI3QsXv49AcLww1+o8mEaMpkejJzEqcfyksZhthGO/zBQTJxxorcED
-        l538meflyYYeH0R+06BL+YhlcHX2nNEUZ2BR4kdeOF1g7oiV3ioFRAdWhcxbhAwXMEaqeYPBBDwW
-        BLMoDhdeRJpUGJIY+tTzFrN47oVxohCxi5dHTwcH1iuEAqTue5EfYFYInGPz9ZWo2yUnlUeudk81
-        8du8+mQY6QAxXsziJIrChMaw5pXzeTqMMvcNHcxLoW4PB4wg1USz972adnQh62cf5h4766YRnzci
-        QRQHz3DAQDzCkdQvpyFgffuyRLzNRMC8992L0N5OYDL3FWTpsby6l/T9ZZ/wZv6gPzVCdYb1dDG6
-        oxbLpl/narROLFRg/31OswMLiyAcx9klFFPnPDshoIkK/qhih0VYt899/HSfAvovHT0EeMt5P3/8
-        B6X3NlWGGwAA
+        i/8BAICqqqrq/3SXs7qBqZqHmbme0sE9DgEQEJEQ4R53MVU2d800UzVQFfM0hzRzww/pWmsL067c
+        uEgkMrIyMnJMq8jKSpScG1tnACKW/ft/Cp5s19d1XeuuMbpuG0UueZAlr7kfjMHO90O/27fjuDuM
+        fbcb9tCtR2fawZEil+aF4/PNkzV7c+heFHkWkCVTG73TZqdbUlSEZS1k6Zsf8KRInksnzH3zhPIW
+        Hyk4kKKBxd1PIZbWwK45I7onyjPX7zMpwubuHG/4YsFJ9Gbo1iJpRr4WvuHyXHqh1booQZ7XAkcW
+        Umfzg+hT5lhqsnzDHhvmRT4SVdOTDJeiCxM82ZGnAkVTciwhxToWEsItKUuIt3d6K17W7O5c8Jk9
+        snE2IzKiS1mk3BF0QS7eVSC8fT6Qc/Ajpv6RIoiso+Oc1ihk66rmavsFLilSRuqShCdx6o2pXgzO
+        8jovHQZNqedQnGnV8OjCG9mu2veKdGQvvPEwwW4VXng78eTWiQULh70kYP9nLTIjSqSXfiQ5MnTB
+        k6iyZxSXw3K5EApOOiX31w2fm9eMW6DTnnKQn2Tp9zspeiAXnkKtqKRR/nHGD548GV1pU5nqyTGT
+        criFePQ+o5Q3T7br/gWGzV7XfaMPijyKhPjEdFNKe1aC7Szx6zjCSXjgzIKWOGvzI/JN3Mnqqu5C
+        P2Z9jJnDRJYERX5h43mZULk0k6JhLSGmJYMoYQy7txyb5Obkwxjgm2+NL1rb/cGarmqa9qB7jf8B
+        AICqqqrq/3QN4LOGg6qZpS16c/DIBHDIAA+HdPdLxiFA3VTcQAHMVC1FRQPcIE1d7Lovj7V8IGix
+        jaVysrJysvLlErSpnEQiERK9TI/nboVKSP/rLxSW5MMjkL9l4qOHrfraDJWCuOebE4JFpSvzaqpX
+        00JhDpEy7Od/BA/b9Vpr3da6qvpCCtjF7EYJKd6HmhKYrq6MbmuFC/DdqSx3YlgYKNxTid7x9vFN
+        zMFTIX6lFcaSJS3Et+wmum4rwQIKFCXIdst0SJ7cyXvKI4e1KZawuFKWl5WTL6MggUxCdAa/954p
+        5x7oXYsby7oxuq/NoJA4TCEm3Uhnh8CHPKYSZb/8YcDqnQ7set1W5DzoScuaeahuOxBLd4h2sp0S
+        LCl8EvJRaLm6p7vPBCtcKIDgcrmeYR9uzi6o0MJ5c5fft689RpkaoLhqdvWgtcK/4uKIoLA1RhjT
+        wzRKxvSoTuzXxBLitNw7g+l7P3KlWrDIqfAY4gSLN8qz5A4lDjjYH7vWHCmjt/2SSikKnhIJDm4e
+        y+yEfPr1xaR/DJ9Ur8sBOWZC60YbvcV3Evf8GacQtbCpuKdoOK9gBYtTigSFe8khrpqyXPQRxv1T
+        m/hc2lCXdc4x+0Muq4lqyekYx7l48uvhwJO4MGfYzyeQet9IHL5phqGtW/YQfgIXfQ+RG1nXa/1K
+        niNOqw+V/Sx5g8X5HQpMU0jRwyXBbb+O5wsI0MjihFx71eLM3GmtFQj/AwAAVVVV1f/pGiBnBQd1
+        c/MId71ZmEcGOICDmYOb5SkhDuKmEuYaoK5qICqS4A4JabaJSaA3a+m0/DW9SCQyMhKJZNUKIZGT
+        84b2HJRJ+/+D7otcCEtORw+uNhDSICgETljJwI9yKG32BA7OJzCgtA7vxdGfmu5A5PBhkqAlG5W1
+        a1sZKGFOKMrUqoiDgfIC1aawFOS7DAR/XmrjcynythsBTap6k79nTcJPMJByGvGB10jNPWsScHZl
+        rbVs4ReNtBZ9E6rmFxTqIQcDvC+7XVUbEQEGGuNdvbb7twqXGLLyxHBnDRTipV5g1yHN4OBARULC
+        JGgJBgQf4Lar17U5MvF8iqpebfZcUmNdr7KozEob9MoQjFToYQEWn5x1IXg4pkWlSX6w0MOMg2Dy
+        yP5lU7rmx0blljnIU4igUeutK/YLzeFo2bbFa8FHi3HSiEJ+g3Lo/xJz8BQYTXFBdH5XQwWjIdng
+        QnCv/ncKUsCtf0yXVPYWN/qZ/ETsawrSf79jCQUcnIlbZaY0PXtpFwyE0uV0xlLGGyu4b4yFGGq/
+        iJBjwbRklpDm0dXbuaN2+Ytl6F/m5hb7sHieaRvPnh9wbzFOsRaDgRjwGuJVEqIaKEZi+P8VDWOV
+        Dblx1vl2IMEQC7g/X5MUiU55+mSMnEEt/4HPk94pySl0nHaOHtyustau691+U9vdq+kv/ejB4X8A
+        AKCqqqr6P93lrBYgamawuN0cPMIBHMBhgXCLYxzUVcXNBcBM1UJV1MEcAtxsEz+BrdauYtqklItE
+        IpFIZGS33ayPRFZWVi/T47lbSYnQe9oOEbGpsCy7TanABZtn8rJ1LlJKBwd928JwX1Vr7Cq9UTAF
+        a4SDH14L7YIj6OH64GUfwwxv9Z/m0Y/s6YhfJN+kqxFR192mqrFrSj4FL5i/KWlj79ohwPtXwSPR
+        DNdBgQ1JDj7laLylfSQeHwI9fqCCpxFs8C/Ha1FWeC6KyxGCZE55vlEcXl3wgG/1D0wXurHVKNH4
+        ZKw6OHQz0W1VamwqBRN7ysYnoYcSFNxC9s7E1/lJMbKTgKaowOYkYab4k8xIhaHAnwx5YXn9JNWj
+        AwocJRt5KQoFZ2zC3hg+RvhNsyFEHtmDXrS1leM42ZC9bOc/7CLlgA5SxFEBrTQvyFVytx1FkQGK
+        zlhPAUjSGU4HoXkwq7lNBL3ETAE41+twgf5upuRCFZrHEez1wcvCfgQFOXNyuw9dISr4y8YLgwq9
+        HiNapLsuxS3SvTxFZwlR2I+fRnYVXomlLnRZ6AagqM+t7ZbShZ5CjrYkeg+flNSMAygQs9ZB6doj
+        Cf+yneVhobMFnJ2ZbJ6MkEMveyt1/40fStkkYA4O+rptN9fpJz0jZv3yI3veSK68KTKDGfRwCp5A
+        wS0n9k+VZEfKnR8nZ8mPVzPpbeFdMev5STGyo2/8DwAAVFVVVf+na4CcFRzUFjc3s5ulB0SCAziY
+        ObhZnuIkYSphoQnmogaioglmkGab+IGus5ZOy1C4SGQkMhKJ5KZVJLJySs4dzBlFhL8gjIGhBTCg
+        uN94XpMjB61KIgOOFP0aof38D95BW52ttVlZNk1VVI0BFeSIs/rAd890c9BeGmutrQqb53WTG1DB
+        tCOnSB3YZ5ciz2xVGEDnhGKkSarAb0WZ2brIGgNzSKxyQAuPOxgQWvy4lJGcYMfH7TEaCBYVlaBz
+        op1em3YvGXRo7UkdlWlP8g3uOpQGPI/VqKadv0l8vAZH0CtmUHt8BQ3DvevfgYjq/OwdrLXPrc1s
+        biD6hVGTkEoUmC22LrIwcn0AgrKwTscW6Nd+AjQW1Ury/Fs5wAAHnnDHr5U6U9eF7c+00jgQSyRF
+        TZ+oOWRgQNAvuj3lxVYCY7V8KDPbXHI82BiSzKKHRhJTb2Z9zwu08E5RPeMmcL/QAG12qi/bhujM
+        l16fsiKgivtccRiSbklLg47piwFbaDDAgTH7LSFtBE033pJ27AqTcpd5VGSH4t6M4q6fu6Q/Qbwe
+        QmCNVp67kzyfiBjU3J5vRr7ifsV1TisqOQPpNPwjEe9oX1i2xaJr37JTZsqOZJwi8LnsD3uN7s/l
+        WoWs2ve3fiO8xF6H718YfXxGOCTXJEI8H7l4CgZ87AM/MMbpRxK037hGYqAfRMjLEdqCqOdlGuqT
+        Z0BoC6KeF/wPAABUVVVV/6drgpzVA0RNzW27BXiEAwSAQYRDhCUEQATEQVxNwE0B1FUMVNUizCLA
+        rbn9/3TWqohY+4Nw8ePionFxUczp4+Ki0RANIeqGjuNvYgG0d54lDLTS2fP/4HKCDu9QQeRZYnbh
+        8rjydc7jtXqgFTp919Qrkz/QeiBvF0+ZR8bwTe/o7LzL27DNDB28sfcc4falIEg4UUp5irJcpgfO
+        5HyC7vNLgXeBe7GUnYRhmzlB9/kHo9jlyiH3WPY8jdBVBhF12bSmxKZS/LlyGnWLiFgZLIqmLRDL
+        +3GMnBKNUYN8U2psjG4VeLEixnSQ0QF7k5uPUa5wU3+fmaPnT/o+q/aSdkWFrTZIoGxTkhm6QYGV
+        lJ9CWiIFy8fI7jJl6FfSN2Vu8E/9264weNztTj0MuXpermeOw+ZCgDURKCE5OoDLku6UeTlSSGSz
+        k+CdrG6E02Ndm0JjZRScZQkjxa3nb/bQwYeb96A65oaGDga2v/JD/2o4FyvABJ/eBTaP0mtd3qCD
+        99eXQ3//DgoiX5wEghSzpEzeVCj3ZlehhggoLyHHTcLJHeVM6+seq8aqwL3G4qYMhbvWkQ39H0UU
+        6+kHP4DeGcjvGpHuy+I61RD8qkZENHXZ6rKCiwAAQFVVVfV/ugbwWcFAzdTczFxvBh4QAA7gYO4Q
+        brcAP6ibCrhrgJmqgaoogDs4mC23h03NSXOQzSMuEhcXifZIiESj4IYix6/E1X7bCdgw5YU8Hy10
+        20kpZdmqqpSN8nffWxspJYy0Ff5TdSk7Ve4F5jAZdsGP75UOwRI0rk+3/sSwYBOfEZue2OPupc04
+        8qqt92XdrHKtNjqbHgO2m0DKy2LiG/rvgylkzzFCXE4QiPRwwWfq+s/RpXMwoXGAS3f6gVIoqA1m
+        EXKX86kfviHA5tVnfobo+N2Gk/VOILFh6lNyD092CNDAuVEe58xr5jTbNd+d2pJ9Snxl462J9uvX
+        MK0NM0xweexWE5r7TNCqKnaVIMlBy6JSrwVZ0UG3Rd2F9D6YecqzYfp5iDF98GObOmRRhQS9aFnZ
+        BQ8tCym32zY=
     headers:
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 02 Mar 2021 07:44:26 GMT
+      - Thu, 16 Dec 2021 11:49:27 GMT
       Location:
-      - /api/v2/companies/242975/transactions/1001389317861
-      Server:
-      - Kestrel
+      - /api/v2/companies/242975/transactions/78000017321063
       ServerDuration:
-      - '00:00:00.0429835'
+      - '00:00:00.0839580'
       Transfer-Encoding:
       - chunked
       Vary:
       - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - d95945f6-00c7-4c73-baeb-68091bd5e466
+      x-correlation-id:
+      - d95945f6-00c7-4c73-baeb-68091bd5e466
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
     status:
       code: 201
       message: Created

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit.yaml
@@ -6,7 +6,7 @@ interactions:
       "30.000", "taxCode": "O9999999", "taxIncluded": true, "itemCode": "SKU_A", "description":
       "Test product", "ref1": "SKU_A"}, {"quantity": 1, "amount": "10.000", "taxCode":
       "FR000000", "taxIncluded": true, "itemCode": "Shipping", "description": null}],
-      "code": "0bed46c0-b896-47b7-8ac2-46e4f77f92b9", "date": "2021-12-17", "customerCode":
+      "code": "a6235109-b91d-4f31-8c15-d7275a1894be", "date": "2021-12-20", "customerCode":
       0, "addresses": {"shipFrom": {"line1": "Teczowa 7", "line2": null, "city": "Wroclaw",
       "region": "", "country": "PL", "postalCode": "53-601"}, "shipTo": {"line1":
       "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW", "region": "", "country":
@@ -30,40 +30,40 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEA+1a227jNhD9lYWeY0MX35/q5lIEDeIgdnaBLRYFLdGxWllyKSkbd5F/7xleZFp2
-        nKS5IAg2T85wOBxyZg6Ph/7hxJEz6LRc/HndrtsO+v0DJ8wi7gwcd8qjVid0G9Nev9NodafdRo+F
-        fqPV4a1Ztzvr+9O+Q9qLJUtXpzDkt/x+t33gRKwgA77rew3Pb3hdqOUFK8oc0jG74REExWpJSmOW
-        8Pw0vcnikEM6ZUU4P1QOkPFSCJ6GKy25Gh9ByG/DOUuv+SWWOdylEJZ5kS24uMrZNZ+odWheWsTF
-        6irntn2l+ZmnUSa03JULqwFLxG/5YlmcZ3AaCoKHWRrGCfYymLEk5wdOkoWsiLN0bV7wZSaKOL0+
-        2xpalgK7yPlIRFysjc447dfyMKfzWXKR23YLdju64ULEkdneeZbS8VkDw0VWpoUzcJvuhvySM9hS
-        myiygiVGseM32z5USXYs92omk+QozkPbIMkm7NYZeK1m0NPTIGDTBGG1bUF4yJKwTBAuHJbWZ9Ff
-        iNICMakcOs+KoZTK/FgrHPE8FPGSjla5jYP+2zp3wa+rIemjWEHv4gzngUPK5ZiHDMxmxXcm+Gcj
-        c3yv6fnNoEkBz0R8HafDKBI8zymZUQ74C1q9IAg8TI94jkjKANta7U0tOzePZzMeFvENP9pRD7Yi
-        DoWChBU298kXLE6wlQJL/8Jv2WKZ8CbqDe5OyzxOpaeU1bNYZZ7Jo0UWQcajrYUnXnvguQO3j417
-        Qd8LvsKW0UZlCFnGvcDrUyaw2y0DUE9oYWfwxw8JHj3av9tp+W2/16FMEyzNGbadpWSrji00+bxc
-        TLnAvjzaCJIqYmJl8pkmwczjS3jz1CY4qk9LkUVlWMD644L2cOx18ptSkTUVaSEBjPZaQcSGlhId
-        clFs6JhIxflpwRdV3RSiBJDE+Xg8uahwJYaGxpTx71d/DnUMzDIBvMHfgfNPySTCOQOkNCHUzFP1
-        gk+++aQBaVdgBb8ZhrrICeLyDBgF8MLUo3XyYwCJgcg2cVXgExW87YoU2gVvFPUWRn31p+yQkA6m
-        HbQoeXZnHMTHKaqT7gs1zWSLBneNfvuLAlbMNOPvXmxkt6dpmJQRIY2KS8QLFKSV+wHO3Wt1ux23
-        53fg/jr3z+At7euJ5cEs/KkhSw3ZKtCTOCcHVyenF2N1RHTb8vW/W3kp80VJFfySry1kXjqmmWbD
-        f5UiznXc5DpScM4WFImL0dnwnO5jKYziquZ9HIoL/Mjja+BlKezbjKwPcxrhkakBOV9H8vB8UrNo
-        BujyAbAfOGmWTjbTzhTAeuSyTExNroXaEtEGGocpIffqNn0KJJWMHpKn4bn9LnZBsjFVgjEIlNRH
-        AgsP1oi0i9Srl4mRa6dGZbEsCbGgOi6nJCUnnJES0f+/iaxcSuFpCt1hGtmTdFAQPoLT6BPtUs0d
-        lsUcCFesjNEWKBqWuZTXJhn03bYMGIS1wjVemsKRjKA6Ku27WRPL0WGRVB/QWHlAe79K4wKVU4HV
-        Oix6xARRZWVNWGL2aPYry2PYcC4QAc37SA+LxPl5ll6wPJ/MRbkGzvyEI1M1PavI2ERFQy9BHsFx
-        w9RgZ3N8c/hYEqO1d9ZMTNOoWBmDqHagdH2yaZzocGAzY54kuA3vvsnMpj0Uc0T6en5UoQ2G6N40
-        JJIOWIFQlIUlUShCG3uUgtqV4NRGbP2gHeAqtHRpvI5MZtwmNzUKBN4l+Y8d4Xm8PBGgJHcHPzaW
-        2HKHvmR4z3Onhoj3uDPJ5GHODXAhPcIsL07TvAQ+h/xE8Ph6bpjxDSsqgBs3AASjRkNRR1YookK7
-        pQNzaYsxnRwArqI8YIYW7JPeXsrjw5uflOe5lMfHd47+/ZTHsKRX4T3tZodivono0iEpteu9UtUZ
-        9oGoT8ejct5PfZ5WJj+pz4eiPpT7VKG7CkXLCViJ4rxD6mN5/2LUpwKtd0N9NGpVdOWZ3EfBXWWt
-        Rn7U6Juxn84DdKMGTq/Nfoht7WM/j3DnvbAf+V1JN3yeyH6Cl2c/sPjhmjzg1Evquyjab5oVvaaH
-        o7fbPLJr+MptHq/Z626hOLmyxXYqTc12Ti6R8/jDNnAJkJDYMSiD6hvt6kBB7102ejryu9R+tvO0
-        svjJdj4U26Hc38F2TMkir98x2bGcfzGyY3b+briOgqyKnDyT6iisq6zVqI4afTOqg2/Ce7lFDZle
-        merIvtI+qvMId96E6pzc3+hBw00DtPXS1a159UDbx3R5zvgNp0e8r/GyrW90epaZ8PDf7Dv7RG/j
-        1NzTDzT0McAwpCF6hPj05XJ0eDb8AkHV8sfnJTpaLNE3bTtodFx6TKu9EQB26k1e08Oqv26+1WZE
-        Fibs+0tthhqjVk+y1hS1RmRfTsWvF/TbPnEQUwe7enZm7CWaoXU3VFP1f7tRy0J7/zodxuCPugma
-        l4sFHlfla20tOapsWj/s6DvqsHpqedz7D9Js440BJA8vDMjP7aeevRchkl0/d9zzmGFeF6BovTnA
-        5saPDkiL3inMow7Gq18d4LPdoNO/RVhfUup9g35iQr/1kL8coHeJu293/wGpEvZIKyMAAA==
+        H4sIAAAAAAAEA+1a227bOBD9lULPsWHJdz+tN5dFsIEdxE4LdFEsaIm21ZUlLyml8Rb59z3Di0Qr
+        t7a5ICiaJ2c4HA45M4fHQ3/14sgbDVr05w86frs77B94YRZxb+SxXtDu+q1hYzH0o0Zn2fYbg9Dv
+        NqJ+0O8yfzDsLLhH2pstS3enMBR0gmG/e+BFLCcDQSvwG37QCFpQkznLCwnpjF3xCIJ8tyWlGUu4
+        PE2vsjgkawuWh+tD7QAZL4TgabgzksvZEYT8OlyzdMUvsMzhXQphIfNsw8WlZCs+1+vQvDSP892l
+        5K59rfmep1EmjJzctSYcEb/mm20+yeA0FAQPszSME+xltGSJ5AdekoUsj7O0Mi/4NhN5nK7Obg1t
+        C4FdSD4VEReV0SWn/ToeSjqfLRfStZuz6+kVFyKO7PYmWUrH5wyMN1mR5t6o1WztyS84gy29iTzL
+        WWIVe0GzG0CVZMdqr3YySY5iGboGSTZn197I7zTbAzMNArZIEFbXFoSHLAmLBOHCYRl9Fn1GlDaI
+        SenQJMvHSqryo1I44jIU8ZaOVruNg/7HOXfBV+WQ8lHsoHd+hvPAIUk15iMDs2X+hQn+3sq8wG/6
+        QbPdpIBnIl7F6TiKBJeSkrmvqqLd84Nhq42qiLhEJFWAHa3ekNQqLTc3j5dLHubxFT+6ox5cRRwK
+        BQkr7O+Tb1icYCs5lv6NX7PNNuFN1BvcXRQyTpWnlNXLWGeezaNNFkHGo1sLz1vDUbc78rtNVHq3
+        4w8/wpbVRmUIVcaDtj+kTGDXtwxAPaGFvdFfXxV46GPq9fr93nAwxCTBUsmw7SwlW3VsocmTYrPg
+        AvvyaSNIqoiJnc1nmoSzsPX3eAnvn9ocR/VuK7KoCHNY/7agPR57k/y2VFRNRUZIAGO81hCxp6VF
+        h1zkezo2UrE8zfmmrJtcFACSWM5m8/MSV2JoGEyZ/Xn599jEwC7Thjf4O/D+LZhCOG+ElCaEWvq6
+        XvApsJ8MIN0VWMGvxqEpcoI4mQGjAF6YelQlPwaQGCjxJkVbF7zrihK6BW8VzRamQ/2n7ZCQDqbb
+        7sDlezIO4uMU1Un3hZ5ms8WAu0G/h4sCVuw06++D2MiuT9MwKSJCGh2XiOcoyCr3VXL7cH3QaXWB
+        ME7un8Fb2td3lger8KeOLDVkK0FP4Zwa3J2cns/0EdFty6t/b+Wlyhct1fBLvnaQeemMZtoNfy5E
+        LE3c1DpKMGEbisT59Gw8oftYCaO4rPkAZKIF/JDxCnhZCPc2I+tjSSM8sjWg5ptIHk7mNYt2gC4f
+        APuBl2bpfD/tbAFUIxdFYmuyEhpLRBtoHKaE2murGbR1BdH/dmoH1KePXZBsRpVgDQIlzZHAwqM1
+        ok4aqUf3ok27smIhN05Ni3xbEGJBNCsWJKWQeFMtov//EFmxVcLTFLrjNHInmaAgfASn0TvapZ47
+        LvI1EC7fWaMdUDQsc6GuTTIYIHspYBDWCtd6bwtHMQIlpGMxvts1sZyVmgOaaQ9o75dpnKNyyq1X
+        YTEjNog6K2vCArOny9+ZjGHDO0cEDO8jPSwSy0mWnjMp52tRVMApTzgy1dCzkozNdTTMEuQRgaUB
+        RtjZH98fPlbEqPLOmYlpBhVLYxDVDpSuT7aIExMObGbGkwS34c0nldm0h3yNSK/WRyXaYIjuTUsi
+        6dg1CEVZWBCFIrRxRymoCj/87qDX8ns9QLWrS+N1ZLLjDrmpUyDwLsV/yAEb4XW8PRGgJDcHX/eW
+        qLujbD3NnToi3uPOPFOHubbAhfQIM5mfprIANwn5ieDxam2Z8RXLS4CbNQAE00ZDU0eWa6Jiy6ZF
+        W4zp5HxCix+jPAG8+UV5nkp5AnznAPG+j/JYlvQivKfb7NFVv4/oyqFbAFqqmgz7magP1cAj1Of7
+        yuQX9fmpqA/lPlXoXYVi5IY+uCzmrVAfx/tnoz4laL0Z6mNQq6QrT+Q+Gu5KazXyo0dfi/2oO/oh
+        ulEDp5dmP/hOBLhUZKyPqrDLlV8TH3fnzbAf2soPsp/287MfWPzpmjzg1Fvqu2jab781Dpo+vqa6
+        nEd1DV+4zeM3B2h+1lCcXLnFdkpNw3ZOLihRWtRcxXQS0teOTr+v+0Z3daCg9zYbPbp8H2z0fF9Z
+        /GI7PxXbody/g+3YkkVev2Gy4zj/bGTH7vzNcB0NWSU5eSLV0VhXWpvv93n06KtRHWpePsQtashk
+        ucdLNXo6T3bndajOyf2NHjTcDEA7L111r5xuP11s9Zcu2+U541ecHvE+xtuuudHpWWbOw/+yL+xd
+        38jMAw31+doYhjREjxCfPlxMD8/GHyAoW/74vEVHiyXmpu22G+jy0RTTJDevn4CdepO37GHRzey8
+        W77WZkQWJuzLc22GGqNOT7LWFHVGqgB1UCq9Vgcv1rYOqrHqJxB27DlqpO6Govo/7EY9C939m3SY
+        gT+aJqgsNhs8rqrX2lpylNlUPeyYO+qwfGr5tvcfpNneGwNIHl4YkJ+3n3oevAiR7Oa5457HDPu6
+        AEXnzQE29350QFr0TmEfdTBe/uoAn92GvPktQnVJ6fcN+okJ/dZD/XKA3iVuPt38D1+02xgrIwAA
     headers:
       Connection:
       - keep-alive
@@ -72,11 +72,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Dec 2021 15:10:09 GMT
+      - Mon, 20 Dec 2021 09:55:15 GMT
       Location:
-      - /api/v2/companies/242975/transactions/64000017705399
+      - /api/v2/companies/242975/transactions/80000018413597
       ServerDuration:
-      - '00:00:00.1019362'
+      - '00:00:00.1210240'
       Transfer-Encoding:
       - chunked
       Vary:
@@ -88,9 +88,9 @@ interactions:
       strict-transport-security:
       - max-age=31536000; includeSubdomains
       x-avalara-uid:
-      - 9495c406-c7c4-44a2-b90a-81addfb4d597
+      - 7d1cef5c-d16d-454a-b5d7-720249a0741f
       x-correlation-id:
-      - 9495c406-c7c4-44a2-b90a-81addfb4d597
+      - 7d1cef5c-d16d-454a-b5d7-720249a0741f
       x-frame-options:
       - sameorigin
       x-permitted-cross-domain-policies:

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit.yaml
@@ -1,26 +1,28 @@
 interactions:
 - request:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
-      "lines": [{"quantity": 3, "amount": "30.000", "taxCode": "O9999999", "taxIncluded":
-      true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 1, "amount":
-      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
-      "description": null}], "code": "d1a8b22e-d8b8-46ff-9f87-b4e16de726bc", "date":
-      "2021-12-16", "customerCode": 0, "addresses": {"shipFrom": {"line1": "Teczowa
-      7", "line2": null, "city": "Wroclaw", "region": "", "country": "PL", "postalCode":
-      "53-601"}, "shipTo": {"line1": "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW",
-      "region": "", "country": "PL", "postalCode": "53-601"}}, "commit": false, "currencyCode":
-      "USD", "email": "test@example.com"}}'
+      "lines": [{"quantity": 3, "amount": "36.900", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 3, "amount":
+      "30.000", "taxCode": "O9999999", "taxIncluded": true, "itemCode": "SKU_A", "description":
+      "Test product", "ref1": "SKU_A"}, {"quantity": 1, "amount": "10.000", "taxCode":
+      "FR000000", "taxIncluded": true, "itemCode": "Shipping", "description": null}],
+      "code": "0bed46c0-b896-47b7-8ac2-46e4f77f92b9", "date": "2021-12-17", "customerCode":
+      0, "addresses": {"shipFrom": {"line1": "Teczowa 7", "line2": null, "city": "Wroclaw",
+      "region": "", "country": "PL", "postalCode": "53-601"}, "shipTo": {"line1":
+      "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW", "region": "", "country":
+      "PL", "postalCode": "53-601"}}, "commit": false, "currencyCode": "USD", "email":
+      "test@example.com"}}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Authorization:
       - Basic Og==
       Connection:
       - keep-alive
       Content-Length:
-      - '777'
+      - '927'
       User-Agent:
       - python-requests/2.26.0
     method: POST
@@ -28,82 +30,53 @@ interactions:
   response:
     body:
       string: !!binary |
-        i/8BAICqqqrq/3SXs7qBqZqHmbme0sE9DgEQEJEQ4R53MVU2d800UzVQFfM0hzRzww/pWmsL067c
-        uEgkMrIyMnJMq8jKSpScG1tnACKW/ft/Cp5s19d1XeuuMbpuG0UueZAlr7kfjMHO90O/27fjuDuM
-        fbcb9tCtR2fawZEil+aF4/PNkzV7c+heFHkWkCVTG73TZqdbUlSEZS1k6Zsf8KRInksnzH3zhPIW
-        Hyk4kKKBxd1PIZbWwK45I7onyjPX7zMpwubuHG/4YsFJ9Gbo1iJpRr4WvuHyXHqh1booQZ7XAkcW
-        Umfzg+hT5lhqsnzDHhvmRT4SVdOTDJeiCxM82ZGnAkVTciwhxToWEsItKUuIt3d6K17W7O5c8Jk9
-        snE2IzKiS1mk3BF0QS7eVSC8fT6Qc/Ajpv6RIoiso+Oc1ihk66rmavsFLilSRuqShCdx6o2pXgzO
-        8jovHQZNqedQnGnV8OjCG9mu2veKdGQvvPEwwW4VXng78eTWiQULh70kYP9nLTIjSqSXfiQ5MnTB
-        k6iyZxSXw3K5EApOOiX31w2fm9eMW6DTnnKQn2Tp9zspeiAXnkKtqKRR/nHGD548GV1pU5nqyTGT
-        criFePQ+o5Q3T7br/gWGzV7XfaMPijyKhPjEdFNKe1aC7Szx6zjCSXjgzIKWOGvzI/JN3Mnqqu5C
-        P2Z9jJnDRJYERX5h43mZULk0k6JhLSGmJYMoYQy7txyb5Obkwxjgm2+NL1rb/cGarmqa9qB7jf8B
-        AICqqqrq/3QN4LOGg6qZpS16c/DIBHDIAA+HdPdLxiFA3VTcQAHMVC1FRQPcIE1d7Lovj7V8IGix
-        jaVysrJysvLlErSpnEQiERK9TI/nboVKSP/rLxSW5MMjkL9l4qOHrfraDJWCuOebE4JFpSvzaqpX
-        00JhDpEy7Od/BA/b9Vpr3da6qvpCCtjF7EYJKd6HmhKYrq6MbmuFC/DdqSx3YlgYKNxTid7x9vFN
-        zMFTIX6lFcaSJS3Et+wmum4rwQIKFCXIdst0SJ7cyXvKI4e1KZawuFKWl5WTL6MggUxCdAa/954p
-        5x7oXYsby7oxuq/NoJA4TCEm3Uhnh8CHPKYSZb/8YcDqnQ7set1W5DzoScuaeahuOxBLd4h2sp0S
-        LCl8EvJRaLm6p7vPBCtcKIDgcrmeYR9uzi6o0MJ5c5fft689RpkaoLhqdvWgtcK/4uKIoLA1RhjT
-        wzRKxvSoTuzXxBLitNw7g+l7P3KlWrDIqfAY4gSLN8qz5A4lDjjYH7vWHCmjt/2SSikKnhIJDm4e
-        y+yEfPr1xaR/DJ9Ur8sBOWZC60YbvcV3Evf8GacQtbCpuKdoOK9gBYtTigSFe8khrpqyXPQRxv1T
-        m/hc2lCXdc4x+0Muq4lqyekYx7l48uvhwJO4MGfYzyeQet9IHL5phqGtW/YQfgIXfQ+RG1nXa/1K
-        niNOqw+V/Sx5g8X5HQpMU0jRwyXBbb+O5wsI0MjihFx71eLM3GmtFQj/AwAAVVVV1f/pGiBnBQd1
-        c/MId71ZmEcGOICDmYOb5SkhDuKmEuYaoK5qICqS4A4JabaJSaA3a+m0/DW9SCQyMhKJZNUKIZGT
-        84b2HJRJ+/+D7otcCEtORw+uNhDSICgETljJwI9yKG32BA7OJzCgtA7vxdGfmu5A5PBhkqAlG5W1
-        a1sZKGFOKMrUqoiDgfIC1aawFOS7DAR/XmrjcynythsBTap6k79nTcJPMJByGvGB10jNPWsScHZl
-        rbVs4ReNtBZ9E6rmFxTqIQcDvC+7XVUbEQEGGuNdvbb7twqXGLLyxHBnDRTipV5g1yHN4OBARULC
-        JGgJBgQf4Lar17U5MvF8iqpebfZcUmNdr7KozEob9MoQjFToYQEWn5x1IXg4pkWlSX6w0MOMg2Dy
-        yP5lU7rmx0blljnIU4igUeutK/YLzeFo2bbFa8FHi3HSiEJ+g3Lo/xJz8BQYTXFBdH5XQwWjIdng
-        QnCv/ncKUsCtf0yXVPYWN/qZ/ETsawrSf79jCQUcnIlbZaY0PXtpFwyE0uV0xlLGGyu4b4yFGGq/
-        iJBjwbRklpDm0dXbuaN2+Ytl6F/m5hb7sHieaRvPnh9wbzFOsRaDgRjwGuJVEqIaKEZi+P8VDWOV
-        Dblx1vl2IMEQC7g/X5MUiU55+mSMnEEt/4HPk94pySl0nHaOHtyustau691+U9vdq+kv/ejB4X8A
-        AKCqqqr6P93lrBYgamawuN0cPMIBHMBhgXCLYxzUVcXNBcBM1UJV1MEcAtxsEz+BrdauYtqklItE
-        IpFIZGS33ayPRFZWVi/T47lbSYnQe9oOEbGpsCy7TanABZtn8rJ1LlJKBwd928JwX1Vr7Cq9UTAF
-        a4SDH14L7YIj6OH64GUfwwxv9Z/m0Y/s6YhfJN+kqxFR192mqrFrSj4FL5i/KWlj79ohwPtXwSPR
-        DNdBgQ1JDj7laLylfSQeHwI9fqCCpxFs8C/Ha1FWeC6KyxGCZE55vlEcXl3wgG/1D0wXurHVKNH4
-        ZKw6OHQz0W1VamwqBRN7ysYnoYcSFNxC9s7E1/lJMbKTgKaowOYkYab4k8xIhaHAnwx5YXn9JNWj
-        AwocJRt5KQoFZ2zC3hg+RvhNsyFEHtmDXrS1leM42ZC9bOc/7CLlgA5SxFEBrTQvyFVytx1FkQGK
-        zlhPAUjSGU4HoXkwq7lNBL3ETAE41+twgf5upuRCFZrHEez1wcvCfgQFOXNyuw9dISr4y8YLgwq9
-        HiNapLsuxS3SvTxFZwlR2I+fRnYVXomlLnRZ6AagqM+t7ZbShZ5CjrYkeg+flNSMAygQs9ZB6doj
-        Cf+yneVhobMFnJ2ZbJ6MkEMveyt1/40fStkkYA4O+rptN9fpJz0jZv3yI3veSK68KTKDGfRwCp5A
-        wS0n9k+VZEfKnR8nZ8mPVzPpbeFdMev5STGyo2/8DwAAVFVVVf+na4CcFRzUFjc3s5ulB0SCAziY
-        ObhZnuIkYSphoQnmogaioglmkGab+IGus5ZOy1C4SGQkMhKJ5KZVJLJySs4dzBlFhL8gjIGhBTCg
-        uN94XpMjB61KIgOOFP0aof38D95BW52ttVlZNk1VVI0BFeSIs/rAd890c9BeGmutrQqb53WTG1DB
-        tCOnSB3YZ5ciz2xVGEDnhGKkSarAb0WZ2brIGgNzSKxyQAuPOxgQWvy4lJGcYMfH7TEaCBYVlaBz
-        op1em3YvGXRo7UkdlWlP8g3uOpQGPI/VqKadv0l8vAZH0CtmUHt8BQ3DvevfgYjq/OwdrLXPrc1s
-        biD6hVGTkEoUmC22LrIwcn0AgrKwTscW6Nd+AjQW1Ury/Fs5wAAHnnDHr5U6U9eF7c+00jgQSyRF
-        TZ+oOWRgQNAvuj3lxVYCY7V8KDPbXHI82BiSzKKHRhJTb2Z9zwu08E5RPeMmcL/QAG12qi/bhujM
-        l16fsiKgivtccRiSbklLg47piwFbaDDAgTH7LSFtBE033pJ27AqTcpd5VGSH4t6M4q6fu6Q/Qbwe
-        QmCNVp67kzyfiBjU3J5vRr7ifsV1TisqOQPpNPwjEe9oX1i2xaJr37JTZsqOZJwi8LnsD3uN7s/l
-        WoWs2ve3fiO8xF6H718YfXxGOCTXJEI8H7l4CgZ87AM/MMbpRxK037hGYqAfRMjLEdqCqOdlGuqT
-        Z0BoC6KeF/wPAABUVVVV/6drgpzVA0RNzW27BXiEAwSAQYRDhCUEQATEQVxNwE0B1FUMVNUizCLA
-        rbn9/3TWqohY+4Nw8ePionFxUczp4+Ki0RANIeqGjuNvYgG0d54lDLTS2fP/4HKCDu9QQeRZYnbh
-        8rjydc7jtXqgFTp919Qrkz/QeiBvF0+ZR8bwTe/o7LzL27DNDB28sfcc4falIEg4UUp5irJcpgfO
-        5HyC7vNLgXeBe7GUnYRhmzlB9/kHo9jlyiH3WPY8jdBVBhF12bSmxKZS/LlyGnWLiFgZLIqmLRDL
-        +3GMnBKNUYN8U2psjG4VeLEixnSQ0QF7k5uPUa5wU3+fmaPnT/o+q/aSdkWFrTZIoGxTkhm6QYGV
-        lJ9CWiIFy8fI7jJl6FfSN2Vu8E/9264weNztTj0MuXpermeOw+ZCgDURKCE5OoDLku6UeTlSSGSz
-        k+CdrG6E02Ndm0JjZRScZQkjxa3nb/bQwYeb96A65oaGDga2v/JD/2o4FyvABJ/eBTaP0mtd3qCD
-        99eXQ3//DgoiX5wEghSzpEzeVCj3ZlehhggoLyHHTcLJHeVM6+seq8aqwL3G4qYMhbvWkQ39H0UU
-        6+kHP4DeGcjvGpHuy+I61RD8qkZENHXZ6rKCiwAAQFVVVfV/ugbwWcFAzdTczFxvBh4QAA7gYO4Q
-        brcAP6ibCrhrgJmqgaoogDs4mC23h03NSXOQzSMuEhcXifZIiESj4IYix6/E1X7bCdgw5YU8Hy10
-        20kpZdmqqpSN8nffWxspJYy0Ff5TdSk7Ve4F5jAZdsGP75UOwRI0rk+3/sSwYBOfEZue2OPupc04
-        8qqt92XdrHKtNjqbHgO2m0DKy2LiG/rvgylkzzFCXE4QiPRwwWfq+s/RpXMwoXGAS3f6gVIoqA1m
-        EXKX86kfviHA5tVnfobo+N2Gk/VOILFh6lNyD092CNDAuVEe58xr5jTbNd+d2pJ9Snxl462J9uvX
-        MK0NM0xweexWE5r7TNCqKnaVIMlBy6JSrwVZ0UG3Rd2F9D6YecqzYfp5iDF98GObOmRRhQS9aFnZ
-        BQ8tCym32zY=
+        H4sIAAAAAAAEA+1a227jNhD9lYWeY0MX35/q5lIEDeIgdnaBLRYFLdGxWllyKSkbd5F/7xleZFp2
+        nKS5IAg2T85wOBxyZg6Ph/7hxJEz6LRc/HndrtsO+v0DJ8wi7gwcd8qjVid0G9Nev9NodafdRo+F
+        fqPV4a1Ztzvr+9O+Q9qLJUtXpzDkt/x+t33gRKwgA77rew3Pb3hdqOUFK8oc0jG74REExWpJSmOW
+        8Pw0vcnikEM6ZUU4P1QOkPFSCJ6GKy25Gh9ByG/DOUuv+SWWOdylEJZ5kS24uMrZNZ+odWheWsTF
+        6irntn2l+ZmnUSa03JULqwFLxG/5YlmcZ3AaCoKHWRrGCfYymLEk5wdOkoWsiLN0bV7wZSaKOL0+
+        2xpalgK7yPlIRFysjc447dfyMKfzWXKR23YLdju64ULEkdneeZbS8VkDw0VWpoUzcJvuhvySM9hS
+        myiygiVGseM32z5USXYs92omk+QozkPbIMkm7NYZeK1m0NPTIGDTBGG1bUF4yJKwTBAuHJbWZ9Ff
+        iNICMakcOs+KoZTK/FgrHPE8FPGSjla5jYP+2zp3wa+rIemjWEHv4gzngUPK5ZiHDMxmxXcm+Gcj
+        c3yv6fnNoEkBz0R8HafDKBI8zymZUQ74C1q9IAg8TI94jkjKANta7U0tOzePZzMeFvENP9pRD7Yi
+        DoWChBU298kXLE6wlQJL/8Jv2WKZ8CbqDe5OyzxOpaeU1bNYZZ7Jo0UWQcajrYUnXnvguQO3j417
+        Qd8LvsKW0UZlCFnGvcDrUyaw2y0DUE9oYWfwxw8JHj3av9tp+W2/16FMEyzNGbadpWSrji00+bxc
+        TLnAvjzaCJIqYmJl8pkmwczjS3jz1CY4qk9LkUVlWMD644L2cOx18ptSkTUVaSEBjPZaQcSGlhId
+        clFs6JhIxflpwRdV3RSiBJDE+Xg8uahwJYaGxpTx71d/DnUMzDIBvMHfgfNPySTCOQOkNCHUzFP1
+        gk+++aQBaVdgBb8ZhrrICeLyDBgF8MLUo3XyYwCJgcg2cVXgExW87YoU2gVvFPUWRn31p+yQkA6m
+        HbQoeXZnHMTHKaqT7gs1zWSLBneNfvuLAlbMNOPvXmxkt6dpmJQRIY2KS8QLFKSV+wHO3Wt1ux23
+        53fg/jr3z+At7euJ5cEs/KkhSw3ZKtCTOCcHVyenF2N1RHTb8vW/W3kp80VJFfySry1kXjqmmWbD
+        f5UiznXc5DpScM4WFImL0dnwnO5jKYziquZ9HIoL/Mjja+BlKezbjKwPcxrhkakBOV9H8vB8UrNo
+        BujyAbAfOGmWTjbTzhTAeuSyTExNroXaEtEGGocpIffqNn0KJJWMHpKn4bn9LnZBsjFVgjEIlNRH
+        AgsP1oi0i9Srl4mRa6dGZbEsCbGgOi6nJCUnnJES0f+/iaxcSuFpCt1hGtmTdFAQPoLT6BPtUs0d
+        lsUcCFesjNEWKBqWuZTXJhn03bYMGIS1wjVemsKRjKA6Ku27WRPL0WGRVB/QWHlAe79K4wKVU4HV
+        Oix6xARRZWVNWGL2aPYry2PYcC4QAc37SA+LxPl5ll6wPJ/MRbkGzvyEI1M1PavI2ERFQy9BHsFx
+        w9RgZ3N8c/hYEqO1d9ZMTNOoWBmDqHagdH2yaZzocGAzY54kuA3vvsnMpj0Uc0T6en5UoQ2G6N40
+        JJIOWIFQlIUlUShCG3uUgtqV4NRGbP2gHeAqtHRpvI5MZtwmNzUKBN4l+Y8d4Xm8PBGgJHcHPzaW
+        2HKHvmR4z3Onhoj3uDPJ5GHODXAhPcIsL07TvAQ+h/xE8Ph6bpjxDSsqgBs3AASjRkNRR1YookK7
+        pQNzaYsxnRwArqI8YIYW7JPeXsrjw5uflOe5lMfHd47+/ZTHsKRX4T3tZodivono0iEpteu9UtUZ
+        9oGoT8ejct5PfZ5WJj+pz4eiPpT7VKG7CkXLCViJ4rxD6mN5/2LUpwKtd0N9NGpVdOWZ3EfBXWWt
+        Rn7U6Juxn84DdKMGTq/Nfoht7WM/j3DnvbAf+V1JN3yeyH6Cl2c/sPjhmjzg1Evquyjab5oVvaaH
+        o7fbPLJr+MptHq/Z626hOLmyxXYqTc12Ti6R8/jDNnAJkJDYMSiD6hvt6kBB7102ejryu9R+tvO0
+        svjJdj4U26Hc38F2TMkir98x2bGcfzGyY3b+briOgqyKnDyT6iisq6zVqI4afTOqg2/Ce7lFDZle
+        merIvtI+qvMId96E6pzc3+hBw00DtPXS1a159UDbx3R5zvgNp0e8r/GyrW90epaZ8PDf7Dv7RG/j
+        1NzTDzT0McAwpCF6hPj05XJ0eDb8AkHV8sfnJTpaLNE3bTtodFx6TKu9EQB26k1e08Oqv26+1WZE
+        Fibs+0tthhqjVk+y1hS1RmRfTsWvF/TbPnEQUwe7enZm7CWaoXU3VFP1f7tRy0J7/zodxuCPugma
+        l4sFHlfla20tOapsWj/s6DvqsHpqedz7D9Js440BJA8vDMjP7aeevRchkl0/d9zzmGFeF6BovTnA
+        5saPDkiL3inMow7Gq18d4LPdoNO/RVhfUup9g35iQr/1kL8coHeJu293/wGpEvZIKyMAAA==
     headers:
       Connection:
       - keep-alive
       Content-Encoding:
-      - br
+      - gzip
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 16 Dec 2021 11:49:27 GMT
+      - Fri, 17 Dec 2021 15:10:09 GMT
       Location:
-      - /api/v2/companies/242975/transactions/78000017321063
+      - /api/v2/companies/242975/transactions/64000017705399
       ServerDuration:
-      - '00:00:00.0839580'
+      - '00:00:00.1019362'
       Transfer-Encoding:
       - chunked
       Vary:
@@ -115,9 +88,9 @@ interactions:
       strict-transport-security:
       - max-age=31536000; includeSubdomains
       x-avalara-uid:
-      - d95945f6-00c7-4c73-baeb-68091bd5e466
+      - 9495c406-c7c4-44a2-b90a-81addfb4d597
       x-correlation-id:
-      - d95945f6-00c7-4c73-baeb-68091bd5e466
+      - 9495c406-c7c4-44a2-b90a-81addfb4d597
       x-frame-options:
       - sameorigin
       x-permitted-cross-domain-policies:

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit_with_discount.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit_with_discount.yaml
@@ -6,7 +6,7 @@ interactions:
       "30.000", "taxCode": "O9999999", "taxIncluded": true, "itemCode": "SKU_A", "description":
       "Test product", "ref1": "SKU_A"}, {"quantity": 1, "amount": "10.000", "taxCode":
       "FR000000", "taxIncluded": true, "itemCode": "Shipping", "description": null}],
-      "code": "250ef413-3eeb-49c4-9de3-c23112c4eb21", "date": "2021-12-17", "customerCode":
+      "code": "4e51b4fe-6f6b-48e1-851e-bf62cf898f25", "date": "2021-12-17", "customerCode":
       0, "addresses": {"shipFrom": {"line1": "Teczowa 7", "line2": null, "city": "Wroclaw",
       "region": "", "country": "PL", "postalCode": "53-601"}, "shipTo": {"line1":
       "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW", "region": "", "country":
@@ -16,7 +16,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate, br
+      - gzip, deflate
       Authorization:
       - Basic Og==
       Connection:
@@ -30,104 +30,54 @@ interactions:
   response:
     body:
       string: !!binary |
-        i/8BAICqqqrq/3SXs7qBqpq5ubue0sE9DgEQEJEQ4R53cVU2D800UzVQFfM0h3xtEojTWt2WG/+/
-        Ixqi0Ugkbp8T0Wi0xLmxdQYgYtmb/1MM5Ha91lqbXd/uu71W5HMAObJbjaEz7aYFbpvu4LvNIaDd
-        eNsaY32HmzWkyOdp5vR8DeRsZw+7raLAAhNY19ZsjN2YHSmqwrJUcvTFDwRSJM8ZEM6MqK/pkaMH
-        Kbqx+J9TiMAN9FIKkn+iNHP9OpMirP6H0x2fLDiJTgZ+qZInlGvlOy69AteaJFGe1wpHElIn9Y0U
-        cuFINJnvsMWKaZb3TNW4UuBz8nFEIDfwWKFozJ4l5lRHQkIwcy4S0/2NPvLnpfgfrvgoAcU4qQEF
-        yafMtvKIOqNU78IRXj8eKCWGEWN/zwlElt5xyksScrrRXKk/wTUnyohdsvAojr23zdbiJC/z4mXA
-        ynaO1ZsWjLsXXsmZrmn3ioSoL7zybYTfzr/weuLRLyMLQs3mcPizVJmQJNTW3rMcGRTsCNxE+ozq
-        S5yvF77R25j9Xzv43X0ruEc6fnIOypMc/X4jRQ+UyqNrFNU8yD8u+MajJWsaY5u2eXSYySXeYzqG
-        UFDrayDX734GDNtup0237xQFVInpkfGhlP7sBPuZ/ZdhgJf4wJkFLaFq+yfSQ9zJmUZ3wT+zLmPi
-        OJIjQZVfWHmaRzQ+T6TottSY0iJvdh3i9oVrl8yUQxwiQvOj0cVo17ZOd03ftfse/wMAAFVVVdX/
-        6RrAZw0HsSVN3fXm4JEJYJABHg7p7peMQ4C6qbiBApipWqqKBphBmm7htTRv9X82rYARJLKyEln5
-        8pMls7oSOflyRs4tm49nV6gbKP1F0/yFwhydf3p298ypdzD1vqkOtYLY9c0Kw6Cmunqt6tdKQ2Hy
-        gTPM5394B6M7IqKuJd12ulOQZEO2g/gYegejuxIEle6afbsnhQNw71zmBycYVFB4xBKcTdvHN6fk
-        HZPAr0hhKFnizOme7ci3bWEYQIGDeNnumU/RMcx3HOch+UV8DDC4cZaXJUVXBkEBmfhgA/7oXOKc
-        78DoOmJYNq2mqt23CjH50YeiXddxCJzPQyxBjvMbJgztKLHpbVuYy+SV56XyUGE7cZLb0QkUO0cY
-        UfjG5154vtnVPiaGkVQ4geB6vV1gnnbKEFR41pzc9ff964hRciMUN7QjIlL4V2wYERSm4QhL/Kwu
-        Ykv8rL/ELzGJD+NyH8zE38dBK9WGRY4lDT6MMHjjPEsZUObAhOl2hy/K5Mdxng1nOiURnOw0lMkK
-        u+LtJWN8HB5cz8oJ3zuYH03bzW/JncSuP8PogxGSil0dI3n+KxicY2AoPEr2Yc+UvaJPPyyf2riv
-        rY1zo9yOtD9ss5Wotpz6MEzFsduNBI7F+inDfPo/xQ0RVa1udFvvdez13Qdt9MlfpFujPlWWs0gb
-        DC7vUEg8erpUkFLgtl/95QoBNLNYYWirRrwq90SkwCv+BwAAqqqqqv/TNUHOCg5qHu4eGXqzNM9M
-        cAAH8wA3y1NCHMRNJcw1QV3UQFQkwRwS0mwTP9BdrYVpmY5eJBIZGYmMZNUqsrJycu5gzihC/Jse
-        i14Ja+FThLBzkHhQVIKgYuTgj0mqXYkEAd7PAObR4yNoupzb/ghEtpgmTVrpfut947cOapoZ1YRU
-        soKD2gG9rSyMYl+AoKPTGJ9LQLt+BDQ31ZP8vRirPMEBFx5xxVum9lGMFYLfeO89W+jVMq2Fb6Kp
-        6RWVcqDgQPYl9Zvti0hijGkun3aNf3vd4smGYjIxNHkHlWSpndk48QwBjlQ1MTqBCBworhAOm7fh
-        SHTmSl6G3obiOlieLqaLaW0ag90Y8CAdLnBizH5KsYUgd+LFtOVYWLTD+EGRI0r8sik+9b41vRdJ
-        +hQCa/TdvjvpleZ0tE32QbHi2mGeLKNS3KB0l78kkiIZhsUuFl37NlOZaSbJMEXie9kvTlrX35dL
-        NvYU77R+Jq6IyDjp5fMb1lTfEQFJZyLE0zMXT8FBqn3hd6x1vItB+MRcicH4QYS8AqGliCaex6ne
-        rQmjL5xTiU8p5fuEdXcgXRy+XcDaYZ5M3Z2DnPCW8kky++QoZxL4/+EL8R4P9C7F5vuRFFOuEH5/
-        VMKYzmX6MGKTmQr/QSyTPYj1nDIqO0UIX/8aQbNvDvtm1zQuv3SnCOH14D3+BwAAqqqqqv/TNYHP
-        6g6iZuZmHnYz8MgAcEgHDwdw82NCgrqauLkCmKlaqoo6uEOAm23iJ3DM2lXbQLlIJBJZGYnstqv1
-        kcjKGjm3bD6eXSkqsPVvRHVFTVU3tcIQbJ7ZSzcMkVPaD2jrhoiorBrS1bZSmII14oLvXwvvwsBo
-        cb675SuGGW/1gzHRHJznQ8AnmbfYVkSkN7re6ErrlUnwgmlNvQ8XKGXYNUpzH/D+q3BPNMNzKNiQ
-        ZO9TjsZb/orsxrugpTUpPIxgg386nFdFSd+r1emAIk3HPF859i8VbOitfuDoQpvYWInGJ2PdwUnN
-        Qjd1ua22pDA5z9P4JloUULiG7AcTX98PjtENFtCSFGxOEmaOl2RGXgwFf5rZi5PXJTHV8AwKAycb
-        3SIueLToOcmvJYYhWwHwEOdN4OM4v/lnQnSj86C3LOxksDO4ZEP20s1v2A2rBe1tiVaBnzwvyE1J
-        jx1HsQRKydiPAQrojkt74bk3T3OdGK3EzAU453N/QnszU0qhC8+agzn/ufzrYCVXQn5RrcsPIoX/
-        2XiL0NGWB4oj8k2jLY3It2Iv+5GXEMX58dMIHwUcKvRKFyvdAID+6KxgKg2LFHK0zo9o8cnJ0OhC
-        QcwT7WZd608SCaObQ25FJpUrzs5MNk9GeIC/djnt++PBZZwUdI9ELysK+slvEvP87UfniaOk6s2R
-        c1ihxTF4hsI1J+d/XZI7027uB+Rq+7nV7+aQvaClNSngfwAAoKqqqvo/XRPkrOCgZqZu6qE3Sw+I
-        BAdwMHNwszjFSdxUwkMTzFUNREUTzCDNNvGTtJu1nbYBuEhkJDISieSmFbKyckrOHeo5iojt7wS3
-        4R8xB093wpwiOAAFgtslzkvx5MEJF1LgSTAsGdzXfwgenDVa68rYxpr6ZBUIY8w4S0jxGiJdPDhr
-        tda6Ndqa1rYKhDHtSCnWBu4r2zYnc9IK0HumnGlYG/RbY6yuzMkomFOJwjs4uF1BAdMzjEsJSQmx
-        f1xuowGOLCgEvSba6LVK95JBB6cPjVGZ7Fu7DkZBiGM1DEzL5m/hkM/JE/SSBHqPr6BhuHb9OxAS
-        PswStPi+1rrStYIcnhGlMKmIwWzSuswiyPcJCErCPu1roJ/7CVApqpXU+W95BwUxxQk3fCzUmfpc
-        2H4vC9mCaeJS1PyOkkMBChj9outD3WyFFavlg6n0m61xjjEVnkUPz8Sm3sruQ3yCg3fKEiJuAvkJ
-        DeCOh7baNkxm/ojaHJo3Tspgw1BkLVLLPpYHA/XQYIBZsfjDqawETZe4FumiL7yUw8yjYPTI/pdT
-        5Pq5K/KTOMguBNVo5jgV2f0VkYJe6+PRaC+4nXGZy4JC3sHVhk8iurBlXSq69i1LVaYsycYpWO81
-        fsYgGZz9c7lXYat4fq/fiF2JQYbv35hDfo7YEJ8LM8V5z8VTUBByn+INc55+uID7xiUTA/8gQs7H
-        TGtiCfE54YaPhT5jkAyuxv8AAEBVVVX1f7rLWd1B1czczMNuDh4RAA5g4OEAbn4KiIO6mriZAKip
-        WoiKOrhBQFhu4j3Q1VrIssz6lTYnkS8R8iVy1e4lEiEn5NyYctxNKUHnb6pt+aaAcYksFMZzDL19
-        2bvHWyBJ0OqtVkDZzMcL50XSz8bevqDdbWtzZfd7+zpa77K3ggMj/acneydPsvbrgtDCFb1Hhv8f
-        BSGGi01JJo55nN5RLPkE7fePAk8Bu+isUAz9umCC9vsPhujyjEE6lCunAdraaK3NztQ7Uxmj+PmH
-        M2karbWuK91UdVPjYQ/DwJgSDawhflk12lT7SoGPTsSmxzg4EG+i5ZPjDP/qr0zOjr8f77GQ9FbW
-        eLX1saHSpiQzLoMCF5OcQspsg8NPRhongfkGfVrhRv/SXTdFqb82m0sHSRnOeb4j96uLQG0TpO6B
-        exSesA3JOqEY3IKNVBlNU5f7aq/V+KS+tgotlKDgHnMYLK9fT2SmAS9iqhW4nCTOyLdkRywMgn4Z
-        MQjJeksoNc5AwYDJMS1CMUAwdaFggdsIDzFfIzSRaaRAytigcAZKLuYgh/mEs0lXgn0rkirAVZA7
-        s4b7EVkcxRrUcwSRYimdBOd+vYKBVjhjAs712l+gfVifQlDB2WccrxMtC4UROhiuau5+a0qtFfxm
-        GxoDD1qz1QoYH6ZU6IyP4iudW63vVv5VLBe6MBtTbEwDChifB+diDgL4HwAAqKqqqv5P1wQ5axio
-        mmmYWujNwD0jwQAc3APM/JYncVMJT00wFzVQFU1wh7TaYrugfq3/5njADfHiRSKRSNQZcyASDdGo
-        m2qPc8lAUbT9lQdQUFLNa+Q7eDhSkcgoMTEoEHyCN83gfrnF20bjI1UW8ENjOoKLA25r3VAoRB+L
-        QwoEHj5n/WFWE2KaAnjr3Ec6/YgSiUWrW/Nm2jfjYkP/yffIJDK0uvyjnGOg62sn8PU5MYGCWy2R
-        qZQpEEv8jmvb9HOC1CfatOtGF6ZKDjNhSZxy//fE61YDBfCSKykIJBi3Av73f4gBvOu11sa6ztl2
-        GBRIRi64Skx8ikzeYG4wjLm32tne9SrslEJEZaeN67vBDloBhpBN0MH3NFedddrYwSpY54xNfoGH
-        rxMoyHSP7TIhKaC/PqevxUDoRVAIeoz0pMcu46qi6aYwlMm+pepgFUResqGm+9+aY1kTKtSKCfQz
-        Pg6Hy2k8H4GIPcRVolbYt1ob3Soo8c4oNZNKrNBbtLGwMArLuSXhss12OF8BjUVVyTKCQQEnvt69
-        i5p6YX2u29XiO1HUfEaJYQcFGf2i6abtphIE0/TBGv3hWjzU5T1ARb1QNnUI+/lLkWlX6fnShsZ0
-        By747CsOlyp7lfsdfKk3BrIVgwscBOu/cqo7wWnivcrIIfFU9jIvghwwhx9GkfPnscqflKO8hCAa
-        Zt+rs86XiALuW/1udKtA8HnAba0b/gcAAKqqqqr/0zWBz+oOqm4r6C3CMx0gAAzcDcItIQAyIQ7i
-        phJuCqCuaqCq5umWAW7TSQfdanW3/OetRzRIZGXlJHKyea2Qk8i5ofP4J2CIvaXMBlpt20ZKgUyP
-        051jtIah5VZKAKlImYd1ZmicM3lD0QCptg98DJwxgZ7o4vi3tzlBt1tVjMD0wQ9g22c7fvBtzorS
-        gfzibT59vVKyCRo9x/0SI/tx5SILAZuOwfeU0jDFBfqLXGIE48Dc2YPIc4jZ+uvw7VZMrQQ7Bm+n
-        K0V/OTyu8BjoERv/6bs9uXFxodZIwFm6WGfzGuF2Y+c44vmZDMkmiTzFsFynn5zJugT991OJwHMX
-        Rso2eDEECr9hwrjc2OfOMg6ZNwNdV1JKVam6UqVSgt8Kx5r2mrjVpWzKuqk51b8YEzklGqxuCmFR
-        NlKVbSnggonazxxMdj7EcMNTWPpc6/qpjFFp6RsbQqBkU7JZ0hAYQ8pvPi2R/MiHyPY6ZfzPuATu
-        lLkl7rvzZlfIw2bTdwApOC63C8dhnTkRqDwTlBJi5RvwsAbOznyO5BONx4IotTFO71VTF23ZSoFL
-        WLyhuHZ8ZweNP3auIHBjPChoDDz+D//oR4M+2w5LkFC0eHJ2tHmFxsf7ad+9fEAg8tUGT2A3h5TJ
-        LVV8VWxqqRAB5uJzVEL77TAzPd51JB5TO1kpuXuKb1gDXTdSSgmVAQCAqqqq6v90DeCzpoHYsoTe
-        HDwgARLAwSMg3AESIAPiIG4qEKEJZqoGqqIZ7hngltvuH5i1OzdrB9GPH4lEIpGIwdoJkWg0RN3B
-        jE8h+WPbjVR3U2egiUPmWX0MvxzsOBAR1ePQTt1EBpdYguN0O8g/WWDxx289DBYfpIbFWeb/8Ysf
-        Rpg65QYWqZE2eHb2eoPF7xTnhb9gkOTDx0DgV1vMyss+OoFF3/4YqIbBHEvQ1In25QAD5etrH3mN
-        3zTU19Tc3w2WOLP6GM63TTLs2zdcnMsqQQ/o4vt0fLwLbTs1Q/3YjIbrAi5DoLv5nFPvnEuSMw06
-        jIHOtdvyKH90+vTbzxRX3I2UTTKNgpCUXYLaZ1LSOcIhlFzWlX2Evn17unI9IThc/pbks4/IsNib
-        byISD+yo6chroHp5PuyOT9/hdlf0MyavtzE80/UGWVlll7P/COKO8duclK8sbvBcdCuKMqVTuSD2
-        KMYtUyfl4Di5h1dWgUFiFbI54aNnxJdFYIem6hsmD2CpaloioiVUw9Zd1U45Dfa8zGVhFYe4HGI4
-        D7JKVR8m5Crrpj4GWKqI7u/3AQ==
+        H4sIAAAAAAAEA+1a227bOBD9lULPsaGL5dvTepNmEWwQB7HTAl0UC1qiY3VlyUtRabJF/33P8CLR
+        StJb0iIomidnOBwOOTOHx0N/8LLUm44DH3/BaOTH0WR04CVlyr2pN+BxsBqseW+4Hq56gzEPeuM4
+        4L3Vehgm6/FkvA5jj7S3O1bcnsBQOAgno/jAS5kkA6EfBr0g7AUjqFWSybqCdMGueQqBvN2R0oLl
+        vDoprsss4ZCumEw2h9oBMl4LwYvk1kguF0cQ8ptkw4orfoFlDu9TSOpKllsuLit2xZd6HZpXyEze
+        Xlbcta81X/EiLYWR+2phPeCI+A3f7uRZCaehIHhSFkmWYy/TNcsrfuDlZcJkVhatecF3pZBZcXV6
+        Z2hXC+yi4nORctEaXXPar+NhReez46Jy7Up2M7/mQmSp3d5ZWdDxOQOzbVkX0pv6fX9PfsEZbOlN
+        yFKy3CoOw34cQpVkL9Ve7WSSHGVV4hok2ZLdeNNg0I/GZhoEbJUjrK4tCA9ZntQ5woXDMvosfYco
+        bRGTxqGzUs6UVOVHq3DEq0RkOzpa7TYO+h/n3AW/aoaUj+IWeuenOA8cUqXGAmRguZbvmeCvrMwL
+        g34Q9qM+BbwU2VVWzNJU8KqiZB5FVBXRYBxFkY+qSHmFSKoAu1qqdlotNzdfrtc8kdk1P7qnHlxF
+        HAoFCSvs75NvWZZjKxJL/8Zv2HaX8z7qDe6u6iorlKeU1etMZ57No22ZQsbTOwsvg3ga+FN/3I/H
+        2Fw8eQNbVhuVIVQZj6NgQpnAbu4YgHpOC3vTvz4o8BiqYxoOwjgcx6h9KVhRMWy7LMhWF1to8lm9
+        XXGBfQW0ESRVysStzWeahLP48hLeP7UljurFTpRpnUhY/7KgfT72JvltqaiaSo2QAMZ4rSFiT0uL
+        DrmQezo2Ull1Ivm2qRspagBJVi0Wy/MGVzJoGExZ/Hn598zEwC4TwRv8HXj/1kwhnDdFShNCrQNd
+        L/gU2k8GkO4LrODXs8QUOUFcVQKjAF6YetQmPwaQGCjx/kR9ooJ3XVFCt+CtotnCfKL/tB0S0sHE
+        0QAuP5BxEL8sUJ10X+hpNlsMuBv0+3RRwIqdZv39JDaym5MiyeuUkEbHJeUSBdnm/phyPxiMRkN/
+        HABhnNw/hbe0r68sD+bgTwdZOsjWgJ7COTV4e3xyvtBHRLctb/+9k5cqX7RUwy/5OkDmFQuaaTf8
+        rhZZZeKm1lGCM7alSJzPT2dndB8rYZo1NR/iUHzgR5VdAS9r4d5mZH1W0QhPbQ2o+SaSh2fLjkU7
+        QJcPgP3AK8piqe8ZJ4xqQ+3IRZ3bmmyFxhLRBhqHKaH26vdDBWL6fzt1EPiTEXZBOguqBGsQKGmO
+        BBY+WyPKMaRet0ys3Dg1r+WuJsSC6qJekZRC4s21iP7/Q5T1TglPCujOitSdZIKC8BGcpi9ol3ru
+        rJYbIJy8tUYHBNPs5kJdm2Qw9GMVMAg7hWu9tIWjGIES0rEY3+2aWM5KzQEttAe098sik6icBqza
+        sJgRi2I6KzvCGrPn699ZlcGGd44IGN5Helgkq87K4pxV1XIj6hY4q2OOTDX0rCFjSx0NswR5BMct
+        U4Od/fH94ZeKGLXeOTMxzaBiYwyizoHS9clWWW7Cgc0seJ7jNvz4VmU27UFuEOmrzVGDNhiie9OS
+        SDp2DUJpmdREoQht3FEK6nCEOAUxYhtG0RBXoaOrxjsXtx13yY1SackNeJfiP+SAjfAm2x0LUJKP
+        Bx/2lrjjzuTx7nQQ8QF3lqU6zI0FLqRHUlbypKhqcJOEHwueXW0sM75msgG4RQ9AMO/1NHVkUhMV
+        WzY+bTGjkx1gK/63UZ4Q3vyiPI+lPCG+cyCfHqI8liV9F94T94d01e8junJISd16b1RNhv1E1GdE
+        tfgZ6vN1ZfKL+vxU1Idynyr0vkIxckMfXBbzXKiP4/2TUZ8GtJ4N9TGo1dCVR3IfDXeNtQ750aM/
+        iv2gu9GyH+redNlPB5zs+HdiP6oNYsnYN7rzXNhPTEf7bewnenr2A4s/XZMHnHpHfRdN++233HE/
+        AB93OY/qGn7nNk/QHyNfOyhOrtxhO42mYTvHF5QoPjVXMZ2E9LUD3RLdN7qvAwW959noIbSwbIc6
+        o22Ts2n0fF1Z/GI7PxXbody/h+3YkkVeP2Oy4zj/ZGTH7vzZcB0NWQ05eSTV0VjXWFvu93n06I+i
+        Oqod8Slu0UGm70x1hkS9HunOD6E6xw83etBwMwDtvHSpr7zOg6BzCdDF1n3psl2eU37N6RHvTbaj
+        53Jq5NGzzJIn/5Xv2Qt6GyeZeaChjxGGIU3QI8Sn1xfzw9PZawialj8+79DRYrm5aeOoN/TpMa3z
+        RgDY6TZ5bQ+r+7r5ozYjyiRn759qM9QYdXqSnaaoM0IBGqnvBNE4msThCG8dtg7uC54de4qvA103
+        qBHqf7sbX1UbVb3d4nFVvdZ2kqPJpvZhx9xRh81Ty5e9/yDN9t4YQPLwwoD8vPvU88mLEMlunjse
+        eMywrwtQdN4cYHPvRwekRe8U9lEH482vDvDZbdCZ3yK0l5R+36CfmNBvPdQvB+hd4uPbj/8DRnt1
+        sisjAAA=
     headers:
       Connection:
       - keep-alive
       Content-Encoding:
-      - br
+      - gzip
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Dec 2021 10:33:04 GMT
+      - Fri, 17 Dec 2021 15:10:08 GMT
       Location:
-      - /api/v2/companies/242975/transactions/76000017638480
+      - /api/v2/companies/242975/transactions/81000017705397
       ServerDuration:
-      - '00:00:00.0999207'
+      - '00:00:00.1340435'
       Transfer-Encoding:
       - chunked
       Vary:
@@ -139,9 +89,9 @@ interactions:
       strict-transport-security:
       - max-age=31536000; includeSubdomains
       x-avalara-uid:
-      - f8409604-1374-444b-a5a0-271836f2d470
+      - 89ee2bf4-9bd2-4b85-b0f1-2ad8dd62dbda
       x-correlation-id:
-      - f8409604-1374-444b-a5a0-271836f2d470
+      - 89ee2bf4-9bd2-4b85-b0f1-2ad8dd62dbda
       x-frame-options:
       - sameorigin
       x-permitted-cross-domain-policies:

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit_with_discount.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit_with_discount.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
+      "lines": [{"quantity": 3, "amount": "36.900", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 3, "amount":
+      "30.000", "taxCode": "O9999999", "taxIncluded": true, "itemCode": "SKU_A", "description":
+      "Test product", "ref1": "SKU_A"}, {"quantity": 1, "amount": "10.000", "taxCode":
+      "FR000000", "taxIncluded": true, "itemCode": "Shipping", "description": null}],
+      "code": "250ef413-3eeb-49c4-9de3-c23112c4eb21", "date": "2021-12-17", "customerCode":
+      0, "addresses": {"shipFrom": {"line1": "Teczowa 7", "line2": null, "city": "Wroclaw",
+      "region": "", "country": "PL", "postalCode": "53-601"}, "shipTo": {"line1":
+      "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW", "region": "", "country":
+      "PL", "postalCode": "53-601"}}, "commit": false, "currencyCode": "USD", "email":
+      "test@example.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '927'
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: https://rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: !!binary |
+        i/8BAICqqqrq/3SXs7qBqpq5ubue0sE9DgEQEJEQ4R53cVU2D800UzVQFfM0h3xtEojTWt2WG/+/
+        Ixqi0Ugkbp8T0Wi0xLmxdQYgYtmb/1MM5Ha91lqbXd/uu71W5HMAObJbjaEz7aYFbpvu4LvNIaDd
+        eNsaY32HmzWkyOdp5vR8DeRsZw+7raLAAhNY19ZsjN2YHSmqwrJUcvTFDwRSJM8ZEM6MqK/pkaMH
+        Kbqx+J9TiMAN9FIKkn+iNHP9OpMirP6H0x2fLDiJTgZ+qZInlGvlOy69AteaJFGe1wpHElIn9Y0U
+        cuFINJnvsMWKaZb3TNW4UuBz8nFEIDfwWKFozJ4l5lRHQkIwcy4S0/2NPvLnpfgfrvgoAcU4qQEF
+        yafMtvKIOqNU78IRXj8eKCWGEWN/zwlElt5xyksScrrRXKk/wTUnyohdsvAojr23zdbiJC/z4mXA
+        ynaO1ZsWjLsXXsmZrmn3ioSoL7zybYTfzr/weuLRLyMLQs3mcPizVJmQJNTW3rMcGRTsCNxE+ozq
+        S5yvF77R25j9Xzv43X0ruEc6fnIOypMc/X4jRQ+UyqNrFNU8yD8u+MajJWsaY5u2eXSYySXeYzqG
+        UFDrayDX734GDNtup0237xQFVInpkfGhlP7sBPuZ/ZdhgJf4wJkFLaFq+yfSQ9zJmUZ3wT+zLmPi
+        OJIjQZVfWHmaRzQ+T6TottSY0iJvdh3i9oVrl8yUQxwiQvOj0cVo17ZOd03ftfse/wMAAFVVVdX/
+        6RrAZw0HsSVN3fXm4JEJYJABHg7p7peMQ4C6qbiBApipWqqKBphBmm7htTRv9X82rYARJLKyEln5
+        8pMls7oSOflyRs4tm49nV6gbKP1F0/yFwhydf3p298ypdzD1vqkOtYLY9c0Kw6Cmunqt6tdKQ2Hy
+        gTPM5394B6M7IqKuJd12ulOQZEO2g/gYegejuxIEle6afbsnhQNw71zmBycYVFB4xBKcTdvHN6fk
+        HZPAr0hhKFnizOme7ci3bWEYQIGDeNnumU/RMcx3HOch+UV8DDC4cZaXJUVXBkEBmfhgA/7oXOKc
+        78DoOmJYNq2mqt23CjH50YeiXddxCJzPQyxBjvMbJgztKLHpbVuYy+SV56XyUGE7cZLb0QkUO0cY
+        UfjG5154vtnVPiaGkVQ4geB6vV1gnnbKEFR41pzc9ff964hRciMUN7QjIlL4V2wYERSm4QhL/Kwu
+        Ykv8rL/ELzGJD+NyH8zE38dBK9WGRY4lDT6MMHjjPEsZUObAhOl2hy/K5Mdxng1nOiURnOw0lMkK
+        u+LtJWN8HB5cz8oJ3zuYH03bzW/JncSuP8PogxGSil0dI3n+KxicY2AoPEr2Yc+UvaJPPyyf2riv
+        rY1zo9yOtD9ss5Wotpz6MEzFsduNBI7F+inDfPo/xQ0RVa1udFvvdez13Qdt9MlfpFujPlWWs0gb
+        DC7vUEg8erpUkFLgtl/95QoBNLNYYWirRrwq90SkwCv+BwAAqqqqqv/TNUHOCg5qHu4eGXqzNM9M
+        cAAH8wA3y1NCHMRNJcw1QV3UQFQkwRwS0mwTP9BdrYVpmY5eJBIZGYmMZNUqsrJycu5gzihC/Jse
+        i14Ja+FThLBzkHhQVIKgYuTgj0mqXYkEAd7PAObR4yNoupzb/ghEtpgmTVrpfut947cOapoZ1YRU
+        soKD2gG9rSyMYl+AoKPTGJ9LQLt+BDQ31ZP8vRirPMEBFx5xxVum9lGMFYLfeO89W+jVMq2Fb6Kp
+        6RWVcqDgQPYl9Zvti0hijGkun3aNf3vd4smGYjIxNHkHlWSpndk48QwBjlQ1MTqBCBworhAOm7fh
+        SHTmSl6G3obiOlieLqaLaW0ag90Y8CAdLnBizH5KsYUgd+LFtOVYWLTD+EGRI0r8sik+9b41vRdJ
+        +hQCa/TdvjvpleZ0tE32QbHi2mGeLKNS3KB0l78kkiIZhsUuFl37NlOZaSbJMEXie9kvTlrX35dL
+        NvYU77R+Jq6IyDjp5fMb1lTfEQFJZyLE0zMXT8FBqn3hd6x1vItB+MRcicH4QYS8AqGliCaex6ne
+        rQmjL5xTiU8p5fuEdXcgXRy+XcDaYZ5M3Z2DnPCW8kky++QoZxL4/+EL8R4P9C7F5vuRFFOuEH5/
+        VMKYzmX6MGKTmQr/QSyTPYj1nDIqO0UIX/8aQbNvDvtm1zQuv3SnCOH14D3+BwAAqqqqqv/TNYHP
+        6g6iZuZmHnYz8MgAcEgHDwdw82NCgrqauLkCmKlaqoo6uEOAm23iJ3DM2lXbQLlIJBJZGYnstqv1
+        kcjKGjm3bD6eXSkqsPVvRHVFTVU3tcIQbJ7ZSzcMkVPaD2jrhoiorBrS1bZSmII14oLvXwvvwsBo
+        cb675SuGGW/1gzHRHJznQ8AnmbfYVkSkN7re6ErrlUnwgmlNvQ8XKGXYNUpzH/D+q3BPNMNzKNiQ
+        ZO9TjsZb/orsxrugpTUpPIxgg386nFdFSd+r1emAIk3HPF859i8VbOitfuDoQpvYWInGJ2PdwUnN
+        Qjd1ua22pDA5z9P4JloUULiG7AcTX98PjtENFtCSFGxOEmaOl2RGXgwFf5rZi5PXJTHV8AwKAycb
+        3SIueLToOcmvJYYhWwHwEOdN4OM4v/lnQnSj86C3LOxksDO4ZEP20s1v2A2rBe1tiVaBnzwvyE1J
+        jx1HsQRKydiPAQrojkt74bk3T3OdGK3EzAU453N/QnszU0qhC8+agzn/ufzrYCVXQn5RrcsPIoX/
+        2XiL0NGWB4oj8k2jLY3It2Iv+5GXEMX58dMIHwUcKvRKFyvdAID+6KxgKg2LFHK0zo9o8cnJ0OhC
+        QcwT7WZd608SCaObQ25FJpUrzs5MNk9GeIC/djnt++PBZZwUdI9ELysK+slvEvP87UfniaOk6s2R
+        c1ihxTF4hsI1J+d/XZI7027uB+Rq+7nV7+aQvaClNSngfwAAoKqqqvo/XRPkrOCgZqZu6qE3Sw+I
+        BAdwMHNwszjFSdxUwkMTzFUNREUTzCDNNvGTtJu1nbYBuEhkJDISieSmFbKyckrOHeo5iojt7wS3
+        4R8xB093wpwiOAAFgtslzkvx5MEJF1LgSTAsGdzXfwgenDVa68rYxpr6ZBUIY8w4S0jxGiJdPDhr
+        tda6Ndqa1rYKhDHtSCnWBu4r2zYnc9IK0HumnGlYG/RbY6yuzMkomFOJwjs4uF1BAdMzjEsJSQmx
+        f1xuowGOLCgEvSba6LVK95JBB6cPjVGZ7Fu7DkZBiGM1DEzL5m/hkM/JE/SSBHqPr6BhuHb9OxAS
+        PswStPi+1rrStYIcnhGlMKmIwWzSuswiyPcJCErCPu1roJ/7CVApqpXU+W95BwUxxQk3fCzUmfpc
+        2H4vC9mCaeJS1PyOkkMBChj9outD3WyFFavlg6n0m61xjjEVnkUPz8Sm3sruQ3yCg3fKEiJuAvkJ
+        DeCOh7baNkxm/ojaHJo3Tspgw1BkLVLLPpYHA/XQYIBZsfjDqawETZe4FumiL7yUw8yjYPTI/pdT
+        5Pq5K/KTOMguBNVo5jgV2f0VkYJe6+PRaC+4nXGZy4JC3sHVhk8iurBlXSq69i1LVaYsycYpWO81
+        fsYgGZz9c7lXYat4fq/fiF2JQYbv35hDfo7YEJ8LM8V5z8VTUBByn+INc55+uID7xiUTA/8gQs7H
+        TGtiCfE54YaPhT5jkAyuxv8AAEBVVVX1f7rLWd1B1czczMNuDh4RAA5g4OEAbn4KiIO6mriZAKip
+        WoiKOrhBQFhu4j3Q1VrIssz6lTYnkS8R8iVy1e4lEiEn5NyYctxNKUHnb6pt+aaAcYksFMZzDL19
+        2bvHWyBJ0OqtVkDZzMcL50XSz8bevqDdbWtzZfd7+zpa77K3ggMj/acneydPsvbrgtDCFb1Hhv8f
+        BSGGi01JJo55nN5RLPkE7fePAk8Bu+isUAz9umCC9vsPhujyjEE6lCunAdraaK3NztQ7Uxmj+PmH
+        M2karbWuK91UdVPjYQ/DwJgSDawhflk12lT7SoGPTsSmxzg4EG+i5ZPjDP/qr0zOjr8f77GQ9FbW
+        eLX1saHSpiQzLoMCF5OcQspsg8NPRhongfkGfVrhRv/SXTdFqb82m0sHSRnOeb4j96uLQG0TpO6B
+        exSesA3JOqEY3IKNVBlNU5f7aq/V+KS+tgotlKDgHnMYLK9fT2SmAS9iqhW4nCTOyLdkRywMgn4Z
+        MQjJeksoNc5AwYDJMS1CMUAwdaFggdsIDzFfIzSRaaRAytigcAZKLuYgh/mEs0lXgn0rkirAVZA7
+        s4b7EVkcxRrUcwSRYimdBOd+vYKBVjhjAs712l+gfVifQlDB2WccrxMtC4UROhiuau5+a0qtFfxm
+        GxoDD1qz1QoYH6ZU6IyP4iudW63vVv5VLBe6MBtTbEwDChifB+diDgL4HwAAqKqqqv5P1wQ5axio
+        mmmYWujNwD0jwQAc3APM/JYncVMJT00wFzVQFU1wh7TaYrugfq3/5njADfHiRSKRSNQZcyASDdGo
+        m2qPc8lAUbT9lQdQUFLNa+Q7eDhSkcgoMTEoEHyCN83gfrnF20bjI1UW8ENjOoKLA25r3VAoRB+L
+        QwoEHj5n/WFWE2KaAnjr3Ec6/YgSiUWrW/Nm2jfjYkP/yffIJDK0uvyjnGOg62sn8PU5MYGCWy2R
+        qZQpEEv8jmvb9HOC1CfatOtGF6ZKDjNhSZxy//fE61YDBfCSKykIJBi3Av73f4gBvOu11sa6ztl2
+        GBRIRi64Skx8ikzeYG4wjLm32tne9SrslEJEZaeN67vBDloBhpBN0MH3NFedddrYwSpY54xNfoGH
+        rxMoyHSP7TIhKaC/PqevxUDoRVAIeoz0pMcu46qi6aYwlMm+pepgFUResqGm+9+aY1kTKtSKCfQz
+        Pg6Hy2k8H4GIPcRVolbYt1ob3Soo8c4oNZNKrNBbtLGwMArLuSXhss12OF8BjUVVyTKCQQEnvt69
+        i5p6YX2u29XiO1HUfEaJYQcFGf2i6abtphIE0/TBGv3hWjzU5T1ARb1QNnUI+/lLkWlX6fnShsZ0
+        By747CsOlyp7lfsdfKk3BrIVgwscBOu/cqo7wWnivcrIIfFU9jIvghwwhx9GkfPnscqflKO8hCAa
+        Zt+rs86XiALuW/1udKtA8HnAba0b/gcAAKqqqqr/0zWBz+oOqm4r6C3CMx0gAAzcDcItIQAyIQ7i
+        phJuCqCuaqCq5umWAW7TSQfdanW3/OetRzRIZGXlJHKyea2Qk8i5ofP4J2CIvaXMBlpt20ZKgUyP
+        051jtIah5VZKAKlImYd1ZmicM3lD0QCptg98DJwxgZ7o4vi3tzlBt1tVjMD0wQ9g22c7fvBtzorS
+        gfzibT59vVKyCRo9x/0SI/tx5SILAZuOwfeU0jDFBfqLXGIE48Dc2YPIc4jZ+uvw7VZMrQQ7Bm+n
+        K0V/OTyu8BjoERv/6bs9uXFxodZIwFm6WGfzGuF2Y+c44vmZDMkmiTzFsFynn5zJugT991OJwHMX
+        Rso2eDEECr9hwrjc2OfOMg6ZNwNdV1JKVam6UqVSgt8Kx5r2mrjVpWzKuqk51b8YEzklGqxuCmFR
+        NlKVbSnggonazxxMdj7EcMNTWPpc6/qpjFFp6RsbQqBkU7JZ0hAYQ8pvPi2R/MiHyPY6ZfzPuATu
+        lLkl7rvzZlfIw2bTdwApOC63C8dhnTkRqDwTlBJi5RvwsAbOznyO5BONx4IotTFO71VTF23ZSoFL
+        WLyhuHZ8ZweNP3auIHBjPChoDDz+D//oR4M+2w5LkFC0eHJ2tHmFxsf7ad+9fEAg8tUGT2A3h5TJ
+        LVV8VWxqqRAB5uJzVEL77TAzPd51JB5TO1kpuXuKb1gDXTdSSgmVAQCAqqqq6v90DeCzpoHYsoTe
+        HDwgARLAwSMg3AESIAPiIG4qEKEJZqoGqqIZ7hngltvuH5i1OzdrB9GPH4lEIpGIwdoJkWg0RN3B
+        jE8h+WPbjVR3U2egiUPmWX0MvxzsOBAR1ePQTt1EBpdYguN0O8g/WWDxx289DBYfpIbFWeb/8Ysf
+        Rpg65QYWqZE2eHb2eoPF7xTnhb9gkOTDx0DgV1vMyss+OoFF3/4YqIbBHEvQ1In25QAD5etrH3mN
+        3zTU19Tc3w2WOLP6GM63TTLs2zdcnMsqQQ/o4vt0fLwLbTs1Q/3YjIbrAi5DoLv5nFPvnEuSMw06
+        jIHOtdvyKH90+vTbzxRX3I2UTTKNgpCUXYLaZ1LSOcIhlFzWlX2Evn17unI9IThc/pbks4/IsNib
+        byISD+yo6chroHp5PuyOT9/hdlf0MyavtzE80/UGWVlll7P/COKO8duclK8sbvBcdCuKMqVTuSD2
+        KMYtUyfl4Di5h1dWgUFiFbI54aNnxJdFYIem6hsmD2CpaloioiVUw9Zd1U45Dfa8zGVhFYe4HGI4
+        D7JKVR8m5Crrpj4GWKqI7u/3AQ==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - br
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Dec 2021 10:33:04 GMT
+      Location:
+      - /api/v2/companies/242975/transactions/76000017638480
+      ServerDuration:
+      - '00:00:00.0999207'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - f8409604-1374-444b-a5a0-271836f2d470
+      x-correlation-id:
+      - f8409604-1374-444b-a5a0-271836f2d470
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -477,9 +477,74 @@ def test_calculate_order_line_total(
         order_line,
         variant,
         product,
-    )
+    ).price_with_discounts
     total = quantize_price(total, total.currency)
     assert total == TaxedMoney(net=Money("30.00", "USD"), gross=Money("36.90", "USD"))
+
+
+@pytest.mark.vcr()
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_calculate_order_line_total_with_discount(
+    order_line,
+    address,
+    ship_to_pl_address,
+    shipping_zone,
+    site_settings,
+    monkeypatch,
+    plugin_configuration,
+):
+    # given
+    plugin_configuration()
+    manager = get_plugins_manager()
+
+    site_settings.company_address = address
+    site_settings.save(update_fields=["company_address"])
+
+    order = order_line.order
+    order.shipping_address = ship_to_pl_address
+    order.shipping_method = shipping_zone.shipping_methods.get()
+    order.save(update_fields=["shipping_address", "shipping_method"])
+
+    variant = order_line.variant
+    product = variant.product
+    product.metadata = {}
+    product.charge_taxes = True
+    product.save()
+    product.product_type.save()
+
+    channel = order_line.order.channel
+    channel_listing = variant.channel_listings.get(channel=channel)
+
+    discount_amount = Decimal("2.0")
+    currency = order_line.currency
+    order_line.unit_discount = Money(discount_amount, currency)
+    order_line.unit_discount_value = discount_amount
+
+    net = variant.get_price(product, [], channel, channel_listing)
+    unit_price = TaxedMoney(net=net, gross=net)
+    order_line.unit_price = unit_price
+    undiscounted_unit_price = order_line.unit_price + order_line.unit_discount
+    order_line.undiscounted_unit_price = undiscounted_unit_price
+    total_price = unit_price * order_line.quantity
+    order_line.total_price = total_price
+    order_line.undiscounted_total_price = undiscounted_unit_price * order_line.quantity
+    order_line.save()
+
+    # when
+    total_price_data = manager.calculate_order_line_total(
+        order_line.order,
+        order_line,
+        variant,
+        product,
+    )
+
+    # then
+    assert total_price_data.undiscounted_price == TaxedMoney(
+        net=Money(Decimal("29.27"), currency), gross=Money(Decimal("36.00"), currency)
+    )
+    assert total_price_data.price_with_discounts == TaxedMoney(
+        net=Money(Decimal("24.39"), currency), gross=Money(Decimal("30.00"), currency)
+    )
 
 
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
@@ -519,7 +584,7 @@ def test_calculate_order_line_total_order_not_valid(
         order_line,
         variant,
         product,
-    )
+    ).price_with_discounts
     total = quantize_price(total, total.currency)
     assert total == expected_total_price
 
@@ -954,12 +1019,57 @@ def test_calculate_order_line_unit(
     site_settings.company_address = address_usa
     site_settings.save()
 
-    line_price = manager.calculate_order_line_unit(
+    line_price_data = manager.calculate_order_line_unit(
         order, order_line, order_line.variant, order_line.variant.product
     )
-    line_price = quantize_price(line_price, line_price.currency)
 
-    assert line_price == TaxedMoney(
+    expected_line_price = TaxedMoney(
+        net=Money("8.13", "USD"), gross=Money("10.00", "USD")
+    )
+    assert line_price_data.undiscounted_price == expected_line_price
+    assert line_price_data.price_with_discounts == expected_line_price
+
+
+@pytest.mark.vcr
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_calculate_order_line_unit_with_discount(
+    order_line,
+    shipping_zone,
+    site_settings,
+    address_usa,
+    plugin_configuration,
+):
+    # given
+    plugin_configuration()
+    manager = get_plugins_manager()
+    unit_price = TaxedMoney(net=Money("10.00", "USD"), gross=Money("10.00", "USD"))
+    order_line.unit_price = unit_price
+    currency = order_line.currency
+    discount_amount = Decimal("2.5")
+    order_line.unit_discount = Money(discount_amount, currency)
+    order_line.unit_discount_value = discount_amount
+    order_line.save()
+
+    order = order_line.order
+    method = shipping_zone.shipping_methods.get()
+    order.shipping_address = order.billing_address.get_copy()
+    order.shipping_method_name = method.name
+    order.shipping_method = method
+    order.save()
+
+    site_settings.company_address = address_usa
+    site_settings.save()
+
+    # when
+    line_price_data = manager.calculate_order_line_unit(
+        order, order_line, order_line.variant, order_line.variant.product
+    )
+
+    # then
+    assert line_price_data.undiscounted_price == TaxedMoney(
+        net=Money("10.00", "USD"), gross=Money("12.30", "USD")
+    )
+    assert line_price_data.price_with_discounts == TaxedMoney(
         net=Money("8.13", "USD"), gross=Money("10.00", "USD")
     )
 
@@ -2692,7 +2802,13 @@ def test_get_order_lines_data_sets_different_tax_code_for_zero_amount(
 
     line = order_with_lines.lines.first()
     line.unit_price_gross_amount = Decimal("0")
-    line.save()
+    line.undiscounted_unit_price_gross_amount = Decimal("0")
+    line.save(
+        update_fields=[
+            "unit_price_gross_amount",
+            "undiscounted_unit_price_gross_amount",
+        ]
+    )
     variant = line.variant
     variant.product.store_value_in_metadata(
         {META_CODE_KEY: "taxcode", META_DESCRIPTION_KEY: "tax_description"}
@@ -2728,7 +2844,14 @@ def test_get_order_lines_data_sets_different_tax_code_only_for_zero_amount(
     line = order_with_lines.lines.first()
     line.quantity = 1
     line.unit_price_gross_amount = Decimal("10.0")
-    line.save()
+    line.undiscounted_unit_price_gross_amount = Decimal("10.0")
+    line.save(
+        update_fields=[
+            "quantity",
+            "unit_price_gross_amount",
+            "undiscounted_unit_price_gross_amount",
+        ]
+    )
     variant = line.variant
     variant.product.store_value_in_metadata(
         {META_CODE_KEY: "taxcode", META_DESCRIPTION_KEY: "tax_description"}

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -1026,7 +1026,10 @@ def test_calculate_order_line_unit(
     expected_line_price = TaxedMoney(
         net=Money("8.13", "USD"), gross=Money("10.00", "USD")
     )
-    assert line_price_data.undiscounted_price == expected_line_price
+    expected_undiscounted_line_price = TaxedMoney(
+        net=Money("10.00", "USD"), gross=Money("12.30", "USD")
+    )
+    assert line_price_data.undiscounted_price == expected_undiscounted_line_price
     assert line_price_data.price_with_discounts == expected_line_price
 
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -9,7 +9,7 @@ from django_countries.fields import Country
 from measurement.measures import Weight
 from prices import Money, TaxedMoney
 
-from ..checkout.interface import TaxedPricesData
+from ..checkout.interface import CheckoutTaxedPricesData
 from ..payment.interface import (
     CustomerSource,
     GatewayResponse,
@@ -154,7 +154,7 @@ class BasePlugin:
             Iterable["DiscountInfo"],
             TaxedMoney,
         ],
-        TaxedPricesData,
+        CheckoutTaxedPricesData,
     ]
 
     #  Calculate checkout line unit price.
@@ -167,7 +167,7 @@ class BasePlugin:
             Iterable["DiscountInfo"],
             Any,
         ],
-        TaxedPricesData,
+        CheckoutTaxedPricesData,
     ]
 
     #  Calculate the shipping costs for checkout.

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -22,11 +22,12 @@ from prices import Money, TaxedMoney
 
 from ..channel.models import Channel
 from ..checkout import base_calculations
-from ..checkout.interface import TaxedPricesData
+from ..checkout.interface import CheckoutTaxedPricesData
 from ..core.payments import PaymentInterface
 from ..core.prices import quantize_price
 from ..core.taxes import TaxType, zero_taxed_money
 from ..discount import DiscountInfo
+from ..order.interface import OrderTaxedPricesData
 from .base_plugin import ExcludedShippingMethod, ExternalAccessTokens, ShippingMethod
 from .models import PluginConfiguration
 
@@ -293,7 +294,7 @@ class PluginsManager(PaymentInterface):
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-    ) -> TaxedPricesData:
+    ) -> CheckoutTaxedPricesData:
         default_value = base_calculations.base_checkout_line_total(
             checkout_line_info,
             checkout_info.channel,
@@ -327,20 +328,25 @@ class PluginsManager(PaymentInterface):
         order_line: "OrderLine",
         variant: "ProductVariant",
         product: "Product",
-    ):
+    ) -> OrderTaxedPricesData:
         default_value = base_calculations.base_order_line_total(order_line)
-        return quantize_price(
-            self.__run_method_on_plugins(
-                "calculate_order_line_total",
-                default_value,
-                order,
-                order_line,
-                variant,
-                product,
-                channel_slug=order.channel.slug,
-            ),
-            order.currency,
+        line_total = self.__run_method_on_plugins(
+            "calculate_order_line_total",
+            default_value,
+            order,
+            order_line,
+            variant,
+            product,
+            channel_slug=order.channel.slug,
         )
+        currency = order_line.currency
+        line_total.price_with_discounts = quantize_price(
+            line_total.price_with_discounts, currency
+        )
+        line_total.undiscounted_price = quantize_price(
+            line_total.undiscounted_price, currency
+        )
+        return line_total
 
     def calculate_checkout_line_unit_price(
         self,
@@ -349,7 +355,7 @@ class PluginsManager(PaymentInterface):
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-    ) -> TaxedPricesData:
+    ) -> CheckoutTaxedPricesData:
         default_value = base_calculations.base_checkout_line_unit_price(
             checkout_line_info, checkout_info.channel, discounts
         )
@@ -379,21 +385,28 @@ class PluginsManager(PaymentInterface):
         order_line: "OrderLine",
         variant: "ProductVariant",
         product: "Product",
-    ) -> TaxedMoney:
-        unit_price = order_line.unit_price
-        default_value = quantize_price(unit_price, unit_price.currency)
-        return quantize_price(
-            self.__run_method_on_plugins(
-                "calculate_order_line_unit",
-                default_value,
-                order,
-                order_line,
-                variant,
-                product,
-                channel_slug=order.channel.slug,
-            ),
-            order_line.currency,
+    ) -> OrderTaxedPricesData:
+        default_value = OrderTaxedPricesData(
+            undiscounted_price=order_line.undiscounted_unit_price,
+            price_with_discounts=order_line.unit_price,
         )
+        currency = order_line.currency
+        line_unit = self.__run_method_on_plugins(
+            "calculate_order_line_unit",
+            default_value,
+            order,
+            order_line,
+            variant,
+            product,
+            channel_slug=order.channel.slug,
+        )
+        line_unit.price_with_discounts = quantize_price(
+            line_unit.price_with_discounts, currency
+        )
+        line_unit.undiscounted_price = quantize_price(
+            line_unit.undiscounted_price, currency
+        )
+        return line_unit
 
     def get_checkout_line_tax_rate(
         self,

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -7,8 +7,9 @@ from django_countries.fields import Country
 from prices import Money, TaxedMoney
 
 from ...account.models import User
-from ...checkout.interface import TaxedPricesData
+from ...checkout.interface import CheckoutTaxedPricesData
 from ...core.taxes import TaxType
+from ...order.interface import OrderTaxedPricesData
 from ..base_plugin import BasePlugin, ConfigurationTypeField, ExternalAccessTokens
 
 if TYPE_CHECKING:
@@ -93,10 +94,10 @@ class PluginSample(BasePlugin):
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-        previous_value: TaxedMoney,
+        previous_value: CheckoutTaxedPricesData,
     ):
         price = Money("1.0", currency=checkout_info.checkout.currency)
-        return TaxedPricesData(
+        return CheckoutTaxedPricesData(
             price_with_sale=TaxedMoney(price, price),
             price_with_discounts=TaxedMoney(price, price),
             undiscounted_price=TaxedMoney(price, price),
@@ -108,10 +109,13 @@ class PluginSample(BasePlugin):
         order_line: "OrderLine",
         variant: "ProductVariant",
         product: "Product",
-        previous_value: TaxedMoney,
+        previous_value: OrderTaxedPricesData,
     ) -> TaxedMoney:
         price = Money("1.0", currency=order.currency)
-        return TaxedMoney(price, price)
+        return OrderTaxedPricesData(
+            price_with_discounts=TaxedMoney(price, price),
+            undiscounted_price=TaxedMoney(price, price),
+        )
 
     def calculate_checkout_line_unit_price(
         self,
@@ -120,11 +124,11 @@ class PluginSample(BasePlugin):
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-        previous_value: TaxedMoney,
+        previous_value: CheckoutTaxedPricesData,
     ):
         currency = checkout_info.checkout.currency
         price = Money("10.0", currency)
-        return TaxedPricesData(
+        return CheckoutTaxedPricesData(
             price_with_sale=TaxedMoney(price, price),
             price_with_discounts=TaxedMoney(price, price),
             undiscounted_price=TaxedMoney(price, price),
@@ -136,11 +140,14 @@ class PluginSample(BasePlugin):
         order_line: "OrderLine",
         variant: "ProductVariant",
         product: "Product",
-        previous_value: TaxedMoney,
+        previous_value: OrderTaxedPricesData,
     ):
         currency = order_line.unit_price.currency
         price = Money("1.0", currency)
-        return TaxedMoney(price, price)
+        return OrderTaxedPricesData(
+            price_with_discounts=TaxedMoney(price, price),
+            undiscounted_price=TaxedMoney(price, price),
+        )
 
     def get_tax_rate_type_choices(self, previous_value):
         return [TaxType(code="123", description="abc")]

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -261,8 +261,12 @@ def test_manager_calculates_order_line_total(order_line, plugins):
         if plugins
         else quantize_price(order_line.unit_price * order_line.quantity, currency)
     )
-    taxed_total = PluginsManager(plugins=plugins).calculate_order_line_total(
-        order_line.order, order_line, order_line.variant, order_line.variant.product
+    taxed_total = (
+        PluginsManager(plugins=plugins)
+        .calculate_order_line_total(
+            order_line.order, order_line, order_line.variant, order_line.variant.product
+        )
+        .price_with_discounts
     )
     assert expected_total == taxed_total
 
@@ -492,8 +496,12 @@ def test_manager_calculates_order_line(order_line, plugins, amount):
     variant = order_line.variant
     currency = order_line.unit_price.currency
     expected_price = Money(amount, currency)
-    unit_price = PluginsManager(plugins=plugins).calculate_order_line_unit(
-        order_line.order, order_line, variant, variant.product
+    unit_price = (
+        PluginsManager(plugins=plugins)
+        .calculate_order_line_unit(
+            order_line.order, order_line, variant, variant.product
+        )
+        .price_with_discounts
     )
     assert expected_price == unit_price.gross
 

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -16,9 +16,10 @@ from django_prices_vatlayer.utils import (
 from prices import Money, TaxedMoney, TaxedMoneyRange
 
 from ...checkout import base_calculations, calculations
-from ...checkout.interface import PricesData, TaxedPricesData
+from ...checkout.interface import CheckoutTaxedPricesData
 from ...core.taxes import TaxType
 from ...graphql.core.utils.error_codes import PluginErrorCode
+from ...order.interface import OrderTaxedPricesData
 from ...product.models import ProductType
 from ..base_plugin import BasePlugin, ConfigurationTypeField
 from ..manager import get_plugins_manager
@@ -126,7 +127,13 @@ class VatlayerPlugin(BasePlugin):
 
     def _skip_plugin(
         self,
-        previous_value: Union[TaxedMoney, TaxedMoneyRange, Decimal, TaxedPricesData],
+        previous_value: Union[
+            TaxedMoney,
+            TaxedMoneyRange,
+            Decimal,
+            CheckoutTaxedPricesData,
+            OrderTaxedPricesData,
+        ],
     ) -> bool:
         if not self.active or not self.config.access_key:
             return True
@@ -141,11 +148,18 @@ class VatlayerPlugin(BasePlugin):
         if isinstance(previous_value, TaxedMoney):
             return previous_value.net != previous_value.gross
 
-        if isinstance(previous_value, TaxedPricesData):
+        if isinstance(previous_value, CheckoutTaxedPricesData):
             return (
                 previous_value.price_with_sale.net
                 != previous_value.price_with_sale.gross
             )
+
+        if isinstance(previous_value, OrderTaxedPricesData):
+            return (
+                previous_value.price_with_discounts.net
+                != previous_value.price_with_discounts.gross
+            )
+
         return False
 
     def calculate_checkout_total(
@@ -258,8 +272,8 @@ class VatlayerPlugin(BasePlugin):
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-        previous_value: TaxedPricesData,
-    ) -> TaxedPricesData:
+        previous_value: CheckoutTaxedPricesData,
+    ) -> CheckoutTaxedPricesData:
         unit_taxed_prices_data = self.__calculate_checkout_line_unit_price(
             checkout_line_info,
             checkout_info.channel,
@@ -271,7 +285,7 @@ class VatlayerPlugin(BasePlugin):
             return previous_value
 
         quantity = checkout_line_info.line.quantity
-        return TaxedPricesData(
+        return CheckoutTaxedPricesData(
             price_with_discounts=unit_taxed_prices_data.price_with_discounts * quantity,
             price_with_sale=unit_taxed_prices_data.price_with_sale * quantity,
             undiscounted_price=unit_taxed_prices_data.undiscounted_price * quantity,
@@ -283,19 +297,21 @@ class VatlayerPlugin(BasePlugin):
         order_line: "OrderLine",
         variant: "ProductVariant",
         product: "Product",
-        previous_value: TaxedMoney,
-    ) -> TaxedMoney:
-        unit_price = self.__calculate_order_line_unit(
+        previous_value: OrderTaxedPricesData,
+    ) -> OrderTaxedPricesData:
+        unit_price_data = self.__calculate_order_line_unit(
             order,
             order_line,
             variant,
             product,
             previous_value,
         )
-        return (
-            unit_price * order_line.quantity
-            if unit_price is not None
-            else previous_value
+        if unit_price_data is None:
+            return previous_value
+        quantity = order_line.quantity
+        return OrderTaxedPricesData(
+            undiscounted_price=unit_price_data.undiscounted_price * quantity,
+            price_with_discounts=unit_price_data.price_with_discounts * quantity,
         )
 
     def calculate_checkout_line_unit_price(
@@ -305,8 +321,8 @@ class VatlayerPlugin(BasePlugin):
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-        previous_value: TaxedPricesData,
-    ) -> TaxedPricesData:
+        previous_value: CheckoutTaxedPricesData,
+    ) -> CheckoutTaxedPricesData:
         unit_taxed_prices_data = self.__calculate_checkout_line_unit_price(
             checkout_line_info,
             checkout_info.channel,
@@ -322,7 +338,7 @@ class VatlayerPlugin(BasePlugin):
         channel: "Channel",
         discounts: Iterable["DiscountInfo"],
         address: Optional["Address"],
-        previous_value: TaxedPricesData,
+        previous_value: CheckoutTaxedPricesData,
     ):
         if self._skip_plugin(previous_value):
             return
@@ -334,7 +350,7 @@ class VatlayerPlugin(BasePlugin):
         )
 
         country = address.country if address else None
-        taxed_prices_data = TaxedPricesData(
+        taxed_prices_data = CheckoutTaxedPricesData(
             price_with_sale=self.__apply_taxes_to_product(
                 checkout_line_info.product, prices_data.price_with_sale, country
             ),
@@ -353,12 +369,12 @@ class VatlayerPlugin(BasePlugin):
         order_line: "OrderLine",
         variant: "ProductVariant",
         product: "Product",
-        previous_value: TaxedMoney,
-    ) -> TaxedMoney:
-        unit_price = self.__calculate_order_line_unit(
+        previous_value: OrderTaxedPricesData,
+    ) -> OrderTaxedPricesData:
+        unit_price_data = self.__calculate_order_line_unit(
             order, order_line, variant, product, previous_value
         )
-        return unit_price if unit_price is not None else previous_value
+        return unit_price_data if unit_price_data is not None else previous_value
 
     def __calculate_order_line_unit(
         self,
@@ -366,7 +382,7 @@ class VatlayerPlugin(BasePlugin):
         order_line: "OrderLine",
         variant: "ProductVariant",
         product: "Product",
-        previous_value: TaxedMoney,
+        previous_value: OrderTaxedPricesData,
     ):
         if self._skip_plugin(previous_value):
             return
@@ -375,7 +391,15 @@ class VatlayerPlugin(BasePlugin):
         country = address.country if address else None
         if not variant:
             return
-        return self.__apply_taxes_to_product(product, order_line.unit_price, country)
+        taxed_prices_data = OrderTaxedPricesData(
+            undiscounted_price=self.__apply_taxes_to_product(
+                product, order_line.undiscounted_unit_price, country
+            ),
+            price_with_discounts=self.__apply_taxes_to_product(
+                product, order_line.unit_price, country
+            ),
+        )
+        return taxed_prices_data
 
     def get_checkout_line_tax_rate(
         self,

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -537,7 +537,9 @@ def test_calculate_order_line_unit(vatlayer, order_line, shipping_zone, site_set
     manager.assign_tax_code_to_object_meta(product, "standard")
     product.save()
 
-    line_price = manager.calculate_order_line_unit(order, order_line, variant, product)
+    line_price = manager.calculate_order_line_unit(
+        order, order_line, variant, product
+    ).price_with_discounts
     line_price = quantize_price(line_price, line_price.currency)
     assert line_price == TaxedMoney(
         net=Money("8.13", "USD"), gross=Money("10.00", "USD")
@@ -569,7 +571,9 @@ def test_calculate_order_line_unit_from_origin_country(
     manager.assign_tax_code_to_object_meta(product, "standard")
     product.save()
 
-    line_price = manager.calculate_order_line_unit(order, order_line, variant, product)
+    line_price = manager.calculate_order_line_unit(
+        order, order_line, variant, product
+    ).price_with_discounts
     line_price = quantize_price(line_price, line_price.currency)
 
     # make sure that we applied DE taxes (19%)
@@ -601,7 +605,9 @@ def test_calculate_order_line_unit_with_excluded_country(
     manager.assign_tax_code_to_object_meta(product, "standard")
     product.save()
 
-    line_price = manager.calculate_order_line_unit(order, order_line, variant, product)
+    line_price = manager.calculate_order_line_unit(
+        order, order_line, variant, product
+    ).price_with_discounts
     line_price = quantize_price(line_price, line_price.currency)
 
     assert line_price == TaxedMoney(
@@ -751,7 +757,7 @@ def test_calculate_order_line_total(vatlayer, order_line, site_settings):
         order_line,
         variant,
         product,
-    )
+    ).price_with_discounts
 
     total_price_amount = total_price.net.amount
     currency = total_price.currency


### PR DESCRIPTION
The extension of #8793.

Attach information about the discount when a variant is added to the order (`UNCONFIRMED` or `DRAFT`).
Only sales are included, as we do not want to apply vouchers to new order lines.

[Breaking] use a new interface for the response received from plugins/pluginManager. Methods: 
- `calculate_checkout_line_unit_price` and `calculate_checkout_line_total` returns `CheckoutTaxedPricesData` instead of `TaxedMoney`.
- `calculate_order_line_unit` and `calculate_order_line_total` returns `OrderTaxedPricesData` instead of `TaxedMoney`.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
