### PR TITLE
Fix incorrect stock allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - Rename checkout interfaces: `CheckoutTaxedPricesData` instead of `TaxedPricesData`
   and `CheckoutPricesData` instead of `PricesData`
   - New interface for handling more data for prices: `OrderTaxedPricesData` used in plugins/pluginManager.
+- Fix incorrect stock allocation - #8931 by @IKarbowiak
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/order/tests/test_fulfillments_actions.py
+++ b/saleor/order/tests/test_fulfillments_actions.py
@@ -418,3 +418,80 @@ def test_create_fulfillments_with_variant_without_inventory_tracking_and_without
     )
 
     mock_email_fulfillment.assert_not_called()
+
+
+@patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
+def test_create_fulfillments_quantity_allocated_lower_than_line_quantity(
+    mock_email_fulfillment,
+    staff_user,
+    order_with_lines,
+    warehouse,
+):
+    """Ensure that when for some lines quantity allocated is lower than line quantity
+    and an error is raised during the deallocation uantity allocated value for
+    all allocation will be updated."""
+
+    # given
+    order = order_with_lines
+    order_line1, order_line2 = order.lines.all()
+    line_1_qty = 3
+    line_2_qty = 2
+
+    allocation_1 = order_line1.allocations.first()
+    allocation_2 = order_line2.allocations.first()
+
+    stock_quantity = 100
+    allocation_1_qty_allocated = line_1_qty - 1
+    allocation_2_qty_allocated = line_2_qty
+
+    stock_1 = allocation_1.stock
+    stock_2 = allocation_2.stock
+    stock_1.quantity = stock_quantity
+    stock_2.quantity = stock_quantity
+    Stock.objects.bulk_update([stock_1, stock_2], ["quantity"])
+
+    allocation_1.quantity_allocated = allocation_1_qty_allocated
+    allocation_2.quantity_allocated = allocation_2_qty_allocated
+    Allocation.objects.bulk_update([allocation_1, allocation_2], ["quantity_allocated"])
+
+    fulfillment_lines_for_warehouses = {
+        str(warehouse.pk): [
+            {"order_line": order_line1, "quantity": line_1_qty},
+            {"order_line": order_line2, "quantity": line_2_qty},
+        ]
+    }
+    manager = get_plugins_manager()
+
+    # when
+    [fulfillment] = create_fulfillments(
+        staff_user, None, order, fulfillment_lines_for_warehouses, manager, True
+    )
+    flush_post_commit_hooks()
+
+    # then
+    order.refresh_from_db()
+    fulfillment_lines = FulfillmentLine.objects.filter(
+        fulfillment__order=order
+    ).order_by("pk")
+    assert fulfillment_lines[0].stock == order_line1.variant.stocks.get()
+    assert fulfillment_lines[0].quantity == line_1_qty
+    assert fulfillment_lines[1].stock == order_line2.variant.stocks.get()
+    assert fulfillment_lines[1].quantity == line_2_qty
+
+    assert order.status == OrderStatus.FULFILLED
+    assert order.fulfillments.get() == fulfillment
+
+    order_line1, order_line2 = order.lines.all()
+    assert order_line1.quantity_fulfilled == line_1_qty
+    assert order_line2.quantity_fulfilled == line_2_qty
+
+    assert (
+        Allocation.objects.filter(
+            order_line__order=order, quantity_allocated__gt=0
+        ).count()
+        == 0
+    )
+
+    mock_email_fulfillment.assert_called_once_with(
+        order, order.fulfillments.get(), staff_user, None, manager
+    )

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -44,7 +44,6 @@ from ..utils import (
     get_voucher_discount_for_order,
     recalculate_order,
     restock_fulfillment_lines,
-    restock_order_lines,
     update_order_prices,
     update_order_status,
 )
