### PR TITLE
Add tests for incorrect tax calculations in JPY

### DIFF
--- a/saleor/graphql/channel/tests/fixtures.py
+++ b/saleor/graphql/channel/tests/fixtures.py
@@ -36,3 +36,14 @@ def channel_PLN(db):
         default_country="PL",
         is_active=True,
     )
+
+
+@pytest.fixture
+def channel_JPY(db):
+    return Channel.objects.create(
+        name="Channel=JPY",
+        slug="c-jpy",
+        currency_code="JPY",
+        default_country="JP",
+        is_active=True,
+    )

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_unit_price_in_JPY.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_unit_price_in_JPY.yaml
@@ -1,0 +1,90 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
+      "lines": [{"quantity": 3, "amount": "3600", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
+      "700.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
+      "description": null}], "code": "a04119d9-fc1f-40dd-9b5f-520d2b4c5315", "date":
+      "2021-12-23", "customerCode": 0, "addresses": {"shipFrom": {"line1": "Teczowa
+      7", "line2": null, "city": "Wroclaw", "region": "", "country": "PL", "postalCode":
+      "53-601"}, "shipTo": {"line1": "O\u0142awska 10", "line2": "", "city": "WROC\u0141AW",
+      "region": "", "country": "PL", "postalCode": "53-105"}}, "commit": false, "currencyCode":
+      "JPY", "email": ""}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '757'
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: https://rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA+1X227iSBD9lcjPAdkGQswbSyZSVhFEgexoZzUPjd1Az/i23e1MmFH+fU/1hUuA
+        STSrzdPyZKqrylWnqk6XfwQiCwbheZBWGQ8GAQu7UZRkSWuRRotWN8yyVjLvLVq9OMzieTftdaJe
+        QNpFzcr1DWzjbpz0e+dBxjQ5iMM4akVxK+5ArWbrgpf66siR0kw3CgYzXtSVZHINfb2uyceU5VxN
+        ZMYlZHOm09XIRkdvbqTkZbp2kt/v/oSQP6UrVi75PV40OqaQNkpXBZcPii35zL6F7Eot9PpB8V3/
+        VvMPXmaVdPLQvNge7Ij4E2LX4wohQ0HytCpTkXOAsmC54udBXqVMi6rcupccyWpRLm8PjupGIgvF
+        TeJbpwtO+e5EqAidmku161dXmuXDompKHQw63aTXTrrAk6QfTJQochtlNpIroVKruZXN2FMwuAw7
+        GyUI2DxHOfa9QTxiedrkgBqJOguWfQHCVOt7zhAYEBlXemikUDNIfN0B5hHhA5dgEO0X78NiwVMt
+        HvmxltmtMiwpUl4wkVv4iyoTC8GzA8tZFA/C3qATtZMkjsP+J4TjlVF6aZr4shMlMeBhTwf2FL0o
+        OXr1rx9+WrRkpWKItCrJHJGQyrgp5ujZQRDB5u0tl3GVSlGTM9jOuNJntayyJtVwk7la+dqaitnG
+        OyIacaldQPvNKdSN5sWmplo2aE8BkWvNyMwrJeG9xkl80b7shMjt74aZQUEvEOiSLyKLOZ5i/+T6
+        +hh8QDUYXPRtb9m2evEWg/xuX221XYCTxP4ACdyRkPLsdboI6ETVIL4p07zJqPFsxhnXaJhTpbxF
+        +g69wwKbiQFLDYK7WwQh+dLWy/w7UpAvjRTKBW90jGDMCmK4u8ntcHwFN0SDfKiUWJY880NvNB1L
+        jcYzqBlJJkzD+QOaYMOaZVXO9lE1TSIN64btGDWkKgIOW4Wob/7QdB8rg/M/aXTdUAfCbtrMSUrY
+        BBMrcolMNSszJrMzol57Mmz0qpLgVW/Sxe0AJy/LS2FQjO593hOceKlDbwpRUwo9WfzGlKA7445L
+        T/MPOMC5UOOqvGNKzVay2fCvUNcccDs23nCvQ4tM4c01OpXU9TBc7atYPP2xJVRnvX8Esy3GG3+Q
+        Hks+F2wucgcUspryPAd9PH8+D1BSSkavZNUsV1ebrsXRyjcVsk4rpW9K1YCNUn4tuViuQP8mpEem
+        N803xW0cTlot04Y4sDzlyxM+n7+V12J655uv0neirulK1DVuVMS2y1+9i6QdRfv0Ze6MX6OvqGNg
+        1fuDZl9y0N5bZVeD63uawZD2CHggIc1St99PjOAEaf7PXi/Yi3C9tJDtstdOFRyZ/Kfk5aPwNEWj
+        62gQ9fXS9yEvn/qGa/4ld21y82T3grv8+fty1/Vp7gIjsiyTXKnXNrQ5LkxcVetb/shpZ/wkavqU
+        Ic6gdWaSs2/qKzuLaEhJ6DYbeuzgHNIUXI2nj/eT0e3wI9XaLwF4rsHFLHdV73VaUWg/lOwt7bYG
+        DP+9saHxj8NeFGLpxCotNLYU+5K8Kpebvz+l5lcSmvH0e/WNnfVfzUdWKZJ/JZ+L0Gy1buv41XxQ
+        LtUUBX3u0Tr906Vqbw3abDtG6mA+vVcB6L09BGSLLQQVOty2oHqaNagxAAx0Tiw8ftyhuEMC0H/x
+        8UR6dDXvbWOXYbcdXhxcH16MLWDmHZnbx66ZZu/E/+fPz/8A3ESQGr8PAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Dec 2021 12:05:31 GMT
+      Location:
+      - /api/v2/companies/242975/transactions/0
+      ServerDuration:
+      - '00:00:00.0199441'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - 89bba73b-966e-4316-b910-f90430c5f444
+      x-correlation-id:
+      - 89bba73b-966e-4316-b910-f90430c5f444
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit.yaml
@@ -1,17 +1,15 @@
 interactions:
 - request:
     body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
