### PR TITLE
Once per customer voucher 3ds handle

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -676,6 +676,7 @@ def complete_checkout(
         action_required = txn.action_required
         if action_required:
             action_data = txn.action_required_data
+            release_voucher_usage(order_data)
 
     order = None
     if not action_required:

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -9,9 +9,14 @@ from ...account.models import CustomerEvent
 from ...core.exceptions import InsufficientStock
 from ...core.notify_events import NotifyEventType
 from ...core.taxes import zero_money, zero_taxed_money
+from ...discount.models import VoucherCustomer
+from ...graphql.checkout.tests.test_checkout_complete import (
+    ACTION_REQUIRED_GATEWAY_RESPONSE,
+)
 from ...order import OrderEvents
 from ...order.models import OrderEvent
 from ...order.notifications import get_default_order_payload
+from ...payment.models import Payment
 from ...plugins.manager import get_plugins_manager
 from ...product.models import ProductTranslation, ProductVariantTranslation
 from ...tests.utils import flush_post_commit_hooks
@@ -970,3 +975,60 @@ def test_complete_checkout_0_total_captured_payment_creates_expected_events(
     assert placement_event.order == order  # check the associated order is valid
     assert placement_event.date  # ensure a date was set
     assert not placement_event.parameters  # should not have any additional parameters
+
+
+@mock.patch("saleor.checkout.complete_checkout._create_order")
+@mock.patch(
+    "saleor.checkout.complete_checkout._process_payment",
+    return_value=ACTION_REQUIRED_GATEWAY_RESPONSE,
+)
+def test_complete_checkout_action_required_voucher_once_per_customer(
+    _,
+    mocked_create_order,
+    voucher,
+    customer_user,
+    checkout,
+    app,
+    payment_txn_to_confirm,
+):
+    # given
+    payment = Payment.objects.create(
+        gateway="mirumee.payments.dummy", is_active=True, checkout=checkout
+    )
+    payment.to_confirm = True
+    payment.save()
+
+    checkout.user = customer_user
+    checkout.billing_address = customer_user.default_billing_address
+    checkout.shipping_address = customer_user.default_billing_address
+    checkout.tracking_code = ""
+    checkout.redirect_url = "https://www.example.com"
+    checkout.voucher_code = voucher.code
+    checkout.save()
+
+    voucher.apply_once_per_customer = True
+    voucher.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+
+    # when
+    order, action_required, _ = complete_checkout(
+        checkout_info=checkout_info,
+        manager=manager,
+        lines=lines,
+        payment_data={},
+        store_source=False,
+        discounts=None,
+        user=customer_user,
+        app=app,
+    )
+    # then
+    voucher_customer = VoucherCustomer.objects.filter(
+        voucher=voucher, customer_email=customer_user.email
+    )
+    assert not order
+    assert action_required is True
+    assert not voucher_customer.exists()
+    mocked_create_order.assert_not_called()

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -62,9 +62,11 @@ def remove_voucher_usage_by_customer(voucher: "Voucher", customer_email: str) ->
 
 def release_voucher_usage(order_data: dict):
     voucher = order_data.get("voucher")
-    if voucher and voucher.usage_limit:
+    if not voucher:
+        return
+    if voucher.usage_limit:
         decrease_voucher_usage(voucher)
-    if voucher and "user_email" in order_data:
+    if "user_email" in order_data:
         remove_voucher_usage_by_customer(voucher, order_data["user_email"])
 
 

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -64,8 +64,8 @@ def release_voucher_usage(order_data: dict):
     voucher = order_data.get("voucher")
     if voucher and voucher.usage_limit:
         decrease_voucher_usage(voucher)
-        if "user_email" in order_data:
-            remove_voucher_usage_by_customer(voucher, order_data["user_email"])
+    if voucher and "user_email" in order_data:
+        remove_voucher_usage_by_customer(voucher, order_data["user_email"])
 
 
 def get_product_discount_on_sale(


### PR DESCRIPTION
I want to merge this change because if user used a voucher that was marked as 'once per customer' and used 3d secure payment, the voucher was marked as not valid.

<!-- Please mention all relevant issue numbers. -->

Fixes #7588

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
