### PR TITLE
fix shipping zone update mutation and test for default=True in 3.1

### DIFF
--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -155,7 +155,7 @@ class ShippingZoneMixin:
                 )
             else:
                 countries = get_countries_without_shipping_zone()
-                data["countries"] = countries
+                data["countries"].extend([country for country in countries])
         else:
             data["default"] = False
         return data


### PR DESCRIPTION
It is a port of changes from #8850

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
