### PR TITLE
Use QuerySet.iterator() where possible

### DIFF
--- a/saleor/graphql/product/dataloaders/attributes.py
+++ b/saleor/graphql/product/dataloaders/attributes.py
@@ -117,7 +117,7 @@ class AttributeVariantsByProductTypeIdLoader(DataLoader):
             )
         attribute_variants = qs.filter(product_type_id__in=keys)
         producttype_to_attributevariants = defaultdict(list)
-        for attribute_variant in attribute_variants:
+        for attribute_variant in attribute_variants.iterator():
             producttype_to_attributevariants[attribute_variant.product_type_id].append(
                 attribute_variant
             )
@@ -141,7 +141,7 @@ class AssignedProductAttributesByProductIdLoader(DataLoader):
             ).filter(assignment__attribute__visible_in_storefront=True)
         assigned_product_attributes = qs.filter(product_id__in=keys)
         product_to_assignedproductattributes = defaultdict(list)
-        for assigned_product_attribute in assigned_product_attributes:
+        for assigned_product_attribute in assigned_product_attributes.iterator():
             product_to_assignedproductattributes[
                 assigned_product_attribute.product_id
             ].append(assigned_product_attribute)
@@ -167,7 +167,7 @@ class AssignedVariantAttributesByProductVariantId(DataLoader):
             "assignment__attribute"
         )
         variant_attributes = defaultdict(list)
-        for assigned_variant_attribute in assigned_variant_attributes:
+        for assigned_variant_attribute in assigned_variant_attributes.iterator():
             variant_attributes[assigned_variant_attribute.variant_id].append(
                 assigned_variant_attribute
             )
@@ -178,9 +178,11 @@ class AttributeValuesByAssignedProductAttributeIdLoader(DataLoader):
     context_key = "attributevalues_by_assignedproductattribute"
 
     def batch_load(self, keys):
-        attribute_values = AssignedProductAttributeValue.objects.using(
-            self.database_connection_name
-        ).filter(assignment_id__in=keys)
+        attribute_values = list(
+            AssignedProductAttributeValue.objects.using(self.database_connection_name)
+            .filter(assignment_id__in=keys)
+            .iterator()
+        )
         value_ids = [a.value_id for a in attribute_values]
 
         def map_assignment_to_values(values):
@@ -203,9 +205,11 @@ class AttributeValuesByAssignedVariantAttributeIdLoader(DataLoader):
     context_key = "attributevalues_by_assignedvariantattribute"
 
     def batch_load(self, keys):
-        attribute_values = AssignedVariantAttributeValue.objects.using(
-            self.database_connection_name
-        ).filter(assignment_id__in=keys)
+        attribute_values = list(
+            AssignedVariantAttributeValue.objects.using(self.database_connection_name)
+            .filter(assignment_id__in=keys)
+            .iterator()
+        )
         value_ids = [a.value_id for a in attribute_values]
 
         def map_assignment_to_values(values):

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -70,7 +70,7 @@ class ProductChannelListingByProductIdLoader(DataLoader[int, ProductChannelListi
             self.database_connection_name
         ).filter(product_id__in=keys)
         product_id_variant_channel_listings_map = defaultdict(list)
-        for product_channel_listing in product_channel_listings:
+        for product_channel_listing in product_channel_listings.iterator():
             product_id_variant_channel_listings_map[
                 product_channel_listing.product_id
             ].append(product_channel_listing)
@@ -147,7 +147,7 @@ class MediaByProductIdLoader(DataLoader):
             product_id__in=keys
         )
         media_map = defaultdict(list)
-        for media_obj in media:
+        for media_obj in media.iterator():
             media_map[media_obj.product_id].append(media_obj)
         return [media_map[product_id] for product_id in keys]
 
@@ -160,7 +160,7 @@ class ImagesByProductIdLoader(DataLoader):
             product_id__in=keys, type=ProductMediaTypes.IMAGE
         )
         images_map = defaultdict(list)
-        for image in images:
+        for image in images.iterator():
             images_map[image.product_id].append(image)
         return [images_map[product_id] for product_id in keys]
 
@@ -250,7 +250,7 @@ class VariantChannelListingByVariantIdLoader(DataLoader):
             self.database_connection_name
         ).filter(variant_id__in=keys)
         variant_id_variant_channel_listings_map = defaultdict(list)
-        for variant_channel_listing in variant_channel_listings:
+        for variant_channel_listing in variant_channel_listings.iterator():
             variant_id_variant_channel_listings_map[
                 variant_channel_listing.variant_id
             ].append(variant_channel_listing)
@@ -416,7 +416,7 @@ class ProductImageByProductIdLoader(DataLoader):
             type=ProductMediaTypes.IMAGE, product_id__in=keys
         )
         product_id_medias_map = defaultdict(list)
-        for media in medias:
+        for media in medias.iterator():
             product_id_medias_map[media.product_id].append(media)
         return [product_id_medias_map.get(product_id, []) for product_id in keys]
 
@@ -432,7 +432,7 @@ class MediaByProductVariantIdLoader(DataLoader):
         )
 
         variant_media_pairs = defaultdict(list)
-        for variant_id, media_id in variant_media:
+        for variant_id, media_id in variant_media.iterator():
             variant_media_pairs[variant_id].append(media_id)
 
         def map_variant_media(variant_media):
@@ -460,7 +460,7 @@ class ImagesByProductVariantIdLoader(DataLoader):
         )
 
         variant_media_pairs = defaultdict(list)
-        for variant_id, media_id in variant_media:
+        for variant_id, media_id in variant_media.iterator():
             variant_media_pairs[variant_id].append(media_id)
 
         def map_variant_media(variant_media):
@@ -499,6 +499,7 @@ class CollectionsByProductIdLoader(DataLoader):
             .filter(product_id__in=keys)
             .order_by("id")
             .values_list("product_id", "collection_id")
+            .iterator()
         )
         product_collection_map = defaultdict(list)
         for pid, cid in product_collection_pairs:
@@ -578,7 +579,7 @@ class CollectionChannelListingByCollectionIdLoader(DataLoader):
             self.database_connection_name
         ).filter(collection_id__in=keys)
         collection_id_collection_channel_listings_map = defaultdict(list)
-        for collection_channel_listing in collections_channel_listings:
+        for collection_channel_listing in collections_channel_listings.iterator():
             collection_id_collection_channel_listings_map[
                 collection_channel_listing.collection_id
             ].append(collection_channel_listing)
@@ -600,7 +601,7 @@ class CollectionChannelListingByCollectionIdAndChannelSlugLoader(DataLoader):
             .annotate(channel_slug=F("channel__slug"))
         )
         collections_channel_listings_by_collection_and_channel_map = {}
-        for collections_channel_listing in collections_channel_listings:
+        for collections_channel_listing in collections_channel_listings.iterator():
             key = (
                 collections_channel_listing.collection_id,
                 collections_channel_listing.channel_slug,
@@ -622,7 +623,7 @@ class CategoryChildrenByCategoryIdLoader(DataLoader):
             parent__isnull=False
         )
         parent_to_children_mapping = defaultdict(list)
-        for category in categories:
+        for category in categories.iterator():
             parent_to_children_mapping[category.parent_id].append(category)
 
         return [parent_to_children_mapping.get(key, []) for key in keys]


### PR DESCRIPTION
Unless `.iterator()` is used, Django will spend extra time populating the query cache on a QuerySet object that we're about to discard.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
