### PR TITLE
Add attributes delete to page and page_type bulk delete mutation

### DIFF
--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -1,9 +1,13 @@
 import graphene
+from django.core.exceptions import ValidationError
 
+from ...attribute import AttributeInputType
+from ...attribute import models as attribute_models
 from ...core.permissions import PagePermissions, PageTypePermissions
 from ...page import models
 from ..core.mutations import BaseBulkMutation, ModelBulkDeleteMutation
 from ..core.types.common import PageError
+from .types import Page, PageType
 
 
 class PageBulkDelete(ModelBulkDeleteMutation):
@@ -18,6 +22,22 @@ class PageBulkDelete(ModelBulkDeleteMutation):
         permissions = (PagePermissions.MANAGE_PAGES,)
         error_type_class = PageError
         error_type_field = "page_errors"
+
+    @classmethod
+    def perform_mutation(cls, _root, info, ids, **data):
+        try:
+            pks = cls.get_global_ids_or_error(ids, only_type=Page, field="pk")
+        except ValidationError as error:
+            return 0, error
+        cls.delete_assigned_attribute_values(pks)
+        return super().perform_mutation(_root, info, ids, **data)
+
+    @staticmethod
+    def delete_assigned_attribute_values(instance_pks):
+        attribute_models.AttributeValue.objects.filter(
+            pageassignments__page_id__in=instance_pks,
+            attribute__input_type__in=AttributeInputType.TYPES_WITH_UNIQUE_VALUES,
+        ).delete()
 
 
 class PageBulkPublish(BaseBulkMutation):
@@ -55,3 +75,19 @@ class PageTypeBulkDelete(ModelBulkDeleteMutation):
         permissions = (PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,)
         error_type_class = PageError
         error_type_field = "page_errors"
+
+    @classmethod
+    def perform_mutation(cls, _root, info, ids, **data):
+        try:
+            pks = cls.get_global_ids_or_error(ids, only_type=PageType, field="pk")
+        except ValidationError as error:
+            return 0, error
+        cls.delete_assigned_attribute_values(pks)
+        return super().perform_mutation(_root, info, ids, **data)
+
+    @staticmethod
+    def delete_assigned_attribute_values(instance_pks):
+        attribute_models.AttributeValue.objects.filter(
+            pageassignments__assignment__page_type_id__in=instance_pks,
+            attribute__input_type__in=AttributeInputType.TYPES_WITH_UNIQUE_VALUES,
+        ).delete()

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from ...attribute import AttributeInputType
 from ...attribute import models as attribute_models
 from ...core.permissions import PagePermissions, PageTypePermissions
+from ...core.tracing import traced_atomic_transaction
 from ...page import models
 from ..core.mutations import BaseBulkMutation, ModelBulkDeleteMutation
 from ..core.types.common import PageError
@@ -24,6 +25,7 @@ class PageBulkDelete(ModelBulkDeleteMutation):
         error_type_field = "page_errors"
 
     @classmethod
+    @traced_atomic_transaction()
     def perform_mutation(cls, _root, info, ids, **data):
         try:
             pks = cls.get_global_ids_or_error(ids, only_type=Page, field="pk")
@@ -77,6 +79,7 @@ class PageTypeBulkDelete(ModelBulkDeleteMutation):
         error_type_field = "page_errors"
 
     @classmethod
+    @traced_atomic_transaction()
     def perform_mutation(cls, _root, info, ids, **data):
         try:
             pks = cls.get_global_ids_or_error(ids, only_type=PageType, field="pk")

--- a/saleor/graphql/page/tests/test_page_bulk_delete.py
+++ b/saleor/graphql/page/tests/test_page_bulk_delete.py
@@ -1,17 +1,28 @@
-import graphene
+from unittest import mock
 
+import graphene
+import pytest
+
+from ....attribute.utils import associate_attribute_values_to_instance
 from ....page.models import Page
 from ...tests.utils import get_graphql_content
 
-
-def test_delete_pages(staff_api_client, page_list, permission_manage_pages):
-    query = """
+PAGE_BULK_DELETE_MUTATION = """
     mutation pageBulkDelete($ids: [ID]!) {
         pageBulkDelete(ids: $ids) {
             count
+            errors {
+                code
+                field
+                message
+            }
         }
     }
