### PR TITLE
Deprecate order token related queries and fields

### DIFF
--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -94,6 +94,7 @@ def test_checkout_complete_unconfirmed_order_already_exists(
 
     order_data = data["order"]
     assert Order.objects.count() == orders_count
+    assert order_data["id"] == graphene.Node.to_global_id("Order", order_with_lines.id)
     assert str(order_with_lines.id) == order_data["token"]
     assert order_data["origin"] == order_with_lines.origin.upper()
     assert not order_data["original"]
@@ -118,6 +119,7 @@ def test_checkout_complete_order_already_exists(
 
     order_data = data["order"]
     assert Order.objects.count() == orders_count
+    assert order_data["id"] == graphene.Node.to_global_id("Order", order_with_lines.id)
     assert str(order_with_lines.id) == order_data["token"]
     assert order_data["origin"] == order_with_lines.origin.upper()
     assert not order_data["original"]
@@ -249,11 +251,13 @@ def test_checkout_complete(
     assert not data["errors"]
 
     order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
     assert Order.objects.count() == orders_count + 1
     order = Order.objects.first()
     assert order.status == OrderStatus.UNFULFILLED
     assert order.origin == OrderOrigin.CHECKOUT
     assert not order.original
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
     assert str(order.id) == order_token
     assert order.redirect_url == redirect_url
     assert order.total.gross == total.gross
@@ -547,9 +551,9 @@ def test_checkout_complete_with_variant_without_sku(
     data = content["data"]["checkoutComplete"]
     assert not data["errors"]
 
-    order_token = data["order"]["token"]
+    order_id = graphene.Node.from_global_id(data["order"]["id"])[1]
     assert Order.objects.count() == orders_count + 1
-    order = Order.objects.get(id=order_token)
+    order = Order.objects.get(id=order_id)
     assert order.status == OrderStatus.UNFULFILLED
     assert order.origin == OrderOrigin.CHECKOUT
 
@@ -671,9 +675,11 @@ def test_checkout_with_voucher_complete(
     assert not data["errors"]
 
     order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
     assert Order.objects.count() == orders_count + 1
     order = Order.objects.first()
     assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
     assert order.metadata == checkout.metadata
     assert order.private_metadata == checkout.private_metadata
 
@@ -784,9 +790,11 @@ def test_checkout_complete_without_inventory_tracking(
     assert not data["errors"]
 
     order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
     assert Order.objects.count() == orders_count + 1
     order = Order.objects.first()
     assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
     assert order.total.gross == total.gross
     assert order.metadata == checkout.metadata
     assert order.private_metadata == checkout.private_metadata
@@ -1378,9 +1386,11 @@ def test_checkout_complete_own_reservation(
     assert not data["errors"]
 
     order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
     assert Order.objects.count() == orders_count + 1
     order = Order.objects.first()
     assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
 
     order_line = order.lines.first()
     assert order_line.quantity == quantity_available
@@ -1440,9 +1450,11 @@ def test_checkout_complete_without_redirect_url(
     assert not data["errors"]
 
     order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
     assert Order.objects.count() == orders_count + 1
     order = Order.objects.first()
     assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
     assert order.total.gross == total.gross
 
     order_line = order.lines.first()
@@ -1532,9 +1544,11 @@ def test_order_already_exists(
     assert not data["errors"]
 
     order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
     assert Order.objects.count() == 1
     order = Order.objects.first()
     assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
 
     assert Checkout.objects.count() == 0
 
@@ -1669,9 +1683,11 @@ def test_checkout_complete_0_total_value(
     assert not data["errors"]
 
     order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
     assert Order.objects.count() == orders_count + 1
     order = Order.objects.first()
     assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
     assert order.total.gross == total.gross
     assert order.metadata == checkout.metadata
     assert order.private_metadata == checkout.private_metadata
@@ -1975,12 +1991,14 @@ def test_checkout_complete_with_preorder_variant(
     assert not data["errors"]
 
     order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
     assert Order.objects.count() == orders_count + 1
     order = Order.objects.first()
     assert order.status == OrderStatus.UNFULFILLED
     assert order.origin == OrderOrigin.CHECKOUT
     assert not order.original
     assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
     assert order.total.gross == total.gross
 
     assert order.lines.count() == len(variants_and_quantities)
@@ -2356,9 +2374,11 @@ def test_checkout_complete_0_total_value_no_payment(
     assert not data["errors"]
 
     order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
     assert Order.objects.count() == orders_count + 1
     order = Order.objects.first()
     assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
     assert order.total.gross == total.gross
     assert order.metadata == checkout.metadata
     assert order.private_metadata == checkout.private_metadata
@@ -2412,9 +2432,11 @@ def test_checkout_complete_0_total_value_from_voucher(
     assert not data["errors"]
 
     order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
     assert Order.objects.count() == orders_count + 1
     order = Order.objects.first()
     assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
     assert order.total.gross == total.gross
     assert order.metadata == checkout.metadata
     assert order.private_metadata == checkout.private_metadata
@@ -2464,9 +2486,11 @@ def test_checkout_complete_0_total_value_from_giftcard(
     assert not data["errors"]
 
     order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
     assert Order.objects.count() == orders_count + 1
     order = Order.objects.first()
     assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
     assert order.total.gross == total.gross
     assert order.metadata == checkout.metadata
     assert order.private_metadata == checkout.private_metadata

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -108,7 +108,7 @@ class OrderQueries(graphene.ObjectType):
     )
     order_by_token = graphene.Field(
         Order,
-        description="Look up an order by token. {DEPRECATED_IN_3X_FIELD}",
+        description="{DEPRECATED_IN_3X_FIELD} Look up an order by token.",
         token=graphene.Argument(UUID, description="The order's token.", required=True),
     )
 

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -1636,7 +1636,7 @@ def test_query_order_as_app(app_api_client, permission_manage_orders, order):
     query = """
     query OrderQuery($id: ID!) {
         order(id: $id) {
-            token
+            id
         }
     }
     """
@@ -1647,7 +1647,7 @@ def test_query_order_as_app(app_api_client, permission_manage_orders, order):
     )
     content = get_graphql_content(response)
     order_data = content["data"]["order"]
-    assert order_data["token"] == str(order.id)
+    assert order_data["id"] == graphene.Node.to_global_id("Order", order.id)
 
 
 QUERY_ORDER_BY_ID = """

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -696,7 +696,10 @@ class Order(ModelObjectType):
         TaxedMoney, description="Total price of shipping.", required=True
     )
     shipping_tax_rate = graphene.Float(required=True)
-    token = graphene.String(required=True)
+    token = graphene.String(
+        required=True,
+        deprecation_reason=(f"{DEPRECATED_IN_3X_FIELD} Use `id` instead."),
+    )
     voucher = graphene.Field(Voucher)
     gift_cards = graphene.List(GiftCard, description="List of user gift cards.")
     display_gross_prices = graphene.Boolean(required=True)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4226,7 +4226,7 @@ type Order implements Node & ObjectWithMetadata {
   shippingMethod: ShippingMethod @deprecated(reason: "This field will be removed in Saleor 4.0. Use `deliveryMethod` instead.")
   shippingPrice: TaxedMoney!
   shippingTaxRate: Float!
-  token: String!
+  token: String! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `id` instead.")
   voucher: Voucher
   giftCards: [GiftCard]
   displayGrossPrices: Boolean!


### PR DESCRIPTION
Deprecate `order.token` field. `orderByToken` query was already deprecated.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
