### PR TITLE
Add checkout dataloader to payment type

### DIFF
--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -844,6 +844,9 @@ QUERY_PAYMENT_BY_ID = """
     query payment($id: ID!) {
         payment(id: $id) {
             id
+            checkout {
+                token
+            }
         }
     }
 """
@@ -858,8 +861,30 @@ def test_query_payment(payment_dummy, user_api_client, permission_manage_orders)
         query, variables, permissions=[permission_manage_orders]
     )
     content = get_graphql_content(response)
-    received_id = content["data"]["payment"]["id"]
+    payment_data = content["data"]["payment"]
+    received_id = payment_data["id"]
     assert received_id == payment_id
+    assert not payment_data["checkout"]
+
+
+def test_query_payment_with_checkout(
+    payment_dummy, user_api_client, permission_manage_orders, checkout
+):
+    query = QUERY_PAYMENT_BY_ID
+    payment = payment_dummy
+    payment.order = None
+    payment.checkout = checkout
+    payment.save()
+    payment_id = graphene.Node.to_global_id("Payment", payment.pk)
+    variables = {"id": payment_id}
+    response = user_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    payment_data = content["data"]["payment"]
+    received_id = payment_data["id"]
+    assert received_id == payment_id
+    assert payment_data["checkout"]["token"] == str(checkout.pk)
 
 
 def test_staff_query_payment_by_invalid_id(

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -4,6 +4,7 @@ from graphene import relay
 from ...core.permissions import OrderPermissions
 from ...core.tracing import traced_resolver
 from ...payment import models
+from ..checkout.dataloaders import CheckoutByTokenLoader
 from ..core.connection import CountableDjangoObjectType
 from ..core.types import Money
 from ..decorators import permission_required
@@ -169,6 +170,12 @@ class Payment(CountableDjangoObjectType):
         if not any(data.values()):
             return None
         return CreditCard(**data)
+
+    @staticmethod
+    def resolve_checkout(root: models.Payment, info):
+        if not root.checkout_id:
+            return None
+        return CheckoutByTokenLoader(info.context).load(root.checkout_id)
 
 
 class PaymentInitialized(graphene.ObjectType):


### PR DESCRIPTION
I want to merge this change because of adding a missing dataloader. 
In some cases default resolver course error. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
