### PR TITLE
Handle mutations and queries for old ids

### DIFF
--- a/saleor/graphql/core/tests/test_base_mutation.py
+++ b/saleor/graphql/core/tests/test_base_mutation.py
@@ -9,6 +9,9 @@ from graphql.execution import ExecutionResult
 from saleor.core.permissions import ProductPermissions
 from saleor.plugins.tests.sample_plugins import PluginSample
 
+from ....order.models import Order
+from ....product.models import Product
+from ...order import types as order_types
 from ...product import types as product_types
 from ..mutations import BaseMutation
 from . import ErrorTest
@@ -56,14 +59,36 @@ class RestrictedMutation(Mutation):
         error_type_class = ErrorTest
 
 
+class OrderMutation(BaseMutation):
+    number = graphene.Field(graphene.String)
+
+    class Arguments:
+        id = graphene.ID(required=True)
+        channel = graphene.String()
+
+    class Meta:
+        description = "Base mutation"
+        error_type_class = ErrorTest
+
+    @classmethod
+    def perform_mutation(cls, _root, info, id, channel):
+        # Need to mock `app_middleware`
+        info.context.app = None
+
+        order = cls.get_node_or_error(info, id, only_type=order_types.Order)
+        return OrderMutation(number=order.number)
+
+
 class Mutations(graphene.ObjectType):
     test = Mutation.Field()
     test_with_custom_errors = MutationWithCustomErrors.Field()
     restricted_mutation = RestrictedMutation.Field()
+    test_order_mutation = OrderMutation.Field()
 
 
 schema = graphene.Schema(
-    mutation=Mutations, types=[product_types.Product, product_types.ProductVariant]
+    mutation=Mutations,
+    types=[product_types.Product, product_types.ProductVariant, order_types.Order],
 )
 
 
@@ -121,6 +146,46 @@ def test_user_error_nonexistent_id(schema_context, channel_USD):
     assert user_errors
     assert user_errors[0]["field"] == "productId"
     assert user_errors[0]["message"] == "Couldn't resolve id: not-really."
+
+
+TEST_ORDER_MUTATION = """
+    mutation TestOrderMutation($id: ID!, $channel: String) {
+        testOrderMutation(id: $id, channel: $channel) {
+            number
+            errors {
+                field
+                message
+            }
+        }
+    }
+"""
+
+
+def test_order_mutation_resolve_uuid_id(order, schema_context, channel_USD):
+    """Ensure that order migrations can be perfromed with use of
+    new order id (uuid type)."""
+    order_id = graphene.Node.to_global_id("Order", order.pk)
+    variables = {"id": order_id, "channel": channel_USD.slug}
+    result = schema.execute(
+        TEST_ORDER_MUTATION, variables=variables, context_value=schema_context
+    )
+    assert not result.errors
+    assert result.data["testOrderMutation"]["number"] == str(order.number)
+
+
+def test_order_mutation_for_old_int_id(order, schema_context, channel_USD):
+    """Ensure that order migrations for orders with `use_old_id` flag set to True,
+    can be perfromed with use of old order id (int type)."""
+    order.use_old_id = True
+    order.save(update_fields=["use_old_id"])
+
+    order_id = graphene.Node.to_global_id("Order", order.number)
+    variables = {"id": order_id, "channel": channel_USD.slug}
+    result = schema.execute(
+        TEST_ORDER_MUTATION, variables=variables, context_value=schema_context
+    )
+    assert not result.errors
+    assert result.data["testOrderMutation"]["number"] == str(order.number)
 
 
 def test_mutation_custom_errors_default_value(product, schema_context, channel_USD):
@@ -306,3 +371,63 @@ def test_mutation_calls_plugin_perform_mutation_after_permission_checks(
     )
     assert len(result.errors) == 1, result.to_dict()
     assert result.errors[0].message == "My Custom Error"
