### PR TITLE
Fix menu item reordering

### DIFF
--- a/saleor/graphql/core/utils/reordering.py
+++ b/saleor/graphql/core/utils/reordering.py
@@ -141,7 +141,6 @@ class Reordering:
         self.qs.model.objects.bulk_update(batch, ["sort_order"])
 
     def run(self):
-
         for pk, move in self.operations.items():
             # Skip operation if it was deleted in concurrence
             if pk not in self.ordered_node_map:

--- a/saleor/graphql/menu/tests/test_menu.py
+++ b/saleor/graphql/menu/tests/test_menu.py
@@ -1011,6 +1011,50 @@ def test_menu_reorder(staff_api_client, permission_manage_menus, menu_item_list)
     assert menu_data == expected_data
 
 
+def test_menu_reorder_move_the_same_item_multiple_times(
+    staff_api_client, permission_manage_menus, menu_item_list
+):
+
+    menu_item_list = list(menu_item_list)
+    menu_global_id = graphene.Node.to_global_id("Menu", menu_item_list[0].menu_id)
+
+    assert len(menu_item_list) == 3
+
+    items_global_ids = [
+        graphene.Node.to_global_id("MenuItem", item.pk) for item in menu_item_list
+    ]
+
+    moves_input = [
+        {"itemId": items_global_ids[0], "parentId": None, "sortOrder": 1},
+        {"itemId": items_global_ids[2], "parentId": None, "sortOrder": -1},
+        {"itemId": items_global_ids[2], "parentId": None, "sortOrder": -1},
+    ]
+
+    expected_data = {
+        "id": menu_global_id,
+        "items": [
+            {"id": items_global_ids[2], "parent": None, "children": []},
+            {"id": items_global_ids[1], "parent": None, "children": []},
+            {"id": items_global_ids[0], "parent": None, "children": []},
+        ],
+    }
+
+    response = get_graphql_content(
+        staff_api_client.post_graphql(
+            QUERY_REORDER_MENU,
+            {"moves": moves_input, "menu": menu_global_id},
+            [permission_manage_menus],
+        )
+    )["data"]["menuItemMove"]
+
+    menu_data = response["menu"]
+    assert not response["errors"]
+    assert menu_data
+
+    # Ensure the order is right
+    assert menu_data == expected_data
+
+
 def test_menu_reorder_assign_parent(
     staff_api_client, permission_manage_menus, menu_item_list
 ):
@@ -1066,6 +1110,160 @@ def test_menu_reorder_assign_parent(
                     },
                 ],
             }
+        ],
+    }
+
+    response = get_graphql_content(
+        staff_api_client.post_graphql(
+            QUERY_REORDER_MENU,
+            {"moves": moves_input, "menu": menu_id},
+            [permission_manage_menus],
+        )
+    )["data"]["menuItemMove"]
+
+    menu_data = response["menu"]
+    assert not response["errors"]
+    assert menu_data
+
+    # Ensure the parent and sort orders were assigned correctly
+    assert menu_data == expected_data
+
+
+def test_menu_reorder_assign_and_unassign_parent(
+    staff_api_client, permission_manage_menus, menu_item_list
+):
+    """Assign a menu item as parent of given menu items. Ensure the menu items
+    are properly pushed at the bottom of the item's children.
+    """
+
+    menu_item_list = list(menu_item_list)
+    assert len(menu_item_list) == 3
+
+    menu_id = graphene.Node.to_global_id("Menu", menu_item_list[1].menu_id)
+
+    root = menu_item_list[0]
+
+    item1 = menu_item_list[1]
+    item1.parent = root
+    item1.save()
+
+    item2 = menu_item_list[2]
+
+    item2_child = MenuItem.objects.create(menu=root.menu, parent=item2, name="Child")
+
+    root_id = graphene.Node.to_global_id("MenuItem", root.pk)
+    items_global_ids = [
+        graphene.Node.to_global_id("MenuItem", item.pk) for item in menu_item_list
+    ]
+
+    moves_input = [
+        {"itemId": items_global_ids[2], "parentId": root_id, "sortOrder": 1},
+        {"itemId": items_global_ids[2], "parentId": None, "sortOrder": 1},
+    ]
+
+    expected_data = {
+        "id": menu_id,
+        "items": [
+            {
+                "id": items_global_ids[0],
+                "parent": None,
+                "children": [
+                    {
+                        "id": items_global_ids[1],
+                        "parent": {"id": root_id},
+                        "children": [],
+                    },
+                ],
+            },
+            {
+                "id": items_global_ids[2],
+                "parent": None,
+                "children": [
+                    {
+                        "id": graphene.Node.to_global_id("MenuItem", item2_child.pk),
+                        "parent": {"id": items_global_ids[2]},
+                        "children": [],
+                    },
+                ],
+            },
+        ],
+    }
+
+    response = get_graphql_content(
+        staff_api_client.post_graphql(
+            QUERY_REORDER_MENU,
+            {"moves": moves_input, "menu": menu_id},
+            [permission_manage_menus],
+        )
+    )["data"]["menuItemMove"]
+
+    menu_data = response["menu"]
+    assert not response["errors"]
+    assert menu_data
+
+    # Ensure the parent and sort orders were assigned correctly
+    assert menu_data == expected_data
+
+
+def test_menu_reorder_unassign_and_assign_parent(
+    staff_api_client, permission_manage_menus, menu_item_list
+):
+    """Assign a menu item as parent of given menu items. Ensure the menu items
+    are properly pushed at the bottom of the item's children.
+    """
+
+    menu_item_list = list(menu_item_list)
+    assert len(menu_item_list) == 3
+
+    menu_id = graphene.Node.to_global_id("Menu", menu_item_list[1].menu_id)
+
+    root = menu_item_list[0]
+
+    item1 = menu_item_list[1]
+    item1.parent = root
+    item1.save()
+
+    item2 = menu_item_list[2]
+    item2.parent = root
+    item2.save()
+
+    item2_child = MenuItem.objects.create(menu=root.menu, parent=item2, name="Child")
+
+    root_id = graphene.Node.to_global_id("MenuItem", root.pk)
+    items_global_ids = [
+        graphene.Node.to_global_id("MenuItem", item.pk) for item in menu_item_list
+    ]
+
+    moves_input = [
+        {"itemId": items_global_ids[2], "parentId": None, "sortOrder": 1},
+        {"itemId": items_global_ids[2], "parentId": root_id, "sortOrder": -1},
+    ]
+
+    expected_data = {
+        "id": menu_id,
+        "items": [
+            {
+                "id": items_global_ids[0],
+                "parent": None,
+                "children": [
+                    {
+                        "id": items_global_ids[2],
+                        "parent": {"id": root_id},
+                        "children": [
+                            {
+                                "id": graphene.Node.to_global_id(
+                                    "MenuItem", item2_child.pk
+                                ),
+                            },
+                        ],
+                    },
+                    {
+                        "id": items_global_ids[1],
+                        "parent": {"id": root_id},
+                        "children": [],
+                    },
+                ],
+            },
         ],
     }
 


### PR DESCRIPTION
Port changes from #9016

Previously when operations were analyzed, the parent changes were checked with the current menu item parent and previous operations haven't been taken into consideration. Because of that, previously when somebody sends a few operations and the last operation is coming back to starting position it's not performed correctly.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
