### PR TITLE
Fix dataloaders for product media to be removed

### DIFF
--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -439,7 +439,7 @@ class MediaByProductVariantIdLoader(DataLoader):
     def batch_load(self, keys):
         variant_media = (
             VariantMedia.objects.using(self.database_connection_name)
-            .filter(variant_id__in=keys)
+            .filter(variant_id__in=keys, media__to_remove=False)
             .values_list("variant_id", "media_id")
         )
 
@@ -467,7 +467,11 @@ class ImagesByProductVariantIdLoader(DataLoader):
     def batch_load(self, keys):
         variant_media = (
             VariantMedia.objects.using(self.database_connection_name)
-            .filter(variant_id__in=keys, media__type=ProductMediaTypes.IMAGE)
+            .filter(
+                variant_id__in=keys,
+                media__type=ProductMediaTypes.IMAGE,
+                media__to_remove=False,
+            )
             .values_list("variant_id", "media_id")
         )
 


### PR DESCRIPTION
I want to merge this change because it fixes product media dataloaders that were missing filtering out of media to be deleted (with `to_remove` field set to `True`). Added tests for those cases where media is set to be removed but is not removed yet.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
