### PR TITLE
Allow fetching unpublished pages by app with manage pages permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable, unreleased changes to this project will be documented in this file.
 unavailable - #8978 by @IKarbowiak
 - Fix disabled warehouses appearing as valid click and collect points when checkout contains only preorders - #9052 by @rafalp
 - Fix crash when Avalara plugin was used together with Webhooks plugin for shipping methods - #9121 by @rafalp
+- Allow fetching unpublished pages by app with manage pages permission - #9181 by @IKarbowiak
 
 
 # 3.0.0

--- a/saleor/graphql/page/resolvers.py
+++ b/saleor/graphql/page/resolvers.py
@@ -1,24 +1,25 @@
 from ...page import models
 from ..core.utils import from_global_id_or_error
 from ..core.validators import validate_one_of_args_is_in_query
+from ..utils import get_user_or_app_from_context
 from .types import Page
 
 
 def resolve_page(info, global_page_id=None, slug=None):
     validate_one_of_args_is_in_query("id", global_page_id, "slug", slug)
-    user = info.context.user
+    requestor = get_user_or_app_from_context(info.context)
 
     if slug is not None:
-        page = models.Page.objects.visible_to_user(user).filter(slug=slug).first()
+        page = models.Page.objects.visible_to_user(requestor).filter(slug=slug).first()
     else:
         _type, page_pk = from_global_id_or_error(global_page_id, Page)
-        page = models.Page.objects.visible_to_user(user).filter(pk=page_pk).first()
+        page = models.Page.objects.visible_to_user(requestor).filter(pk=page_pk).first()
     return page
 
 
 def resolve_pages(info, **_kwargs):
-    user = info.context.user
-    return models.Page.objects.visible_to_user(user)
+    requestor = get_user_or_app_from_context(info.context)
+    return models.Page.objects.visible_to_user(requestor)
 
 
 def resolve_page_type(id):

--- a/saleor/graphql/page/tests/queries/test_page.py
+++ b/saleor/graphql/page/tests/queries/test_page.py
@@ -134,6 +134,85 @@ def test_staff_query_unpublished_page_by_id_without_required_permission(
     assert content["data"]["page"] is None
 
 
+def test_app_query_unpublished_page_by_id(
+    app_api_client, page, permission_manage_pages
+):
+    # given
+    page.is_published = False
+    page.save()
+
+    app_api_client.app.permissions.add(permission_manage_pages)
+
+    variables = {"id": graphene.Node.to_global_id("Page", page.id)}
+
+    # when
+    response = app_api_client.post_graphql(
+        PAGE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["page"]["id"] == variables["id"]
+
+
+def test_app_query_unpublished_page_by_id_without_required_permission(
+    app_api_client,
+    page,
+):
+    # given
+    page.is_published = False
+    page.save()
+
+    variables = {"id": graphene.Node.to_global_id("Page", page.id)}
+
+    # when
+    response = app_api_client.post_graphql(PAGE_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["page"] is None
+
+
+def test_app_query_unpublished_page_by_slug(
+    app_api_client, page, permission_manage_pages
+):
+    # given
+    page.is_published = False
+    page.save()
+
+    app_api_client.app.permissions.add(permission_manage_pages)
+
+    variables = {"slug": page.slug}
+
+    # when
+    response = app_api_client.post_graphql(
+        PAGE_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["page"]["id"] == graphene.Node.to_global_id("Page", page.id)
+
+
+def test_app_query_unpublished_page_by_slug_without_required_permission(
+    app_api_client,
+    page,
+):
+    # given
+    page.is_published = False
+    page.save()
+
+    # when
+    variables = {"slug": page.slug}
+
+    # then
+    response = app_api_client.post_graphql(PAGE_QUERY, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["page"] is None
+
+
 def test_staff_query_unpublished_page_by_slug(
     staff_api_client, page, permission_manage_pages
 ):

--- a/saleor/graphql/page/tests/queries/test_pages.py
+++ b/saleor/graphql/page/tests/queries/test_pages.py
@@ -163,3 +163,132 @@ def test_query_pages_with_sort(
 
     for order, page_name in enumerate(result_order):
         assert pages[order]["node"]["title"] == page_name
+
+
+PAGES_QUERY = """
+    query {
+        pages(first: 10) {
+            edges {
+                node {
+                    id
+                    title
+                    slug
+                    pageType {
+                        id
+                    }
+                    content
+                    contentJson
+                    attributes {
+                        attribute {
+                            slug
+                        }
+                        values {
+                            id
+                            slug
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+def test_query_pages_by_staff(
+    staff_api_client, page_list, page, permission_manage_pages
+):
+    """Ensure staff user with manage pages permission can query all pages,
+    including unpublished pages."""
+    # given
+    unpublished_page = page
+    unpublished_page.is_published = False
+    unpublished_page.save(update_fields=["is_published"])
+
+    page_count = Page.objects.count()
+
+    staff_api_client.user.user_permissions.add(permission_manage_pages)
+
+    # when
+    response = staff_api_client.post_graphql(PAGES_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pages"]["edges"]
+    assert len(data) == page_count
+
+
+def test_query_pages_by_app(app_api_client, page_list, page, permission_manage_pages):
+    """Ensure app with manage pages permission can query all pages,
+    including unpublished pages."""
+    # given
+    unpublished_page = page
+    unpublished_page.is_published = False
+    unpublished_page.save(update_fields=["is_published"])
+
+    page_count = Page.objects.count()
+
+    app_api_client.app.permissions.add(permission_manage_pages)
+
+    # when
+    response = app_api_client.post_graphql(PAGES_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pages"]["edges"]
+    assert len(data) == page_count
+
+
+def test_query_pages_by_staff_no_perm(staff_api_client, page_list, page):
+    """Ensure staff user without manage pages permission can query
+    only published pages."""
+
+    # given
+    unpublished_page = page
+    unpublished_page.is_published = False
+    unpublished_page.save(update_fields=["is_published"])
+
+    page_count = Page.objects.count()
+
+    # when
+    response = staff_api_client.post_graphql(PAGES_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pages"]["edges"]
+    assert len(data) == page_count - 1
+
+
+def test_query_pages_by_app_no_perm(app_api_client, page_list, page):
+    """Ensure app without manage pages permission can query only published pages."""
+    # given
+    unpublished_page = page
+    unpublished_page.is_published = False
+    unpublished_page.save(update_fields=["is_published"])
+
+    page_count = Page.objects.count()
+
+    # when
+    response = app_api_client.post_graphql(PAGES_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pages"]["edges"]
+    assert len(data) == page_count - 1
+
+
+def test_query_pages_by_customer(api_client, page_list, page):
+    """Ensure customer user can query only published pages."""
+    # given
+    unpublished_page = page
+    unpublished_page.is_published = False
+    unpublished_page.save(update_fields=["is_published"])
+
+    page_count = Page.objects.count()
+
+    # when
+    response = api_client.post_graphql(PAGES_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pages"]["edges"]
+    assert len(data) == page_count - 1

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4508,7 +4508,7 @@ def page_with_rich_text_attribute(db, page_type_with_rich_text_attribute):
 @pytest.fixture
 def page_list(db, page_type):
     data_1 = {
-        "slug": "test-url",
+        "slug": "test-url-1",
         "title": "Test page",
         "content": dummy_editorjs("Test content."),
         "is_published": True,


### PR DESCRIPTION
Allow fetching unpublished pages by app with manage pages permission

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
