### PR TITLE
Fix leaking order data for unauthorized user

### DIFF
--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -685,21 +685,31 @@ COMPLETE_CHECKOUT_MUTATION = (
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-def test_complete_checkout(api_client, checkout_with_charged_payment, count_queries):
+def test_complete_checkout(
+    staff_api_client,
+    checkout_with_charged_payment,
+    permission_manage_orders,
+    count_queries,
+):
     query = COMPLETE_CHECKOUT_MUTATION
 
     variables = {
         "token": checkout_with_charged_payment.token,
     }
 
-    response = get_graphql_content(api_client.post_graphql(query, variables))
+    response = get_graphql_content(
+        staff_api_client.post_graphql(query, variables, [permission_manage_orders])
+    )
     assert not response["data"]["checkoutComplete"]["errors"]
 
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
 def test_complete_checkout_with_single_line(
-    api_client, checkout_with_charged_payment, count_queries
+    staff_api_client,
+    checkout_with_charged_payment,
+    permission_manage_orders,
+    count_queries,
 ):
     query = COMPLETE_CHECKOUT_MUTATION
     checkout_with_charged_payment.lines.set(
@@ -710,14 +720,20 @@ def test_complete_checkout_with_single_line(
         "token": checkout_with_charged_payment.token,
     }
 
-    response = get_graphql_content(api_client.post_graphql(query, variables))
+    response = get_graphql_content(
+        staff_api_client.post_graphql(query, variables, [permission_manage_orders])
+    )
     assert not response["data"]["checkoutComplete"]["errors"]
 
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
 def test_customer_complete_checkout(
-    api_client, checkout_with_charged_payment, count_queries, customer_user
+    staff_api_client,
+    checkout_with_charged_payment,
+    permission_manage_orders,
+    count_queries,
+    customer_user,
 ):
     query = COMPLETE_CHECKOUT_MUTATION
     checkout = checkout_with_charged_payment
@@ -727,5 +743,7 @@ def test_customer_complete_checkout(
         "token": checkout.token,
     }
 
-    response = get_graphql_content(api_client.post_graphql(query, variables))
+    response = get_graphql_content(
+        staff_api_client.post_graphql(query, variables, [permission_manage_orders])
+    )
     assert not response["data"]["checkoutComplete"]["errors"]

--- a/saleor/graphql/order/tests/benchmark/test_order.py
+++ b/saleor/graphql/order/tests/benchmark/test_order.py
@@ -100,7 +100,10 @@ FRAGMENT_ORDER_DETAILS = (
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
 def test_user_order_details(
-    user_api_client, order_with_lines_and_events, count_queries
+    staff_api_client,
+    order_with_lines_and_events,
+    permission_manage_orders,
+    count_queries,
 ):
     query = (
         FRAGMENT_ORDER_DETAILS
@@ -115,7 +118,9 @@ def test_user_order_details(
     variables = {
         "token": order_with_lines_and_events.token,
     }
-    get_graphql_content(user_api_client.post_graphql(query, variables))
+    get_graphql_content(
+        staff_api_client.post_graphql(query, variables, [permission_manage_orders])
+    )
 
 
 FRAGMENT_STAFF_ORDER_DETAILS = (


### PR DESCRIPTION
Require permission `manage_orders` for most of the order fields.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