-      "lines": [{"quantity": 3, "amount": "36.900", "taxCode": "O9999999", "taxIncluded":
-      true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 3, "amount":
-      "30.000", "taxCode": "O9999999", "taxIncluded": true, "itemCode": "SKU_A", "description":
-      "Test product", "ref1": "SKU_A"}, {"quantity": 1, "amount": "10.000", "taxCode":
-      "FR000000", "taxIncluded": true, "itemCode": "Shipping", "description": null}],
-      "code": "a6235109-b91d-4f31-8c15-d7275a1894be", "date": "2021-12-20", "customerCode":
-      0, "addresses": {"shipFrom": {"line1": "Teczowa 7", "line2": null, "city": "Wroclaw",
-      "region": "", "country": "PL", "postalCode": "53-601"}, "shipTo": {"line1":
-      "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW", "region": "", "country":
-      "PL", "postalCode": "53-601"}}, "commit": false, "currencyCode": "USD", "email":
-      "test@example.com"}}'
+      "lines": [{"quantity": 3, "amount": "30.000", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "SKU_A", "description": "Test product"}, {"quantity": 1, "amount":
+      "10.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
+      "description": null}], "code": "9c6f6276-3c68-49a9-996d-081cd843cf89", "date":
+      "2021-12-23", "customerCode": 0, "addresses": {"shipFrom": {"line1": "Teczowa
+      7", "line2": null, "city": "Wroclaw", "region": "", "country": "PL", "postalCode":
+      "53-601"}, "shipTo": {"line1": "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW",
+      "region": "", "country": "PL", "postalCode": "53-601"}}, "commit": false, "currencyCode":
+      "USD", "email": "test@example.com"}}'
     headers:
       Accept:
       - '*/*'
@@ -22,7 +20,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '927'
+      - '777'
       User-Agent:
       - python-requests/2.26.0
     method: POST
