### PR TITLE
Allow create attribute values that generates the same slug  - port changes

### DIFF
--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -15,6 +15,7 @@ from ...core.permissions import (
     ProductTypePermissions,
 )
 from ...core.tracing import traced_atomic_transaction
+from ...core.utils import generate_unique_slug
 from ...product import models as product_models
 from ...product.search import update_products_search_document
 from ..attribute.types import Attribute, AttributeValue
@@ -635,7 +636,9 @@ class AttributeValueCreate(AttributeMixin, ModelMutation):
     def clean_input(cls, info, instance, data):
         cleaned_input = super().clean_input(info, instance, data)
         if "name" in cleaned_input:
-            cleaned_input["slug"] = slugify(cleaned_input["name"], allow_unicode=True)
+            cleaned_input["slug"] = generate_unique_slug(
+                instance, cleaned_input["name"]
+            )
         input_type = instance.attribute.input_type
 
         is_swatch_attr = input_type == AttributeInputType.SWATCH

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
@@ -245,9 +245,8 @@ def test_create_attribute_value_not_unique_name(
     # then
     content = get_graphql_content(response)
     data = content["data"]["attributeValueCreate"]
-    assert data["errors"]
-    assert data["errors"][0]["code"] == AttributeErrorCode.ALREADY_EXISTS.name
-    assert data["errors"][0]["field"] == "name"
+    assert not data["errors"]
+    assert data["attributeValue"]["slug"] == "red-2"
 
 
 def test_create_attribute_value_capitalized_name(
@@ -268,6 +267,5 @@ def test_create_attribute_value_capitalized_name(
     # then
     content = get_graphql_content(response)
     data = content["data"]["attributeValueCreate"]
-    assert data["errors"]
-    assert data["errors"][0]["code"] == AttributeErrorCode.ALREADY_EXISTS.name
-    assert data["errors"][0]["field"] == "name"
+    assert not data["errors"]
+    assert data["attributeValue"]["slug"] == "red-2"

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -88,10 +88,8 @@ def test_update_attribute_value_name_not_unique(
     # then
     content = get_graphql_content(response)
     data = content["data"]["attributeValueUpdate"]
-    assert data["errors"]
-    assert data["errors"][0]["message"]
-    assert data["errors"][0]["field"] == "name"
-    assert data["errors"][0]["code"] == AttributeErrorCode.ALREADY_EXISTS.name
+    assert not data["errors"]
+    assert data["attributeValue"]["slug"] == "pink-2"
 
 
 def test_update_attribute_value_product_search_document_updated(


### PR DESCRIPTION
Port changes #8949 

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
