### PR TITLE
Better API for fetching metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - Deprecate `PUBLICATION_DATE` in `CollectionSortField`, the `PUBLISHED_AT` should be used instead.
   - Deprecate `PUBLICATION_DATE` in `PageSortField`, the `PUBLISHED_AT` should be used instead.
   - Add a new column `pubished at` to export products. The new field should be used instead of `publication_date`.
+- Add an alternative API for fetching metadata - #9231 by @patrys
 
 # 3.2.0
 

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -77,9 +77,29 @@ class ChannelContextTypeWithMetadataForObjectType(ChannelContextTypeForObjectTyp
         return ObjectWithMetadata.resolve_metadata(root.node, info)
 
     @staticmethod
+    def resolve_metafield(root: ChannelContext, info, *, key: str):
+        # Used in metadata API to resolve metadata fields from an instance.
+        return ObjectWithMetadata.resolve_metafield(root.node, info, key=key)
+
+    @staticmethod
+    def resolve_metafields(root: ChannelContext, info, keys=None):
+        # Used in metadata API to resolve metadata fields from an instance.
+        return ObjectWithMetadata.resolve_metafields(root.node, info, keys=keys)
+
+    @staticmethod
     def resolve_private_metadata(root: ChannelContext, info):
         # Used in metadata API to resolve private metadata fields from an instance.
         return ObjectWithMetadata.resolve_private_metadata(root.node, info)
+
+    @staticmethod
+    def resolve_private_metafield(root: ChannelContext, info, *, key: str):
+        # Used in metadata API to resolve private metadata fields from an instance.
+        return ObjectWithMetadata.resolve_private_metafield(root.node, info, key=key)
+
+    @staticmethod
+    def resolve_private_metafields(root: ChannelContext, info, keys=None):
+        # Used in metadata API to resolve private metadata fields from an instance.
+        return ObjectWithMetadata.resolve_private_metafields(root.node, info, keys=keys)
 
 
 class ChannelContextTypeWithMetadata(

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -7,9 +7,9 @@ DEPRECATED_IN_3X_FIELD = "This field will be removed in Saleor 4.0."
 DEPRECATED_IN_3X_INPUT = "\n\nDEPRECATED: this field will be removed in Saleor 4.0."
 
 
-ADDED_IN_31 = "New in Saleor 3.1."
-ADDED_IN_32 = "New in Saleor 3.2."
-ADDED_IN_33 = "New in Saleor 3.3."
+ADDED_IN_31 = "Added in Saleor 3.1."
+ADDED_IN_32 = "Added in Saleor 3.2."
+ADDED_IN_33 = "Added in Saleor 3.3."
 PREVIEW_FEATURE = (
     "Note: this feature is in a preview state and can be subject to changes at later "
     "point."

--- a/saleor/graphql/meta/resolvers.py
+++ b/saleor/graphql/meta/resolvers.py
@@ -80,7 +80,7 @@ def resolve_metadata(metadata: dict):
     )
 
 
-def resolve_private_metadata(root: ModelWithMetadata, info):
+def check_private_metadata_privilege(root: ModelWithMetadata, info):
     item_type, item_id = resolve_object_with_metadata_type(root)
     if not item_type:
         raise NotImplementedError(
@@ -101,4 +101,7 @@ def resolve_private_metadata(root: ModelWithMetadata, info):
     if not requester.has_perms(required_permissions):
         raise PermissionDenied()
 
+
+def resolve_private_metadata(root: ModelWithMetadata, info):
+    check_private_metadata_privilege(root, info)
     return resolve_metadata(root.private_metadata)

--- a/saleor/graphql/meta/tests/test_meta_queries.py
+++ b/saleor/graphql/meta/tests/test_meta_queries.py
@@ -54,6 +54,8 @@ QUERY_SELF_PUBLIC_META = """
                 key
                 value
             }
+            metafields(keys: ["INVALID", "key"])
+            keyFieldValue: metafield(key: "key")
         }
     }
 """
@@ -73,6 +75,10 @@ def test_query_public_meta_for_me_as_customer(user_api_client):
     metadata = content["data"]["me"]["metadata"][0]
     assert metadata["key"] == PUBLIC_KEY
     assert metadata["value"] == PUBLIC_VALUE
+    metafields = content["data"]["me"]["metafields"]
+    assert metafields[PUBLIC_KEY] == PUBLIC_VALUE
+    field_value = content["data"]["me"]["keyFieldValue"]
+    assert field_value == PUBLIC_VALUE
 
 
 def test_query_public_meta_for_me_as_staff(staff_api_client):
@@ -89,6 +95,10 @@ def test_query_public_meta_for_me_as_staff(staff_api_client):
     metadata = content["data"]["me"]["metadata"][0]
     assert metadata["key"] == PUBLIC_KEY
     assert metadata["value"] == PUBLIC_VALUE
+    metafields = content["data"]["me"]["metafields"]
+    assert metafields[PUBLIC_KEY] == PUBLIC_VALUE
+    field_value = content["data"]["me"]["keyFieldValue"]
+    assert field_value == PUBLIC_VALUE
 
 
 QUERY_USER_PUBLIC_META = """

--- a/saleor/graphql/meta/types.py
+++ b/saleor/graphql/meta/types.py
@@ -1,9 +1,12 @@
 import graphene
+from graphene.types.generic import GenericScalar
 
 from ...core.models import ModelWithMetadata
 from ..channel import ChannelContext
+from ..core.descriptions import ADDED_IN_33, PREVIEW_FEATURE
 from ..core.types import NonNullList
 from .resolvers import (
+    check_private_metadata_privilege,
     resolve_metadata,
     resolve_object_with_metadata_type,
     resolve_private_metadata,
@@ -15,13 +18,50 @@ class MetadataItem(graphene.ObjectType):
     value = graphene.String(required=True, description="Value of a metadata item.")
 
 
+class Metadata(GenericScalar):
+    """Metadata is a map of key-value pairs, both keys and values are `String`.
+
+    Example:
+    ```
+    {
+        "key1": "value1",
+        "key2": "value2"
+    }
+    ```
+
+    """
+
+
+def _filter_metadata(metadata, keys):
+    if keys is None:
+        return metadata
+    return {key: value for key, value in metadata.items() if key in keys}
+
+
 class ObjectWithMetadata(graphene.Interface):
     private_metadata = NonNullList(
         MetadataItem,
         required=True,
         description=(
-            "List of private metadata items."
-            "Requires proper staff permissions to access."
+            "List of private metadata items. Requires staff permissions to access."
+        ),
+    )
+    private_metafield = graphene.String(
+        args={"key": graphene.NonNull(graphene.String)},
+        description=(
+            "A single key from private metadata. "
+            "Requires staff permissions to access.\n\n"
+            "Tip: Use GraphQL aliases to fetch multiple keys.\n\n"
+            f"{ADDED_IN_33}\n\n{PREVIEW_FEATURE}"
+        ),
+    )
+    private_metafields = Metadata(
+        args={"keys": NonNullList(graphene.String)},
+        description=(
+            "Private metadata. Requires staff permissions to access. "
+            "Use `keys` to control which fields you want to include. "
+            "The default is to include everything.\n\n"
+            f"{ADDED_IN_33}\n\n{PREVIEW_FEATURE}"
         ),
     )
     metadata = NonNullList(
@@ -31,14 +71,48 @@ class ObjectWithMetadata(graphene.Interface):
             "List of public metadata items. Can be accessed without permissions."
         ),
     )
+    metafield = graphene.String(
+        args={"key": graphene.NonNull(graphene.String)},
+        description=(
+            "A single key from public metadata.\n\n"
+            "Tip: Use GraphQL aliases to fetch multiple keys.\n\n"
+            f"{ADDED_IN_33}\n\n{PREVIEW_FEATURE}"
+        ),
+    )
+    metafields = Metadata(
+        args={"keys": NonNullList(graphene.String)},
+        description=(
+            "Public metadata. Use `keys` to control which fields you want to include. "
+            "The default is to include everything.\n\n"
+            f"{ADDED_IN_33}\n\n{PREVIEW_FEATURE}"
+        ),
+    )
 
     @staticmethod
     def resolve_metadata(root: ModelWithMetadata, _info):
         return resolve_metadata(root.metadata)
 
     @staticmethod
+    def resolve_metafield(root: ModelWithMetadata, _info, *, key: str):
+        return root.metadata.get(key)
+
+    @staticmethod
+    def resolve_metafields(root: ModelWithMetadata, _info, *, keys=None):
+        return _filter_metadata(root.metadata, keys)
+
+    @staticmethod
     def resolve_private_metadata(root: ModelWithMetadata, info):
         return resolve_private_metadata(root, info)
+
+    @staticmethod
+    def resolve_private_metafield(root: ModelWithMetadata, info, *, key: str):
+        check_private_metadata_privilege(root, info)
+        return root.private_metadata.get(key)
+
+    @staticmethod
+    def resolve_private_metafields(root: ModelWithMetadata, info, *, keys=None):
+        check_private_metadata_privilege(root, info)
+        return _filter_metadata(root.private_metadata, keys)
 
     @classmethod
     def resolve_type(cls, instance: ModelWithMetadata, _info):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -649,12 +649,12 @@ type Query {
   """
   giftCards(
     """
-    New in Saleor 3.1. Sort gift cards. Note: this feature is in a preview state and can be subject to changes at later point.
+    Added in Saleor 3.1. Sort gift cards. Note: this feature is in a preview state and can be subject to changes at later point.
     """
     sortBy: GiftCardSortingInput
 
     """
-    New in Saleor 3.1. Filtering options for gift cards. Note: this feature is in a preview state and can be subject to changes at later point.
+    Added in Saleor 3.1. Filtering options for gift cards. Note: this feature is in a preview state and can be subject to changes at later point.
     """
     filter: GiftCardFilterInput
 
@@ -672,12 +672,12 @@ type Query {
   ): GiftCardCountableConnection
 
   """
-  New in Saleor 3.1. List of gift card currencies. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. List of gift card currencies. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardCurrencies: [String!]!
 
   """
-  New in Saleor 3.1. List of gift card tags. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. List of gift card tags. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardTags(
     """Filtering options for gift card tags."""
@@ -859,10 +859,10 @@ type Query {
   List of checkouts. Requires one of the following permissions: MANAGE_CHECKOUTS.
   """
   checkouts(
-    """New in Saleor 3.1. Sort checkouts."""
+    """Added in Saleor 3.1. Sort checkouts."""
     sortBy: CheckoutSortingInput
 
-    """New in Saleor 3.1. Filtering options for checkouts."""
+    """Added in Saleor 3.1. Filtering options for checkouts."""
     filter: CheckoutFilterInput
 
     """Slug of a channel for which the data should be returned."""
@@ -981,7 +981,7 @@ type Query {
   ): App
 
   """
-  New in Saleor 3.1. List of all extensions. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  Added in Saleor 3.1. List of all extensions. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   appExtensions(
     """Filtering options for apps extensions."""
@@ -1001,7 +1001,7 @@ type Query {
   ): AppExtensionCountableConnection
 
   """
-  New in Saleor 3.1. Look up an app extension by ID. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  Added in Saleor 3.1. Look up an app extension by ID. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   appExtension(
     """ID of the app extension."""
@@ -1547,13 +1547,51 @@ enum WebhookEventTypeAsyncEnum {
 type App implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
 
   """List of the app's permissions."""
   permissions: [Permission!]
@@ -1604,19 +1642,57 @@ type App implements Node & ObjectWithMetadata {
   accessToken: String
 
   """
-  New in Saleor 3.1. App's dashboard extensions. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. App's dashboard extensions. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   extensions: [AppExtension!]!
 }
 
 interface ObjectWithMetadata {
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
 }
 
 type MetadataItem {
@@ -1626,6 +1702,19 @@ type MetadataItem {
   """Value of a metadata item."""
   value: String!
 }
+
+"""
+Metadata is a map of key-value pairs, both keys and values are `String`.
+
+Example:
+```
+{
+    "key1": "value1",
+    "key2": "value2"
+}
+```
+"""
+scalar Metadata
 
 """Represents a permission object in a friendly form."""
 type Permission {
@@ -1962,13 +2051,51 @@ enum WebhookSampleEventTypeEnum {
 type Warehouse implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   name: String!
   slug: String!
   email: String!
@@ -1979,7 +2106,7 @@ type Warehouse implements Node & ObjectWithMetadata {
   companyName: String! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `Address.companyName` instead.")
 
   """
-  New in Saleor 3.1. Click and collect options: local, all or disabled. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Click and collect options: local, all or disabled. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   clickAndCollectOption: WarehouseClickAndCollectOptionEnum!
   shippingZones(
@@ -2083,13 +2210,51 @@ Represents a shipping zone in the shop. Zones are the concept used only for grou
 type ShippingZone implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   name: String!
   default: Boolean!
 
@@ -2139,13 +2304,51 @@ type ShippingMethodType implements Node & ObjectWithMetadata {
   """Shipping method ID."""
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
 
   """Shipping method name."""
   name: String!
@@ -3037,7 +3240,7 @@ type Channel implements Node {
   hasOrders: Boolean!
 
   """
-  New in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
+  Added in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
   """
   defaultCountry: CountryDisplay!
 }
@@ -3084,13 +3287,51 @@ type ProductCountableEdge {
 type Product implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   seoTitle: String
   seoDescription: String
   name: String!
@@ -3198,13 +3439,51 @@ Represents a type of product. It defines what attributes are available to produc
 type ProductType implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   name: String!
   slug: String!
   hasVariants: Boolean!
@@ -3243,7 +3522,7 @@ type ProductType implements Node & ObjectWithMetadata {
   ): [Attribute!] @deprecated(reason: "This field will be removed in Saleor 4.0. Use `assignedVariantAttributes` instead.")
 
   """
-  New in Saleor 3.1. Variant attributes of that product type with attached variant selection.
+  Added in Saleor 3.1. Variant attributes of that product type with attached variant selection.
   """
   assignedVariantAttributes(
     """Define scope of returned attributes."""
@@ -3312,13 +3591,51 @@ Custom attribute of a product. Attributes can be assigned to products and varian
 type Attribute implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
 
   """The input type to use for entering attribute values in the dashboard."""
   inputType: AttributeInputTypeEnum
@@ -3622,7 +3939,7 @@ enum VariantAttributeScope {
 }
 
 """
-New in Saleor 3.1. Represents assigned attribute to variant with variant selection attached.
+Added in Saleor 3.1. Represents assigned attribute to variant with variant selection attached.
 """
 type AssignedVariantAttribute {
   """Attribute assigned to variant."""
@@ -3687,13 +4004,51 @@ Represents a single category of products. Categories allow to organize products 
 type Category implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   seoTitle: String
   seoDescription: String
   name: String!
@@ -3810,13 +4165,51 @@ type CategoryTranslation implements Node {
 type ProductVariant implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   name: String!
   sku: String
   product: Product!
@@ -3915,7 +4308,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
   ): Int
 
   """
-  New in Saleor 3.1. Preorder data for product variant. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Preorder data for product variant. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   preorder: PreorderData
   created: DateTime!
@@ -3937,7 +4330,7 @@ type ProductVariantChannelListing implements Node {
   margin: Int
 
   """
-  New in Saleor 3.1. Preorder variant data. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Preorder variant data. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   preorderThreshold: PreorderThreshold
 }
@@ -4344,13 +4737,51 @@ type ProductVariantTranslation implements Node {
 type DigitalContent implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   useDefaultSettings: Boolean!
   automaticFulfillment: Boolean!
   contentFile: String!
@@ -4454,14 +4885,14 @@ type ProductChannelListing implements Node {
   id: ID!
   publicationDate: Date @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `publishedAt` field to fetch the publication date.")
 
-  """New in Saleor 3.3. The product publication date time."""
+  """Added in Saleor 3.3. The product publication date time."""
   publishedAt: DateTime
   isPublished: Boolean!
   channel: Channel!
   visibleInListings: Boolean!
   availableForPurchase: Date @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `availableForPurchaseAt` field to fetch the available for purchase date.")
 
-  """New in Saleor 3.3. The product available for purchase date time."""
+  """Added in Saleor 3.3. The product available for purchase date time."""
   availableForPurchaseAt: DateTime
 
   """The price of the cheapest variant (including discounts)."""
@@ -4500,13 +4931,51 @@ type Margin {
 type Collection implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   seoTitle: String
   seoDescription: String
   name: String!
@@ -4733,7 +5202,7 @@ type CollectionChannelListing implements Node {
   id: ID!
   publicationDate: Date @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `publishedAt` field to fetch the publication date.")
 
-  """New in Saleor 3.3. The collection publication date."""
+  """Added in Saleor 3.3. The collection publication date."""
   publishedAt: DateTime
   isPublished: Boolean!
   channel: Channel!
@@ -4963,13 +5432,51 @@ A static page that can be manually added by a shop operator through the dashboar
 type Page implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   seoTitle: String
   seoDescription: String
   title: String!
@@ -4978,7 +5485,7 @@ type Page implements Node & ObjectWithMetadata {
   content: JSONString
   publicationDate: Date @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `publishedAt` field to fetch the publication date.")
 
-  """New in Saleor 3.3. The page publication date."""
+  """Added in Saleor 3.3. The page publication date."""
   publishedAt: DateTime
   isPublished: Boolean!
   slug: String!
@@ -5004,13 +5511,51 @@ Represents a type of page. It defines what attributes are available to pages of 
 type PageType implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   name: String!
   slug: String!
 
@@ -5089,13 +5634,51 @@ Sales allow creating discounts for categories, collections or products and are v
 type Sale implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   name: String!
   type: SaleType!
   startDate: DateTime!
@@ -5153,7 +5736,7 @@ type Sale implements Node & ObjectWithMetadata {
   ): ProductCountableConnection
 
   """
-  New in Saleor 3.1. List of product variants this sale applies to. Requires one of the following permissions: MANAGE_DISCOUNTS.
+  Added in Saleor 3.1. List of product variants this sale applies to. Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   variants(
     """Return the elements in the list that come before the specified cursor."""
@@ -5264,13 +5847,51 @@ Vouchers allow giving discounts to particular customers on categories, collectio
 type Voucher implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   name: String
   code: String!
   usageLimit: Int
@@ -5332,7 +5953,7 @@ type Voucher implements Node & ObjectWithMetadata {
   ): ProductCountableConnection
 
   """
-  New in Saleor 3.1. List of product variants this voucher applies to. Requires one of the following permissions: MANAGE_DISCOUNTS.
+  Added in Saleor 3.1. List of product variants this voucher applies to. Requires one of the following permissions: MANAGE_DISCOUNTS.
   """
   variants(
     """Return the elements in the list that come before the specified cursor."""
@@ -5428,13 +6049,51 @@ Represents a single item of the related menu. Can store categories, collection o
 type MenuItem implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   name: String!
   menu: Menu!
   parent: MenuItem
@@ -5468,13 +6127,51 @@ Represents a single menu - an object that is used to help navigate through the s
 type Menu implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   name: String!
   slug: String!
   items: [MenuItem!]
@@ -5547,7 +6244,7 @@ type Shop {
   ): [ShippingMethod!]
 
   """
-  New in Saleor 3.1. List of all currencies supported by shop's channels. Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
+  Added in Saleor 3.1. List of all currencies supported by shop's channels. Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   channelCurrencies: [String!]!
 
@@ -5601,10 +6298,10 @@ type Shop {
   """Include taxes in prices."""
   includeTaxesInPrices: Boolean!
 
-  """New in Saleor 3.1. Automatically approve all new fulfillments."""
+  """Added in Saleor 3.1. Automatically approve all new fulfillments."""
   fulfillmentAutoApprove: Boolean!
 
-  """New in Saleor 3.1. Allow to approve fulfillments which are unpaid."""
+  """Added in Saleor 3.1. Allow to approve fulfillments which are unpaid."""
   fulfillmentAllowUnpaid: Boolean!
 
   """Display prices with tax in store."""
@@ -5631,17 +6328,17 @@ type Shop {
   automaticFulfillmentDigitalProducts: Boolean
 
   """
-  New in Saleor 3.1. Default number of minutes stock will be reserved for anonymous checkout or null when stock reservation is disabled. Requires one of the following permissions: MANAGE_SETTINGS.
+  Added in Saleor 3.1. Default number of minutes stock will be reserved for anonymous checkout or null when stock reservation is disabled. Requires one of the following permissions: MANAGE_SETTINGS.
   """
   reserveStockDurationAnonymousUser: Int
 
   """
-  New in Saleor 3.1. Default number of minutes stock will be reserved for authenticated checkout or null when stock reservation is disabled. Requires one of the following permissions: MANAGE_SETTINGS.
+  Added in Saleor 3.1. Default number of minutes stock will be reserved for authenticated checkout or null when stock reservation is disabled. Requires one of the following permissions: MANAGE_SETTINGS.
   """
   reserveStockDurationAuthenticatedUser: Int
 
   """
-  New in Saleor 3.1. Default number of maximum line quantity in single checkout (per single checkout line). Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_SETTINGS.
+  Added in Saleor 3.1. Default number of maximum line quantity in single checkout (per single checkout line). Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_SETTINGS.
   """
   limitQuantityPerCheckout: Int
 
@@ -5718,13 +6415,51 @@ type ShippingMethod implements Node & ObjectWithMetadata {
   """Unique ID of ShippingMethod available for Order."""
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
 
   """Type of the shipping method."""
   type: ShippingMethodTypeEnum @deprecated(reason: "This field will be removed in Saleor 4.0.")
@@ -5817,13 +6552,51 @@ type StaffNotificationRecipient implements Node {
 type User implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   email: String!
   firstName: String!
   lastName: String!
@@ -5916,13 +6689,51 @@ type User implements Node & ObjectWithMetadata {
 type Checkout implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   created: DateTime!
   lastChange: DateTime!
   user: User
@@ -5942,7 +6753,7 @@ type Checkout implements Node & ObjectWithMetadata {
   shippingMethods: [ShippingMethod!]!
 
   """
-  New in Saleor 3.1. Collection points that can be used for this order. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Collection points that can be used for this order. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   availableCollectionPoints: [Warehouse!]!
 
@@ -5962,7 +6773,7 @@ type Checkout implements Node & ObjectWithMetadata {
   quantity: Int!
 
   """
-  New in Saleor 3.1. Date when oldest stock reservation for this checkout  expires or null if no stock is reserved.
+  Added in Saleor 3.1. Date when oldest stock reservation for this checkout  expires or null if no stock is reserved.
   """
   stockReservationExpires: DateTime
 
@@ -5978,7 +6789,7 @@ type Checkout implements Node & ObjectWithMetadata {
   shippingMethod: ShippingMethod @deprecated(reason: "This field will be removed in Saleor 4.0. Use `deliveryMethod` instead.")
 
   """
-  New in Saleor 3.1. The delivery method selected for this checkout. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The delivery method selected for this checkout. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   deliveryMethod: DeliveryMethod
 
@@ -6003,13 +6814,51 @@ A gift card is a prepaid electronic payment card accepted in stores. They can be
 type GiftCard implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
 
   """Code in format which allows displaying in a user interface."""
   displayCode: String!
@@ -6024,39 +6873,39 @@ type GiftCard implements Node & ObjectWithMetadata {
   created: DateTime!
 
   """
-  New in Saleor 3.1. The user who bought or issued a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The user who bought or issued a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   createdBy: User
 
   """
-  New in Saleor 3.1. The customer who used a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The customer who used a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   usedBy: User
 
   """
-  New in Saleor 3.1. Email address of the user who bought or issued gift card. Requires one of the following permissions: AccountPermissions.MANAGE_USERS, AuthorizationFilters.OWNER. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Email address of the user who bought or issued gift card. Requires one of the following permissions: AccountPermissions.MANAGE_USERS, AuthorizationFilters.OWNER. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   createdByEmail: String
 
   """
-  New in Saleor 3.1. Email address of the customer who used a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Email address of the customer who used a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   usedByEmail: String
   lastUsedOn: DateTime
   expiryDate: Date
 
   """
-  New in Saleor 3.1. App which created the gift card. Requires one of the following permissions: AppPermission.MANAGE_APPS, AuthorizationFilters.OWNER. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. App which created the gift card. Requires one of the following permissions: AppPermission.MANAGE_APPS, AuthorizationFilters.OWNER. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   app: App
 
   """
-  New in Saleor 3.1. Related gift card product. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Related gift card product. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   product: Product
 
   """
-  New in Saleor 3.1. List of events associated with the gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. List of events associated with the gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   events(
     """Filtering options for gift card events."""
@@ -6064,12 +6913,12 @@ type GiftCard implements Node & ObjectWithMetadata {
   ): [GiftCardEvent!]!
 
   """
-  New in Saleor 3.1. The gift card tag. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. The gift card tag. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   tags: [GiftCardTag!]!
 
   """
-  New in Saleor 3.1. Slug of the channel where the gift card was bought. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Slug of the channel where the gift card was bought. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   boughtInChannel: String
   isActive: Boolean!
@@ -6087,7 +6936,7 @@ type GiftCard implements Node & ObjectWithMetadata {
 }
 
 """
-New in Saleor 3.1. History log of the gift card. Note: this feature is in a preview state and can be subject to changes at later point.
+Added in Saleor 3.1. History log of the gift card. Note: this feature is in a preview state and can be subject to changes at later point.
 """
 type GiftCardEvent implements Node {
   id: ID!
@@ -6172,7 +7021,7 @@ input GiftCardEventFilterInput {
 }
 
 """
-New in Saleor 3.1. The gift card tag. Note: this feature is in a preview state and can be subject to changes at later point.
+Added in Saleor 3.1. The gift card tag. Note: this feature is in a preview state and can be subject to changes at later point.
 """
 type GiftCardTag implements Node {
   id: ID!
@@ -6193,7 +7042,7 @@ type CheckoutLine implements Node {
 }
 
 """
-New in Saleor 3.1. Represents a delivery method chosen for the checkout. `Warehouse` type is used when checkout is marked as "click and collect" and `ShippingMethod` otherwise. Note: this feature is in a preview state and can be subject to changes at later point.
+Added in Saleor 3.1. Represents a delivery method chosen for the checkout. `Warehouse` type is used when checkout is marked as "click and collect" and `ShippingMethod` otherwise. Note: this feature is in a preview state and can be subject to changes at later point.
 """
 union DeliveryMethod = Warehouse | ShippingMethod
 
@@ -6235,13 +7084,51 @@ type OrderCountableEdge {
 type Order implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   created: DateTime!
   updatedAt: DateTime!
   status: OrderStatus!
@@ -6283,7 +7170,7 @@ type Order implements Node & ObjectWithMetadata {
   shippingMethods: [ShippingMethod!]!
 
   """
-  New in Saleor 3.1. Collection points that can be used for this order. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Collection points that can be used for this order. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   availableCollectionPoints: [Warehouse!]!
 
@@ -6369,7 +7256,7 @@ type Order implements Node & ObjectWithMetadata {
   isShippingRequired: Boolean!
 
   """
-  New in Saleor 3.1. The delivery method selected for this checkout. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The delivery method selected for this checkout. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   deliveryMethod: DeliveryMethod
   languageCode: String! @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `languageCodeEnum` field to fetch the language code. ")
@@ -6409,13 +7296,51 @@ enum OrderStatus {
 type Fulfillment implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   fulfillmentOrder: Int!
   status: FulfillmentStatus!
   trackingNumber: String!
@@ -6502,7 +7427,7 @@ type OrderLine implements Node {
   """
   allocations: [Allocation!]
 
-  """New in Saleor 3.1. A quantity of items remaining to be fulfilled."""
+  """Added in Saleor 3.1. A quantity of items remaining to be fulfilled."""
   quantityToFulfill: Int!
 
   """Type of the discount: fixed or percent"""
@@ -6547,13 +7472,51 @@ enum OrderAction {
 
 """Represents an Invoice."""
 type Invoice implements ObjectWithMetadata & Job & Node {
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
 
   """Job status."""
   status: JobStatusEnum!
@@ -6615,13 +7578,51 @@ enum PaymentChargeStatusEnum {
 type Payment implements Node & ObjectWithMetadata {
   id: ID!
 
-  """
-  List of private metadata items.Requires proper staff permissions to access.
-  """
+  """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
 
   """List of public metadata items. Can be accessed without permissions."""
   metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
   gateway: String!
   isActive: Boolean!
   created: DateTime!
@@ -7071,7 +8072,7 @@ type PaymentSource {
   creditCardInfo: CreditCard
 
   """
-  New in Saleor 3.1. List of public metadata items. Can be accessed without permissions.
+  Added in Saleor 3.1. List of public metadata items. Can be accessed without permissions.
   """
   metadata: [MetadataItem!]!
 }
@@ -8584,7 +9585,7 @@ type Mutation {
   ): ProductAttributeAssign
 
   """
-  New in Saleor 3.1. Update attributes assigned to product variant for given product type. Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Added in Saleor 3.1. Update attributes assigned to product variant for given product type. Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   productAttributeAssignmentUpdate(
     """The operations to perform."""
@@ -9092,7 +10093,7 @@ type Mutation {
   ): ProductVariantReorderAttributeValues
 
   """
-  New in Saleor 3.1. Deactivates product variant preorder. It changes all preorder allocation into regular allocation. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_PRODUCTS.
+  Added in Saleor 3.1. Deactivates product variant preorder. It changes all preorder allocation into regular allocation. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantPreorderDeactivate(
     """ID of a variant which preorder should be deactivated."""
@@ -9421,7 +10422,7 @@ type Mutation {
   ): FulfillmentCancel
 
   """
-  New in Saleor 3.1. Approve existing fulfillment. Requires one of the following permissions: MANAGE_ORDERS.
+  Added in Saleor 3.1. Approve existing fulfillment. Requires one of the following permissions: MANAGE_ORDERS.
   """
   orderFulfillmentApprove(
     """True if stock could be exceeded."""
@@ -9832,7 +10833,7 @@ type Mutation {
   ): GiftCardCreate
 
   """
-  New in Saleor 3.1. Delete gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. Delete gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardDelete(
     """ID of the gift card to delete."""
@@ -9859,7 +10860,7 @@ type Mutation {
   ): GiftCardUpdate
 
   """
-  New in Saleor 3.1. Resend a gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. Resend a gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardResend(
     """Fields required to resend a gift card."""
@@ -9867,7 +10868,7 @@ type Mutation {
   ): GiftCardResend
 
   """
-  New in Saleor 3.1. Adds note to the gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. Adds note to the gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardAddNote(
     """ID of the gift card to add a note for."""
@@ -9878,7 +10879,7 @@ type Mutation {
   ): GiftCardAddNote
 
   """
-  New in Saleor 3.1. Create gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. Create gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardBulkCreate(
     """Fields required to create gift cards."""
@@ -9886,7 +10887,7 @@ type Mutation {
   ): GiftCardBulkCreate
 
   """
-  New in Saleor 3.1. Delete gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. Delete gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardBulkDelete(
     """List of gift card IDs to delete."""
@@ -9894,7 +10895,7 @@ type Mutation {
   ): GiftCardBulkDelete
 
   """
-  New in Saleor 3.1. Activate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. Activate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardBulkActivate(
     """List of gift card IDs to activate."""
@@ -9902,7 +10903,7 @@ type Mutation {
   ): GiftCardBulkActivate
 
   """
-  New in Saleor 3.1. Deactivate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. Deactivate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardBulkDeactivate(
     """List of gift card IDs to deactivate."""
@@ -9924,7 +10925,7 @@ type Mutation {
   ): PluginUpdate
 
   """
-  New in Saleor 3.1. Trigger sending a notification with the notify plugin method. Serializes nodes provided as ids parameter and includes this data in the notification payload.
+  Added in Saleor 3.1. Trigger sending a notification with the notify plugin method. Serializes nodes provided as ids parameter and includes this data in the notification payload.
   """
   externalNotificationTrigger(
     """
@@ -10108,7 +11109,7 @@ type Mutation {
   ): ExportProducts
 
   """
-  New in Saleor 3.1. Export gift cards to csv file. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+  Added in Saleor 3.1. Export gift cards to csv file. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   exportGiftCards(
     """Fields required to export gift cards data."""
@@ -10373,7 +11374,7 @@ type Mutation {
   ): CheckoutShippingMethodUpdate @deprecated(reason: "This field will be removed in Saleor 4.0. Use `checkoutDeliveryMethodUpdate` instead.")
 
   """
-  New in Saleor 3.1. Updates the delivery method (shipping method or pick up point) of the checkout. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Updates the delivery method (shipping method or pick up point) of the checkout. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   checkoutDeliveryMethodUpdate(
     """Delivery Method ID (`Warehouse` ID or `ShippingMethod` ID)."""
@@ -10400,7 +11401,7 @@ type Mutation {
   ): CheckoutLanguageCodeUpdate
 
   """
-  New in Saleor 3.2. Create new order from existing checkout. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: HANDLE_CHECKOUTS.
+  Added in Saleor 3.2. Create new order from existing checkout. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: HANDLE_CHECKOUTS.
   """
   orderCreateFromCheckout(
     """ID of a checkout that will be converted to an order."""
@@ -11132,7 +12133,7 @@ input WebhookCreateInput {
   secretKey: String
 
   """
-  New in Saleor 3.2. Subscription query used to define a webhook payload. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Subscription query used to define a webhook payload. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   query: String
 }
@@ -11185,7 +12186,7 @@ input WebhookUpdateInput {
   secretKey: String
 
   """
-  New in Saleor 3.2. Subscription query used to define a webhook payload. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Subscription query used to define a webhook payload. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   query: String
 }
@@ -11271,12 +12272,12 @@ input WarehouseUpdateInput {
   address: AddressInput
 
   """
-  New in Saleor 3.1. Click and collect options: local, all or disabled. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Click and collect options: local, all or disabled. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   clickAndCollectOption: WarehouseClickAndCollectOptionEnum
 
   """
-  New in Saleor 3.1. Visibility of warehouse stocks. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Visibility of warehouse stocks. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   isPrivate: Boolean
 }
@@ -11423,11 +12424,13 @@ input ShopSettingsInput {
   """Enable automatic fulfillment for all digital products."""
   automaticFulfillmentDigitalProducts: Boolean
 
-  """New in Saleor 3.1. Enable automatic approval of all new fulfillments."""
+  """
+  Added in Saleor 3.1. Enable automatic approval of all new fulfillments.
+  """
   fulfillmentAutoApprove: Boolean
 
   """
-  New in Saleor 3.1. Enable ability to approve fulfillments which are unpaid.
+  Added in Saleor 3.1. Enable ability to approve fulfillments which are unpaid.
   """
   fulfillmentAllowUnpaid: Boolean
 
@@ -11447,17 +12450,17 @@ input ShopSettingsInput {
   customerSetPasswordUrl: String
 
   """
-  New in Saleor 3.1. Default number of minutes stock will be reserved for anonymous checkout. Enter 0 or null to disable.
+  Added in Saleor 3.1. Default number of minutes stock will be reserved for anonymous checkout. Enter 0 or null to disable.
   """
   reserveStockDurationAnonymousUser: Int
 
   """
-  New in Saleor 3.1. Default number of minutes stock will be reserved for authenticated checkout. Enter 0 or null to disable.
+  Added in Saleor 3.1. Default number of minutes stock will be reserved for authenticated checkout. Enter 0 or null to disable.
   """
   reserveStockDurationAuthenticatedUser: Int
 
   """
-  New in Saleor 3.1. Default number of maximum line quantity in single checkout. Minimum possible value is 1, default value is 50. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Default number of maximum line quantity in single checkout. Minimum possible value is 1, default value is 50. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   limitQuantityPerCheckout: Int
 }
@@ -11944,7 +12947,7 @@ input ProductAttributeAssignInput {
   type: ProductAttributeType!
 
   """
-  New in Saleor 3.1. Whether attribute is allowed in variant selection. Allowed types are: ['dropdown', 'boolean', 'swatch', 'numeric'].
+  Added in Saleor 3.1. Whether attribute is allowed in variant selection. Allowed types are: ['dropdown', 'boolean', 'swatch', 'numeric'].
   """
   variantSelection: Boolean
 }
@@ -11955,7 +12958,7 @@ enum ProductAttributeType {
 }
 
 """
-New in Saleor 3.1. Update attributes assigned to product variant for given product type. Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+Added in Saleor 3.1. Update attributes assigned to product variant for given product type. Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
 """
 type ProductAttributeAssignmentUpdate {
   """The updated product type."""
@@ -11969,7 +12972,7 @@ input ProductAttributeAssignmentUpdateInput {
   id: ID!
 
   """
-  New in Saleor 3.1. Whether attribute is allowed in variant selection. Allowed types are: ['dropdown', 'boolean', 'swatch', 'numeric'].
+  Added in Saleor 3.1. Whether attribute is allowed in variant selection. Allowed types are: ['dropdown', 'boolean', 'swatch', 'numeric'].
   """
   variantSelection: Boolean!
 }
@@ -12300,7 +13303,7 @@ input PublishableChannelListingInput {
   """
   publicationDate: Date
 
-  """New in Saleor 3.3. Publication date time. ISO 8601 standard."""
+  """Added in Saleor 3.3. Publication date time. ISO 8601 standard."""
   publishedAt: DateTime
 }
 
@@ -12511,7 +13514,7 @@ input ProductChannelListingAddInput {
   """
   publicationDate: Date
 
-  """New in Saleor 3.3. Publication date time. ISO 8601 standard."""
+  """Added in Saleor 3.3. Publication date time. ISO 8601 standard."""
   publishedAt: DateTime
 
   """
@@ -12530,7 +13533,7 @@ input ProductChannelListingAddInput {
   availableForPurchaseDate: Date
 
   """
-  New in Saleor 3.3. A start date time from which a product will be available for purchase. When not set and `isAvailable` is set to True, the current day is assumed.
+  Added in Saleor 3.3. A start date time from which a product will be available for purchase. When not set and `isAvailable` is set to True, the current day is assumed.
   """
   availableForPurchaseAt: DateTime
 
@@ -12829,12 +13832,12 @@ input ProductVariantCreateInput {
   weight: WeightScalar
 
   """
-  New in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   preorder: PreorderSettingsInput
 
   """
-  New in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   quantityLimitPerCustomer: Int
 
@@ -12927,12 +13930,12 @@ input ProductVariantBulkCreateInput {
   weight: WeightScalar
 
   """
-  New in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   preorder: PreorderSettingsInput
 
   """
-  New in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   quantityLimitPerCustomer: Int
 
@@ -12969,7 +13972,7 @@ input ProductVariantChannelListingAddInput {
   costPrice: PositiveDecimal
 
   """
-  New in Saleor 3.1. The threshold for preorder variant in channel. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The threshold for preorder variant in channel. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   preorderThreshold: Int
 }
@@ -13084,12 +14087,12 @@ input ProductVariantInput {
   weight: WeightScalar
 
   """
-  New in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Determines if variant is in preorder. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   preorder: PreorderSettingsInput
 
   """
-  New in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   quantityLimitPerCustomer: Int
 }
@@ -13137,7 +14140,7 @@ type ProductVariantReorderAttributeValues {
 }
 
 """
-New in Saleor 3.1. Deactivates product variant preorder. It changes all preorder allocation into regular allocation. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_PRODUCTS.
+Added in Saleor 3.1. Deactivates product variant preorder. It changes all preorder allocation into regular allocation. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_PRODUCTS.
 """
 type ProductVariantPreorderDeactivate {
   """Product variant with ended preorder."""
@@ -13358,7 +14361,7 @@ input PageCreateInput {
   """
   publicationDate: String
 
-  """New in Saleor 3.3. Publication date time. ISO 8601 standard."""
+  """Added in Saleor 3.3. Publication date time. ISO 8601 standard."""
   publishedAt: DateTime
 
   """Search engine optimization fields."""
@@ -13429,7 +14432,7 @@ input PageInput {
   """
   publicationDate: String
 
-  """New in Saleor 3.3. Publication date time. ISO 8601 standard."""
+  """Added in Saleor 3.3. Publication date time. ISO 8601 standard."""
   publishedAt: DateTime
 
   """Search engine optimization fields."""
@@ -13798,7 +14801,7 @@ input FulfillmentCancelInput {
 }
 
 """
-New in Saleor 3.1. Approve existing fulfillment. Requires one of the following permissions: MANAGE_ORDERS.
+Added in Saleor 3.1. Approve existing fulfillment. Requires one of the following permissions: MANAGE_ORDERS.
 """
 type FulfillmentApprove {
   """An approved fulfillment."""
@@ -14543,12 +15546,12 @@ type GiftCardCreate {
 
 input GiftCardCreateInput {
   """
-  New in Saleor 3.1. The gift card tags to add. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The gift card tags to add. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   addTags: [String!]
 
   """
-  New in Saleor 3.1. The gift card expiry date. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The gift card expiry date. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   expiryDate: Date
 
@@ -14573,12 +15576,12 @@ input GiftCardCreateInput {
   userEmail: String
 
   """
-  New in Saleor 3.1. Slug of a channel from which the email should be sent. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Slug of a channel from which the email should be sent. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   channel: String
 
   """
-  New in Saleor 3.1. Determine if gift card is active. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Determine if gift card is active. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   isActive: Boolean!
 
@@ -14590,7 +15593,7 @@ input GiftCardCreateInput {
   code: String
 
   """
-  New in Saleor 3.1. The gift card note from the staff member. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The gift card note from the staff member. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   note: String
 }
@@ -14604,7 +15607,7 @@ input PriceInput {
 }
 
 """
-New in Saleor 3.1. Delete gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+Added in Saleor 3.1. Delete gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
 type GiftCardDelete {
   giftCardErrors: [GiftCardError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
@@ -14633,12 +15636,12 @@ type GiftCardUpdate {
 
 input GiftCardUpdateInput {
   """
-  New in Saleor 3.1. The gift card tags to add. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The gift card tags to add. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   addTags: [String!]
 
   """
-  New in Saleor 3.1. The gift card expiry date. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The gift card expiry date. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   expiryDate: Date
 
@@ -14657,18 +15660,18 @@ input GiftCardUpdateInput {
   endDate: Date
 
   """
-  New in Saleor 3.1. The gift card tags to remove. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The gift card tags to remove. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   removeTags: [String!]
 
   """
-  New in Saleor 3.1. The gift card balance amount. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. The gift card balance amount. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   balanceAmount: PositiveDecimal
 }
 
 """
-New in Saleor 3.1. Resend a gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+Added in Saleor 3.1. Resend a gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
 type GiftCardResend {
   """Gift card which has been sent."""
@@ -14688,7 +15691,7 @@ input GiftCardResendInput {
 }
 
 """
-New in Saleor 3.1. Adds note to the gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+Added in Saleor 3.1. Adds note to the gift card. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
 type GiftCardAddNote {
   """Gift card with the note added."""
@@ -14705,7 +15708,7 @@ input GiftCardAddNoteInput {
 }
 
 """
-New in Saleor 3.1. Create gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+Added in Saleor 3.1. Create gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
 type GiftCardBulkCreate {
   """Returns how many objects were created."""
@@ -14734,7 +15737,7 @@ input GiftCardBulkCreateInput {
 }
 
 """
-New in Saleor 3.1. Delete gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+Added in Saleor 3.1. Delete gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
 type GiftCardBulkDelete {
   """Returns how many objects were affected."""
@@ -14743,7 +15746,7 @@ type GiftCardBulkDelete {
 }
 
 """
-New in Saleor 3.1. Activate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+Added in Saleor 3.1. Activate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
 type GiftCardBulkActivate {
   """Returns how many objects were affected."""
@@ -14752,7 +15755,7 @@ type GiftCardBulkActivate {
 }
 
 """
-New in Saleor 3.1. Deactivate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+Added in Saleor 3.1. Deactivate gift cards. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
 type GiftCardBulkDeactivate {
   """Returns how many objects were affected."""
@@ -14809,7 +15812,7 @@ input ConfigurationItemInput {
 }
 
 """
-New in Saleor 3.1. Trigger sending a notification with the notify plugin method. Serializes nodes provided as ids parameter and includes this data in the notification payload.
+Added in Saleor 3.1. Trigger sending a notification with the notify plugin method. Serializes nodes provided as ids parameter and includes this data in the notification payload.
 """
 type ExternalNotificationTrigger {
   errors: [ExternalNotificationError!]!
@@ -14968,7 +15971,7 @@ input CatalogueInput {
   """Collections related to the discount."""
   collections: [ID!]
 
-  """New in Saleor 3.1. Product variant related to the discount."""
+  """Added in Saleor 3.1. Product variant related to the discount."""
   variants: [ID!]
 }
 
@@ -15048,7 +16051,7 @@ input VoucherInput {
   """Products discounted by the voucher."""
   products: [ID!]
 
-  """New in Saleor 3.1. Variants discounted by the voucher."""
+  """Added in Saleor 3.1. Variants discounted by the voucher."""
   variants: [ID!]
 
   """Collections discounted by the voucher."""
@@ -15259,7 +16262,7 @@ enum FileTypesEnum {
 }
 
 """
-New in Saleor 3.1. Export gift cards to csv file. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
+Added in Saleor 3.1. Export gift cards to csv file. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
 type ExportGiftCards {
   """
@@ -15440,7 +16443,7 @@ input CheckoutLineInput {
   variantId: ID!
 
   """
-  New in Saleor 3.1. Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   price: PositiveDecimal
 }
@@ -15516,7 +16519,7 @@ input CheckoutLineUpdateInput {
   variantId: ID!
 
   """
-  New in Saleor 3.1. Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.1. Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   price: PositiveDecimal
 }
@@ -15559,10 +16562,10 @@ input PaymentInput {
   """
   returnUrl: String
 
-  """New in Saleor 3.1. Payment store type."""
+  """Added in Saleor 3.1. Payment store type."""
   storePaymentMethod: StorePaymentMethodEnum = none
 
-  """New in Saleor 3.1. User public metadata."""
+  """Added in Saleor 3.1. User public metadata."""
   metadata: [MetadataInput!]
 }
 
@@ -15599,7 +16602,7 @@ type CheckoutShippingMethodUpdate {
 }
 
 """
-New in Saleor 3.1. Updates the delivery method (shipping method or pick up point) of the checkout. Note: this feature is in a preview state and can be subject to changes at later point.
+Added in Saleor 3.1. Updates the delivery method (shipping method or pick up point) of the checkout. Note: this feature is in a preview state and can be subject to changes at later point.
 """
 type CheckoutDeliveryMethodUpdate {
   """An updated checkout."""
@@ -15616,7 +16619,7 @@ type CheckoutLanguageCodeUpdate {
 }
 
 """
-New in Saleor 3.2. Create new order from existing checkout. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: HANDLE_CHECKOUTS.
+Added in Saleor 3.2. Create new order from existing checkout. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: HANDLE_CHECKOUTS.
 """
 type OrderCreateFromCheckout {
   """Placed order."""
@@ -15713,7 +16716,7 @@ input ChannelCreateInput {
   currencyCode: String!
 
   """
-  New in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
+  Added in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
   """
   defaultCountry: CountryCode!
 
@@ -15741,7 +16744,7 @@ input ChannelUpdateInput {
   slug: String
 
   """
-  New in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
+  Added in Saleor 3.1. Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
   """
   defaultCountry: CountryCode
 
@@ -16984,7 +17987,7 @@ type PermissionGroupDelete {
 
 type Subscription {
   """
-  New in Saleor 3.2. Look up subscription event. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up subscription event. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   event: Event
 }
@@ -16993,147 +17996,147 @@ union Event = CategoryCreated | CategoryUpdated | CategoryDeleted | ChannelCreat
 
 type CategoryCreated {
   """
-  New in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   category: Category
 }
 
 type CategoryUpdated {
   """
-  New in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   category: Category
 }
 
 type CategoryDeleted {
   """
-  New in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   category: Category
 }
 
 type ChannelCreated {
   """
-  New in Saleor 3.2. Look up a channel. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a channel. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   channel: Channel
 }
 
 type ChannelUpdated {
   """
-  New in Saleor 3.2. Look up a channel. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a channel. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   channel: Channel
 }
 
 type ChannelDeleted {
   """
-  New in Saleor 3.2. Look up a channel. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a channel. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   channel: Channel
 }
 
 type ChannelStatusChanged {
   """
-  New in Saleor 3.2. Look up a channel. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a channel. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   channel: Channel
 }
 
 type GiftCardCreated {
   """
-  New in Saleor 3.2. Look up a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   giftCard: GiftCard
 }
 
 type GiftCardUpdated {
   """
-  New in Saleor 3.2. Look up a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   giftCard: GiftCard
 }
 
 type GiftCardDeleted {
   """
-  New in Saleor 3.2. Look up a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   giftCard: GiftCard
 }
 
 type GiftCardStatusChanged {
   """
-  New in Saleor 3.2. Look up a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a gift card. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   giftCard: GiftCard
 }
 
 type OrderCreated {
   """
-  New in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   order: Order
 }
 
 type OrderUpdated {
   """
-  New in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   order: Order
 }
 
 type OrderConfirmed {
   """
-  New in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   order: Order
 }
 
 type OrderFullyPaid {
   """
-  New in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   order: Order
 }
 
 type OrderCancelled {
   """
-  New in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   order: Order
 }
 
 type OrderFulfilled {
   """
-  New in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   order: Order
 }
 
 type DraftOrderCreated {
   """
-  New in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   order: Order
 }
 
 type DraftOrderUpdated {
   """
-  New in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   order: Order
 }
 
 type DraftOrderDeleted {
   """
-  New in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an order. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   order: Order
 }
 
 type ProductCreated {
   """
-  New in Saleor 3.2. Look up a product. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a product. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   product(
     """Slug of a channel for which the data should be returned."""
@@ -17141,14 +18144,14 @@ type ProductCreated {
   ): Product
 
   """
-  New in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   category: Category
 }
 
 type ProductUpdated {
   """
-  New in Saleor 3.2. Look up a product. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a product. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   product(
     """Slug of a channel for which the data should be returned."""
@@ -17156,14 +18159,14 @@ type ProductUpdated {
   ): Product
 
   """
-  New in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   category: Category
 }
 
 type ProductDeleted {
   """
-  New in Saleor 3.2. Look up a product. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a product. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   product(
     """Slug of a channel for which the data should be returned."""
@@ -17171,14 +18174,14 @@ type ProductDeleted {
   ): Product
 
   """
-  New in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a category. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   category: Category
 }
 
 type ProductVariantCreated {
   """
-  New in Saleor 3.2. Look up a product variant. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a product variant. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   productVariant(
     """Slug of a channel for which the data should be returned."""
@@ -17188,7 +18191,7 @@ type ProductVariantCreated {
 
 type ProductVariantUpdated {
   """
-  New in Saleor 3.2. Look up a product variant. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a product variant. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   productVariant(
     """Slug of a channel for which the data should be returned."""
@@ -17198,7 +18201,7 @@ type ProductVariantUpdated {
 
 type ProductVariantOutOfStock {
   """
-  New in Saleor 3.2. Look up a product variant. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a product variant. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   productVariant(
     """Slug of a channel for which the data should be returned."""
@@ -17206,14 +18209,14 @@ type ProductVariantOutOfStock {
   ): ProductVariant
 
   """
-  New in Saleor 3.2. Look up a warehouse. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a warehouse. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   warehouse: Warehouse
 }
 
 type ProductVariantBackInStock {
   """
-  New in Saleor 3.2. Look up a product variant. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a product variant. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   productVariant(
     """Slug of a channel for which the data should be returned."""
@@ -17221,14 +18224,14 @@ type ProductVariantBackInStock {
   ): ProductVariant
 
   """
-  New in Saleor 3.2. Look up a warehouse. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a warehouse. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   warehouse: Warehouse
 }
 
 type ProductVariantDeleted {
   """
-  New in Saleor 3.2. Look up a product variant. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a product variant. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   productVariant(
     """Slug of a channel for which the data should be returned."""
@@ -17238,7 +18241,7 @@ type ProductVariantDeleted {
 
 type SaleCreated {
   """
-  New in Saleor 3.2. Look up a sale. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a sale. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   sale(
     """Slug of a channel for which the data should be returned."""
@@ -17248,7 +18251,7 @@ type SaleCreated {
 
 type SaleUpdated {
   """
-  New in Saleor 3.2. Look up a sale. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a sale. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   sale(
     """Slug of a channel for which the data should be returned."""
@@ -17258,7 +18261,7 @@ type SaleUpdated {
 
 type SaleDeleted {
   """
-  New in Saleor 3.2. Look up a sale. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a sale. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   sale(
     """Slug of a channel for which the data should be returned."""
@@ -17268,56 +18271,56 @@ type SaleDeleted {
 
 type InvoiceRequested {
   """
-  New in Saleor 3.2. Look up an Invoice. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an Invoice. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   invoice: Invoice
 }
 
 type InvoiceDeleted {
   """
-  New in Saleor 3.2. Look up an Invoice. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an Invoice. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   invoice: Invoice
 }
 
 type InvoiceSent {
   """
-  New in Saleor 3.2. Look up an Invoice. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up an Invoice. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   invoice: Invoice
 }
 
 type FulfillmentCreated {
   """
-  New in Saleor 3.2. Look up a Fulfillment. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a Fulfillment. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   fulfillment: Fulfillment
 }
 
 type FulfillmentCanceled {
   """
-  New in Saleor 3.2. Look up a Fulfillment. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a Fulfillment. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   fulfillment: Fulfillment
 }
 
 type CustomerCreated {
   """
-  New in Saleor 3.2. Look up a user. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a user. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   user: User
 }
 
 type CustomerUpdated {
   """
-  New in Saleor 3.2. Look up a user. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a user. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   user: User
 }
 
 type CollectionCreated {
   """
-  New in Saleor 3.2. Look up a collection. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a collection. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   collection(
     """Slug of a channel for which the data should be returned."""
@@ -17327,7 +18330,7 @@ type CollectionCreated {
 
 type CollectionUpdated {
   """
-  New in Saleor 3.2. Look up a collection. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a collection. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   collection(
     """Slug of a channel for which the data should be returned."""
@@ -17337,7 +18340,7 @@ type CollectionUpdated {
 
 type CollectionDeleted {
   """
-  New in Saleor 3.2. Look up a collection. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a collection. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   collection(
     """Slug of a channel for which the data should be returned."""
@@ -17347,42 +18350,42 @@ type CollectionDeleted {
 
 type CheckoutCreated {
   """
-  New in Saleor 3.2. Look up a Checkout. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a Checkout. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   checkout: Checkout
 }
 
 type CheckoutUpdated {
   """
-  New in Saleor 3.2. Look up a Checkout. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a Checkout. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   checkout: Checkout
 }
 
 type PageCreated {
   """
-  New in Saleor 3.2. Look up a page. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a page. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   page: Page
 }
 
 type PageUpdated {
   """
-  New in Saleor 3.2. Look up a page. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a page. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   page: Page
 }
 
 type PageDeleted {
   """
-  New in Saleor 3.2. Look up a page. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a page. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   page: Page
 }
 
 type ShippingPriceCreated {
   """
-  New in Saleor 3.2. Look up a shipping method. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a shipping method. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   shippingMethod(
     """Slug of a channel for which the data should be returned."""
@@ -17390,7 +18393,7 @@ type ShippingPriceCreated {
   ): ShippingMethodType
 
   """
-  New in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   shippingZone(
     """Slug of a channel for which the data should be returned."""
@@ -17400,7 +18403,7 @@ type ShippingPriceCreated {
 
 type ShippingPriceUpdated {
   """
-  New in Saleor 3.2. Look up a shipping method. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a shipping method. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   shippingMethod(
     """Slug of a channel for which the data should be returned."""
@@ -17408,7 +18411,7 @@ type ShippingPriceUpdated {
   ): ShippingMethodType
 
   """
-  New in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   shippingZone(
     """Slug of a channel for which the data should be returned."""
@@ -17418,7 +18421,7 @@ type ShippingPriceUpdated {
 
 type ShippingPriceDeleted {
   """
-  New in Saleor 3.2. Look up a shipping method. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a shipping method. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   shippingMethod(
     """Slug of a channel for which the data should be returned."""
@@ -17426,7 +18429,7 @@ type ShippingPriceDeleted {
   ): ShippingMethodType
 
   """
-  New in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   shippingZone(
     """Slug of a channel for which the data should be returned."""
@@ -17436,7 +18439,7 @@ type ShippingPriceDeleted {
 
 type ShippingZoneCreated {
   """
-  New in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   shippingZone(
     """Slug of a channel for which the data should be returned."""
@@ -17446,7 +18449,7 @@ type ShippingZoneCreated {
 
 type ShippingZoneUpdated {
   """
-  New in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   shippingZone(
     """Slug of a channel for which the data should be returned."""
@@ -17456,7 +18459,7 @@ type ShippingZoneUpdated {
 
 type ShippingZoneDeleted {
   """
-  New in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a shipping zone. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   shippingZone(
     """Slug of a channel for which the data should be returned."""
@@ -17466,7 +18469,7 @@ type ShippingZoneDeleted {
 
 type TranslationCreated {
   """
-  New in Saleor 3.2. Look up a translation. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a translation. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   translation: TranslationTypes
 }
@@ -17475,7 +18478,7 @@ union TranslationTypes = ProductTranslation | CollectionTranslation | CategoryTr
 
 type TranslationUpdated {
   """
-  New in Saleor 3.2. Look up a translation. Note: this feature is in a preview state and can be subject to changes at later point.
+  Added in Saleor 3.2. Look up a translation. Note: this feature is in a preview state and can be subject to changes at later point.
   """
   translation: TranslationTypes
 }


### PR DESCRIPTION
This exploration was inspired by discussion https://github.com/saleor/saleor/discussions/9223

It makes working with metadata easier in languages like JS where unmarshalling a JSON structure happens automatically.

New API (we likely need a better field name but `metadata` is already taken):

```graphql
query {
  product(id: ...) {
    metafields
  }
}
```

Response:

```json
{
  "data": {
    "product": {
      "metafields": {
        "myKey": "myValue",
        "anotherKey": "anotherValue"
      }
    }
  }
}
```

You can also ask for only particular keys to be returned:

```graphql
query {
  product(id: ...) {
    metafields(keys: ["foo", "myKey"])
  }
}
```

Or ask for a single key:

```graphql
query {
  product(id: ...) {
    fooValue: metafield(key: "foo")
  }
}
```

I declared a new scalar type so strictly typed clients can provide a custom type override like `Map<string, string>`.

For now, a write/update API is out of scope.

If we like that, we should also implement a similar interface for all Editor.js content.

Tracked under SALEOR-6043

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