@@ -30,40 +28,38 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEA+1a227bOBD9lULPsWHJdz+tN5dFsIEdxE4LdFEsaIm21ZUlLyml8Rb59z3Di0Qr
-        t7a5ICiaJ2c4HA45M4fHQ3/14sgbDVr05w86frs77B94YRZxb+SxXtDu+q1hYzH0o0Zn2fYbg9Dv
-        NqJ+0O8yfzDsLLhH2pstS3enMBR0gmG/e+BFLCcDQSvwG37QCFpQkznLCwnpjF3xCIJ8tyWlGUu4
-        PE2vsjgkawuWh+tD7QAZL4TgabgzksvZEYT8OlyzdMUvsMzhXQphIfNsw8WlZCs+1+vQvDSP892l
-        5K59rfmep1EmjJzctSYcEb/mm20+yeA0FAQPszSME+xltGSJ5AdekoUsj7O0Mi/4NhN5nK7Obg1t
-        C4FdSD4VEReV0SWn/ToeSjqfLRfStZuz6+kVFyKO7PYmWUrH5wyMN1mR5t6o1WztyS84gy29iTzL
-        WWIVe0GzG0CVZMdqr3YySY5iGboGSTZn197I7zTbAzMNArZIEFbXFoSHLAmLBOHCYRl9Fn1GlDaI
-        SenQJMvHSqryo1I44jIU8ZaOVruNg/7HOXfBV+WQ8lHsoHd+hvPAIUk15iMDs2X+hQn+3sq8wG/6
-        QbPdpIBnIl7F6TiKBJeSkrmvqqLd84Nhq42qiLhEJFWAHa3ekNQqLTc3j5dLHubxFT+6ox5cRRwK
-        BQkr7O+Tb1icYCs5lv6NX7PNNuFN1BvcXRQyTpWnlNXLWGeezaNNFkHGo1sLz1vDUbc78rtNVHq3
-        4w8/wpbVRmUIVcaDtj+kTGDXtwxAPaGFvdFfXxV46GPq9fr93nAwxCTBUsmw7SwlW3VsocmTYrPg
-        AvvyaSNIqoiJnc1nmoSzsPX3eAnvn9ocR/VuK7KoCHNY/7agPR57k/y2VFRNRUZIAGO81hCxp6VF
-        h1zkezo2UrE8zfmmrJtcFACSWM5m8/MSV2JoGEyZ/Xn599jEwC7Thjf4O/D+LZhCOG+ElCaEWvq6
-        XvApsJ8MIN0VWMGvxqEpcoI4mQGjAF6YelQlPwaQGCjxJkVbF7zrihK6BW8VzRamQ/2n7ZCQDqbb
-        7sDlezIO4uMU1Un3hZ5ms8WAu0G/h4sCVuw06++D2MiuT9MwKSJCGh2XiOcoyCr3VXL7cH3QaXWB
-        ME7un8Fb2td3lger8KeOLDVkK0FP4Zwa3J2cns/0EdFty6t/b+Wlyhct1fBLvnaQeemMZtoNfy5E
-        LE3c1DpKMGEbisT59Gw8oftYCaO4rPkAZKIF/JDxCnhZCPc2I+tjSSM8sjWg5ptIHk7mNYt2gC4f
-        APuBl2bpfD/tbAFUIxdFYmuyEhpLRBtoHKaE2murGbR1BdH/dmoH1KePXZBsRpVgDQIlzZHAwqM1
-        ok4aqUf3ok27smIhN05Ni3xbEGJBNCsWJKWQeFMtov//EFmxVcLTFLrjNHInmaAgfASn0TvapZ47
-        LvI1EC7fWaMdUDQsc6GuTTIYIHspYBDWCtd6bwtHMQIlpGMxvts1sZyVmgOaaQ9o75dpnKNyyq1X
-        YTEjNog6K2vCArOny9+ZjGHDO0cEDO8jPSwSy0mWnjMp52tRVMApTzgy1dCzkozNdTTMEuQRgaUB
-        RtjZH98fPlbEqPLOmYlpBhVLYxDVDpSuT7aIExMObGbGkwS34c0nldm0h3yNSK/WRyXaYIjuTUsi
-        6dg1CEVZWBCFIrRxRymoCj/87qDX8ns9QLWrS+N1ZLLjDrmpUyDwLsV/yAEb4XW8PRGgJDcHX/eW
-        qLujbD3NnToi3uPOPFOHubbAhfQIM5mfprIANwn5ieDxam2Z8RXLS4CbNQAE00ZDU0eWa6Jiy6ZF
-        W4zp5HxCix+jPAG8+UV5nkp5AnznAPG+j/JYlvQivKfb7NFVv4/oyqFbAFqqmgz7magP1cAj1Of7
-        yuQX9fmpqA/lPlXoXYVi5IY+uCzmrVAfx/tnoz4laL0Z6mNQq6QrT+Q+Gu5KazXyo0dfi/2oO/oh
-        ulEDp5dmP/hOBLhUZKyPqrDLlV8TH3fnzbAf2soPsp/287MfWPzpmjzg1Fvqu2jab781Dpo+vqa6
-        nEd1DV+4zeM3B2h+1lCcXLnFdkpNw3ZOLihRWtRcxXQS0teOTr+v+0Z3daCg9zYbPbp8H2z0fF9Z
-        /GI7PxXbody/g+3YkkVev2Gy4zj/bGTH7vzNcB0NWSU5eSLV0VhXWpvv93n06KtRHWpePsQtashk
-        ucdLNXo6T3bndajOyf2NHjTcDEA7L111r5xuP11s9Zcu2+U541ecHvE+xtuuudHpWWbOw/+yL+xd
-        38jMAw31+doYhjREjxCfPlxMD8/GHyAoW/74vEVHiyXmpu22G+jy0RTTJDevn4CdepO37GHRzey8
-        W77WZkQWJuzLc22GGqNOT7LWFHVGqgB1UCq9Vgcv1rYOqrHqJxB27DlqpO6Govo/7EY9C939m3SY
-        gT+aJqgsNhs8rqrX2lpylNlUPeyYO+qwfGr5tvcfpNneGwNIHl4YkJ+3n3oevAiR7Oa5457HDPu6
-        AEXnzQE29350QFr0TmEfdTBe/uoAn92GvPktQnVJ6fcN+okJ/dZD/XKA3iVuPt38D1+02xgrIwAA
+        H4sIAAAAAAAEA+1Y227bOBD9lULPsSHJtnx5Wm8ui2ADO4idFuiiWDASbWtXlrwklcZb5N/3DC+S
+        LKfpvSiKzUMgD4fDGc7M4SHfeWniTYY+/QXjPv4PBydeXCTcm3jjOFpF4TDq9OJo1OmP2bgzHkdJ
+        xx8FcTLq9+LVaOyR9nbH8v0lDIX9cEwGEqbIQOiHQScIO2EPalIxVUpIF+yeJxCo/Y6UFizj8jK/
+        L9KYQ3rHVLw5NQ6Q8VIInsd7K7ldnEHIH+INy9f8BsucPqUQl1IVWy5uJVvzpVmH5uUqVftbyZv2
+        jeZLnieFsHJfL2wGGiL+wLc7NSvgNBQEj4s8TjPEMlmxTPITLytiptIir80LviuESvP11dHQrhSI
+        QvK5SLioja44xdvwUNL+7LiQTbuKPczvuRBp4sKbFTltX2Ngui3KXHkTv+sfyG84gy0ThCoUy5xi
+        L+wOQqiS7FzH6iaT5CyVcdMgyZbsAdXT7Y/sLPxmdxmy2jQF4SnL4jJDtqjYtDpL/kKOtshI5c6s
+        UFMt1dVRK5xxGYt0RxtrnMY2/93YdcHX1ZD2UOyhd32F3cAWST0WoP6KlXrLBH/pZF4YdIOw2+tS
+        uguRrtN8miSCS0mlHI2pJ3rDcTgaR5iecIk86vQ2tUaHWs3KPF+teKzSe372RDc0Fb1JQCnCCodx
+        8i1LM4SisPQv/IFtdxnvotvg7l0p01x7SjW9Sk3duSraFglkPDlaeBmEE7+PNu32/CiIgsFr2HLa
+        6Auhm3jUC8ZUB+zhyADUM1rYm/zxzkCHxo6hH/b9cEh1JlguGcIucrLVRhaaPCu3d1wgroACQUkl
+        TOxdNdMkmPn4Bj7ctSW26sVOFEkZK1j/uKR9OPe29F2j6I5KrJDgxXptAOJAy4hOuVAHOi5TqbxU
+        fFu1jRIlYCSVi8XyukKVFBoWURa/3/45tTlwy1AyUasn3j8l0/iG7qNyEnwVmH7BV+i+LBw9lVjB
+        76exbXECOFkAoQBdmHpWFz8GUBjeZNClrsAnNfyBL1ra7PhK1UYxH5s/Y4qEtDeDXp/q5+mig/g8
+        R4PSgWGmuYKx6G7h7/m+gBU3zXn8LDiyh8s8zsqEwMakJuEKPVmXf0T9j0bq9wajiFCwLv8reEtx
+        DT+tQ1gDglrg0gK3Cvc01OnB/cXl9cJsER23vP55VJrwmw5SOtEMApOvfRRfvqCZLuC/SpFKmze9
+        jhbM2JYycT2/ms7oQNbCJK3aPsSm+IAQma4BmaVoHmdkfSpphCeuDfR8m8nT2bJl0Q3Q6QNsP/Hy
+        Il8eFh7SqAOqR27KzLVlLbSWiDfQOEwJHavfDXvGAP12U/uBPx4iCpItqBmcQQCl3RJY+HCb0E6j
+        9I4axcqtU/NS7UoCLaguyjuSUkq8uRHR799EUe608DKH7jRPmpNsUpA+QtTkBUVp5k5LtQHIqb0z
+        2gdHwzI3+uQkg6E/0AmDsN251kvXOJoS6L2mbbG+uzWxnJPaDVoYDyj22zxV6JwKr+q02BGXRFOV
+        LWGJ2fPVr0ymsOFdIwOW+JEeFknlrMivmZTLjShr7JQXHJVq+VnFxpYmG3YJ7REBpgVHGDpU0CBR
+        DZ/rpqnda8zENIeMlTpk7S2lQ5TdpZnNCOJZ8CzDmfj4Rhc3haE2SPZ6c1YBDobo9HREknbe4FBS
+        xCURKQKc5ijlNSJKH0TD/iAYjCMciA1dGm+DkxtvUpwWEQL70iyIHHBJ3qS7CwFi8njy7mCJI3ei
+        L3enBYrvcWdZ6M3cOOxChcSFVJe5LAHRMb8QPF1vHDu+Z6rCuAWuK/680zEEkilDV1zn+BRiSjun
+        /fg84hPCm69MfGDxpyM7qKod8Q9T+O7EHnUDYHWT7mj2/I3pTtAdDY9QnFzRwmaDV5q2oi5u6GTx
+        6ZKhAAWW7fSHw7EWPMXEoPdDsh3NZD7Adj6tLf5nOz8V26Haf4LtuJZFXVvC0OQtPwrZaTj/1ciO
+        i/yH4ToGsipy8oVUx2BdZa1Fdczod6M6hDzPUZ0WMn1rqkO06Qvd0R7XT1DfhupcvJ/qgHJagG68
+        +Ogrb+NhrHHl1YySzrrGW7LjOVf8ntNj1ut0N7AnOj1PLHn8b/GWvRhamX2oIKbbwzCkMVgyvl7d
+        zE+vpq8gqO69+N6B07HMnrSDXify6VGpdVEG7LRvOo7FtV/5vlcwoogz9vZrBUNXgwYrb10LGiM1
+        5e+Hg2EvCuhh014JnkqeG/sa14G2G7q4P9+NT+oNWW63eGTUr5at4qiqqX7dsGfUafXe8HGPICiz
+        g4s2nlNwzUZ9Hr93PHsQotjtnf89N3p3xYZi4+INmwdv76RFl3X3soFx3FrMW/3hldQI6yPKXPHd
+        65B+P6er+eObx/8A6Hr8lC8aAAA=
     headers:
       Connection:
       - keep-alive
