### PR TITLE
Revert restriction on updating metadata by ID for checkouts

### DIFF
--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -57,13 +57,12 @@ class BaseMetadataMutation(BaseMutation):
 
         try:
             type_name, _ = from_global_id_or_error(object_id)
-            if type_name in ["Order", "Checkout"]:
-                type_name = type_name.lower()
+            if type_name == "Order":
                 raise ValidationError(
                     {
                         "id": ValidationError(
-                            f"Changing {type_name} metadata with use of `id` "
-                            f"is forbidden. Use {type_name} token instead.",
+                            "Changing order metadata with `Order.id` is forbidden. "
+                            "Use `Order.token` as an identifier instead.",
                             code=MetadataErrorCode.GRAPHQL_ERROR.value,
                         )
                     }

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -349,8 +349,9 @@ def test_add_public_metadata_for_checkout(api_client, checkout):
     )
 
     # then
-    errors = response["data"]["updateMetadata"]["errors"]
-    assert invalid_id_graphql_error_raised(errors)
+    assert item_contains_proper_public_metadata(
+        response["data"]["updateMetadata"]["item"], checkout, checkout_id
+    )
 
 
 def test_add_public_metadata_for_checkout_by_token(api_client, checkout):
@@ -368,7 +369,10 @@ def test_add_public_metadata_for_checkout_by_token(api_client, checkout):
     )
 
 
-def test_add_metadata_for_checkout_triggers_checkout_updated_hook(api_client, checkout):
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_add_metadata_for_checkout_triggers_checkout_updated_hook(
+    mock_checkout_updated, api_client, checkout
+):
     # given
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
 
@@ -378,8 +382,8 @@ def test_add_metadata_for_checkout_triggers_checkout_updated_hook(api_client, ch
     )
 
     # then
-    errors = response["data"]["updateMetadata"]["errors"]
-    assert invalid_id_graphql_error_raised(errors)
+    assert response["data"]["updateMetadata"]["errors"] == []
+    mock_checkout_updated.assert_called_once_with(checkout)
 
 
 def test_add_public_metadata_for_order_by_id(api_client, order):
@@ -1134,7 +1138,9 @@ def test_delete_public_metadata_for_checkout(api_client, checkout):
     )
 
     # then
-    assert invalid_id_graphql_error_raised(response["data"]["deleteMetadata"]["errors"])
+    assert item_without_public_metadata(
+        response["data"]["deleteMetadata"]["item"], checkout, checkout_id
+    )
 
 
 def test_delete_public_metadata_for_checkout_by_token(api_client, checkout):
@@ -1939,8 +1945,8 @@ def test_add_private_metadata_for_checkout(
     )
 
     # then
-    assert invalid_id_graphql_error_raised(
-        response["data"]["updatePrivateMetadata"]["errors"]
+    assert item_contains_proper_private_metadata(
+        response["data"]["updatePrivateMetadata"]["item"], checkout, checkout_id
     )
 
 
@@ -2784,8 +2790,8 @@ def test_delete_private_metadata_for_checkout(
     )
 
     # then
-    assert invalid_id_graphql_error_raised(
-        response["data"]["deletePrivateMetadata"]["errors"]
+    assert item_without_private_metadata(
+        response["data"]["deletePrivateMetadata"]["item"], checkout, checkout_id
     )
 
 


### PR DESCRIPTION
In PR https://github.com/saleor/saleor/pull/8906 we added the restriction to use metadata mutations with tokens for Checkouts and Orders, while it should have been applied only to Orders.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
