### PR TITLE
Do not create unnecessary gift card events

### DIFF
--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -160,8 +160,8 @@ class GiftCardCreate(ModelMutation):
             cleaned_input["created_by_email"] = user.email
         cleaned_input["app"] = info.context.app
 
-    @staticmethod
-    def clean_expiry_date(cleaned_input, instance):
+    @classmethod
+    def clean_expiry_date(cls, cleaned_input, instance):
         expiry_date = cleaned_input.get("expiry_date")
         if expiry_date and not is_date_in_future(expiry_date):
             raise ValidationError(
@@ -266,6 +266,13 @@ class GiftCardUpdate(GiftCardCreate):
         permissions = (GiftcardPermissions.MANAGE_GIFT_CARD,)
         error_type_class = GiftCardError
         error_type_field = "gift_card_errors"
+
+    @classmethod
+    def clean_expiry_date(cls, cleaned_input, instance):
+        super().clean_expiry_date(cleaned_input, instance)
+        expiry_date = cleaned_input.get("expiry_date")
+        if expiry_date and expiry_date == instance.expiry_date:
+            del cleaned_input["expiry_date"]
 
     @staticmethod
     def clean_balance(cleaned_input, instance):


### PR DESCRIPTION
Do not create `EXPIRY_DATE_UPDATED` event when `expiry_date` hasn't been changed.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