@@ -72,11 +68,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 20 Dec 2021 09:55:15 GMT
+      - Thu, 23 Dec 2021 12:04:24 GMT
       Location:
-      - /api/v2/companies/242975/transactions/80000018413597
+      - /api/v2/companies/242975/transactions/70000019400075
       ServerDuration:
-      - '00:00:00.1210240'
+      - '00:00:00.1001416'
       Transfer-Encoding:
       - chunked
       Vary:
@@ -88,9 +84,9 @@ interactions:
       strict-transport-security:
       - max-age=31536000; includeSubdomains
       x-avalara-uid:
-      - 7d1cef5c-d16d-454a-b5d7-720249a0741f
+      - 04522cbc-2e72-4d92-8782-019c7b038d0c
       x-correlation-id:
-      - 7d1cef5c-d16d-454a-b5d7-720249a0741f
+      - 04522cbc-2e72-4d92-8782-019c7b038d0c
       x-frame-options:
       - sameorigin
       x-permitted-cross-domain-policies:

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit_in_JPY.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_line_unit_in_JPY.yaml
@@ -1,0 +1,99 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
+      "lines": [{"quantity": 3, "amount": "3600.000", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
+      "700.000", "taxCode": "FR000000", "taxIncluded": true, "itemCode": "Shipping",
+      "description": null}], "code": "6b66cae1-cd65-42bf-b234-ce3a3934e49b", "date":
+      "2021-12-23", "customerCode": 0, "addresses": {"shipFrom": {"line1": "Teczowa
+      7", "line2": null, "city": "Wroclaw", "region": "", "country": "PL", "postalCode":
+      "53-601"}, "shipTo": {"line1": "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW",
+      "region": "", "country": "PL", "postalCode": "53-601"}}, "commit": false, "currencyCode":
+      "JPY", "email": "test@example.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '778'
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: https://rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA+1Y2W7bRhT9lUDPlsBN1PJU1UvhwpAMS0nQFHkYkSOJLUWqw6FjNfC/99xZuHnJ
+        HgRB8xDId+5c3vXMmXnfS+LeNBw7+OdOAvrPP+lFecx70164DsOIcbcfxeGwH3jrTX/t+UE/4j7z
+        J37Ag8m6R9r7A8uOlzDkBd5kNDzpxUySAc/x3L7r9T0faoVksiwgXbJbHkMgjwdSWrKUF5fZbZ5E
+        HNI1k9HuVDtAxksheBYdjeT36z8g5HfRjmVbfoPPnD6mEJWFzPdcvCzYlq/0d2hfJhN5fFnwpn2t
+        +YpncS6M3FEf1gsNEb/j+4Oc53AaCoJHeRYlKWKZblha8JNemkdMJnlWmxf8kAuZZNurB0uHUiCK
+        gi9EzEVtdMMp3oaHBeXnwEXRtCvZ3eKWC5HENrx5nlH6GguzfV5msjd1Bk5LfsMZbOkgZC5ZahX9
+        YDIcTAIok/RcRWu3k+QsKaKmSZKt2F1vOnZ89Q0jYOsUhW1bg94pS6MyRcmQMLODxX+hUnvUpXJq
+        nsuZkqoeqRXOeBGJ5EDp1a4j2X83ci/4tlpSXooj9K6vkBMkqlBrLrow38h3TPBXVtbz3IHrDRAA
+        NHORbJNsFseCFwU1dBjSZPijiTdxxx4amxeopipyU2vY1mr25/lmwyOZ3PKzR2aiqdibupREfKEd
+        J9+zJEUoEp/+hd+x/SHlA8wc3F2XRZIpT6mzN4nuPttL+zyGjMcPPrxyvakznLrhYOiGnjt+A1NW
+        GcMh1CSPfXeCgNFPD/ZDPaXv9qZ/vtf4AeBwnJHjBc5wiPGXgmUFQ9R5ppLYgRfaPC/3ay4Qlktx
+        oKtiJo62pWkTUvHxU9xO2gqZenEQeVxGEtY/rmYfLr3pfjstaqxiIySMMV5rlGhpadEpF7KlYwuV
+        FJeS7zEhenCkKIElSbFcrq4raEmgYWDFVXBKSbQf8SZeOBj7DnL2T8kUyGH+qJsE37h6XPDLs78M
+        Jj1WWMFvZ5GZckK5IgdMAb+w9azufSygMTAeIz342vWOO0qnOfS1tolkMdH/tDkSUn6GfgDPn2g8
+        iM8zzCidHHqbbRoD8wYHnx8NWLHbrNPPoiS7u8yitIwJb3R5Yi4xlvUIjGgE3NAN/DAYhq0RuIK3
+        FFf4aVPCGijUwZcOvlXQp9BOLR4vLq+XOkV07vL6zwftCb/pRKWjTYMw+YpDIMmWtNMG/FcpksLU
+        TX1HCeZsT5W4XlzN5meohxLGSTX6HpLiAEaKZAvULEXzXCPrs4JWeGxHQe03lTydrzoW7QIdQoD3
+        k16WZ6t276GMKqB65aZM7WjWQmOJCAStw5RQsToDD2NEGaG/7dbAdSYjREGyJQ2ENQiwNCmBhQ+P
+        ijsiy2g+GnTbeI3hxYpxbFHKQ0ngBdGyXJOUytJbaBH9/ZvIy4MSXmbQnWVxc5MpDEpIyBq/oEj1
+        3lkpdwA7ebRGA0JsdnejDlAy6DlDVTQIu+NbRWDHR/GDKmHGe/tVfJBSRlKTpqX2geJ/mSUS89MI
+        vy6PWbPF1N3ZEZbYv9j8yooEVnrXqIRhgqSHzyTFPM+uWVGsdqKscbS44OhYQ9gqerbSNTGfMD7B
+        e0vfYKqtouCiWj5X41M72NiJbRon3VFb+jC1dKyydZKa2iCqJU9TnJL3b1WrUzByh7Jvd2cV/GCJ
+        jgLLLynXGpXiPCqJWRH8NFepwiNqcjccBUPPC8c4Ihu6tN6FKrve5DwdZgQ6pmhRs9i75HAhwFTu
+        T963PvHAHQ2eX+ROByKfcGeVq2TuLJKhT6K8kJdZUYKzRPxC8GS7s6T5lskK8Za4xTiLfl8zSiY1
+        gaFoKWEOhZhQ5pQfn0eFPHjzlakQLP5s9GeJrjoQI9GNb2F0GE4GrtumQIpQf2MK5PqWOTRBXXuj
+        cLU557Wy6auLGzptHLp7ENoaBhSMRhMleIyhQe/HZEA43CoGBKxrXAIqBvRpw/E/A/qpGBA1/3jy
+        CAOqRxe9TYhKROcHJECtAL4aAaqj/2H4j0Wvit98If3RiXua/tj170Z/CIeeoz8dnPrW9Ieo1Be6
+        ozyu36m+Df25eJr+gIYauG6+C3W8ahwJimV23oUs97nit5xevN4kh6E55ekRY8Wjf/N37MXIyMxz
+        BrFfH8uQRmDO+PX6ZnF6NXsNQXUzxu8DeB5Lzbk79PuhQ09Pnas0AKh7D6qYXYfwfq9gRB6l7N3X
+        CoauCw2m3rkqNFZUgdRdOPCGI388wqOGnYPHimfXvsYVoeuGaqPPd6PThc34TTsQpzRXg6Lc7/EU
+        qd42O81RdVP9/mFOq9PqReLjnknQZq1rOB5ccAlHfz58EXn2SESzmxeBJ+779voNxcalHDb1U2P1
+        Rk96dJW3rx/QoEf6YODQW1b7HcCK6+NKPwLYVyT11E5X9/u39/8BRLG50mAaAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Dec 2021 12:05:16 GMT
+      Location:
+      - /api/v2/companies/242975/transactions/68000019400193
+      ServerDuration:
+      - '00:00:00.1104409'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - 6fd3edce-8123-4492-8104-cec91c28f68a
+      x-correlation-id:
+      - 6fd3edce-8123-4492-8104-cec91c28f68a
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from ....account.models import Address
@@ -17,9 +19,12 @@ def vcr_config():
 
 @pytest.fixture
 def plugin_configuration(db, channel_USD):
