### PR TITLE
Fix product search string generator for numeric attributes without units

### DIFF
--- a/saleor/product/search.py
+++ b/saleor/product/search.py
@@ -102,7 +102,7 @@ def generate_attributes_search_document_value(
                 clean_editor_js(value.rich_text, to_string=True) for value in values
             ]
         elif input_type == AttributeInputType.NUMERIC:
-            unit = attribute.unit
+            unit = attribute.unit or ""
             values_list = [value.name + unit for value in values]
         elif input_type in [AttributeInputType.DATE, AttributeInputType.DATE_TIME]:
             values_list = [value.date_time.isoformat() for value in values]

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1320,6 +1320,22 @@ def numeric_attribute(db):
 
 
 @pytest.fixture
+def numeric_attribute_without_unit(db):
+    attribute = Attribute.objects.create(
+        slug="count",
+        name="Count",
+        type=AttributeType.PRODUCT_TYPE,
+        input_type=AttributeInputType.NUMERIC,
+        filterable_in_storefront=True,
+        filterable_in_dashboard=True,
+        available_in_grid=True,
+    )
+    AttributeValue.objects.create(attribute=attribute, name="9", slug="9")
+    AttributeValue.objects.create(attribute=attribute, name="15", slug="15")
+    return attribute
+
+
+@pytest.fixture
 def file_attribute(db):
     attribute = Attribute.objects.create(
         slug="image",


### PR DESCRIPTION
I want to merge this change because of fixing the product search string generator for numeric attributes without units.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
