### PR TITLE
Do no allow using id for updating order metadata 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@ All notable, unreleased changes to this project will be documented in this file.
   and `CheckoutPricesData` instead of `PricesData`
   - New interface for handling more data for prices: `OrderTaxedPricesData` used in plugins/pluginManager.
 - Fix incorrect stock allocation - #8931 by @IKarbowiak
+- Do no allow using id for updating checkout and order metadata - #8944 by @IKarbowiak
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki
@@ -288,6 +289,8 @@ All notable, unreleased changes to this project will be documented in this file.
   - Rename checkout interfaces: `CheckoutTaxedPricesData` instead of `TaxedPricesData`
   and `CheckoutPricesData` instead of `PricesData`
 - Add additional validation for `from_global_id_or_error` function - #8780 by @CossackDex
+- Do no allow using `id` for updating checkout and order metadata - #8944 by @IKarbowiak
+  - Use `token` instead
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,7 +173,7 @@ All notable, unreleased changes to this project will be documented in this file.
   and `CheckoutPricesData` instead of `PricesData`
   - New interface for handling more data for prices: `OrderTaxedPricesData` used in plugins/pluginManager.
 - Fix incorrect stock allocation - #8931 by @IKarbowiak
-- Do no allow using id for updating checkout and order metadata - #8944 by @IKarbowiak
+- Do no allow using id for updating order metadata - #8944 by @IKarbowiak
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki
@@ -289,7 +289,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - Rename checkout interfaces: `CheckoutTaxedPricesData` instead of `TaxedPricesData`
   and `CheckoutPricesData` instead of `PricesData`
 - Add additional validation for `from_global_id_or_error` function - #8780 by @CossackDex
-- Do no allow using `id` for updating checkout and order metadata - #8944 by @IKarbowiak
+- Do no allow using `id` for updating order metadata - #8944 by @IKarbowiak
   - Use `token` instead
 
 ### Other

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import List
 
 import graphene
@@ -58,7 +57,15 @@ class BaseMetadataMutation(BaseMutation):
         try:
             type_name, _ = from_global_id_or_error(object_id)
             if type_name == "Order":
-                warnings.warn("DEPRECATED. Use token for changing order metadata.")
+                raise ValidationError(
+                    {
+                        "id": ValidationError(
+                            "Changing order metadata with use of `id` is forbidden. "
+                            "Use order token instead.",
+                            code=MetadataErrorCode.GRAPHQL_ERROR.value,
+                        )
+                    }
+                )
             # ShippingMethod type isn't model-based class
             if type_name == "ShippingMethod":
                 qs = shipping_models.ShippingMethod.objects
@@ -66,7 +73,13 @@ class BaseMetadataMutation(BaseMutation):
         except GraphQLError as e:
             if instance := cls.get_instance_by_token(object_id, qs):
                 return instance
-            raise ValidationError({"id": ValidationError(str(e), code="graphql_error")})
+            raise ValidationError(
+                {
+                    "id": ValidationError(
+                        str(e), code=MetadataErrorCode.GRAPHQL_ERROR.value
+                    )
+                }
+            )
 
     @classmethod
     def get_instance_by_token(cls, object_id, qs):

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -56,13 +56,13 @@ class BaseMetadataMutation(BaseMutation):
 
         try:
             type_name, _ = from_global_id_or_error(object_id)
-            if type_name in ["Order", "Checkout"]:
+            if type_name == "Order":
                 type_name = type_name.lower()
                 raise ValidationError(
                     {
                         "id": ValidationError(
-                            f"Changing {type_name} metadata with use of `id` "
-                            f"is forbidden. Use {type_name} token instead.",
+                            "Changing order metadata with use of `id` "
+                            "is forbidden. Use order token instead.",
                             code=MetadataErrorCode.GRAPHQL_ERROR.value,
                         )
                     }

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -56,12 +56,13 @@ class BaseMetadataMutation(BaseMutation):
 
         try:
             type_name, _ = from_global_id_or_error(object_id)
-            if type_name == "Order":
+            if type_name in ["Order", "Checkout"]:
+                type_name = type_name.lower()
                 raise ValidationError(
                     {
                         "id": ValidationError(
-                            "Changing order metadata with use of `id` is forbidden. "
-                            "Use order token instead.",
+                            f"Changing {type_name} metadata with use of `id` "
+                            f"is forbidden. Use {type_name} token instead.",
                             code=MetadataErrorCode.GRAPHQL_ERROR.value,
                         )
                     }

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -348,8 +348,9 @@ def test_add_public_metadata_for_checkout(api_client, checkout):
     )
 
     # then
-    errors = response["data"]["updateMetadata"]["errors"]
-    assert invalid_id_graphql_error_raised(errors)
+    assert item_contains_proper_public_metadata(
+        response["data"]["updateMetadata"]["item"], checkout, checkout_id
+    )
 
 
 def test_add_public_metadata_for_checkout_by_token(api_client, checkout):
@@ -367,7 +368,10 @@ def test_add_public_metadata_for_checkout_by_token(api_client, checkout):
     )
 
 
