### PR TITLE
Fix disabled warehouses not being excluded from CC points for preorders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable, unreleased changes to this project will be documented in this file.
 `CheckoutAddPromoCode`, `CheckoutPaymentCreate` will raise a ValidationError when product in the checkout is
 unavailable - #8978 by @IKarbowiak
 - Fix disabled warehouses appearing as valid click and collect points when checkout contains only preorders - #9052 by rafalp
+- Fix disabled warehouses appearing as valid click and collect points when checkout contains only preorders - #9052 by @rafalp
 
 
 # 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ All notable, unreleased changes to this project will be documented in this file.
 - Change metadata mutations to use token for order and checkout as identifier - #8426 by @IKarbowiak
   - After changes, using the order `id` for changing order metadata is deprecated
 - Add `withChoices` flag for Attribute type - #7733 by @dexon44
+`CheckoutAddPromoCode`, `CheckoutPaymentCreate` will raise a ValidationError when product in the checkout is
+unavailable - #8978 by @IKarbowiak
+- Fix disabled warehouses appearing as valid click and collect points when checkout contains only preorders - #9052 by rafalp
 
 
 # 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `withChoices` flag for Attribute type - #7733 by @dexon44
 `CheckoutAddPromoCode`, `CheckoutPaymentCreate` will raise a ValidationError when product in the checkout is
 unavailable - #8978 by @IKarbowiak
-- Fix disabled warehouses appearing as valid click and collect points when checkout contains only preorders - #9052 by rafalp
 - Fix disabled warehouses appearing as valid click and collect points when checkout contains only preorders - #9052 by @rafalp
 
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -45,6 +45,7 @@ from ....shipping import models as shipping_models
 from ....shipping.models import ShippingMethodTranslation
 from ....shipping.utils import convert_to_shipping_method_data
 from ....tests.utils import dummy_editorjs
