### PR TITLE
Drop product channel listings when removing last available variant

### DIFF
--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -608,7 +608,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
         )
 
         cls.delete_assigned_attribute_values(pks)
-        cls.delete_product_channel_listing_without_available_variants(product_pks, pks)
+        cls.delete_product_channel_listings_without_available_variants(product_pks, pks)
         response = super().perform_mutation(_root, info, ids, **data)
 
         transaction.on_commit(
@@ -653,9 +653,14 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
         ).delete()
 
     @staticmethod
-    def delete_product_channel_listing_without_available_variants(
+    def delete_product_channel_listings_without_available_variants(
         product_pks: Iterable[int], variant_pks: Iterable[int]
     ):
+        """Delete invalid channel listings.
+
+        Delete product channel listings for product and channel for which
+        the last available variant has been deleted.
+        """
         variants = models.ProductVariant.objects.filter(
             product_id__in=product_pks
         ).exclude(id__in=variant_pks)

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -1,9 +1,10 @@
 from collections import defaultdict
+from typing import Iterable
 
 import graphene
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from graphene.types import InputObjectType
 
 from ....attribute import AttributeInputType
@@ -605,6 +606,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
         )
 
         cls.delete_assigned_attribute_values(pks)
+        cls.delete_product_channel_listing_without_available_variants(product_pks, pks)
         response = super().perform_mutation(_root, info, ids, **data)
 
         transaction.on_commit(
@@ -647,6 +649,34 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
             variantassignments__variant_id__in=instance_pks,
             attribute__input_type__in=AttributeInputType.TYPES_WITH_UNIQUE_VALUES,
         ).delete()
+
+    @staticmethod
+    def delete_product_channel_listing_without_available_variants(
+        product_pks: Iterable[int], variant_pks: Iterable[int]
+    ):
+        for product_pk in product_pks:
+            channel_ids = set(
+                models.ProductVariantChannelListing.objects.filter(
+                    variant_id__in=variant_pks
+                ).values_list("channel_id", flat=True)
+            )
+            variants = (
+                models.ProductVariant.objects.filter(product_id=product_pk)
+                .exclude(id__in=variant_pks)
+                .values("id")
+            )
+            available_channel_ids = set(
+                models.ProductVariantChannelListing.objects.filter(
+                    Exists(
+                        variants.filter(id=OuterRef("variant_id")),
+                        channel_id__in=channel_ids,
+                    )
+                ).values_list("channel_id", flat=True)
+            )
+            not_available_channel_ids = channel_ids - available_channel_ids
+            models.ProductChannelListing.objects.filter(
+                product_id=product_pk, channel_id__in=not_available_channel_ids
+            ).delete()
 
 
 class ProductVariantStocksCreate(BaseMutation):

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1143,7 +1143,7 @@ class ProductVariantDelete(ModelDeleteMutation):
         ).get(id=instance.id)
 
         cls.delete_assigned_attribute_values(variant)
-        cls.delete_product_channel_listing_without_available_variants(variant)
+        cls.delete_product_channel_listings_without_available_variants(variant)
         response = super().perform_mutation(_root, info, **data)
 
         # delete order lines for deleted variant
@@ -1176,7 +1176,12 @@ class ProductVariantDelete(ModelDeleteMutation):
         ).delete()
 
     @staticmethod
-    def delete_product_channel_listing_without_available_variants(instance):
+    def delete_product_channel_listings_without_available_variants(instance):
+        """Delete invalid product channel listings.
+
+        Delete product channel listings for channels for which the deleted variant
+        was the last available variant.
+        """
         channel_ids = set(
             instance.channel_listings.values_list("channel_id", flat=True)
         )

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 import graphene
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from django.utils.text import slugify
 
 from ....attribute import AttributeInputType, AttributeType
@@ -1143,6 +1143,7 @@ class ProductVariantDelete(ModelDeleteMutation):
         ).get(id=instance.id)
 
         cls.delete_assigned_attribute_values(variant)
+        cls.delete_product_channel_listing_without_available_variants(variant)
         response = super().perform_mutation(_root, info, **data)
 
         # delete order lines for deleted variant
@@ -1172,6 +1173,30 @@ class ProductVariantDelete(ModelDeleteMutation):
         attribute_models.AttributeValue.objects.filter(
             variantassignments__variant_id=instance.id,
             attribute__input_type__in=AttributeInputType.TYPES_WITH_UNIQUE_VALUES,
+        ).delete()
+
+    @staticmethod
+    def delete_product_channel_listing_without_available_variants(instance):
+        channel_ids = set(
+            instance.channel_listings.values_list("channel_id", flat=True)
+        )
+        product_id = instance.product_id
+        variants = (
+            models.ProductVariant.objects.filter(product_id=product_id)
+            .exclude(id=instance.id)
+            .values("id")
+        )
+        available_channel_ids = set(
+            models.ProductVariantChannelListing.objects.filter(
+                Exists(
+                    variants.filter(id=OuterRef("variant_id")),
+                    channel_id__in=channel_ids,
+                )
+            ).values_list("channel_id", flat=True)
+        )
+        not_available_channel_ids = channel_ids - available_channel_ids
+        models.ProductChannelListing.objects.filter(
+            product_id=product_id, channel_id__in=not_available_channel_ids
         ).delete()
 
 


### PR DESCRIPTION
Drop product channel listings when removing the last available variant:
- update `ProductVariantBulkDelete` mutation
- update `ProductVariantDelete` mutation

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
