### PR TITLE
fix attribute assignment permissions

### DIFF
--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -368,12 +368,7 @@ class ProductAttributeAssignmentUpdate(BaseMutation, VariantAssignmentValidation
 
         error_type_class = ProductError
         error_type_field = "product_errors"
-
-    @classmethod
-    def check_permissions(cls, context):
-        return context.user.has_perm(
-            ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES
-        )
+        permissions = (ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,)
 
     @classmethod
     def get_operations(

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -802,22 +802,29 @@ def test_assignment_attribute_update_assigned_unsupported_type_should_raise_an_e
         assert error in expected_errors
 
 
+@pytest.mark.parametrize("api_client", ["app_api_client", "staff_api_client"])
 def test_assignment_attribute_update_assigned_should_modify_variant_selection(
-    staff_api_client,
+    api_client,
     permission_manage_product_types_and_attributes,
     size_attribute,
     color_attribute_without_values,
+    request,
 ):
     """The productAttributeAssignmentUpdate mutation should modify
     variant selection when validation successful."""
-
+    chosen_api_client = request.getfixturevalue(api_client)
     product_type = ProductType.objects.create(name="Type", kind=ProductTypeKind.NORMAL)
     attribute_1 = color_attribute_without_values
     attribute_2 = size_attribute
 
-    staff_api_client.user.user_permissions.add(
-        permission_manage_product_types_and_attributes
-    )
+    if api_client == "staff_api_client":
+        chosen_api_client.user.user_permissions.add(
+            permission_manage_product_types_and_attributes
+        )
+    else:
+        chosen_api_client.app.permissions.add(
+            permission_manage_product_types_and_attributes
+        )
 
     product_type.variant_attributes.add(
         attribute_1, through_defaults={"variant_selection": False}
@@ -840,7 +847,7 @@ def test_assignment_attribute_update_assigned_should_modify_variant_selection(
     ]
     variables = {"productTypeId": product_type_global_id, "operations": operations}
 
-    content = get_graphql_content(staff_api_client.post_graphql(query, variables))[
+    content = get_graphql_content(chosen_api_client.post_graphql(query, variables))[
         "data"
     ]["productAttributeAssignmentUpdate"]
 


### PR DESCRIPTION
I want to merge this change because it fixes permissions for apps which automates attribute assignment process.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
