### PR TITLE
Allow create attribute values that generates the same slug

### DIFF
--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -14,6 +14,7 @@ from ...core.permissions import (
     ProductTypePermissions,
 )
 from ...core.tracing import traced_atomic_transaction
+from ...core.utils import generate_unique_slug
 from ..attribute.types import Attribute, AttributeValue
 from ..core.enums import MeasurementUnitsEnum
 from ..core.inputs import ReorderInput
@@ -569,7 +570,7 @@ class AttributeValueCreate(ModelMutation):
     @classmethod
     def clean_input(cls, info, instance, data):
         cleaned_input = super().clean_input(info, instance, data)
-        cleaned_input["slug"] = slugify(cleaned_input["name"], allow_unicode=True)
+        cleaned_input["slug"] = generate_unique_slug(instance, cleaned_input["name"])
         return cleaned_input
 
     @classmethod

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
@@ -3,7 +3,6 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.utils.text import slugify
 
-from .....attribute.error_codes import AttributeErrorCode
 from .....attribute.models import AttributeValue
 from ....tests.utils import get_graphql_content
 from ...mutations import validate_value_is_unique
@@ -104,9 +103,8 @@ def test_create_attribute_value_not_unique_name(
     # then
     content = get_graphql_content(response)
     data = content["data"]["attributeValueCreate"]
-    assert data["errors"]
-    assert data["errors"][0]["code"] == AttributeErrorCode.ALREADY_EXISTS.name
-    assert data["errors"][0]["field"] == "name"
+    assert not data["errors"]
+    assert data["attributeValue"]["slug"] == "red-2"
 
 
 def test_create_attribute_value_capitalized_name(
@@ -127,6 +125,5 @@ def test_create_attribute_value_capitalized_name(
     # then
     content = get_graphql_content(response)
     data = content["data"]["attributeValueCreate"]
-    assert data["errors"]
-    assert data["errors"][0]["code"] == AttributeErrorCode.ALREADY_EXISTS.name
-    assert data["errors"][0]["field"] == "name"
+    assert not data["errors"]
+    assert data["attributeValue"]["slug"] == "red-2"


### PR DESCRIPTION
All details are presented in the task description. Now we can create multiple attribute values with different slug.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