-def test_add_metadata_for_checkout_triggers_checkout_updated_hook(api_client, checkout):
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_add_metadata_for_checkout_triggers_checkout_updated_hook(
+    mock_checkout_updated, api_client, checkout
+):
     # given
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
 
@@ -377,8 +381,8 @@ def test_add_metadata_for_checkout_triggers_checkout_updated_hook(api_client, ch
     )
 
     # then
-    errors = response["data"]["updateMetadata"]["errors"]
-    assert invalid_id_graphql_error_raised(errors)
+    assert response["data"]["updateMetadata"]["errors"] == []
+    mock_checkout_updated.assert_called_once_with(checkout)
 
 
 def test_add_public_metadata_for_order_by_id(api_client, order):
@@ -1036,7 +1040,9 @@ def test_delete_public_metadata_for_checkout(api_client, checkout):
     )
 
     # then
-    assert invalid_id_graphql_error_raised(response["data"]["deleteMetadata"]["errors"])
+    assert item_without_public_metadata(
+        response["data"]["deleteMetadata"]["item"], checkout, checkout_id
+    )
 
 
 def test_delete_public_metadata_for_checkout_by_token(api_client, checkout):
@@ -1803,8 +1809,8 @@ def test_add_private_metadata_for_checkout(
     )
 
     # then
