### PR TITLE
Don't trace async resolvers

### DIFF
--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -156,7 +156,6 @@ class ProductChannelListing(ModelObjectType):
         return root.is_available_for_purchase()
 
     @staticmethod
-    @traced_resolver
     def resolve_pricing(root: models.ProductChannelListing, info, address=None):
         context = info.context
 

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -468,7 +468,6 @@ class ProductVariant(ChannelContextTypeWithMetadata, ModelObjectType):
         return getattr(root.node, "digital_content", None)
 
     @staticmethod
-    @traced_resolver
     def resolve_attributes(
         root: ChannelContext[models.ProductVariant],
         info,
@@ -511,7 +510,6 @@ class ProductVariant(ChannelContextTypeWithMetadata, ModelObjectType):
         return VariantChannelListingByVariantIdLoader(info.context).load(root.node.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_pricing(
         root: ChannelContext[models.ProductVariant], info, address=None
     ):
@@ -887,7 +885,6 @@ class Product(ChannelContextTypeWithMetadata, ModelObjectType):
         return ""
 
     @staticmethod
-    @traced_resolver
     def resolve_pricing(root: ChannelContext[models.Product], info, address=None):
         if not root.channel_slug:
             return None


### PR DESCRIPTION
The current tracing decorator can't properly trace Promise-based resolvers so we only waste time executing the tracing wrappers.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
