### PR TITLE
Add support for hiding plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Other changes
 - Filter Customer/Order/Sale/Product/ProductVariant by datetime of last modification - #9137 by @rafalp
-
+- Add possibility for plugins to execute code before each mutation - #9193 by @NyanKiyoshi
+- Add support for hiding plugins - #9219 by @NyanKiyoshi
 
 # 3.1.0
 

--- a/saleor/graphql/plugins/mutations.py
+++ b/saleor/graphql/plugins/mutations.py
@@ -62,7 +62,7 @@ class PluginUpdate(BaseMutation):
 
         manager = info.context.plugins
         plugin = manager.get_plugin(plugin_id, channel_slug)
-        if not plugin:
+        if not plugin or plugin.HIDDEN is True:
             raise ValidationError(
                 {
                     "id": ValidationError(

--- a/saleor/graphql/plugins/resolvers.py
+++ b/saleor/graphql/plugins/resolvers.py
@@ -44,17 +44,18 @@ def aggregate_plugins_configuration(
 
     for plugin in manager.all_plugins:
         hide_private_configuration_fields(plugin.configuration, plugin.CONFIG_STRUCTURE)
-        if not getattr(plugin, "CONFIGURATION_PER_CHANNEL", False):
-            global_plugins[plugin.PLUGIN_ID] = plugin
-        else:
-            plugins_per_channel[plugin.PLUGIN_ID].append(plugin)
+        if plugin.HIDDEN is False:
+            if not getattr(plugin, "CONFIGURATION_PER_CHANNEL", False):
+                global_plugins[plugin.PLUGIN_ID] = plugin
+            else:
+                plugins_per_channel[plugin.PLUGIN_ID].append(plugin)
     return global_plugins, plugins_per_channel
 
 
 def resolve_plugin(id, manager):
     global_plugins, plugins_per_channel = aggregate_plugins_configuration(manager)
     plugin: BasePlugin = manager.get_plugin(id)
-    if not plugin:
+    if not plugin or plugin.HIDDEN is True:
         return None
 
     return Plugin(

--- a/saleor/graphql/plugins/resolvers.py
+++ b/saleor/graphql/plugins/resolvers.py
@@ -44,11 +44,12 @@ def aggregate_plugins_configuration(
 
     for plugin in manager.all_plugins:
         hide_private_configuration_fields(plugin.configuration, plugin.CONFIG_STRUCTURE)
-        if plugin.HIDDEN is False:
-            if not getattr(plugin, "CONFIGURATION_PER_CHANNEL", False):
-                global_plugins[plugin.PLUGIN_ID] = plugin
-            else:
-                plugins_per_channel[plugin.PLUGIN_ID].append(plugin)
+        if plugin.HIDDEN is True:
+            continue
+        if not getattr(plugin, "CONFIGURATION_PER_CHANNEL", False):
+            global_plugins[plugin.PLUGIN_ID] = plugin
+        else:
+            plugins_per_channel[plugin.PLUGIN_ID].append(plugin)
     return global_plugins, plugins_per_channel
 
 

--- a/saleor/graphql/plugins/tests/queries/test_plugin.py
+++ b/saleor/graphql/plugins/tests/queries/test_plugin.py
@@ -256,7 +256,7 @@ def test_cannot_retrieve_hidden_plugin(settings, staff_api_client_can_manage_plu
     """Ensure one cannot retrieve the details of a hidden global plugin"""
     client = staff_api_client_can_manage_plugins
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    variables = {"id": ChannelPluginSample.PLUGIN_ID}
+    variables = {"id": PluginSample.PLUGIN_ID}
 
     # Ensure when visible we find the plugin
     response = client.post_graphql(PLUGIN_QUERY, variables)

--- a/saleor/graphql/plugins/tests/queries/test_plugin.py
+++ b/saleor/graphql/plugins/tests/queries/test_plugin.py
@@ -1,4 +1,5 @@
 import copy
+from unittest import mock
 
 import pytest
 
@@ -249,3 +250,45 @@ def test_query_plugin_configuration_as_customer_user(user_api_client, settings):
     response = user_api_client.post_graphql(PLUGIN_QUERY, variables)
 
     assert_no_permission(response)
+
+
+def test_cannot_retrieve_hidden_plugin(settings, staff_api_client_can_manage_plugins):
+    """Ensure one cannot retrieve the details of a hidden global plugin"""
+    client = staff_api_client_can_manage_plugins
+    settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
+    variables = {"id": ChannelPluginSample.PLUGIN_ID}
+
+    # Ensure when visible we find the plugin
+    response = client.post_graphql(PLUGIN_QUERY, variables)
+    assert response.status_code == 200
+    content = get_graphql_content(response)
+    assert content["data"]["plugin"] is not None, "should have found plugin"
+
+    # Make the plugin hidden
+    with mock.patch.object(PluginSample, "HIDDEN", new=True):
+        response = client.post_graphql(PLUGIN_QUERY, variables)
+    assert response.status_code == 200
+    content = get_graphql_content(response)
+    assert content["data"] == {"plugin": None}, "shouldn't have found plugin"
+
+
+def test_cannot_retrieve_hidden_multi_channel_plugin(
+    settings, staff_api_client_can_manage_plugins, channel_PLN
+):
+    """Ensure one cannot retrieve the details of a hidden multi channel plugin"""
+    client = staff_api_client_can_manage_plugins
+    settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.ChannelPluginSample"]
+    variables = {"id": ChannelPluginSample.PLUGIN_ID}
+
+    # Ensure when visible we find the plugin
+    response = client.post_graphql(PLUGIN_QUERY, variables)
+    assert response.status_code == 200
+    content = get_graphql_content(response)
+    assert content["data"]["plugin"] is not None, "should have found plugin"
+
+    # Make the plugin hidden
+    with mock.patch.object(PluginSample, "HIDDEN", new=True):
+        response = client.post_graphql(PLUGIN_QUERY, variables)
+    assert response.status_code == 200
+    content = get_graphql_content(response)
+    assert content["data"] == {"plugin": None}, "shouldn't have found plugin"

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -95,6 +95,7 @@ class BasePlugin:
     CONFIGURATION_PER_CHANNEL = True
     DEFAULT_CONFIGURATION = []
     DEFAULT_ACTIVE = False
+    HIDDEN = False
 
     @classmethod
     def check_plugin_id(cls, plugin_id: str) -> bool:


### PR DESCRIPTION
This would allow to make some plugins readonly and invisible to the user.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
