### PR TITLE
Fix delivery attempt response content

### DIFF
--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -342,7 +342,9 @@ def send_webhook_request_sync(app_name, delivery):
                 attempt.id,
             )
             response.status = EventDeliveryStatus.FAILED
-            response.content = e.response
+            if e.response:
+                response.content = e.response.text
+                response.response_headers = dict(e.response.headers)
 
         except JSONDecodeError as e:
             logger.warning(
@@ -353,7 +355,6 @@ def send_webhook_request_sync(app_name, delivery):
                 attempt.id,
             )
             response.status = EventDeliveryStatus.FAILED
-            response.content = e.msg
         else:
             logger.debug(
                 "[Webhook] Success response from %r."


### PR DESCRIPTION
I want to merge this change because it changes `send_webhook_request_sync` task to store raw response content in case of JSON decode error while parsing this response. We log that such a situation occurs, so it will be more valuable to store problematic responses than JSON decode error messages. 
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
