### PR TITLE
Add draft order validation in DraftOrderComplete mutation

### DIFF
--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -418,8 +418,21 @@ class DraftOrderComplete(BaseMutation):
                 order.user = None
 
     @classmethod
+    def validate_order(cls, order):
+        if not order.is_draft():
+            raise ValidationError(
+                {
+                    "id": ValidationError(
+                        "The order is not draft.", code=OrderErrorCode.INVALID.value
+                    )
+                }
+            )
+
+    @classmethod
     def perform_mutation(cls, _root, info, id):
         order = cls.get_node_or_error(info, id, only_type=Order)
+        cls.validate_order(order)
+
         country = get_order_country(order)
         validate_draft_order(order, country, info.context.plugins)
         cls.update_user_fields(order)

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -3533,6 +3533,22 @@ def test_draft_order_complete_unavailable_for_purchase(
     assert error["code"] == OrderErrorCode.PRODUCT_UNAVAILABLE_FOR_PURCHASE.name
 
 
+def test_draft_order_complete_not_draft_order(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+):
+    order_id = graphene.Node.to_global_id("Order", order_with_lines.id)
+    variables = {"id": order_id}
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_COMPLETE_MUTATION, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderComplete"]
+    assert data["errors"][0]["code"] == OrderErrorCode.INVALID.name
+    assert data["errors"][0]["field"] == "id"
+
+
 ORDER_LINES_CREATE_MUTATION = """
     mutation OrderLinesCreate($orderId: ID!, $variantId: ID!, $quantity: Int!) {
         orderLinesCreate(id: $orderId,


### PR DESCRIPTION
Do not allow to perform `DraftOrderComplete` mutation for not draft orders.

Running `DraftOrderComplete` for normal order was raising an error.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