+from ....warehouse import WarehouseClickAndCollectOption
 from ....warehouse.models import PreorderReservation, Reservation, Stock, Warehouse
 from ...tests.utils import assert_no_permission, get_graphql_content
 from ..mutations import (
@@ -2124,9 +2125,12 @@ query AvailableCollectionPoints($token: UUID!) {
 def test_available_collection_points_for_preorders_variants_in_checkout(
     api_client, staff_api_client, checkout_with_preorders_only
 ):
-
     expected_collection_points = list(
-        Warehouse.objects.for_country("US").values("name")
+        Warehouse.objects.for_country("US")
+        .exclude(
+            click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+        )
+        .values("name")
     )
     response = staff_api_client.post_graphql(
         QUERY_GET_ALL_COLLECTION_POINTS_FROM_CHECKOUT,

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -2008,6 +2008,63 @@ def test_checkout_complete_with_preorder_variant(
     order_confirmed_mock.assert_called_once_with(order)
 
 
+def test_checkout_complete_with_preorder_raises_InvalidShippingMethod_when_warehouse_disabled(
+    warehouse_for_cc,
+    checkout_with_items_for_cc,
+    address,
+    api_client,
+    payment_dummy,
+):
+    initial_order_count = Order.objects.count()
+    checkout = checkout_with_items_for_cc
+    variables = {"token": checkout.token, "redirectUrl": "https://www.example.com"}
+
+    checkout.billing_address = address
+    checkout.collection_point = warehouse_for_cc
+
+    checkout_line = checkout.lines.first()
+    checkout_line.variant.is_preorder = True
+    checkout_line.variant.preorder_global_threshold = 100
+    checkout_line.variant.save()
+
+    checkout.save(
+        update_fields=["shipping_address", "billing_address", "collection_point"]
+    )
+
+    warehouse_for_cc.click_and_collect_option = WarehouseClickAndCollectOption.DISABLED
+    warehouse_for_cc.save()
+
+    manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.checkout_total(
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
+    )
+
+    assert not checkout_info.valid_pick_up_points
+    assert not checkout_info.delivery_method_info.is_method_in_valid_methods(
+        checkout_info
+    )
+
+    payment = payment_dummy
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.checkout = checkout
+    payment.save()
+
+    assert not payment.transactions.exists()
+
+    response = api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+    content = get_graphql_content(response)["data"]["checkoutComplete"]
+
+    assert (
+        content["errors"][0]["code"] == CheckoutErrorCode.INVALID_SHIPPING_METHOD.name
+    )
+    assert Order.objects.count() == initial_order_count
+
+
 def test_checkout_complete_variant_channel_listing_does_not_exist(
     user_api_client,
     checkout_with_items,

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -2008,7 +2008,7 @@ def test_checkout_complete_with_preorder_variant(
     order_confirmed_mock.assert_called_once_with(order)
 
 
-def test_checkout_complete_with_preorder_raises_InvalidShippingMethod_when_warehouse_disabled(
+def test_checkout_complete_with_click_collect_preorder_fails_for_disabled_warehouse(
     warehouse_for_cc,
     checkout_with_items_for_cc,
     address,

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -2027,6 +2027,16 @@ def test_checkout_complete_with_click_collect_preorder_fails_for_disabled_wareho
     checkout_line.variant.preorder_global_threshold = 100
     checkout_line.variant.save()
 
+    for line in checkout.lines.all():
+        if line.variant.channel_listings.filter(channel=checkout.channel).exists():
+            continue
+
+        line.variant.channel_listings.create(
+            channel=checkout.channel,
+            price_amount=Decimal(15),
+            currency=checkout.currency,
+        )
+
     checkout.save(
         update_fields=["shipping_address", "billing_address", "collection_point"]
     )
@@ -2035,7 +2045,7 @@ def test_checkout_complete_with_click_collect_preorder_fails_for_disabled_wareho
     warehouse_for_cc.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -21,6 +21,7 @@ from ...payment import ChargeStatus
 from ...payment.models import Payment
 from ...plugins.manager import get_plugins_manager
 from ...product.models import Collection
+from ...warehouse import WarehouseClickAndCollectOption
 from ...warehouse.models import Stock, Warehouse
 from ...warehouse.tests.utils import get_quantity_allocated_for_stock
 from .. import FulfillmentStatus, OrderEvents, OrderStatus
@@ -1302,7 +1303,9 @@ def test_available_collection_points_for_preorders_variants_in_order(
     api_client, staff_api_client, order_with_preorder_lines, permission_manage_orders
 ):
     expected_collection_points = list(
-        Warehouse.objects.for_country("US").values("name")
+        Warehouse.objects.for_country("US").exclude(
+            click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+        ).values("name")
     )
     response = staff_api_client.post_graphql(
         GET_ORDER_AVAILABLE_COLLECTION_POINTS,

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -1303,9 +1303,11 @@ def test_available_collection_points_for_preorders_variants_in_order(
     api_client, staff_api_client, order_with_preorder_lines, permission_manage_orders
 ):
     expected_collection_points = list(
-        Warehouse.objects.for_country("US").exclude(
+        Warehouse.objects.for_country("US")
+        .exclude(
             click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
-        ).values("name")
+        )
+        .values("name")
     )
     response = staff_api_client.post_graphql(
         GET_ORDER_AVAILABLE_COLLECTION_POINTS,
@@ -1328,9 +1330,11 @@ def test_available_collection_points_for_preorders_and_regular_variants_in_order
     permission_manage_orders,
 ):
     expected_collection_points = list(
-        Warehouse.objects.for_country("US").exclude(
+        Warehouse.objects.for_country("US")
+        .exclude(
             click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
-        ).values("name")
+        )
+        .values("name")
     )
 
     response = staff_api_client.post_graphql(

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -1326,10 +1326,13 @@ def test_available_collection_points_for_preorders_and_regular_variants_in_order
     staff_api_client,
     order_with_preorder_lines,
     permission_manage_orders,
-    warehouse,
 ):
+    expected_collection_points = list(
+        Warehouse.objects.for_country("US").exclude(
+            click_and_collect_option=WarehouseClickAndCollectOption.DISABLED,
+        ).values("name")
+    )
 
-    expected_collection_points = [{"name": warehouse.name}]
     response = staff_api_client.post_graphql(
         GET_ORDER_AVAILABLE_COLLECTION_POINTS,
         variables={

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -107,11 +107,11 @@ class WarehouseQueryset(models.QuerySet):
         )
 
     def _for_country_click_and_collect(self, country: str) -> QuerySet["Warehouse"]:
-        warehouse_cc_option_enum = WarehouseClickAndCollectOption
-
         return self.for_country(country).filter(
-            Q(click_and_collect_option=warehouse_cc_option_enum.LOCAL_STOCK)
-            | Q(click_and_collect_option=warehouse_cc_option_enum.ALL_WAREHOUSES)
+            click_and_collect_option__in=[
+                WarehouseClickAndCollectOption.LOCAL_STOCK,
+                WarehouseClickAndCollectOption.ALL_WAREHOUSES
+            ]
         )
 
 

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -110,7 +110,7 @@ class WarehouseQueryset(models.QuerySet):
         return self.for_country(country).filter(
             click_and_collect_option__in=[
                 WarehouseClickAndCollectOption.LOCAL_STOCK,
-                WarehouseClickAndCollectOption.ALL_WAREHOUSES
+                WarehouseClickAndCollectOption.ALL_WAREHOUSES,
             ]
         )
 

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -43,7 +43,7 @@ class WarehouseQueryset(models.QuerySet):
             line.variant.is_preorder_active()
             for line in lines_qs.select_related("variant").only("variant_id")
         ):
-            return self.for_country(country)
+            return self._for_country_click_and_collect(country)
 
         stocks_qs = Stock.objects.filter(
             product_variant__id__in=lines_qs.values("variant_id"),
@@ -65,7 +65,7 @@ class WarehouseQueryset(models.QuerySet):
             line.variant.is_preorder_active()
             for line in lines_qs.select_related("variant").only("variant_id")
         ):
-            return self.for_country(country)
+            return self._for_country_click_and_collect(country)
 
         lines_quantity = (
             lines_qs.filter(variant_id=OuterRef("product_variant_id"))
@@ -104,6 +104,14 @@ class WarehouseQueryset(models.QuerySet):
                 & Q(click_and_collect_option=warehouse_cc_option_enum.LOCAL_STOCK)
                 | Q(click_and_collect_option=warehouse_cc_option_enum.ALL_WAREHOUSES)
             )
+        )
+
+    def _for_country_click_and_collect(self, country: str) -> QuerySet["Warehouse"]:
+        warehouse_cc_option_enum = WarehouseClickAndCollectOption
+
+        return self.for_country(country).filter(
+            Q(click_and_collect_option=warehouse_cc_option_enum.LOCAL_STOCK)
+            | Q(click_and_collect_option=warehouse_cc_option_enum.ALL_WAREHOUSES)
         )
 
 


### PR DESCRIPTION
This PR fixes disabled warehouses appearing on list of available click and collect points when checkout contains only preorders.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