+
+
+def test_base_mutation_get_node_by_pk_with_order_qs_and_old_int_id(staff_user, order):
+    # given
+    order.use_old_id = True
+    order.save(update_fields=["use_old_id"])
+
+    info = mock.Mock(context=mock.Mock(user=staff_user))
+
+    # when
+    node = BaseMutation._get_node_by_pk(
+        info, order_types.Order, order.number, qs=Order.objects.all()
+    )
+
+    # then
+    assert node.id == order.id
+
+
+def test_base_mutation_get_node_by_pk_with_order_qs_and_new_uuid_id(staff_user, order):
+    # given
+    info = mock.Mock(context=mock.Mock(user=staff_user))
+
+    # when
+    node = BaseMutation._get_node_by_pk(
+        info, order_types.Order, order.pk, qs=Order.objects.all()
+    )
+
+    # then
+    assert node.id == order.id
+
+
+def test_base_mutation_get_node_by_pk_with_order_qs_and_int_id_use_old_id_set_to_false(
+    staff_user, order
+):
+    # given
+    order.use_old_id = False
+    order.save(update_fields=["use_old_id"])
+
+    info = mock.Mock(context=mock.Mock(user=staff_user))
+
+    # when
+    node = BaseMutation._get_node_by_pk(
+        info, order_types.Order, order.number, qs=Order.objects.all()
+    )
+
+    # then
+    assert node is None
+
+
+def test_base_mutation_get_node_by_pk_with_qs_for_product(staff_user, product):
+    # given
+    info = mock.Mock(context=mock.Mock(user=staff_user))
+
+    # when
+    node = BaseMutation._get_node_by_pk(
+        info, product_types.Product, product.pk, qs=Product.objects.all()
+    )
+
+    # then
+    assert node.id == product.id

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -9,7 +9,9 @@ from django.shortcuts import reverse
 from graphql.error import GraphQLError
 from graphql_relay import to_global_id
 
+from ....order import models as order_models
 from ...core.utils import from_global_id_or_error
+from ...order.types import Order
 from ...product.types import Product
 from ...tests.utils import get_graphql_content
 from ...utils import get_nodes
@@ -269,6 +271,69 @@ def test_get_nodes(product_list):
         get_nodes(global_ids, Product)
 
     assert exc.value.args == (msg,)
+
+
+def test_get_nodes_for_order_with_int_id(order_list):
+    """Ensure that `get_nodes` returns correct nodes, when old id is used
+    for orders with the `use_old_id` flag set to True."""
+    order_models.Order.objects.update(use_old_id=True)
+
+    # given
+    global_ids = [to_global_id("Order", order.number) for order in order_list]
+
+    # Make sure function works even if duplicated ids are provided
+    global_ids.append(to_global_id("Order", order_list[0].number))
+
+    # when
+    orders = get_nodes(global_ids, Order)
+
+    # then
+    assert orders == order_list
+
+
+def test_get_nodes_for_order_with_uuid_id(order_list):
+    """Ensure that `get_nodes` returns correct nodes, when the new uuid order id
+    is used."""
+    # given
+    global_ids = [to_global_id("Order", order.pk) for order in order_list]
+
+    # Make sure function works even if duplicated ids are provided
+    global_ids.append(to_global_id("Order", order_list[0].pk))
+
+    # when
+    orders = get_nodes(global_ids, Order)
+
+    # then
+    assert orders == order_list
+
+
+def test_get_nodes_for_order_with_int_id_and_use_old_id_set_to_false(order_list):
+    """Ensure that `get_nodes` does not return nodes, when old id is used
+    for orders with `use_old_id` flag set to False."""
+    # given
+    global_ids = [to_global_id("Order", order.number) for order in order_list]
+
+    # Make sure function works even if duplicated ids are provided
+    global_ids.append(to_global_id("Order", order_list[0].pk))
+
+    # when
+    with pytest.raises(AssertionError):
+        get_nodes(global_ids, Order)
+
+
+def test_get_nodes_for_order_with_uuid_and_int_id(order_list):
+    """Ensure that `get_nodes` returns correct nodes,
+    when old and new order id is provided."""
+    # given
+    order_models.Order.objects.update(use_old_id=True)
+    global_ids = [to_global_id("Order", order.pk) for order in order_list[:-1]]
+    global_ids.append(to_global_id("Order", order_list[-1].number))
+
+    # when
+    orders = get_nodes(global_ids, Order)
+
+    # then
+    assert orders == order_list
 
 
 @patch("saleor.product.models.Product.objects")

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -136,6 +136,7 @@ class GiftCardEvent(ModelObjectType):
 
     @staticmethod
     def resolve_order_id(root: models.GiftCardEvent, info):
