### PR TITLE
Allow filtering staff users and permission groups by ids

### DIFF
--- a/saleor/graphql/account/filters.py
+++ b/saleor/graphql/account/filters.py
@@ -1,11 +1,13 @@
 import django_filters
 from django.db.models import Count
+from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
 from ...account.models import User
 from ...account.search import search_users
 from ..core.filters import EnumFilter, MetadataFilterBase, ObjectTypeFilter
 from ..core.types.common import DateRangeInput, IntRangeInput
-from ..utils.filters import filter_range_field
+from ..utils.filters import filter_by_id, filter_range_field
+from . import types as account_types
 from .enums import StaffMemberStatus
 
 
@@ -64,12 +66,17 @@ class CustomerFilter(MetadataFilterBase):
 
 class PermissionGroupFilter(django_filters.FilterSet):
     search = django_filters.CharFilter(method=filter_search)
+    ids = GlobalIDMultipleChoiceFilter(method=filter_by_id(account_types.Group))
 
 
 class StaffUserFilter(django_filters.FilterSet):
     status = EnumFilter(input_class=StaffMemberStatus, method=filter_staff_status)
     search = django_filters.CharFilter(method=filter_user_search)
-
+    ids = GlobalIDMultipleChoiceFilter(
+        method=filter_by_id(
+            account_types.User,
+        )
+    )
     # TODO - Figure out after permission types
     # department = ObjectTypeFilter
 

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -4856,6 +4856,30 @@ def test_query_staff_members_with_filter_status(
     assert len(users) == count
 
 
+def test_query_staff_members_with_filter_by_ids(
+    query_staff_users_with_filter,
+    staff_api_client,
+    permission_manage_staff,
+    staff_user,
+):
+    # given
+    variables = {
+        "filter": {
+            "ids": [graphene.Node.to_global_id("User", staff_user.pk)],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query_staff_users_with_filter, variables, permissions=[permission_manage_staff]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    users = content["data"]["staffUsers"]["edges"]
+    assert len(users) == 1
+
+
 def test_query_staff_members_app_no_permission(
     query_staff_users_with_filter,
     app_api_client,

--- a/saleor/graphql/account/tests/test_account_permission_group.py
+++ b/saleor/graphql/account/tests/test_account_permission_group.py
@@ -2174,6 +2174,32 @@ def test_permission_groups_query(
     assert len(data) == count
 
 
+def test_permission_groups_query_with_filter_by_ids(
+    permission_group_manage_users,
+    permission_manage_staff,
+    staff_api_client,
+):
+    # given
+    query = QUERY_PERMISSION_GROUP_WITH_FILTER
+    variables = {
+        "filter": {
+            "ids": [
+                graphene.Node.to_global_id("Group", permission_group_manage_users.pk)
+            ]
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_staff]
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["permissionGroups"]["edges"]
+    assert len(data) == 1
+
+
 def test_permission_groups_app_no_permission(
     permission_group_manage_users,
     permission_manage_staff,

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -14,7 +14,7 @@ from ..core.types.common import DateRangeInput
 from ..core.utils import from_global_id_or_error
 from ..payment.enums import PaymentChargeStatusEnum
 from ..utils import resolve_global_ids_to_primary_keys
-from ..utils.filters import filter_range_field
+from ..utils.filters import filter_by_id, filter_range_field
 from .enums import OrderStatusFilter
 
 
@@ -106,13 +106,6 @@ def filter_is_preorder(qs, _, values):
     return qs
 
 
-def filter_order_ids(qs, _, values):
-    if values:
-        _, order_ids = resolve_global_ids_to_primary_keys(values, "Order")
-        qs = qs.filter(id__in=order_ids)
-    return qs
-
-
 def filter_gift_card_used(qs, _, value):
     return filter_by_gift_card(qs, value, GiftCardEvents.USED_IN_ORDER)
 
@@ -153,7 +146,7 @@ class OrderFilter(DraftOrderFilter):
         method=filter_is_click_and_collect
     )
     is_preorder = django_filters.BooleanFilter(method=filter_is_preorder)
-    ids = GlobalIDMultipleChoiceFilter(method=filter_order_ids)
+    ids = GlobalIDMultipleChoiceFilter(method=filter_by_id("Order"))
     gift_card_used = django_filters.BooleanFilter(method=filter_gift_card_used)
     gift_card_bought = django_filters.BooleanFilter(method=filter_gift_card_bought)
 

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -6,6 +6,7 @@ from ...page import models
 from ..core.filters import MetadataFilterBase
 from ..core.types import FilterInputObjectType
 from ..utils import resolve_global_ids_to_primary_keys
+from ..utils.filters import filter_by_id
 from .types import Page, PageType
 
 
@@ -26,13 +27,6 @@ def filter_page_page_types(qs, _, value):
     return qs.filter(page_type_id__in=page_types_pks)
 
 
-def filter_page_ids(qs, _, value):
-    if not value:
-        return qs
-    _, page_pks = resolve_global_ids_to_primary_keys(value, Page)
-    return qs.filter(id__in=page_pks)
-
-
 def filter_page_type_search(qs, _, value):
     if not value:
         return qs
@@ -42,7 +36,7 @@ def filter_page_type_search(qs, _, value):
 class PageFilter(MetadataFilterBase):
     search = django_filters.CharFilter(method=filter_page_search)
     page_types = GlobalIDMultipleChoiceFilter(method=filter_page_page_types)
-    ids = GlobalIDMultipleChoiceFilter(method=filter_page_ids)
+    ids = GlobalIDMultipleChoiceFilter(method=filter_by_id(Page))
 
     class Meta:
         model = models.Page

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -44,7 +44,7 @@ from ..core.filters import (
 from ..core.types import ChannelFilterInputObjectType, FilterInputObjectType
 from ..core.types.common import IntRangeInput, PriceRangeInput
 from ..utils import resolve_global_ids_to_primary_keys
-from ..utils.filters import filter_range_field
+from ..utils.filters import filter_by_id, filter_range_field
 from ..warehouse import types as warehouse_types
 from . import types as product_types
 from .enums import (
@@ -380,13 +380,6 @@ def filter_product_types(qs, _, value):
     return qs.filter(product_type_id__in=product_type_pks)
 
 
-def filter_product_ids(qs, _, value):
-    if not value:
-        return qs
-    _, product_pks = resolve_global_ids_to_primary_keys(value, product_types.Product)
-    return qs.filter(id__in=product_pks)
-
-
 def filter_has_category(qs, _, value):
     return qs.filter(category__isnull=not value)
 
@@ -590,11 +583,11 @@ class ProductFilter(MetadataFilterBase):
     stock_availability = EnumFilter(
         input_class=StockAvailability, method="filter_stock_availability"
     )
+    ids = GlobalIDMultipleChoiceFilter(method=filter_by_id("Product"))
     product_types = GlobalIDMultipleChoiceFilter(method=filter_product_types)
     stocks = ObjectTypeFilter(input_class=ProductStockFilterInput, method=filter_stocks)
     search = django_filters.CharFilter(method=filter_search)
     gift_card = django_filters.BooleanFilter(method=filter_gift_card)
-    ids = GlobalIDMultipleChoiceFilter(method=filter_product_ids)
     has_preordered_variants = django_filters.BooleanFilter(
         method=filter_has_preordered_variants
     )

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -583,11 +583,11 @@ class ProductFilter(MetadataFilterBase):
     stock_availability = EnumFilter(
         input_class=StockAvailability, method="filter_stock_availability"
     )
-    ids = GlobalIDMultipleChoiceFilter(method=filter_by_id("Product"))
     product_types = GlobalIDMultipleChoiceFilter(method=filter_product_types)
     stocks = ObjectTypeFilter(input_class=ProductStockFilterInput, method=filter_stocks)
     search = django_filters.CharFilter(method=filter_search)
     gift_card = django_filters.BooleanFilter(method=filter_gift_card)
+    ids = GlobalIDMultipleChoiceFilter(method=filter_by_id("Product"))
     has_preordered_variants = django_filters.BooleanFilter(
         method=filter_has_preordered_variants
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5580,9 +5580,9 @@ input ProductFilterInput {
   metadata: [MetadataFilter]
   price: PriceRangeInput
   minimalPrice: PriceRangeInput
-  ids: [ID]
   productTypes: [ID]
   giftCard: Boolean
+  ids: [ID]
   hasPreorderedVariants: Boolean
   channel: String
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5229,6 +5229,7 @@ enum PermissionGroupErrorCode {
 
 input PermissionGroupFilterInput {
   search: String
+  ids: [ID]
 }
 
 enum PermissionGroupSortField {
@@ -6793,6 +6794,7 @@ input StaffUpdateInput {
 input StaffUserInput {
   status: StaffMemberStatus
   search: String
+  ids: [ID]
 }
 
 type Stock implements Node {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5580,9 +5580,9 @@ input ProductFilterInput {
   metadata: [MetadataFilter]
   price: PriceRangeInput
   minimalPrice: PriceRangeInput
+  ids: [ID]
   productTypes: [ID]
   giftCard: Boolean
-  ids: [ID]
   hasPreorderedVariants: Boolean
   channel: String
 }

--- a/saleor/graphql/utils/filters.py
+++ b/saleor/graphql/utils/filters.py
@@ -60,3 +60,15 @@ def filter_range_field(qs, field, value):
         lookup = {f"{field}__lte": lte}
         qs = qs.filter(**lookup)
     return qs
+
+
+def filter_by_id(object_type):
+    from saleor.graphql.utils import resolve_global_ids_to_primary_keys
+
+    def inner(qs, _, value):
+        if not value:
+            return qs
+        _, obj_pks = resolve_global_ids_to_primary_keys(value, object_type)
+        return qs.filter(id__in=obj_pks)
+
+    return inner

--- a/saleor/graphql/utils/filters.py
+++ b/saleor/graphql/utils/filters.py
@@ -63,7 +63,7 @@ def filter_range_field(qs, field, value):
 
 
 def filter_by_id(object_type):
-    from saleor.graphql.utils import resolve_global_ids_to_primary_keys
+    from . import resolve_global_ids_to_primary_keys
 
     def inner(qs, _, value):
         if not value:


### PR DESCRIPTION
I want to merge this change because I'm porting changes from #8916 to 3.1.

Unit test check:
- saleor/graphql/account/tests/test_account.py::test_query_staff_members_with_filter_by_ids
- saleor/graphql/account/tests/test_account_permission_group.py::test_permission_groups_query_with_filter_by_ids
- saleor/graphql/page/tests/test_page.py::test_pages_query_with_filter_by_ids
- saleor/graphql/order/tests/test_order.py::test_orders_query_with_filter_by_orders_id
- saleor/graphql/product/tests/test_product.py::test_query_products_with_filter_ids

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
