### PR TITLE
Fix incorrect handling of unavailable products in checkout

### DIFF
--- a/saleor/checkout/error_codes.py
+++ b/saleor/checkout/error_codes.py
@@ -28,3 +28,4 @@ class CheckoutErrorCode(Enum):
     CHANNEL_INACTIVE = "channel_inactive"
     UNAVAILABLE_VARIANT_IN_CHANNEL = "unavailable_variant_in_channel"
     EMAIL_NOT_SET = "email_not_set"
+    NO_LINES = "no_lines"

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -1,7 +1,17 @@
 import itertools
 from dataclasses import dataclass
 from functools import singledispatch
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from django.utils.encoding import smart_text
 from django.utils.functional import SimpleLazyObject
@@ -22,6 +32,7 @@ if TYPE_CHECKING:
     from ..product.models import (
         Collection,
         Product,
+        ProductChannelListing,
         ProductType,
         ProductVariant,
         ProductVariantChannelListing,
@@ -195,12 +206,13 @@ def get_delivery_method_info(
 
 def fetch_checkout_lines(
     checkout: "Checkout", prefetch_variant_attributes=False
-) -> Iterable[CheckoutLineInfo]:
+) -> Tuple[Iterable[CheckoutLineInfo], Iterable[int]]:
     """Fetch checkout lines as CheckoutLineInfo objects."""
-    from .utils import get_discounted_lines, get_voucher_for_checkout
+    from .utils import get_voucher_for_checkout
 
     prefetched_fields = [
         "variant__product__collections",
+        "variant__product__channel_listings__channel",
         "variant__channel_listings__channel",
         "variant__product__product_type",
     ]
@@ -213,6 +225,8 @@ def fetch_checkout_lines(
         )
     lines = checkout.lines.prefetch_related(*prefetched_fields)
     lines_info = []
+    unavailable_variant_pks = []
+    product_channel_listing_mapping: Dict[int, Optional["ProductChannelListing"]] = {}
 
     for line in lines:
         variant = line.variant
@@ -220,14 +234,14 @@ def fetch_checkout_lines(
         product_type = product.product_type
         collections = list(product.collections.all())
 
-        variant_channel_listing = None
-        for channel_listing in line.variant.channel_listings.all():
-            if channel_listing.channel_id == checkout.channel_id:
-                variant_channel_listing = channel_listing
+        variant_channel_listing = _get_variant_channel_listing(
+            variant, checkout.channel_id
+        )
 
-        # FIXME: Temporary solution to pass type checks. Figure out how to handle case
-        # when variant channel listing is not defined for a checkout line.
-        if not variant_channel_listing:
+        if not _is_variant_valid(
+            checkout, product, variant_channel_listing, product_channel_listing_mapping
+        ):
+            unavailable_variant_pks.append(variant.pk)
             continue
 
         lines_info.append(
@@ -240,6 +254,7 @@ def fetch_checkout_lines(
                 collections=collections,
             )
         )
+
     if checkout.voucher_code and lines_info:
         channel_slug = checkout.channel.slug
         voucher = get_voucher_for_checkout(
@@ -248,35 +263,83 @@ def fetch_checkout_lines(
         if not voucher:
             # in case when voucher is expired, it will be null so no need to apply any
             # discount from voucher
-            return lines_info
+            return lines_info, unavailable_variant_pks
         if voucher.type == VoucherType.SPECIFIC_PRODUCT or voucher.apply_once_per_order:
-            discounted_lines_by_voucher: List[CheckoutLineInfo] = []
-            if voucher.apply_once_per_order:
-                discounts = fetch_active_discounts()
-                channel = checkout.channel
-                cheapest_line_price = None
-                cheapest_line = None
-                for line_info in lines_info:
-                    line_price = line_info.variant.get_price(
-                        product=line_info.product,
-                        collections=line_info.collections,
-                        channel=channel,
-                        channel_listing=line_info.channel_listing,
-                        discounts=discounts,
-                    )
-                    if not cheapest_line or cheapest_line_price > line_price:
-                        cheapest_line_price = line_price
-                        cheapest_line = line_info
-                if cheapest_line:
-                    discounted_lines_by_voucher.append(cheapest_line)
-            else:
-                discounted_lines_by_voucher.extend(
-                    get_discounted_lines(lines_info, voucher)
-                )
-            for line_info in lines_info:
-                if line_info in discounted_lines_by_voucher:
-                    line_info.voucher = voucher
-    return lines_info
+            _apply_voucher_on_product(voucher, checkout, lines_info)
+    return lines_info, unavailable_variant_pks
+
+
+def _get_variant_channel_listing(variant: "ProductVariant", channel_id: int):
+    variant_channel_listing = None
+    for channel_listing in variant.channel_listings.all():
+        if channel_listing.channel_id == channel_id:
+            variant_channel_listing = channel_listing
+    return variant_channel_listing
+
+
+def _is_variant_valid(
+    checkout: "Checkout",
+    product: "Product",
+    variant_channel_listing: "ProductVariantChannelListing",
+    product_channel_listing_mapping: dict,
+):
+    if not variant_channel_listing or variant_channel_listing.price is None:
+        return False
+
+    product_channel_listing = _get_product_channel_listing(
+        product_channel_listing_mapping, checkout.channel_id, product
+    )
+
+    if (
+        not product_channel_listing
+        or product_channel_listing.is_available_for_purchase() is False
+    ):
+        return False
+
+    return True
+
+
+def _get_product_channel_listing(
+    product_channel_listing_mapping: dict, channel_id: int, product: "Product"
+):
+    product_channel_listing = product_channel_listing_mapping.get(product.id)
+    if product.id not in product_channel_listing_mapping:
+        for channel_listing in product.channel_listings.all():  # type: ignore
+            if channel_listing.channel_id == channel_id:
+                product_channel_listing = channel_listing
+        product_channel_listing_mapping[product.id] = product_channel_listing
+    return product_channel_listing
+
+
+def _apply_voucher_on_product(
+    voucher: "Voucher", checkout: "Checkout", lines_info: Iterable[CheckoutLineInfo]
+):
+    from .utils import get_discounted_lines
+
+    discounted_lines_by_voucher: List[CheckoutLineInfo] = []
+    if voucher.apply_once_per_order:
+        discounts = fetch_active_discounts()
+        channel = checkout.channel
+        cheapest_line_price = None
+        cheapest_line = None
+        for line_info in lines_info:
+            line_price = line_info.variant.get_price(
+                product=line_info.product,
+                collections=line_info.collections,
+                channel=channel,
+                channel_listing=line_info.channel_listing,
+                discounts=discounts,
+            )
+            if not cheapest_line or cheapest_line_price > line_price:
+                cheapest_line_price = line_price
+                cheapest_line = line_info
+        if cheapest_line:
+            discounted_lines_by_voucher.append(cheapest_line)
+    else:
+        discounted_lines_by_voucher.extend(get_discounted_lines(lines_info, voucher))
+    for line_info in lines_info:
+        if line_info in discounted_lines_by_voucher:
+            line_info.voucher = voucher
 
 
 def fetch_checkout_info(

--- a/saleor/checkout/tests/test_base_calculations.py
+++ b/saleor/checkout/tests/test_base_calculations.py
@@ -14,7 +14,8 @@ from ..fetch import fetch_checkout_lines
 
 def test_calculate_base_line_unit_price(checkout_with_single_item):
     # given
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert not checkout_line_info.voucher
     variant = checkout_line_info.variant
 
@@ -40,7 +41,8 @@ def test_calculate_base_line_unit_price_with_variant_on_sale(
     checkout_with_single_item, discount_info, category
 ):
     # given
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert not checkout_line_info.voucher
     variant = checkout_line_info.variant
     # set category on sale
@@ -93,7 +95,8 @@ def test_calculate_base_line_unit_price_with_fixed_voucher(
     voucher_channel_listing.save()
 
     checkout_with_single_item.voucher_code = voucher.code
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert checkout_line_info.voucher
     variant = checkout_line_info.variant
 
@@ -132,7 +135,8 @@ def test_calculate_base_line_unit_price_with_percentage_voucher(
     voucher_channel_listing.save()
 
     checkout_with_single_item.voucher_code = voucher.code
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert checkout_line_info.voucher
     variant = checkout_line_info.variant
 
@@ -173,7 +177,8 @@ def test_calculate_base_line_unit_price_with_discounts_apply_once_per_order(
     voucher_channel_listing.save()
 
     checkout_with_single_item.voucher_code = voucher.code
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert checkout_line_info.voucher
     variant = checkout_line_info.variant
 
@@ -209,7 +214,8 @@ def test_calculate_base_line_unit_price_with_variant_on_sale_and_voucher(
     voucher_channel_listing.discount = voucher_amount
     voucher_channel_listing.save()
     checkout_with_single_item.voucher_code = voucher.code
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert checkout_line_info.voucher
     variant = checkout_line_info.variant
 
@@ -254,7 +260,8 @@ def test_calculate_base_line_total_price(checkout_with_single_item):
     checkout_line.quantity = quantity
     checkout_line.save()
 
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert not checkout_line_info.voucher
     variant = checkout_line_info.variant
 
@@ -285,7 +292,8 @@ def test_calculate_base_line_total_price_with_variant_on_sale(
     checkout_line.quantity = quantity
     checkout_line.save()
 
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert not checkout_line_info.voucher
     variant = checkout_line_info.variant
     # set category on sale
@@ -343,7 +351,8 @@ def test_calculate_base_line_total_price_with_fixed_voucher(
     voucher_channel_listing.save()
 
     checkout_with_single_item.voucher_code = voucher.code
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert checkout_line_info.voucher
     variant = checkout_line_info.variant
 
@@ -390,7 +399,8 @@ def test_calculate_base_line_total_price_with_percentage_voucher(
     voucher_channel_listing.save()
 
     checkout_with_single_item.voucher_code = voucher.code
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert checkout_line_info.voucher
     variant = checkout_line_info.variant
 
@@ -439,7 +449,8 @@ def test_calculate_base_line_total_price_with_discounts_apply_once_per_order(
     voucher_channel_listing.save()
 
     checkout_with_single_item.voucher_code = voucher.code
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert checkout_line_info.voucher
     variant = checkout_line_info.variant
 
@@ -487,7 +498,8 @@ def test_calculate_base_line_total_price_with_variant_on_sale_and_voucher(
     voucher_channel_listing.save()
 
     checkout_with_single_item.voucher_code = voucher.code
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert checkout_line_info.voucher
     variant = checkout_line_info.variant
 
@@ -550,7 +562,8 @@ def test_calculate_base_line_total_price_with_variant_on_sale_and_voucher_applie
     voucher_channel_listing.save()
 
     checkout_with_single_item.voucher_code = voucher.code
-    checkout_line_info = fetch_checkout_lines(checkout_with_single_item)[0]
+    checkout_lines_info, _ = fetch_checkout_lines(checkout_with_single_item)
+    checkout_line_info = checkout_lines_info[0]
     assert checkout_line_info.voucher
     variant = checkout_line_info.variant
 

--- a/saleor/checkout/tests/test_cart.py
+++ b/saleor/checkout/tests/test_cart.py
@@ -35,7 +35,7 @@ def test_adding_same_variant(checkout, product):
     checkout_info = fetch_checkout_info(checkout, [], [], get_plugins_manager())
     add_variant_to_checkout(checkout_info, variant, 1)
     add_variant_to_checkout(checkout_info, variant, 2)
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_quantity = calculate_checkout_quantity(lines)
     assert checkout.lines.count() == 1
     assert checkout_quantity == 3
@@ -59,7 +59,7 @@ def test_replacing_same_variant(checkout, product):
     checkout_info = fetch_checkout_info(checkout, [], [], get_plugins_manager())
     add_variant_to_checkout(checkout_info, variant, 1, replace=True)
     add_variant_to_checkout(checkout_info, variant, 2, replace=True)
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     assert calculate_checkout_quantity(lines) == 2
 
@@ -104,7 +104,7 @@ def test_get_prices_of_discounted_specific_product(
     voucher.categories.add(category)
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     prices = utils.get_prices_of_discounted_specific_product(
         manager, checkout_info, lines, voucher
@@ -136,7 +136,7 @@ def test_get_prices_of_discounted_specific_product_only_product(
     add_variant_to_checkout(checkout_info, product2.variants.get(), 1)
     voucher.products.add(product)
 
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     prices = utils.get_prices_of_discounted_specific_product(
         manager, checkout_info, lines, voucher
     )
@@ -170,7 +170,7 @@ def test_get_prices_of_discounted_specific_product_only_collection(
     product.collections.add(collection)
     voucher.collections.add(collection)
 
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     prices = utils.get_prices_of_discounted_specific_product(
         manager, checkout_info, lines, voucher
     )
@@ -206,7 +206,7 @@ def test_get_prices_of_discounted_specific_product_only_category(
     add_variant_to_checkout(checkout_info, product2.variants.get(), 1)
     voucher.categories.add(category)
 
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     prices = utils.get_prices_of_discounted_specific_product(
         manager, checkout_info, lines, voucher
     )
@@ -231,7 +231,7 @@ def test_get_prices_of_discounted_specific_product_all_products(
     variant_channel_listing = line.variant.channel_listings.get(channel=channel)
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     prices = utils.get_prices_of_discounted_specific_product(
         manager, checkout_info, lines, voucher
@@ -272,5 +272,5 @@ def test_get_total_weight(checkout_with_item):
     variant.save()
     line.quantity = 6
     line.save()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     assert checkout_with_item.get_total_weight(lines) == Weight(kg=60)

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -52,7 +52,7 @@ def test_is_valid_delivery_method(checkout_with_item, address, shipping_zone):
     checkout.shipping_address = address
     checkout.save()
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     delivery_method_info = checkout_info.delivery_method_info
     # no shipping method assigned
@@ -100,7 +100,7 @@ def test_is_valid_delivery_method_external_method(
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     delivery_method_info = checkout_info.delivery_method_info
 
@@ -130,7 +130,7 @@ def test_is_valid_delivery_method_external_method_no_longer_available(
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     delivery_method_info = checkout_info.delivery_method_info
 
@@ -244,7 +244,7 @@ def test_get_voucher_discount_for_checkout_voucher_validation(
     mock_validate_voucher, voucher, checkout_with_voucher
 ):
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_voucher)
+    lines, _ = fetch_checkout_lines(checkout_with_voucher)
     quantity = calculate_checkout_quantity(lines)
     checkout_info = fetch_checkout_info(checkout_with_voucher, lines, [], manager)
     manager = get_plugins_manager()
@@ -353,7 +353,7 @@ def test_get_discount_for_checkout_specific_products_voucher(
     for product in product_list:
         voucher.products.add(product)
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_items)
+    lines, _ = fetch_checkout_lines(checkout_with_items)
     checkout_info = fetch_checkout_info(checkout_with_items, lines, [], manager)
     discount = get_voucher_discount_for_checkout(
         manager, voucher, checkout_info, lines, None, []
@@ -798,7 +798,7 @@ def test_recalculate_checkout_discount(
     voucher.channel_listings.filter(channel=channel_USD).update(discount_value=10)
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_voucher)
+    lines, _ = fetch_checkout_lines(checkout_with_voucher)
     checkout_info = fetch_checkout_info(checkout_with_voucher, lines, [], manager)
 
     recalculate_checkout_discount(manager, checkout_info, lines, None)
@@ -813,7 +813,7 @@ def test_recalculate_checkout_discount_with_sale(
 ):
     checkout = checkout_with_voucher_percentage
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     recalculate_checkout_discount(manager, checkout_info, lines, [discount_info])
@@ -837,7 +837,7 @@ def test_recalculate_checkout_discount_voucher_not_applicable(
     voucher.channel_listings.filter(channel=channel_USD).update(min_spent_amount=100)
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     recalculate_checkout_discount(manager, checkout_info, lines, None)
 
@@ -853,7 +853,7 @@ def test_recalculate_checkout_discount_expired_voucher(checkout_with_voucher, vo
     voucher.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     recalculate_checkout_discount(manager, checkout_info, lines, None)
 
@@ -870,7 +870,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_less_than_shipping
 ):
     checkout = checkout_with_voucher_percentage_and_shipping
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     channel_listing = shipping_method.channel_listings.get(channel_id=channel_USD.id)
     channel_listing.price = (
@@ -912,7 +912,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_bigger_than_shippi
 ):
     checkout = checkout_with_voucher_percentage_and_shipping
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     channel_listing = shipping_method.channel_listings.get(channel=channel_USD)
     channel_listing.price = (
@@ -951,7 +951,7 @@ def test_recalculate_checkout_discount_free_shipping_for_checkout_without_shippi
 ):
     checkout = checkout_with_voucher_percentage
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     recalculate_checkout_discount(manager, checkout_info, lines, None)
 
@@ -962,7 +962,7 @@ def test_recalculate_checkout_discount_free_shipping_for_checkout_without_shippi
 
 def test_change_address_in_checkout(checkout, address):
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     change_shipping_address_in_checkout(
         checkout_info,
@@ -986,7 +986,7 @@ def test_change_address_in_checkout_to_none(checkout, address):
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     change_shipping_address_in_checkout(
         checkout_info,
@@ -1012,7 +1012,7 @@ def test_change_address_in_checkout_to_same(checkout, address):
     billing_address_id = checkout.billing_address.id
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     change_shipping_address_in_checkout(
         checkout_info,
@@ -1038,7 +1038,7 @@ def test_change_address_in_checkout_to_other(checkout, address):
     other_address = Address.objects.create(country=Country("DE"))
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     change_shipping_address_in_checkout(
         checkout_info,
@@ -1068,7 +1068,7 @@ def test_change_address_in_checkout_from_user_address_to_other(
     other_address = Address.objects.create(country=Country("DE"))
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     change_shipping_address_in_checkout(
         checkout_info,
@@ -1090,7 +1090,7 @@ def test_change_address_in_checkout_from_user_address_to_other(
 def test_add_voucher_to_checkout(checkout_with_item, voucher):
     assert checkout_with_item.voucher_code is None
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     add_voucher_to_checkout(manager, checkout_info, lines, voucher)
     assert checkout_with_item.voucher_code == voucher.code
@@ -1102,7 +1102,7 @@ def test_add_staff_voucher_to_anonymous_checkout(checkout_with_item, voucher):
 
     assert checkout_with_item.voucher_code is None
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     with pytest.raises(NotApplicable):
         add_voucher_to_checkout(manager, checkout_info, lines, voucher)
@@ -1118,7 +1118,7 @@ def test_add_staff_voucher_to_customer_checkout(
 
     assert checkout_with_item.voucher_code is None
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     with pytest.raises(NotApplicable):
         add_voucher_to_checkout(manager, checkout_info, lines, voucher)
@@ -1132,7 +1132,7 @@ def test_add_staff_voucher_to_staff_checkout(checkout_with_item, voucher, staff_
 
     assert checkout_with_item.voucher_code is None
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     add_voucher_to_checkout(manager, checkout_info, lines, voucher)
@@ -1142,7 +1142,7 @@ def test_add_voucher_to_checkout_fail(
     checkout_with_item, voucher_with_high_min_spent_amount
 ):
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     with pytest.raises(NotApplicable):
         add_voucher_to_checkout(
@@ -1222,7 +1222,7 @@ def test_get_last_active_payment(checkout_with_payments):
 def test_is_fully_paid(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager,
@@ -1244,7 +1244,7 @@ def test_is_fully_paid(checkout_with_item, payment_dummy):
 def test_is_fully_paid_many_payments(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager,
@@ -1274,7 +1274,7 @@ def test_is_fully_paid_many_payments(checkout_with_item, payment_dummy):
 def test_is_fully_paid_partially_paid(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager,
@@ -1296,7 +1296,7 @@ def test_is_fully_paid_partially_paid(checkout_with_item, payment_dummy):
 def test_is_fully_paid_no_payment(checkout_with_item):
     checkout = checkout_with_item
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     is_paid = is_fully_paid(manager, checkout_info, lines, None)
     assert not is_paid
@@ -1320,7 +1320,7 @@ def test_chckout_without_delivery_method_creates_empty_delivery_method(
 ):
     checkout = checkout_with_item
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     delivery_method_info = checkout_info.delivery_method_info
 

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -51,7 +51,7 @@ def test_create_order_captured_payment_creates_expected_events(
 
     # Place checkout
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     order = _create_order(
         checkout_info=checkout_info,
@@ -201,7 +201,7 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
 
     # Place checkout
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     order = _create_order(
         checkout_info=checkout_info,
@@ -346,7 +346,7 @@ def test_create_order_preauth_payment_creates_expected_events(
 
     # Place checkout
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     order = _create_order(
         checkout_info=checkout_info,
@@ -459,7 +459,7 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
 
     # Place checkout
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     order = _create_order(
         checkout_info=checkout_info,
@@ -551,7 +551,7 @@ def test_create_order_insufficient_stock(
     checkout.tracking_code = "tracking_code"
     checkout.save()
 
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     with pytest.raises(InsufficientStock):
         _prepare_order_data(
             manager=manager,
@@ -575,7 +575,7 @@ def test_create_order_doesnt_duplicate_order(
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     order_data = _prepare_order_data(
         manager=manager,
@@ -621,7 +621,7 @@ def test_create_order_with_gift_card(
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     subtotal = calculations.checkout_subtotal(
@@ -678,7 +678,7 @@ def test_create_order_with_gift_card_partial_use(
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     price_without_gift_card = calculations.checkout_total(
@@ -738,7 +738,7 @@ def test_create_order_with_many_gift_cards(
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     price_without_gift_card = calculations.checkout_total(
@@ -809,7 +809,7 @@ def test_create_order_gift_card_bought(
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     subtotal = calculations.checkout_subtotal(
@@ -888,7 +888,7 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     subtotal = calculations.checkout_subtotal(
@@ -948,7 +948,7 @@ def test_create_order_gift_card_bought_do_not_fulfill_gift_cards_automatically(
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     subtotal = calculations.checkout_subtotal(
@@ -991,7 +991,7 @@ def test_note_in_created_order(checkout_with_item, address, customer_user):
     checkout_with_item.redirect_url = "https://www.example.com"
     checkout_with_item.save()
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     order = _create_order(
         checkout_info=checkout_info,
@@ -1024,7 +1024,7 @@ def test_create_order_with_variant_tracking_false(
     checkout_info = fetch_checkout_info(checkout, [], [], manager)
     add_variant_to_checkout(checkout_info, variant, 10, check_quantity=False)
 
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     order_data = _prepare_order_data(
         manager=manager,
         checkout_info=checkout_info,
@@ -1062,7 +1062,7 @@ def test_create_order_use_translations(
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     variant = lines[0].variant
@@ -1111,7 +1111,7 @@ def test_complete_checkout_0_total_captured_payment_creates_expected_events(
 
     # Place checkout
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     order, action_required, action_data = complete_checkout(
         checkout_info=checkout_info,

--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -410,7 +410,7 @@ def test_specific_products_voucher_checkout_discount(
     )
     checkout = checkout_with_item
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
     manager = get_plugins_manager()
     discount = get_voucher_discount_for_checkout(

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -32,7 +32,6 @@ from ...checkout.utils import (
     remove_promo_code_from_checkout,
     remove_voucher_from_checkout,
     set_external_shipping_id,
-    validate_variants_in_checkout_lines,
 )
 from ...core import analytics
 from ...core.exceptions import InsufficientStock, PermissionDenied
@@ -596,7 +595,7 @@ class CheckoutLinesAdd(BaseMutation):
                 reservation_length=get_reservation_length(info.context),
             )
 
-        lines = fetch_checkout_lines(checkout)
+        lines, _ = fetch_checkout_lines(checkout)
         shipping_channel_listings = checkout.channel.shipping_method_listings.all()
         update_delivery_method_lists_for_checkout_info(
             checkout_info,
@@ -639,7 +638,7 @@ class CheckoutLinesAdd(BaseMutation):
             checkout, [], discounts, manager, shipping_channel_listings
         )
 
-        lines = fetch_checkout_lines(checkout)
+        lines, _ = fetch_checkout_lines(checkout)
         lines = cls.clean_input(
             info,
             checkout,
@@ -743,7 +742,7 @@ class CheckoutLinesDelete(BaseMutation):
         cls.validate_lines(checkout, lines_to_delete)
         checkout.lines.filter(id__in=lines_to_delete).delete()
 
-        lines = fetch_checkout_lines(checkout)
+        lines, _ = fetch_checkout_lines(checkout)
 
         manager = info.context.plugins
         checkout_info = fetch_checkout_info(
@@ -798,7 +797,7 @@ class CheckoutLineDelete(BaseMutation):
             line.delete()
 
         manager = info.context.plugins
-        lines = fetch_checkout_lines(checkout)
+        lines, _ = fetch_checkout_lines(checkout)
         checkout_info = fetch_checkout_info(
             checkout, lines, info.context.discounts, manager
         )
@@ -1009,7 +1008,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
                     }
                 )
 
-        lines = fetch_checkout_lines(checkout)
+        lines, _ = fetch_checkout_lines(checkout)
         if not is_shipping_required(lines):
             raise ValidationError(
                 {
@@ -1262,7 +1261,23 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             )
 
         manager = info.context.plugins
-        lines = fetch_checkout_lines(checkout)
+
+        lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
+        if unavailable_variant_pks:
+            not_available_variants_ids = {
+                graphene.Node.to_global_id("ProductVariant", pk)
+                for pk in unavailable_variant_pks
+            }
+            raise ValidationError(
+                {
+                    "lines": ValidationError(
+                        "Some of the checkout lines variants are unavailable.",
+                        code=CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.value,
+                        params={"variants": not_available_variants_ids},
+                    )
+                }
+            )
+
         checkout_info = fetch_checkout_info(
             checkout, lines, info.context.discounts, manager
         )
@@ -1566,10 +1581,22 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
         checkout = get_checkout_by_token(token)
 
         manager = info.context.plugins
-        lines = fetch_checkout_lines(checkout)
-        checkout_info = fetch_checkout_info(
-            checkout, lines, info.context.discounts, manager
-        )
+        lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
+        if unavailable_variant_pks:
+            not_available_variants_ids = {
+                graphene.Node.to_global_id("ProductVariant", pk)
+                for pk in unavailable_variant_pks
+            }
+            raise ValidationError(
+                {
+                    "lines": ValidationError(
+                        "Some of the checkout lines variants are unavailable.",
+                        code=CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.value,
+                        params={"variants": not_available_variants_ids},
+                    )
+                }
+            )
+
         if not is_shipping_required(lines):
             raise ValidationError(
                 {
@@ -1581,6 +1608,9 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             )
         type_name = cls._resolve_delivery_method_type(delivery_method_id)
 
+        checkout_info = fetch_checkout_info(
+            checkout, lines, info.context.discounts, manager
+        )
         if type_name == "Warehouse":
             return cls.perform_on_collection_point(
                 info, delivery_method_id, checkout_info, lines, checkout, manager
@@ -1703,8 +1733,30 @@ class CheckoutComplete(BaseMutation):
             validate_checkout_email(checkout)
 
             manager = info.context.plugins
-            lines = fetch_checkout_lines(checkout)
-            validate_variants_in_checkout_lines(lines)
+            lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
+            if unavailable_variant_pks:
+                not_available_variants_ids = {
+                    graphene.Node.to_global_id("ProductVariant", pk)
+                    for pk in unavailable_variant_pks
+                }
+                raise ValidationError(
+                    {
+                        "lines": ValidationError(
+                            "Some of the checkout lines variants are unavailable.",
+                            code=CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.value,
+                            params={"variants": not_available_variants_ids},
+                        )
+                    }
+                )
+            if not lines:
+                raise ValidationError(
+                    {
+                        "lines": ValidationError(
+                            "Cannot complete checkout without lines.",
+                            code=CheckoutErrorCode.NO_LINES.value,
+                        )
+                    }
+                )
             checkout_info = fetch_checkout_info(
                 checkout, lines, info.context.discounts, manager
             )
@@ -1780,7 +1832,23 @@ class CheckoutAddPromoCode(BaseMutation):
 
         manager = info.context.plugins
         discounts = info.context.discounts
-        lines = fetch_checkout_lines(checkout)
+
+        lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
+        if unavailable_variant_pks:
+            not_available_variants_ids = {
+                graphene.Node.to_global_id("ProductVariant", pk)
+                for pk in unavailable_variant_pks
+            }
+            raise ValidationError(
+                {
+                    "lines": ValidationError(
+                        "Some of the checkout lines variants are unavailable.",
+                        code=CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.value,
+                        params={"variants": not_available_variants_ids},
+                    )
+                }
+            )
+
         shipping_channel_listings = checkout.channel.shipping_method_listings.all()
         checkout_info = fetch_checkout_info(
             checkout, lines, discounts, manager, shipping_channel_listings

--- a/saleor/graphql/checkout/tests/benchmark/conftest.py
+++ b/saleor/graphql/checkout/tests/benchmark/conftest.py
@@ -120,7 +120,7 @@ def checkout_with_billing_address_for_cc(checkout_with_delivery_method_for_cc, a
 def checkout_with_voucher(checkout_with_billing_address, voucher):
     checkout = checkout_with_billing_address
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     add_voucher_to_checkout(manager, checkout_info, lines, voucher)
     return checkout
@@ -130,7 +130,7 @@ def checkout_with_voucher(checkout_with_billing_address, voucher):
 def checkout_with_charged_payment(checkout_with_voucher):
     checkout = checkout_with_voucher
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout_with_voucher, lines, [], manager)
     manager = get_plugins_manager()
     taxed_total = calculations.checkout_total(
@@ -174,7 +174,7 @@ def checkout_with_digital_line_with_charged_payment(
     checkout_info = fetch_checkout_info(checkout, [], [], get_plugins_manager())
     add_variant_to_checkout(checkout_info, variant, 1)
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     taxed_total = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,
@@ -206,7 +206,7 @@ def checkout_with_digital_line_with_charged_payment(
 def checkout_with_charged_payment_for_cc(checkout_with_billing_address_for_cc):
     checkout = checkout_with_billing_address_for_cc
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     manager = get_plugins_manager()
     taxed_total = calculations.checkout_total(
@@ -245,12 +245,12 @@ def checkout_preorder_with_charged_payment(
 ):
     checkout = checkout_with_billing_address
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     add_variant_to_checkout(checkout_info, preorder_variant_channel_threshold, 1)
     add_variant_to_checkout(checkout_info, preorder_variant_global_threshold, 1)
 
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     manager = get_plugins_manager()
     taxed_total = calculations.checkout_total(
         manager=manager,

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -706,7 +706,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-    with django_assert_num_queries(53):
+    with django_assert_num_queries(57):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "token": checkout.token,
@@ -720,7 +720,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(53):
+    with django_assert_num_queries(57):
         variables = {
             "token": checkout.token,
             "lines": [],
@@ -961,7 +961,7 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(53):
+    with django_assert_num_queries(57):
         variables = {
             "checkoutId": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -974,7 +974,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(53):
+    with django_assert_num_queries(57):
         variables = {
             "checkoutId": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,
@@ -1099,7 +1099,7 @@ def test_checkout_payment_charge(
     """
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_billing_address)
+    lines, _ = fetch_checkout_lines(checkout_with_billing_address)
     checkout_info = fetch_checkout_info(
         checkout_with_billing_address, lines, [], manager
     )

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_complete.py
@@ -90,7 +90,7 @@ def test_checkout_complete(
     checkout_line_variant = checkout_line.variant
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_line_delete.py
@@ -39,7 +39,7 @@ def test_checkout_line_delete_by_id(
     mocked_update_shipping_method, user_api_client, checkout_with_item
 ):
     checkout = checkout_with_item
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
@@ -55,7 +55,7 @@ def test_checkout_line_delete_by_id(
     data = content["data"]["checkoutLineDelete"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 0
     assert calculate_checkout_quantity(lines) == 0
     manager = get_plugins_manager()

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_add.py
@@ -43,7 +43,7 @@ def test_checkout_lines_add_by_checkout_id(
     variant = stock.product_variant
     checkout = checkout_with_item
     line = checkout.lines.first()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
@@ -58,14 +58,14 @@ def test_checkout_lines_add_by_checkout_id(
     data = content["data"]["checkoutLinesAdd"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     line = checkout.lines.latest("pk")
     assert line.variant == variant
     assert line.quantity == 1
     assert calculate_checkout_quantity(lines) == 4
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_update.py
@@ -42,7 +42,7 @@ def test_checkout_lines_update(
     mocked_update_shipping_method, user_api_client, checkout_with_item
 ):
     checkout = checkout_with_item
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     assert calculate_checkout_quantity(lines) == 3
     line = checkout.lines.first()
@@ -62,7 +62,7 @@ def test_checkout_lines_update(
     data = content["data"]["checkoutLinesUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     assert line.variant == variant
@@ -70,7 +70,7 @@ def test_checkout_lines_update(
     assert calculate_checkout_quantity(lines) == 1
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_address_update.py
@@ -66,7 +66,7 @@ def test_checkout_shipping_address_update_by_id(
     assert checkout.shipping_address.country == shipping_address["country"]
     assert checkout.shipping_address.city == shipping_address["city"].upper()
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_method_update.py
@@ -57,7 +57,7 @@ def test_checkout_shipping_method_update_by_id(
     checkout.refresh_from_db()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     checkout_info.delivery_method_info = get_delivery_method_info(
         convert_to_shipping_method_data(
@@ -102,7 +102,7 @@ def test_checkout_shipping_method_update_by_token(
     checkout.refresh_from_db()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     checkout_info.delivery_method_info = get_delivery_method_info(
         convert_to_shipping_method_data(

--- a/saleor/graphql/checkout/tests/test_checkout_digital.py
+++ b/saleor/graphql/checkout/tests/test_checkout_digital.py
@@ -162,7 +162,7 @@ def test_remove_shipping_method_if_only_digital_in_checkout(
 
     assert checkout.shipping_method
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     update_checkout_shipping_method_if_invalid(checkout_info, lines)
 

--- a/saleor/graphql/checkout/tests/test_checkout_lines.py
+++ b/saleor/graphql/checkout/tests/test_checkout_lines.py
@@ -56,7 +56,7 @@ def test_checkout_lines_add(
     variant = stock.product_variant
     checkout = checkout_with_item
     line = checkout.lines.first()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     previous_last_change = checkout.last_change
@@ -71,7 +71,7 @@ def test_checkout_lines_add(
     data = content["data"]["checkoutLinesAdd"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     line = checkout.lines.latest("pk")
     assert line.variant == variant
     assert line.quantity == 1
@@ -79,7 +79,7 @@ def test_checkout_lines_add(
     assert not Reservation.objects.exists()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change
@@ -91,7 +91,7 @@ def test_checkout_lines_add_with_reservations(
     variant = stock.product_variant
     checkout = checkout_with_item
     line = checkout.lines.first()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
 
@@ -105,7 +105,7 @@ def test_checkout_lines_add_with_reservations(
     data = content["data"]["checkoutLinesAdd"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     line = checkout.lines.latest("pk")
     assert line.variant == variant
     assert line.quantity == 1
@@ -126,7 +126,7 @@ def test_checkout_lines_add_updates_reservation(
     variant = checkout_line_with_one_reservation.variant
     checkout = checkout_line_with_one_reservation.checkout
     line = checkout_line_with_one_reservation
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 2
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
 
@@ -140,7 +140,7 @@ def test_checkout_lines_add_updates_reservation(
     data = content["data"]["checkoutLinesAdd"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     line = checkout.lines.latest("pk")
     assert line.variant == variant
     assert line.quantity == 3
@@ -163,7 +163,7 @@ def test_checkout_lines_add_new_variant_updates_other_lines_reservations_expirat
     checkout = checkout_line_with_one_reservation.checkout
     line = checkout_line_with_one_reservation
     reservation = line.reservations.get()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 2
 
     variant_other = product.variants.create(sku="SKU_B")
@@ -188,7 +188,7 @@ def test_checkout_lines_add_new_variant_updates_other_lines_reservations_expirat
     data = content["data"]["checkoutLinesAdd"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     line.refresh_from_db()
     assert line.variant == variant
     assert line.quantity == 2
@@ -655,7 +655,7 @@ def test_checkout_lines_update(
     mocked_update_shipping_method, user_api_client, checkout_with_item
 ):
     checkout = checkout_with_item
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     assert calculate_checkout_quantity(lines) == 3
     line = checkout.lines.first()
@@ -675,7 +675,7 @@ def test_checkout_lines_update(
     data = content["data"]["checkoutLinesUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     assert line.variant == variant
@@ -683,7 +683,7 @@ def test_checkout_lines_update(
     assert calculate_checkout_quantity(lines) == 1
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change
@@ -696,7 +696,7 @@ def test_checkout_lines_update_with_new_reservations(
 ):
     assert Reservation.objects.count() == 2
     checkout = checkout_line_with_reservation_in_many_stocks.checkout
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     assert calculate_checkout_quantity(lines) == 3
     line = checkout.lines.first()
@@ -719,7 +719,7 @@ def test_checkout_lines_update_with_new_reservations(
     data = content["data"]["checkoutLinesUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     assert line.variant == variant
@@ -741,7 +741,7 @@ def test_checkout_lines_update_against_reserved_stock(
 ):
     assert Reservation.objects.count() == 0
     checkout = checkout_line.checkout
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     assert calculate_checkout_quantity(lines) == 3
     variant = checkout_line.variant
@@ -776,7 +776,7 @@ def test_checkout_lines_update_against_reserved_stock(
     assert data["errors"][0]["field"] == "quantity"
 
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     assert line.variant == variant
@@ -798,7 +798,7 @@ def test_checkout_lines_update_other_lines_reservations_expirations(
     line = checkout_line_with_one_reservation
     reservation = line.reservations.get()
     checkout_info = fetch_checkout_info(checkout, [], [], get_plugins_manager())
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 2
 
     variant_other = product.variants.create(sku="SKU_B")
@@ -823,7 +823,7 @@ def test_checkout_lines_update_other_lines_reservations_expirations(
     data = content["data"]["checkoutLinesUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     line.refresh_from_db()
     assert line.variant == variant
     assert line.quantity == 2
@@ -975,7 +975,7 @@ def test_checkout_line_delete_by_zero_quantity(
     checkout.refresh_from_db()
     assert checkout.lines.count() == 0
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change
@@ -1010,7 +1010,7 @@ def test_checkout_line_delete_by_zero_quantity_when_variant_unavailable_for_purc
     checkout.refresh_from_db()
     assert checkout.lines.count() == 0
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
@@ -1045,7 +1045,7 @@ def test_checkout_line_update_by_zero_quantity_dont_create_new_lines(
     checkout.refresh_from_db()
     assert checkout.lines.count() == 0
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change
@@ -1125,7 +1125,7 @@ def test_checkout_lines_update_with_chosen_shipping(
     data = content["data"]["checkoutLinesUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 1
 
 
@@ -1162,7 +1162,7 @@ def test_checkout_line_delete(
     assert Reservation.objects.count() == 2
     checkout = checkout_line_with_reservation_in_many_stocks.checkout
     previous_last_change = checkout.last_change
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
@@ -1177,7 +1177,7 @@ def test_checkout_line_delete(
     data = content["data"]["checkoutLineDelete"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 0
     assert calculate_checkout_quantity(lines) == 0
     assert Reservation.objects.count() == 0
@@ -1235,7 +1235,7 @@ def test_checkout_lines_delete(
     data = content["data"]["checkoutLinesDelete"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() + len(lines_list) == checkout_lines_count
     remaining_lines = data["checkout"]["lines"]
     lines_ids = [line["id"] for line in remaining_lines]

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -317,6 +317,11 @@ class PageError(Error):
 
 class PaymentError(Error):
     code = PaymentErrorCode(description="The error code.", required=True)
+    variants = graphene.List(
+        graphene.NonNull(graphene.ID),
+        description="List of varint IDs which causes the error.",
+        required=False,
+    )
 
 
 class GiftCardError(Error):

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -224,7 +224,30 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         cls.validate_gateway(manager, gateway, checkout.currency)
         cls.validate_return_url(data)
 
-        lines = fetch_checkout_lines(checkout)
+        lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
+        if unavailable_variant_pks:
+            not_available_variants_ids = {
+                graphene.Node.to_global_id("ProductVariant", pk)
+                for pk in unavailable_variant_pks
+            }
+            raise ValidationError(
+                {
+                    "token": ValidationError(
+                        "Some of the checkout lines variants are unavailable.",
+                        code=PaymentErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.value,
+                        params={"variants": not_available_variants_ids},
+                    )
+                }
+            )
+        if not lines:
+            raise ValidationError(
+                {
+                    "lines": ValidationError(
+                        "Cannot create payment for checkout without lines.",
+                        code=PaymentErrorCode.NO_CHECKOUT_LINES.value,
+                    )
+                }
+            )
         checkout_info = fetch_checkout_info(
             checkout, lines, info.context.discounts, manager
         )

--- a/saleor/graphql/payment/tests/deprecated/test_checkout_payment_create.py
+++ b/saleor/graphql/payment/tests/deprecated/test_checkout_payment_create.py
@@ -35,7 +35,7 @@ def test_checkout_add_payment_by_checkout_id(
 
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
@@ -72,7 +72,7 @@ def test_checkout_add_payment_neither_token_and_id_given(
     checkout.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
@@ -101,7 +101,7 @@ def test_checkout_add_payment_both_token_and_id_given(
 
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -590,7 +590,7 @@ def test_delete_products_removes_checkout_lines(
     # given
     checkout = checkout_with_items
     lines_count = checkout.lines.count()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     old_quantity = calculate_checkout_quantity(lines)
 
     query = DELETE_PRODUCTS_MUTATION
@@ -608,7 +608,7 @@ def test_delete_products_removes_checkout_lines(
     assert content["data"]["productBulkDelete"]["count"] == 3
 
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == lines_count - 3
     assert old_quantity == calculate_checkout_quantity(lines) + 3
 
@@ -936,7 +936,7 @@ def test_delete_product_variants_removes_checkout_lines(
         add_variant_to_checkout(checkout_info, variant, 1)
 
     lines_count = checkout.lines.count()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     old_quantity = calculate_checkout_quantity(lines)
 
     assert ProductVariantChannelListing.objects.filter(
@@ -960,7 +960,7 @@ def test_delete_product_variants_removes_checkout_lines(
         id__in=[variant.id for variant in variant_list]
     ).exists()
     checkout.refresh_from_db()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
 
     assert checkout.lines.count() == lines_count - 2
     assert old_quantity == calculate_checkout_quantity(lines) + 2

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1146,6 +1146,7 @@ enum CheckoutErrorCode {
   CHANNEL_INACTIVE
   UNAVAILABLE_VARIANT_IN_CHANNEL
   EMAIL_NOT_SET
+  NO_LINES
 }
 
 input CheckoutFilterInput {
@@ -5092,6 +5093,7 @@ type PaymentError {
   field: String
   message: String
   code: PaymentErrorCode!
+  variants: [ID!]
 }
 
 enum PaymentErrorCode {
@@ -5110,6 +5112,8 @@ enum PaymentErrorCode {
   CHANNEL_INACTIVE
   BALANCE_CHECK_ERROR
   CHECKOUT_EMAIL_NOT_SET
+  UNAVAILABLE_VARIANT_IN_CHANNEL
+  NO_CHECKOUT_LINES
 }
 
 input PaymentFilterInput {

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -356,7 +356,7 @@ def test_add_gift_cards_to_order(
     checkout.user = staff_user
     checkout.gift_cards.add(gift_card, gift_card_expiry_date)
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     # when
@@ -413,7 +413,7 @@ def test_add_gift_cards_to_order_no_checkout_user(
 
     checkout.gift_cards.add(gift_card, gift_card_expiry_date)
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     # when

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -17,3 +17,5 @@ class PaymentErrorCode(Enum):
     CHANNEL_INACTIVE = "channel_inactive"
     BALANCE_CHECK_ERROR = "balance_check_error"
     CHECKOUT_EMAIL_NOT_SET = "checkout_email_not_set"
+    UNAVAILABLE_VARIANT_IN_CHANNEL = "unavailable_variant_in_channel"
+    NO_CHECKOUT_LINES = "no_checkout_lines"

--- a/saleor/payment/gateways/adyen/tests/conftest.py
+++ b/saleor/payment/gateways/adyen/tests/conftest.py
@@ -75,7 +75,7 @@ def payment_adyen_for_checkout(checkout_with_items, address, shipping_method):
     checkout_with_items.shipping_method = shipping_method
     checkout_with_items.save()
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_items)
+    lines, _ = fetch_checkout_lines(checkout_with_items)
     checkout_info = fetch_checkout_info(checkout_with_items, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
@@ -160,7 +160,7 @@ def test_handle_authorization_for_checkout(
 
     payment = payment_adyen_for_checkout
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address
@@ -213,7 +213,7 @@ def test_handle_authorization_for_checkout_one_of_variants_deleted(
 
     payment = payment_adyen_for_checkout
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address
@@ -258,7 +258,7 @@ def test_handle_authorization_with_adyen_auto_capture(
 
     payment = payment_adyen_for_checkout
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address
@@ -452,7 +452,7 @@ def test_handle_capture_for_checkout(
 
     payment = payment_adyen_for_checkout
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address
@@ -510,7 +510,7 @@ def test_handle_capture_for_checkout_order_not_created_checkout_line_variant_del
 
     payment = payment_adyen_for_checkout
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -229,7 +229,7 @@ def append_checkout_details(payment_information: "PaymentData", payment_data: di
         raise PaymentError("Unable to calculate products for klarna.")
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     discounts = fetch_active_discounts()
     checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
     currency = payment_information.currency
@@ -308,7 +308,7 @@ def request_data_for_gateway_config(
     manager = get_plugins_manager()
     address = checkout.billing_address or checkout.shipping_address
     discounts = fetch_active_discounts()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
     total = checkout_total(
         manager=manager,

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -164,7 +164,11 @@ def create_payment_notification_for_order(
 def create_order(payment, checkout, manager):
     try:
         discounts = fetch_active_discounts()
-        lines = fetch_checkout_lines(checkout)
+        lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
+        if unavailable_variant_pks:
+            raise ValidationError(
+                "Some of the checkout lines variants are unavailable."
+            )
         checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
         checkout_total = calculate_checkout_total_with_gift_cards(
             manager=manager,

--- a/saleor/payment/gateways/stripe/tests/conftest.py
+++ b/saleor/payment/gateways/stripe/tests/conftest.py
@@ -20,7 +20,7 @@ def payment_stripe_for_checkout(checkout_with_items, address, shipping_method):
     checkout_with_items.email = "test@example.com"
     checkout_with_items.save()
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_items)
+    lines, _ = fetch_checkout_lines(checkout_with_items)
     checkout_info = fetch_checkout_info(checkout_with_items, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -171,7 +171,9 @@ def _finalize_checkout(
 
     manager = get_plugins_manager()
     discounts = fetch_active_discounts()
-    lines = fetch_checkout_lines(checkout)  # type: ignore
+    lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
+    if unavailable_variant_pks:
+        raise ValidationError("Some of the checkout lines variants are unavailable.")
     checkout_info = fetch_checkout_info(
         checkout, lines, discounts, manager  # type: ignore
     )

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -104,7 +104,7 @@ def test_create_payment(checkout_with_item, address):
     checkout_with_item.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     total = checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
@@ -145,7 +145,7 @@ def test_create_payment_from_checkout_requires_billing_address(checkout_with_ite
     checkout_with_item.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     total = checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=None
@@ -187,7 +187,7 @@ def test_create_payment_information_for_checkout_payment(address, checkout_with_
     checkout_with_item.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     total = checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
@@ -291,7 +291,7 @@ def test_create_payment_information_store(checkout_with_item, address, store):
     checkout_with_item.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     total = checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
@@ -326,7 +326,7 @@ def test_create_payment_information_metadata(checkout_with_item, address, metada
     checkout_with_item.save()
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     total = checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -321,7 +321,13 @@ class AvataxPlugin(BasePlugin):
         Raise an error when can't receive taxes.
         """
         if lines is None:
-            lines = fetch_checkout_lines(checkout_info.checkout)
+            lines, unavailable_variant_pks = fetch_checkout_lines(
+                checkout_info.checkout
+            )
+            if unavailable_variant_pks:
+                raise ValidationError(
+                    "Some of the checkout lines variants are unavailable."
+                )
         if self._skip_plugin(previous_value):
             return previous_value
 

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -102,7 +102,7 @@ def test_calculate_checkout_line_total(
     product.product_type.save()
     discounts = [discount_info] if with_discount else None
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts, manager)
     checkout_line_info = lines[0]
 
@@ -138,7 +138,7 @@ def test_calculate_checkout_line_total_with_variant_on_sale(
     line = checkout_with_item.lines.first()
     line.quantity = quantity
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line = lines[0]
 
     manager = get_plugins_manager()
@@ -207,7 +207,7 @@ def test_calculate_checkout_line_total_with_voucher(
 
     checkout_with_item.voucher_code = voucher.code
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
     manager = get_plugins_manager()
@@ -275,7 +275,7 @@ def test_calculate_checkout_line_total_with_voucher_once_per_order(
 
     checkout_with_item.voucher_code = voucher.code
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
     manager = get_plugins_manager()
@@ -343,7 +343,7 @@ def test_calculate_checkout_line_total_with_variant_on_sale_and_voucher(
 
     checkout_with_item.voucher_code = voucher.code
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
     manager = get_plugins_manager()
@@ -412,7 +412,7 @@ def test_calculate_checkout_line_total_with_variant_on_sale_and_voucher_only_onc
 
     checkout_with_item.voucher_code = voucher.code
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
     manager = get_plugins_manager()
@@ -499,7 +499,7 @@ def test_calculate_checkout_line_without_sku_total(
     product.product_type.save()
     discounts = [discount_info] if with_discount else None
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts, manager)
     checkout_line_info = lines[0]
 
@@ -831,7 +831,7 @@ def test_calculate_checkout_total_uses_default_calculation(
     discounts = [discount_info] if with_discount else None
     checkout_info = fetch_checkout_info(checkout_with_item, [], discounts, manager)
     add_variant_to_checkout(checkout_info, product_with_single_variant.variants.get())
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
 
     total = manager.calculate_checkout_total(checkout_info, lines, address, discounts)
     total = quantize_price(total, total.currency)
@@ -900,7 +900,7 @@ def test_calculate_checkout_total(
     discounts = [discount_info] if with_discount else None
     checkout_info = fetch_checkout_info(checkout_with_item, [], discounts, manager)
     add_variant_to_checkout(checkout_info, product_with_single_variant.variants.get())
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     total = manager.calculate_checkout_total(
         checkout_info, lines, ship_to_pl_address, discounts
     )
@@ -956,7 +956,7 @@ def test_calculate_checkout_total_not_charged_product_and_shipping_with_0_price(
 
     discounts = None
     checkout_info = fetch_checkout_info(checkout_with_item, [], discounts, manager)
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     total = manager.calculate_checkout_total(
         checkout_info, lines, ship_to_pl_address, discounts
     )
@@ -993,7 +993,7 @@ def test_calculate_checkout_shipping(
     checkout_with_item.shipping_address = ship_to_pl_address
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
     checkout_with_item.save()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -1051,7 +1051,7 @@ def test_calculate_checkout_subtotal(
 
     checkout_info = fetch_checkout_info(checkout_with_item, [], discounts, manager)
     add_variant_to_checkout(checkout_info, variant, 2)
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     total = manager.calculate_checkout_subtotal(
         checkout_info, lines, address, discounts
     )
@@ -1095,7 +1095,7 @@ def test_calculate_checkout_subtotal_for_product_without_tax(
     checkout_info = fetch_checkout_info(checkout, [], [], manager)
     add_variant_to_checkout(checkout_info, variant, quantity)
 
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     assert len(lines) == 1
     update_delivery_method_lists_for_checkout_info(
         checkout_info,
@@ -1280,7 +1280,7 @@ def test_calculate_checkout_line_unit_price(
     plugin_configuration()
     checkout = checkout_with_item
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line = lines[0]
     product = checkout_line.variant.product
     product.charge_taxes = charge_taxes
@@ -1334,7 +1334,7 @@ def test_calculate_checkout_line_unit_price_in_JPY(
     checkout = checkout_JPY_with_item
     plugin_configuration(channel=channel_JPY)
 
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_line = lines[0]
 
     manager = get_plugins_manager()
@@ -1381,7 +1381,7 @@ def test_calculate_checkout_line_unit_price_with_variant_on_sale(
     plugin_configuration()
     checkout = checkout_with_item
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line = lines[0]
 
     manager = get_plugins_manager()
@@ -1446,7 +1446,7 @@ def test_calculate_checkout_line_unit_price_with_voucher(
 
     checkout_with_item.voucher_code = voucher.code
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
     manager = get_plugins_manager()
@@ -1514,7 +1514,7 @@ def test_calculate_checkout_line_unit_price_with_voucher_once_per_order(
 
     checkout_with_item.voucher_code = voucher.code
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
     manager = get_plugins_manager()
@@ -1583,7 +1583,7 @@ def test_calculate_checkout_line_unit_price_with_variant_on_sale_and_voucher(
 
     checkout_with_item.voucher_code = voucher.code
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
     manager = get_plugins_manager()
@@ -1652,7 +1652,7 @@ def test_calculate_checkout_line_unit_price_with_variant_on_sale_and_voucher_onl
 
     checkout_with_item.voucher_code = voucher.code
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
     manager = get_plugins_manager()
@@ -1717,7 +1717,7 @@ def test_preprocess_order_creation(
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
     checkout_with_item.save()
     discounts = [discount_info]
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts, manager)
     manager.preprocess_order_creation(checkout_info, discounts, lines)
 
@@ -1748,7 +1748,7 @@ def test_preprocess_order_creation_no_lines_data(
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
     checkout_with_item.save()
     discounts = [discount_info]
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts, manager)
     manager.preprocess_order_creation(checkout_info, discounts)
 
@@ -1775,7 +1775,7 @@ def test_preprocess_order_creation_wrong_data(
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
     checkout_with_item.save()
     discounts = [discount_info]
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts, manager)
     with pytest.raises(TaxError):
         manager.preprocess_order_creation(checkout_info, discounts, lines)
@@ -1818,7 +1818,7 @@ def test_checkout_needs_new_fetch(checkout_with_item, address, shipping_method):
         from_country="PL",
     )
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_data = generate_request_data_from_checkout(checkout_info, lines, config)
     assert taxes_need_new_fetch(checkout_data, None)
@@ -1837,7 +1837,7 @@ def test_taxes_need_new_fetch_uses_cached_data(checkout_with_item, address):
         from_country="PL",
     )
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_data = generate_request_data_from_checkout(checkout_info, lines, config)
     assert not taxes_need_new_fetch(checkout_data, (checkout_data, None))
@@ -1884,7 +1884,7 @@ def test_get_checkout_line_tax_rate(
         valid_pick_up_points=[],
         all_shipping_methods=[],
     )
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
     # when
@@ -1943,7 +1943,7 @@ def test_get_checkout_line_tax_rate_for_product_with_charge_taxes_set_to_false(
         valid_pick_up_points=[],
         all_shipping_methods=[],
     )
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
     product = checkout_line_info.product
     product.charge_taxes = False
@@ -2020,7 +2020,7 @@ def test_get_checkout_line_tax_rate_for_product_type_with_non_taxable_product(
 
     assert checkout_with_item.lines.count() == 2
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     order = [checkout_with_item.lines.first().variant.pk, variant2.pk]
     lines.sort(key=lambda line: order.index(line.variant.pk))
 
@@ -2057,7 +2057,7 @@ def test_get_checkout_line_tax_rate_checkout_no_shipping_method_default_value_re
     checkout_with_item.shipping_address = address
     checkout_with_item.save(update_fields=["shipping_address"])
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_line_info = lines[0]
 
@@ -2093,7 +2093,7 @@ def test_get_checkout_line_tax_rate_error_in_response(
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
     checkout_with_item.save(update_fields=["shipping_address", "shipping_method"])
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_line_info = lines[0]
 
@@ -2231,7 +2231,7 @@ def test_get_checkout_shipping_tax_rate(
     checkout_with_item.save(update_fields=["shipping_address", "shipping_method"])
     delivery_method = checkout_with_item.shipping_method
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = CheckoutInfo(
         checkout=checkout_with_item,
         delivery_method_info=get_delivery_method_info(
@@ -2300,7 +2300,7 @@ def test_get_checkout_shipping_tax_rate_checkout_not_valid_default_value_returne
     checkout_with_item.shipping_address = address
     checkout_with_item.save(update_fields=["shipping_address"])
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     # when
@@ -2334,7 +2334,7 @@ def test_get_checkout_shipping_tax_rate_error_in_response(
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
     checkout_with_item.save(update_fields=["shipping_address", "shipping_method"])
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     # when
@@ -2368,7 +2368,7 @@ def test_get_checkout_shipping_tax_rate_skip_plugin(
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
     checkout_with_item.save(update_fields=["shipping_address", "shipping_method"])
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     # when
@@ -2681,7 +2681,7 @@ def test_plugin_uses_configuration_from_db(
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
     checkout_with_item.save()
     discounts = [discount_info]
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts, manager)
     manager.preprocess_order_creation(checkout_info, discounts, lines)
 
@@ -3130,7 +3130,7 @@ def test_get_checkout_lines_data_sets_different_tax_code_for_zero_amount(
     )
     variant.product.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [], get_plugins_manager()
     )
@@ -3163,7 +3163,7 @@ def test_get_checkout_lines_data_sets_different_tax_code_only_for_zero_amount(
     )
     variant.product.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [], get_plugins_manager()
     )
@@ -3205,7 +3205,7 @@ def test_get_checkout_lines_data_with_collection_point(
     checkout_with_item.collection_point = warehouse
     checkout_with_item.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [], get_plugins_manager()
     )
@@ -3245,7 +3245,7 @@ def test_get_checkout_lines_data_with_shipping_method(
     checkout_with_item.collection_point = None
     checkout_with_item.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [], get_plugins_manager()
     )

--- a/saleor/plugins/avatax/tests/test_avatax_caching.py
+++ b/saleor/plugins/avatax/tests/test_avatax_caching.py
@@ -31,7 +31,7 @@ def test_calculate_checkout_total_use_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
         checkout_info, lines, plugin.config, []
     )
@@ -75,7 +75,7 @@ def test_calculate_checkout_total_save_avatax_response_in_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     mocked_avalara = Mock(
         return_value=avalara_response_for_checkout_with_items_and_shipping
     )
@@ -120,7 +120,7 @@ def test_calculate_checkout_subtotal_use_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
         checkout_info, lines, plugin.config, []
     )
@@ -164,7 +164,7 @@ def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     mocked_avalara = Mock(
         return_value=avalara_response_for_checkout_with_items_and_shipping
     )
@@ -209,7 +209,7 @@ def test_calculate_checkout_shipping_use_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
         checkout_info, lines, plugin.config, []
     )
@@ -253,7 +253,7 @@ def test_calculate_checkout_shipping_save_avatax_response_in_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     mocked_avalara = Mock(
         return_value=avalara_response_for_checkout_with_items_and_shipping
     )
@@ -298,7 +298,7 @@ def test_calculate_checkout_line_total_use_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
         checkout_info, lines, plugin.config, []
@@ -343,7 +343,7 @@ def test_calculate_checkout_line_save_avatax_response_in_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     mocked_avalara = Mock(
         return_value=avalara_response_for_checkout_with_items_and_shipping
@@ -389,7 +389,7 @@ def test_calculate_checkout_line_unit_price_use_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
         checkout_info, lines, plugin.config, []
@@ -438,7 +438,7 @@ def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     mocked_avalara = Mock(
         return_value=avalara_response_for_checkout_with_items_and_shipping
@@ -492,7 +492,7 @@ def test_get_checkout_line_tax_rate_use_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
         checkout_info, lines, plugin.config, []
@@ -543,7 +543,7 @@ def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     mocked_avalara = Mock(
         return_value=avalara_response_for_checkout_with_items_and_shipping
@@ -600,7 +600,7 @@ def test_get_checkout_shipping_tax_rate_use_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
         checkout_info, lines, plugin.config, []
     )
@@ -645,7 +645,7 @@ def test_get_checkout_shipping_tax_rate_save_avatax_response_in_cache(
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     mocked_avalara = Mock(
         return_value=avalara_response_for_checkout_with_items_and_shipping
     )

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -154,7 +154,7 @@ def test_manager_calculates_checkout_total(
     currency = checkout_with_item.currency
     expected_total = Money(total_amount, currency)
     manager = PluginsManager(plugins=plugins)
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -174,7 +174,7 @@ def test_manager_calculates_checkout_subtotal(
     currency = checkout_with_item.currency
     expected_subtotal = Money(subtotal_amount, currency)
     manager = PluginsManager(plugins=plugins)
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -194,7 +194,7 @@ def test_manager_calculates_checkout_shipping(
     currency = checkout_with_item.currency
     expected_shipping_price = Money(shipping_amount, currency)
     manager = PluginsManager(plugins=plugins)
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -234,7 +234,7 @@ def test_manager_calculates_checkout_line_total(
     currency = checkout_with_item.currency
     expected_total = Money(amount, currency)
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -281,7 +281,7 @@ def test_manager_get_checkout_line_tax_rate_sample_plugin(
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -309,7 +309,7 @@ def test_manager_get_checkout_line_tax_rate_no_plugins(
     checkout_with_item, discount_info, unit_price, expected_tax_rate
 ):
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -371,7 +371,7 @@ def test_manager_get_checkout_shipping_tax_rate_sample_plugin(
     shipping_price = TaxedMoney(Money(12, "USD"), Money(14, "USD"))
 
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -397,7 +397,7 @@ def test_manager_get_checkout_shipping_tax_rate_no_plugins(
     checkout_with_item, discount_info, shipping_price, expected_tax_rate
 ):
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -466,7 +466,7 @@ def test_manager_calculates_checkout_line_unit_price(
     plugins, total_line_price, quantity, checkout_with_item, address
 ):
     manager = PluginsManager(plugins=plugins)
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_line_info = lines[0]
 

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -222,7 +222,7 @@ def test_calculate_checkout_total(
     site_settings.save()
 
     discounts = [discount_info] if with_discount else None
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts, manager)
     total = manager.calculate_checkout_total(checkout_info, lines, address, discounts)
     total = quantize_price(total, total.currency)
@@ -253,7 +253,7 @@ def test_calculate_checkout_total_from_origin_country(
     plugin.assign_tax_code_to_object_meta(product, "standard", None)
     product.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -289,7 +289,7 @@ def test_calculate_checkout_total_with_excluded_country(
     plugin.assign_tax_code_to_object_meta(product, "standard", None)
     product.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -342,7 +342,7 @@ def test_calculate_checkout_subtotal(
     discounts = [discount_info] if with_discount else None
     checkout_info = fetch_checkout_info(checkout_with_item, [], discounts, manager)
     add_variant_to_checkout(checkout_info, variant, 2)
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     total = manager.calculate_checkout_subtotal(
         checkout_info, lines, address, discounts
     )
@@ -375,7 +375,7 @@ def test_calculate_checkout_subtotal_from_origin_country(
     plugin.assign_tax_code_to_object_meta(product, "standard", None)
     product.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -412,7 +412,7 @@ def test_calculate_checkout_subtotal_with_excluded_country(
     plugin.assign_tax_code_to_object_meta(product, "standard", None)
     product.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -613,7 +613,7 @@ def test_calculate_checkout_line_total(
     manager.assign_tax_code_to_object_meta(variant.product, "standard")
     product.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_line_info = lines[0]
 
@@ -653,7 +653,7 @@ def test_calculate_checkout_line_total_from_origin_country(
     manager.assign_tax_code_to_object_meta(variant.product, "standard")
     product.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_line_info = lines[0]
 
@@ -692,7 +692,7 @@ def test_calculate_checkout_line_total_with_excluded_country(
     manager.assign_tax_code_to_object_meta(variant.product, "standard")
     product.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_line_info = lines[0]
 
@@ -768,7 +768,7 @@ def test_calculate_checkout_line_unit_price(
     manager.assign_tax_code_to_object_meta(variant.product, "standard")
     product.save()
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_line_info = lines[0]
 
@@ -978,7 +978,7 @@ def test_calculations_checkout_total_with_vatlayer(
 ):
     settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_subtotal = calculations.checkout_total(
         manager=manager,
@@ -996,7 +996,7 @@ def test_calculations_checkout_subtotal_with_vatlayer(
 ):
     settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_subtotal = calculations.checkout_subtotal(
         manager=manager,
@@ -1014,7 +1014,7 @@ def test_calculations_checkout_shipping_price_with_vatlayer(
 ):
     settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
     manager = get_plugins_manager()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_shipping_price = calculations.checkout_shipping_price(
         manager=manager,
@@ -1066,7 +1066,7 @@ def test_get_checkout_line_tax_rate(
 
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_line_info = lines[0]
     tax_rate = manager.get_checkout_line_tax_rate(
@@ -1107,7 +1107,7 @@ def test_get_checkout_line_tax_rate_from_origin_country(
 
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_line_info = lines[0]
     tax_rate = manager.get_checkout_line_tax_rate(
@@ -1146,7 +1146,7 @@ def test_get_checkout_line_tax_rate_with_excluded_country(
 
     unit_price = TaxedMoney(Money(15, "USD"), Money(15, "USD"))
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_line_info = lines[0]
     tax_rate = manager.get_checkout_line_tax_rate(
@@ -1178,7 +1178,7 @@ def test_get_checkout_line_tax_rate_order_not_valid(
 
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_line_info = lines[0]
 
@@ -1344,7 +1344,7 @@ def test_get_checkout_shipping_tax_rate(
 
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     tax_rate = manager.get_checkout_shipping_tax_rate(
@@ -1384,7 +1384,7 @@ def test_get_checkout_shipping_tax_rate_from_origin_country(
 
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     tax_rate = manager.get_checkout_shipping_tax_rate(
@@ -1422,7 +1422,7 @@ def test_get_checkout_shipping_tax_rate_with_excluded_country(
 
     unit_price = TaxedMoney(Money(15, "USD"), Money(15, "USD"))
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     tax_rate = manager.get_checkout_shipping_tax_rate(
@@ -1453,7 +1453,7 @@ def test_get_checkout_shipping_tax_rate_no_address(
 
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     tax_rate = manager.get_checkout_shipping_tax_rate(
@@ -1491,7 +1491,7 @@ def test_get_checkout_shipping_tax_rate_skip_plugin(
 
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     tax_rate = manager.get_checkout_shipping_tax_rate(
@@ -1665,7 +1665,7 @@ def test_calculate_checkout_shipping(
     checkout_with_item.shipping_address = address
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
     checkout_with_item.save()
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )
@@ -1692,7 +1692,7 @@ def test_calculate_checkout_shipping_no_shipping_price(
     checkout_with_item.collection_point = warehouse_for_cc
     checkout_with_item.save(update_fields=["shipping_address", "collection_point"])
 
-    lines = fetch_checkout_lines(checkout_with_item)
+    lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
         checkout_with_item, lines, [discount_info], manager
     )

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -511,7 +511,7 @@ def checkout_with_preorders_only(
     preorder_variant_with_end_date,
     preorder_variant_channel_threshold,
 ):
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], get_plugins_manager())
     add_variant_to_checkout(checkout_info, preorder_variant_with_end_date, 2)
     add_variant_to_checkout(checkout_info, preorder_variant_channel_threshold, 2)
@@ -524,7 +524,7 @@ def checkout_with_preorders_only(
 def checkout_with_preorders_and_regular_variant(
     checkout, stocks_for_cc, preorder_variant_with_end_date, product_variant_list
 ):
-    lines = fetch_checkout_lines(checkout)
+    lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], get_plugins_manager())
     add_variant_to_checkout(checkout_info, preorder_variant_with_end_date, 2)
     add_variant_to_checkout(checkout_info, product_variant_list[0], 2)
@@ -1842,6 +1842,7 @@ def product_price_0(category, warehouse, channel_USD):
         channel=channel_USD,
         is_published=True,
         visible_in_listings=True,
+        available_for_purchase=datetime.date(1999, 1, 1),
     )
     variant = ProductVariant.objects.create(product=product, sku="SKU_C")
     ProductVariantChannelListing.objects.create(
@@ -2542,6 +2543,7 @@ def product_without_shipping(category, warehouse, channel_USD):
         channel=channel_USD,
         is_published=True,
         visible_in_listings=True,
+        available_for_purchase=datetime.date(1999, 1, 1),
     )
     variant = ProductVariant.objects.create(product=product, sku="SKU_B")
     ProductVariantChannelListing.objects.create(
@@ -2604,6 +2606,7 @@ def product_list(product_type, category, warehouse, channel_USD, channel_PLN):
                 discounted_price_amount=10,
                 currency=channel_USD.currency_code,
                 visible_in_listings=True,
+                available_for_purchase=datetime.date(1999, 1, 1),
             ),
             ProductChannelListing(
                 product=products[1],
@@ -2612,6 +2615,7 @@ def product_list(product_type, category, warehouse, channel_USD, channel_PLN):
                 discounted_price_amount=20,
                 currency=channel_USD.currency_code,
                 visible_in_listings=True,
+                available_for_purchase=datetime.date(1999, 1, 1),
             ),
             ProductChannelListing(
                 product=products[2],
@@ -2620,6 +2624,7 @@ def product_list(product_type, category, warehouse, channel_USD, channel_PLN):
                 discounted_price_amount=30,
                 currency=channel_USD.currency_code,
                 visible_in_listings=True,
+                available_for_purchase=datetime.date(1999, 1, 1),
             ),
         ]
     )

--- a/saleor/warehouse/tests/test_stock_availability.py
+++ b/saleor/warehouse/tests/test_stock_availability.py
@@ -295,7 +295,9 @@ def test_check_stock_quantity_bulk_with_reservations(
         )
 
     # test that it passes if checkout lines are excluded
-    checkout_lines = fetch_checkout_lines(checkout_line_with_one_reservation.checkout)
+    checkout_lines, _ = fetch_checkout_lines(
+        checkout_line_with_one_reservation.checkout
+    )
     assert (
         check_stock_quantity_bulk(
             [variant_with_many_stocks],

--- a/saleor/webhook/serializers.py
+++ b/saleor/webhook/serializers.py
@@ -18,7 +18,8 @@ def serialize_checkout_lines(checkout: "Checkout") -> List[dict]:
     data = []
     channel = checkout.channel
     currency = channel.currency_code
-    for line_info in fetch_checkout_lines(checkout, prefetch_variant_attributes=True):
+    lines, _ = fetch_checkout_lines(checkout, prefetch_variant_attributes=True)
+    for line_info in lines:
         variant = line_info.variant
         channel_listing = line_info.channel_listing
         collections = line_info.collections


### PR DESCRIPTION
Port changes from https://github.com/saleor/saleor/pull/8978.

Raise a `ValidationError` in `CheckoutCreate` and `CheckoutPaymentCreate` when any of the checkout line variant is unavailable for purchase. In other words, any of the following is True:  
- `ProductChannelListing` does not exist 
- `ProductChannelListing`'s `available_for_purchase` value is  None or is in feature 
- `ProductVariantChannelListing` does not exist
- `ProductVariantChannelListing` does not have price data

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
