### PR TITLE
Move some logic from graphql middlewares to context setup

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -1,3 +1,6 @@
+from django.urls import reverse
+from django.utils.functional import SimpleLazyObject
+
 from ..graphql.notifications.schema import ExternalNotificationMutations
 from .account.schema import AccountMutations, AccountQueries
 from .app.schema import AppMutations, AppQueries
@@ -23,6 +26,8 @@ from .shop.schema import ShopMutations, ShopQueries
 from .translations.schema import TranslationQueries
 from .warehouse.schema import StockQueries, WarehouseMutations, WarehouseQueries
 from .webhook.schema import WebhookMutations, WebhookQueries
+
+API_PATH = SimpleLazyObject(lambda: reverse("api"))
 
 
 class Query(

--- a/saleor/graphql/context.py
+++ b/saleor/graphql/context.py
@@ -1,0 +1,48 @@
+from typing import Optional
+
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import AnonymousUser
+from django.db.models import Exists, OuterRef
+from django.utils.functional import SimpleLazyObject
+
+from ..app.models import App, AppToken
+from ..core.auth import get_token_from_request
+from .api import API_PATH
+
+
+def get_context_value(request):
+    set_app_on_context(request)
+    set_auth_on_context(request)
+    return request
+
+
+def get_app(auth_token) -> Optional[App]:
+    tokens = AppToken.objects.filter(auth_token=auth_token).values("pk")
+    return App.objects.filter(
+        Exists(tokens.filter(app_id=OuterRef("pk"))), is_active=True
+    ).first()
+
+
+def set_app_on_context(request):
+    if request.path == API_PATH and not hasattr(request, "app"):
+        request.app = None
+        auth_token = get_token_from_request(request)
+        if auth_token and len(auth_token) == 30:
+            request.app = SimpleLazyObject(lambda: get_app(auth_token))
+
+
+def get_user(request):
+    if not hasattr(request, "_cached_user"):
+        request._cached_user = authenticate(request=request)
+    return request._cached_user
+
+
+def set_auth_on_context(request):
+    if hasattr(request, "app") and request.app:
+        request.user = AnonymousUser()
+        return request
+
+    def user():
+        return get_user(request) or AnonymousUser()
+
+    request.user = SimpleLazyObject(lambda: user())

--- a/saleor/graphql/core/tests/test_context.py
+++ b/saleor/graphql/core/tests/test_context.py
@@ -1,5 +1,3 @@
-from unittest.mock import Mock
-
 from django.urls import reverse
 
 from ...context import set_app_on_context

--- a/saleor/graphql/core/tests/test_context.py
+++ b/saleor/graphql/core/tests/test_context.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 from django.urls import reverse
 
-from ...middleware import app_middleware
+from ...context import set_app_on_context
 
 
 def test_app_middleware_accepts_app_requests(app, rf):
@@ -13,7 +13,7 @@ def test_app_middleware_accepts_app_requests(app, rf):
     request.META = {"HTTP_AUTHORIZATION": f"Bearer {token}"}
 
     # when
-    app_middleware(lambda root, info: info.context, Mock(), Mock(context=request))
+    set_app_on_context(request)
 
     # then
     assert request.app == app
@@ -26,7 +26,7 @@ def test_app_middleware_accepts_saleors_header(app, rf):
     request.META = {"HTTP_AUTHORIZATION_BEARER": f"{token}"}
 
     # when
-    app_middleware(lambda root, info: info.context, Mock(), Mock(context=request))
+    set_app_on_context(request)
 
     # then
     assert request.app == app
@@ -38,7 +38,7 @@ def test_app_middleware_skips_when_token_length_is_different_than_30(app, rf):
     request.META = {"HTTP_AUTHORIZATION_BEARER": "a" * 31}
 
     # when
-    app_middleware(lambda root, info: info.context, Mock(), Mock(context=request))
+    set_app_on_context(request)
 
     # then
     assert not request.app

--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -1,55 +1,9 @@
 from typing import Optional
 
 from django.conf import settings
-from django.contrib.auth import authenticate
-from django.contrib.auth.models import AnonymousUser
-from django.db.models import Exists, OuterRef
-from django.utils.functional import SimpleLazyObject
 
-from ..app.models import App, AppToken
-from ..core.auth import get_token_from_request
 from ..core.exceptions import ReadOnlyException
-from .views import API_PATH, GraphQLView
-
-
-def get_user(request):
-    if not hasattr(request, "_cached_user"):
-        request._cached_user = authenticate(request=request)
-    return request._cached_user
-
-
-class JWTMiddleware:
-    def resolve(self, next, root, info, **kwargs):
-        request = info.context
-
-        if hasattr(request, "app") and request.app:
-            request.user = AnonymousUser()
-            return next(root, info, **kwargs)
-
-        def user():
-            return get_user(request) or AnonymousUser()
-
-        request.user = SimpleLazyObject(lambda: user())
-        return next(root, info, **kwargs)
-
-
-def get_app(auth_token) -> Optional[App]:
-    tokens = AppToken.objects.filter(auth_token=auth_token).values("pk")
-    return App.objects.filter(
-        Exists(tokens.filter(app_id=OuterRef("pk"))), is_active=True
-    ).first()
-
-
-def app_middleware(next, root, info, **kwargs):
-    request = info.context
-
-    if request.path == API_PATH:
-        if not hasattr(request, "app"):
-            request.app = None
-            auth_token = get_token_from_request(request)
-            if auth_token and len(auth_token) == 30:
-                request.app = SimpleLazyObject(lambda: get_app(auth_token))
-    return next(root, info, **kwargs)
+from .views import GraphQLView
 
 
 class ReadOnlyMiddleware:

--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from django.conf import settings
 
 from ..core.exceptions import ReadOnlyException

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -13,8 +13,6 @@ from django.db import connection
 from django.db.backends.postgresql.base import DatabaseWrapper
 from django.http import HttpRequest, HttpResponseNotAllowed, JsonResponse
 from django.shortcuts import render
-from django.urls import reverse
-from django.utils.functional import SimpleLazyObject
 from django.views.generic import View
 from graphene_django.settings import graphene_settings
 from graphene_django.views import instantiate_middleware
@@ -27,12 +25,12 @@ from jwt.exceptions import PyJWTError
 from .. import __version__ as saleor_version
 from ..core.exceptions import PermissionDenied, ReadOnlyException
 from ..core.utils import is_valid_ipv4, is_valid_ipv6
-from .api import schema
+from .api import API_PATH, schema
+from .context import get_context_value
 from .core.validators.query_cost import validate_query_cost
 from .query_cost_map import COST_MAP
 from .utils import query_fingerprint
 
-API_PATH = SimpleLazyObject(lambda: reverse("api"))
 INT_ERROR_MSG = "Int cannot represent non 32-bit signed integer value"
 
 unhandled_errors_logger = logging.getLogger("saleor.graphql.errors.unhandled")
@@ -314,7 +312,7 @@ class GraphQLView(View):
                             root=self.get_root_value(),
                             variables=variables,
                             operation_name=operation_name,
-                            context=request,
+                            context=get_context_value(request),
                             middleware=self.middleware,
                             **extra_options,
                         )

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -548,11 +548,6 @@ def SENTRY_INIT(dsn: str, sentry_opts: dict):
 GRAPHENE = {
     "RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST": True,
     "RELAY_CONNECTION_MAX_LIMIT": 100,
-    "MIDDLEWARE": [
-        # Those middlewares are executed from bottom to top
-        "saleor.graphql.middleware.JWTMiddleware",
-        "saleor.graphql.middleware.app_middleware",
-    ],
 }
 
 # Set GRAPHQL_QUERY_MAX_COMPLEXITY=0 in env to disable (not recommended)


### PR DESCRIPTION
App and auth logic for GraphQL currently lives in GraphQL middlewares. This is a problem because those middlewares are ran before every resolver call by query executor.

This PR moves some of those middlewares into new `saleor.graphql.context` and turns them into functions called only once per request via `get_context_value` utility.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
