### PR TITLE
Fix failing `on_failure` export tasks method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Raise ValidationError in `CheckoutAddPromoCode`, `CheckoutPaymentCreate` when product in the checkout is
 unavailable - #8978 by @IKarbowiak
 - Remove `graphene-django` dependency - #9170 by @rafalp
+- Fix disabled warehouses appearing as valid click and collect points when checkout contains only preorders - #9052 by @rafalp
+- Fix failing `on_failure` export tasks method - #9160 by @IKarbowiak
 
 
 # 3.0.0

--- a/saleor/csv/tasks.py
+++ b/saleor/csv/tasks.py
@@ -1,5 +1,6 @@
 from typing import Dict, Union
 
+import celery
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core.files.storage import default_storage
@@ -17,37 +18,44 @@ from .utils.export import export_gift_cards, export_products
 task_logger = get_task_logger(__name__)
 
 
-def on_task_failure(self, exc, task_id, args, kwargs, einfo):
-    export_file_id = args[0]
-    export_file = ExportFile.objects.get(pk=export_file_id)
+class ExportTask(celery.Task):
+    # should be updated when new export task is added
+    TASK_NAME_TO_DATA_TYPE_MAPPING = {
+        "export-products": "products",
+        "export-gift-cards": "gift cards",
+    }
 
-    export_file.content_file = None
-    export_file.status = JobStatus.FAILED
-    export_file.save(update_fields=["status", "updated_at", "content_file"])
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        export_file_id = args[0]
+        export_file = ExportFile.objects.get(pk=export_file_id)
 
-    events.export_failed_event(
-        export_file=export_file,
-        user=export_file.user,
-        app=export_file.app,
-        message=str(exc),
-        error_type=str(einfo.type),
-    )
+        export_file.content_file = None
+        export_file.status = JobStatus.FAILED
+        export_file.save(update_fields=["status", "updated_at", "content_file"])
 
-    send_export_failed_info(export_file)
+        events.export_failed_event(
+            export_file=export_file,
+            user=export_file.user,
+            app=export_file.app,
+            message=str(exc),
+            error_type=str(einfo.type),
+        )
+
+        data_type = ExportTask.TASK_NAME_TO_DATA_TYPE_MAPPING.get(self.name)
+        send_export_failed_info(export_file, data_type)
+
+    def on_success(self, retval, task_id, args, kwargs):
+        export_file_id = args[0]
+
+        export_file = ExportFile.objects.get(pk=export_file_id)
+        export_file.status = JobStatus.SUCCESS
+        export_file.save(update_fields=["status", "updated_at"])
+        events.export_success_event(
+            export_file=export_file, user=export_file.user, app=export_file.app
+        )
 
 
-def on_task_success(self, retval, task_id, args, kwargs):
-    export_file_id = args[0]
-
-    export_file = ExportFile.objects.get(pk=export_file_id)
-    export_file.status = JobStatus.SUCCESS
-    export_file.save(update_fields=["status", "updated_at"])
-    events.export_success_event(
-        export_file=export_file, user=export_file.user, app=export_file.app
-    )
-
-
-@app.task(on_success=on_task_success, on_failure=on_task_failure)
+@app.task(name="export-products", base=ExportTask)
 def export_products_task(
     export_file_id: int,
     scope: Dict[str, Union[str, dict]],
@@ -59,7 +67,7 @@ def export_products_task(
     export_products(export_file, scope, export_info, file_type, delimiter)
 
 
-@app.task(on_success=on_task_success, on_failure=on_task_failure)
+@app.task(name="export-gift-cards", base=ExportTask)
 def export_gift_cards_task(
     export_file_id: int,
     scope: Dict[str, Union[str, dict]],


### PR DESCRIPTION
- Fix failing `on_failure` csv tasks method
- Refactor csv tasks file - introduce `ExportTask` - basic celery task class for exports

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
