### PR TITLE
Fix gift cards tests

### DIFF
--- a/saleor/giftcard/tests/test_tasks.py
+++ b/saleor/giftcard/tests/test_tasks.py
@@ -1,6 +1,7 @@
 import datetime
 
 import pytest
+from django.utils import timezone
 
 from .. import GiftCardEvents
 from ..models import GiftCard
@@ -43,8 +44,8 @@ def test_deactivate_expired_cards_task(
 @pytest.mark.parametrize(
     "expiry_date",
     [
-        datetime.date.today(),
-        datetime.date.today() + datetime.timedelta(days=1),
+        timezone.now().date(),
+        timezone.now().date() + datetime.timedelta(days=1),
     ],
 )
 def test_deactivate_expired_cards_task_cards_not_deactivated(

--- a/saleor/giftcard/tests/test_utils.py
+++ b/saleor/giftcard/tests/test_utils.py
@@ -745,7 +745,7 @@ def test_is_gift_card_expired_true(gift_card):
 
 
 @pytest.mark.parametrize(
-    "expiry_date", [date.today(), date.today() + timedelta(days=1)]
+    "expiry_date", [timezone.now().date(), timezone.now().date() + timedelta(days=1)]
 )
 def test_is_gift_card_expired_false(expiry_date, gift_card):
     # given


### PR DESCRIPTION
I want to merge this change because it changes `datetime` to `django.utils.timezone` in tests where the actual date is needed. The difference in the use of aware and naive `datetime` objects could lead to failing tests in the specified time interval during a day.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
