### PR TITLE
Fix menu item reordering

### DIFF
--- a/saleor/graphql/core/utils/reordering.py
+++ b/saleor/graphql/core/utils/reordering.py
@@ -141,7 +141,6 @@ class Reordering:
         self.qs.model.objects.bulk_update(batch, ["sort_order"])
 
     def run(self):
-
         for pk, move in self.operations.items():
             # Skip operation if it was deleted in concurrence
             if pk not in self.ordered_node_map:

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -19,6 +19,7 @@ from ..core.utils import validate_slug_and_generate_if_needed
 from ..core.utils.reordering import perform_reordering
 from ..page.types import Page
 from ..product.types import Category, Collection
+from .dataloaders import MenuItemsByParentMenuLoader
 from .enums import NavigationType
 from .types import Menu, MenuItem, MenuItemMoveInput
 
@@ -349,18 +350,30 @@ class MenuItemMove(BaseMutation):
 
     @classmethod
     def get_operation(
-        cls, info, menu: models.Menu, move: MenuItemMoveInput
+        cls,
+        info,
+        menu_item_to_current_parent,
+        menu: models.Menu,
+        move: MenuItemMoveInput,
     ) -> _MenuMoveOperation:
         menu_item = cls.get_node_or_error(
             info, move.item_id, field="item", only_type="MenuItem", qs=menu.items
         )
         new_parent, parent_changed = None, False
 
+        # we want to check if parent has changes in relation to previous operations
+        # as moves are performed sequentially
+        old_parent_id = (
+            menu_item_to_current_parent[menu_item.pk]
+            if menu_item.pk in menu_item_to_current_parent
+            else menu_item.parent_id
+        )
+
         if move.parent_id is not None:
             parent_pk = cls.get_global_id_or_error(
                 move.parent_id, only_type=MenuItem, field="parent_id"
             )
-            if int(parent_pk) != menu_item.parent_id:
+            if int(parent_pk) != old_parent_id:
                 new_parent = cls.get_node_or_error(
                     info,
                     move.parent_id,
@@ -369,7 +382,7 @@ class MenuItemMove(BaseMutation):
                     qs=menu.items,
                 )
                 parent_changed = True