+    default_username = os.environ.get("AVALARA_USERNAME", "test")
+    default_password = os.environ.get("AVALARA_PASSWORD", "test")
+
     def set_configuration(
-        username="test",
-        password="test",
+        username=default_username,
+        password=default_password,
         sandbox=False,
         channel=None,
         active=True,

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -264,12 +264,30 @@ def checkout(db, channel_USD):
 
 
 @pytest.fixture
+def checkout_JPY(channel_JPY):
+    checkout = Checkout.objects.create(
+        currency=channel_JPY.currency_code, channel=channel_JPY
+    )
+    checkout.set_country("JP", commit=True)
+    return checkout
+
+
+@pytest.fixture
 def checkout_with_item(checkout, product):
     variant = product.variants.get()
     checkout_info = fetch_checkout_info(checkout, [], [], get_plugins_manager())
     add_variant_to_checkout(checkout_info, variant, 3)
     checkout.save()
     return checkout
+
+
+@pytest.fixture
+def checkout_JPY_with_item(checkout_JPY, product_in_channel_JPY):
+    variant = product_in_channel_JPY.variants.get()
+    checkout_info = fetch_checkout_info(checkout_JPY, [], [], get_plugins_manager())
+    add_variant_to_checkout(checkout_info, variant, 3)
+    checkout_JPY.save()
+    return checkout_JPY
 
 
 @pytest.fixture
@@ -608,6 +626,20 @@ def order(customer_user, channel_USD):
 
 
 @pytest.fixture
+def order_JPY(customer_user, channel_JPY):
+    address = customer_user.default_billing_address.get_copy()
+    return Order.objects.create(
+        billing_address=address,
+        channel=channel_JPY,
+        currency=channel_JPY.currency_code,
+        shipping_address=address,
+        user_email=customer_user.email,
+        user=customer_user,
+        origin=OrderOrigin.CHECKOUT,
+    )
+
+
+@pytest.fixture
 def order_unconfirmed(order):
     order.status = OrderStatus.UNCONFIRMED
     order.save(update_fields=["status"])
@@ -670,6 +702,20 @@ def shipping_zone(db, channel_USD):  # pylint: disable=W0613
         shipping_method=method,
         minimum_order_price=Money(0, channel_USD.currency_code),
         price=Money(10, channel_USD.currency_code),
+    )
+    return shipping_zone
+
+
+@pytest.fixture
+def shipping_zone_JPY(shipping_zone, channel_JPY):
+    shipping_zone.channels.add(channel_JPY)
+    method = shipping_zone.shipping_methods.get()
+    ShippingMethodChannelListing.objects.create(
+        channel=channel_JPY,
+        currency=channel_JPY.currency_code,
+        shipping_method=method,
+        minimum_order_price=Money(0, channel_JPY.currency_code),
+        price=Money(700, channel_JPY.currency_code),
     )
     return shipping_zone
 
