### PR TITLE
Missing update_stocks_quantity_allocated_task task decorator

### DIFF
--- a/saleor/warehouse/tasks.py
+++ b/saleor/warehouse/tasks.py
@@ -33,6 +33,7 @@ def delete_expired_reservations_task():
         )
 
 
+@app.task
 def update_stocks_quantity_allocated_task():
     stocks_to_update = []
     for mismatched_stock in Stock.objects.annotate(


### PR DESCRIPTION
I want to merge this change because it adds a missing decorator to mark the update_stocks_quantity_allocated_task as an actual task.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
