### PR TITLE
Add command to update search indexes

### DIFF
--- a/saleor/core/management/commands/update_search_indexes.py
+++ b/saleor/core/management/commands/update_search_indexes.py
@@ -1,0 +1,30 @@
+from django.core.management.base import BaseCommand
+
+from ....account.models import User
+from ....order.models import Order
+from ....product.models import Product
+from ...search_tasks import (
+    set_order_search_document_values,
+    set_product_search_document_values,
+    set_user_search_document_values,
+)
+
+
+class Command(BaseCommand):
+    help = "Populate search indexes."
+
+    def handle(self, *args, **options):
+        # Update products
+        products_total_count = Product.objects.filter(search_document="").count()
+        set_product_search_document_values.delay(products_total_count, 0)
+        self.stdout.write(f"Updating products: {products_total_count}")
+
+        # Update orders
+        orders_total_count = Order.objects.filter(search_document="").count()
+        set_order_search_document_values.delay(orders_total_count, 0)
+        self.stdout.write(f"Updating orders: {orders_total_count}")
+
+        # Update users
+        users_total_count = User.objects.filter(search_document="").count()
+        set_user_search_document_values.delay(users_total_count, 0)
+        self.stdout.write(f"Updating users: {users_total_count}")


### PR DESCRIPTION
Usage: `python manage.py update_search_indexes`

- Updates empty search_document fields for products, orders and users.


# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
