### PR TITLE
Revert additional validation for unavailable products. Add validation for visibility of product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - New interface for handling more data for prices: `OrderTaxedPricesData` used in plugins/pluginManager.
 - Fix incorrect stock allocation - #8931 by @IKarbowiak
 - Fix incorrect handling of unavailable products in checkout - #8978 by @IKarbowiak
+- Revert the additional validation for unavailable products introduced in #8978 - #9119 by @korycins
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -1118,21 +1118,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
 
         manager = info.context.plugins
 
-        lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
-        if unavailable_variant_pks:
-            not_available_variants_ids = {
-                graphene.Node.to_global_id("ProductVariant", pk)
-                for pk in unavailable_variant_pks
-            }
-            raise ValidationError(
-                {
-                    "lines": ValidationError(
-                        "Some of the checkout lines variants are unavailable.",
-                        code=CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.value,
-                        params={"variants": not_available_variants_ids},
-                    )
-                }
-            )
+        lines, _ = fetch_checkout_lines(checkout)
 
         checkout_info = fetch_checkout_info(
             checkout, lines, info.context.discounts, manager
@@ -1392,21 +1378,7 @@ class CheckoutAddPromoCode(BaseMutation):
         manager = info.context.plugins
         discounts = info.context.discounts
 
-        lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
-        if unavailable_variant_pks:
-            not_available_variants_ids = {
-                graphene.Node.to_global_id("ProductVariant", pk)
-                for pk in unavailable_variant_pks
-            }
-            raise ValidationError(
-                {
-                    "lines": ValidationError(
-                        "Some of the checkout lines variants are unavailable.",
-                        code=CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.value,
-                        params={"variants": not_available_variants_ids},
-                    )
-                }
-            )
+        lines, _ = fetch_checkout_lines(checkout)
 
         checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2845,35 +2845,6 @@ def test_checkout_shipping_method_update_excluded_postal_code(
     )
 
 
-def test_checkout_shipping_method_update_unavailable_variant(
-    staff_api_client,
-    shipping_method,
-    checkout_with_item,
-    address,
-):
-    checkout = checkout_with_item
-    checkout.shipping_address = address
-    checkout.save(update_fields=["shipping_address"])
-    checkout_with_item.lines.first().variant.channel_listings.filter(
-        channel=checkout_with_item.channel
-    ).delete()
-    query = MUTATION_UPDATE_SHIPPING_METHOD
-
-    method_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
-
-    response = staff_api_client.post_graphql(
-        query, {"token": checkout_with_item.token, "shippingMethodId": method_id}
-    )
-    data = get_graphql_content(response)["data"]["checkoutShippingMethodUpdate"]
-
-    checkout.refresh_from_db()
-
-    errors = data["errors"]
-    assert len(errors) == 1
-    assert errors[0]["field"] == "lines"
-    assert errors[0]["code"] == CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name
-
-
 @patch(
     "saleor.plugins.webhook.plugin.WebhookPlugin.excluded_shipping_methods_for_checkout"
 )

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -332,21 +332,6 @@ def test_checkout_add_voucher_code_without_display_gross_prices(
     assert checkout_with_item.last_change == previous_checkout_last_change
 
 
-def test_checkout_add_voucher_code_variant_unavailable(
-    api_client, checkout_with_item, voucher
-):
-    variables = {"token": checkout_with_item.token, "promoCode": voucher.code}
-    checkout_with_item.lines.first().variant.channel_listings.filter(
-        channel=checkout_with_item.channel
-    ).delete()
-    data = _mutate_checkout_add_promo_code(api_client, variables)
-
-    errors = data["errors"]
-    assert len(errors) == 1
-    assert errors[0]["code"] == CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name
-    assert errors[0]["field"] == "lines"
-
-
 def test_checkout_add_voucher_code_checkout_with_sale(
     api_client, checkout_with_item, voucher_percentage, discount_info
 ):

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -155,30 +155,8 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         cls.validate_gateway(manager, gateway, checkout.currency)
         cls.validate_return_url(data)
 
-        lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
-        if unavailable_variant_pks:
-            not_available_variants_ids = {
-                graphene.Node.to_global_id("ProductVariant", pk)
-                for pk in unavailable_variant_pks
-            }
-            raise ValidationError(
-                {
-                    "token": ValidationError(
-                        "Some of the checkout lines variants are unavailable.",
-                        code=PaymentErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.value,
-                        params={"variants": not_available_variants_ids},
-                    )
-                }
-            )
-        if not lines:
-            raise ValidationError(
-                {
-                    "lines": ValidationError(
-                        "Cannot create payment for checkout without lines.",
-                        code=PaymentErrorCode.NO_CHECKOUT_LINES.value,
-                    )
-                }
-            )
+        lines, _ = fetch_checkout_lines(checkout)
+
         checkout_info = fetch_checkout_info(
             checkout, lines, info.context.discounts, manager
         )

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -6,7 +6,6 @@ import graphene
 import pytest
 
 from ....checkout import calculations
-from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import add_variant_to_checkout
 from ....payment import PaymentError
@@ -428,125 +427,6 @@ def test_create_payment_for_checkout_with_active_payments(
     active_payments = checkout.payments.all().filter(is_active=True)
     assert active_payments.count() == 1
     assert active_payments.first().pk not in previous_active_payments_ids
-
-
-def test_checkout_add_payment_no_variant_channel_listings(
-    user_api_client, checkout_without_shipping_required, address, customer_user
-):
-    checkout = checkout_without_shipping_required
-    checkout.billing_address = address
-    checkout.email = "old@example"
-    checkout.user = customer_user
-    checkout.save()
-
-    variant = checkout.lines.first().variant
-    variant.product.channel_listings.filter(channel=checkout.channel_id).delete()
-
-    manager = get_plugins_manager()
-    lines, _ = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
-    total = calculations.checkout_total(
-        manager=manager, checkout_info=checkout_info, lines=lines, address=address
-    )
-    return_url = "https://www.example.com"
-    variables = {
-        "token": checkout.token,
-        "input": {
-            "gateway": DUMMY_GATEWAY,
-            "token": "sample-token",
-            "amount": total.gross.amount,
-            "returnUrl": return_url,
-        },
-    }
-    response = user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
-    content = get_graphql_content(response)
-    data = content["data"]["checkoutPaymentCreate"]
-
-    errors = data["errors"]
-    assert len(errors) == 1
-    assert errors[0]["code"] == CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name
-    assert errors[0]["field"] == "token"
-    assert errors[0]["variants"] == [
-        graphene.Node.to_global_id("ProductVariant", variant.pk)
-    ]
-
-
-def test_checkout_add_payment_no_product_channel_listings(
-    user_api_client, checkout_without_shipping_required, address, customer_user
-):
-    checkout = checkout_without_shipping_required
-    checkout.billing_address = address
-    checkout.email = "old@example"
-    checkout.user = customer_user
-    checkout.save()
-
-    variant = checkout.lines.first().variant
-    variant.channel_listings.filter(channel=checkout.channel_id).delete()
-
-    manager = get_plugins_manager()
-    lines, _ = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
-    total = calculations.checkout_total(
-        manager=manager, checkout_info=checkout_info, lines=lines, address=address
-    )
-    return_url = "https://www.example.com"
-    variables = {
-        "token": checkout.token,
-        "input": {
-            "gateway": DUMMY_GATEWAY,
-            "token": "sample-token",
-            "amount": total.gross.amount,
-            "returnUrl": return_url,
-        },
-    }
-    response = user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
-    content = get_graphql_content(response)
-    data = content["data"]["checkoutPaymentCreate"]
-
-    errors = data["errors"]
-    assert len(errors) == 1
-    assert errors[0]["code"] == CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name
-    assert errors[0]["field"] == "token"
-    assert errors[0]["variants"] == [
-        graphene.Node.to_global_id("ProductVariant", variant.pk)
-    ]
-
-
-def test_checkout_add_payment_checkout_without_lines(
-    user_api_client, checkout_without_shipping_required, address, customer_user
-):
-    checkout = checkout_without_shipping_required
-    checkout.billing_address = address
-    checkout.email = "old@example"
-    checkout.user = customer_user
-    checkout.save()
-
-    checkout.lines.all().delete()
-
-    manager = get_plugins_manager()
-    lines, _ = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
-    total = calculations.checkout_total(
-        manager=manager, checkout_info=checkout_info, lines=lines, address=address
-    )
-    return_url = "https://www.example.com"
-    variables = {
-        "token": checkout.token,
-        "input": {
-            "gateway": DUMMY_GATEWAY,
-            "token": "sample-token",
-            "amount": total.gross.amount,
-            "returnUrl": return_url,
-        },
-    }
-    response = user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
-    content = get_graphql_content(response)
-    data = content["data"]["checkoutPaymentCreate"]
-
-    errors = data["errors"]
-    assert len(errors) == 1
-    assert errors[0]["field"] == "lines"
-    assert errors[0]["code"] == PaymentErrorCode.NO_CHECKOUT_LINES.name
 
 
 CAPTURE_QUERY = """


### PR DESCRIPTION
I want to merge this change because it reverts validation added to 3.0 that could break already existing storefronts. This validation will be added to 3.1

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
