### PR TITLE
3.1 Add checking if given attributes are variant attributes in ProductVariantCreate mutation

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -934,14 +934,14 @@ class ProductVariantCreate(ModelMutation):
                 product_type.variant_attributes.all().values_list("pk", flat=True)
             )
         ]
-
-        # Check if given attributes are variant attributes
-        for attr in data.get("attributes") or []:
-            if attr["id"] not in variant_attributes_ids:
-                raise ValidationError(
-                    "Given attribute is not a variant attribute",
-                    ProductErrorCode.ATTRIBUTE_CANNOT_BE_ASSIGNED.value,
-                )
+        attributes_ids = [attr["id"] for attr in data.get("attributes") or []]
+        invalid_attributes = set(attributes_ids) - set(variant_attributes_ids)
+        if len(invalid_attributes) > 0:
+            raise ValidationError(
+                "Given attributes are not a variant attributes.",
+                code=ProductErrorCode.ATTRIBUTE_CANNOT_BE_ASSIGNED.value,
+                params={"attributes": invalid_attributes},
+            )
 
         # Run the validation only if product type is configurable
         if product_type.has_variants:
@@ -971,7 +971,7 @@ class ProductVariantCreate(ModelMutation):
                 raise ValidationError({"attributes": exc})
         else:
             raise ValidationError(
-                "Product type is not configurable",
+                "Product type is not configurable.",
                 ProductErrorCode.ATTRIBUTE_CANNOT_BE_ASSIGNED.value,
             )
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -936,7 +936,7 @@ class ProductVariantCreate(ModelMutation):
         ]
 
         # Check if given attributes are variant attributes
-        for attr in data["attributes"]:
+        for attr in data.get("attributes") or []:
             if attr["id"] not in variant_attributes_ids:
                 raise ValidationError(
                     "Given attribute is not a variant attribute",

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -928,14 +928,14 @@ class ProductVariantCreate(ModelMutation):
                 cleaned_input["product"]
             )
 
-        variant_attributes_ids = [
+        variant_attributes_ids = {
             graphene.Node.to_global_id("Attribute", attr_id)
             for attr_id in list(
                 product_type.variant_attributes.all().values_list("pk", flat=True)
             )
-        ]
-        attributes_ids = [attr["id"] for attr in data.get("attributes") or []]
-        invalid_attributes = set(attributes_ids) - set(variant_attributes_ids)
+        }
+        attributes_ids = {attr["id"] for attr in data.get("attributes") or []}
+        invalid_attributes = attributes_ids - variant_attributes_ids
         if len(invalid_attributes) > 0:
             raise ValidationError(
                 "Given attributes are not a variant attributes.",

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -928,6 +928,21 @@ class ProductVariantCreate(ModelMutation):
                 cleaned_input["product"]
             )
 
+        variant_attributes_ids = [
+            graphene.Node.to_global_id("Attribute", attr_id)
+            for attr_id in list(
+                product_type.variant_attributes.all().values_list("pk", flat=True)
+            )
+        ]
+
+        # Check if given attributes are variant attributes
+        for attr in data["attributes"]:
+            if attr["id"] not in variant_attributes_ids:
+                raise ValidationError(
+                    "Given attribute is not a variant attribute",
+                    ProductErrorCode.ATTRIBUTE_CANNOT_BE_ASSIGNED.value,
+                )
+
         # Run the validation only if product type is configurable
         if product_type.has_variants:
             # Attributes are provided as list of `AttributeValueInput` objects.
@@ -954,6 +969,11 @@ class ProductVariantCreate(ModelMutation):
                     )
             except ValidationError as exc:
                 raise ValidationError({"attributes": exc})