-        elif move.parent_id is None and menu_item.parent_id is not None:
+        elif move.parent_id is None and old_parent_id is not None:
             parent_changed = True
 
         return _MenuMoveOperation(
@@ -383,24 +396,34 @@ class MenuItemMove(BaseMutation):
     def clean_moves(
         cls, info, menu: models.Menu, move_operations: List[MenuItemMoveInput]
     ) -> List[_MenuMoveOperation]:
-
         operations = []
+        item_to_current_parent: Dict[int, Optional[models.MenuItem]] = {}
         for move in move_operations:
             cls.clean_move(move)
-            operation = cls.get_operation(info, menu, move)
-            cls.clean_operation(operation)
+            operation = cls.get_operation(info, item_to_current_parent, menu, move)
+            if operation.parent_changed:
+                cls.clean_operation(operation)
+                item_to_current_parent[operation.menu_item.id] = operation.new_parent
             operations.append(operation)
         return operations
 
     @staticmethod
     def perform_change_parent_operation(operation: _MenuMoveOperation):
-        menu_item = operation.menu_item  # type: models.MenuItem
+        menu_item = operation.menu_item
 
         if not operation.parent_changed:
             return
 
+        # we need to refresh item, as it might be changes in previous operations
+        # and in such case the parent and level values are invalid
+        menu_item.refresh_from_db()
+
+        # parent cache need to be update in case of the item parent is changed
+        # more than once
+        menu_item._mptt_meta.update_mptt_cached_fields(menu_item)
+
         # Move the parent
-        menu_item.move_to(operation.new_parent)
+        menu_item.parent = operation.new_parent
         menu_item.sort_order = None
         menu_item.save()
 
@@ -422,7 +445,14 @@ class MenuItemMove(BaseMutation):
             menu_item = operation.menu_item
             parent_pk = operation.menu_item.parent_id
 
-            sort_operations[parent_pk][menu_item.pk] = operation.sort_order
+            # we want to keep the final relative value, as moves are performed
+            # sequentially
+            new_sort_value = (
+                sort_operations[parent_pk].get(menu_item.pk, 0) + operation.sort_order
+                if operation.sort_order is not None
+                else None
+            )
+            sort_operations[parent_pk][menu_item.pk] = new_sort_value
             sort_querysets[parent_pk] = menu_item.get_ordering_queryset()
 
         for parent_pk, operations in sort_operations.items():
@@ -430,6 +460,7 @@ class MenuItemMove(BaseMutation):
             perform_reordering(ordering_qs, operations)
 
         menu = qs.get(pk=menu.pk)
+        MenuItemsByParentMenuLoader(info.context).clear(menu.id)
         return MenuItemMove(menu=ChannelContext(node=menu, channel_slug=None))
 
 

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -1,10 +1,9 @@
-from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Type
 
 import graphene
 from django.core.exceptions import ValidationError
-from django.db.models import Model, QuerySet
+from django.db.models import Model
 
 from ...core.permissions import MenuPermissions, SitePermissions
 from ...core.tracing import traced_atomic_transaction
@@ -436,28 +435,17 @@ class MenuItemMove(BaseMutation):
         menu = cls.get_node_or_error(info, menu, only_type=Menu, field="menu", qs=qs)
 
         operations = cls.clean_moves(info, menu, moves)
-        sort_operations: Dict[Optional[int], Dict[int, int]] = defaultdict(dict)
-        sort_querysets: Dict[Optional[int], QuerySet] = {}
 
         for operation in operations:
             cls.perform_change_parent_operation(operation)
 
             menu_item = operation.menu_item
-            parent_pk = operation.menu_item.parent_id
 
-            # we want to keep the final relative value, as moves are performed
-            # sequentially
-            new_sort_value = (
-                sort_operations[parent_pk].get(menu_item.pk, 0) + operation.sort_order
-                if operation.sort_order is not None
-                else None
-            )
-            sort_operations[parent_pk][menu_item.pk] = new_sort_value
-            sort_querysets[parent_pk] = menu_item.get_ordering_queryset()
-
-        for parent_pk, operations in sort_operations.items():
-            ordering_qs = sort_querysets[parent_pk]
-            perform_reordering(ordering_qs, operations)
+            if operation.sort_order:
+                perform_reordering(
+                    menu_item.get_ordering_queryset(),
+                    {menu_item.pk: operation.sort_order},
+                )
 
         menu = qs.get(pk=menu.pk)
         MenuItemsByParentMenuLoader(info.context).clear(menu.id)

--- a/saleor/graphql/menu/tests/test_menu.py
+++ b/saleor/graphql/menu/tests/test_menu.py
@@ -1011,6 +1011,50 @@ def test_menu_reorder(staff_api_client, permission_manage_menus, menu_item_list)
     assert menu_data == expected_data
 
 
+def test_menu_reorder_move_the_same_item_multiple_times(
+    staff_api_client, permission_manage_menus, menu_item_list
+):
+
+    menu_item_list = list(menu_item_list)
+    menu_global_id = graphene.Node.to_global_id("Menu", menu_item_list[0].menu_id)
+
+    assert len(menu_item_list) == 3
+
+    items_global_ids = [
+        graphene.Node.to_global_id("MenuItem", item.pk) for item in menu_item_list
+    ]
+
+    moves_input = [
+        {"itemId": items_global_ids[0], "parentId": None, "sortOrder": 1},
+        {"itemId": items_global_ids[2], "parentId": None, "sortOrder": -1},
+        {"itemId": items_global_ids[2], "parentId": None, "sortOrder": -1},
+    ]
+
+    expected_data = {
+        "id": menu_global_id,
+        "items": [
+            {"id": items_global_ids[2], "parent": None, "children": []},
+            {"id": items_global_ids[1], "parent": None, "children": []},
+            {"id": items_global_ids[0], "parent": None, "children": []},
+        ],
+    }
+
+    response = get_graphql_content(
+        staff_api_client.post_graphql(
+            QUERY_REORDER_MENU,
+            {"moves": moves_input, "menu": menu_global_id},
+            [permission_manage_menus],
+        )
+    )["data"]["menuItemMove"]
+
+    menu_data = response["menu"]
+    assert not response["errors"]
+    assert menu_data
+
+    # Ensure the order is right
+    assert menu_data == expected_data
+
+
 def test_menu_reorder_assign_parent(
     staff_api_client, permission_manage_menus, menu_item_list
 ):
@@ -1066,6 +1110,160 @@ def test_menu_reorder_assign_parent(
                     },
                 ],
             }
