### PR TITLE
Update checkout `last_change` value when checkout changed

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -463,6 +463,7 @@ def recalculate_checkout_discount(
                     "discount_amount",
                     "discount_name",
                     "currency",
+                    "last_change",
                 ]
             )
     else:
@@ -548,6 +549,7 @@ def add_voucher_to_checkout(
             "discount_name",
             "translated_discount_name",
             "discount_amount",
+            "last_change",
         ]
     )
 
@@ -580,6 +582,7 @@ def remove_voucher_from_checkout(checkout: Checkout):
             "translated_discount_name",
             "discount_amount",
             "currency",
+            "last_change",
         ]
     )
 

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -15,6 +15,7 @@ def add_gift_card_code_to_checkout(checkout: Checkout, promo_code: str):
     except GiftCard.DoesNotExist:
         raise InvalidPromoCode()
     checkout.gift_cards.add(gift_card)
+    checkout.save(update_fields=["last_change"])
 
 
 def remove_gift_card_code_from_checkout(checkout: Checkout, gift_card_code: str):
@@ -22,6 +23,7 @@ def remove_gift_card_code_from_checkout(checkout: Checkout, gift_card_code: str)
     gift_card = checkout.gift_cards.filter(code=gift_card_code).first()
     if gift_card:
         checkout.gift_cards.remove(gift_card)
+        checkout.save(update_fields=["last_change"])
 
 
 def deactivate_gift_card(gift_card: GiftCard):

--- a/saleor/graphql/checkout/tests/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/test_checkout_language_code_update.py
@@ -23,6 +23,7 @@ def test_checkout_update_language_code(
 ):
     language_code = "PL"
     checkout = checkout_with_gift_card
+    previous_last_change = checkout.last_change
     variables = {"token": checkout.token, "languageCode": language_code}
 
     response = user_api_client.post_graphql(
@@ -36,3 +37,4 @@ def test_checkout_update_language_code(
     assert data["checkout"]["languageCode"] == language_code
     checkout.refresh_from_db()
     assert checkout.language_code == language_code.lower()
+    assert checkout.last_change != previous_last_change

--- a/saleor/graphql/checkout/tests/test_checkout_lines.py
+++ b/saleor/graphql/checkout/tests/test_checkout_lines.py
@@ -49,6 +49,7 @@ def test_checkout_lines_add(
     lines = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    previous_last_change = checkout.last_change
 
     variables = {
         "token": checkout.token,
@@ -70,12 +71,14 @@ def test_checkout_lines_add(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_lines_add_existing_variant(user_api_client, checkout_with_item):
     checkout = checkout_with_item
     line = checkout.lines.first()
     variant_id = graphene.Node.to_global_id("ProductVariant", line.variant.pk)
+    previous_last_change = checkout.last_change
 
     variables = {
         "token": checkout.token,
@@ -89,6 +92,7 @@ def test_checkout_lines_add_existing_variant(user_api_client, checkout_with_item
     checkout.refresh_from_db()
     line = checkout.lines.latest("pk")
     assert line.quantity == 10
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_lines_add_existing_variant_over_allowed_stock(
@@ -413,6 +417,7 @@ def test_checkout_lines_update(
     line = checkout.lines.first()
     variant = line.variant
     assert line.quantity == 3
+    previous_last_change = checkout.last_change
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
 
@@ -437,12 +442,14 @@ def test_checkout_lines_update(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_lines_update_with_unavailable_variant(
     user_api_client, checkout_with_item
 ):
     checkout = checkout_with_item
+    previous_last_change = checkout.last_change
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     variant = line.variant
@@ -464,6 +471,8 @@ def test_checkout_lines_update_with_unavailable_variant(
     assert errors[0]["code"] == CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name
     assert errors[0]["field"] == "lines"
     assert errors[0]["variants"] == [variant_id]
+    checkout.refresh_from_db()
+    assert checkout.last_change == previous_last_change
 
 
 def test_checkout_lines_update_channel_without_shipping_zones(
@@ -521,6 +530,7 @@ def test_checkout_lines_delete_with_by_zero_quantity_when_variant_out_of_stock(
     stock = line.variant.stocks.first()
     stock.quantity = 0
     stock.save(update_fields=["quantity"])
+    previous_last_change = checkout.last_change
 
     variables = {
         "token": checkout.token,
@@ -531,6 +541,8 @@ def test_checkout_lines_delete_with_by_zero_quantity_when_variant_out_of_stock(
     content = get_graphql_content(response)
     data = content["data"]["checkoutLinesUpdate"]
     assert not data["checkout"]["lines"]
+    checkout.refresh_from_db()
+    assert checkout.last_change != previous_last_change
 
 
 @mock.patch(
@@ -545,6 +557,7 @@ def test_checkout_line_delete_by_zero_quantity(
     line = checkout.lines.first()
     variant = line.variant
     assert line.quantity == 3
+    previous_last_change = checkout.last_change
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
 
@@ -563,6 +576,7 @@ def test_checkout_line_delete_by_zero_quantity(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 @mock.patch(
@@ -613,6 +627,7 @@ def test_checkout_line_update_by_zero_quantity_dont_create_new_lines(
     variant = line.variant
     checkout.lines.all().delete()
     assert checkout.lines.count() == 0
+    previous_last_change = checkout.last_change
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
 
@@ -631,6 +646,7 @@ def test_checkout_line_update_by_zero_quantity_dont_create_new_lines(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_lines_update_with_unpublished_product(
@@ -740,6 +756,7 @@ def test_checkout_line_delete(
     mocked_update_shipping_method, user_api_client, checkout_with_item
 ):
     checkout = checkout_with_item
+    previous_last_change = checkout.last_change
     lines = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3
     assert checkout.lines.count() == 1
@@ -761,6 +778,7 @@ def test_checkout_line_delete(
     manager = get_plugins_manager()
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 MUTATION_CHECKOUT_LINES_DELETE = """
@@ -796,6 +814,7 @@ def test_checkout_lines_delete(
 ):
     checkout = checkout_with_items
     checkout_lines_count = checkout.lines.count()
+    previous_last_change = checkout.last_change
     line = checkout.lines.first()
     second_line = checkout.lines.last()
 
@@ -818,12 +837,14 @@ def test_checkout_lines_delete(
     manager = get_plugins_manager()
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_lines_delete_invalid_checkout_token(
     user_api_client, checkout_with_items
 ):
     checkout = checkout_with_items
+    previous_last_change = checkout.last_change
     line = checkout.lines.first()
     second_line = checkout.lines.last()
 
@@ -839,10 +860,13 @@ def test_checkout_lines_delete_invalid_checkout_token(
     content = get_graphql_content(response)
     errors = content["data"]["checkoutLinesDelete"]["errors"][0]
     assert errors["code"] == CheckoutErrorCode.NOT_FOUND.name
+    checkout.refresh_from_db()
+    assert checkout.last_change == previous_last_change
 
 
 def tests_checkout_lines_delete_invalid_lines_ids(user_api_client, checkout_with_items):
     checkout = checkout_with_items
+    previous_last_change = checkout.last_change
     line = checkout.lines.first()
 
     first_line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
@@ -853,3 +877,5 @@ def tests_checkout_lines_delete_invalid_lines_ids(user_api_client, checkout_with
     content = get_graphql_content(response, ignore_errors=True)
     errors = content["errors"][0]
     assert errors["extensions"]["exception"]["code"] == "GraphQLError"
+    checkout.refresh_from_db()
+    assert checkout.last_change == previous_last_change


### PR DESCRIPTION
Ensure that whenever checkout is changing, the checkout `last_updated` value is updated.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
