### PR TITLE
Fix invalid available shipping methods calculation for checkout

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -61,6 +61,7 @@ class CheckoutInfo:
     delivery_method_info: "DeliveryMethodBase"
     all_shipping_methods: List["ShippingMethodData"]
     valid_pick_up_points: List["Warehouse"]
+    voucher: Optional["Voucher"] = None
 
     @property
     def valid_shipping_methods(self) -> List["ShippingMethodData"]:
@@ -352,10 +353,13 @@ def fetch_checkout_info(
     ] = None,
 ) -> CheckoutInfo:
     """Fetch checkout as CheckoutInfo object."""
+    from .utils import get_voucher_for_checkout
+
     channel = checkout.channel
     shipping_address = checkout.shipping_address
     if shipping_channel_listings is None:
         shipping_channel_listings = channel.shipping_method_listings.all()
+    voucher = get_voucher_for_checkout(checkout, channel_slug=channel.slug)
 
     delivery_method_info = get_delivery_method_info(None, shipping_address)
     checkout_info = CheckoutInfo(
@@ -367,6 +371,7 @@ def fetch_checkout_info(
         delivery_method_info=delivery_method_info,
         all_shipping_methods=[],
         valid_pick_up_points=[],
+        voucher=voucher,
     )
     update_delivery_method_lists_for_checkout_info(
         checkout_info,
@@ -466,7 +471,14 @@ def get_valid_internal_shipping_method_list_for_checkout_info(
     subtotal = manager.calculate_checkout_subtotal(
         checkout_info, lines, checkout_info.shipping_address, discounts
     )
-    subtotal -= checkout_info.checkout.discount
+    # if a voucher is applied to shipping, we don't want to subtract the discount amount
+    # as some methods based on shipping price may become unavailable,
+    # for example, method on which the discount was applied
+    is_shipping_voucher = (
+        checkout_info.voucher and checkout_info.voucher.type == VoucherType.SHIPPING
+    )
+    if not is_shipping_voucher:
+        subtotal -= checkout_info.checkout.discount
     valid_shipping_methods = get_valid_internal_shipping_methods_for_checkout(
         checkout_info,
         lines,

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -483,8 +483,7 @@ def recalculate_checkout_discount(
     applicable.
     """
     checkout = checkout_info.checkout
-    voucher = get_voucher_for_checkout_info(checkout_info)
-    if voucher is not None:
+    if voucher := checkout_info.voucher:
         address = checkout_info.shipping_address or checkout_info.billing_address
         try:
             discount = get_voucher_discount_for_checkout(
@@ -492,6 +491,7 @@ def recalculate_checkout_discount(
             )
         except NotApplicable:
             remove_voucher_from_checkout(checkout)
+            checkout_info.voucher = None
         else:
             subtotal = calculations.checkout_subtotal(
                 manager=manager,
@@ -612,6 +612,7 @@ def add_voucher_to_checkout(
             "last_change",
         ]
     )
+    checkout_info.voucher = voucher
 
 
 def remove_promo_code_from_checkout(checkout_info: "CheckoutInfo", promo_code: str):
@@ -624,9 +625,10 @@ def remove_promo_code_from_checkout(checkout_info: "CheckoutInfo", promo_code: s
 
 def remove_voucher_code_from_checkout(checkout_info: "CheckoutInfo", voucher_code: str):
     """Remove voucher data from checkout by code."""
-    existing_voucher = get_voucher_for_checkout_info(checkout_info)
+    existing_voucher = checkout_info.voucher
     if existing_voucher and existing_voucher.code == voucher_code:
         remove_voucher_from_checkout(checkout_info.checkout)
+        checkout_info.voucher = None
 
 
 def remove_voucher_from_checkout(checkout: Checkout):

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1942,6 +1942,52 @@ def test_checkout_shipping_methods_with_price_based_shipping_method_and_discount
     assert shipping_method.name not in shipping_methods
 
 
+def test_checkout_shipping_methods_with_price_based_shipping_and_shipping_discount(
+    api_client,
+    checkout_with_item,
+    address,
+    shipping_method,
+    voucher_shipping_type,
+):
+    """Ensure that price based shipping method is returned when checkout
+    has discount on shipping."""
+    checkout_with_item.shipping_address = address
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
+
+    subtotal = calculations.checkout_subtotal(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=checkout_with_item.shipping_address,
+    )
+
+    checkout_with_item.discount_amount = Decimal(5.0)
+    checkout_with_item.voucher_code = voucher_shipping_type.code
+    checkout_with_item.save(
+        update_fields=["shipping_address", "discount_amount", "voucher_code"]
+    )
+
+    shipping_method.name = "Price based"
+    shipping_method.save(update_fields=["name"])
+
+    shipping_channel_listing = shipping_method.channel_listings.get(
+        channel=checkout_with_item.channel
+    )
+    shipping_channel_listing.minimum_order_price_amount = subtotal.gross.amount - 1
+    shipping_channel_listing.save(update_fields=["minimum_order_price_amount"])
+
+    query = GET_CHECKOUT_AVAILABLE_SHIPPING_METHODS
+    variables = {"token": checkout_with_item.token}
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkout"]
+
+    shipping_methods = [method["name"] for method in data["availableShippingMethods"]]
+    assert shipping_method.name in shipping_methods
+
+
 def test_checkout_available_shipping_methods_shipping_zone_without_channels(
     api_client, checkout_with_item, address, shipping_zone
 ):

--- a/saleor/graphql/discount/dataloaders.py
+++ b/saleor/graphql/discount/dataloaders.py
@@ -96,6 +96,18 @@ class VoucherByIdLoader(DataLoader):
         return [vouchers.get(voucher_id) for voucher_id in keys]
 
 
+class VoucherByCodeLoader(DataLoader):
+    context_key = "voucher_by_code"
+
+    def batch_load(self, keys):
+        vouchers = (
+            Voucher.objects.using(self.database_connection_name)
+            .filter(code__in=keys)
+            .in_bulk(field_name="code")
+        )
+        return [vouchers.get(code) for code in keys]
+
+
 class VoucherChannelListingByVoucherIdAndChanneSlugLoader(DataLoader):
     context_key = "voucherchannelisting_by_voucher_and_channel"
 


### PR DESCRIPTION
Port changes from #9102

**Issue description**

Given:
- checkout with shipping method price based set

Situation:
- shipping voucher is applied, the voucher discount reduces the price, so the minimal price condition for the current shipping method is not fulfilled

Previous behavior:
- the current shipping method was removed

Current solution
- the current method is not removed, as the voucher is applied on shipping, which conditions were already fulfilled;
(i.e. somebody applied free shipping voucher - we should ensure that the shipping is not removed)
- available shipping methods are updated when discount concerns entire orders or specific products

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