@@ -1493,6 +1539,29 @@ def product(product_type, category, warehouse, channel_USD):
     Stock.objects.create(warehouse=warehouse, product_variant=variant, quantity=10)
 
     associate_attribute_values_to_instance(variant, variant_attr, variant_attr_value)
+    return product
+
+
+@pytest.fixture
+def product_in_channel_JPY(product, channel_JPY, warehouse_JPY):
+    ProductChannelListing.objects.create(
+        product=product,
+        channel=channel_JPY,
+        is_published=True,
+        discounted_price_amount="1200",
+        currency=channel_JPY.currency_code,
+        visible_in_listings=True,
+        available_for_purchase=datetime.date(1999, 1, 1),
+    )
+    variant = product.variants.get()
+    ProductVariantChannelListing.objects.create(
+        variant=variant,
+        channel=channel_JPY,
+        price_amount=Decimal(1200),
+        cost_price_amount=Decimal(300),
+        currency=channel_JPY.currency_code,
+    )
+    Stock.objects.create(warehouse=warehouse_JPY, product_variant=variant, quantity=10)
     return product
 
 
@@ -2470,6 +2539,32 @@ def order_line(order, variant):
     quantity = 3
     unit_price = TaxedMoney(net=net, gross=gross)
     return order.lines.create(
+        product_name=str(product),
+        variant_name=str(variant),
+        product_sku=variant.sku,
+        is_shipping_required=variant.is_shipping_required(),
+        quantity=quantity,
+        variant=variant,
+        unit_price=unit_price,
+        total_price=unit_price * quantity,
+        undiscounted_unit_price=unit_price,
+        undiscounted_total_price=unit_price * quantity,
+        tax_rate=Decimal("0.23"),
+    )
+
+
+@pytest.fixture
+def order_line_JPY(order_JPY, product_in_channel_JPY):
+    product = product_in_channel_JPY
+    variant = product_in_channel_JPY.variants.get()
+    channel = order_JPY.channel
+    channel_listing = variant.channel_listings.get(channel=channel)
+    net = variant.get_price(product, [], channel, channel_listing)
+    currency = net.currency
+    gross = Money(amount=net.amount * Decimal(1.23), currency=currency)
+    quantity = 3
+    unit_price = TaxedMoney(net=net, gross=gross)
+    return order_JPY.lines.create(
         product_name=str(product),
         variant_name=str(variant),
         product_sku=variant.sku,
@@ -4140,6 +4235,19 @@ def warehouse(address, shipping_zone):
         email="test@example.com",
     )
     warehouse.shipping_zones.add(shipping_zone)
+    warehouse.save()
+    return warehouse
+
+
+@pytest.fixture
+def warehouse_JPY(address, shipping_zone_JPY):
+    warehouse = Warehouse.objects.create(
+        address=address,
+        name="Example Warehouse JPY",
+        slug="example-warehouse-jpy",
+        email="test-jpy@example.com",
+    )
+    warehouse.shipping_zones.add(shipping_zone_JPY)
     warehouse.save()
     return warehouse
 


### PR DESCRIPTION
I want to merge this change because adding tests for incorrect tax calculations in JPY

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
