### PR TITLE
Invalidate stocks dataloader

### DIFF
--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -36,6 +36,9 @@ from ...core.types.common import (
 )
 from ...core.utils import get_duplicated_values
 from ...core.validators import validate_price_precision
+from ...warehouse.dataloaders import (
+    StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader,
+)
 from ...warehouse.types import Warehouse
 from ..mutations.channels import ProductVariantChannelListingAddInput
 from ..mutations.products import (
@@ -691,8 +694,11 @@ class ProductVariantStocksCreate(BaseMutation):
                     lambda: manager.product_variant_back_in_stock(stock)
                 )
 
-        variant = ChannelContext(node=variant, channel_slug=None)
+        StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader(
+            info.context
+        ).clear((variant.id, None, None))
 
+        variant = ChannelContext(node=variant, channel_slug=None)
         return cls(product_variant=variant)
 
     @classmethod
@@ -764,6 +770,10 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
             manager = info.context.plugins
             cls.update_or_create_variant_stocks(variant, stocks, warehouses, manager)
 
+        StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader(
+            info.context
+        ).clear((variant.id, None, None))
+
         variant = ChannelContext(node=variant, channel_slug=None)
         return cls(product_variant=variant)
 
@@ -827,13 +837,16 @@ class ProductVariantStocksDelete(BaseMutation):
             product_variant=variant, warehouse__pk__in=warehouses_pks
         )
 
-        variant = ChannelContext(node=variant, channel_slug=None)
-
         for stock in stocks_to_delete:
             transaction.on_commit(lambda: manager.product_variant_out_of_stock(stock))
 
         stocks_to_delete.delete()
 
+        StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader(
+            info.context
+        ).clear((variant.id, None, None))
+
+        variant = ChannelContext(node=variant, channel_slug=None)
         return cls(product_variant=variant)
 
 

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -5609,6 +5609,192 @@ def test_product_variant_stocks_delete_mutation_invalid_object_type_of_warehouse
     assert errors[0]["field"] == "warehouseIds"
 
 
+VARIANT_UPDATE_AND_STOCKS_REMOVE_MUTATION = """
+  fragment ProductVariant on ProductVariant {
+    stocks {
+      id
+    }
+  }
+
+  mutation VariantUpdate($removeStocks: [ID!]!, $id: ID!) {
+    productVariantUpdate(id: $id, input: {}) {
+      productVariant {
+        ...ProductVariant
+      }
+    }
+    productVariantStocksDelete(variantId: $id, warehouseIds: $removeStocks) {
+      productVariant {
+        ...ProductVariant
+      }
+    }
+  }
+"""
+
+
+def test_invalidate_stocks_dataloader_on_removing_stocks(
+    staff_api_client, variant_with_many_stocks, permission_manage_products
+):
+    # given
+    variant = variant_with_many_stocks
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    warehouse_ids = [
+        graphene.Node.to_global_id("Warehouse", stock.warehouse.id)
+        for stock in variant_with_many_stocks.stocks.all()
+    ]
+    variables = {
+        "id": variant_id,
+        "removeStocks": warehouse_ids,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        VARIANT_UPDATE_AND_STOCKS_REMOVE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_products,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    variant_data = content["data"]["productVariantUpdate"]["productVariant"]
+    remove_stocks_data = content["data"]["productVariantStocksDelete"]["productVariant"]
+
+    # no stocks were removed in the first mutation
+    assert len(variant_data["stocks"]) == len(warehouse_ids)
+
+    # stocks are empty in the second mutation
+    assert remove_stocks_data["stocks"] == []
+
+
+VARIANT_UPDATE_AND_STOCKS_CREATE_MUTATION = """
+  fragment ProductVariant on ProductVariant {
+    id
+    name
+    stocks {
+      quantity
+      warehouse {
+        id
+        name
+      }
+    }
+  }
+
+  mutation VariantUpdate($id: ID!, $stocks: [StockInput!]!) {
+    productVariantUpdate(id: $id, input: {}) {
+      productVariant {
+        ...ProductVariant
+      }
+    }
+    productVariantStocksCreate(variantId: $id, stocks: $stocks) {
+      productVariant {
+        ...ProductVariant
+      }
+    }
+  }
+"""
+
+
+def test_invalidate_stocks_dataloader_on_create_stocks(
+    staff_api_client, variant_with_many_stocks, permission_manage_products
+):
+    # given
+    variant = variant_with_many_stocks
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    warehouse_ids = [
+        graphene.Node.to_global_id("Warehouse", stock.warehouse.id)
+        for stock in variant_with_many_stocks.stocks.all()
+    ]
+    variant.stocks.all().delete()
+    variables = {
+        "id": variant_id,
+        "stocks": [
+            {"warehouse": warehouse_id, "quantity": 10}
+            for warehouse_id in warehouse_ids
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        VARIANT_UPDATE_AND_STOCKS_CREATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_products,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    variant_data = content["data"]["productVariantUpdate"]["productVariant"]
+    create_stocks_data = content["data"]["productVariantStocksCreate"]["productVariant"]
+
+    # no stocks are present after the first mutation
+    assert variant_data["stocks"] == []
+
+    # stocks are returned in the second mutation, after dataloader invalidation
+    assert len(create_stocks_data["stocks"]) == len(warehouse_ids)
+
+
+VARIANT_UPDATE_AND_STOCKS_UPDATE_MUTATION = """
+  fragment ProductVariant on ProductVariant {
+    id
+    name
+    stocks {
+      quantity
+      warehouse {
+        id
+        name
+      }
+    }
+  }
+
+  mutation VariantUpdate($id: ID!, $stocks: [StockInput!]!) {
+    productVariantUpdate(id: $id, input: {}) {
+      productVariant {
+        ...ProductVariant
+      }
+    }
+    productVariantStocksUpdate(variantId: $id, stocks: $stocks) {
+      productVariant {
+        ...ProductVariant
+      }
+    }
+  }
+"""
+
+
+def test_invalidate_stocks_dataloader_on_update_stocks(
+    staff_api_client, variant_with_many_stocks, permission_manage_products
+):
+    # given
+    variant = variant_with_many_stocks
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    stock = variant.stocks.first()
+    # keep only one stock record for test purposes
+    variant.stocks.exclude(id=stock.id).delete()
+    warehouse_id = graphene.Node.to_global_id("Warehouse", stock.warehouse.id)
+    old_quantity = stock.quantity
+    new_quantity = old_quantity + 500
+    variables = {
+        "id": variant_id,
+        "stocks": [{"warehouse": warehouse_id, "quantity": new_quantity}],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        VARIANT_UPDATE_AND_STOCKS_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_products,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    variant_data = content["data"]["productVariantUpdate"]["productVariant"]
+    update_stocks_data = content["data"]["productVariantStocksUpdate"]["productVariant"]
+
+    # stocks is not updated in the first mutation
+    assert variant_data["stocks"][0]["quantity"] == old_quantity
+
+    # stock is updated in the second mutation
+    assert update_stocks_data["stocks"][0]["quantity"] == new_quantity
+
+
 def test_query_product_variant_for_federation(api_client, variant, channel_USD):
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     variables = {


### PR DESCRIPTION
Stocks dataloader needs to be invalidated after editing stocks in mutations. Without it, the dashboard renders an invalid state after editing stocks which uses a couple of mutations run sequentially.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
