### PR TITLE
App name in tracing spans

### DIFF
--- a/saleor/core/tracing.py
+++ b/saleor/core/tracing.py
@@ -44,7 +44,7 @@ def webhooks_opentracing_trace(span_name, domain, sync=False, app_name=None):
     ) as scope:
         span = scope.span
         if app_name:
-            span.set_tag("webhooks.app", app_name)
+            span.set_tag("app.name", app_name)
         span.set_tag(opentracing.tags.COMPONENT, "webhooks")
         span.set_tag("service.name", "webhooks")
         span.set_tag("webhooks.domain", domain)

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -173,9 +173,6 @@ class GraphQLView(View):
                 break
 
             response = self._handle_query(request)
-
-            if app := getattr(request, "app"):
-                span.set_tag("app.name", app.name)
             span.set_tag(opentracing.tags.HTTP_STATUS_CODE, response.status_code)
 
             # RFC2616: Content-Length is defined in bytes,
@@ -302,9 +299,13 @@ class GraphQLView(View):
                         )
                         if should_use_cache_for_scheme:
                             cache.set(key, response)
+                    if app := getattr(request, "app", None):
+                        span.set_tag("app.name", app.name)
                     return response
             except Exception as e:
                 span.set_tag(opentracing.tags.ERROR, True)
+                if app := getattr(request, "app", None):
+                    span.set_tag("app.name", app.name)
                 # In the graphql-core version that we are using,
                 # the Exception is raised for too big integers value.
                 # As it's a validation error we want to raise GraphQLError instead.

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -173,6 +173,9 @@ class GraphQLView(View):
                 break
 
             response = self._handle_query(request)
+
+            if app := getattr(request, "app"):
+                span.set_tag("app.name", app.name)
             span.set_tag(opentracing.tags.HTTP_STATUS_CODE, response.status_code)
 
             # RFC2616: Content-Length is defined in bytes,


### PR DESCRIPTION
I want to merge this change because it adds app name (when it's possible) to graphql_query spans.
![image](https://user-images.githubusercontent.com/12252472/146919114-b218d169-4280-4350-ba11-1071bed0d41a.png)


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
