### PR TITLE
Fix consuming to much memory when updating product search document values

### DIFF
--- a/saleor/core/search_tasks.py
+++ b/saleor/core/search_tasks.py
@@ -63,9 +63,12 @@ def set_order_search_document_values(total_count, updated_count):
 
 @app.task
 def set_product_search_document_values(total_count, updated_count):
+    # set lower batch size as it was crashing for products with
+    # lots of attributes because out of memory issues
+    batch_size = 500
     qs = Product.objects.filter(search_document="").prefetch_related(
         *PRODUCT_FIELDS_TO_PREFETCH
-    )[:BATCH_SIZE]
+    )[:batch_size]
     if not qs:
         task_logger.info("No products to update.")
         return


### PR DESCRIPTION
Change `btach_size` for `set_product_search_document_values` task. I got information that for batch size `1000` it was still crashing sometimes, so I reduced it even more, to be sure that will not crash again.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
