### PR TITLE
Query cost in graphql spans tracing

### DIFF
--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -279,17 +279,17 @@ class GraphQLView(View):
                 except GraphQLError as e:
                     return ExecutionResult(errors=[e], invalid=True)
 
-                if settings.GRAPHQL_QUERY_MAX_COMPLEXITY:
-                    query_cost, cost_errors = validate_query_cost(
-                        schema,
-                        document,
-                        variables,
-                        COST_MAP,
-                        settings.GRAPHQL_QUERY_MAX_COMPLEXITY,
-                    )
-                    if cost_errors:
-                        result = ExecutionResult(errors=cost_errors, invalid=True)
-                        return set_query_cost_on_result(result, query_cost)
+                query_cost, cost_errors = validate_query_cost(
+                    schema,
+                    document,
+                    variables,
+                    COST_MAP,
+                    settings.GRAPHQL_QUERY_MAX_COMPLEXITY,
+                )
+                span.set_tag("graphql.query_cost", query_cost)
+                if settings.GRAPHQL_QUERY_MAX_COMPLEXITY and cost_errors:
+                    result = ExecutionResult(errors=cost_errors, invalid=True)
+                    return set_query_cost_on_result(result, query_cost)
 
             extra_options: Dict[str, Optional[Any]] = {}
 


### PR DESCRIPTION
I want to merge this change because it adds a new tag to `graphql` tracing span - `graphql.query_cost`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
