### PR TITLE
Fix preorders to update stock quantity_allocated

### DIFF
--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -698,10 +698,17 @@ def deactivate_preorder_for_variant(product_variant: ProductVariant):
 
     allocations_to_create = []
     stocks_to_create = []
+    stocks_to_update = []
     for preorder_allocation in preorder_allocations:
         stock = _get_stock_for_preorder_allocation(preorder_allocation, product_variant)
         if stock._state.adding:
+            stock.quantity_allocated += preorder_allocation.quantity
             stocks_to_create.append(stock)
+        else:
+            stock.quantity_allocated = (
+                F("quantity_allocated") + preorder_allocation.quantity
+            )
+            stocks_to_update.append(stock)
         allocations_to_create.append(
             Allocation(
                 order_line=preorder_allocation.order_line,
@@ -712,6 +719,9 @@ def deactivate_preorder_for_variant(product_variant: ProductVariant):
 
     if stocks_to_create:
         Stock.objects.bulk_create(stocks_to_create)
+
+    if stocks_to_update:
+        Stock.objects.bulk_update(stocks_to_update, ["quantity_allocated"])
 
     if allocations_to_create:
         Allocation.objects.bulk_create(allocations_to_create)


### PR DESCRIPTION
I want to merge this change because the task to find differences between stock level quantity_allocated and sum(stock_allocations) found some inconsistencies in 3.1. Most likely these are caused by preorders which were not ported from 3.0. We should merge this first and observe for a couple of days before merging #9274

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
