### PR TITLE
Handle external shipping methods in translations resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `quantity_limit_per_customer` field to ProductVariant #8405 by @kuchichan
 - Optimize products stock availability filter - #8809 by @fowczarek
 - Do no allow using id for updating checkout and order metadata - #8906 by @IKarbowiak
+- Fix crash when querying external shipping method's `translation` field - #8971 by @rafalp
 
 # 3.0.0 [Unreleased]
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1758,11 +1758,13 @@ def test_checkout_available_shipping_methods_excluded_postal_codes(
     assert data["availableShippingMethods"] == []
 
 
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
 @pytest.mark.parametrize(
     "expected_price_type, expected_price, display_gross_prices",
     (("gross", 13, True), ("net", 10, False)),
 )
 def test_checkout_available_shipping_methods_with_price_displayed(
+    send_webhook_request_sync,
     expected_price_type,
     expected_price,
     display_gross_prices,
@@ -1772,6 +1774,7 @@ def test_checkout_available_shipping_methods_with_price_displayed(
     address,
     shipping_zone,
     site_settings,
+    shipping_app,
 ):
     shipping_method = shipping_zone.shipping_methods.first()
     shipping_price = shipping_method.channel_listings.get(
@@ -3163,6 +3166,9 @@ MUTATION_UPDATE_DELIVERY_METHOD = """
                 ... on ShippingMethod {
                     name
                     id
+                    translation(languageCode: EN_US) {
+                        name
+                    }
                 }
                 ... on Warehouse {
                    name

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -29,7 +29,6 @@ from ..decorators import permission_required
 from ..meta.types import ObjectWithMetadata
 from ..shipping.resolvers import resolve_price_range
 from ..translations.fields import TranslationField
-from ..translations.resolvers import resolve_translation
 from ..translations.types import ShippingMethodTranslation
 from ..warehouse.types import Warehouse
 from .dataloaders import (

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -29,6 +29,7 @@ from ..decorators import permission_required
 from ..meta.types import ObjectWithMetadata
 from ..shipping.resolvers import resolve_price_range
 from ..translations.fields import TranslationField
+from ..translations.resolvers import resolve_translation
 from ..translations.types import ShippingMethodTranslation
 from ..warehouse.types import Warehouse
 from .dataloaders import (
@@ -86,7 +87,7 @@ class ShippingMethod(ChannelContextTypeWithMetadataForObjectType):
     translation = TranslationField(
         ShippingMethodTranslation,
         type_name="shipping method",
-        resolver=ChannelContextType.resolve_translation,
+        resolver=None,  # Disable default resolver
     )
     channel_listings = graphene.List(
         graphene.NonNull(ShippingMethodChannelListing),
@@ -138,6 +139,17 @@ class ShippingMethod(ChannelContextTypeWithMetadataForObjectType):
             # todo external shipping to base64
             return root.node.id
         return graphene.Node.to_global_id("ShippingMethod", root.node.id)
+
+    @staticmethod
+    def resolve_translation(
+        root: ChannelContext[Union[ShippingMethodData, models.ShippingMethod]],
+        info,
+        language_code,
+    ):
+        if getattr(root.node, "is_external", False):
+            return None
+
+        return ChannelContextType.resolve_translation(root, info, language_code)
 
     @staticmethod
     def resolve_price(


### PR DESCRIPTION
Fixes default translations resolvers not working with shipping methods that were retrieved via a webhook.

This is achieved by testing received shipping data for `is_external` in custom resolver logic wrapping default logic.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
