### PR TITLE
Prevent tax rate calculations division by zero error in 3.1

### DIFF
--- a/saleor/checkout/base_calculations.py
+++ b/saleor/checkout/base_calculations.py
@@ -223,8 +223,8 @@ def base_order_line_total(order_line: "OrderLine") -> OrderTaxedPricesData:
 
 def base_tax_rate(price: TaxedMoney):
     tax_rate = Decimal("0.0")
-    # The condition will return False when unit_price.gross is 0.0
-    if not isinstance(price, Decimal) and price.gross:
+    # The condition will return False when unit_price.gross or unit_price.net is 0.0
+    if not isinstance(price, Decimal) and all((price.gross, price.net)):
         tax_rate = price.tax / price.net
     return tax_rate
 

--- a/saleor/checkout/tests/test_base_calculations.py
+++ b/saleor/checkout/tests/test_base_calculations.py
@@ -1,10 +1,11 @@
 from decimal import Decimal
 
-from prices import Money
+from prices import Money, TaxedMoney
 
 from ...discount import DiscountValueType, VoucherType
 from ...discount.utils import get_product_discount_on_sale
 from ..base_calculations import (
+    base_tax_rate,
     calculate_base_line_total_price,
     calculate_base_line_unit_price,
 )
@@ -588,3 +589,13 @@ def test_calculate_base_line_total_price_with_variant_on_sale_and_voucher_applie
         prices_data.price_with_discounts
         == (expected_unit_price * quantity) - voucher_amount
     )
+
+
+def test_base_tax_rate_net_price_zero():
+    price = TaxedMoney(net=Money(0, "USD"), gross=Money(3, "USD"))
+    assert base_tax_rate(price) == Decimal("0.0")
+
+
+def test_base_tax_rate_gross_price_zero():
+    price = TaxedMoney(net=Money(3, "USD"), gross=Money(0, "USD"))
+    assert base_tax_rate(price) == Decimal("0.0")


### PR DESCRIPTION
I want to merge this change because we need to secure our tax rate calculation mechanism from raising DivisionByZero exception in edge-case situation when price net value is zero.

it is port of #8932 changes

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
