### PR TITLE
Fix missing update of payment methods when using stored payment method

### DIFF
--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -244,10 +244,13 @@ class StripeGatewayPlugin(BasePlugin):
         intent_id = None
         kind = TransactionKind.ACTION_TO_CONFIRM
         action_required = True
+        payment_method_info = None
         if intent:
             kind, action_required = self._get_transaction_details_for_stripe_status(
                 intent.status
             )
+            if kind in (TransactionKind.AUTH, TransactionKind.CAPTURE):
+                payment_method_info = get_payment_method_details(intent)
             client_secret = intent.client_secret
             last_response = intent.last_response
             raw_response = last_response.data if last_response else None
@@ -265,6 +268,7 @@ class StripeGatewayPlugin(BasePlugin):
             action_required_data={"client_secret": client_secret, "id": intent_id},
             customer_id=customer.id if customer else None,
             psp_reference=intent.id if intent else None,
+            payment_method_info=payment_method_info,
         )
 
     @require_active_plugin

--- a/saleor/payment/gateways/stripe/tests/test_plugin_deprecated.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin_deprecated.py
@@ -25,11 +25,13 @@ def test_process_payment_with_customer_and_future_usage(
     dummy_response = {
         "id": "evt_1Ip9ANH1Vac4G4dbE9ch7zGS",
     }
+    dummy_charges = {}
     payment_intent_id = "payment-intent-id"
     payment_intent.id = payment_intent_id
     payment_intent.client_secret = client_secret
     payment_intent.last_response.data = dummy_response
     payment_intent.status = SUCCESS_STATUS
+    payment_intent.get.side_effect = dummy_charges.get
 
     plugin = stripe_plugin(auto_capture=True)
 


### PR DESCRIPTION
I want to merge this change because it fixes missing payment details when processing stored payment method.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
