### PR TITLE
Fix duplicated records in avatax for confirmed orders

### DIFF
--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -360,7 +360,7 @@ def get_order_lines_data(
             amount=undiscounted_amount,
         )
 
-        # for invoice transaction we want to include only undiscounted price
+        # for invoice transaction we want to include only final price
         if (
             not invoice_transaction_type
             and undiscounted_amount != price_with_discounts_amount
@@ -371,18 +371,17 @@ def get_order_lines_data(
                 ref1=line.variant.sku,
             )
 
-    if not invoice_transaction_type:
-        discount_amount = get_total_order_discount(order)
-        if discount_amount:
-            append_line_to_data(
-                data=data,
-                quantity=1,
-                amount=discount_amount.amount * -1,
-                tax_code=COMMON_DISCOUNT_VOUCHER_CODE,
-                item_code="Voucher",
-                name="Order discount",
-                tax_included=True,  # Voucher should be always applied as a gross amount
-            )
+    discount_amount = get_total_order_discount(order)
+    if discount_amount:
+        append_line_to_data(
+            data=data,
+            quantity=1,
+            amount=discount_amount.amount * -1,
+            tax_code=COMMON_DISCOUNT_VOUCHER_CODE,
+            item_code="Voucher",
+            name="Order discount",
+            tax_included=True,  # Voucher should be always applied as a gross amount
+        )
 
     shipping_method_channel_listing = ShippingMethodChannelListing.objects.filter(
         shipping_method=order.shipping_method_id, channel=order.channel_id

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -309,7 +309,7 @@ def get_checkout_lines_data(
 
 
 def get_order_lines_data(
-    order: "Order", config: AvataxConfiguration
+    order: "Order", config: AvataxConfiguration, invoice_transaction_type: bool = False
 ) -> List[Dict[str, Union[str, int, bool, None]]]:
     data: List[Dict[str, Union[str, int, bool, None]]] = []
     lines = order.lines.prefetch_related(
@@ -360,24 +360,29 @@ def get_order_lines_data(
             amount=undiscounted_amount,
         )
 
-        if undiscounted_amount != price_with_discounts_amount:
+        # for invoice transaction we want to include only undiscounted price
+        if (
+            not invoice_transaction_type
+            and undiscounted_amount != price_with_discounts_amount
+        ):
             append_line_to_data(
                 **append_line_to_data_kwargs,
                 amount=price_with_discounts_amount,
                 ref1=line.variant.sku,
             )
 
-    discount_amount = get_total_order_discount(order)
-    if discount_amount:
-        append_line_to_data(
-            data=data,
-            quantity=1,
-            amount=discount_amount.amount * -1,
-            tax_code=COMMON_DISCOUNT_VOUCHER_CODE,
-            item_code="Voucher",
-            name="Order discount",
-            tax_included=True,  # Voucher should be always applied as a gross amount
-        )
+    if not invoice_transaction_type:
+        discount_amount = get_total_order_discount(order)
+        if discount_amount:
+            append_line_to_data(
+                data=data,
+                quantity=1,
+                amount=discount_amount.amount * -1,
+                tax_code=COMMON_DISCOUNT_VOUCHER_CODE,
+                item_code="Voucher",
+                name="Order discount",
+                tax_included=True,  # Voucher should be always applied as a gross amount
+            )
 
     shipping_method_channel_listing = ShippingMethodChannelListing.objects.filter(
         shipping_method=order.shipping_method_id, channel=order.channel_id
@@ -513,12 +518,13 @@ def get_checkout_tax_data(
 
 def get_order_request_data(order: "Order", config: AvataxConfiguration):
     address = order.shipping_address or order.billing_address
-    lines = get_order_lines_data(order, config)
     transaction = (
         TransactionType.INVOICE
         if not (order.is_draft() or order.is_unconfirmed())
         else TransactionType.ORDER
     )
+    is_invoice_transaction = transaction == TransactionType.INVOICE
+    lines = get_order_lines_data(order, config, is_invoice_transaction)
     data = generate_request_data(
         transaction_type=transaction,
         lines=lines,

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -19,7 +19,8 @@ from ....checkout.fetch import (
 from ....checkout.utils import add_variant_to_checkout
 from ....core.prices import quantize_price
 from ....core.taxes import TaxError, TaxType
-from ....discount import VoucherType
+from ....discount import DiscountValueType, OrderDiscountType, VoucherType
+from ....order import OrderStatus
 from ....product.models import Product, ProductType
 from ....shipping.utils import convert_to_shipping_method_data
 from ...manager import get_plugins_manager
@@ -2749,6 +2750,192 @@ def test_get_order_request_data_checks_when_taxes_are_not_included_to_price(
     assert len(lines_with_taxes) == 1
 
     assert line_without_taxes[0]["itemCode"] == line.product_sku
+
+
+def test_get_order_request_data_confirmed_order_with_voucher(
+    order_with_lines, shipping_zone, site_settings, address, voucher
+):
+    site_settings.include_taxes_in_prices = True
+    site_settings.company_address = address
+    site_settings.save()
+    method = shipping_zone.shipping_methods.get()
+    line = order_with_lines.lines.first()
+    line.unit_price_gross_amount = line.unit_price_net_amount
+    line.save()
+
+    order_with_lines.discounts.create(
+        type=OrderDiscountType.VOUCHER,
+        value_type=DiscountValueType.FIXED,
+        value=Decimal("10.0"),
+        name=voucher.code,
+        currency="USD",
+        amount_value=Decimal("10.0"),
+    )
+
+    order_with_lines.status = OrderStatus.UNFULFILLED
+    order_with_lines.shipping_address = order_with_lines.billing_address.get_copy()
+    order_with_lines.shipping_method_name = method.name
+    order_with_lines.shipping_method = method
+    order_with_lines.save(
+        update_fields=[
+            "status",
+            "shipping_address",
+            "shipping_method_name",
+            "shipping_method",
+        ]
+    )
+
+    config = AvataxConfiguration(
+        username_or_account="",
+        password_or_license="",
+        use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
+    )
+    request_data = get_order_request_data(order_with_lines, config)
+    lines_data = request_data["createTransactionModel"]["lines"]
+
+    # extra one from shipping data
+    assert len(lines_data) == order_with_lines.lines.count() + 1
+
+
+def test_get_order_request_data_confirmed_order_with_sale(
+    order_with_lines, shipping_zone, site_settings, address, sale
+):
+    site_settings.include_taxes_in_prices = True
+    site_settings.company_address = address
+    site_settings.save()
+    method = shipping_zone.shipping_methods.get()
+    line = order_with_lines.lines.first()
+    line.unit_price_gross_amount = line.unit_price_net_amount
+    line.save()
+
+    sale.variants.add(line.variant)
+
+    order_with_lines.status = OrderStatus.UNFULFILLED
+    order_with_lines.shipping_address = order_with_lines.billing_address.get_copy()
+    order_with_lines.shipping_method_name = method.name
+    order_with_lines.shipping_method = method
+    order_with_lines.save(
+        update_fields=[
+            "status",
+            "shipping_address",
+            "shipping_method_name",
+            "shipping_method",
+        ]
+    )
+
+    config = AvataxConfiguration(
+        username_or_account="",
+        password_or_license="",
+        use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
+    )
+    request_data = get_order_request_data(order_with_lines, config)
+    lines_data = request_data["createTransactionModel"]["lines"]
+
+    # extra one from shipping data
+    assert len(lines_data) == order_with_lines.lines.count() + 1
+
+
+def test_get_order_request_data_draft_order_with_voucher(
+    order_with_lines, shipping_zone, site_settings, address, voucher
+):
+    site_settings.include_taxes_in_prices = True
+    site_settings.company_address = address
+    site_settings.save()
+    method = shipping_zone.shipping_methods.get()
+    line = order_with_lines.lines.first()
+    line.unit_price_gross_amount = line.unit_price_net_amount
+    line.save()
+
+    order_with_lines.discounts.create(
+        type=OrderDiscountType.VOUCHER,
+        value_type=DiscountValueType.FIXED,
+        value=Decimal("10.0"),
+        name=voucher.code,
+        currency="USD",
+        amount_value=Decimal("10.0"),
+    )
+
+    order_with_lines.status = OrderStatus.DRAFT
+    order_with_lines.shipping_address = order_with_lines.billing_address.get_copy()
+    order_with_lines.shipping_method_name = method.name
+    order_with_lines.shipping_method = method
+    order_with_lines.save(
+        update_fields=[
+            "status",
+            "shipping_address",
+            "shipping_method_name",
+            "shipping_method",
+        ]
+    )
+
+    config = AvataxConfiguration(
+        username_or_account="",
+        password_or_license="",
+        use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
+    )
+    request_data = get_order_request_data(order_with_lines, config)
+    lines_data = request_data["createTransactionModel"]["lines"]
+
+    # every line has additional discount data and extra one from shipping data
+    assert len(lines_data) == order_with_lines.lines.count() * 2 + 1
+
+
+def test_get_order_request_data_draft_order_with_sale(
+    order_with_lines, shipping_zone, site_settings, address, sale
+):
+    site_settings.include_taxes_in_prices = True
+    site_settings.company_address = address
+    site_settings.save()
+    method = shipping_zone.shipping_methods.get()
+    line = order_with_lines.lines.first()
+    line.unit_price_gross_amount = line.unit_price_net_amount
+    line.save()
+
+    sale.variants.add(line.variant)
+
+    order_with_lines.status = OrderStatus.DRAFT
+    order_with_lines.shipping_address = order_with_lines.billing_address.get_copy()
+    order_with_lines.shipping_method_name = method.name
+    order_with_lines.shipping_method = method
+    order_with_lines.save(
+        update_fields=[
+            "status",
+            "shipping_address",
+            "shipping_method_name",
+            "shipping_method",
+        ]
+    )
+
+    config = AvataxConfiguration(
+        username_or_account="",
+        password_or_license="",
+        use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
+    )
+    request_data = get_order_request_data(order_with_lines, config)
+    lines_data = request_data["createTransactionModel"]["lines"]
+
+    # one additional line from variant sale and one from shipping data
+    assert len(lines_data) == order_with_lines.lines.count() + 1 + 1
 
 
 @patch("saleor.plugins.avatax.get_order_request_data")

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -2798,8 +2798,8 @@ def test_get_order_request_data_confirmed_order_with_voucher(
     request_data = get_order_request_data(order_with_lines, config)
     lines_data = request_data["createTransactionModel"]["lines"]
 
-    # extra one from shipping data
-    assert len(lines_data) == order_with_lines.lines.count() + 1
+    # extra one from shipping data and from discount
+    assert len(lines_data) == order_with_lines.lines.count() + 1 + 1
 
 
 def test_get_order_request_data_confirmed_order_with_sale(


### PR DESCRIPTION
When an order is confirmed we want to attach only an undiscounted amount to request data for avatax.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
