### PR TITLE
Add checkout dataloader to payment type in 3.1

### DIFF
--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -5,6 +5,7 @@ from ...core.exceptions import PermissionDenied
 from ...core.permissions import OrderPermissions
 from ...core.tracing import traced_resolver
 from ...payment import models
+from ..checkout.dataloaders import CheckoutByTokenLoader
 from ..core.connection import CountableConnection
 from ..core.descriptions import ADDED_IN_31
 from ..core.types import ModelObjectType, Money
@@ -185,6 +186,11 @@ class Payment(ModelObjectType):
         if not requester.has_perms(permissions):
             raise PermissionDenied()
         return resolve_metadata(root.metadata)
+
+    def resolve_checkout(root: models.Payment, info):
+        if not root.checkout_id:
+            return None
+        return CheckoutByTokenLoader(info.context).load(root.checkout_id)
 
 
 class PaymentCountableConnection(CountableConnection):


### PR DESCRIPTION
I want to merge this change because coping changes from #9071 to 3.1.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
