### PR TITLE
Update checkout last_change value when checkout changed

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -514,6 +514,7 @@ def recalculate_checkout_discount(
                     "discount_amount",
                     "discount_name",
                     "currency",
+                    "last_change",
                 ]
             )
     else:
@@ -605,6 +606,7 @@ def add_voucher_to_checkout(
             "discount_name",
             "translated_discount_name",
             "discount_amount",
+            "last_change",
         ]
     )
 
@@ -637,6 +639,7 @@ def remove_voucher_from_checkout(checkout: Checkout):
             "translated_discount_name",
             "discount_amount",
             "currency",
+            "last_change",
         ]
     )
 

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -51,6 +51,7 @@ def add_gift_card_code_to_checkout(
         raise InvalidPromoCode()
 
     checkout.gift_cards.add(gift_card)
+    checkout.save(update_fields=["last_change"])
 
 
 def remove_gift_card_code_from_checkout(checkout: Checkout, gift_card_code: str):
@@ -58,6 +59,7 @@ def remove_gift_card_code_from_checkout(checkout: Checkout, gift_card_code: str)
     gift_card = checkout.gift_cards.filter(code=gift_card_code).first()
     if gift_card:
         checkout.gift_cards.remove(gift_card)
+        checkout.save(update_fields=["last_change"])
 
 
 def deactivate_gift_card(gift_card: GiftCard):

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2031,6 +2031,7 @@ def test_checkout_customer_attach(
     checkout.email = "old@email.com"
     checkout.save()
     assert checkout.user is None
+    previous_last_change = checkout.last_change
 
     query = """
         mutation checkoutCustomerAttach($token: UUID) {
@@ -2060,6 +2061,7 @@ def test_checkout_customer_attach(
     checkout.refresh_from_db()
     assert checkout.user == customer_user
     assert checkout.email == customer_user.email
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_customer_attach_by_app(
@@ -2069,6 +2071,7 @@ def test_checkout_customer_attach_by_app(
     checkout.email = "old@email.com"
     checkout.save()
     assert checkout.user is None
+    previous_last_change = checkout.last_change
 
     query = """
         mutation checkoutCustomerAttach($token: UUID, $customerId: ID) {
@@ -2096,6 +2099,7 @@ def test_checkout_customer_attach_by_app(
     checkout.refresh_from_db()
     assert checkout.user == customer_user
     assert checkout.email == customer_user.email
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_customer_attach_by_app_without_permission(
@@ -2312,6 +2316,7 @@ def test_checkout_customer_detach(user_api_client, checkout_with_item, customer_
     checkout = checkout_with_item
     checkout.user = customer_user
     checkout.save(update_fields=["user"])
+    previous_last_change = checkout.last_change
 
     variables = {"token": checkout.token}
 
@@ -2324,6 +2329,7 @@ def test_checkout_customer_detach(user_api_client, checkout_with_item, customer_
     assert not data["errors"]
     checkout.refresh_from_db()
     assert checkout.user is None
+    assert checkout.last_change != previous_last_change
 
     # Mutation should fail when user calling it doesn't own the checkout.
     other_user = User.objects.create_user("othercustomer@example.com", "password")
@@ -2341,6 +2347,7 @@ def test_checkout_customer_detach_by_app(
     checkout = checkout_with_item
     checkout.user = customer_user
     checkout.save(update_fields=["user"])
+    previous_last_change = checkout.last_change
 
     variables = {"token": checkout.token}
 
@@ -2355,6 +2362,7 @@ def test_checkout_customer_detach_by_app(
     assert not data["errors"]
     checkout.refresh_from_db()
     assert checkout.user is None
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_customer_detach_by_app_without_permissions(
@@ -2363,6 +2371,7 @@ def test_checkout_customer_detach_by_app_without_permissions(
     checkout = checkout_with_item
     checkout.user = customer_user
     checkout.save(update_fields=["user"])
+    previous_last_change = checkout.last_change
 
     variables = {"token": checkout.token}
 
@@ -2370,6 +2379,8 @@ def test_checkout_customer_detach_by_app_without_permissions(
     response = app_api_client.post_graphql(MUTATION_CHECKOUT_CUSTOMER_DETACH, variables)
 
     assert_no_permission(response)
+    checkout.refresh_from_db()
+    assert checkout.last_change == previous_last_change
 
 
 MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE = """
@@ -2402,6 +2413,7 @@ def test_checkout_shipping_address_update(
 ):
     checkout = checkout_with_item
     assert checkout.shipping_address is None
+    previous_last_change = checkout.last_change
 
     shipping_address = graphql_address_data
     variables = {"token": checkout_with_item.token, "shippingAddress": shipping_address}
@@ -2429,6 +2441,7 @@ def test_checkout_shipping_address_update(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 @mock.patch(
@@ -2449,6 +2462,7 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     checkout_info = fetch_checkout_info(checkout, [], [], get_plugins_manager())
     add_variant_to_checkout(checkout_info, variant, 1)
     assert checkout.shipping_address is None
+    previous_last_change = checkout.last_change
 
     shipping_address = graphql_address_data
     shipping_address["country"] = "US"
@@ -2480,6 +2494,7 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.country == shipping_address["country"]
+    assert checkout.last_change != previous_last_change
 
 
 @mock.patch(
@@ -2503,6 +2518,7 @@ def test_checkout_shipping_address_update_insufficient_stocks(
         warehouse__shipping_zones__countries__contains="US", product_variant=variant
     ).update(quantity=0)
     assert checkout.shipping_address is None
+    previous_last_change = checkout.last_change
 
     shipping_address = graphql_address_data
     shipping_address["country"] = "US"
@@ -2518,6 +2534,8 @@ def test_checkout_shipping_address_update_insufficient_stocks(
     errors = data["errors"]
     assert errors[0]["code"] == CheckoutErrorCode.INSUFFICIENT_STOCK.name
     assert errors[0]["field"] == "quantity"
+    checkout.refresh_from_db()
+    assert checkout.last_change == previous_last_change
 
 
 @mock.patch(
@@ -2628,6 +2646,7 @@ def test_checkout_shipping_address_update_channel_without_shipping_zones(
     checkout = checkout_with_item
     checkout.channel.shipping_zones.clear()
     assert checkout.shipping_address is None
+    previous_last_change = checkout.last_change
 
     shipping_address = graphql_address_data
     variables = {"token": checkout.token, "shippingAddress": shipping_address}
@@ -2640,6 +2659,8 @@ def test_checkout_shipping_address_update_channel_without_shipping_zones(
     errors = data["errors"]
     assert errors[0]["code"] == CheckoutErrorCode.INSUFFICIENT_STOCK.name
     assert errors[0]["field"] == "quantity"
+    checkout.refresh_from_db()
+    assert checkout.last_change == previous_last_change
 
 
 def test_checkout_shipping_address_with_invalid_phone_number_returns_error(
@@ -2714,6 +2735,7 @@ def test_checkout_billing_address_update(
 ):
     checkout = checkout_with_item
     assert checkout.shipping_address is None
+    previous_last_change = checkout.last_change
 
     query = """
     mutation checkoutBillingAddressUpdate(
@@ -2752,6 +2774,7 @@ def test_checkout_billing_address_update(
     assert checkout.billing_address.postal_code == billing_address["postalCode"]
     assert checkout.billing_address.country == billing_address["country"]
     assert checkout.billing_address.city == billing_address["city"].upper()
+    assert checkout.last_change != previous_last_change
 
 
 CHECKOUT_EMAIL_UPDATE_MUTATION = """
@@ -2779,6 +2802,7 @@ def test_checkout_email_update(user_api_client, checkout_with_item):
     checkout = checkout_with_item
     checkout.email = None
     checkout.save(update_fields=["email"])
+    previous_last_change = checkout.last_change
 
     email = "test@example.com"
     variables = {"token": checkout.token, "email": email}
@@ -2789,6 +2813,7 @@ def test_checkout_email_update(user_api_client, checkout_with_item):
     assert not data["errors"]
     checkout.refresh_from_db()
     assert checkout.email == email
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_email_update_validation(user_api_client, checkout_with_item):
@@ -2796,6 +2821,7 @@ def test_checkout_email_update_validation(user_api_client, checkout_with_item):
 
     response = user_api_client.post_graphql(CHECKOUT_EMAIL_UPDATE_MUTATION, variables)
     content = get_graphql_content(response)
+    previous_last_change = checkout_with_item.last_change
 
     errors = content["data"]["checkoutEmailUpdate"]["errors"]
     assert errors
@@ -2804,6 +2830,7 @@ def test_checkout_email_update_validation(user_api_client, checkout_with_item):
 
     checkout_errors = content["data"]["checkoutEmailUpdate"]["errors"]
     assert checkout_errors[0]["code"] == CheckoutErrorCode.REQUIRED.name
+    assert checkout_with_item.last_change == previous_last_change
 
 
 @pytest.fixture
@@ -3194,6 +3221,7 @@ def test_checkout_shipping_method_update(
     old_shipping_method = checkout.shipping_method
     query = MUTATION_UPDATE_SHIPPING_METHOD
     mock_clean_shipping.return_value = is_valid_shipping_method
+    previous_last_change = checkout.last_change
 
     method_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
 
@@ -3220,6 +3248,7 @@ def test_checkout_shipping_method_update(
         assert not errors
         assert data["checkout"]["token"] == str(checkout_with_item.token)
         assert checkout.shipping_method == shipping_method
+        assert checkout.last_change != previous_last_change
     else:
         assert len(errors) == 1
         assert errors[0]["field"] == "shippingMethod"
@@ -3227,6 +3256,7 @@ def test_checkout_shipping_method_update(
             errors[0]["code"] == CheckoutErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.name
         )
         assert checkout.shipping_method is None
+        assert checkout.last_change == previous_last_change
 
 
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")

--- a/saleor/graphql/checkout/tests/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/test_checkout_language_code_update.py
@@ -23,6 +23,7 @@ def test_checkout_update_language_code(
 ):
     language_code = "PL"
     checkout = checkout_with_gift_card
+    previous_last_change = checkout.last_change
     variables = {"token": checkout.token, "languageCode": language_code}
 
     response = user_api_client.post_graphql(
@@ -36,3 +37,4 @@ def test_checkout_update_language_code(
     assert data["checkout"]["languageCode"] == language_code
     checkout.refresh_from_db()
     assert checkout.language_code == language_code.lower()
+    assert checkout.last_change != previous_last_change

--- a/saleor/graphql/checkout/tests/test_checkout_lines.py
+++ b/saleor/graphql/checkout/tests/test_checkout_lines.py
@@ -59,6 +59,7 @@ def test_checkout_lines_add(
     lines = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    previous_last_change = checkout.last_change
 
     variables = {
         "token": checkout.token,
@@ -81,6 +82,7 @@ def test_checkout_lines_add(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_lines_add_with_reservations(
@@ -215,6 +217,7 @@ def test_checkout_lines_add_existing_variant(user_api_client, checkout_with_item
     checkout = checkout_with_item
     line = checkout.lines.first()
     variant_id = graphene.Node.to_global_id("ProductVariant", line.variant.pk)
+    previous_last_change = checkout.last_change
 
     variables = {
         "token": checkout.token,
@@ -228,6 +231,7 @@ def test_checkout_lines_add_existing_variant(user_api_client, checkout_with_item
     checkout.refresh_from_db()
     line = checkout.lines.latest("pk")
     assert line.quantity == 10
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_lines_add_existing_variant_over_allowed_stock(
@@ -657,6 +661,7 @@ def test_checkout_lines_update(
     line = checkout.lines.first()
     variant = line.variant
     assert line.quantity == 3
+    previous_last_change = checkout.last_change
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
 
@@ -681,6 +686,7 @@ def test_checkout_lines_update(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_lines_update_with_new_reservations(
@@ -845,6 +851,7 @@ def test_checkout_lines_update_with_unavailable_variant(
     user_api_client, checkout_with_item
 ):
     checkout = checkout_with_item
+    previous_last_change = checkout.last_change
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     variant = line.variant
@@ -866,6 +873,8 @@ def test_checkout_lines_update_with_unavailable_variant(
     assert errors[0]["code"] == CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name
     assert errors[0]["field"] == "lines"
     assert errors[0]["variants"] == [variant_id]
+    checkout.refresh_from_db()
+    assert checkout.last_change == previous_last_change
 
 
 def test_checkout_lines_update_channel_without_shipping_zones(
@@ -923,6 +932,7 @@ def test_checkout_lines_delete_with_by_zero_quantity_when_variant_out_of_stock(
     stock = line.variant.stocks.first()
     stock.quantity = 0
     stock.save(update_fields=["quantity"])
+    previous_last_change = checkout.last_change
 
     variables = {
         "token": checkout.token,
@@ -933,6 +943,8 @@ def test_checkout_lines_delete_with_by_zero_quantity_when_variant_out_of_stock(
     content = get_graphql_content(response)
     data = content["data"]["checkoutLinesUpdate"]
     assert not data["checkout"]["lines"]
+    checkout.refresh_from_db()
+    assert checkout.last_change != previous_last_change
 
 
 @mock.patch(
@@ -947,6 +959,7 @@ def test_checkout_line_delete_by_zero_quantity(
     line = checkout.lines.first()
     variant = line.variant
     assert line.quantity == 3
+    previous_last_change = checkout.last_change
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
 
@@ -965,6 +978,7 @@ def test_checkout_line_delete_by_zero_quantity(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 @mock.patch(
@@ -1015,6 +1029,7 @@ def test_checkout_line_update_by_zero_quantity_dont_create_new_lines(
     variant = line.variant
     checkout.lines.all().delete()
     assert checkout.lines.count() == 0
+    previous_last_change = checkout.last_change
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
 
@@ -1033,6 +1048,7 @@ def test_checkout_line_update_by_zero_quantity_dont_create_new_lines(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_lines_update_with_unpublished_product(
@@ -1145,6 +1161,7 @@ def test_checkout_line_delete(
 ):
     assert Reservation.objects.count() == 2
     checkout = checkout_line_with_reservation_in_many_stocks.checkout
+    previous_last_change = checkout.last_change
     lines = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3
     assert checkout.lines.count() == 1
@@ -1167,6 +1184,7 @@ def test_checkout_line_delete(
     manager = get_plugins_manager()
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 MUTATION_CHECKOUT_LINES_DELETE = """
@@ -1202,6 +1220,7 @@ def test_checkout_lines_delete(
 ):
     checkout = checkout_with_items
     checkout_lines_count = checkout.lines.count()
+    previous_last_change = checkout.last_change
     line = checkout.lines.first()
     second_line = checkout.lines.last()
 
@@ -1224,12 +1243,14 @@ def test_checkout_lines_delete(
     manager = get_plugins_manager()
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
 
 
 def test_checkout_lines_delete_invalid_checkout_token(
     user_api_client, checkout_with_items
 ):
     checkout = checkout_with_items
+    previous_last_change = checkout.last_change
     line = checkout.lines.first()
     second_line = checkout.lines.last()
 
@@ -1245,10 +1266,13 @@ def test_checkout_lines_delete_invalid_checkout_token(
     content = get_graphql_content(response)
     errors = content["data"]["checkoutLinesDelete"]["errors"][0]
     assert errors["code"] == CheckoutErrorCode.NOT_FOUND.name
+    checkout.refresh_from_db()
+    assert checkout.last_change == previous_last_change
 
 
 def tests_checkout_lines_delete_invalid_lines_ids(user_api_client, checkout_with_items):
     checkout = checkout_with_items
+    previous_last_change = checkout.last_change
     line = checkout.lines.first()
 
     first_line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
@@ -1261,6 +1285,7 @@ def tests_checkout_lines_delete_invalid_lines_ids(user_api_client, checkout_with
     assert errors["code"] == CheckoutErrorCode.INVALID.name
     assert errors["lines"] == lines_list[1:]
     assert errors["field"] == "lineId"
+    assert checkout.last_change == previous_last_change
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -324,6 +324,8 @@ def test_checkout_add_voucher_code_with_display_gross_prices(
     site_settings.display_gross_prices = True
     site_settings.save()
 
+    previous_checkout_last_change = checkout_with_item.last_change
+
     voucher = voucher
     voucher_channel_listing = voucher.channel_listings.first()
     voucher_channel_listing.min_spent_amount = 100
@@ -342,6 +344,8 @@ def test_checkout_add_voucher_code_with_display_gross_prices(
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_item.token)
     assert data["checkout"]["voucherCode"] == voucher.code
+    checkout_with_item.refresh_from_db()
+    assert checkout_with_item.last_change != previous_checkout_last_change
 
 
 def test_checkout_add_voucher_code_without_display_gross_prices(
@@ -349,6 +353,8 @@ def test_checkout_add_voucher_code_without_display_gross_prices(
 ):
     site_settings.display_gross_prices = False
     site_settings.save()
+
+    previous_checkout_last_change = checkout_with_item.last_change
 
     voucher = voucher
     voucher_channel_listing = voucher.channel_listings.first()
@@ -367,6 +373,9 @@ def test_checkout_add_voucher_code_without_display_gross_prices(
 
     assert data["errors"][0]["code"] == CheckoutErrorCode.VOUCHER_NOT_APPLICABLE.name
     assert data["errors"][0]["field"] == "promoCode"
+
+    checkout_with_item.refresh_from_db()
+    assert checkout_with_item.last_change == previous_checkout_last_change
 
 
 def test_checkout_add_voucher_code_checkout_with_sale(
@@ -387,6 +396,8 @@ def test_checkout_add_voucher_code_checkout_with_sale(
         discounts=[discount_info],
     )
     assert subtotal > subtotal_discounted
+    previous_checkout_last_change = checkout_with_item.last_change
+
     variables = {
         "token": checkout_with_item.token,
         "promoCode": voucher_percentage.code,
@@ -397,6 +408,7 @@ def test_checkout_add_voucher_code_checkout_with_sale(
     assert not data["errors"]
     assert checkout_with_item.voucher_code == voucher_percentage.code
     assert checkout_with_item.discount_amount == Decimal(1.5)
+    assert checkout_with_item.last_change != previous_checkout_last_change
 
 
 def test_checkout_add_specific_product_voucher_code_checkout_with_sale(
@@ -888,6 +900,7 @@ def _mutate_checkout_remove_promo_code(client, variables):
 
 def test_checkout_remove_voucher_code(api_client, checkout_with_voucher):
     assert checkout_with_voucher.voucher_code is not None
+    previous_checkout_last_change = checkout_with_voucher.last_change
 
     variables = {
         "token": checkout_with_voucher.token,
@@ -901,6 +914,7 @@ def test_checkout_remove_voucher_code(api_client, checkout_with_voucher):
     assert data["checkout"]["token"] == str(checkout_with_voucher.token)
     assert data["checkout"]["voucherCode"] is None
     assert checkout_with_voucher.voucher_code is None
+    assert checkout_with_voucher.last_change != previous_checkout_last_change
 
 
 def test_checkout_remove_voucher_code_with_inactive_channel(
@@ -909,6 +923,7 @@ def test_checkout_remove_voucher_code_with_inactive_channel(
     channel = checkout_with_voucher.channel
     channel.is_active = False
     channel.save()
+    previous_checkout_last_change = checkout_with_voucher.last_change
 
     variables = {
         "token": checkout_with_voucher.token,
@@ -921,10 +936,12 @@ def test_checkout_remove_voucher_code_with_inactive_channel(
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_voucher.token)
     assert data["checkout"]["voucherCode"] == checkout_with_voucher.voucher_code
+    assert checkout_with_voucher.last_change == previous_checkout_last_change
 
 
 def test_checkout_remove_gift_card_code(api_client, checkout_with_gift_card):
     assert checkout_with_gift_card.gift_cards.count() == 1
+    previous_checkout_last_change = checkout_with_gift_card.last_change
 
     variables = {
         "token": checkout_with_gift_card.token,
@@ -936,6 +953,8 @@ def test_checkout_remove_gift_card_code(api_client, checkout_with_gift_card):
     assert data["checkout"]["token"] == str(checkout_with_gift_card.token)
     assert data["checkout"]["giftCards"] == []
     assert not checkout_with_gift_card.gift_cards.all().exists()
+    checkout_with_gift_card.refresh_from_db()
+    assert checkout_with_gift_card.last_change != previous_checkout_last_change
 
 
 def test_checkout_remove_one_of_gift_cards(
@@ -943,6 +962,7 @@ def test_checkout_remove_one_of_gift_cards(
 ):
     checkout_with_gift_card.gift_cards.add(gift_card_created_by_staff)
     checkout_with_gift_card.save()
+    previous_checkout_last_change = checkout_with_gift_card.last_change
     gift_card_first = checkout_with_gift_card.gift_cards.first()
     gift_card_last = checkout_with_gift_card.gift_cards.last()
 
@@ -957,15 +977,20 @@ def test_checkout_remove_one_of_gift_cards(
     assert data["checkout"]["token"] == str(checkout_with_gift_card.token)
     assert checkout_gift_cards.filter(code=gift_card_last.code).exists()
     assert not checkout_gift_cards.filter(code=gift_card_first.code).exists()
+    checkout_with_gift_card.refresh_from_db()
+    assert checkout_with_gift_card.last_change != previous_checkout_last_change
 
 
 def test_checkout_remove_promo_code_invalid_promo_code(api_client, checkout_with_item):
+    previous_checkout_last_change = checkout_with_item.last_change
     variables = {"token": checkout_with_item.token, "promoCode": "unexisting_code"}
 
     data = _mutate_checkout_remove_promo_code(api_client, variables)
 
     assert not data["errors"]
     assert data["checkout"]["token"] == str(checkout_with_item.token)
+    checkout_with_item.refresh_from_db()
+    assert checkout_with_item.last_change == previous_checkout_last_change
 
 
 def test_checkout_remove_promo_code_invalid_checkout(api_client, voucher):


### PR DESCRIPTION
Ensure that whenever checkout is changing, the checkout `last_updated` value is updated.

Port changes from #8908

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