-    assert invalid_id_graphql_error_raised(
-        response["data"]["updatePrivateMetadata"]["errors"]
+    assert item_contains_proper_private_metadata(
+        response["data"]["updatePrivateMetadata"]["item"], checkout, checkout_id
     )
 
 
@@ -2511,8 +2517,8 @@ def test_delete_private_metadata_for_checkout(
     )
 
     # then
-    assert invalid_id_graphql_error_raised(
-        response["data"]["deletePrivateMetadata"]["errors"]
+    assert item_without_private_metadata(
+        response["data"]["deletePrivateMetadata"]["item"], checkout, checkout_id
     )
 
 

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -756,15 +756,15 @@ def test_update_public_metadata_for_item(api_client, checkout):
 
 
 def test_update_public_metadata_for_non_exist_item(
-    staff_api_client, permission_manage_payments
+    staff_api_client, permission_manage_products
 ):
     # given
-    payment_id = "Payment: 0"
-    payment_id = base64.b64encode(str.encode(payment_id)).decode("utf-8")
+    category_id = "Category: 0"
+    category_id = base64.b64encode(str.encode(category_id)).decode("utf-8")
 
     # when
     response = execute_update_public_metadata_for_item(
-        staff_api_client, permission_manage_payments, payment_id, "Payment"
+        staff_api_client, permission_manage_products, category_id, "Category"
     )
 
     # then
@@ -1453,15 +1453,15 @@ def test_delete_public_metadata_for_menu_item(
 
 
 def test_delete_public_metadata_for_non_exist_item(
-    staff_api_client, permission_manage_payments
+    staff_api_client, permission_manage_products
 ):
     # given
-    payment_id = "Payment: 0"
-    payment_id = base64.b64encode(str.encode(payment_id)).decode("utf-8")
+    category_id = "Category: 0"
+    category_id = base64.b64encode(str.encode(category_id)).decode("utf-8")
 
     # when
     response = execute_clear_public_metadata_for_item(
-        staff_api_client, permission_manage_payments, payment_id, "Checkout"
+        staff_api_client, permission_manage_products, category_id, "Category"
     )
 
     # then
@@ -2223,15 +2223,15 @@ def test_update_private_metadata_for_item(
 
 
 def test_update_private_metadata_for_non_exist_item(
-    staff_api_client, permission_manage_payments
+    staff_api_client, permission_manage_products
 ):
     # given
-    payment_id = "Payment: 0"
-    payment_id = base64.b64encode(str.encode(payment_id)).decode("utf-8")
+    category_id = "Category: 0"
+    category_id = base64.b64encode(str.encode(category_id)).decode("utf-8")
 
     # when
     response = execute_update_private_metadata_for_item(
-        staff_api_client, permission_manage_payments, payment_id, "Payment"
+        staff_api_client, permission_manage_products, category_id, "Category"
     )
 
     # then
@@ -2946,15 +2946,15 @@ def test_delete_private_metadata_for_menu_item(
 
 
 def test_delete_private_metadata_for_non_exist_item(
-    staff_api_client, permission_manage_payments
+    staff_api_client, permission_manage_products
 ):
     # given
-    payment_id = "Payment: 0"
-    payment_id = base64.b64encode(str.encode(payment_id)).decode("utf-8")
+    category_id = "Category: 0"
+    category_id = base64.b64encode(str.encode(category_id)).decode("utf-8")
 
     # when
     response = execute_clear_private_metadata_for_item(
-        staff_api_client, permission_manage_payments, payment_id, "Payment"
+        staff_api_client, permission_manage_products, category_id, "Category"
     )
 
     # then

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -1,6 +1,5 @@
 import base64
 import uuid
-import warnings
 from unittest.mock import patch
 
 import graphene
@@ -373,18 +372,15 @@ def test_add_public_metadata_for_order_by_id(api_client, order):
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_update_public_metadata_for_item(
-            api_client, None, order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_update_public_metadata_for_item(
+        api_client, None, order_id, "Order"
+    )
 
     # then
-    assert item_contains_proper_public_metadata(
-        response["data"]["updateMetadata"]["item"], order, order_id
-    )
+    errors = response["data"]["updateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_add_public_metadata_for_order_by_token(api_client, order):
@@ -407,18 +403,15 @@ def test_add_public_metadata_for_draft_order_by_id(api_client, draft_order):
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_update_public_metadata_for_item(
-            api_client, None, draft_order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_update_public_metadata_for_item(
+        api_client, None, draft_order_id, "Order"
+    )
 
     # then
-    assert item_contains_proper_public_metadata(
-        response["data"]["updateMetadata"]["item"], draft_order, draft_order_id
-    )
+    errors = response["data"]["updateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_add_public_metadata_for_draft_order_by_token(api_client, draft_order):
@@ -1060,18 +1053,15 @@ def test_delete_public_metadata_for_order_by_id(api_client, order):
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_clear_public_metadata_for_item(
-            api_client, None, order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_clear_public_metadata_for_item(
+        api_client, None, order_id, "Order"
+    )
 
     # then
-    assert item_without_public_metadata(
-        response["data"]["deleteMetadata"]["item"], order, order_id
-    )
+    errors = response["data"]["deleteMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_delete_public_metadata_for_order_by_token(api_client, order):
@@ -1098,18 +1088,15 @@ def test_delete_public_metadata_for_draft_order_by_id(api_client, draft_order):
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_clear_public_metadata_for_item(
-            api_client, None, draft_order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_clear_public_metadata_for_item(
+        api_client, None, draft_order_id, "Order"
+    )
 
     # then
-    assert item_without_public_metadata(
-        response["data"]["deleteMetadata"]["item"], draft_order, draft_order_id
-    )
+    errors = response["data"]["deleteMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_delete_public_metadata_for_draft_order_by_token(api_client, draft_order):
@@ -1835,18 +1822,15 @@ def test_add_private_metadata_for_order_by_id(
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_update_private_metadata_for_item(
-            staff_api_client, permission_manage_orders, order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_update_private_metadata_for_item(
+        staff_api_client, permission_manage_orders, order_id, "Order"
+    )
 
     # then
-    assert item_contains_proper_private_metadata(
-        response["data"]["updatePrivateMetadata"]["item"], order, order_id
-    )
+    errors = response["data"]["updatePrivateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_add_private_metadata_for_order_by_token(
@@ -1873,18 +1857,15 @@ def test_add_private_metadata_for_draft_order_by_id(
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_update_private_metadata_for_item(
-            staff_api_client, permission_manage_orders, draft_order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_update_private_metadata_for_item(
+        staff_api_client, permission_manage_orders, draft_order_id, "Order"
+    )
 
     # then
-    assert item_contains_proper_private_metadata(
-        response["data"]["updatePrivateMetadata"]["item"], draft_order, draft_order_id
-    )
+    errors = response["data"]["updatePrivateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_add_private_metadata_for_draft_order_by_token(
@@ -2557,18 +2538,15 @@ def test_delete_private_metadata_for_order_by_id(
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_clear_private_metadata_for_item(
-            staff_api_client, permission_manage_orders, order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_clear_private_metadata_for_item(
+        staff_api_client, permission_manage_orders, order_id, "Order"
+    )
 
     # then
-    assert item_without_private_metadata(
-        response["data"]["deletePrivateMetadata"]["item"], order, order_id
-    )
+    errors = response["data"]["deletePrivateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_delete_private_metadata_for_order_by_token(
@@ -2599,18 +2577,15 @@ def test_delete_private_metadata_for_draft_order_by_id(
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
     # when
-    with warnings.catch_warnings(record=True) as warns:
-        response = execute_clear_private_metadata_for_item(
-            staff_api_client, permission_manage_orders, draft_order_id, "Order"
-        )
-        expected_warning = "DEPRECATED. Use token for changing order metadata."
-
-        assert any([str(warning.message) == expected_warning for warning in warns])
+    response = execute_clear_private_metadata_for_item(
+        staff_api_client, permission_manage_orders, draft_order_id, "Order"
+    )
 
     # then
-    assert item_without_private_metadata(
-        response["data"]["deletePrivateMetadata"]["item"], draft_order, draft_order_id
-    )
+    errors = response["data"]["deletePrivateMetadata"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "id"
 
 
 def test_delete_private_metadata_for_draft_order_by_token(


### PR DESCRIPTION
Allow changing `Order` and `Checkout` metadata only with the use of `token`.

Port changes from #8906

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
