### PR TITLE
Fix invalid available shipping methods calculation for checkout

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -429,8 +429,7 @@ def recalculate_checkout_discount(
     applicable.
     """
     checkout = checkout_info.checkout
-    voucher = get_voucher_for_checkout_info(checkout_info)
-    if voucher is not None:
+    if voucher := checkout_info.voucher:
         address = checkout_info.shipping_address or checkout_info.billing_address
         try:
             discount = get_voucher_discount_for_checkout(
@@ -438,6 +437,7 @@ def recalculate_checkout_discount(
             )
         except NotApplicable:
             remove_voucher_from_checkout(checkout)
+            checkout_info.voucher = None
         else:
             subtotal = calculations.checkout_subtotal(
                 manager=manager,
@@ -552,6 +552,7 @@ def add_voucher_to_checkout(
             "last_change",
         ]
     )
+    checkout_info.voucher = voucher
 
 
 def remove_promo_code_from_checkout(checkout_info: "CheckoutInfo", promo_code: str):
@@ -564,9 +565,10 @@ def remove_promo_code_from_checkout(checkout_info: "CheckoutInfo", promo_code: s
 
 def remove_voucher_code_from_checkout(checkout_info: "CheckoutInfo", voucher_code: str):
     """Remove voucher data from checkout by code."""
-    existing_voucher = get_voucher_for_checkout_info(checkout_info)
+    existing_voucher = checkout_info.voucher
     if existing_voucher and existing_voucher.code == voucher_code:
         remove_voucher_from_checkout(checkout_info.checkout)
+        checkout_info.voucher = None
 
 
 def remove_voucher_from_checkout(checkout: Checkout):

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -14,6 +14,7 @@ from ...checkout.models import Checkout, CheckoutLine
 from ...shipping.utils import convert_to_shipping_method_data
 from ..account.dataloaders import AddressByIdLoader, UserByUserIdLoader
 from ..core.dataloaders import DataLoader
+from ..discount.dataloaders import VoucherByCodeLoader
 from ..product.dataloaders import (
     CollectionsByVariantIdLoader,
     ProductByVariantIdLoader,
@@ -201,6 +202,12 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                         self.context
                     ).load_many(channel_slugs)
                 )
+                voucher_codes = {
+                    checkout.voucher_code
+                    for checkout in checkouts
+                    if checkout.voucher_code
+                }
+                vouchers = VoucherByCodeLoader(self.context).load_many(voucher_codes)
 
                 def with_checkout_info(results):
                     (
@@ -208,6 +215,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                         users,
                         shipping_methods,
                         listings_for_channels,
+                        vouchers,
                     ) = results
                     address_map = {address.id: address for address in addresses}
                     user_map = {user.id: user for user in users}
@@ -221,6 +229,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                         for listing in channel_listings
                         if listing
                     }
+                    voucher_map = {voucher.code: voucher for voucher in vouchers}
 
                     checkout_info_map = {}
                     for key, checkout, channel, checkout_lines in zip(
@@ -243,6 +252,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                         delivery_method_info = get_delivery_method_info(
                             delivery_method, shipping_address
                         )
+                        voucher = voucher_map.get(checkout.voucher_code)
                         checkout_info = CheckoutInfo(
                             checkout=checkout,
                             user=user_map.get(checkout.user_id),
@@ -255,6 +265,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                             ),
                             delivery_method_info=delivery_method_info,
                             all_shipping_methods=[],
+                            voucher=voucher,
                         )
 
                         def fetch_valid_shipping_methods():
@@ -291,6 +302,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                         users,
                         shipping_methods,
                         shipping_method_channel_listings,
+                        vouchers,
                     ]
                 ).then(with_checkout_info)
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1669,6 +1669,52 @@ def test_checkout_shipping_methods_with_price_based_shipping_method_and_discount
     assert shipping_method.name not in shipping_methods
 
 
+def test_checkout_shipping_methods_with_price_based_shipping_and_shipping_discount(
+    api_client,
+    checkout_with_item,
+    address,
+    shipping_method,
+    voucher_shipping_type,
+):
+    """Ensure that price based shipping method is returned when checkout
+    has discount on shipping."""
+    checkout_with_item.shipping_address = address
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
+
+    subtotal = calculations.checkout_subtotal(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=checkout_with_item.shipping_address,
+    )
+
+    checkout_with_item.discount_amount = Decimal(5.0)
+    checkout_with_item.voucher_code = voucher_shipping_type.code
+    checkout_with_item.save(
+        update_fields=["shipping_address", "discount_amount", "voucher_code"]
+    )
+
+    shipping_method.name = "Price based"
+    shipping_method.save(update_fields=["name"])
+
+    shipping_channel_listing = shipping_method.channel_listings.get(
+        channel=checkout_with_item.channel
+    )
+    shipping_channel_listing.minimum_order_price_amount = subtotal.gross.amount - 1
+    shipping_channel_listing.save(update_fields=["minimum_order_price_amount"])
+
+    query = GET_CHECKOUT_AVAILABLE_SHIPPING_METHODS
+    variables = {"token": checkout_with_item.token}
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkout"]
+
+    shipping_methods = [method["name"] for method in data["availableShippingMethods"]]
+    assert shipping_method.name in shipping_methods
+
+
 def test_checkout_available_shipping_methods_shipping_zone_without_channels(
     api_client, checkout_with_item, address, shipping_zone
 ):

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 
 import graphene
+import pytest
 from prices import Money
 
 from ....checkout import calculations
@@ -742,6 +743,103 @@ def test_checkout_add_promo_code_invalidate_shipping_method(
     )
     assert data["checkout"]["shippingMethod"] is None
     assert shipping_method_id not in data["checkout"]["availableShippingMethods"]
+
+
+@pytest.mark.parametrize("shipping_price", [12, 10, 5])
+def test_checkout_add_free_shipping_voucher_do_not_invalidate_shipping_method(
+    shipping_price,
+    api_client,
+    checkout_with_item,
+    voucher_free_shipping,
+    shipping_method,
+    address_usa,
+):
+    """Ensure that adding free shipping voucher do not invalidate
+    current shipping method.
+    """
+    checkout_with_item.shipping_method = shipping_method
+    checkout_with_item.shipping_address = address_usa
+    checkout_with_item.save(update_fields=["shipping_method", "shipping_address"])
+
+    channel = checkout_with_item.channel
+
+    line = checkout_with_item.lines.first()
+    line.quantity = 1
+    line.save(update_fields=["quantity"])
+
+    variant_listing = line.variant.channel_listings.get(channel=channel)
+    variant_listing.price = Money(10, "USD")
+    variant_listing.save(update_fields=["price_amount"])
+
+    # set minimal price similar to order subtotal price;
+    # set shipping price so big, that in case the discount will be applied
+    # substracted from subtotal the shipping method will be not valid anymore
+    shipping_listing = shipping_method.channel_listings.get(channel=channel)
+    shipping_listing.price = Money(shipping_price, "USD")
+    shipping_listing.minimum_order_price = Money(8, "USD")
+    shipping_listing.save(update_fields=["price_amount", "minimum_order_price_amount"])
+
+    variables = {
+        "token": checkout_with_item.token,
+        "promoCode": voucher_free_shipping.code,
+    }
+    data = _mutate_checkout_add_promo_code(api_client, variables)
+
+    # ensure that shipping method wasn't invalidate
+    assert data["checkout"]["shippingMethod"]["id"] == graphene.Node.to_global_id(
+        "ShippingMethod", shipping_method.id
+    )
+
+
+@pytest.mark.parametrize("shipping_discount", [12, 10, 5])
+def test_checkout_add_shipping_voucher_do_not_invalidate_shipping_method(
+    shipping_discount,
+    api_client,
+    checkout_with_item,
+    voucher_shipping_type,
+    shipping_method,
+    address_usa,
+):
+    """Ensure that adding shipping voucher do not invalidate current shipping method."""
+    checkout_with_item.shipping_method = shipping_method
+    checkout_with_item.shipping_address = address_usa
+    checkout_with_item.save(update_fields=["shipping_method", "shipping_address"])
+
+    channel = checkout_with_item.channel
+
+    line = checkout_with_item.lines.first()
+    line.quantity = 1
+    line.save(update_fields=["quantity"])
+
+    variant_listing = line.variant.channel_listings.get(channel=channel)
+    variant_listing.price = Money(10, "USD")
+    variant_listing.save(update_fields=["price_amount"])
+
+    # set minimal price similar to order subtotal price;
+    shipping_listing = shipping_method.channel_listings.get(channel=channel)
+    shipping_listing.price = Money(20, "USD")
+    shipping_listing.minimum_order_price = Money(8, "USD")
+    shipping_listing.save(update_fields=["price_amount", "minimum_order_price_amount"])
+
+    # set shipping voucher price so big, that in case the discount will be
+    # substracted from subtotal price the shipping method will be not valid anymore
+    voucher_listing = voucher_shipping_type.channel_listings.get(channel=channel)
+    voucher_listing.discount = Money(shipping_discount, "USD")
+    voucher_listing.save(update_fields=["discount_value"])
+
+    voucher_shipping_type.countries = []
+    voucher_shipping_type.save(update_fields=["countries"])
+
+    variables = {
+        "token": checkout_with_item.token,
+        "promoCode": voucher_shipping_type.code,
+    }
+    data = _mutate_checkout_add_promo_code(api_client, variables)
+
+    # ensure that shipping method wasn't invalidate
+    assert data["checkout"]["shippingMethod"]["id"] == graphene.Node.to_global_id(
+        "ShippingMethod", shipping_method.id
+    )
 
 
 MUTATION_CHECKOUT_REMOVE_PROMO_CODE = """

--- a/saleor/graphql/discount/dataloaders.py
+++ b/saleor/graphql/discount/dataloaders.py
@@ -96,6 +96,18 @@ class VoucherByIdLoader(DataLoader):
         return [vouchers.get(voucher_id) for voucher_id in keys]
 
 
+class VoucherByCodeLoader(DataLoader):
+    context_key = "voucher_by_code"
+
+    def batch_load(self, keys):
+        vouchers = (
+            Voucher.objects.using(self.database_connection_name)
+            .filter(code__in=keys)
+            .in_bulk(field_name="code")
+        )
+        return [vouchers.get(code) for code in keys]
+
+
 class VoucherChannelListingByVoucherIdAndChanneSlugLoader(DataLoader):
     context_key = "voucherchannelisting_by_voucher_and_channel"
 


### PR DESCRIPTION
**Issue description**

Given:
- checkout with shipping method price based set

Situation:
- shipping voucher is applied, the voucher discount reduces the price, so the minimal price condition for the current shipping method is not fulfilled

Previous behavior:
- the current shipping method was removed

Current solution
- the current method is not removed, as the voucher is applied on shipping, which conditions were already fulfilled;
(i.e. somebody applied free shipping voucher - we should ensure that the shipping is not removed)
- available shipping methods are updated when discount concerns entire orders or specific products

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
