### PR TITLE
Do no allow using id for updating checkout and order metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add query complexity limit to GraphQL API - #8526 by rafalp
 - Add `quantity_limit_per_customer` field to ProductVariant #8405 by @kuchichan
 - Optimize products stock availability filter - #8809 by @fowczarek
+- Do no allow using id for updating checkout and order metadata - #8906 by @IKarbowiak
 
 # 3.0.0 [Unreleased]
 
@@ -305,6 +306,8 @@ All notable, unreleased changes to this project will be documented in this file.
   `OrderTaxedPricesData` instead of `TaxedMoney`.
   - Rename checkout interfaces: `CheckoutTaxedPricesData` instead of `TaxedPricesData`
   and `CheckoutPricesData` instead of `PricesData`
+- Do no allow using `id` for updating checkout and order metadata - #8906 by @IKarbowiak
+  - Use `token` instead
 
 ### Other
 

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import List
 
 import graphene
@@ -59,7 +58,15 @@ class BaseMetadataMutation(BaseMutation):
         try:
             type_name, _ = from_global_id_or_error(object_id)
             if type_name == "Order":
-                warnings.warn("DEPRECATED. Use token for changing order metadata.")
+                raise ValidationError(
+                    {
+                        "id": ValidationError(
+                            "Changing order metadata with use of `id` is forbidden. "
+                            "Use order token instead.",
+                            code=MetadataErrorCode.GRAPHQL_ERROR.value,
+                        )
+                    }
+                )
             # ShippingMethod type isn't model-based class
             if type_name == "ShippingMethod":
                 qs = shipping_models.ShippingMethod.objects
@@ -67,7 +74,13 @@ class BaseMetadataMutation(BaseMutation):
         except GraphQLError as e:
             if instance := cls.get_instance_by_token(object_id, qs):
                 return instance
-            raise ValidationError({"id": ValidationError(str(e), code="graphql_error")})
+            raise ValidationError(
+                {
+                    "id": ValidationError(
+                        str(e), code=MetadataErrorCode.GRAPHQL_ERROR.value
+                    )
+                }
+            )
 
     @classmethod
     def get_instance_by_token(cls, object_id, qs):

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -57,12 +57,13 @@ class BaseMetadataMutation(BaseMutation):
 
         try:
             type_name, _ = from_global_id_or_error(object_id)
