### PR TITLE
Excessive webhooks payloads 3.1

### DIFF
--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -155,9 +155,12 @@ MUTATION_CHECKOUT_CREATE = """
 """
 
 
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_checkout_create_triggers_webhooks(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     user_api_client,
     stock,
     graphql_address_data,
@@ -165,6 +168,7 @@ def test_checkout_create_triggers_webhooks(
     channel_USD,
 ):
     """Create checkout object using GraphQL API."""
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     variant = stock.product_variant
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)

--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -1235,10 +1235,18 @@ def test_page_delete_mutation(staff_api_client, page, permission_manage_pages):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_delete_trigger_webhook(
-    mocked_webhook_trigger, staff_api_client, page, permission_manage_pages, settings
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    staff_api_client,
+    page,
+    permission_manage_pages,
+    settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     variables = {"id": graphene.Node.to_global_id("Page", page.id)}
     response = staff_api_client.post_graphql(
@@ -1251,7 +1259,7 @@ def test_page_delete_trigger_webhook(
         page.refresh_from_db()
     expected_data = generate_page_payload(page, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.PAGE_DELETED
+        expected_data, WebhookEventAsyncType.PAGE_DELETED, [any_webhook]
     )
 
 
@@ -1393,14 +1401,22 @@ def test_update_page(staff_api_client, permission_manage_pages, page):
         assert attr_data in expected_attributes
 
 
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 @freeze_time("2020-03-18 12:00:00")
 def test_update_page_trigger_webhook(
-    mocked_webhook_trigger, staff_api_client, permission_manage_pages, page, settings
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    staff_api_client,
+    permission_manage_pages,
+    page,
+    settings,
 ):
     query = UPDATE_PAGE_MUTATION
 
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
 
     page_title = page.title
     new_slug = "new-slug"
@@ -1431,8 +1447,7 @@ def test_update_page_trigger_webhook(
     page.publication_date = date(2020, 3, 18)
     expected_data = generate_page_payload(page, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
-        WebhookEventAsyncType.PAGE_UPDATED,
+        expected_data, WebhookEventAsyncType.PAGE_UPDATED, [any_webhook]
     )
 
 

--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -388,7 +388,7 @@ def test_page_create_trigger_page_webhook(
     expected_data = generate_page_payload(page, staff_api_client.user)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.PAGE_CREATED
+        expected_data, WebhookEventAsyncType.PAGE_CREATED, [any_webhook]
     )
 
 

--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -345,14 +345,18 @@ def test_page_create_mutation(staff_api_client, permission_manage_pages, page_ty
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_create_trigger_page_webhook(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     permission_manage_pages,
     page_type,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     page_slug = "test-slug"

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -487,11 +487,14 @@ def test_delete_products_with_images(
     mocked_recalculate_orders_task.assert_not_called()
 
 
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
 def test_delete_products_trigger_webhook(
     mocked_recalculate_orders_task,
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     product_list,
     permission_manage_products,
@@ -499,6 +502,7 @@ def test_delete_products_trigger_webhook(
     settings,
 ):
     # given
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     query = DELETE_PRODUCTS_MUTATION
@@ -518,9 +522,12 @@ def test_delete_products_trigger_webhook(
     mocked_recalculate_orders_task.assert_not_called()
 
 
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_delete_products_without_variants(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     product_list,
     permission_manage_products,
@@ -528,6 +535,7 @@ def test_delete_products_without_variants(
     settings,
 ):
     # given
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     for product in product_list:

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -7564,7 +7564,7 @@ def test_delete_product_trigger_webhook(
         product, variants_id, staff_api_client.user
     )
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.PRODUCT_DELETED
+        expected_data, WebhookEventAsyncType.PRODUCT_DELETED, [any_webhook]
     )
     mocked_recalculate_orders_task.assert_not_called()
 

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -7531,16 +7531,20 @@ def test_delete_product_with_image(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
 def test_delete_product_trigger_webhook(
     mocked_recalculate_orders_task,
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     product,
     permission_manage_products,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     query = DELETE_PRODUCT_MUTATION

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -828,14 +828,18 @@ PRODUCT_TRANSLATE_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_create_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     product,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     product_id = graphene.Node.to_global_id("Product", product.id)
@@ -948,14 +952,18 @@ def test_product_create_translation_validates_name_length(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     product,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     translation = product.translations.create(language_code="pl", name="Produkt")
@@ -1003,15 +1011,19 @@ mutation productVariantTranslate(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_variant_create_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     variant,
     channel_USD,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     product_variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
@@ -1052,14 +1064,18 @@ def test_product_variant_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_variant_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     variant,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     translation = variant.translations.create(language_code="pl", name="Wariant")
@@ -1133,14 +1149,18 @@ mutation collectionTranslate($collectionId: ID!, $input: TranslationInput!) {
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_collection_create_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     published_collection,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     collection_id = graphene.Node.to_global_id("Collection", published_collection.id)
@@ -1217,14 +1237,18 @@ def test_collection_create_translation_for_description_name_as_null(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_collection_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     published_collection,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     translation = published_collection.translations.create(
@@ -1288,14 +1312,18 @@ mutation categoryTranslate($categoryId: ID!, $input: TranslationInput!) {
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_category_create_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     category,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     category_id = graphene.Node.to_global_id("Category", category.id)
@@ -1372,14 +1400,18 @@ def test_category_create_translation_for_description_name_as_null(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_category_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     category,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     translation = category.translations.create(language_code="pl", name="Kategoria")
@@ -1421,14 +1453,18 @@ VOUCHER_TRANSLATE_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_voucher_create_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     voucher,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
@@ -1468,14 +1504,18 @@ def test_voucher_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_voucher_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     voucher,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     translation = voucher.translations.create(language_code="pl", name="Kategoria")
 
@@ -1516,14 +1556,18 @@ SALE_TRANSLATION_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_sale_create_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     sale,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     sale_id = graphene.Node.to_global_id("Sale", sale.id)
@@ -1563,14 +1607,18 @@ def test_sale_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_sale_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     sale,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     translation = sale.translations.create(language_code="pl", name="Sale")
@@ -1613,14 +1661,18 @@ mutation pageTranslate($pageId: ID!, $input: PageTranslationInput!) {
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_create_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     page,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     page_id = graphene.Node.to_global_id("Page", page.id)
@@ -1694,14 +1746,18 @@ def test_page_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     page,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     translation = page.translations.create(language_code="pl", title="Strona")
 
@@ -1744,14 +1800,18 @@ ATTRIBUTE_TRANSLATE_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_attribute_create_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     color_attribute,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     attribute_id = graphene.Node.to_global_id("Attribute", color_attribute.id)
@@ -1791,14 +1851,18 @@ def test_attribute_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_attribute_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     color_attribute,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     translation = color_attribute.translations.create(language_code="pl", name="Kolor")
@@ -1842,14 +1906,18 @@ ATTRIBUTE_VALUE_TRANSLATE_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_attribute_value_create_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     pink_attribute_value,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     attribute_value_id = graphene.Node.to_global_id(
@@ -1889,14 +1957,18 @@ def test_attribute_value_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_attribute_value_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     pink_attribute_value,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     translation = pink_attribute_value.translations.create(
@@ -1951,14 +2023,18 @@ SHIPPING_PRICE_TRANSLATE = """
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_shipping_method_create_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     shipping_method,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethodType", shipping_method.id
@@ -2012,14 +2088,18 @@ def test_shipping_method_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_shipping_method_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     shipping_method,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     translation = shipping_method.translations.create(language_code="pl", name="DHL")
@@ -2081,14 +2161,18 @@ MENU_ITEM_TRANSLATE = """
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_menu_item_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     menu_item,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     translation = menu_item.translations.create(language_code="pl", name="Odnośnik")
@@ -2130,14 +2214,18 @@ def test_menu_item_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_shop_create_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     site_settings,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     query = """
@@ -2193,14 +2281,18 @@ SHOP_SETTINGS_TRANSLATE_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_shop_update_translation(
     mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
     staff_api_client,
     site_settings,
     permission_manage_translations,
     settings,
 ):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
     translation = site_settings.translations.create(

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -856,7 +856,7 @@ def test_product_create_translation(
     translation = product.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED, [any_webhook]
     )
 
 
@@ -982,7 +982,7 @@ def test_product_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 
@@ -1040,7 +1040,7 @@ def test_product_variant_create_translation(
     translation = variant.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED, [any_webhook]
     )
 
 
@@ -1094,7 +1094,7 @@ def test_product_variant_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 
@@ -1177,7 +1177,7 @@ def test_collection_create_translation(
     translation = published_collection.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED, [any_webhook]
     )
 
 
@@ -1269,7 +1269,7 @@ def test_collection_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 
@@ -1340,7 +1340,7 @@ def test_category_create_translation(
     translation = category.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED, [any_webhook]
     )
 
 
@@ -1430,7 +1430,7 @@ def test_category_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 
@@ -1481,7 +1481,7 @@ def test_voucher_create_translation(
     translation = voucher.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED, [any_webhook]
     )
 
 
@@ -1533,7 +1533,7 @@ def test_voucher_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 
@@ -1584,7 +1584,7 @@ def test_sale_create_translation(
     translation = sale.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED, [any_webhook]
     )
 
 
@@ -1637,7 +1637,7 @@ def test_sale_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 
@@ -1689,7 +1689,7 @@ def test_page_create_translation(
     translation = page.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED, [any_webhook]
     )
 
 
@@ -1775,7 +1775,7 @@ def test_page_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 
@@ -1828,7 +1828,7 @@ def test_attribute_create_translation(
     translation = color_attribute.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED, [any_webhook]
     )
 
 
@@ -1881,7 +1881,7 @@ def test_attribute_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 
@@ -1936,7 +1936,7 @@ def test_attribute_value_create_translation(
     translation = pink_attribute_value.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED, [any_webhook]
     )
 
 
@@ -1991,7 +1991,7 @@ def test_attribute_value_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 
@@ -2058,7 +2058,7 @@ def test_shipping_method_create_translation(
     translation = shipping_method.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED, [any_webhook]
     )
 
 
@@ -2137,7 +2137,7 @@ def test_shipping_method_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 
@@ -2193,7 +2193,7 @@ def test_menu_item_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 
@@ -2255,7 +2255,7 @@ def test_shop_create_translation(
     translation = site_settings.translations.first()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED
+        expected_payload, WebhookEventAsyncType.TRANSLATION_CREATED, [any_webhook]
     )
 
 
@@ -2312,8 +2312,7 @@ def test_shop_update_translation(
     translation.refresh_from_db()
     expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
-        WebhookEventAsyncType.TRANSLATION_UPDATED,
+        expected_payload, WebhookEventAsyncType.TRANSLATION_UPDATED, [any_webhook]
     )
 
 

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -376,7 +376,7 @@ class WebhookPlugin(BasePlugin):
             product_variant_data = generate_product_variant_with_stock_payload(
                 [stock], self.requestor
             )
-            trigger_webhooks_async(event_type, product_variant_data, webhooks)
+            trigger_webhooks_async(product_variant_data, event_type, webhooks)
 
     def checkout_created(self, checkout: "Checkout", previous_value: Any) -> Any:
         if not self.active:

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -82,39 +82,49 @@ class WebhookPlugin(BasePlugin):
     def order_created(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_async(order_data, WebhookEventAsyncType.ORDER_CREATED)
+        event_type = WebhookEventAsyncType.ORDER_CREATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            order_data = generate_order_payload(order, self.requestor)
+            trigger_webhooks_async(order_data, event_type, webhooks)
 
     def order_confirmed(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_async(order_data, WebhookEventAsyncType.ORDER_CONFIRMED)
+        event_type = WebhookEventAsyncType.ORDER_CONFIRMED
+        if webhooks := _get_webhooks_for_event(event_type):
+            order_data = generate_order_payload(order, self.requestor)
+            trigger_webhooks_async(order_data, event_type, webhooks)
 
     def order_fully_paid(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_async(order_data, WebhookEventAsyncType.ORDER_FULLY_PAID)
+        event_type = WebhookEventAsyncType.ORDER_FULLY_PAID
+        if webhooks := _get_webhooks_for_event(event_type):
+            order_data = generate_order_payload(order, self.requestor)
+            trigger_webhooks_async(order_data, event_type, webhooks)
 
     def order_updated(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_async(order_data, WebhookEventAsyncType.ORDER_UPDATED)
+        event_type = WebhookEventAsyncType.ORDER_UPDATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            order_data = generate_order_payload(order, self.requestor)
+            trigger_webhooks_async(order_data, event_type, webhooks)
 
     def sale_created(
         self, sale: "Sale", current_catalogue: "NodeCatalogueInfo", previous_value: Any
     ) -> Any:
         if not self.active:
             return previous_value
-        sale_data = generate_sale_payload(
-            sale,
-            previous_catalogue=None,
-            current_catalogue=current_catalogue,
-            requestor=self.requestor,
-        )
-        trigger_webhooks_async(sale_data, WebhookEventAsyncType.SALE_CREATED)
+        event_type = WebhookEventAsyncType.SALE_CREATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            sale_data = generate_sale_payload(
+                sale,
+                previous_catalogue=None,
+                current_catalogue=current_catalogue,
+                requestor=self.requestor,
+            )
+            trigger_webhooks_async(sale_data, event_type, webhooks)
 
     def sale_updated(
         self,
@@ -125,20 +135,24 @@ class WebhookPlugin(BasePlugin):
     ) -> Any:
         if not self.active:
             return previous_value
-        sale_data = generate_sale_payload(
-            sale, previous_catalogue, current_catalogue, self.requestor
-        )
-        trigger_webhooks_async(sale_data, WebhookEventAsyncType.SALE_UPDATED)
+        event_type = WebhookEventAsyncType.SALE_UPDATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            sale_data = generate_sale_payload(
+                sale, previous_catalogue, current_catalogue, self.requestor
+            )
+            trigger_webhooks_async(sale_data, event_type, webhooks)
 
     def sale_deleted(
         self, sale: "Sale", previous_catalogue: "NodeCatalogueInfo", previous_value: Any
     ) -> Any:
         if not self.active:
             return previous_value
-        sale_data = generate_sale_payload(
-            sale, previous_catalogue=previous_catalogue, requestor=self.requestor
-        )
-        trigger_webhooks_async(sale_data, WebhookEventAsyncType.SALE_DELETED)
+        event_type = WebhookEventAsyncType.SALE_DELETED
+        if webhooks := _get_webhooks_for_event(event_type):
+            sale_data = generate_sale_payload(
+                sale, previous_catalogue=previous_catalogue, requestor=self.requestor
+            )
+            trigger_webhooks_async(sale_data, event_type, webhooks)
 
     def invoice_request(
         self,
@@ -149,247 +163,296 @@ class WebhookPlugin(BasePlugin):
     ) -> Any:
         if not self.active:
             return previous_value
-        invoice_data = generate_invoice_payload(invoice, self.requestor)
-        trigger_webhooks_async(invoice_data, WebhookEventAsyncType.INVOICE_REQUESTED)
+        event_type = WebhookEventAsyncType.INVOICE_REQUESTED
+        if webhooks := _get_webhooks_for_event(event_type):
+            invoice_data = generate_invoice_payload(invoice, self.requestor)
+            trigger_webhooks_async(invoice_data, event_type, webhooks)
 
     def invoice_delete(self, invoice: "Invoice", previous_value: Any):
         if not self.active:
             return previous_value
-        invoice_data = generate_invoice_payload(invoice, self.requestor)
-        trigger_webhooks_async(invoice_data, WebhookEventAsyncType.INVOICE_DELETED)
+        event_type = WebhookEventAsyncType.INVOICE_DELETED
+        if webhooks := _get_webhooks_for_event(event_type):
+            invoice_data = generate_invoice_payload(invoice, self.requestor)
+            trigger_webhooks_async(invoice_data, event_type, webhooks)
 
     def invoice_sent(self, invoice: "Invoice", email: str, previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        invoice_data = generate_invoice_payload(invoice, self.requestor)
-        trigger_webhooks_async(invoice_data, WebhookEventAsyncType.INVOICE_SENT)
+        event_type = WebhookEventAsyncType.INVOICE_SENT
+        if webhooks := _get_webhooks_for_event(event_type):
+            invoice_data = generate_invoice_payload(invoice, self.requestor)
+            trigger_webhooks_async(invoice_data, event_type, webhooks)
 
     def order_cancelled(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_async(order_data, WebhookEventAsyncType.ORDER_CANCELLED)
+        event_type = WebhookEventAsyncType.ORDER_CANCELLED
+        if webhooks := _get_webhooks_for_event(event_type):
+            order_data = generate_order_payload(order, self.requestor)
+            trigger_webhooks_async(order_data, event_type, webhooks)
 
     def order_fulfilled(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_async(order_data, WebhookEventAsyncType.ORDER_FULFILLED)
+        event_type = WebhookEventAsyncType.ORDER_FULFILLED
+        if webhooks := _get_webhooks_for_event(event_type):
+            order_data = generate_order_payload(order, self.requestor)
+            trigger_webhooks_async(order_data, event_type, webhooks)
 
     def draft_order_created(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_async(order_data, WebhookEventAsyncType.DRAFT_ORDER_CREATED)
+        event_type = WebhookEventAsyncType.DRAFT_ORDER_CREATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            order_data = generate_order_payload(order, self.requestor)
+            trigger_webhooks_async(order_data, event_type, webhooks)
 
     def draft_order_updated(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_async(order_data, WebhookEventAsyncType.DRAFT_ORDER_UPDATED)
+        event_type = WebhookEventAsyncType.DRAFT_ORDER_UPDATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            order_data = generate_order_payload(order, self.requestor)
+            trigger_webhooks_async(order_data, event_type, webhooks)
 
     def draft_order_deleted(self, order: "Order", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        order_data = generate_order_payload(order, self.requestor)
-        trigger_webhooks_async(order_data, WebhookEventAsyncType.DRAFT_ORDER_DELETED)
+        event_type = WebhookEventAsyncType.DRAFT_ORDER_DELETED
+        if webhooks := _get_webhooks_for_event(event_type):
+            order_data = generate_order_payload(order, self.requestor)
+            trigger_webhooks_async(order_data, event_type, webhooks)
 
     def fulfillment_created(self, fulfillment: "Fulfillment", previous_value):
         if not self.active:
             return previous_value
-        fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
-        trigger_webhooks_async(
-            fulfillment_data, WebhookEventAsyncType.FULFILLMENT_CREATED
-        )
+        event_type = WebhookEventAsyncType.FULFILLMENT_CREATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
+            trigger_webhooks_async(fulfillment_data, event_type, webhooks)
 
     def fulfillment_canceled(self, fulfillment: "Fulfillment", previous_value):
         if not self.active:
             return previous_value
-        fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
-        trigger_webhooks_async(
-            fulfillment_data, WebhookEventAsyncType.FULFILLMENT_CANCELED
-        )
+        event_type = WebhookEventAsyncType.FULFILLMENT_CANCELED
+        if webhooks := _get_webhooks_for_event(event_type):
+            fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
+            trigger_webhooks_async(fulfillment_data, event_type, webhooks)
 
     def customer_created(self, customer: "User", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        customer_data = generate_customer_payload(customer, self.requestor)
-        trigger_webhooks_async(customer_data, WebhookEventAsyncType.CUSTOMER_CREATED)
+        event_type = WebhookEventAsyncType.CUSTOMER_CREATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            customer_data = generate_customer_payload(customer, self.requestor)
+            trigger_webhooks_async(customer_data, event_type, webhooks)
 
     def customer_updated(self, customer: "User", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        customer_data = generate_customer_payload(customer, self.requestor)
-        trigger_webhooks_async(customer_data, WebhookEventAsyncType.CUSTOMER_UPDATED)
+        event_type = WebhookEventAsyncType.CUSTOMER_UPDATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            customer_data = generate_customer_payload(customer, self.requestor)
+            trigger_webhooks_async(customer_data, event_type, webhooks)
 
     def collection_created(self, collection: "Collection", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        collection_data = generate_collection_payload(collection, self.requestor)
-        trigger_webhooks_async(
-            collection_data, WebhookEventAsyncType.COLLECTION_CREATED
-        )
+        event_type = WebhookEventAsyncType.COLLECTION_CREATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            collection_data = generate_collection_payload(collection, self.requestor)
+            trigger_webhooks_async(collection_data, event_type, webhooks)
 
     def collection_updated(self, collection: "Collection", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        collection_data = generate_collection_payload(collection, self.requestor)
-        trigger_webhooks_async(
-            collection_data, WebhookEventAsyncType.COLLECTION_UPDATED
-        )
+        event_type = WebhookEventAsyncType.COLLECTION_UPDATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            collection_data = generate_collection_payload(collection, self.requestor)
+            trigger_webhooks_async(collection_data, event_type, webhooks)
 
     def collection_deleted(self, collection: "Collection", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        collection_data = generate_collection_payload(collection, self.requestor)
-        trigger_webhooks_async(
-            collection_data, WebhookEventAsyncType.COLLECTION_DELETED
-        )
+        event_type = WebhookEventAsyncType.COLLECTION_DELETED
+        if webhooks := _get_webhooks_for_event(event_type):
+            collection_data = generate_collection_payload(collection, self.requestor)
+            trigger_webhooks_async(collection_data, event_type, webhooks)
 
     def product_created(self, product: "Product", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        product_data = generate_product_payload(product, self.requestor)
-        trigger_webhooks_async(product_data, WebhookEventAsyncType.PRODUCT_CREATED)
+        event_type = WebhookEventAsyncType.PRODUCT_CREATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            product_data = generate_product_payload(product, self.requestor)
+            trigger_webhooks_async(product_data, event_type, webhooks)
 
     def product_updated(self, product: "Product", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        product_data = generate_product_payload(product, self.requestor)
-        trigger_webhooks_async(product_data, WebhookEventAsyncType.PRODUCT_UPDATED)
+        event_type = WebhookEventAsyncType.PRODUCT_UPDATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            product_data = generate_product_payload(product, self.requestor)
+            trigger_webhooks_async(product_data, event_type, webhooks)
 
     def product_deleted(
         self, product: "Product", variants: List[int], previous_value: Any
     ) -> Any:
         if not self.active:
             return previous_value
-        product_data = generate_product_deleted_payload(
-            product, variants, self.requestor
-        )
-        trigger_webhooks_async(product_data, WebhookEventAsyncType.PRODUCT_DELETED)
+        event_type = WebhookEventAsyncType.PRODUCT_DELETED
+        if webhooks := _get_webhooks_for_event(event_type):
+            product_data = generate_product_deleted_payload(
+                product, variants, self.requestor
+            )
+            trigger_webhooks_async(
+                product_data,
+                event_type,
+                webhooks,
+            )
 
     def product_variant_created(
         self, product_variant: "ProductVariant", previous_value: Any
     ) -> Any:
         if not self.active:
             return previous_value
-
-        product_variant_data = generate_product_variant_payload(
-            [product_variant], self.requestor
-        )
-        trigger_webhooks_async(
-            product_variant_data, WebhookEventAsyncType.PRODUCT_VARIANT_CREATED
-        )
+        event_type = WebhookEventAsyncType.PRODUCT_VARIANT_CREATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            product_variant_data = generate_product_variant_payload(
+                [product_variant], self.requestor
+            )
+            trigger_webhooks_async(
+                product_variant_data,
+                event_type,
+                webhooks,
+            )
 
     def product_variant_updated(
         self, product_variant: "ProductVariant", previous_value: Any
     ) -> Any:
         if not self.active:
             return previous_value
-        product_variant_data = generate_product_variant_payload(
-            [product_variant], self.requestor
-        )
-        trigger_webhooks_async(
-            product_variant_data, WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED
-        )
+        event_type = WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            product_variant_data = generate_product_variant_payload(
+                [product_variant], self.requestor
+            )
+            trigger_webhooks_async(
+                product_variant_data,
+                event_type,
+                webhooks,
+            )
 
     def product_variant_deleted(
         self, product_variant: "ProductVariant", previous_value: Any
     ) -> Any:
         if not self.active:
             return previous_value
-        product_variant_data = generate_product_variant_payload(
-            [product_variant], self.requestor
-        )
-        trigger_webhooks_async(
-            product_variant_data, WebhookEventAsyncType.PRODUCT_VARIANT_DELETED
-        )
+        event_type = WebhookEventAsyncType.PRODUCT_VARIANT_DELETED
+        if webhooks := _get_webhooks_for_event(event_type):
+            product_variant_data = generate_product_variant_payload(
+                [product_variant], self.requestor
+            )
+            trigger_webhooks_async(
+                product_variant_data,
+                event_type,
+                webhooks,
+            )
 
     def product_variant_out_of_stock(self, stock: "Stock", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        product_variant_data = generate_product_variant_with_stock_payload([stock])
-        trigger_webhooks_async(
-            product_variant_data, WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK
-        )
+        event_type = WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK
+        if webhooks := _get_webhooks_for_event(event_type):
+            product_variant_data = generate_product_variant_with_stock_payload([stock])
+            trigger_webhooks_async(product_variant_data, event_type, webhooks)
 
     def product_variant_back_in_stock(self, stock: "Stock", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        product_variant_data = generate_product_variant_with_stock_payload(
-            [stock], self.requestor
-        )
-        trigger_webhooks_async(
-            product_variant_data, WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK
-        )
+        event_type = WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK
+        if webhooks := _get_webhooks_for_event(event_type):
+            product_variant_data = generate_product_variant_with_stock_payload(
+                [stock], self.requestor
+            )
+            trigger_webhooks_async(event_type, product_variant_data, webhooks)
 
     def checkout_created(self, checkout: "Checkout", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        checkout_data = generate_checkout_payload(checkout, self.requestor)
-        trigger_webhooks_async(checkout_data, WebhookEventAsyncType.CHECKOUT_CREATED)
+        event_type = WebhookEventAsyncType.CHECKOUT_CREATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            checkout_data = generate_checkout_payload(checkout, self.requestor)
+            trigger_webhooks_async(checkout_data, event_type, webhooks)
 
     def checkout_updated(self, checkout: "Checkout", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        checkout_data = generate_checkout_payload(checkout, self.requestor)
-        trigger_webhooks_async(checkout_data, WebhookEventAsyncType.CHECKOUT_UPDATED)
+        event_type = WebhookEventAsyncType.CHECKOUT_UPDATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            checkout_data = generate_checkout_payload(checkout, self.requestor)
+            trigger_webhooks_async(checkout_data, event_type, webhooks)
 
     def notify(
         self, event: Union[NotifyEventType, str], payload: dict, previous_value
     ) -> Any:
         if not self.active:
             return previous_value
-
-        notify_user_event = WebhookEventAsyncType.NOTIFY_USER
-        data = {
-            "notify_event": event,
-            "payload": payload,
-            "meta": generate_meta(requestor_data=generate_requestor(self.requestor)),
-        }
-
-        if event not in NotifyEventType.CHOICES:
-            logger.info(
-                f"Webhook {notify_user_event} triggered for {event} notify event."
+        event_type = WebhookEventAsyncType.NOTIFY_USER
+        if webhooks := _get_webhooks_for_event(event_type):
+            data = {
+                "notify_event": event,
+                "payload": payload,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(self.requestor)
+                ),
+            }
+            if event not in NotifyEventType.CHOICES:
+                logger.info(f"Webhook {event_type} triggered for {event} notify event.")
+            trigger_webhooks_async(
+                json.dumps(data, cls=CustomJsonEncoder), event_type, webhooks
             )
-
-        trigger_webhooks_async(
-            json.dumps(data, cls=CustomJsonEncoder), WebhookEventAsyncType.NOTIFY_USER
-        )
 
     def page_created(self, page: "Page", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        page_data = generate_page_payload(page, self.requestor)
-        trigger_webhooks_async(page_data, WebhookEventAsyncType.PAGE_CREATED)
+        event_type = WebhookEventAsyncType.PAGE_CREATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            page_data = generate_page_payload(page, self.requestor)
+            trigger_webhooks_async(page_data, event_type, webhooks)
 
     def page_updated(self, page: "Page", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        page_data = generate_page_payload(page, self.requestor)
-        trigger_webhooks_async(page_data, WebhookEventAsyncType.PAGE_UPDATED)
+        event_type = WebhookEventAsyncType.PAGE_UPDATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            page_data = generate_page_payload(page, self.requestor)
+            trigger_webhooks_async(page_data, event_type, webhooks)
 
     def page_deleted(self, page: "Page", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
-        page_data = generate_page_payload(page, self.requestor)
-        trigger_webhooks_async(page_data, WebhookEventAsyncType.PAGE_DELETED)
+        event_type = WebhookEventAsyncType.PAGE_DELETED
+        if webhooks := _get_webhooks_for_event(event_type):
+            page_data = generate_page_payload(page, self.requestor)
+            trigger_webhooks_async(page_data, event_type, webhooks)
 
     def translation_created(self, translation: "Translation", previous_value: Any):
         if not self.active:
             return previous_value
-        translation_data = generate_translation_payload(translation, self.requestor)
-        trigger_webhooks_async(
-            translation_data, WebhookEventAsyncType.TRANSLATION_CREATED
-        )
+        event_type = WebhookEventAsyncType.TRANSLATION_CREATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            translation_data = generate_translation_payload(translation, self.requestor)
+            trigger_webhooks_async(translation_data, event_type, webhooks)
 
     def translation_updated(self, translation: "Translation", previous_value: Any):
         if not self.active:
             return previous_value
-        translation_data = generate_translation_payload(translation, self.requestor)
-        trigger_webhooks_async(
-            translation_data, WebhookEventAsyncType.TRANSLATION_UPDATED
-        )
+        event_type = WebhookEventAsyncType.TRANSLATION_UPDATED
+        if webhooks := _get_webhooks_for_event(event_type):
+            translation_data = generate_translation_payload(translation, self.requestor)
+            trigger_webhooks_async(translation_data, event_type, webhooks)
 
     def event_delivery_retry(self, delivery: "EventDelivery", previous_value: Any):
         if not self.active:

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -82,9 +82,8 @@ def _get_webhooks_for_event(event_type, webhooks=None):
     return webhooks
 
 
-def trigger_webhooks_async(data, event_type):
+def trigger_webhooks_async(data, event_type, webhooks):
     payload = EventPayload.objects.create(payload=data)
-    webhooks = _get_webhooks_for_event(event_type)
     deliveries = create_event_delivery_list_for_webhooks(
         webhooks=webhooks,
         event_payload=payload,

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -112,8 +112,16 @@ def test_trigger_webhooks_for_event_calls_expected_events(
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_order_created(mocked_webhook_trigger, settings, order_with_lines):
+def test_order_created(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    order_with_lines,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_created(order_with_lines)
@@ -125,8 +133,16 @@ def test_order_created(mocked_webhook_trigger, settings, order_with_lines):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_order_confirmed(mocked_webhook_trigger, settings, order_with_lines):
+def test_order_confirmed(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    order_with_lines,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_confirmed(order_with_lines)
@@ -138,8 +154,16 @@ def test_order_confirmed(mocked_webhook_trigger, settings, order_with_lines):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_draft_order_created(mocked_webhook_trigger, settings, order_with_lines):
+def test_draft_order_created(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    order_with_lines,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.draft_order_created(order_with_lines)
@@ -151,8 +175,16 @@ def test_draft_order_created(mocked_webhook_trigger, settings, order_with_lines)
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_draft_order_deleted(mocked_webhook_trigger, settings, order_with_lines):
+def test_draft_order_deleted(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    order_with_lines,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.draft_order_deleted(order_with_lines)
@@ -164,8 +196,16 @@ def test_draft_order_deleted(mocked_webhook_trigger, settings, order_with_lines)
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_draft_order_updated(mocked_webhook_trigger, settings, order_with_lines):
+def test_draft_order_updated(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    order_with_lines,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.draft_order_updated(order_with_lines)
@@ -177,8 +217,16 @@ def test_draft_order_updated(mocked_webhook_trigger, settings, order_with_lines)
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_customer_created(mocked_webhook_trigger, settings, customer_user):
+def test_customer_created(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    customer_user,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.customer_created(customer_user)
@@ -190,8 +238,16 @@ def test_customer_created(mocked_webhook_trigger, settings, customer_user):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_customer_updated(mocked_webhook_trigger, settings, customer_user):
+def test_customer_updated(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    customer_user,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.customer_updated(customer_user)
@@ -203,8 +259,16 @@ def test_customer_updated(mocked_webhook_trigger, settings, customer_user):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_order_fully_paid(mocked_webhook_trigger, settings, order_with_lines):
+def test_order_fully_paid(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    order_with_lines,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_fully_paid(order_with_lines)
@@ -268,8 +332,16 @@ def test_product_created(mocked_webhook_trigger, settings, product):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_product_updated(mocked_webhook_trigger, settings, product):
+def test_product_updated(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    product,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_updated(product)
@@ -281,8 +353,16 @@ def test_product_updated(mocked_webhook_trigger, settings, product):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_product_deleted(mocked_webhook_trigger, settings, product):
+def test_product_deleted(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    product,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
 
@@ -309,8 +389,16 @@ def test_product_deleted(mocked_webhook_trigger, settings, product):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_product_variant_created(mocked_webhook_trigger, settings, variant):
+def test_product_variant_created(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    variant,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_variant_created(variant)
@@ -322,8 +410,16 @@ def test_product_variant_created(mocked_webhook_trigger, settings, variant):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_product_variant_updated(mocked_webhook_trigger, settings, variant):
+def test_product_variant_updated(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    variant,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_variant_updated(variant)
@@ -335,8 +431,16 @@ def test_product_variant_updated(mocked_webhook_trigger, settings, variant):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_product_variant_deleted(mocked_webhook_trigger, settings, variant):
+def test_product_variant_deleted(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    variant,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_variant_deleted(variant)
@@ -382,8 +486,16 @@ def test_product_variant_back_in_stock(
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_order_updated(mocked_webhook_trigger, settings, order_with_lines):
+def test_order_updated(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    order_with_lines,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_updated(order_with_lines)
@@ -395,8 +507,16 @@ def test_order_updated(mocked_webhook_trigger, settings, order_with_lines):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_order_cancelled(mocked_webhook_trigger, settings, order_with_lines):
+def test_order_cancelled(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    order_with_lines,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_cancelled(order_with_lines)
@@ -408,8 +528,16 @@ def test_order_cancelled(mocked_webhook_trigger, settings, order_with_lines):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_checkout_created(mocked_webhook_trigger, settings, checkout_with_items):
+def test_checkout_created(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    checkout_with_items,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.checkout_created(checkout_with_items)
@@ -421,8 +549,16 @@ def test_checkout_created(mocked_webhook_trigger, settings, checkout_with_items)
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_checkout_updated(mocked_webhook_trigger, settings, checkout_with_items):
+def test_checkout_updated(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    checkout_with_items,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.checkout_updated(checkout_with_items)
@@ -434,8 +570,12 @@ def test_checkout_updated(mocked_webhook_trigger, settings, checkout_with_items)
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_page_created(mocked_webhook_trigger, settings, page):
+def test_page_created(
+    mocked_webhook_trigger, mocked_get_webhooks_for_event, any_webhook, settings, page
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.page_created(page)
@@ -447,8 +587,12 @@ def test_page_created(mocked_webhook_trigger, settings, page):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_page_updated(mocked_webhook_trigger, settings, page):
+def test_page_updated(
+    mocked_webhook_trigger, mocked_get_webhooks_for_event, any_webhook, settings, page
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.page_updated(page)
@@ -460,8 +604,12 @@ def test_page_updated(mocked_webhook_trigger, settings, page):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_page_deleted(mocked_webhook_trigger, settings, page):
+def test_page_deleted(
+    mocked_webhook_trigger, mocked_get_webhooks_for_event, any_webhook, settings, page
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     page_id = page.id
@@ -476,8 +624,16 @@ def test_page_deleted(mocked_webhook_trigger, settings, page):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_invoice_request(mocked_webhook_trigger, settings, fulfilled_order):
+def test_invoice_request(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    fulfilled_order,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     invoice = fulfilled_order.invoices.first()
@@ -490,8 +646,16 @@ def test_invoice_request(mocked_webhook_trigger, settings, fulfilled_order):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_invoice_delete(mocked_webhook_trigger, settings, fulfilled_order):
+def test_invoice_delete(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    fulfilled_order,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     invoice = fulfilled_order.invoices.first()
@@ -504,8 +668,16 @@ def test_invoice_delete(mocked_webhook_trigger, settings, fulfilled_order):
 
 
 @freeze_time("1914-06-28 10:50")
+@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
-def test_invoice_sent(mocked_webhook_trigger, settings, fulfilled_order):
+def test_invoice_sent(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    settings,
+    fulfilled_order,
+):
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     invoice = fulfilled_order.invoices.first()

--- a/saleor/plugins/webhook/tests/test_webhook_protocols.py
+++ b/saleor/plugins/webhook/tests/test_webhook_protocols.py
@@ -46,7 +46,9 @@ def test_trigger_webhooks_with_aws_sqs(
     webhook.save()
 
     expected_data = serialize("json", [order_with_lines])
-    trigger_webhooks_async(expected_data, WebhookEventAsyncType.ORDER_CREATED)
+    trigger_webhooks_async(
+        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+    )
 
     mocked_client_constructor.assert_called_once_with(
         "sqs",
@@ -99,7 +101,9 @@ def test_trigger_webhooks_with_aws_sqs_and_secret_key(
     expected_signature = signature_for_payload(
         message.encode("utf-8"), webhook.secret_key
     )
-    trigger_webhooks_async(expected_data, WebhookEventAsyncType.ORDER_CREATED)
+    trigger_webhooks_async(
+        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+    )
 
     mocked_client_constructor.assert_called_once_with(
         "sqs",
@@ -136,7 +140,9 @@ def test_trigger_webhooks_with_google_pub_sub(
     webhook.save()
     expected_data = serialize("json", [order_with_lines])
 
-    trigger_webhooks_async(expected_data, WebhookEventAsyncType.ORDER_CREATED)
+    trigger_webhooks_async(
+        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+    )
     mocked_publisher.publish.assert_called_once_with(
         "projects/saleor/topics/test",
         expected_data.encode("utf-8"),
@@ -169,7 +175,9 @@ def test_trigger_webhooks_with_google_pub_sub_and_secret_key(
     expected_signature = signature_for_payload(
         message.encode("utf-8"), webhook.secret_key
     )
-    trigger_webhooks_async(expected_data, WebhookEventAsyncType.ORDER_CREATED)
+    trigger_webhooks_async(
+        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+    )
     mocked_publisher.publish.assert_called_once_with(
         "projects/saleor/topics/test",
         message.encode("utf-8"),
@@ -195,7 +203,9 @@ def test_trigger_webhooks_with_http(
 
     expected_data = serialize("json", [order_with_lines])
 
-    trigger_webhooks_async(expected_data, WebhookEventAsyncType.ORDER_CREATED)
+    trigger_webhooks_async(
+        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+    )
 
     expected_headers = {
         "Content-Type": "application/json",
@@ -227,7 +237,9 @@ def test_trigger_webhooks_with_http_and_secret_key(
     webhook.save()
 
     expected_data = serialize("json", [order_with_lines])
-    trigger_webhooks_async(expected_data, WebhookEventAsyncType.ORDER_CREATED)
+    trigger_webhooks_async(
+        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+    )
 
     expected_signature = signature_for_payload(
         expected_data.encode("utf-8"), webhook.secret_key

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -5110,7 +5110,7 @@ def any_webhook(app):
     webhook = Webhook.objects.create(
         name="Any webhook", app=app, target_url="http://www.example.com/any"
     )
-    webhook.events.create(event_type=WebhookEventType.ANY)
+    webhook.events.create(event_type=WebhookEventAsyncType.ANY)
     return webhook
 
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -5106,6 +5106,15 @@ def webhook(app):
 
 
 @pytest.fixture
+def any_webhook(app):
+    webhook = Webhook.objects.create(
+        name="Any webhook", app=app, target_url="http://www.example.com/any"
+    )
+    webhook.events.create(event_type=WebhookEventType.ANY)
+    return webhook
+
+
+@pytest.fixture
 def fake_payment_interface(mocker):
     return mocker.Mock(spec=PaymentInterface)
 


### PR DESCRIPTION
I want to merge this change because it's a 3.1 port of https://github.com/saleor/saleor/pull/8934.
It fixes webhooks performance - generates payloads only when necessary instead of always when plugin hook is fired.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
