### PR TITLE
Remove tracing form trivial resolvers

### DIFF
--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -5,7 +5,6 @@ import graphene
 from ...attribute import AttributeInputType, AttributeType, models
 from ...core.exceptions import PermissionDenied
 from ...core.permissions import PagePermissions, ProductPermissions
-from ...core.tracing import traced_resolver
 from ...graphql.utils import get_user_or_app_from_context
 from ..core.connection import CountableDjangoObjectType
 from ..core.enums import MeasurementUnitsEnum
@@ -56,7 +55,6 @@ class AttributeValue(CountableDjangoObjectType):
         model = models.AttributeValue
 
     @staticmethod
-    @traced_resolver
     def resolve_input_type(root: models.AttributeValue, info, *_args):
         def _resolve_input_type(attribute):
             requester = get_user_or_app_from_context(info.context)

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -3,7 +3,6 @@ from urllib.parse import urljoin
 import graphene
 from django.conf import settings
 
-from ....core.tracing import traced_resolver
 from ....product.product_images import get_thumbnail
 from ...account.enums import AddressTypeEnum
 from ..enums import (
@@ -435,7 +434,6 @@ class Job(graphene.Interface):
     message = graphene.String(description="Job message.")
 
     @classmethod
-    @traced_resolver
     def resolve_type(cls, instance, _info):
         """Map a data object to a Graphene type."""
         MODEL_TO_TYPE_MAP = {

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -2,7 +2,6 @@ import graphene
 
 from ...core.exceptions import PermissionDenied
 from ...core.permissions import AccountPermissions, GiftcardPermissions
-from ...core.tracing import traced_resolver
 from ...giftcard import models
 from ..account.utils import requestor_has_access
 from ..core.connection import CountableDjangoObjectType
@@ -50,7 +49,6 @@ class GiftCard(CountableDjangoObjectType):
         raise PermissionDenied()
 
     @staticmethod
-    @traced_resolver
     def resolve_code(root: models.GiftCard, info, **_kwargs):
         user = info.context.user
         # Staff user has access to show gift card code only for gift card without user.

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -273,7 +273,6 @@ class OrderEvent(CountableDjangoObjectType):
         return root.parameters.get("invoice_number")
 
     @staticmethod
-    @traced_resolver
     def resolve_lines(root: models.OrderEvent, info):
         raw_lines = root.parameters.get("lines", None)
 
@@ -472,7 +471,6 @@ class OrderLine(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_thumbnail(root: models.OrderLine, info, *, size=255):
         if not root.variant_id:
             return None
@@ -753,7 +751,6 @@ class Order(CountableDjangoObjectType):
         return OrderDiscountsByOrderIDLoader(info.context).load(root.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_discount(root: models.Order, info):
         def return_voucher_discount(discounts) -> Optional[Money]:
             if not discounts:
@@ -770,7 +767,6 @@ class Order(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_discount_name(root: models.Order, info):
         def return_voucher_name(discounts) -> Optional[Money]:
             if not discounts:
@@ -787,7 +783,6 @@ class Order(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_translated_discount_name(root: models.Order, info):
         def return_voucher_translated_name(discounts) -> Optional[Money]:
             if not discounts:
@@ -832,7 +827,6 @@ class Order(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_shipping_address(root: models.Order, info):
         def _resolve_shipping_address(data):
             if isinstance(data, Address):
@@ -909,7 +903,6 @@ class Order(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_subtotal(root: models.Order, info):
         def _resolve_subtotal(order_lines):
             return get_subtotal(order_lines, root.currency)
@@ -1017,7 +1010,6 @@ class Order(CountableDjangoObjectType):
         return root.get_status_display()
 
     @staticmethod
-    @traced_resolver
     def resolve_can_finalize(root: models.Order, info):
         if root.status == OrderStatus.DRAFT:
             country = get_order_country(root)
@@ -1063,12 +1055,10 @@ class Order(CountableDjangoObjectType):
         return UserByUserIdLoader(info.context).load(root.user_id).then(_resolve_user)
 
     @staticmethod
-    @traced_resolver
     def resolve_available_shipping_methods(root: models.Order, info):
         return resolve_order_shipping_methods(root, info, include_active_only=True)
 
     @staticmethod
-    @traced_resolver
     def resolve_shipping_methods(root: models.Order, info):
         return resolve_order_shipping_methods(root, info)
 

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -2,7 +2,6 @@ import graphene
 from graphene import relay
 
 from ...core.permissions import OrderPermissions
-from ...core.tracing import traced_resolver
 from ...payment import models
 from ..checkout.dataloaders import CheckoutByTokenLoader
 from ..core.connection import CountableDjangoObjectType
@@ -131,7 +130,6 @@ class Payment(CountableDjangoObjectType):
         return actions
 
     @staticmethod
-    @traced_resolver
     def resolve_total(root: models.Payment, _info):
         return root.get_total()
 

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -4,7 +4,6 @@ import graphene
 from django_countries.fields import Country
 
 from ....core.permissions import ProductPermissions
-from ....core.tracing import traced_resolver
 from ....core.utils import get_currency_for_country
 from ....graphql.core.types import Money, MoneyRange
 from ....product import models
@@ -76,7 +75,6 @@ class ProductChannelListing(CountableDjangoObjectType):
         return ChannelByIdLoader(info.context).load(root.channel_id)
 
     @staticmethod
-    @traced_resolver
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_purchase_cost(root: models.ProductChannelListing, info, *_kwargs):
         channel = ChannelByIdLoader(info.context).load(root.channel_id)
@@ -114,7 +112,6 @@ class ProductChannelListing(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_margin(root: models.ProductChannelListing, info, *_kwargs):
         channel = ChannelByIdLoader(info.context).load(root.channel_id)

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -445,7 +445,6 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
-    @traced_resolver
     def resolve_revenue(root: ChannelContext[models.ProductVariant], info, period):
         start_date = reporting_period_to_date(period)
         variant = root.node
@@ -671,7 +670,6 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return TaxType(tax_code=tax_data.code, description=tax_data.description)
 
     @staticmethod
-    @traced_resolver
     def resolve_thumbnail(root: ChannelContext[models.Product], info, *, size=255):
         def return_first_thumbnail(product_media):
             if product_media:
@@ -883,7 +881,6 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return ProductChannelListingByProductIdLoader(info.context).load(root.node.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_collections(root: ChannelContext[models.Product], info, **_kwargs):
         requestor = get_user_or_app_from_context(info.context)
 
@@ -939,7 +936,6 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return convert_weight_to_default_weight_unit(root.node.weight)
 
     @staticmethod
-    @traced_resolver
     def resolve_is_available_for_purchase(root: ChannelContext[models.Product], info):
         if not root.channel_slug:
             return None
@@ -957,7 +953,6 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_available_for_purchase(root: ChannelContext[models.Product], info):
         if not root.channel_slug:
             return None
@@ -1062,7 +1057,6 @@ class ProductType(CountableDjangoObjectType):
         return ProductAttributesByProductTypeIdLoader(info.context).load(root.pk)
 
     @staticmethod
-    @traced_resolver
     def resolve_variant_attributes(
         root: models.ProductType,
         info,
@@ -1291,7 +1285,6 @@ class Category(CountableDjangoObjectType):
         return ""
 
     @staticmethod
-    @traced_resolver
     def resolve_products(root: models.Category, info, channel=None, **_kwargs):
         requestor = get_user_or_app_from_context(info.context)
         has_required_permissions = has_one_of_permissions(

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -2,7 +2,6 @@ import graphene
 from graphene import ObjectType, relay
 
 from ...core.permissions import ShippingPermissions
-from ...core.tracing import traced_resolver
 from ...core.weight import convert_weight_to_default_weight_unit
 from ...shipping import models
 from ...shipping.interface import ShippingMethodData
@@ -204,7 +203,6 @@ class ShippingZone(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         only_fields = ["default", "id", "name"]
 
     @staticmethod
-    @traced_resolver
     def resolve_price_range(root: ChannelContext[models.ShippingZone], *_args):
         return resolve_price_range(root.channel_slug)
 

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -7,7 +7,6 @@ from ...attribute import AttributeInputType
 from ...attribute import models as attribute_models
 from ...attribute.models import AttributeValue
 from ...core.permissions import DiscountPermissions, ShippingPermissions
-from ...core.tracing import traced_resolver
 from ...discount import models as discount_models
 from ...menu import models as menu_models
 from ...page import models as page_models
@@ -59,7 +58,6 @@ class BaseTranslationType(CountableDjangoObjectType):
         abstract = True
 
     @staticmethod
-    @traced_resolver
     def resolve_language(root, *_args):
         try:
             language = next(

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -1,6 +1,5 @@
 from ...core.exceptions import PermissionDenied
 from ...core.permissions import AppPermission
-from ...core.tracing import traced_resolver
 from ...webhook import models, payloads
 from ...webhook.event_types import WebhookEventType
 from ..core.utils import from_global_id_or_error
@@ -37,7 +36,6 @@ def resolve_webhook_events():
     ]
 
 
-@traced_resolver
 def resolve_sample_payload(info, event_name):
     app = info.context.app
     required_permission = WebhookEventType.PERMISSIONS.get(event_name)

--- a/saleor/product/utils/availability.py
+++ b/saleor/product/utils/availability.py
@@ -238,54 +238,53 @@ def get_variant_availability(
     country: Country,
     local_currency: Optional[str] = None,
 ) -> VariantAvailability:
-    with opentracing.global_tracer().start_active_span("get_variant_availability"):
-        channel_slug = channel.slug
-        discounted = plugins.apply_taxes_to_product(
-            product,
-            get_variant_price(
-                variant=variant,
-                variant_channel_listing=variant_channel_listing,
-                product=product,
-                collections=collections,
-                discounts=discounts,
-                channel=channel,
-            ),
-            country,
-            channel_slug=channel_slug,
-        )
-        undiscounted = plugins.apply_taxes_to_product(
-            product,
-            get_variant_price(
-                variant=variant,
-                variant_channel_listing=variant_channel_listing,
-                product=product,
-                collections=collections,
-                discounts=[],
-                channel=channel,
-            ),
-            country,
-            channel_slug=channel_slug,
-        )
+    channel_slug = channel.slug
+    discounted = plugins.apply_taxes_to_product(
+        product,
+        get_variant_price(
+            variant=variant,
+            variant_channel_listing=variant_channel_listing,
+            product=product,
+            collections=collections,
+            discounts=discounts,
+            channel=channel,
+        ),
+        country,
+        channel_slug=channel_slug,
+    )
+    undiscounted = plugins.apply_taxes_to_product(
+        product,
+        get_variant_price(
+            variant=variant,
+            variant_channel_listing=variant_channel_listing,
+            product=product,
+            collections=collections,
+            discounts=[],
+            channel=channel,
+        ),
+        country,
+        channel_slug=channel_slug,
+    )
 
-        discount = _get_total_discount(undiscounted, discounted)
+    discount = _get_total_discount(undiscounted, discounted)
 
-        if local_currency:
-            price_local_currency = to_local_currency(discounted, local_currency)
-            discount_local_currency = to_local_currency(discount, local_currency)
-        else:
-            price_local_currency = None
-            discount_local_currency = None
+    if local_currency:
+        price_local_currency = to_local_currency(discounted, local_currency)
+        discount_local_currency = to_local_currency(discount, local_currency)
+    else:
+        price_local_currency = None
+        discount_local_currency = None
 
-        is_visible = (
-            product_channel_listing is not None and product_channel_listing.is_visible
-        )
-        is_on_sale = is_visible and discount is not None
+    is_visible = (
+        product_channel_listing is not None and product_channel_listing.is_visible
+    )
+    is_on_sale = is_visible and discount is not None
 
-        return VariantAvailability(
-            on_sale=is_on_sale,
-            price=discounted,
-            price_undiscounted=undiscounted,
-            discount=discount,
-            price_local_currency=price_local_currency,
-            discount_local_currency=discount_local_currency,
-        )
+    return VariantAvailability(
+        on_sale=is_on_sale,
+        price=discounted,
+        price_undiscounted=undiscounted,
+        discount=discount,
+        price_local_currency=price_local_currency,
+        discount_local_currency=discount_local_currency,
+    )


### PR DESCRIPTION
The current tracing decorator can't properly trace Promise-based resolvers so we only waste time executing the tracing wrappers.

Next part of #9107


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
