### PR TITLE
Do not allow to process a checkout with unpublished products

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -293,6 +293,7 @@ def _is_variant_valid(
     if (
         not product_channel_listing
         or product_channel_listing.is_available_for_purchase() is False
+        or not product_channel_listing.is_visible
     ):
         return False
 


### PR DESCRIPTION
I want to merge this change because it adds validation for not allowing the processing of products that are not published anymore. This is a part of missing validation that was added to 3.0 in https://github.com/saleor/saleor/pull/9119

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
