### PR TITLE
Add validators for translation mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Do no allow using id for updating checkout and order metadata - #8906 by @IKarbowiak
 - Fix crash when querying external shipping method's `translation` field - #8971 by @rafalp
 - Add `COLLECTION_CREATED`, `COLLECTION_UPDATED`, `COLLECTION_DELETED` events and webhooks - #8974 by @rafalp
+- Fix crash when too long translation strings were passed to `translate` mutations - #8942 by rafalp
 
 # 3.0.0 [Unreleased]
 

--- a/saleor/core/error_codes.py
+++ b/saleor/core/error_codes.py
@@ -18,7 +18,7 @@ class MetadataErrorCode(Enum):
     REQUIRED = "required"
 
 
-class TranslationErrorCode(str, Enum):
+class TranslationErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
     REQUIRED = "required"

--- a/saleor/core/error_codes.py
+++ b/saleor/core/error_codes.py
@@ -20,9 +20,9 @@ class MetadataErrorCode(Enum):
 
 class TranslationErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
+    INVALID = "invalid"
     NOT_FOUND = "not_found"
     REQUIRED = "required"
-    TOO_LONG = "too_long"
 
 
 class UploadErrorCode(Enum):

--- a/saleor/core/error_codes.py
+++ b/saleor/core/error_codes.py
@@ -18,7 +18,7 @@ class MetadataErrorCode(Enum):
     REQUIRED = "required"
 
 
