### PR TITLE
Remove duplicated checkout dataloader

### DIFF
--- a/saleor/graphql/channel/dataloaders.py
+++ b/saleor/graphql/channel/dataloaders.py
@@ -5,7 +5,7 @@ from django.db.models import Exists, OuterRef
 from ...channel.models import Channel
 from ...order.models import Order
 from ...shipping.models import ShippingZone
-from ..checkout.dataloaders import CheckoutByIdLoader, CheckoutLineByIdLoader
+from ..checkout.dataloaders import CheckoutByTokenLoader, CheckoutLineByIdLoader
 from ..core.dataloaders import DataLoader
 from ..order.dataloaders import OrderByIdLoader, OrderLineByIdLoader
 from ..shipping.dataloaders import ShippingZoneByIdLoader
@@ -42,7 +42,7 @@ class ChannelByCheckoutLineIDLoader(DataLoader):
                 return ChannelByIdLoader(self.context).load_many(channel_ids)
 
             return (
-                CheckoutByIdLoader(self.context)
+                CheckoutByTokenLoader(self.context)
                 .load_many(checkout_ids)
                 .then(channels_by_checkout)
             )

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -31,11 +31,7 @@ class CheckoutByTokenLoader(DataLoader):
     context_key = "checkout_by_token"
 
     def batch_load(self, keys):
-        checkouts = (
-            Checkout.objects.using(self.database_connection_name)
-            .filter(token__in=keys)
-            .in_bulk()
-        )
+        checkouts = Checkout.objects.using(self.database_connection_name).in_bulk(keys)
         return [checkouts.get(token) for token in keys]
 
 
@@ -115,14 +111,6 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader):
             keys
         )
         return Promise.all([checkouts, checkout_lines]).then(with_checkout_lines)
-
-
-class CheckoutByIdLoader(DataLoader):
-    context_key = "checkout_by_id"
-
-    def batch_load(self, keys):
-        checkouts = Checkout.objects.using(self.database_connection_name).in_bulk(keys)
-        return [checkouts.get(checkout_id) for checkout_id in keys]
 
 
 class CheckoutByUserLoader(DataLoader):


### PR DESCRIPTION
I want to merge this change because remove duplicated checkout dataloader. 

`checkout.id` and `checkout.token` is the same filed. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
