### PR TITLE
Call manager in transaction.on_commit in OrderMarkAsPaid

### DIFF
--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -513,8 +513,11 @@ def mark_order_as_paid(
         app=app,
         transaction_reference=external_reference,
     )
-    manager.order_fully_paid(order)
-    manager.order_updated(order)
+
+    transaction.on_commit(lambda: manager.order_fully_paid(order))
+
+    transaction.on_commit(lambda: manager.order_updated(order))
+
     order.update_total_paid()
 
 

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -515,7 +515,6 @@ def mark_order_as_paid(
     )
 
     transaction.on_commit(lambda: manager.order_fully_paid(order))
-
     transaction.on_commit(lambda: manager.order_updated(order))
 
     order.update_total_paid()


### PR DESCRIPTION
I want to merge this change because it adds missing transaction.on_commit wrapper.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
