### PR TITLE
Update required permissions for attribute options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ unavailable - #8978 by @IKarbowiak
 - Fix disabled warehouses appearing as valid click and collect points when checkout contains only preorders - #9052 by @rafalp
 - Fix crash when Avalara plugin was used together with Webhooks plugin for shipping methods - #9121 by @rafalp
 - Allow fetching unpublished pages by app with manage pages permission - #9181 by @IKarbowiak
+- Update required permissions for attribute options - #9204 by @IKarbowiak
+  - Product attribute options can be fetched by requestors with manage product types and attributes permission.
+  - Page attribute options can be fetched by requestors with manage page types and attributes permission.
 
 
 # 3.0.0

--- a/saleor/graphql/decorators.py
+++ b/saleor/graphql/decorators.py
@@ -8,7 +8,9 @@ from ..attribute import AttributeType
 from ..core.exceptions import PermissionDenied
 from ..core.permissions import (
     PagePermissions,
+    PageTypePermissions,
     ProductPermissions,
+    ProductTypePermissions,
     has_one_of_permissions,
 )
 from ..core.permissions import permission_required as core_permission_required
@@ -100,9 +102,19 @@ def check_attribute_required_permissions():
     def check_perms(context, attribute):
         requestor = get_user_or_app_from_context(context)
         if attribute.type == AttributeType.PAGE_TYPE:
-            return core_permission_required((PagePermissions.MANAGE_PAGES,), requestor)
-        return core_permission_required(
-            (ProductPermissions.MANAGE_PRODUCTS,), requestor
+            return has_one_of_permissions(
+                requestor,
+                (
+                    PagePermissions.MANAGE_PAGES,
+                    PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+                ),
+            )
+        return has_one_of_permissions(
+            requestor,
+            (
+                ProductPermissions.MANAGE_PRODUCTS,
+                ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+            ),
         )
 
     return account_passes_test_for_attribute(check_perms)

--- a/saleor/graphql/page/tests/mutations/test_page_attribute_assign.py
+++ b/saleor/graphql/page/tests/mutations/test_page_attribute_assign.py
@@ -18,6 +18,12 @@ PAGE_ASSIGN_ATTR_QUERY = """
           id
           attributes {
             id
+            visibleInStorefront
+            filterableInDashboard
+            filterableInStorefront
+            availableInGrid
+            valueRequired
+            storefrontSearchPosition
           }
         }
       }

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -280,9 +280,18 @@ PRODUCT_ASSIGN_ATTR_QUERY = """
           id
           productAttributes {
             id
+            visibleInStorefront
+            filterableInDashboard
+            filterableInStorefront
           }
           variantAttributes {
             id
+            visibleInStorefront
+            filterableInDashboard
+            filterableInStorefront
+            availableInGrid
+            valueRequired
+            storefrontSearchPosition
           }
         }
       }


### PR DESCRIPTION
- Product attribute options should be available also for requestors with manage product types and attributes.
- Page attribute options should be available also for requestors with manage page types and attributes.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
