### PR TITLE
Do not create order in gateways when checkout line variant is deleted

### DIFF
--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
@@ -104,7 +104,7 @@ def test_handle_api_response_auto_capture_false_cannot_create_order_void_payment
     assert not refund_mock.called
 
     assert payment_adyen_for_checkout.can_void()
-    assert void_mock.call_count == 2
+    assert void_mock.call_count == 1
 
 
 @patch("saleor.payment.gateway.void")
@@ -137,7 +137,7 @@ def test_handle_api_response_auto_capture_cannot_create_order_refund_payment(
     assert not payment_adyen_for_checkout.order
 
     assert payment_adyen_for_checkout.can_refund()
-    assert refund_mock.call_count == 2
+    assert refund_mock.call_count == 1
 
     assert not payment_adyen_for_checkout.can_void()
     assert not void_mock.called

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
@@ -141,3 +141,40 @@ def test_handle_api_response_auto_capture_cannot_create_order_refund_payment(
 
     assert not payment_adyen_for_checkout.can_void()
     assert not void_mock.called
+
+
+@patch("saleor.payment.gateway.void")
+@patch("saleor.payment.gateway.refund")
+def test_handle_api_response_auto_capture_cannot_create_order_variant_deleted(
+    refund_mock, void_mock, payment_adyen_for_checkout, adyen_plugin
+):
+    payment_adyen_for_checkout.to_confirm = True
+    payment_adyen_for_checkout.save(update_fields=["to_confirm"])
+
+    checkout = payment_adyen_for_checkout.checkout
+    checkout.lines.first().delete()
+
+    plugin = adyen_plugin(adyen_auto_capture=True)
+
+    adyen_response = AdyenResult(
+        {
+            "additionalData": {"paymentMethod": "visa"},
+            "pspReference": "882635241694695D",
+            "resultCode": "Authorised",
+            "amount": {"currency": "USD", "value": payment_adyen_for_checkout.total},
+            "merchantReference": "UGF5bWVudDoxMDU=",
+        }
+    )
+
+    handle_api_response(payment_adyen_for_checkout, adyen_response, plugin.channel.slug)
+
+    payment_adyen_for_checkout.refresh_from_db()
+
+    assert payment_adyen_for_checkout.charge_status == ChargeStatus.FULLY_CHARGED
+    assert not payment_adyen_for_checkout.order
+
+    assert payment_adyen_for_checkout.can_refund()
+    assert refund_mock.call_count == 1
+
+    assert not payment_adyen_for_checkout.can_void()
+    assert not void_mock.called

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
@@ -1181,7 +1181,7 @@ def test_handle_not_created_order_refund_when_create_order_raises(
     )
 
     assert payment_adyen_for_checkout.can_refund()
-    assert refund_mock.call_count == 2
+    assert refund_mock.call_count == 1
 
 
 @patch("saleor.payment.gateway.void")
@@ -1204,7 +1204,7 @@ def test_handle_not_created_order_void_when_create_order_raises(
     )
 
     assert payment_adyen_for_checkout.can_void()
-    assert void_mock.call_count == 2
+    assert void_mock.call_count == 1
 
 
 @pytest.mark.parametrize(
@@ -1285,7 +1285,7 @@ def test_handle_not_created_order_success_transaction_create_order_raises_and_re
     assert all_payment_transactions[1].kind == TransactionKind.AUTH
 
     assert payment_adyen_for_checkout.can_refund()
-    assert refund_mock.call_count == 2
+    assert refund_mock.call_count == 1
 
 
 @patch("saleor.payment.gateway.void")
@@ -1317,7 +1317,7 @@ def test_handle_not_created_order_success_transaction_create_order_raises_and_vo
     assert all_payment_transactions[1].kind == TransactionKind.AUTH
 
     assert payment_adyen_for_checkout.can_void()
-    assert void_mock.call_count == 2
+    assert void_mock.call_count == 1
 
 
 def test_confirm_payment_and_set_back_to_confirm(

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
@@ -196,6 +196,57 @@ def test_handle_authorization_for_checkout(
     assert external_events.count() == 1
 
 
+@patch("saleor.payment.gateway.void")
+def test_handle_authorization_for_checkout_one_of_variants_deleted(
+    void_mock,
+    notification,
+    adyen_plugin,
+    payment_adyen_for_checkout,
+    address,
+    shipping_method,
+):
+    checkout = payment_adyen_for_checkout.checkout
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    payment = payment_adyen_for_checkout
+    manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.to_confirm = True
+    payment.save()
+
+    checkout.lines.first().delete()
+
+    payment_id = graphene.Node.to_global_id("Payment", payment.pk)
+    notification = notification(
+        merchant_reference=payment_id,
+        value=price_to_minor_unit(payment.total, payment.currency),
+    )
+    config = adyen_plugin().config
+    handle_authorization(notification, config)
+
+    payment.refresh_from_db()
+    assert void_mock.call_count == 1
+    assert not payment.order
+    assert payment.checkout
+    assert payment.transactions.count() == 2
+    transaction = payment.transactions.exclude(
+        kind=TransactionKind.ACTION_TO_CONFIRM
+    ).get()
+    assert transaction.is_success is True
+    assert transaction.kind == TransactionKind.AUTH
+
+
 def test_handle_authorization_with_adyen_auto_capture(
     notification, adyen_plugin, payment_adyen_for_checkout, address, shipping_method
 ):
@@ -435,6 +486,66 @@ def test_handle_capture_for_checkout(
         type=OrderEvents.EXTERNAL_SERVICE_NOTIFICATION
     )
     assert external_events.count() == 1
+
+
+@patch("saleor.payment.gateway.void")
+def test_handle_capture_for_checkout_order_not_created_checkout_line_variant_deleted(
+    void_mock,
+    notification,
+    adyen_plugin,
+    payment_adyen_for_checkout,
+    address,
+    shipping_method,
+):
+    """
+    Ensure that payment is not captured when one of checkout line variant is deleted.
+    """
+
+    # given
+    checkout = payment_adyen_for_checkout.checkout
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    payment = payment_adyen_for_checkout
+    manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.to_confirm = True
+    payment.save()
+
+    checkout.lines.first().delete()
+
+    payment_id = graphene.Node.to_global_id("Payment", payment.pk)
+    notification = notification(
+        merchant_reference=payment_id,
+        value=price_to_minor_unit(payment.total, payment.currency),
+    )
+    config = adyen_plugin().config
+
+    # when
+    handle_capture(notification, config)
+
+    # then
+    payment.refresh_from_db()
+    assert void_mock.call_count == 1
+    assert not payment.order
+    assert payment.checkout
+
+    assert payment.transactions.count() == 2
+    transaction = payment.transactions.exclude(
+        kind=TransactionKind.ACTION_TO_CONFIRM
+    ).get()
+    assert transaction.is_success is True
+    assert transaction.kind == TransactionKind.AUTH
 
 
 def test_handle_capture_invalid_payment_id(
@@ -1013,6 +1124,41 @@ def test_handle_not_created_order_order_created(
     payment_adyen_for_checkout.refresh_from_db()
 
     assert payment_adyen_for_checkout.order
+
+
+@patch("saleor.payment.gateway.refund")
+def test_handle_not_created_order_order_not_created_checkout_line_variant_deleted(
+    refund_mock,
+    checkout_ready_to_complete,
+    payment_adyen_for_checkout,
+    adyen_plugin,
+    notification,
+):
+    """Validate if order is not created when one of checkout line variant is deleted."""
+
+    # given
+    checkout = payment_adyen_for_checkout.checkout
+    checkout.lines.first().variant.delete()
+
+    payment_adyen_for_checkout.charge_status = ChargeStatus.FULLY_CHARGED
+    payment_adyen_for_checkout.captured_amount = payment_adyen_for_checkout.total
+    payment_adyen_for_checkout.save(update_fields=["charge_status", "captured_amount"])
+
+    adyen_plugin()
+
+    # when
+    handle_not_created_order(
+        notification(),
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        TransactionKind.CAPTURE,
+        get_plugins_manager(),
+    )
+
+    # then
+    assert refund_mock.call_count == 1
+    payment_adyen_for_checkout.refresh_from_db()
+    assert not payment_adyen_for_checkout.order
 
 
 @patch("saleor.payment.gateway.refund")

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -24,6 +24,7 @@ from django.http.request import HttpHeaders
 from django.http.response import HttpResponseRedirect
 from graphql_relay import from_global_id
 
+from ....checkout.calculations import calculate_checkout_total_with_gift_cards
 from ....checkout.complete_checkout import complete_checkout
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.models import Checkout
@@ -165,6 +166,19 @@ def create_order(payment, checkout, manager):
         discounts = fetch_active_discounts()
         lines = fetch_checkout_lines(checkout)
         checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
+        checkout_total = calculate_checkout_total_with_gift_cards(
+            manager=manager,
+            checkout_info=checkout_info,
+            lines=lines,
+            address=checkout.shipping_address or checkout.billing_address,
+            discounts=discounts,
+        )
+        # when checkout total value is different than total amount from payments
+        # it means that some products has been removed during the payment was completed
+        if checkout_total.gross.amount != payment.total:
+            raise ValidationError(
+                "Cannot create order - some products do not exist anymore."
+            )
         order, _, _ = complete_checkout(
             manager=manager,
             checkout_info=checkout_info,


### PR DESCRIPTION
Update `Adyen` and `Stripe` plugins - do not create an order when some checkout line variants are removed during payment.

Get rid of duplicated `refund` and `void` calls in Adyen plugin.

Port changes from #8896

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