-class TranslationErrorCode(Enum):
+class TranslationErrorCode(str, Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
     REQUIRED = "required"

--- a/saleor/core/error_codes.py
+++ b/saleor/core/error_codes.py
@@ -22,6 +22,7 @@ class TranslationErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
     REQUIRED = "required"
+    TOO_LONG = "too_long"
 
 
 class UploadErrorCode(Enum):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6883,6 +6883,7 @@ enum TranslationErrorCode {
   GRAPHQL_ERROR
   NOT_FOUND
   REQUIRED
+  TOO_LONG
 }
 
 input TranslationInput {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6881,9 +6881,9 @@ type TranslationError {
 
 enum TranslationErrorCode {
   GRAPHQL_ERROR
+  INVALID
   NOT_FOUND
   REQUIRED
-  TOO_LONG
 }
 
 input TranslationInput {

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -1,10 +1,9 @@
 import graphene
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import CharField, Model
+from django.db.models import Model
 
 from ...attribute import models as attribute_models
-from ...core.error_codes import TranslationErrorCode
 from ...core.permissions import SitePermissions
 from ...core.tracing import traced_atomic_transaction
 from ...discount import models as discount_models

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from django.db.models import CharField, Model
 
 from ...attribute import models as attribute_models
+from ...core.error_codes import TranslationErrorCode
 from ...core.permissions import SitePermissions
 from ...core.tracing import traced_atomic_transaction
 from ...discount import models as discount_models
@@ -61,7 +62,7 @@ def validate_input_against_model(model: Model, input_data: dict):
         if value and len(value) > model_field.max_length:
             errors[field_name] = ValidationError(
                 f"This value can't be longer than {model_field.max_length}",
-                code="too_long",
+                code=TranslationErrorCode.TOO_LONG.value,
             )
 
     if errors:

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -52,7 +52,7 @@ TRANSLATABLE_CONTENT_TO_TYPE = {
 }
 
 
-def validate_input(model: Model, input_data: dict):
+def validate_input_against_model(model: Model, input_data: dict):
     errors = {}
     for field_name, value in input_data.items():
         model_field = model._meta.get_field(field_name)
@@ -95,7 +95,7 @@ class BaseTranslateMutation(ModelMutation):
 
     @classmethod
     def validate_input(cls, input_data):
-        validate_input(cls._meta.model, input_data)
+        validate_input_against_model(cls._meta.model, input_data)
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
@@ -476,7 +476,7 @@ class ShopSettingsTranslate(BaseMutation):
     @traced_atomic_transaction()
     def perform_mutation(cls, _root, info, language_code, **data):
         instance = info.context.site.settings
-        validate_input(SiteSettings, data["input"])
+        validate_input_against_model(SiteSettings, data["input"])
         translation, created = instance.translations.update_or_create(
             language_code=language_code, defaults=data.get("input")
         )

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -4,7 +4,6 @@ from django.db import transaction
 from django.db.models import CharField, Model
 
 from ...attribute import models as attribute_models
-from ...core.error_codes import TranslationErrorCode
 from ...core.permissions import SitePermissions
 from ...core.tracing import traced_atomic_transaction
 from ...discount import models as discount_models
@@ -62,7 +61,7 @@ def validate_input_against_model(model: Model, input_data: dict):
         if value and len(value) > model_field.max_length:
             errors[field_name] = ValidationError(
                 f"This value can't be longer than {model_field.max_length}",
-                code=TranslationErrorCode.TOO_LONG,
+                code="too_long",
             )
 
     if errors:

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -11,8 +11,8 @@ from ...menu import models as menu_models
 from ...page import models as page_models
 from ...product import models as product_models
 from ...shipping import models as shipping_models
-from ..attribute import types as attribute_types
 from ...site.models import SiteSettings
+from ..attribute import types as attribute_types
 from ..channel import ChannelContext
 from ..core.enums import LanguageCodeEnum
 from ..core.mutations import BaseMutation, ModelMutation, registry

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -58,8 +58,6 @@ def validate_input(model: Model, input_data: dict):
         model_field = model._meta.get_field(field_name)
         if not isinstance(model_field, CharField):
             continue
-        if value:
-            print(field_name, len(value), model_field.max_length)
         if value and len(value) > model_field.max_length:
             errors[field_name] = ValidationError(
                 f"This value can't be longer than {model_field.max_length}",

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -4,7 +4,6 @@ from django.db import transaction
 from django.db.models import CharField, Model
 
 from ...attribute import models as attribute_models
-from ...core.error_codes import TranslationErrorCode
 from ...core.permissions import SitePermissions
 from ...core.tracing import traced_atomic_transaction
 from ...discount import models as discount_models
@@ -64,7 +63,7 @@ def validate_input(model: Model, input_data: dict):
         if value and len(value) > model_field.max_length:
             errors[field_name] = ValidationError(
                 f"This value can't be longer than {model_field.max_length}",
-                code=TranslationErrorCode.TOO_LONG,
+                code="too_long",
             )
 
     if errors:
@@ -81,7 +80,7 @@ class BaseTranslateMutation(ModelMutation):
             raise ValidationError(
                 {
                     "id": ValidationError(
-                        "This field is required", code=TranslationErrorCode.REQUIRED
+                        "This field is required", code="required"
                     )
                 }
             )

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from django.db.models import CharField, Model
 
 from ...attribute import models as attribute_models
+from ...core.error_codes import TranslationErrorCode
 from ...core.permissions import SitePermissions
 from ...core.tracing import traced_atomic_transaction
 from ...discount import models as discount_models
@@ -61,7 +62,7 @@ def validate_input_against_model(model: Model, input_data: dict):
         if value and len(value) > model_field.max_length:
             errors[field_name] = ValidationError(
                 f"This value can't be longer than {model_field.max_length}",
-                code="too_long",
+                code=TranslationErrorCode.TOO_LONG,
             )
 
     if errors:

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -55,7 +55,7 @@ TRANSLATABLE_CONTENT_TO_TYPE = {
 
 def validate_input_against_model(model: Model, input_data: dict):
     data_to_validate = {key: value for key, value in input_data.items() if value}
-    instance = model(**data_to_validate)
+    instance = model(**data_to_validate)  # type: ignore
     all_fields = [field.name for field in model._meta.fields]
     exclude_fields = set(all_fields) - set(data_to_validate)
     instance.full_clean(exclude=exclude_fields, validate_unique=False)

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -78,11 +78,7 @@ class BaseTranslateMutation(ModelMutation):
     def clean_node_id(cls, **data):
         if "id" in data and not data["id"]:
             raise ValidationError(
-                {
-                    "id": ValidationError(
-                        "This field is required", code="required"
-                    )
-                }
+                {"id": ValidationError("This field is required", code="required")}
             )
 
         node_id = data["id"]

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -1263,7 +1263,6 @@ def test_collection_translation_mutation_validates_inputs_length(
         permissions=[permission_manage_translations],
     )
     data = get_graphql_content(response)["data"]["collectionTranslate"]
-    print(data)
 
     assert data["collection"] is None
     assert data["errors"] == [{"field": "name", "code": "TOO_LONG"}]

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -818,6 +818,10 @@ PRODUCT_TRANSLATE_MUTATION = """
                     }
                 }
             }
+            errors {
+                field
+                code
+            }
         }
     }
 """
@@ -922,6 +926,28 @@ def test_product_create_translation_by_translatable_content_id(
     assert data["product"]["translation"]["language"]["code"] == "PL"
 
 
+def test_product_create_translation_validates_name_length(
+    staff_api_client, product, permission_manage_translations
+):
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    description = dummy_editorjs("description", True)
+    variables = {
+        "productId": product_id,
+        "input": {"description": None, "name": "Long" * 100},
+    }
+    response = staff_api_client.post_graphql(
+        PRODUCT_TRANSLATE_MUTATION,
+        variables,
+        permissions=[permission_manage_translations],
+    )
+    data = get_graphql_content(response)["data"]["productTranslate"]
+
+    assert data["product"] is None
+    assert data["errors"] == [
+        {"field": "name", "code": "TOO_LONG"},
+    ]
+
+
 @freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_update_translation(
@@ -967,6 +993,10 @@ mutation productVariantTranslate(
                     code
                 }
             }
+        }
+        errors {
+            field
+            code
         }
     }
 }
@@ -1053,6 +1083,33 @@ def test_product_variant_update_translation(
     )
 
 
+def test_product_variant_translation_mutation_validates_inputs_length(
+    staff_api_client,
+    variant,
+    channel_USD,
+    permission_manage_translations,
+):
+    translatable_content_id = graphene.Node.to_global_id(
+        "ProductVariantTranslatableContent", variant.id
+    )
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_TRANSLATE_MUTATION,
+        {
+            "productVariantId": translatable_content_id,
+            "input": {"name": "Wariant PL" * 100},
+        },
+        permissions=[permission_manage_translations],
+    )
+    data = get_graphql_content(response)["data"]["productVariantTranslate"]
+    assert data["productVariant"] is None
+    assert data["errors"] == [
+        {
+            "field": "name",
+            "code": "TOO_LONG",
+        }
+    ]
+
+
 COLLECTION_TRANSLATE_MUTATION = """
 mutation collectionTranslate($collectionId: ID!, $input: TranslationInput!) {
     collectionTranslate(
@@ -1066,6 +1123,10 @@ mutation collectionTranslate($collectionId: ID!, $input: TranslationInput!) {
                     code
                 }
             }
+        }
+        errors {
+            field
+            code
         }
     }
 }
@@ -1187,6 +1248,26 @@ def test_collection_update_translation(
     mocked_webhook_trigger.assert_called_once_with(
         expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
     )
+
+
+def test_collection_translation_mutation_validates_inputs_length(
+    staff_api_client, published_collection, permission_manage_translations
+):
+    collection_id = graphene.Node.to_global_id("Collection", published_collection.id)
+    description = dummy_editorjs("description", True)
+    response = staff_api_client.post_graphql(
+        COLLECTION_TRANSLATE_MUTATION,
+        {
+            "collectionId": collection_id,
+            "input": {"description": description, "name": "long" * 100},
+        },
+        permissions=[permission_manage_translations],
+    )
+    data = get_graphql_content(response)["data"]["collectionTranslate"]
+    print(data)
+
+    assert data["collection"] is None
+    assert data["errors"] == [{"field": "name", "code": "TOO_LONG"}]
 
 
 CATEGORY_TRANSLATE_MUTATION = """
@@ -2092,6 +2173,27 @@ def test_shop_create_translation(
     )
 
 
+SHOP_SETTINGS_TRANSLATE_MUTATION = """
+    mutation shopSettingsTranslate($input: ShopSettingsTranslationInput!) {
+        shopSettingsTranslate(
+                languageCode: PL, input: $input) {
+            shop {
+                translation(languageCode: PL) {
+                    headerText
+                    language {
+                        code
+                    }
+                }
+            }
+            errors {
+                field
+                code
+            }
+        }
+    }
+"""
+
+
 @freeze_time("1914-06-28 10:50")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_shop_update_translation(
@@ -2107,24 +2209,10 @@ def test_shop_update_translation(
         language_code="pl", header_text="Nagłówek"
     )
 
-    query = """
-    mutation shopSettingsTranslate {
-        shopSettingsTranslate(
-                languageCode: PL, input: {headerText: "Nagłówek PL"}) {
-            shop {
-                translation(languageCode: PL) {
-                    headerText
-                    language {
-                        code
-                    }
-                }
-            }
-        }
-    }
-    """
-
     response = staff_api_client.post_graphql(
-        query, permissions=[permission_manage_translations]
+        SHOP_SETTINGS_TRANSLATE_MUTATION,
+        {"input": {"headerText": "Nagłówek PL"}},
+        permissions=[permission_manage_translations],
     )
     data = get_graphql_content(response)["data"]["shopSettingsTranslate"]
 
@@ -2137,6 +2225,32 @@ def test_shop_update_translation(
         expected_payload,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
     )
+
+
+@freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
+def test_shop_translation_validates_values_lengths(
+    mocked_webhook_trigger,
+    staff_api_client,
+    site_settings,
+    permission_manage_translations,
+    settings,
+):
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+
+    translation = site_settings.translations.create(
+        language_code="pl", header_text="Nagłówek"
+    )
+
+    response = staff_api_client.post_graphql(
+        SHOP_SETTINGS_TRANSLATE_MUTATION,
+        {"input": {"headerText": "Nagłówek PL" * 100}},
+        permissions=[permission_manage_translations],
+    )
+    data = get_graphql_content(response)["data"]["shopSettingsTranslate"]
+
+    assert data["shop"] is None
+    assert data["errors"] == [{"field": "headerText", "code": "TOO_LONG"}]
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -943,7 +943,7 @@ def test_product_create_translation_validates_name_length(
 
     assert data["product"] is None
     assert data["errors"] == [
-        {"field": "name", "code": "TOO_LONG"},
+        {"field": "name", "code": "INVALID"},
     ]
 
 
@@ -1104,7 +1104,7 @@ def test_product_variant_translation_mutation_validates_inputs_length(
     assert data["errors"] == [
         {
             "field": "name",
-            "code": "TOO_LONG",
+            "code": "INVALID",
         }
     ]
 
@@ -1265,7 +1265,7 @@ def test_collection_translation_mutation_validates_inputs_length(
     data = get_graphql_content(response)["data"]["collectionTranslate"]
 
     assert data["collection"] is None
-    assert data["errors"] == [{"field": "name", "code": "TOO_LONG"}]
+    assert data["errors"] == [{"field": "name", "code": "INVALID"}]
 
 
 CATEGORY_TRANSLATE_MUTATION = """
@@ -2244,7 +2244,7 @@ def test_shop_translation_validates_values_lengths(
     data = get_graphql_content(response)["data"]["shopSettingsTranslate"]
 
     assert data["shop"] is None
-    assert data["errors"] == [{"field": "headerText", "code": "TOO_LONG"}]
+    assert data["errors"] == [{"field": "headerText", "code": "INVALID"}]
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -930,7 +930,6 @@ def test_product_create_translation_validates_name_length(
     staff_api_client, product, permission_manage_translations
 ):
     product_id = graphene.Node.to_global_id("Product", product.id)
-    description = dummy_editorjs("description", True)
     variables = {
         "productId": product_id,
         "input": {"description": None, "name": "Long" * 100},
@@ -2237,10 +2236,6 @@ def test_shop_translation_validates_values_lengths(
     settings,
 ):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-
-    translation = site_settings.translations.create(
-        language_code="pl", header_text="Nagłówek"
-    )
 
     response = staff_api_client.post_graphql(
         SHOP_SETTINGS_TRANSLATE_MUTATION,


### PR DESCRIPTION
Adds max length validation to translation mutations

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
