### PR TITLE
Send COLLECTION_DELETED webhook when collections are deleted in bulk

### DIFF
--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -101,7 +101,11 @@ class CollectionBulkDelete(ModelBulkDeleteMutation):
             .filter(collections__in=collections_ids)
             .distinct()
         )
+
+        for collection in queryset.iterator():
+            info.context.plugins.collection_deleted(collection)
         queryset.delete()
+
         for product in products:
             info.context.plugins.product_updated(product)
 


### PR DESCRIPTION
Updates collections bulk delete mutation so `COLLECTION_DELETED` webhook is called for deleted collections

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
