### PR TITLE
Saleor 5715 fix breaking calculate order shipping avatax method 3.1

### DIFF
--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -327,14 +327,6 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
                 "Unable to calculate taxes - %s" % str(tax_error),
                 code=OrderErrorCode.TAX_ERROR.value,
             )
-        except Exception as e:
-            raise ValidationError(
-                {
-                    "shipping_method": ValidationError(
-                        str(e), code=OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.value
-                    )
-                }
-            )
 
         if new_instance:
             transaction.on_commit(

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -327,6 +327,14 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
                 "Unable to calculate taxes - %s" % str(tax_error),
                 code=OrderErrorCode.TAX_ERROR.value,
             )
+        except Exception as e:
+            raise ValidationError(
+                {
+                    "shipping_method": ValidationError(
+                        str(e), code=OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.value
+                    )
+                }
+            )
 
         if new_instance:
             transaction.on_commit(

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -243,20 +243,11 @@ class OrderUpdate(DraftOrderCreate):
             instance.user = user
         instance.search_document = prepare_order_search_document_value(instance)
         instance.save()
-        try:
-            update_order_prices(
-                instance,
-                info.context.plugins,
-                info.context.site.settings.include_taxes_in_prices,
-            )
-        except Exception as e:
-            raise ValidationError(
-                {
-                    "shipping_method": ValidationError(
-                        str(e), code=OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.value
-                    )
-                }
-            )
+        update_order_prices(
+            instance,
+            info.context.plugins,
+            info.context.site.settings.include_taxes_in_prices,
+        )
         transaction.on_commit(lambda: info.context.plugins.order_updated(instance))
 
 
@@ -417,20 +408,11 @@ class OrderUpdateShipping(EditableOrderValidationMixin, BaseMutation):
                 "shipping_tax_rate",
             ]
         )