-            if type_name == "Order":
+            if type_name in ["Order", "Checkout"]:
+                type_name = type_name.lower()
                 raise ValidationError(
                     {
                         "id": ValidationError(
-                            "Changing order metadata with use of `id` is forbidden. "
-                            "Use order token instead.",
+                            f"Changing {type_name} metadata with use of `id` "
+                            f"is forbidden. Use {type_name} token instead.",
                             code=MetadataErrorCode.GRAPHQL_ERROR.value,
                         )
                     }

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -1,6 +1,5 @@
 import base64
 import uuid
-import warnings
 from unittest.mock import patch
 
 import graphene
@@ -374,18 +373,15 @@ def test_add_public_metadata_for_order_by_id(api_client, order):
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_update_public_metadata_for_item(
-            api_client, None, order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_update_public_metadata_for_item(
+        api_client, None, order_id, "Order"
+    )
 
     # then
-    assert item_contains_proper_public_metadata(
-        response["data"]["updateMetadata"]["item"], order, order_id
-    )
+    errors = response["data"]["updateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_add_public_metadata_for_order_by_token(api_client, order):
@@ -408,18 +404,15 @@ def test_add_public_metadata_for_draft_order_by_id(api_client, draft_order):
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_update_public_metadata_for_item(
-            api_client, None, draft_order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_update_public_metadata_for_item(
+        api_client, None, draft_order_id, "Order"
+    )
 
     # then
-    assert item_contains_proper_public_metadata(
-        response["data"]["updateMetadata"]["item"], draft_order, draft_order_id
-    )
+    errors = response["data"]["updateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_add_public_metadata_for_draft_order_by_token(api_client, draft_order):
@@ -1158,18 +1151,15 @@ def test_delete_public_metadata_for_order_by_id(api_client, order):
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_clear_public_metadata_for_item(
-            api_client, None, order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_clear_public_metadata_for_item(
+        api_client, None, order_id, "Order"
+    )
 
     # then
-    assert item_without_public_metadata(
-        response["data"]["deleteMetadata"]["item"], order, order_id
-    )
+    errors = response["data"]["deleteMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_delete_public_metadata_for_order_by_token(api_client, order):
@@ -1196,18 +1186,15 @@ def test_delete_public_metadata_for_draft_order_by_id(api_client, draft_order):
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_clear_public_metadata_for_item(
-            api_client, None, draft_order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_clear_public_metadata_for_item(
+        api_client, None, draft_order_id, "Order"
+    )
 
     # then
-    assert item_without_public_metadata(
-        response["data"]["deleteMetadata"]["item"], draft_order, draft_order_id
-    )
+    errors = response["data"]["deleteMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_delete_public_metadata_for_draft_order_by_token(api_client, draft_order):
@@ -1971,18 +1958,15 @@ def test_add_private_metadata_for_order_by_id(
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_update_private_metadata_for_item(
-            staff_api_client, permission_manage_orders, order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_update_private_metadata_for_item(
+        staff_api_client, permission_manage_orders, order_id, "Order"
+    )
 
     # then
-    assert item_contains_proper_private_metadata(
-        response["data"]["updatePrivateMetadata"]["item"], order, order_id
-    )
+    errors = response["data"]["updatePrivateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_add_private_metadata_for_order_by_token(
@@ -2009,18 +1993,15 @@ def test_add_private_metadata_for_draft_order_by_id(
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_update_private_metadata_for_item(
-            staff_api_client, permission_manage_orders, draft_order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_update_private_metadata_for_item(
+        staff_api_client, permission_manage_orders, draft_order_id, "Order"
+    )
 
     # then
-    assert item_contains_proper_private_metadata(
-        response["data"]["updatePrivateMetadata"]["item"], draft_order, draft_order_id
-    )
+    errors = response["data"]["updatePrivateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_add_private_metadata_for_draft_order_by_token(
@@ -2830,18 +2811,15 @@ def test_delete_private_metadata_for_order_by_id(
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_clear_private_metadata_for_item(
-            staff_api_client, permission_manage_orders, order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_clear_private_metadata_for_item(
+        staff_api_client, permission_manage_orders, order_id, "Order"
+    )
 
     # then
-    assert item_without_private_metadata(
-        response["data"]["deletePrivateMetadata"]["item"], order, order_id
-    )
+    errors = response["data"]["deletePrivateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_delete_private_metadata_for_order_by_token(
@@ -2872,18 +2850,15 @@ def test_delete_private_metadata_for_draft_order_by_id(
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_clear_private_metadata_for_item(
-            staff_api_client, permission_manage_orders, draft_order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_clear_private_metadata_for_item(
+        staff_api_client, permission_manage_orders, draft_order_id, "Order"
+    )
 
     # then
-    assert item_without_private_metadata(
-        response["data"]["deletePrivateMetadata"]["item"], draft_order, draft_order_id
-    )
+    errors = response["data"]["deletePrivateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_delete_private_metadata_for_draft_order_by_token(

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -1,5 +1,4 @@
 import base64
-import uuid
 from unittest.mock import patch
 
 import graphene
@@ -125,17 +124,31 @@ def item_contains_multiple_proper_public_metadata(
     )
 
 
+def invalid_id_graphql_error_raised(errors_from_respone):
+    return all(
+        [
+            len(errors_from_respone) == 1,
+            errors_from_respone[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name,
+            errors_from_respone[0]["field"] == "id",
+        ]
+    )
+
+
 @patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_base_metadata_mutation_handles_errors_from_extra_action(
     mock_checkout_updated, api_client, checkout
 ):
+    # given
     error_field = "field"
     error_msg = "boom"
     mock_checkout_updated.side_effect = ValidationError({error_field: error_msg})
-    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
     response = execute_update_public_metadata_for_item(
-        api_client, None, checkout_id, "Checkout"
+        api_client, None, checkout.token, "Checkout"
     )
+
+    # then
     errors = response["data"]["updateMetadata"]["errors"]
     assert errors[0]["field"] == error_field
     assert errors[0]["message"] == error_msg
@@ -336,9 +349,8 @@ def test_add_public_metadata_for_checkout(api_client, checkout):
     )
 
     # then
-    assert item_contains_proper_public_metadata(
-        response["data"]["updateMetadata"]["item"], checkout, checkout_id
-    )
+    errors = response["data"]["updateMetadata"]["errors"]
+    assert invalid_id_graphql_error_raised(errors)
 
 
 def test_add_public_metadata_for_checkout_by_token(api_client, checkout):
@@ -356,16 +368,18 @@ def test_add_public_metadata_for_checkout_by_token(api_client, checkout):
     )
 
 
-@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
-def test_add_metadata_for_checkout_triggers_checkout_updated_hook(
-    mock_checkout_updated, api_client, checkout
-):
+def test_add_metadata_for_checkout_triggers_checkout_updated_hook(api_client, checkout):
+    # given
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
     response = execute_update_public_metadata_for_item(
         api_client, None, checkout_id, "Checkout"
     )
-    assert response["data"]["updateMetadata"]["errors"] == []
-    mock_checkout_updated.assert_called_once_with(checkout)
+
+    # then
+    errors = response["data"]["updateMetadata"]["errors"]
+    assert invalid_id_graphql_error_raised(errors)
 
 
 def test_add_public_metadata_for_order_by_id(api_client, order):
@@ -379,9 +393,7 @@ def test_add_public_metadata_for_order_by_id(api_client, order):
 
     # then
     errors = response["data"]["updateMetadata"]["errors"]
-    assert len(errors) == 1
-    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
-    assert errors[0]["field"] == "id"
+    assert invalid_id_graphql_error_raised(errors)
 
 
 def test_add_public_metadata_for_order_by_token(api_client, order):
@@ -410,9 +422,7 @@ def test_add_public_metadata_for_draft_order_by_id(api_client, draft_order):
 
     # then
     errors = response["data"]["updateMetadata"]["errors"]
-    assert len(errors) == 1
-    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
-    assert errors[0]["field"] == "id"
+    assert invalid_id_graphql_error_raised(errors)
 
 
 def test_add_public_metadata_for_draft_order_by_token(api_client, draft_order):
@@ -734,7 +744,7 @@ def test_update_public_metadata_for_item(api_client, checkout):
 
     # when
     response = execute_update_public_metadata_for_item(
-        api_client, None, checkout_id, "Checkout", value="NewMetaValue"
+        api_client, None, checkout.token, "Checkout", value="NewMetaValue"
     )
 
     # then
@@ -746,14 +756,16 @@ def test_update_public_metadata_for_item(api_client, checkout):
     )
 
 
-def test_update_public_metadata_for_non_exist_item(api_client):
+def test_update_public_metadata_for_non_exist_item(
+    staff_api_client, permission_manage_payments
+):
     # given
-    checkout_id = "Checkout:" + str(uuid.uuid4())
-    checkout_id = base64.b64encode(str.encode(checkout_id)).decode("utf-8")
+    payment_id = "Payment: 0"
+    payment_id = base64.b64encode(str.encode(payment_id)).decode("utf-8")
 
     # when
     response = execute_update_public_metadata_for_item(
-        api_client, None, checkout_id, "Checkout"
+        staff_api_client, permission_manage_payments, payment_id, "Payment"
     )
 
     # then
@@ -1122,9 +1134,7 @@ def test_delete_public_metadata_for_checkout(api_client, checkout):
     )
 
     # then
-    assert item_without_public_metadata(
-        response["data"]["deleteMetadata"]["item"], checkout, checkout_id
-    )
+    assert invalid_id_graphql_error_raised(response["data"]["deleteMetadata"]["errors"])
 
 
 def test_delete_public_metadata_for_checkout_by_token(api_client, checkout):
@@ -1157,9 +1167,7 @@ def test_delete_public_metadata_for_order_by_id(api_client, order):
 
     # then
     errors = response["data"]["deleteMetadata"]["errors"]
-    assert len(errors) == 1
-    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
-    assert errors[0]["field"] == "id"
+    assert invalid_id_graphql_error_raised(errors)
 
 
 def test_delete_public_metadata_for_order_by_token(api_client, order):
@@ -1542,14 +1550,16 @@ def test_delete_public_metadata_for_menu_item(
     )
 
 
-def test_delete_public_metadata_for_non_exist_item(api_client):
+def test_delete_public_metadata_for_non_exist_item(
+    staff_api_client, permission_manage_payments
+):
     # given
-    checkout_id = "Checkout:" + str(uuid.uuid4())
-    checkout_id = base64.b64encode(str.encode(checkout_id)).decode("utf-8")
+    payment_id = "Payment: 0"
+    payment_id = base64.b64encode(str.encode(payment_id)).decode("utf-8")
 
     # when
     response = execute_clear_public_metadata_for_item(
-        api_client, None, checkout_id, "Checkout"
+        staff_api_client, permission_manage_payments, payment_id, "Checkout"
     )
 
     # then
@@ -1584,7 +1594,7 @@ def test_delete_public_metadata_for_not_exist_key(api_client, checkout):
 
     # when
     response = execute_clear_public_metadata_for_item(
-        api_client, None, checkout_id, "Checkout", key="Not-exits"
+        api_client, None, checkout.token, "Checkout", key="Not-exits"
     )
 
     # then
@@ -1603,7 +1613,7 @@ def test_delete_public_metadata_for_one_key(api_client, checkout):
 
     # when
     response = execute_clear_public_metadata_for_item(
-        api_client, None, checkout_id, "Checkout", key="to_clear"
+        api_client, None, checkout.token, "Checkout", key="to_clear"
     )
 
     # then
@@ -1929,8 +1939,8 @@ def test_add_private_metadata_for_checkout(
     )
 
     # then
-    assert item_contains_proper_private_metadata(
-        response["data"]["updatePrivateMetadata"]["item"], checkout, checkout_id
+    assert invalid_id_graphql_error_raised(
+        response["data"]["updatePrivateMetadata"]["errors"]
     )
 
 
@@ -1964,9 +1974,7 @@ def test_add_private_metadata_for_order_by_id(
 
     # then
     errors = response["data"]["updatePrivateMetadata"]["errors"]
-    assert len(errors) == 1
-    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
-    assert errors[0]["field"] == "id"
+    assert invalid_id_graphql_error_raised(errors)
 
 
 def test_add_private_metadata_for_order_by_token(
@@ -1999,9 +2007,7 @@ def test_add_private_metadata_for_draft_order_by_id(
 
     # then
     errors = response["data"]["updatePrivateMetadata"]["errors"]
-    assert len(errors) == 1
-    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
-    assert errors[0]["field"] == "id"
+    assert invalid_id_graphql_error_raised(errors)
 
 
 def test_add_private_metadata_for_draft_order_by_token(
@@ -2338,7 +2344,7 @@ def test_update_private_metadata_for_item(
     response = execute_update_private_metadata_for_item(
         staff_api_client,
         permission_manage_checkouts,
-        checkout_id,
+        checkout.token,
         "Checkout",
         value="NewMetaValue",
     )
@@ -2353,15 +2359,15 @@ def test_update_private_metadata_for_item(
 
 
 def test_update_private_metadata_for_non_exist_item(
-    staff_api_client, permission_manage_checkouts
+    staff_api_client, permission_manage_payments
 ):
     # given
-    checkout_id = "Checkout:" + str(uuid.uuid4())
-    checkout_id = base64.b64encode(str.encode(checkout_id)).decode("utf-8")
+    payment_id = "Payment: 0"
+    payment_id = base64.b64encode(str.encode(payment_id)).decode("utf-8")
 
     # when
     response = execute_update_private_metadata_for_item(
-        staff_api_client, permission_manage_checkouts, checkout_id, "Checkout"
+        staff_api_client, permission_manage_payments, payment_id, "Payment"
     )
 
     # then
@@ -2778,8 +2784,8 @@ def test_delete_private_metadata_for_checkout(
     )
 
     # then
-    assert item_without_private_metadata(
-        response["data"]["deletePrivateMetadata"]["item"], checkout, checkout_id
+    assert invalid_id_graphql_error_raised(
+        response["data"]["deletePrivateMetadata"]["errors"]
     )
 
 
@@ -2817,9 +2823,7 @@ def test_delete_private_metadata_for_order_by_id(
 
     # then
     errors = response["data"]["deletePrivateMetadata"]["errors"]
-    assert len(errors) == 1
-    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
-    assert errors[0]["field"] == "id"
+    assert invalid_id_graphql_error_raised(errors)
 
 
 def test_delete_private_metadata_for_order_by_token(
@@ -2856,9 +2860,7 @@ def test_delete_private_metadata_for_draft_order_by_id(
 
     # then
     errors = response["data"]["deletePrivateMetadata"]["errors"]
-    assert len(errors) == 1
-    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
-    assert errors[0]["field"] == "id"
+    assert invalid_id_graphql_error_raised(errors)
 
 
 def test_delete_private_metadata_for_draft_order_by_token(
@@ -3217,15 +3219,15 @@ def test_delete_private_metadata_for_menu_item(
 
 
 def test_delete_private_metadata_for_non_exist_item(
-    staff_api_client, permission_manage_checkouts
+    staff_api_client, permission_manage_payments
 ):
     # given
-    checkout_id = "Checkout:" + str(uuid.uuid4())
-    checkout_id = base64.b64encode(str.encode(checkout_id)).decode("utf-8")
+    payment_id = "Payment: 0"
+    payment_id = base64.b64encode(str.encode(payment_id)).decode("utf-8")
 
     # when
     response = execute_clear_private_metadata_for_item(
-        staff_api_client, permission_manage_checkouts, checkout_id, "Checkout"
+        staff_api_client, permission_manage_payments, payment_id, "Payment"
     )
 
     # then
@@ -3264,7 +3266,7 @@ def test_delete_private_metadata_for_not_exist_key(
     response = execute_clear_private_metadata_for_item(
         staff_api_client,
         permission_manage_checkouts,
-        checkout_id,
+        checkout.token,
         "Checkout",
         key="Not-exits",
     )
@@ -3289,7 +3291,7 @@ def test_delete_private_metadata_for_one_key(
     response = execute_clear_private_metadata_for_item(
         staff_api_client,
         permission_manage_checkouts,
-        checkout_id,
+        checkout.token,
         "Checkout",
         key="to_clear",
     )


### PR DESCRIPTION
Allow changing `Order` and `Checkout` metadata only with the use of `token`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