+        else:
+            raise ValidationError(
+                "Product type is not configurable",
+                ProductErrorCode.ATTRIBUTE_CANNOT_BE_ASSIGNED.value,
+            )
 
         if "sku" in cleaned_input:
             cleaned_input["sku"] = clean_variant_sku(cleaned_input.get("sku"))

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -5826,6 +5826,8 @@ VARIANT_CREATE_MUTATION = """
             errors {
                 field,
                 message,
+                code,
+                attributes
             }
         }
     }
@@ -5851,7 +5853,9 @@ def test_variant_create_product_without_variant_attributes(
 
     errors = content["data"]["productVariantCreate"]["errors"]
     assert errors
-    assert errors[0]["message"] == "Given attribute is not a variant attribute"
+    assert errors[0]["code"] == ProductErrorCode.ATTRIBUTE_CANNOT_BE_ASSIGNED.name
+    assert len(errors[0]["attributes"]) == 1
+    assert errors[0]["attributes"][0] == attr_id
 
 
 def test_variant_create_product_with_variant_attributes_variant_flag_false(
@@ -5877,4 +5881,4 @@ def test_variant_create_product_with_variant_attributes_variant_flag_false(
 
     errors = content["data"]["productVariantCreate"]["errors"]
     assert errors
-    assert errors[0]["message"] == "Product type is not configurable"
+    assert errors[0]["code"] == ProductErrorCode.ATTRIBUTE_CANNOT_BE_ASSIGNED.name

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -5808,3 +5808,73 @@ def test_product_variant_deactivate_preorder_as_app(
     )
 
     assert_no_permission(response)
+
+
+VARIANT_CREATE_MUTATION = """
+    mutation variantCreate($productId: ID!, $attrId: ID!) {
+        productVariantCreate (
+            input: {
+                sku: "my-sku",
+                product: $productId,
+                attributes: [{id: $attrId, values:["1"]}]
+            }
+        )
+        {
+            productVariant {
+                id
+            }
+            errors {
+                field,
+                message,
+            }
+        }
+    }
+"""
+
+
+def test_variant_create_product_without_variant_attributes(
+    product_with_product_attributes, staff_api_client, permission_manage_products
+):
+    product = product_with_product_attributes
+
+    prod_id = graphene.Node.to_global_id("Product", product.pk)
+    attr_id = graphene.Node.to_global_id(
+        "Attribute", product.product_type.product_attributes.first().pk
+    )
+
+    response = staff_api_client.post_graphql(
+        VARIANT_CREATE_MUTATION,
+        variables={"productId": prod_id, "attrId": attr_id},
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+
+    errors = content["data"]["productVariantCreate"]["errors"]
+    assert errors
+    assert errors[0]["message"] == "Given attribute is not a variant attribute"
+
+
+def test_variant_create_product_with_variant_attributes_variant_flag_false(
+    product_with_variant_attributes, staff_api_client, permission_manage_products
+):
+    product = product_with_variant_attributes
+
+    product_type = product.product_type
+    product_type.has_variants = False
+    product_type.save()
+
+    prod_id = graphene.Node.to_global_id("Product", product.pk)
+    attr_id = graphene.Node.to_global_id(
+        "Attribute", product.product_type.variant_attributes.first().pk
+    )
+
+    response = staff_api_client.post_graphql(
+        VARIANT_CREATE_MUTATION,
+        variables={"productId": prod_id, "attrId": attr_id},
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+
+    errors = content["data"]["productVariantCreate"]["errors"]
+    assert errors
+    assert errors[0]["message"] == "Product type is not configurable"

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1088,6 +1088,74 @@ def color_attribute(db):
 
 
 @pytest.fixture
+def attribute_without_values():
+    attribute = Attribute.objects.create(
+        slug="dropdown",
+        name="Dropdown",
+        type=AttributeType.PRODUCT_TYPE,
+        filterable_in_storefront=True,
+        filterable_in_dashboard=True,
+        available_in_grid=True,
+        visible_in_storefront=True,
+        entity_type=None,
+    )
+
+    return attribute
+
+
+@pytest.fixture
+def product_type_with_product_attributes(attribute_without_values):
+    product_type = ProductType.objects.create(
+        name="NAME",
+        slug="NAME",
+        has_variants=False,
+        is_shipping_required=False,
+        weight=0,
+    )
+    product_type.product_attributes.add(attribute_without_values)
+    return product_type
+
+
+@pytest.fixture
+def product_type_with_variant_attributes(attribute_without_values):
+    product_type = ProductType.objects.create(
+        name="NAME",
+        slug="NAME",
+        has_variants=False,
+        is_shipping_required=False,
+        weight=0,
+    )
+    product_type.variant_attributes.add(attribute_without_values)
+    return product_type
+
+
+@pytest.fixture
+def product_with_product_attributes(
+    product_type_with_product_attributes, non_default_category
+):
+    product = Product.objects.create(
+        name="Test product",
+        slug="test-product-11",
+        product_type=product_type_with_product_attributes,
+        category=non_default_category,
+    )
+    return product
+
+
+@pytest.fixture
+def product_with_variant_attributes(
+    product_type_with_variant_attributes, non_default_category
+):
+    product = Product.objects.create(
+        name="Test product",
+        slug="test-product-11",
+        product_type=product_type_with_variant_attributes,
+        category=non_default_category,
+    )
+    return product
+
+
+@pytest.fixture
 def date_attribute(db):
     attribute = Attribute.objects.create(
         slug="release-date",

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1106,8 +1106,8 @@ def attribute_without_values():
 @pytest.fixture
 def product_type_with_product_attributes(attribute_without_values):
     product_type = ProductType.objects.create(
-        name="NAME",
-        slug="NAME",
+        name="product_type_with_product_attributes",
+        slug="product-type-with-product-attributes",
         has_variants=False,
         is_shipping_required=False,
         weight=0,
@@ -1119,8 +1119,8 @@ def product_type_with_product_attributes(attribute_without_values):
 @pytest.fixture
 def product_type_with_variant_attributes(attribute_without_values):
     product_type = ProductType.objects.create(
-        name="NAME",
-        slug="NAME",
+        name="product_type_with_variant_attributes",
+        slug="product-type-with-variant-attributes",
         has_variants=False,
         is_shipping_required=False,
         weight=0,
@@ -1134,8 +1134,8 @@ def product_with_product_attributes(
     product_type_with_product_attributes, non_default_category
 ):
     product = Product.objects.create(
-        name="Test product",
-        slug="test-product-11",
+        name="product_with_product_attributes",
+        slug="product-with-product-attributes",
         product_type=product_type_with_product_attributes,
         category=non_default_category,
     )
@@ -1147,8 +1147,8 @@ def product_with_variant_attributes(
     product_type_with_variant_attributes, non_default_category
 ):
     product = Product.objects.create(
-        name="Test product",
-        slug="test-product-11",
+        name="product_with_variant_attributes",
+        slug="product-with-variant-attributes",
         product_type=product_type_with_variant_attributes,
         category=non_default_category,
     )


### PR DESCRIPTION
Port changes #9133 + fix compatibility between `ProductVariantUpdate` and `ProductVariantCreate` mutations.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
