### PR TITLE
Allow filtering staff users and permission groups by ids

### DIFF
--- a/saleor/graphql/account/filters.py
+++ b/saleor/graphql/account/filters.py
@@ -1,10 +1,12 @@
 import django_filters
 from django.db.models import Count, Exists, OuterRef, Q
+from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
 from ...account.models import Address, User
 from ..core.filters import EnumFilter, MetadataFilterBase, ObjectTypeFilter
 from ..core.types.common import DateRangeInput, IntRangeInput
-from ..utils.filters import filter_range_field
+from ..utils.filters import filter_by_id, filter_range_field
+from . import types as account_types
 from .enums import StaffMemberStatus
 
 
@@ -81,12 +83,17 @@ class CustomerFilter(MetadataFilterBase):
 
 class PermissionGroupFilter(django_filters.FilterSet):
     search = django_filters.CharFilter(method=filter_search)
+    ids = GlobalIDMultipleChoiceFilter(method=filter_by_id(account_types.Group))
 
 
 class StaffUserFilter(django_filters.FilterSet):
     status = EnumFilter(input_class=StaffMemberStatus, method=filter_staff_status)
     search = django_filters.CharFilter(method=filter_user_search)
-
+    ids = GlobalIDMultipleChoiceFilter(
+        method=filter_by_id(
+            account_types.User,
+        )
+    )
     # TODO - Figure out after permission types
     # department = ObjectTypeFilter
 

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -4610,6 +4610,30 @@ def test_query_staff_members_with_filter_status(
     assert len(users) == count
 
 
+def test_query_staff_members_with_filter_by_ids(
+    query_staff_users_with_filter,
+    staff_api_client,
+    permission_manage_staff,
+    staff_user,
+):
+    # given
+    variables = {
+        "filter": {
+            "ids": [graphene.Node.to_global_id("User", staff_user.pk)],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query_staff_users_with_filter, variables, permissions=[permission_manage_staff]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    users = content["data"]["staffUsers"]["edges"]
+    assert len(users) == 1
+
+
 def test_query_staff_members_app_no_permission(
     query_staff_users_with_filter,
     app_api_client,

--- a/saleor/graphql/account/tests/test_account_permission_group.py
+++ b/saleor/graphql/account/tests/test_account_permission_group.py
@@ -2174,6 +2174,32 @@ def test_permission_groups_query(
     assert len(data) == count
 
 
+def test_permission_groups_query_with_filter_by_ids(
+    permission_group_manage_users,
+    permission_manage_staff,
+    staff_api_client,
+):
+    # given
+    query = QUERY_PERMISSION_GROUP_WITH_FILTER
+    variables = {
+        "filter": {
+            "ids": [
+                graphene.Node.to_global_id("Group", permission_group_manage_users.pk)
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_staff]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["permissionGroups"]["edges"]
+    assert len(data) == 1
+
+
 def test_permission_groups_app_no_permission(
     permission_group_manage_users,
     permission_manage_staff,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4768,6 +4768,7 @@ enum PermissionGroupErrorCode {
 
 input PermissionGroupFilterInput {
   search: String
+  ids: [ID]
 }
 
 enum PermissionGroupSortField {
@@ -6252,6 +6253,7 @@ input StaffUpdateInput {
 input StaffUserInput {
   status: StaffMemberStatus
   search: String
+  ids: [ID]
 }
 
 type Stock implements Node {

--- a/saleor/graphql/utils/filters.py
+++ b/saleor/graphql/utils/filters.py
@@ -60,3 +60,15 @@ def filter_range_field(qs, field, value):
         lookup = {f"{field}__lte": lte}
         qs = qs.filter(**lookup)
     return qs
+
+
+def filter_by_id(object_type):
+    from saleor.graphql.utils import resolve_global_ids_to_primary_keys
+
+    def inner(qs, _, value):
+        if not value:
+            return qs
+        _, obj_pks = resolve_global_ids_to_primary_keys(value, object_type)
+        return qs.filter(id__in=obj_pks)
+
+    return inner

--- a/saleor/graphql/utils/filters.py
+++ b/saleor/graphql/utils/filters.py
@@ -63,7 +63,7 @@ def filter_range_field(qs, field, value):
 
 
 def filter_by_id(object_type):
-    from saleor.graphql.utils import resolve_global_ids_to_primary_keys
+    from . import resolve_global_ids_to_primary_keys
 
     def inner(qs, _, value):
         if not value:


### PR DESCRIPTION
I want to merge this change because it's going to make it easier to fetch multiple objects by third party apps.

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
