### PR TITLE
Add in_shipping_zones attribute to shop countries query

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1634,7 +1634,7 @@ type CountryDisplay {
 }
 
 input CountryFilterInput {
-  inShippingZones: Boolean
+  attachedToShippingZones: Boolean
 }
 
 type CreateToken {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6053,7 +6053,7 @@ type Shop {
   availablePaymentGateways(currency: String, channel: String): [PaymentGateway!]!
   availableExternalAuthentications: [ExternalAuthentication!]!
   availableShippingMethods(channel: String!, address: AddressInput): [ShippingMethod]
-  countries(languageCode: LanguageCodeEnum): [CountryDisplay!]!
+  countries(languageCode: LanguageCodeEnum, inShippingZones: Boolean): [CountryDisplay!]!
   defaultCountry: CountryDisplay
   defaultMailSenderName: String
   defaultMailSenderAddress: String

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1633,6 +1633,10 @@ type CountryDisplay {
   vat: VAT
 }
 
+input CountryFilterInput {
+  inShippingZones: Boolean
+}
+
 type CreateToken {
   token: String
   refreshToken: String
@@ -6053,7 +6057,7 @@ type Shop {
   availablePaymentGateways(currency: String, channel: String): [PaymentGateway!]!
   availableExternalAuthentications: [ExternalAuthentication!]!
   availableShippingMethods(channel: String!, address: AddressInput): [ShippingMethod]
-  countries(languageCode: LanguageCodeEnum, inShippingZones: Boolean): [CountryDisplay!]!
+  countries(languageCode: LanguageCodeEnum, filter: CountryFilterInput): [CountryDisplay!]!
   defaultCountry: CountryDisplay
   defaultMailSenderName: String
   defaultMailSenderAddress: String

--- a/saleor/graphql/shop/filters.py
+++ b/saleor/graphql/shop/filters.py
@@ -2,4 +2,9 @@ import graphene
 
 
 class CountryFilterInput(graphene.InputObjectType):
-    in_shipping_zones = graphene.Boolean()
+    in_shipping_zones = graphene.Boolean(
+        description="Boolean for filtering countries by having shipping zone assigned."
+        "If 'true', return countries with shipping zone assigned."
+        "If 'false', return countries without any shipping zone assigned."
+        "If the argument is not provided (null), return all countries."
+    )

--- a/saleor/graphql/shop/filters.py
+++ b/saleor/graphql/shop/filters.py
@@ -1,0 +1,5 @@
+import graphene
+
+
+class CountryFilterInput(graphene.InputObjectType):
+    in_shipping_zones = graphene.Boolean()

--- a/saleor/graphql/shop/filters.py
+++ b/saleor/graphql/shop/filters.py
@@ -2,7 +2,7 @@ import graphene
 
 
 class CountryFilterInput(graphene.InputObjectType):
-    in_shipping_zones = graphene.Boolean(
+    attached_to_shipping_zones = graphene.Boolean(
         description="Boolean for filtering countries by having shipping zone assigned."
         "If 'true', return countries with shipping zone assigned."
         "If 'false', return countries without any shipping zone assigned."

--- a/saleor/graphql/shop/resolvers.py
+++ b/saleor/graphql/shop/resolvers.py
@@ -1,8 +1,14 @@
+from django.utils import translation
+from django_countries import countries
+from django_prices_vatlayer.models import VAT
+
 from ...account.models import Address
 from ...core.tracing import traced_resolver
 from ...shipping.models import ShippingMethod, ShippingMethodChannelListing
 from ...shipping.postal_codes import filter_shipping_methods_by_postal_code_rules
 from ...shipping.utils import convert_to_shipping_method_data
+from ..core.types import CountryDisplay
+from .utils import get_countries_codes_list
 
 
 @traced_resolver
@@ -23,6 +29,22 @@ def resolve_available_shipping_methods(info, channel_slug: str, address):
         convert_to_shipping_method_data(method, shipping_mapping[method.pk])
         for method in available
     ]
+
+
+def resolve_countries(**kwargs):
+    countries_filter = kwargs.get("filter", {})
+    in_shipping_zones = countries_filter.get("in_shipping_zones")
+    language_code = kwargs.get("language_code")
+    taxes = {vat.country_code: vat for vat in VAT.objects.all()}
+    # DEPRECATED: translation.override will be dropped in Saleor 4.0
+    with translation.override(language_code):
+        return [
+            CountryDisplay(
+                code=country[0], country=country[1], vat=taxes.get(country[0])
+            )
+            for country in countries
+            if country[0] in get_countries_codes_list(in_shipping_zones)
+        ]
 
 
 def get_shipping_method_to_shipping_listing_mapping(shipping_methods, channel_slug):

--- a/saleor/graphql/shop/resolvers.py
+++ b/saleor/graphql/shop/resolvers.py
@@ -33,7 +33,7 @@ def resolve_available_shipping_methods(info, channel_slug: str, address):
 
 def resolve_countries(**kwargs):
     countries_filter = kwargs.get("filter", {})
-    in_shipping_zones = countries_filter.get("in_shipping_zones")
+    attached_to_shipping_zones = countries_filter.get("attached_to_shipping_zones")
     language_code = kwargs.get("language_code")
     taxes = {vat.country_code: vat for vat in VAT.objects.all()}
     # DEPRECATED: translation.override will be dropped in Saleor 4.0
@@ -43,7 +43,7 @@ def resolve_countries(**kwargs):
                 code=country[0], country=country[1], vat=taxes.get(country[0])
             )
             for country in countries
-            if country[0] in get_countries_codes_list(in_shipping_zones)
+            if country[0] in get_countries_codes_list(attached_to_shipping_zones)
         ]
 
 

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -1386,3 +1386,19 @@ def test_query_countries_filter_shiping_zones_attached_false(
         code in countries_codes_results for code in fixture_countries_code_set
     )
     assert len(data) == (len(countries) - len(shipping_zones))
+
+
+def test_query_countries_filter_shiping_zones_attached_none(
+    user_api_client, shipping_zones
+):
+    # given
+    variables = {"filter": {"attachedToShippingZones": None}}
+
+    # when
+    response = user_api_client.post_graphql(COUNTRY_FILTER_QUERY, variables=variables)
+    content = get_graphql_content(response)
+
+    data = content["data"]["shop"]["countries"]
+
+    # then
+    assert len(data) == len(countries)

--- a/saleor/graphql/shop/tests/test_shop_utils.py
+++ b/saleor/graphql/shop/tests/test_shop_utils.py
@@ -1,16 +1,38 @@
+from django_countries import countries
+
 from ..utils import get_countries_codes_list
 
 
 def test_get_countries_codes_list(shipping_zones):
     # given
-    fixture_countries_code_set = {zone.countries[0].code for zone in shipping_zones}
+    all_countries = {country[0] for country in countries}
 
     # when
     countries_list_all = get_countries_codes_list()
-    countries_list_false = get_countries_codes_list(False)
+
+    # then
+    assert countries_list_all == all_countries
+
+
+def test_get_countries_codes_list_true(shipping_zones):
+    # given
+    fixture_countries_code_set = {zone.countries[0].code for zone in shipping_zones}
+
+    # when
     countries_list_true = get_countries_codes_list(in_shipping_zones=True)
 
     # then
-    assert (countries_list_true | countries_list_false) == countries_list_all
     assert countries_list_true == fixture_countries_code_set
-    assert not any(country in countries_list_true for country in countries_list_false)
+
+
+def test_get_countries_codes_list_false(shipping_zones):
+    # given
+    fixture_countries_code_set = {zone.countries[0].code for zone in shipping_zones}
+
+    # when
+    countries_list_false = get_countries_codes_list(False)
+
+    # then
+    assert not any(
+        country in countries_list_false for country in fixture_countries_code_set
+    )

--- a/saleor/graphql/shop/tests/test_shop_utils.py
+++ b/saleor/graphql/shop/tests/test_shop_utils.py
@@ -1,0 +1,16 @@
+from ..utils import get_countries_codes_list
+
+
+def test_get_countries_codes_list(shipping_zones):
+    # given
+    fixture_countries_code_set = {zone.countries[0].code for zone in shipping_zones}
+
+    # when
+    countries_list_all = get_countries_codes_list()
+    countries_list_false = get_countries_codes_list(False)
+    countries_list_true = get_countries_codes_list(in_shipping_zones=True)
+
+    # then
+    assert (countries_list_true | countries_list_false) == countries_list_all
+    assert countries_list_true == fixture_countries_code_set
+    assert not any(country in countries_list_true for country in countries_list_false)

--- a/saleor/graphql/shop/tests/test_shop_utils.py
+++ b/saleor/graphql/shop/tests/test_shop_utils.py
@@ -19,7 +19,7 @@ def test_get_countries_codes_list_true(shipping_zones):
     fixture_countries_code_set = {zone.countries[0].code for zone in shipping_zones}
 
     # when
-    countries_list_true = get_countries_codes_list(in_shipping_zones=True)
+    countries_list_true = get_countries_codes_list(attached_to_shipping_zones=True)
 
     # then
     assert countries_list_true == fixture_countries_code_set

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -130,7 +130,10 @@ class Shop(graphene.ObjectType):
             ),
         ),
         in_shipping_zones=graphene.Boolean(
-            description="Only countries that have shipping zones assigned",
+            description="If 'true', return countries with shipping zone assigned."
+            "If 'false', return countries without any shipping zone "
+            "assigned."
+            "If the argument is not provided (null), return all countries.",
             required=False,
         ),
         description="List of countries available in the shop.",

--- a/saleor/graphql/shop/utils.py
+++ b/saleor/graphql/shop/utils.py
@@ -5,7 +5,7 @@ from django_countries import countries
 from ...shipping.models import ShippingZone
 
 
-def get_countries_codes_list(in_shipping_zones: Optional[bool] = None):
+def get_countries_codes_list(attached_to_shipping_zones: Optional[bool] = None):
     """Return set of countries codes.
 
     If 'True', return countries with shipping zone assigned.
@@ -14,15 +14,15 @@ def get_countries_codes_list(in_shipping_zones: Optional[bool] = None):
     """
 
     all_countries_codes = {country[0] for country in countries}
-    if in_shipping_zones is not None:
+    if attached_to_shipping_zones is not None:
         covered_countries_codes = set()
         for zone in ShippingZone.objects.iterator():
             covered_countries_codes.update({country.code for country in zone.countries})
 
-        if in_shipping_zones:
+        if attached_to_shipping_zones:
             return covered_countries_codes
 
-        if not in_shipping_zones:
+        if not attached_to_shipping_zones:
             return all_countries_codes - covered_countries_codes
 
     return all_countries_codes

--- a/saleor/graphql/shop/utils.py
+++ b/saleor/graphql/shop/utils.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+from django_countries import countries
+
+from ...shipping.models import ShippingZone
+
+
+def get_countries_codes_list(in_shipping_zones: Optional[bool] = None):
+    """Return set of countries codes."""
+    all_countries_codes = {country[0] for country in countries}
+    if in_shipping_zones is not None:
+        covered_countries_codes = set()
+        for zone in ShippingZone.objects.iterator():
+            covered_countries_codes.update({country.code for country in zone.countries})
+
+        if in_shipping_zones:
+            return covered_countries_codes
+
+        if not in_shipping_zones:
+            return all_countries_codes - covered_countries_codes
+
+    return all_countries_codes

--- a/saleor/graphql/shop/utils.py
+++ b/saleor/graphql/shop/utils.py
@@ -6,7 +6,13 @@ from ...shipping.models import ShippingZone
 
 
 def get_countries_codes_list(in_shipping_zones: Optional[bool] = None):
-    """Return set of countries codes."""
+    """Return set of countries codes.
+
+    If 'True', return countries with shipping zone assigned.
+    If 'False', return countries without any shipping zone assigned."
+    If the argument is not provided (None), return all countries.
+    """
+
     all_countries_codes = {country[0] for country in countries}
     if in_shipping_zones is not None:
         covered_countries_codes = set()


### PR DESCRIPTION
I want to merge this change because  API query for fetching countries with or without shipping zones was needed.
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