+        ],
+    }
+
+    response = get_graphql_content(
+        staff_api_client.post_graphql(
+            QUERY_REORDER_MENU,
+            {"moves": moves_input, "menu": menu_id},
+            [permission_manage_menus],
+        )
+    )["data"]["menuItemMove"]
+
+    menu_data = response["menu"]
+    assert not response["errors"]
+    assert menu_data
+
+    # Ensure the parent and sort orders were assigned correctly
+    assert menu_data == expected_data
+
+
+def test_menu_reorder_assign_and_unassign_parent(
+    staff_api_client, permission_manage_menus, menu_item_list
+):
+    """Assign a menu item as parent of given menu items. Ensure the menu items
+    are properly pushed at the bottom of the item's children.
+    """
+
+    menu_item_list = list(menu_item_list)
+    assert len(menu_item_list) == 3
+
+    menu_id = graphene.Node.to_global_id("Menu", menu_item_list[1].menu_id)
+
+    root = menu_item_list[0]
+
+    item1 = menu_item_list[1]
+    item1.parent = root
+    item1.save()
+
+    item2 = menu_item_list[2]
+
+    item2_child = MenuItem.objects.create(menu=root.menu, parent=item2, name="Child")
+
+    root_id = graphene.Node.to_global_id("MenuItem", root.pk)
+    items_global_ids = [
+        graphene.Node.to_global_id("MenuItem", item.pk) for item in menu_item_list
+    ]
+
+    moves_input = [
+        {"itemId": items_global_ids[2], "parentId": root_id, "sortOrder": 1},
+        {"itemId": items_global_ids[2], "parentId": None, "sortOrder": 1},
+    ]
+
+    expected_data = {
+        "id": menu_id,
+        "items": [
+            {
+                "id": items_global_ids[0],
+                "parent": None,
+                "children": [
+                    {
+                        "id": items_global_ids[1],
+                        "parent": {"id": root_id},
+                        "children": [],
+                    },
+                ],
+            },
+            {
+                "id": items_global_ids[2],
+                "parent": None,
+                "children": [
+                    {
+                        "id": graphene.Node.to_global_id("MenuItem", item2_child.pk),
+                        "parent": {"id": items_global_ids[2]},
+                        "children": [],
+                    },
+                ],
+            },
+        ],
+    }
+
+    response = get_graphql_content(
+        staff_api_client.post_graphql(
+            QUERY_REORDER_MENU,
+            {"moves": moves_input, "menu": menu_id},
+            [permission_manage_menus],
+        )
+    )["data"]["menuItemMove"]
+
+    menu_data = response["menu"]
+    assert not response["errors"]
+    assert menu_data
+
+    # Ensure the parent and sort orders were assigned correctly
+    assert menu_data == expected_data
+
+
+def test_menu_reorder_unassign_and_assign_parent(
+    staff_api_client, permission_manage_menus, menu_item_list
+):
+    """Assign a menu item as parent of given menu items. Ensure the menu items
+    are properly pushed at the bottom of the item's children.
+    """
+
+    menu_item_list = list(menu_item_list)
+    assert len(menu_item_list) == 3
+
+    menu_id = graphene.Node.to_global_id("Menu", menu_item_list[1].menu_id)
+
+    root = menu_item_list[0]
+
+    item1 = menu_item_list[1]
+    item1.parent = root
+    item1.save()
+
+    item2 = menu_item_list[2]
+    item2.parent = root
+    item2.save()
+
+    item2_child = MenuItem.objects.create(menu=root.menu, parent=item2, name="Child")
+
+    root_id = graphene.Node.to_global_id("MenuItem", root.pk)
+    items_global_ids = [
+        graphene.Node.to_global_id("MenuItem", item.pk) for item in menu_item_list
+    ]
+
+    moves_input = [
+        {"itemId": items_global_ids[2], "parentId": None, "sortOrder": 1},
+        {"itemId": items_global_ids[2], "parentId": root_id, "sortOrder": -1},
+    ]
+
+    expected_data = {
+        "id": menu_id,
+        "items": [
+            {
+                "id": items_global_ids[0],
+                "parent": None,
+                "children": [
+                    {
+                        "id": items_global_ids[2],
+                        "parent": {"id": root_id},
+                        "children": [
+                            {
+                                "id": graphene.Node.to_global_id(
+                                    "MenuItem", item2_child.pk
+                                ),
+                            },
+                        ],
+                    },
+                    {
+                        "id": items_global_ids[1],
+                        "parent": {"id": root_id},
+                        "children": [],
+                    },
+                ],
+            },
         ],
     }
 


### PR DESCRIPTION
Previously when operations were analyzed, the parent changes were checked with the current menu item parent and previous operations haven't been taken into consideration. Because of that, previously when somebody sends a few operations and the last operation is coming back to starting position it's not performed correctly.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
