### PR TITLE
Add ADDED_IN_31 marker to DeliveryMethod

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -179,9 +179,9 @@ class CheckoutLineCountableConnection(CountableConnection):
 class DeliveryMethod(graphene.Union):
     class Meta:
         description = (
-            "Represents a delivery method chosen for the checkout. `Warehouse` "
-            'type is used when checkout is marked as "click and collect" and '
-            "`ShippingMethod` otherwise."
+            f"{ADDED_IN_31} Represents a delivery method chosen for the checkout. "
+            '`Warehouse` type is used when checkout is marked as "click and collect" '
+            "and `ShippingMethod` otherwise."
         )
         types = (Warehouse, ShippingMethod)
 


### PR DESCRIPTION
I want to merge this change because Saleor docs do not mention that this type was added only in 3.1

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
