### PR TITLE
Fix incorrect stock allocation

### DIFF
--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -183,7 +183,6 @@ def _create_allocations(
         return insufficient_stock, []
 
 
-@traced_atomic_transaction()
 def deallocate_stock(
     order_lines_data: Iterable["OrderLineInfo"], manager: PluginsManager
 ):
@@ -234,9 +233,6 @@ def deallocate_stock(
         if not quantity_dealocated == quantity:
             not_dellocated_lines.append(order_line)
 
-    if not_dellocated_lines:
-        raise AllocationError(not_dellocated_lines)
-
     allocations_before_update = list(
         Allocation.objects.filter(
             id__in=[a.id for a in allocations_to_update]
@@ -258,6 +254,9 @@ def deallocate_stock(
                     allocation_before_update.stock
                 )
             )
+
+    if not_dellocated_lines:
+        raise AllocationError(not_dellocated_lines)
 
 
 @traced_atomic_transaction()


### PR DESCRIPTION
Previously, when some lines raise an error during stock deallocation, only the quantity allocated for these lines was updated. The changes ensure that all quantities allocated will be updated. Transaction atomic is removed from `deallocate_stock` as we want to save changes for allocations.

Drop unsed `restock_order_lines` order utils function.

Apply changes from #8931.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
