### PR TITLE
Set adyen requests timeout

### DIFF
--- a/saleor/payment/gateways/adyen/tests/test_plugin.py
+++ b/saleor/payment/gateways/adyen/tests/test_plugin.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import Adyen
 import pytest
+import requests
 from django.core.exceptions import ValidationError
 from requests.exceptions import RequestException, SSLError
 
@@ -702,3 +703,21 @@ def test_adyen_check_payment_balance_adyen_raises_error(
         plugin.adyen.checkout.client.call_checkout_api,
         action="paymentMethods/balance",
     )
+
+
+@mock.patch("saleor.payment.gateways.adyen.plugin.HTTP_TIMEOUT", 0.001)
+def test_adyen_check_payment_timeout(adyen_plugin, adyen_check_balance_response):
+    plugin = adyen_plugin()
+
+    data = {
+        "gatewayId": "mirumee.payments.gateway",
+        "method": "givex",
+        "card": {
+            "cvc": "9891",
+            "code": "1234567910",
+            "money": {"currency": "GBP", "amount": Decimal(100.0)},
+        },
+    }
+
+    with pytest.raises(requests.exceptions.ConnectTimeout):
+        plugin.check_payment_balance(data)


### PR DESCRIPTION
Set Adyen requests timeout to 20 seconds.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
