### PR TITLE
Upgrade required Node and NPM versions used by release-it tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "release-it": "^14.5.0"
       },
       "engines": {
-        "node": ">=14 <15",
-        "npm": ">=6.11.0 <7"
+        "node": ">=16 <17",
+        "npm": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "saleor",
   "version": "3.1.0-a.0",
   "engines": {
-    "node": ">=14 <15",
-    "npm": ">=6.11.0 <7"
+    "node": ">=16 <17",
+    "npm": ">=7"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/mirumee/saleor.git"
+    "url": "git://github.com/saleor/saleor.git"
   },
-  "author": "Mirumee Software",
+  "author": "Saleor Commerce",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/mirumee/saleor/issues"
+    "url": "https://github.com/saleor/saleor/issues"
   },
   "homepage": "http://saleor.io/",
   "dependencies": {},


### PR DESCRIPTION
I want to merge this change because `package-lock.json` is generated with `lockfileVersion: 2`, which is supported only by `npm@7` and above. 
I also Upgraded Node to most current LTS version, which is shipped by default with `npm@8`.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