-        try:
-            update_order_prices(
-                order,
-                info.context.plugins,
-                info.context.site.settings.include_taxes_in_prices,
-            )
-        except Exception as e:
-            raise ValidationError(
-                {
-                    "shipping_method": ValidationError(
-                        str(e), code=OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.value
-                    )
-                }
-            )
+        update_order_prices(
+            order,
+            info.context.plugins,
+            info.context.site.settings.include_taxes_in_prices,
+        )
         # Post-process the results
         order_shipping_updated(order, info.context.plugins)
         return OrderUpdateShipping(order=order)

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -2626,17 +2626,12 @@ def test_draft_order_create_invalid_shipping_address(
 DRAFT_UPDATE_QUERY = """
         mutation draftUpdate(
         $id: ID!,
-        $voucher: ID,
-        $channel: ID,
-        $customerNote: String
+        $input: DraftOrderInput!,
         ) {
             draftOrderUpdate(
                 id: $id,
-                input: {
-                    voucher: $voucher,
-                    customerNote: $customerNote
-                    channelId: $channel
-                }) {
+                input: $input
+            ) {
                 errors {
                     field
                     code
@@ -2664,7 +2659,9 @@ def test_draft_order_update_existing_channel_id(
     channel_id = graphene.Node.to_global_id("Channel", channel_PLN.id)
     variables = {
         "id": order_id,
-        "channel": channel_id,
+        "input": {
+            "channelId": channel_id,
+        },
     }
 
     response = staff_api_client.post_graphql(
@@ -2690,7 +2687,9 @@ def test_draft_order_update_voucher_not_available(
     voucher.channel_listings.all().delete()
     variables = {
         "id": order_id,
-        "voucher": voucher_id,
+        "input": {
+            "voucher": voucher_id,
+        },
     }
 
     response = staff_api_client.post_graphql(
@@ -2701,6 +2700,43 @@ def test_draft_order_update_voucher_not_available(
 
     assert error["code"] == OrderErrorCode.NOT_AVAILABLE_IN_CHANNEL.name
     assert error["field"] == "voucher"
+
+
+def test_draft_order_update_shipping_method_no_channel_listing(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    shipping_method,
+    graphql_address_data,
+):
+    order = order_with_lines
+    order.status = OrderStatus.DRAFT
+    order.save()
+    assert order.voucher is None
+    query = DRAFT_UPDATE_QUERY
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    shipping_method_id = graphene.Node.to_global_id(
+        "ShippingMethodType", shipping_method.id
+    )
+    shipping_method.channel_listings.all().delete()
+    variables = {
+        "id": order_id,
+        "input": {
+            "shippingAddress": graphql_address_data,
+            "shippingMethod": shipping_method_id,
+        },
+    }
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    errors = content["data"]["draftOrderUpdate"]["errors"]
+
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["code"] == OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.name
+    assert error["field"] == "shippingMethod"
 
 
 DRAFT_ORDER_UPDATE_MUTATION = """
@@ -4893,6 +4929,32 @@ def test_order_update(
     order_updated_webhook_mock.assert_called_once_with(order)
 
 
+def test_order_update_no_shipping_method_channel_listing(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    graphql_address_data,
+):
+    order = order_with_lines
+    order.user = None
+    order.save()
+    email = "not_default@example.com"
+    assert not order.user_email == email
+    assert not order.shipping_address.first_name == graphql_address_data["firstName"]
+    assert not order.billing_address.last_name == graphql_address_data["lastName"]
+    order.shipping_method.channel_listings.all().delete()
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id, "email": email, "address": graphql_address_data}
+    response = staff_api_client.post_graphql(
+        ORDER_UPDATE_MUTATION, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    errors = content["data"]["orderUpdate"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.name
+    assert errors[0]["field"] == "shippingMethod"
+
+
 @patch("saleor.plugins.manager.PluginsManager.order_updated")
 def test_order_update_with_draft_order(
     order_updated_webhook_mock,
@@ -5763,6 +5825,35 @@ def test_order_update_shipping(
     assert order.shipping_price_gross == shipping_price.gross
     assert order.shipping_tax_rate == Decimal("0.0")
     assert order.shipping_method_name == shipping_method.name
+
+
+@pytest.mark.parametrize("status", [OrderStatus.UNCONFIRMED, OrderStatus.DRAFT])
+def test_order_update_shipping_no_shipping_method_channel_listings(
+    status,
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    shipping_method,
+    staff_user,
+):
+    order = order_with_lines
+    order.status = status
+    order.save()
+    assert order.shipping_method != shipping_method
+    query = ORDER_UPDATE_SHIPPING_QUERY
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    method_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
+    shipping_method.channel_listings.all().delete()
+    variables = {"order": order_id, "shippingMethod": method_id}
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderUpdateShipping"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE.name
+    assert errors[0]["field"] == "shippingMethod"
 
 
 def test_order_update_shipping_tax_included(

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -149,9 +149,18 @@ def _validate_order(order: "Order") -> bool:
     shipping_address = order.shipping_address
     shipping_required = order.is_shipping_required()
     address = shipping_address or order.billing_address
-    return _validate_adddress_details(
-        shipping_address, shipping_required, address, order.shipping_method
+    shipping_method = order.shipping_method
+    valid_address_details = _validate_adddress_details(
+        shipping_address, shipping_required, address, shipping_method
     )
+    if not valid_address_details:
+        return False
+    channel_listing = shipping_method.channel_listings.filter(  # type: ignore
+        channel_id=order.channel_id
+    ).first()
+    if not channel_listing:
+        return False
+    return True
 
 
 def _validate_checkout(

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -657,10 +657,14 @@ class AvataxPlugin(BasePlugin):
                     gross = Money(amount=net + tax, currency=currency)
                     net = Money(amount=net, currency=currency)
                 return TaxedMoney(net=net, gross=gross)
+
+        # Ignore typing checks because it is checked in _validate_order
+        price = order.shipping_method.channel_listings.get(  # type: ignore
+            channel_id=order.channel_id
+        ).price
         return TaxedMoney(
-            # Ignore typing checks because it is checked in _validate_order
-            net=order.shipping_method.price,  # type: ignore
-            gross=order.shipping_method.price,  # type: ignore
+            net=price,
+            gross=price,
         )
 
     def get_tax_rate_type_choices(self, previous_value: Any) -> List[TaxType]:

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -659,9 +659,12 @@ class AvataxPlugin(BasePlugin):
                 return TaxedMoney(net=net, gross=gross)
 
         # Ignore typing checks because it is checked in _validate_order
-        price = order.shipping_method.channel_listings.get(  # type: ignore
+        channel_listing = order.shipping_method.channel_listings.filter(  # type: ignore
             channel_id=order.channel_id
-        ).price
+        ).first()
+        if not channel_listing:
+            raise Exception("Shipping method not available in the given channel.")
+        price = channel_listing.price
         return TaxedMoney(
             net=price,
             gross=price,

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -663,7 +663,7 @@ class AvataxPlugin(BasePlugin):
             channel_id=order.channel_id
         ).first()
         if not channel_listing:
-            raise Exception("Shipping method not available in the given channel.")
+            return previous_value
         price = channel_listing.price
         return TaxedMoney(
             net=price,

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_order_shipping_zero_shipping_amount.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_order_shipping_zero_shipping_amount.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
+      "lines": [{"quantity": 3, "amount": "36.900", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "SKU_A", "description": "Test product"}], "code": "caeb3dd0-d243-4aa0-8eeb-40eac6e313a4",
+      "date": "2022-01-28", "customerCode": 0, "addresses": {"shipFrom": {"line1":
+      "Teczowa 7", "line2": null, "city": "Wroclaw", "region": "", "country": "PL",
+      "postalCode": "53-601"}, "shipTo": {"line1": "T\u0119czowa 7", "line2": "",
+      "city": "WROC\u0141AW", "region": "", "country": "PL", "postalCode": "53-601"}},
+      "commit": false, "currencyCode": "USD", "email": "test@example.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '651'
+      User-Agent:
+      - python-requests/2.27.1
+    method: POST
+    uri: https://rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: !!binary |
+        i/8BAICqqqrq/3SXs5qB2uZurqd0cI+DAwQsEO4eh7yJq7K5a6aZqoGqmKc5pO9voz9AqHUPc9vd
+        +RaNRqJxkXjktkgkmqLu0D1HhWBv/0/ekdlstda60fVuV7U7RTY6kCHLuDXO6cLVbVO0zLrogVvR
+        arDdoKkabkmRjdPM4XVyZOq23m07RY4FZKjWdV3oqqh7UpSFZclk6MxPOFIkr7kS1s48Ip/CM3oL
+        UnRjsY+DiSAF7JISgn2hceV6PpIirPbB4Y5vFhxEO1O7ZIkT0jXzHZfXXAsS2wXx8rpmZIxK6mx+
+        EFxMXFRNln+4x4pplo9I0fQkwcZg/QhHZuAxQ9EYLYuPIS4qCdHNMYkP93e65s9Lsg/O+EwOKXE2
+        AxKCdVk0zwhtRsq5mSO8fj6RknctpvsjBhDJvf0UlyBkdKk5br/BOQbySLdE4VGctFEHgfWtXTri
+        BW1Hn21OJrhz4ZXMptwpkpG98Mq3Ecm4e+H1wKNdRhZcGyTAYfdnyTIhiJ2tfUTZM3TBkYjZI7JN
+        fh4svqbbGO3fZPhNvSXcPZ0+FifpRYa+3knREynz5FaKchzkHyf84Kmjui6rsi63jZWY/N2HvXMJ
+        OZ8cmb76Eph2fdu13a5V5JDFh+3SoBShamVWHGbx34YBVvwTRxZUxPAZBvFFptoQ1LVaeYyJ/UiG
+        BFl+YeVpHlHaOJGi25J9cEty0ufgzy4cR9RN0fnBwxWvLV50bxptdFt2Xb+pttvfpGjC/wAAQFVV
+        VfV/ugbwWcNBTM3Mw01vDh6ZAAYZ4OEQ7n7KQ4C6qbiBApipWqqKBphBmrrYdRtvNR8IWmxjmZys
+        rKysfPkJ2lRWvkQiJG6pZRh7DX6o5F+j80/P7p459Q5GH+qq0wpi13crDANNWr9S9aoPUJh84Azz
+        9z+8g9lrIqqoaxvdHVoFSTZkO4iPIR+i/RsRUU2666qmUwnou3OZH5xgUEHhEUtwNm2fP5ySdxyI
+        X5HCULLEmdM925Fv28IwgAIH8bLdM5+iYzhZx3lIfimKEAY3zvKypOjKIHAgER/sgT06lzjnGpgH
+        XoipPTRt03aNQkx+9MHpblZn5zifh1iCHOc/KAztyLDxbVuYF+WV58Vz12E5cZLqmAQWOUeYpnDF
+        5154vtnVPiaGkVTYAOd6vV1gnnbKEFh47jnr9c/9+7iHPAj5Ne2IiBT+FRtGBIapOUISP6tCSRI/
+        9a3YJSbxYVzuA038cxx6pR4Q5FjS4MMIg3fOsywLShxQmP2uu1Elv47zbFKl0wzOyU5Dmaywc97e
+        bazP7pN6rmqwvYNp6yY6fSR3ELv+CqMPQsgsdlVMqfP3YXCOgaHwKFmf4Nw7rYCfflg+jXGfQwfn
+        QXmklC+2WUrUQw59GKbi2O2mWMdi/ZT1f/PfGiLSLXW0b+tHA0k2ZP0n/vChN+K9pifyommF+lRb
+        TpA2GFw+oJB49HSpIc3BbL/7yxUNkGaxwtDWhXjuPCAiBV55XuSLLf4HAACqqqqq/9M1Qc4KDmoa
+        7h7gerM0j0xwAAczBzfLU0IcxE0lzDVBXdRAVDTBHRLSbBOTwK7WwrT8jl4kEhkZiUSyaYWsRFbO
+        G9pzUCbtfyXzKYDfGog8KiqBV6lk4E+VWLocCDxczmBAaT0+in04t/2RiB7irFFL7p21jXUGSlwY
+        tQqpBAMD5QWqbWHJKfQZCD5fatNrLbKunwANRfUin+fKKi8wwJknfOItUfvIlRW83VhrLZvYtSZa
+        i76JomZXVOohAwOyL5vduDcRAQYa4922sYd3h4uPucrMcGcNFJKlDrDryAt4OFLRyJgErcCA4hP8
+        fnMwx6qeM30zHZvi01johqpr1VlpY70xBCMVBliA+U/JdSV4OPFateUwmJTDjKMiB5TwbVP6zI9t
+        1XuWqC8hgkbd7l5nu9ISjxZ1V7xWfHaY5ppQKWyQDsNfEomBAqMpLojO75ZQwZSQdHQhuJf/4qhl
+        /WO6ZGEv8Y6e9FiVyPcrRx2+vmOJBTxcSLoqQjy/emkXDMTSZ75gKdNdKvgvTIUYaj+IkNdCaM2i
+        kZfJ1bu5ofWZezK1Lal+OMyrAenkzO0HbB2mOdRjMJAi3mI6SUBOA6VEAv8/c2HssaF3yXW5H0kx
+        pgL+9+ckOdM5zz+METKo5T8Iea4PYj3HjmznFMC/N9Zat3cH59yhMf3p3SmA3ztrbWMPu63D/wAA
+        QFVVVfV/ugbwWS1ATc3UzFRvDgbgAA5gEO7gbgAOEA5+UFdTcFcAM1UDVTX3sHBwSze8/gewmgSt
+        jm05WSGRyMqX3ZIFayuRSIREIoTc3NBx/C1GYHgX0XCCwetlMi5thiGYGHcDZJNTSilvSl5yURKM
+        XqtkvevX2bR+MJA4Pey8DX7Ch7xlurWzznT8gXo7NaOUsooJxphgn+zJJ0cVUORU8JJZmkJHX1pq
+        9B6fK8EjtjbtPAi0j2nn4hKU02YbjL0/EiT9pgRPlbjePnSnjBV0n2WHDi9T+Fmmmwn9msJElSE1
+        IQsmQl7esIMCjdXOWikoF5VO1rtsSTUFVxSUCZGXguDmFzeosHbmaUZI/NqZg2C0zuSQ6I3+9y/1
+        VePcMkOIRIqKRzuqbVohcT7u225zBkEwd+sdwYrZx6TGUF7yIqtojhFgWVwKN6FDOixJ/R3vJXoM
+        jPKcsg8J5MrxdyiC16N64QcQrgSj1yrV1R//S0PH/WM5c1PERqhqwUQpmnL2HJCqHzh+6WjTBCNt
+        mz2pTc5aKoGNrFChbuLbDNTugnFdn/uxF5dpUmGFvLyh/QKcAACAqqqq6v90deCzgYGAm7sDuN4M
+        zI8GC7jZ1Q9irgLm6mCmaqAmCmB2MFtetYCtthsOHwc4zDEcPngDHX8sRXiNBwy6GhmiTC54x3//
+        FN02HKvAoAoJ1pmgClYSi4Gi4UXCdW1dNi9kUN7LpL8QnR41Rt7uGTZllXLb3OTFNgEGuCX1ok26
+        JrUNfRoTT3Ne6Xtlbznay5tV3hawCjxWnDstj7PAFJQTZaQWGMqvBZEnVXmHeeRPGrWpeP6mmVVs
+        4NcHP9R4thCyy7KqCx6GcqLzcw4=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - br
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 28 Jan 2022 08:30:04 GMT
+      Location:
+      - /api/v2/companies/242975/transactions/67000030299149
+      ServerDuration:
+      - '00:00:00.0769519'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - 0727935d-d2c5-4401-9e98-fe98ca09cac7
+      x-correlation-id:
+      - 0727935d-d2c5-4401-9e98-fe98ca09cac7
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -18,7 +18,7 @@ from ....checkout.fetch import (
 )
 from ....checkout.utils import add_variant_to_checkout
 from ....core.prices import quantize_price
-from ....core.taxes import TaxError, TaxType
+from ....core.taxes import TaxError, TaxType, zero_taxed_money
 from ....discount import DiscountValueType, OrderDiscountType, VoucherType
 from ....order import OrderStatus
 from ....product import ProductTypeKind
@@ -1162,6 +1162,29 @@ def test_calculate_order_shipping_zero_shipping_amount(
     price = manager.calculate_order_shipping(order)
     price = quantize_price(price, price.currency)
     assert price == TaxedMoney(net=Money("0.00", "USD"), gross=Money("0.00", "USD"))
+
+
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_calculate_order_shipping_no_channel_listing(
+    order_line, shipping_zone, site_settings, address, plugin_configuration
+):
+    plugin_configuration()
+    manager = get_plugins_manager()
+    order = order_line.order
+    method = shipping_zone.shipping_methods.get()
+    order.shipping_address = order.billing_address.get_copy()
+    order.shipping_method_name = method.name
+    order.shipping_method = method
+    order.save()
+
+    method.channel_listings.all().delete()
+
+    site_settings.company_address = address
+    site_settings.save()
+
+    price = manager.calculate_order_shipping(order)
+    price = quantize_price(price, price.currency)
+    assert price == zero_taxed_money(order.currency)
 
 
 @pytest.mark.vcr

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -280,7 +280,7 @@ class PluginsManager(PaymentInterface):
             channel_id=order.channel_id
         ).first()
         if not channel_listing:
-            raise Exception("Shipping method not available in the given channel.")
+            return zero_taxed_money(order.currency)
         shipping_price = channel_listing.price
         default_value = quantize_price(
             TaxedMoney(net=shipping_price, gross=shipping_price),

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -276,9 +276,12 @@ class PluginsManager(PaymentInterface):
     def calculate_order_shipping(self, order: "Order") -> TaxedMoney:
         if not order.shipping_method:
             return zero_taxed_money(order.currency)
-        shipping_price = order.shipping_method.channel_listings.get(
+        channel_listing = order.shipping_method.channel_listings.filter(
             channel_id=order.channel_id
-        ).price
+        ).first()
+        if not channel_listing:
+            raise Exception("Shipping method not available in the given channel.")
+        shipping_price = channel_listing.price
         default_value = quantize_price(
             TaxedMoney(net=shipping_price, gross=shipping_price),
             shipping_price.currency,


### PR DESCRIPTION
Port #9024.

Fix breaking `calculate_order_shipping` avatax method. The `price` field is no longer part of the `ShippingMethod` model.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