-    """
+"""
+
+
+def test_delete_pages(staff_api_client, page_list, permission_manage_pages):
+    query = PAGE_BULK_DELETE_MUTATION
 
     variables = {
         "ids": [graphene.Node.to_global_id("Page", page.id) for page in page_list]
@@ -22,4 +33,45 @@ def test_delete_pages(staff_api_client, page_list, permission_manage_pages):
     content = get_graphql_content(response)
 
     assert content["data"]["pageBulkDelete"]["count"] == len(page_list)
+    assert not Page.objects.filter(id__in=[page.id for page in page_list]).exists()
+
+
+@mock.patch("saleor.attribute.signals.delete_from_storage_task.delay")
+def test_page_bulk_delete_with_file_attribute(
+    delete_from_storage_task_mock,
+    app_api_client,
+    page_list,
+    page_file_attribute,
+    permission_manage_pages,
+):
+    # given
+    app_api_client.app.permissions.add(permission_manage_pages)
+
+    page = page_list[1]
+    page_count = len(page_list)
+    page_type = page.page_type
+
+    value = page_file_attribute.values.first()
+    page_type.page_attributes.add(page_file_attribute)
+    associate_attribute_values_to_instance(page, page_file_attribute, value)
+
+    variables = {
+        "ids": [graphene.Node.to_global_id("Page", page.pk) for page in page_list]
+    }
+    # when
+    response = app_api_client.post_graphql(PAGE_BULK_DELETE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageBulkDelete"]
+
+    assert not data["errors"]
+    assert data["count"] == page_count
+
+    with pytest.raises(page._meta.model.DoesNotExist):
+        page.refresh_from_db()
+    with pytest.raises(value._meta.model.DoesNotExist):
+        value.refresh_from_db()
+    delete_from_storage_task_mock.assert_called_once_with(value.file_url)
+
     assert not Page.objects.filter(id__in=[page.id for page in page_list]).exists()

--- a/saleor/graphql/page/tests/test_page_types_bulk_delete.py
+++ b/saleor/graphql/page/tests/test_page_types_bulk_delete.py
@@ -1,5 +1,9 @@
-import graphene
+from unittest import mock
 
+import graphene
+import pytest
+
+from ....attribute.utils import associate_attribute_values_to_instance
 from ....page.models import Page
 from ...tests.utils import assert_no_permission, get_graphql_content
 
@@ -117,3 +121,54 @@ def test_page_type_bulk_delete_by_app_no_perm(
 
     # then
     assert_no_permission(response)
+
+
+@mock.patch("saleor.attribute.signals.delete_from_storage_task.delay")
+def test_page_type_bulk_delete_with_file_attribute(
+    delete_from_storage_task_mock,
+    app_api_client,
+    page_type_list,
+    page_file_attribute,
+    permission_manage_page_types_and_attributes,
+):
+    # given
+    app_api_client.app.permissions.add(permission_manage_page_types_and_attributes)
+
+    page_type = page_type_list[1]
+
+    page_type_count = len(page_type_list)
+
+    page = Page.objects.filter(page_type=page_type.pk)[0]
+
+    value = page_file_attribute.values.first()
+    page_type.page_attributes.add(page_file_attribute)
+    associate_attribute_values_to_instance(page, page_file_attribute, value)
+
+    pages_pks = list(
+        Page.objects.filter(page_type__in=page_type_list).values_list("pk", flat=True)
+    )
+
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("PageType", page_type.pk)
+            for page_type in page_type_list
+        ]
+    }
+    # when
+    response = app_api_client.post_graphql(PAGE_TYPE_BULK_DELETE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageTypeBulkDelete"]
+
+    assert not data["errors"]
+    assert data["count"] == page_type_count
+
+    with pytest.raises(page_type._meta.model.DoesNotExist):
+        page_type.refresh_from_db()
+    with pytest.raises(value._meta.model.DoesNotExist):
+        value.refresh_from_db()
+
+    delete_from_storage_task_mock.assert_called_once_with(value.file_url)
+
+    assert not Page.objects.filter(pk__in=pages_pks)


### PR DESCRIPTION
I want to merge this change because it adds missing associated attributes delete function to page and page_Type bulk delete mutation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
