### PR TITLE
Support Braintree subaccounts

### DIFF
--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -83,7 +83,7 @@ class AdyenGatewayPlugin(BasePlugin):
         },
         "merchant-account": {
             "type": ConfigurationTypeField.STRING,
-            "help_text": "Yout merchant account name.",
+            "help_text": "Your merchant account name.",
             "label": "Merchant Account",
         },
         "supported-currencies": {

--- a/saleor/payment/gateways/braintree/plugin.py
+++ b/saleor/payment/gateways/braintree/plugin.py
@@ -32,6 +32,7 @@ class BraintreeGatewayPlugin(BasePlugin):
         {"name": "Secret API key", "value": None},
         {"name": "Use sandbox", "value": True},
         {"name": "Merchant ID", "value": None},
+        {"name": "Merchant Account ID", "value": None},
         {"name": "Store customers card", "value": False},
         {"name": "Automatic payment capture", "value": True},
         {"name": "Require 3D secure", "value": False},
@@ -42,28 +43,33 @@ class BraintreeGatewayPlugin(BasePlugin):
         "Public API key": {
             "type": ConfigurationTypeField.SECRET,
             "help_text": "Provide Braintree public API key.",
-            "label": "Public API key",
+            "label": "Public Key",
         },
         "Secret API key": {
             "type": ConfigurationTypeField.SECRET,
-            "help_text": "Provide Braintree secret API key.",
-            "label": "Secret API key",
+            "help_text": "Provide Braintree private API key.",
+            "label": "Private Key",
         },
         "Merchant ID": {
-            "type": ConfigurationTypeField.SECRET,
+            "type": ConfigurationTypeField.STRING,
             "help_text": "Provide Braintree merchant ID.",
             "label": "Merchant ID",
+        },
+        "Merchant Account ID": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": "Optional. If empty, the default account will be used.",
+            "label": "Merchant Account ID",
         },
         "Use sandbox": {
             "type": ConfigurationTypeField.BOOLEAN,
             "help_text": "Determines if Saleor should use Braintree sandbox API.",
-            "label": "Use sandbox",
+            "label": "Sandbox mode",
         },
         "Store customers card": {
             "type": ConfigurationTypeField.BOOLEAN,
             "help_text": "Determines if Saleor should store cards on payments"
             " in Braintree customer.",
-            "label": "Store customers card",
+            "label": "Store customer cards",
         },
         "Automatic payment capture": {
             "type": ConfigurationTypeField.BOOLEAN,
@@ -72,8 +78,8 @@ class BraintreeGatewayPlugin(BasePlugin):
         },
         "Require 3D secure": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should enforce 3D secure during payment.",
-            "label": "Require 3D secure",
+            "help_text": "Determines if Saleor should enforce 3D Secure during payment.",
+            "label": "Require 3D Secure",
         },
         "Supported currencies": {
             "type": ConfigurationTypeField.STRING,
@@ -93,6 +99,7 @@ class BraintreeGatewayPlugin(BasePlugin):
             connection_params={
                 "sandbox_mode": configuration["Use sandbox"],
                 "merchant_id": configuration["Merchant ID"],
+                "merchant_account_id": configuration["Merchant Account ID"],
                 "public_key": configuration["Public API key"],
                 "private_key": configuration["Secret API key"],
             },

--- a/saleor/payment/gateways/braintree/tests/test_braintree.py
+++ b/saleor/payment/gateways/braintree/tests/test_braintree.py
@@ -84,6 +84,7 @@ def gateway_config():
             "merchant_id": "123",
             "public_key": "456",
             "private_key": "789",
+            "merchant_account_id": "",
         },
         supported_currencies="USD",
     )
@@ -255,6 +256,7 @@ def sandbox_braintree_gateway_config(gateway_config):
         "public_key": "fake_public_key",  # CHANGE WHEN RECORDING
         "private_key": "fake_private_key",  # CHANGE WHEN RECORDING
         "sandbox_mode": True,
+        "merchant_account_id": "",
     }
     gateway_config.auto_capture = True
     return gateway_config


### PR DESCRIPTION
This adds a new optional field to the plugin configuration screen. If set, it will override the default merchant account used for transactions.

Refunds and voids automatically use the merchant account that the original transaction used so they don't pass the override.

Tested the changes using the old storefront. See SALEOR-5974 for testing instructions.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
