### PR TITLE
Remove external shipping methods call when resolving delivery method

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -181,10 +181,10 @@ def get_delivery_method_info(
     delivery_method: Optional[Union["ShippingMethodData", "Warehouse", Callable]],
     address=Optional["Address"],
 ) -> DeliveryMethodBase:
-    if delivery_method is None:
-        return DeliveryMethodBase()
     if callable(delivery_method):
         delivery_method = delivery_method()
+    if delivery_method is None:
+        return DeliveryMethodBase()
     if isinstance(delivery_method, ShippingMethodData):
         return ShippingMethodInfo(delivery_method, address)
     if isinstance(delivery_method, Warehouse):

--- a/saleor/graphql/checkout/tests/benchmark/test_homepage.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_homepage.py
@@ -1,4 +1,8 @@
+from unittest.mock import patch
+
 import pytest
+
+from saleor.checkout.utils import set_external_shipping_id
 
 from ....tests.utils import get_graphql_content
 
@@ -139,3 +143,68 @@ def test_user_checkout_details(user_api_client, customer_checkout, count_queries
         }
     """
     get_graphql_content(user_api_client.post_graphql(query))
+
+
+@patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_user_checkout_details_with_external_shipping_method(
+    mock_send_request,
+    api_client,
+    checkout_with_shipping_method,
+    shipping_app,
+    settings,
+):
+    # given
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    external_id = "abcd"
+    mock_json_response = [
+        {
+            "id": external_id,
+            "name": "Provider - Economy",
+            "amount": "10",
+            "currency": "USD",
+            "maximum_delivery_days": "7",
+        }
+    ]
+    checkout = checkout_with_shipping_method
+    checkout.shipping_method = None
+    set_external_shipping_id(checkout, external_id)
+    checkout.save()
+    mock_send_request.return_value = mock_json_response
+    query = """
+        query External($token: UUID!) {
+          checkout(token: $token){
+            id
+            lines{
+              id
+              variant{
+                id
+                product{
+                  productType{
+                    isShippingRequired
+                  }
+                }
+              }
+            }
+            deliveryMethod{
+              __typename
+              ... on ShippingMethod {
+                id
+              }
+            }
+            shippingMethods{
+              id
+            }
+            totalPrice{
+              gross{
+                amount
+              }
+            }
+          }
+        }
+    """
+
+    # when
+    get_graphql_content(api_client.post_graphql(query, {"token": checkout.token}))
+
+    # then
+    assert mock_send_request.call_count == 1

--- a/saleor/graphql/checkout/tests/benchmark/test_homepage.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_homepage.py
@@ -2,8 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from saleor.checkout.utils import set_external_shipping_id
-
+from .....checkout.utils import set_external_shipping_id
 from ....tests.utils import get_graphql_content
 
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -2,16 +2,12 @@ import graphene
 from promise import Promise
 
 from ...checkout import calculations, models
-from ...checkout.utils import (
-    get_external_shipping_id,
-    get_valid_collection_points_for_checkout,
-)
+from ...checkout.utils import get_valid_collection_points_for_checkout
 from ...core.exceptions import PermissionDenied
 from ...core.permissions import AccountPermissions
 from ...core.taxes import zero_taxed_money
 from ...core.tracing import traced_resolver
 from ...shipping.interface import ShippingMethodData
-from ...shipping.utils import convert_to_shipping_method_data
 from ...warehouse import models as warehouse_models
 from ...warehouse.reservations import is_reservation_enabled
 from ..account.dataloaders import AddressByIdLoader
@@ -32,10 +28,6 @@ from ..product.dataloaders import (
     ProductTypeByProductIdLoader,
     ProductTypeByVariantIdLoader,
     ProductVariantByIdLoader,
-)
-from ..shipping.dataloaders import (
-    ShippingMethodByIdLoader,
-    ShippingMethodChannelListingByChannelSlugLoader,
 )
 from ..shipping.types import ShippingMethod
 from ..utils import get_user_or_app_from_context
@@ -312,46 +304,18 @@ class Checkout(ModelObjectType):
 
     @classmethod
     def resolve_shipping_method(cls, root: models.Checkout, info):
-        external_app_shipping_id = get_external_shipping_id(root)
+        def with_checkout_info(checkout_info):
+            delivery_method = checkout_info.delivery_method_info.delivery_method
+            if not delivery_method or not isinstance(
+                delivery_method, ShippingMethodData
+            ):
+                return
+            return delivery_method
 
-        if external_app_shipping_id:
-            shipping_method = info.context.plugins.get_shipping_method(
-                checkout=root,
-                channel_slug=root.channel.slug,
-                shipping_method_id=external_app_shipping_id,
-            )
-            if shipping_method:
-                return shipping_method
-
-        if not root.shipping_method_id:
-            return None
-
-        def with_shipping_method_and_channel(data):
-            shipping_method, channel = data
-
-            def process_listing(listings):
-                for listing in listings:
-                    if listing.shipping_method_id == shipping_method.id:
-                        shipping_method_channel_listing = listing
-                        break
-
-                return convert_to_shipping_method_data(
-                    shipping_method, shipping_method_channel_listing  # type: ignore
-                )
-
-            return (
-                ShippingMethodChannelListingByChannelSlugLoader(info.context)
-                .load(channel.slug)
-                .then(process_listing)
-            )
-
-        shipping_method = ShippingMethodByIdLoader(info.context).load(
-            root.shipping_method_id
-        )
-        channel = ChannelByIdLoader(info.context).load(root.channel_id)
-
-        return Promise.all([shipping_method, channel]).then(
-            with_shipping_method_and_channel
+        return (
+            CheckoutInfoByCheckoutTokenLoader(info.context)
+            .load(root.token)
+            .then(with_checkout_info)
         )
 
     @classmethod


### PR DESCRIPTION
I want to merge this change because it optimises the number of external api calls when fetching delivery method. Implementation of the resolvers is also much more cleaner, as it delegates all the work to CheckoutInfo

It includes a fix introduced in #9048

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
