### PR TITLE
Optimize collection remove products

### DIFF
--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -373,6 +373,8 @@ class ProductsQueryset(models.QuerySet):
             "variants__attributes__assignment__attribute",
             "variants__variant_media__media",
             "variants__stocks__allocations",
+            "variants__channel_listings__channel",
+            "channel_listings__channel",
         )
         if single_object:
             return self.prefetch_related(*common_fields)


### PR DESCRIPTION
I want to merge this change because it optimizes products QS manager method `prefetched_for_webhook`.
We were missing channel prefetching and a lot of payload generators suffered from that, not only in `collectonRemoveProducts`, but actually wherever we called `product_updated` or `variant_updated`.

As for `collectonRemoveProducts` on local DB with 18 channels and just 4 products in collection:

before: **231 queries, avg. 320ms**
after: **32 queries, avg. 86ms**

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
