### PR TITLE
release-it fixes after upgrade

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -9,9 +9,7 @@
   },
   "plugins": {
     "@release-it/bumper": {
-      "in": "composer.json",
       "out": [
-        "package.json",
         {
           "file": "pyproject.toml",
           "path": "tool.poetry.version"


### PR DESCRIPTION
Two fixes: 
* We don't rely on composer.json to determine previous version (and in new release-it it deesn't gracefully fallback to CLI prompt)
 * Version change in package.json is handled bym npm itself (and leaving it for bumper is causing npm to fail with: ERR Version not changed)

It's connected with #9290 #9293

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
