### PR TITLE
Remove unnecessary call to OIDC when the request is sent as App

### DIFF
--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -22,6 +22,10 @@ class JWTMiddleware:
     def resolve(self, next, root, info, **kwargs):
         request = info.context
 
+        if hasattr(request, "app") and request.app:
+            request.user = AnonymousUser()
+            return next(root, info, **kwargs)
+
         def user():
             return get_user(request) or AnonymousUser()
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -531,8 +531,9 @@ GRAPHENE = {
     "RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST": True,
     "RELAY_CONNECTION_MAX_LIMIT": 100,
     "MIDDLEWARE": [
-        "saleor.graphql.middleware.app_middleware",
+        # Those middlewares are executed from bottom to top
         "saleor.graphql.middleware.JWTMiddleware",
+        "saleor.graphql.middleware.app_middleware",
     ],
 }
 


### PR DESCRIPTION
I want to merge this change because removing unnecessary call to OIDC when the request is sent as App.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
