### PR TITLE
Fix Avalara crash with shipping methods webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable, unreleased changes to this project will be documented in this file.
 `CheckoutAddPromoCode`, `CheckoutPaymentCreate` will raise a ValidationError when product in the checkout is
 unavailable - #8978 by @IKarbowiak
 - Fix disabled warehouses appearing as valid click and collect points when checkout contains only preorders - #9052 by @rafalp
+- Fix crash when Avalara plugin was used together with Webhooks plugin for shipping methods - #9121 by @rafalp
 
 
 # 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Do no allow using `id` for updating checkout and order metadata - #8906 by @IKarbowiak
   - Use `token` instead
 - Remove `graphene-django` dependency - #9170 by @rafalp
+- Don't run plugins when calculating checkout's total price for available shipping methods resolution - #9121 by @rafalp
+  - Use either net or gross price depending on store configuration.
 
 ## Other
 

--- a/saleor/checkout/base_calculations.py
+++ b/saleor/checkout/base_calculations.py
@@ -197,6 +197,24 @@ def base_checkout_total(
     return total
 
 
+def base_checkout_lines_total(
+    checkout_lines: Iterable["CheckoutLineInfo"],
+    channel: "Channel",
+    currency: str,
+    discounts: Optional[Iterable[DiscountInfo]] = None,
+) -> TaxedMoney:
+    line_totals = [
+        calculate_base_line_total_price(
+            line,
+            channel,
+            discounts,
+        ).price_with_sale
+        for line in checkout_lines
+    ]
+
+    return sum(line_totals, zero_taxed_money(currency))
+
+
 def base_checkout_line_total(
     checkout_line_info: "CheckoutLineInfo",
     channel: "Channel",

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -16,6 +16,7 @@ from typing import (
 from django.utils.encoding import smart_text
 from django.utils.functional import SimpleLazyObject
 
+from ..core.taxes import zero_taxed_money
 from ..discount import DiscountInfo, VoucherType
 from ..discount.utils import fetch_active_discounts
 from ..shipping.interface import ShippingMethodData
@@ -26,6 +27,7 @@ from ..shipping.utils import (
 )
 from ..warehouse import WarehouseClickAndCollectOption
 from ..warehouse.models import Warehouse
+from . import base_calculations
 
 if TYPE_CHECKING:
     from ..account.models import Address, User
@@ -472,9 +474,18 @@ def get_valid_internal_shipping_method_list_for_checkout_info(
     from .utils import get_valid_internal_shipping_methods_for_checkout
 
     country_code = shipping_address.country.code if shipping_address else None
-    subtotal = manager.calculate_checkout_subtotal(
-        checkout_info, lines, checkout_info.shipping_address, discounts
-    )
+
+    line_totals = [
+        base_calculations.calculate_base_line_total_price(
+            line,
+            checkout_info.channel,
+            discounts,
+        ).price_with_sale
+        for line in lines
+    ]
+
+    subtotal = sum(line_totals, zero_taxed_money(checkout_info.checkout.currency))
+
     # if a voucher is applied to shipping, we don't want to subtract the discount amount
     # as some methods based on shipping price may become unavailable,
     # for example, method on which the discount was applied
@@ -483,6 +494,7 @@ def get_valid_internal_shipping_method_list_for_checkout_info(
     )
     if not is_shipping_voucher:
         subtotal -= checkout_info.checkout.discount
+
     valid_shipping_methods = get_valid_internal_shipping_methods_for_checkout(
         checkout_info,
         lines,

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -16,7 +16,6 @@ from typing import (
 from django.utils.encoding import smart_text
 from django.utils.functional import SimpleLazyObject
 
-from ..core.taxes import zero_taxed_money
 from ..discount import DiscountInfo, VoucherType
 from ..discount.utils import fetch_active_discounts
 from ..shipping.interface import ShippingMethodData
@@ -474,16 +473,12 @@ def get_valid_internal_shipping_method_list_for_checkout_info(
 
     country_code = shipping_address.country.code if shipping_address else None
 
-    line_totals = [
-        base_calculations.calculate_base_line_total_price(
-            line,
-            checkout_info.channel,
-            discounts,
-        ).price_with_sale
-        for line in lines
-    ]
-
-    subtotal = sum(line_totals, zero_taxed_money(checkout_info.checkout.currency))
+    subtotal = base_calculations.base_checkout_lines_total(
+        lines,
+        checkout_info.channel,
+        checkout_info.checkout.currency,
+        discounts,
+    )
 
     # if a voucher is applied to shipping, we don't want to subtract the discount amount
     # as some methods based on shipping price may become unavailable,

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -27,7 +27,6 @@ from ..shipping.utils import (
 )
 from ..warehouse import WarehouseClickAndCollectOption
 from ..warehouse.models import Warehouse
-from . import base_calculations
 
 if TYPE_CHECKING:
     from ..account.models import Address, User
@@ -468,9 +467,9 @@ def get_valid_internal_shipping_method_list_for_checkout_info(
     shipping_address: Optional["Address"],
     lines: Iterable[CheckoutLineInfo],
     discounts: Iterable["DiscountInfo"],
-    manager: "PluginsManager",
     shipping_channel_listings: Iterable[ShippingMethodChannelListing],
 ) -> List["ShippingMethodData"]:
+    from . import base_calculations
     from .utils import get_valid_internal_shipping_methods_for_checkout
 
     country_code = shipping_address.country.code if shipping_address else None
@@ -547,7 +546,6 @@ def update_delivery_method_lists_for_checkout_info(
                     shipping_address,
                     lines,
                     discounts,
-                    manager,
                     shipping_channel_listings,
                 ),
                 get_valid_external_shipping_method_list_for_checkout_info(

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -40,7 +40,6 @@ from ....payment import TransactionKind
 from ....payment.interface import GatewayResponse
 from ....plugins.base_plugin import ExcludedShippingMethod
 from ....plugins.manager import get_plugins_manager
-from ....plugins.models import PluginConfiguration
 from ....plugins.tests.sample_plugins import ActiveDummyPaymentGateway
 from ....product.models import ProductChannelListing, ProductVariant
 from ....shipping import models as shipping_models

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -3606,11 +3606,9 @@ def test_checkout_shipping_method_update_external_shipping_method(
     assert PRIVATE_META_APP_SHIPPING_ID in checkout.private_metadata
 
 
-@mock.patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
-def test_checkout_shipping_method_update_external_shipping_method_with_avatax(
+def test_checkout_shipping_method_update_external_shipping_method_with_tax_plugin(
     mock_send_request,
-    mock_tax_data,
     staff_api_client,
     address,
     checkout_with_item,
@@ -3618,18 +3616,8 @@ def test_checkout_shipping_method_update_external_shipping_method_with_avatax(
     channel_USD,
     settings,
 ):
-    PluginConfiguration.objects.create(
-        active=True,
-        channel=channel_USD,
-        identifier="mirumee.taxes.avalara",
-        configuration=[
-            {"name": "Username or account", "type": "String", "value": "00000000"},
-            {"name": "Password or license", "type": "Password", "value": "00000000"},
-        ],
-    )
-
     settings.PLUGINS = [
-        "saleor.plugins.avatax.plugin.AvataxPlugin",
+        "saleor.plugins.tests.sample_plugins.PluginSample",
         "saleor.plugins.webhook.plugin.WebhookPlugin",
     ]
     response_method_id = "abcd"
@@ -3643,7 +3631,6 @@ def test_checkout_shipping_method_update_external_shipping_method_with_avatax(
         }
     ]
     mock_send_request.return_value = mock_json_response
-    mock_tax_data.return_value = {"lines": []}
 
     checkout = checkout_with_item
     checkout.shipping_address = address

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -40,6 +40,7 @@ from ....payment import TransactionKind
 from ....payment.interface import GatewayResponse
 from ....plugins.base_plugin import ExcludedShippingMethod
 from ....plugins.manager import get_plugins_manager
+from ....plugins.models import PluginConfiguration
 from ....plugins.tests.sample_plugins import ActiveDummyPaymentGateway
 from ....product.models import ProductChannelListing, ProductVariant
 from ....shipping import models as shipping_models
@@ -3603,6 +3604,72 @@ def test_checkout_shipping_method_update_external_shipping_method(
     assert not errors
     assert data["checkout"]["token"] == str(checkout_with_item.token)
     assert PRIVATE_META_APP_SHIPPING_ID in checkout.private_metadata
+
+
+@mock.patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_checkout_shipping_method_update_external_shipping_method_with_avatax(
+    mock_send_request,
+    mock_tax_data,
+    staff_api_client,
+    address,
+    checkout_with_item,
+    shipping_app,
+    channel_USD,
+    settings,
+):
+    PluginConfiguration.objects.create(
+        active=True,
+        channel=channel_USD,
+        identifier="mirumee.taxes.avalara",
+        configuration=[
+            {"name": "Username or account", "type": "String", "value": "00000000"},
+            {"name": "Password or license", "type": "Password", "value": "00000000"},
+        ],
+    )
+
+    settings.PLUGINS = [
+        "saleor.plugins.avatax.plugin.AvataxPlugin",
+        "saleor.plugins.webhook.plugin.WebhookPlugin",
+    ]
+    response_method_id = "abcd"
+    mock_json_response = [
+        {
+            "id": response_method_id,
+            "name": "Provider - Economy",
+            "amount": "10",
+            "currency": "USD",
+            "maximum_delivery_days": "7",
+        }
+    ]
+    mock_send_request.return_value = mock_json_response
+    mock_tax_data.return_value = {"lines": []}
+
+    checkout = checkout_with_item
+    checkout.shipping_address = address
+    checkout.save()
+
+    method_id = graphene.Node.to_global_id(
+        "app", f"{shipping_app.id}:{response_method_id}"
+    )
+
+    # Set external shipping method for first time
+    response = staff_api_client.post_graphql(
+        MUTATION_UPDATE_SHIPPING_METHOD,
+        {"token": checkout_with_item.token, "shippingMethodId": method_id},
+    )
+    data = get_graphql_content(response)["data"]["checkoutShippingMethodUpdate"]
+    assert not data["errors"]
+
+    # Set external shipping for second time
+    # Without a fix this request results in infinite recursion
+    # between Avalara and Webhooks plugins
+    response = staff_api_client.post_graphql(
+        MUTATION_UPDATE_SHIPPING_METHOD,
+        {"token": checkout_with_item.token, "shippingMethodId": method_id},
+    )
+    data = get_graphql_content(response)["data"]["checkoutShippingMethodUpdate"]
+    assert not data["errors"]
 
 
 @pytest.mark.parametrize("is_valid_delivery_method", (True, False))

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -98,6 +98,9 @@ class PluginSample(BasePlugin):
         discounts: Iterable["DiscountInfo"],
         previous_value: CheckoutTaxedPricesData,
     ):
+        # See if delivery method doesn't trigger infinite recursion
+        bool(checkout_info.delivery_method_info.delivery_method)
+
         price = Money("1.0", currency=checkout_info.checkout.currency)
         return CheckoutTaxedPricesData(
             price_with_sale=TaxedMoney(price, price),


### PR DESCRIPTION
This PR removes plugins call from checkout's subtotal calculation done for shipping methods webhook. This plugins call resulted in infinite recursion when both Avalara and webhook plugin are enabled.

This PR also adds test case that reproduced this exact crash before fix.

This change is in line with what we are planning to do for discounts, and from my testing it doesn't affect tax amounts on checkout.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
