### PR TITLE
Remove duplicated checkout dataloder in 3.1

### DIFF
--- a/saleor/graphql/channel/dataloaders.py
+++ b/saleor/graphql/channel/dataloaders.py
@@ -5,7 +5,7 @@ from django.db.models import Exists, OuterRef
 from ...channel.models import Channel
 from ...order.models import Order
 from ...shipping.models import ShippingZone
-from ..checkout.dataloaders import CheckoutByIdLoader, CheckoutLineByIdLoader
+from ..checkout.dataloaders import CheckoutByTokenLoader, CheckoutLineByIdLoader
 from ..core.dataloaders import DataLoader
 from ..order.dataloaders import OrderByIdLoader, OrderLineByIdLoader
 from ..shipping.dataloaders import ShippingZoneByIdLoader
@@ -42,7 +42,7 @@ class ChannelByCheckoutLineIDLoader(DataLoader):
                 return ChannelByIdLoader(self.context).load_many(channel_ids)
 
             return (
-                CheckoutByIdLoader(self.context)
+                CheckoutByTokenLoader(self.context)
                 .load_many(checkout_ids)
                 .then(channels_by_checkout)
             )

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -30,11 +30,7 @@ class CheckoutByTokenLoader(DataLoader):
     context_key = "checkout_by_token"
 
     def batch_load(self, keys):
-        checkouts = (
-            Checkout.objects.using(self.database_connection_name)
-            .filter(token__in=keys)
-            .in_bulk()
-        )
+        checkouts = Checkout.objects.using(self.database_connection_name).in_bulk(keys)
         return [checkouts.get(token) for token in keys]
 
 
@@ -114,14 +110,6 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader):
             keys
         )
         return Promise.all([checkouts, checkout_lines]).then(with_checkout_lines)
-
-
-class CheckoutByIdLoader(DataLoader):
-    context_key = "checkout_by_id"
-
-    def batch_load(self, keys):
-        checkouts = Checkout.objects.using(self.database_connection_name).in_bulk(keys)
-        return [checkouts.get(checkout_id) for checkout_id in keys]
 
 
 class CheckoutByUserLoader(DataLoader):

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -447,7 +447,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(54):
+    with django_assert_num_queries(53):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -465,7 +465,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(54):
+    with django_assert_num_queries(53):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10
@@ -706,7 +706,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-    with django_assert_num_queries(57):
+    with django_assert_num_queries(56):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "token": checkout.token,
@@ -720,7 +720,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(57):
+    with django_assert_num_queries(56):
         variables = {
             "token": checkout.token,
             "lines": [],
@@ -961,7 +961,7 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(57):
+    with django_assert_num_queries(56):
         variables = {
             "checkoutId": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -974,7 +974,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(57):
+    with django_assert_num_queries(56):
         variables = {
             "checkoutId": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,


### PR DESCRIPTION
I want to merge this change because coping changes from #9085 to 3.1.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