@@ -294,77 +293,6 @@ def test_add_variant_to_order_not_allocates_stock_for_existing_variant(
     assert get_quantity_allocated_for_stock(stock) == stock_before
     assert existing_line.quantity == quantity_before + 1
     assert existing_line.quantity_unfulfilled == quantity_unfulfilled_before + 1
-
-
-@pytest.mark.parametrize("track_inventory", (True, False))
-def test_restock_order_lines(order_with_lines, track_inventory):
-
-    order = order_with_lines
-    line_1 = order.lines.first()
-    line_2 = order.lines.last()
-
-    line_1.variant.track_inventory = track_inventory
-    line_2.variant.track_inventory = track_inventory
-
-    line_1.variant.save()
-    line_2.variant.save()
-    stock_1 = Stock.objects.get(product_variant=line_1.variant)
-    stock_2 = Stock.objects.get(product_variant=line_2.variant)
-
-    stock_1_quantity_allocated_before = get_quantity_allocated_for_stock(stock_1)
-    stock_2_quantity_allocated_before = get_quantity_allocated_for_stock(stock_2)
-
-    stock_1_quantity_before = stock_1.quantity
-    stock_2_quantity_before = stock_2.quantity
-
-    restock_order_lines(order)
-
-    stock_1.refresh_from_db()
-    stock_2.refresh_from_db()
-
-    if track_inventory:
-        assert get_quantity_allocated_for_stock(stock_1) == (
-            stock_1_quantity_allocated_before - line_1.quantity
-        )
-        assert get_quantity_allocated_for_stock(stock_2) == (
-            stock_2_quantity_allocated_before - line_2.quantity
-        )
-    else:
-        assert get_quantity_allocated_for_stock(stock_1) == (
-            stock_1_quantity_allocated_before
-        )
-        assert get_quantity_allocated_for_stock(stock_2) == (
-            stock_2_quantity_allocated_before
-        )
-
-    assert stock_1.quantity == stock_1_quantity_before
-    assert stock_2.quantity == stock_2_quantity_before
-    assert line_1.quantity_fulfilled == 0
-    assert line_2.quantity_fulfilled == 0
-
-
-def test_restock_fulfilled_order_lines(fulfilled_order):
-    line_1 = fulfilled_order.lines.first()
-    line_2 = fulfilled_order.lines.last()
-    stock_1 = Stock.objects.get(product_variant=line_1.variant)
-    stock_2 = Stock.objects.get(product_variant=line_2.variant)
-    stock_1_quantity_allocated_before = get_quantity_allocated_for_stock(stock_1)
-    stock_2_quantity_allocated_before = get_quantity_allocated_for_stock(stock_2)
-    stock_1_quantity_before = stock_1.quantity
-    stock_2_quantity_before = stock_2.quantity
-
-    restock_order_lines(fulfilled_order)
-
-    stock_1.refresh_from_db()
-    stock_2.refresh_from_db()
-    assert (
-        get_quantity_allocated_for_stock(stock_1) == stock_1_quantity_allocated_before
-    )
-    assert (
-        get_quantity_allocated_for_stock(stock_2) == stock_2_quantity_allocated_before
-    )
-    assert stock_1.quantity == stock_1_quantity_before + line_1.quantity
-    assert stock_2.quantity == stock_2_quantity_before + line_2.quantity
 
 
 def test_restock_fulfillment_lines(fulfilled_order, warehouse):

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -26,13 +26,11 @@ from ..shipping.interface import ShippingMethodData
 from ..shipping.models import ShippingMethod, ShippingMethodChannelListing
 from ..shipping.utils import convert_to_shipping_method_data
 from ..warehouse.management import (
-    deallocate_stock,
     decrease_allocations,
     get_order_lines_with_track_inventory,
     increase_allocations,
     increase_stock,
 )
-from ..warehouse.models import Warehouse
 from . import events
 
 if TYPE_CHECKING:
@@ -566,35 +564,6 @@ def delete_order_line(line_info):
     if line_info.line.order.is_unconfirmed():
         decrease_allocations([line_info])
     line_info.line.delete()
-
-
-def restock_order_lines(order):
-    """Return ordered products to corresponding stocks."""
-    country = get_order_country(order)
-    default_warehouse = Warehouse.objects.filter(
-        shipping_zones__countries__contains=country
-    ).first()
-
-    dellocating_stock_lines: List[OrderLineData] = []
-    for line in order.lines.all():
-        if line.variant and line.variant.track_inventory:
-            if line.quantity_unfulfilled > 0:
-                dellocating_stock_lines.append(
-                    OrderLineData(line=line, quantity=line.quantity_unfulfilled)
-                )
-            if line.quantity_fulfilled > 0:
-                allocation = line.allocations.first()
-                warehouse = (
-                    allocation.stock.warehouse if allocation else default_warehouse
-                )
-                increase_stock(line, warehouse, line.quantity_fulfilled)
-
-        if line.quantity_fulfilled > 0:
-            line.quantity_fulfilled = 0
-            line.save(update_fields=["quantity_fulfilled"])
-
-    if dellocating_stock_lines:
-        deallocate_stock(dellocating_stock_lines)
 
 
 def restock_fulfillment_lines(fulfillment, warehouse):

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -126,7 +126,6 @@ def _create_allocations(
         return insufficient_stock, []
 
 
-@traced_atomic_transaction()
 def deallocate_stock(order_lines_data: Iterable["OrderLineData"]):
     """Deallocate stocks for given `order_lines`.
 
@@ -175,10 +174,10 @@ def deallocate_stock(order_lines_data: Iterable["OrderLineData"]):
         if not quantity_dealocated == quantity:
             not_dellocated_lines.append(order_line)
 
+    Allocation.objects.bulk_update(allocations_to_update, ["quantity_allocated"])
+
     if not_dellocated_lines:
         raise AllocationError(not_dellocated_lines)
-
-    Allocation.objects.bulk_update(allocations_to_update, ["quantity_allocated"])
 
 
 @traced_atomic_transaction()

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -435,6 +435,74 @@ def test_decrease_stock_multiple_lines(allocations):
     assert allocation_1.quantity_allocated == 10
 
 
+def test_decrease_stock_multiple_lines_deallocate_stock_raises_error(order_with_lines):
+    """Ensure that when some of the lines raise an error during the deallocation
+    quantity allocated value for all allocation will be updated."""
+
+    # given
+    order_line_1 = order_with_lines.lines.first()
+    order_line_2 = order_with_lines.lines.last()
+
+    allocation_1 = order_line_1.allocations.first()
+    allocation_2 = order_line_2.allocations.first()
+
+    stock_quantity = 100
+    allocation_1_qty_allocated = 10
+    allocation_2_qty_allocated = 80
+
+    stock_1 = allocation_1.stock
+    stock_2 = allocation_2.stock
+    stock_1.quantity = stock_quantity
+    stock_2.quantity = stock_quantity
+    Stock.objects.bulk_update([stock_1, stock_2], ["quantity"])
+
+    allocation_1.quantity_allocated = allocation_1_qty_allocated
+    allocation_1.order_line = order_line_1
+    warehouse_pk_1 = stock_1.warehouse.pk
+
+    allocation_2.quantity_allocated = allocation_2_qty_allocated
+    allocation_2.order_line = order_line_2
+    warehouse_pk_2 = stock_2.warehouse.pk
+
+    Allocation.objects.bulk_update(
+        [allocation_1, allocation_2], ["quantity_allocated", "order_line"]
+    )
+
+    line_1_qty = 50
+    line_2_qty = 20
+
+    # when
+    decrease_stock(
+        [
+            OrderLineData(
+                line=order_line_1,
+                quantity=line_1_qty,
+                variant=order_line_1.variant,
+                warehouse_pk=warehouse_pk_1,
+            ),
+            OrderLineData(
+                line=order_line_2,
+                quantity=line_2_qty,
+                variant=order_line_2.variant,
+                warehouse_pk=warehouse_pk_2,
+            ),
+        ],
+    )
+
+    # then
+    stock_1.refresh_from_db()
+    assert stock_1.quantity == stock_quantity - line_1_qty
+
+    stock_2.refresh_from_db()
+    assert stock_2.quantity == stock_quantity - line_2_qty
+
+    allocation_1.refresh_from_db()
+    assert allocation_1.quantity_allocated == 0
+
+    allocation_2.refresh_from_db()
+    assert allocation_2.quantity_allocated == allocation_2_qty_allocated - line_2_qty
+
+
 def test_decrease_stock_partially(allocation):
     stock = allocation.stock
     stock.quantity = 100


### PR DESCRIPTION
Previously, when some lines raise an error during stock deallocation, only the quantity allocated for these lines was updated. The changes ensure that all quantities allocated will be updated. Transaction atomic is removed from `deallocate_stock` as we want to save changes for allocations.

Drop unsed `restock_order_lines` order utils function.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
