### PR TITLE
Fix unavailable products through category in 3.0

### DIFF
--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -1296,7 +1296,7 @@ class Category(CountableDjangoObjectType):
         qs = models.Product.objects.all()
         if not has_required_permissions:
             qs = (
-                qs.published(channel)
+                qs.visible_to_user(requestor, channel)
                 .annotate_visible_in_listings(channel)
                 .exclude(
                     visible_in_listings=False,


### PR DESCRIPTION
I want to merge this change because coping changes from #9144 to 3.0.
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
