### PR TITLE
Fetch plugin config from replica

### DIFF
--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -127,7 +127,11 @@ class PluginsManager(PaymentInterface):
 
     def _get_db_plugin_configs(self):
         with opentracing.global_tracer().start_active_span("_get_db_plugin_configs"):
-            qs = PluginConfiguration.objects.all().prefetch_related("channel")
+            qs = (
+                PluginConfiguration.objects.all()
+                .using(settings.DATABASE_CONNECTION_REPLICA_NAME)
+                .prefetch_related("channel")
+            )
             channel_configs = defaultdict(dict)
             global_configs = {}
             for db_plugin_config in qs:


### PR DESCRIPTION
I want to merge this change because of fetching plugin config from the replica.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