+        # TODO: will be handle in SALEOR-6142
         order_id = root.parameters.get("order_id")
         return graphene.Node.to_global_id("Order", order_id) if order_id else None
 
@@ -464,7 +465,7 @@ class GiftCard(ModelObjectType):
                     .then(get_channel_slug)
                 )
 
-            # TODO: handle for old and new `order_id`
+            # TODO: will be handle in SALEOR-6142; handle for old and new `order_id`
             # consider migration that will rewrite old ids to token
             order_id = bought_event.parameters["order_id"]
             return OrderByIdLoader(info.context).load(UUID(order_id)).then(with_order)

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -1,3 +1,7 @@
+from uuid import UUID
+
+from django.db.models import Q
+
 from ...channel.models import Channel
 from ...core.tracing import traced_resolver
 from ...order import OrderStatus, models
@@ -39,7 +43,14 @@ def resolve_orders_total(_info, period, channel_slug):
 
 
 def resolve_order(id):
-    return models.Order.objects.filter(pk=id).first()
+    if id is None:
+        return None
+    try:
+        id = UUID(id)
+        lookup = Q(id=id)
+    except ValueError:
+        lookup = Q(number=id) & Q(use_old_id=True)
+    return models.Order.objects.filter(lookup).first()
 
 
 def resolve_homepage_events():

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -1618,14 +1618,17 @@ def test_payment_information_order_events_query_for_app(
     assert data["paymentGateway"] == payment_dummy.gateway
 
 
-def test_non_staff_user_cannot_only_see_his_order(user_api_client, order):
-    query = """
+QUERY_ORDER_BY_ID = """
     query OrderQuery($id: ID!) {
         order(id: $id) {
             number
         }
     }
-    """
+"""
+
+
+def test_non_staff_user_cannot_only_see_his_order(user_api_client, order):
+    query = QUERY_ORDER_BY_ID
     ID = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": ID}
     response = user_api_client.post_graphql(query, variables)
@@ -1650,16 +1653,30 @@ def test_query_order_as_app(app_api_client, permission_manage_orders, order):
     assert order_data["token"] == str(order.id)
 
 
-QUERY_ORDER_BY_ID = """
-    query OrderQuery($id: ID!) {
-        order(id: $id) {
-            number
-        }
-    }
-"""
+def test_staff_query_order_by_old_id(staff_api_client, order, permission_manage_orders):
+    order.use_old_id = True
+    order.save(update_fields=["use_old_id"])
+    variables = {"id": graphene.Node.to_global_id("Order", order.number)}
+    response = staff_api_client.post_graphql(
+        QUERY_ORDER_BY_ID, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content_from_response(response)
+    assert content["data"]["order"]["number"] == str(order.number)
 
 
-def test_staff_query_page_type_by_invalid_id(
+def test_staff_query_order_by_old_id_for_order_with_use_old_id_set_to_false(
+    staff_api_client, order, permission_manage_orders
+):
+    assert not order.use_old_id
+    variables = {"id": graphene.Node.to_global_id("Order", order.number)}
+    response = staff_api_client.post_graphql(
+        QUERY_ORDER_BY_ID, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content_from_response(response)
+    assert content["data"]["order"] is None
+
+
+def test_staff_query_order_by_invalid_id(
     staff_api_client, order, permission_manage_orders
 ):
     id = "bh/"
@@ -1673,10 +1690,10 @@ def test_staff_query_page_type_by_invalid_id(
     assert content["data"]["order"] is None
 
 
-def test_staff_query_page_type_with_invalid_object_type(
+def test_staff_query_order_with_invalid_object_type(
     staff_api_client, order, permission_manage_orders
 ):
-    variables = {"id": graphene.Node.to_global_id("Page", order.pk)}
+    variables = {"id": graphene.Node.to_global_id("Checkout", order.pk)}
     response = staff_api_client.post_graphql(
         QUERY_ORDER_BY_ID, variables, permissions=[permission_manage_orders]
     )
@@ -7819,6 +7836,92 @@ def test_orders_query_with_filter_by_orders_id(
     # then
     assert content["data"]["orders"]["totalCount"] == 2
     assert all(ids in response_ids for ids in orders_ids)
+
+
+def test_orders_query_with_filter_by_old_orders_id(
+    orders_query_with_filter,
+    staff_api_client,
+    order,
+    permission_manage_orders,
+    channel_USD,
+):
+
+    # given
+    orders = Order.objects.bulk_create(
+        [
+            Order(
+                user_email="test@mirumee.com",
+                status=OrderStatus.UNFULFILLED,
+                channel=channel_USD,
+                use_old_id=True,
+            ),
+            Order(
+                user_email="user_email1@example.com",
+                status=OrderStatus.FULFILLED,
+                channel=channel_USD,
+                use_old_id=False,
+            ),
+        ]
+    )
+    orders_ids = [graphene.Node.to_global_id("Order", order.number) for order in orders]
+    variables = {"filter": {"ids": orders_ids}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
+    )
+    content = get_graphql_content(response)
+    edges = content["data"]["orders"]["edges"]
+    response_ids = [edge["node"]["id"] for edge in edges]
+
+    # then
+    assert content["data"]["orders"]["totalCount"] == 1
+    assert response_ids == [graphene.Node.to_global_id("Order", orders[0].pk)]
+
+
+def test_orders_query_with_filter_by_old_and_new_orders_id(
+    orders_query_with_filter,
+    staff_api_client,
+    order,
+    permission_manage_orders,
+    channel_USD,
+):
+
+    # given
+    orders = Order.objects.bulk_create(
+        [
+            Order(
+                user_email="test@mirumee.com",
+                status=OrderStatus.UNFULFILLED,
+                channel=channel_USD,
+                use_old_id=True,
+            ),
+            Order(
+                user_email="user_email1@example.com",
+                status=OrderStatus.FULFILLED,
+                channel=channel_USD,
+            ),
+        ]
+    )
+    orders_ids = [
+        graphene.Node.to_global_id("Order", orders[0].number),
+        graphene.Node.to_global_id("Order", orders[1].pk),
+    ]
+    variables = {"filter": {"ids": orders_ids}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
+    )
+    content = get_graphql_content(response)
+    edges = content["data"]["orders"]["edges"]
+    response_ids = [edge["node"]["id"] for edge in edges]
+
+    # then
+    assert content["data"]["orders"]["totalCount"] == 2
+    assert set(response_ids) == {
+        graphene.Node.to_global_id("Order", order.pk) for order in orders
+    }
 
 
 def test_order_query_with_filter_search_by_product_sku_multi_order_lines(

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -1,8 +1,9 @@
 import hashlib
 from typing import Union
+from uuid import UUID
 
 import graphene
-from django.db.models import Value
+from django.db.models import Q, Value
 from django.db.models.functions import Concat
 from graphql import GraphQLDocument
 from graphql.error import GraphQLError
@@ -94,18 +95,41 @@ def get_nodes(
     elif model is not None:
         qs = model.objects
 
-    nodes = list(qs.filter(pk__in=pks))
-    nodes.sort(key=lambda e: pks.index(str(e.pk)))  # preserve order in pks
+    is_order_object_type = str(graphene_type) == "Order"
+    if is_order_object_type:
+        nodes = _get_nodes_for_order(qs, pks)
+    else:
+        nodes = list(qs.filter(pk__in=pks))
+        nodes.sort(key=lambda e: pks.index(str(e.pk)))  # preserve order in pks
 
     if not nodes:
         raise GraphQLError(ERROR_COULD_NO_RESOLVE_GLOBAL_ID % ids)
 
     nodes_pk_list = [str(node.pk) for node in nodes]
+    if is_order_object_type:
+        nodes_pk_list.extend([str(node.number) for node in nodes])
     for pk in pks:
         assert pk in nodes_pk_list, "There is no node of type {} with pk {}".format(
             graphene_type, pk
         )
     return nodes
+
+
+def _get_nodes_for_order(qs, pks):
+    uuid_pks = []
+    old_pks = []
+
+    for pk in pks:
+        try:
+            uuid_pks.append(UUID(str(pk)))
+        except ValueError:
+            old_pks.append(pk)
+    nodes = list(
+        qs.filter(Q(id__in=uuid_pks) | (Q(use_old_id=True) & Q(number__in=old_pks)))
+    )
+    return sorted(
+        nodes, key=lambda e: pks.index(str(e.pk) if e.pk in uuid_pks else str(e.number))
+    )  # preserve order in pks
 
 
 def format_permissions_for_display(permissions):


### PR DESCRIPTION
Allow using old order id for orders with `use_old_id` see to `True`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
