### PR TITLE
skip update taxes for lines with deleted variant in 3.1

### DIFF
--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -1,3 +1,4 @@
+import copy
 from decimal import Decimal
 from unittest.mock import Mock
 
@@ -18,6 +19,7 @@ from ..utils import (
     change_order_line_quantity,
     get_valid_shipping_methods_for_order,
     match_orders_with_new_user,
+    update_taxes_for_order_line,
     update_taxes_for_order_lines,
 )
 
@@ -446,3 +448,41 @@ def test_add_gift_cards_to_order_no_checkout_user(
         },
         "order_id": order.id,
     }
+
+
+def test_update_taxes_for_order_line_deleted_variant(order_with_lines):
+    # given
+    order_line = order_with_lines.lines.first()
+    order_line_unchanged_copy = copy.deepcopy(order_line)
+    unit_discount_amount = Decimal("2.00")
+
+    unit_price = TaxedMoney(net=Money("10.23", "USD"), gross=Money("15.80", "USD"))
+    total_price = TaxedMoney(net=Money("30.34", "USD"), gross=Money("36.49", "USD"))
+    tax_rate = Decimal("0.23")
+    discount = TaxedMoney(
+        net=Money(unit_discount_amount, "USD"), gross=Money(unit_discount_amount, "USD")
+    )
+    unit_price_data = OrderTaxedPricesData(
+        undiscounted_price=unit_price + discount,
+        price_with_discounts=unit_price,
+    )
+    total_price_data = OrderTaxedPricesData(
+        undiscounted_price=total_price + discount,
+        price_with_discounts=total_price,
+    )
+    manager = Mock(
+        calculate_order_line_unit=Mock(return_value=unit_price_data),
+        calculate_order_line_total=Mock(return_value=total_price_data),
+        get_order_line_tax_rate=Mock(return_value=tax_rate),
+    )
+
+    # when
+    order_line.variant = None
+    update_taxes_for_order_line(order_line, order_with_lines, manager, True)
+
+    # then
+    assert order_line.unit_price == order_line_unchanged_copy.unit_price
+    assert order_line.total_price == order_line_unchanged_copy.total_price
+    assert order_line.tax_rate == order_line_unchanged_copy.tax_rate
+    assert order_line.undiscounted_unit_price == order_line_unchanged_copy.unit_price
+    assert order_line.undiscounted_total_price == order_line_unchanged_copy.total_price

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -197,6 +197,8 @@ def update_taxes_for_order_line(
     line: "OrderLine", order: "Order", manager, tax_included
 ):
     variant = line.variant
+    if not variant:
+        return
     product = variant.product  # type: ignore
 
     line_price = line.unit_price.gross if tax_included else line.unit_price.net


### PR DESCRIPTION
* skip update taxes for lines with deleted variant

* add test for removed variant

I want to merge this change because it is a #8880 changes port to 3.1 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
