### PR TITLE
Fix for sending empty emails 3.0

### DIFF
--- a/saleor/plugins/admin_email/notify_events.py
+++ b/saleor/plugins/admin_email/notify_events.py
@@ -24,6 +24,9 @@ def send_set_staff_password_email(
         constants.SET_STAFF_PASSWORD_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.SET_STAFF_PASSWORD_SUBJECT_FIELD,
@@ -45,6 +48,9 @@ def send_csv_product_export_success(
             constants.CSV_PRODUCT_EXPORT_SUCCESS_DEFAULT_TEMPLATE,
             constants.DEFAULT_EMAIL_TEMPLATES_PATH,
         )
+        if not template:
+            # Empty template means that we don't want to trigger a given event.
+            return
         subject = get_email_subject(
             plugin.configuration,
             constants.CSV_PRODUCT_EXPORT_SUCCESS_SUBJECT_FIELD,
@@ -65,6 +71,9 @@ def send_staff_order_confirmation(
         constants.STAFF_ORDER_CONFIRMATION_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.STAFF_ORDER_CONFIRMATION_SUBJECT_FIELD,
@@ -84,6 +93,9 @@ def send_csv_export_failed(payload: dict, config: dict, plugin: "AdminEmailPlugi
             constants.CSV_EXPORT_FAILED_TEMPLATE_DEFAULT_TEMPLATE,
             constants.DEFAULT_EMAIL_TEMPLATES_PATH,
         )
+        if not template:
+            # Empty template means that we don't want to trigger a given event.
+            return
         subject = get_email_subject(
             plugin.configuration,
             constants.CSV_EXPORT_FAILED_SUBJECT_FIELD,
@@ -103,6 +115,9 @@ def send_staff_reset_password(payload: dict, config: dict, plugin: "AdminEmailPl
             constants.STAFF_PASSWORD_RESET_DEFAULT_TEMPLATE,
             constants.DEFAULT_EMAIL_TEMPLATES_PATH,
         )
+        if not template:
+            # Empty template means that we don't want to trigger a given event.
+            return
         subject = get_email_subject(
             plugin.configuration,
             constants.STAFF_PASSWORD_RESET_SUBJECT_FIELD,

--- a/saleor/plugins/admin_email/plugin.py
+++ b/saleor/plugins/admin_email/plugin.py
@@ -1,6 +1,6 @@
 import logging
-from dataclasses import asdict, dataclass
-from typing import List, Optional, Union
+from dataclasses import asdict
+from typing import List, Union
 
 from django.conf import settings
 from promise.promise import Promise
@@ -29,29 +29,6 @@ from .notify_events import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class AdminTemplate:
-    staff_order_confirmation: Optional[str]
-    set_staff_password_email: Optional[str]
-    csv_product_export_success: Optional[str]
-    csv_export_failed: Optional[str]
-    staff_reset_password: Optional[str]
-
-
-def get_admin_template_map(templates: AdminTemplate):
-    return {
-        AdminNotifyEvent.STAFF_ORDER_CONFIRMATION: templates.staff_order_confirmation,
-        AdminNotifyEvent.ACCOUNT_SET_STAFF_PASSWORD: templates.set_staff_password_email,
-        AdminNotifyEvent.CSV_PRODUCT_EXPORT_SUCCESS: (
-            templates.csv_product_export_success
-        ),
-        AdminNotifyEvent.CSV_EXPORT_FAILED: templates.csv_export_failed,
-        AdminNotifyEvent.ACCOUNT_STAFF_RESET_PASSWORD: (
-            templates.set_staff_password_email
-        ),
-    }
 
 
 def get_admin_event_map():
@@ -203,22 +180,6 @@ class AdminEmailPlugin(BasePlugin):
             use_ssl=configuration["use_ssl"] or settings.EMAIL_USE_SSL,
         )
 
-        self.templates = AdminTemplate(
-            csv_export_failed=configuration[constants.CSV_EXPORT_FAILED_TEMPLATE_FIELD],
-            csv_product_export_success=configuration[
-                constants.CSV_PRODUCT_EXPORT_SUCCESS_TEMPLATE_FIELD
-            ],
-            set_staff_password_email=configuration[
-                constants.SET_STAFF_PASSWORD_TEMPLATE_FIELD
-            ],
-            staff_order_confirmation=configuration[
-                constants.STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD
-            ],
-            staff_reset_password=configuration[
-                constants.STAFF_PASSWORD_RESET_TEMPLATE_FIELD
-            ],
-        )
-
     def resolve_plugin_configuration(
         self, request
     ) -> Union[PluginConfigurationType, Promise[PluginConfigurationType]]:
@@ -263,10 +224,6 @@ class AdminEmailPlugin(BasePlugin):
 
         if event not in event_map:
             logger.warning(f"Missing handler for event {event}")
-            return previous_value
-
-        template_map = get_admin_template_map(self.templates)
-        if not template_map.get(event):
             return previous_value
 
         event_func = event_map[event]

--- a/saleor/plugins/admin_email/tests/test_notify_events.py
+++ b/saleor/plugins/admin_email/tests/test_notify_events.py
@@ -37,6 +37,31 @@ def test_send_account_password_reset_event(
 
 
 @mock.patch(
+    "saleor.plugins.admin_email.notify_events.send_staff_password_reset_email_task."
+    "delay"
+)
+def test_send_account_password_reset_event_empty_template(
+    mocked_email_task, customer_user, admin_email_plugin
+):
+    token = "token123"
+    payload = {
+        "user": get_default_user_payload(customer_user),
+        "recipient_email": "user@example.com",
+        "token": token,
+        "reset_url": f"http://localhost:8000/redirect{token}",
+        "domain": "localhost:8000",
+        "site_name": "Saleor",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_staff_reset_password(
+        payload=payload,
+        config=config,
+        plugin=admin_email_plugin(staff_password_reset_template=""),
+    )
+    assert not mocked_email_task.called
+
+
+@mock.patch(
     "saleor.plugins.admin_email.notify_events.send_set_staff_password_email_task.delay"
 )
 def test_send_set_staff_password_email(mocked_email_task, admin_email_plugin):
@@ -52,6 +77,26 @@ def test_send_set_staff_password_email(mocked_email_task, admin_email_plugin):
     mocked_email_task.assert_called_with(
         payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
+
+
+@mock.patch(
+    "saleor.plugins.admin_email.notify_events.send_set_staff_password_email_task.delay"
+)
+def test_send_set_staff_password_email_empty_template(
+    mocked_email_task, admin_email_plugin
+):
+    payload = {
+        "recipient_email": "admin@example.com",
+        "redirect_url": "http://127.0.0.1:8000/redirect",
+        "token": "token123",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_set_staff_password_email(
+        payload=payload,
+        config=config,
+        plugin=admin_email_plugin(set_staff_password_template=""),
+    )
+    assert not mocked_email_task.called
 
 
 @mock.patch(
@@ -74,6 +119,24 @@ def test_send_csv_product_export_success(mocked_email_task, admin_email_plugin):
 
 @mock.patch(
     "saleor.plugins.admin_email.notify_events."
+    "send_email_with_link_to_download_file_task.delay"
+)
+def test_send_csv_product_export_success_empty_template(
+    mocked_email_task, admin_email_plugin
+):
+    payload = {
+        "recipient_email": "admin@example.com",
+        "csv_link": "http://127.0.0.1:8000/download/csv",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_csv_product_export_success(
+        payload=payload, config=config, plugin=admin_email_plugin(csv_product_export="")
+    )
+    assert not mocked_email_task.called
+
+
+@mock.patch(
+    "saleor.plugins.admin_email.notify_events."
     "send_staff_order_confirmation_email_task.delay"
 )
 def test_send_staff_order_confirmation(mocked_email_task, order, admin_email_plugin):
@@ -92,6 +155,27 @@ def test_send_staff_order_confirmation(mocked_email_task, order, admin_email_plu
 
 
 @mock.patch(
+    "saleor.plugins.admin_email.notify_events."
+    "send_staff_order_confirmation_email_task.delay"
+)
+def test_send_staff_order_confirmation_empty_template(
+    mocked_email_task, order, admin_email_plugin
+):
+    order_payload = get_default_order_payload(order)
+    payload = {
+        "order": order_payload,
+        "recipient_list": ["admin@example.com"],
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_staff_order_confirmation(
+        payload=payload,
+        config=config,
+        plugin=admin_email_plugin(staff_order_confirmation=""),
+    )
+    assert not mocked_email_task.called
+
+
+@mock.patch(
     "saleor.plugins.admin_email.notify_events." "send_export_failed_email_task.delay"
 )
 def test_send_csv_export_failed(mocked_email_task, admin_email_plugin):
@@ -103,3 +187,19 @@ def test_send_csv_export_failed(mocked_email_task, admin_email_plugin):
     mocked_email_task.assert_called_with(
         payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
+
+
+@mock.patch(
+    "saleor.plugins.admin_email.notify_events." "send_export_failed_email_task.delay"
+)
+def test_send_csv_export_failed_empty_template(mocked_email_task, admin_email_plugin):
+    payload = {
+        "recipient_email": "admin@example.com",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_csv_export_failed(
+        payload=payload,
+        config=config,
+        plugin=admin_email_plugin(csv_product_export_failed=""),
+    )
+    assert not mocked_email_task.called

--- a/saleor/plugins/user_email/notify_events.py
+++ b/saleor/plugins/user_email/notify_events.py
@@ -211,7 +211,6 @@ def send_fulfillment_confirmation(
         constants.ORDER_FULFILLMENT_CONFIRMATION_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
-    print(template)
     if not template:
         # Empty template means that we don't want to trigger a given event.
         return

--- a/saleor/plugins/user_email/notify_events.py
+++ b/saleor/plugins/user_email/notify_events.py
@@ -33,6 +33,9 @@ def send_account_password_reset_event(
         constants.ACCOUNT_PASSWORD_RESET_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ACCOUNT_PASSWORD_RESET_SUBJECT_FIELD,
@@ -55,6 +58,9 @@ def send_account_confirmation(payload: dict, config: dict, plugin: "UserEmailPlu
         constants.ACCOUNT_CONFIRMATION_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ACCOUNT_CONFIRMATION_SUBJECT_FIELD,
@@ -75,6 +81,9 @@ def send_account_change_email_request(
         constants.ACCOUNT_CHANGE_EMAIL_REQUEST_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ACCOUNT_CHANGE_EMAIL_REQUEST_SUBJECT_FIELD,
@@ -95,6 +104,9 @@ def send_account_change_email_confirm(
         constants.ACCOUNT_CHANGE_EMAIL_CONFIRM_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ACCOUNT_CHANGE_EMAIL_CONFIRM_SUBJECT_FIELD,
@@ -113,6 +125,9 @@ def send_account_delete(payload: dict, config: dict, plugin: "UserEmailPlugin"):
         constants.ACCOUNT_DELETE_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ACCOUNT_DELETE_SUBJECT_FIELD,
@@ -133,6 +148,9 @@ def send_account_set_customer_password(
         constants.ACCOUNT_SET_CUSTOMER_PASSWORD_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ACCOUNT_SET_CUSTOMER_PASSWORD_SUBJECT_FIELD,
@@ -151,6 +169,9 @@ def send_invoice(payload: dict, config: dict, plugin: "UserEmailPlugin"):
         constants.INVOICE_READY_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.INVOICE_READY_SUBJECT_FIELD,
@@ -167,6 +188,9 @@ def send_order_confirmation(payload: dict, config: dict, plugin: "UserEmailPlugi
         constants.ORDER_CONFIRMATION_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ORDER_CONFIRMATION_SUBJECT_FIELD,
@@ -187,6 +211,10 @@ def send_fulfillment_confirmation(
         constants.ORDER_FULFILLMENT_CONFIRMATION_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    print(template)
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ORDER_FULFILLMENT_CONFIRMATION_SUBJECT_FIELD,
@@ -205,6 +233,9 @@ def send_fulfillment_update(payload: dict, config: dict, plugin: "UserEmailPlugi
         constants.ORDER_FULFILLMENT_UPDATE_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ORDER_FULFILLMENT_UPDATE_SUBJECT_FIELD,
@@ -223,6 +254,9 @@ def send_payment_confirmation(payload: dict, config: dict, plugin: "UserEmailPlu
         constants.ORDER_PAYMENT_CONFIRMATION_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ORDER_PAYMENT_CONFIRMATION_SUBJECT_FIELD,
@@ -241,6 +275,9 @@ def send_order_canceled(payload: dict, config: dict, plugin: "UserEmailPlugin"):
         constants.ORDER_CANCELED_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ORDER_CANCELED_SUBJECT_FIELD,
@@ -259,6 +296,9 @@ def send_order_refund(payload: dict, config: dict, plugin: "UserEmailPlugin"):
         constants.ORDER_REFUND_CONFIRMATION_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ORDER_REFUND_CONFIRMATION_SUBJECT_FIELD,
@@ -277,6 +317,9 @@ def send_order_confirmed(payload: dict, config: dict, plugin: "UserEmailPlugin")
         constants.ORDER_CONFIRMED_DEFAULT_TEMPLATE,
         constants.DEFAULT_EMAIL_TEMPLATES_PATH,
     )
+    if not template:
+        # Empty template means that we don't want to trigger a given event.
+        return
     subject = get_email_subject(
         plugin.configuration,
         constants.ORDER_CONFIRMED_SUBJECT_FIELD,

--- a/saleor/plugins/user_email/plugin.py
+++ b/saleor/plugins/user_email/plugin.py
@@ -1,6 +1,6 @@
 import logging
-from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, List, Optional, Union
+from dataclasses import asdict
+from typing import TYPE_CHECKING, List, Union
 
 from promise.promise import Promise
 
@@ -42,53 +42,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class UserTemplate:
-    account_confirmation: Optional[str]
-    account_set_customer_password: Optional[str]
-    account_delete: Optional[str]
-    account_change_email_confirm: Optional[str]
-    account_change_email_request: Optional[str]
-    account_password_reset: Optional[str]
-    invoice_ready: Optional[str]
-    order_confirmation: Optional[str]
-    order_confirmed: Optional[str]
-    order_fulfillment_confirmation: Optional[str]
-    order_fulfillment_update: Optional[str]
-    order_payment_confirmation: Optional[str]
-    order_canceled: Optional[str]
-    order_refund_confirmation: Optional[str]
-
-
-def get_user_template_map(templates: UserTemplate):
-    return {
-        UserNotifyEvent.ACCOUNT_CONFIRMATION: templates.account_confirmation,
-        UserNotifyEvent.ACCOUNT_SET_CUSTOMER_PASSWORD: (
-            templates.account_set_customer_password
-        ),
-        UserNotifyEvent.ACCOUNT_DELETE: templates.account_delete,
-        UserNotifyEvent.ACCOUNT_CHANGE_EMAIL_CONFIRM: (
-            templates.account_change_email_confirm
-        ),
-        UserNotifyEvent.ACCOUNT_CHANGE_EMAIL_REQUEST: (
-            templates.account_change_email_request
-        ),
-        UserNotifyEvent.ACCOUNT_PASSWORD_RESET: templates.account_password_reset,
-        UserNotifyEvent.INVOICE_READY: templates.invoice_ready,
-        UserNotifyEvent.ORDER_CONFIRMATION: templates.order_confirmation,
-        UserNotifyEvent.ORDER_CONFIRMED: templates.order_confirmed,
-        UserNotifyEvent.ORDER_FULFILLMENT_CONFIRMATION: (
-            templates.order_fulfillment_confirmation
-        ),
-        UserNotifyEvent.ORDER_FULFILLMENT_UPDATE: templates.order_fulfillment_update,
-        UserNotifyEvent.ORDER_PAYMENT_CONFIRMATION: (
-            templates.order_payment_confirmation
-        ),
-        UserNotifyEvent.ORDER_CANCELED: templates.order_canceled,
-        UserNotifyEvent.ORDER_REFUND_CONFIRMATION: templates.order_refund_confirmation,
-    }
 
 
 def get_user_event_map():
@@ -380,42 +333,6 @@ class UserEmailPlugin(BasePlugin):
             use_tls=configuration["use_tls"],
             use_ssl=configuration["use_ssl"],
         )
-        self.templates = UserTemplate(
-            account_confirmation=configuration[
-                constants.ACCOUNT_CONFIRMATION_TEMPLATE_FIELD
-            ],
-            account_set_customer_password=configuration[
-                constants.ACCOUNT_SET_CUSTOMER_PASSWORD_TEMPLATE_FIELD
-            ],
-            account_delete=configuration[constants.ACCOUNT_DELETE_TEMPLATE_FIELD],
-            account_change_email_confirm=configuration[
-                constants.ACCOUNT_CHANGE_EMAIL_CONFIRM_TEMPLATE_FIELD
-            ],
-            account_change_email_request=configuration[
-                constants.ACCOUNT_CHANGE_EMAIL_REQUEST_TEMPLATE_FIELD
-            ],
-            account_password_reset=configuration[
-                constants.ACCOUNT_PASSWORD_RESET_TEMPLATE_FIELD
-            ],
-            invoice_ready=configuration[constants.INVOICE_READY_TEMPLATE_FIELD],
-            order_confirmation=configuration[
-                constants.ORDER_CONFIRMATION_TEMPLATE_FIELD
-            ],
-            order_confirmed=configuration[constants.ORDER_CONFIRMED_TEMPLATE_FIELD],
-            order_fulfillment_confirmation=configuration[
-                constants.ORDER_FULFILLMENT_CONFIRMATION_TEMPLATE_FIELD
-            ],
-            order_fulfillment_update=configuration[
-                constants.ORDER_FULFILLMENT_UPDATE_TEMPLATE_FIELD
-            ],
-            order_payment_confirmation=configuration[
-                constants.ORDER_PAYMENT_CONFIRMATION_TEMPLATE_FIELD
-            ],
-            order_canceled=configuration[constants.ORDER_CANCELED_TEMPLATE_FIELD],
-            order_refund_confirmation=configuration[
-                constants.ORDER_REFUND_CONFIRMATION_TEMPLATE_FIELD
-            ],
-        )
 
     def resolve_plugin_configuration(
         self, request
@@ -461,10 +378,6 @@ class UserEmailPlugin(BasePlugin):
 
         if event not in event_map:
             logger.warning(f"Missing handler for event {event}")
-            return previous_value
-
-        template_map = get_user_template_map(self.templates)
-        if not template_map.get(event):
             return previous_value
 
         event_func = event_map[event]

--- a/saleor/plugins/user_email/tests/test_notify_events.py
+++ b/saleor/plugins/user_email/tests/test_notify_events.py
@@ -48,6 +48,30 @@ def test_send_account_password_reset_event(
 
 
 @mock.patch(
+    "saleor.plugins.user_email.notify_events.send_password_reset_email_task.delay"
+)
+def test_send_account_password_reset_event_with_empty_template(
+    mocked_email_task, customer_user, user_email_plugin
+):
+    token = "token123"
+    payload = {
+        "user": get_default_user_payload(customer_user),
+        "recipient_email": "user@example.com",
+        "token": token,
+        "reset_url": f"http://localhost:8000/redirect{token}",
+        "domain": "localhost:8000",
+        "site_name": "Saleor",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_account_password_reset_event(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(password_reset_template=""),
+    )
+    assert not mocked_email_task.called
+
+
+@mock.patch(
     "saleor.plugins.user_email.notify_events.send_account_confirmation_email_task.delay"
 )
 def test_send_account_confirmation(mocked_email_task, customer_user, user_email_plugin):
@@ -67,6 +91,30 @@ def test_send_account_confirmation(mocked_email_task, customer_user, user_email_
     mocked_email_task.assert_called_with(
         payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
+
+
+@mock.patch(
+    "saleor.plugins.user_email.notify_events.send_account_confirmation_email_task.delay"
+)
+def test_send_account_confirmation_with_empty_template(
+    mocked_email_task, customer_user, user_email_plugin
+):
+    token = "token123"
+    payload = {
+        "user": get_default_user_payload(customer_user),
+        "recipient_email": "user@example.com",
+        "token": token,
+        "confirm_url": f"http://localhost:8000/redirect{token}",
+        "domain": "localhost:8000",
+        "site_name": "Saleor",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_account_confirmation(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(account_confirmation_template=""),
+    )
+    assert not mocked_email_task.called
 
 
 @mock.patch(
@@ -96,6 +144,32 @@ def test_send_account_change_email_request(
 
 
 @mock.patch(
+    "saleor.plugins.user_email.notify_events.send_request_email_change_email_task.delay"
+)
+def test_send_account_change_email_request_empty_template(
+    mocked_email_task, customer_user, user_email_plugin
+):
+    token = "token123"
+    payload = {
+        "user": get_default_user_payload(customer_user),
+        "recipient_email": "user@example.com",
+        "token": token,
+        "redirect_url": f"http://localhost:8000/redirect{token}",
+        "old_email": "old.user@example.com",
+        "new_email": "user@example.com",
+        "site_name": "Saleor",
+        "domain": "localhost:8000",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_account_change_email_request(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(email_change_request_template=""),
+    )
+    assert not mocked_email_task.called
+
+
+@mock.patch(
     "saleor.plugins.user_email.notify_events.send_user_change_email_notification_task."
     "delay"
 )
@@ -118,6 +192,28 @@ def test_send_account_change_email_confirm(
 
 
 @mock.patch(
+    "saleor.plugins.user_email.notify_events.send_user_change_email_notification_task."
+    "delay"
+)
+def test_send_account_change_email_confirm_empty_template(
+    mocked_email_task, customer_user, user_email_plugin
+):
+    payload = {
+        "user": get_default_user_payload(customer_user),
+        "recipient_email": "user@example.com",
+        "site_name": "Saleor",
+        "domain": "localhost:8000",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_account_change_email_confirm(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(email_change_confirm_template=""),
+    )
+    assert not mocked_email_task.called
+
+
+@mock.patch(
     "saleor.plugins.user_email.notify_events."
     "send_account_delete_confirmation_email_task.delay"
 )
@@ -136,6 +232,31 @@ def test_send_account_delete(mocked_email_task, customer_user, user_email_plugin
     mocked_email_task.assert_called_with(
         payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
+
+
+@mock.patch(
+    "saleor.plugins.user_email.notify_events."
+    "send_account_delete_confirmation_email_task.delay"
+)
+def test_send_account_delete_with_empty_template(
+    mocked_email_task, customer_user, user_email_plugin
+):
+    token = "token123"
+    payload = {
+        "user": get_default_user_payload(customer_user),
+        "recipient_email": "user@example.com",
+        "token": token,
+        "delete_url": f"http://localhost:8000/redirect{token}",
+        "site_name": "Saleor",
+        "domain": "localhost:8000",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_account_delete(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(account_delete_template=""),
+    )
+    assert not mocked_email_task.called
 
 
 @mock.patch(
@@ -162,6 +283,30 @@ def test_send_account_set_customer_password(
     )
 
 
+@mock.patch(
+    "saleor.plugins.user_email.notify_events.send_set_user_password_email_task.delay"
+)
+def test_send_account_set_customer_password_empty_template(
+    mocked_email_task, customer_user, user_email_plugin
+):
+    token = "token123"
+    payload = {
+        "user": get_default_user_payload(customer_user),
+        "recipient_email": "user@example.com",
+        "token": token,
+        "password_set_url": f"http://localhost:8000/redirect{token}",
+        "site_name": "Saleor",
+        "domain": "localhost:8000",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_account_set_customer_password(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(account_set_password_template=""),
+    )
+    assert not mocked_email_task.called
+
+
 @mock.patch("saleor.plugins.user_email.notify_events.send_invoice_email_task.delay")
 def test_send_invoice(mocked_email_task, user_email_plugin):
     payload = {
@@ -179,6 +324,27 @@ def test_send_invoice(mocked_email_task, user_email_plugin):
     mocked_email_task.assert_called_with(
         payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
+
+
+@mock.patch("saleor.plugins.user_email.notify_events.send_invoice_email_task.delay")
+def test_send_invoice_with_empty_template(mocked_email_task, user_email_plugin):
+    payload = {
+        "invoice": {
+            "id": 1,
+            "number": 999,
+            "download_url": "http://localhost:8000/download",
+        },
+        "recipient_email": "user@example.com",
+        "site_name": "Saleor",
+        "domain": "localhost:8000",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_invoice(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(invoice_ready_template=""),
+    )
+    assert not mocked_email_task.called
 
 
 @mock.patch(
@@ -199,6 +365,27 @@ def test_send_order_confirmation(mocked_email_task, order, user_email_plugin):
 
 
 @mock.patch(
+    "saleor.plugins.user_email.notify_events.send_order_confirmation_email_task.delay"
+)
+def test_send_order_confirmation_empty_template(
+    mocked_email_task, order, user_email_plugin
+):
+    payload = {
+        "order": get_default_order_payload(order, "http://localhost:8000/redirect"),
+        "recipient_email": "user@example.com",
+        "site_name": "Saleor",
+        "domain": "localhost:8000",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_order_confirmation(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(order_confirmation_template=""),
+    )
+    assert not mocked_email_task.called
+
+
+@mock.patch(
     "saleor.plugins.user_email.notify_events.send_fulfillment_confirmation_email_task."
     "delay"
 )
@@ -216,6 +403,23 @@ def test_send_fulfillment_confirmation(
 
 
 @mock.patch(
+    "saleor.plugins.user_email.notify_events.send_fulfillment_confirmation_email_task."
+    "delay"
+)
+def test_send_fulfillment_confirmation_empty_template(
+    mocked_email_task, order, fulfillment, user_email_plugin
+):
+    payload = get_default_fulfillment_payload(order, fulfillment)
+    config = {"host": "localhost", "port": "1025"}
+    send_fulfillment_confirmation(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(fulfillment_confirmation_template=""),
+    )
+    assert not mocked_email_task.called
+
+
+@mock.patch(
     "saleor.plugins.user_email.notify_events.send_fulfillment_update_email_task.delay"
 )
 def test_send_fulfillment_update(
@@ -227,6 +431,22 @@ def test_send_fulfillment_update(
     mocked_email_task.assert_called_with(
         payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
+
+
+@mock.patch(
+    "saleor.plugins.user_email.notify_events.send_fulfillment_update_email_task.delay"
+)
+def test_send_fulfillment_update_empty_template(
+    mocked_email_task, order, fulfillment, user_email_plugin
+):
+    payload = get_default_fulfillment_payload(order, fulfillment)
+    config = {"host": "localhost", "port": "1025"}
+    send_fulfillment_update(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(fulfillment_update_template=""),
+    )
+    assert not mocked_email_task.called
 
 
 @mock.patch(
@@ -259,6 +479,35 @@ def test_send_payment_confirmation(
 
 
 @mock.patch(
+    "saleor.plugins.user_email.notify_events.send_payment_confirmation_email_task.delay"
+)
+def test_send_payment_confirmation_empty_template(
+    mocked_email_task, order, payment_dummy, user_email_plugin
+):
+    payload = {
+        "order": get_default_order_payload(order, "http://localhost:8000/redirect"),
+        "recipient_email": "user@example.com",
+        "payment": {
+            "created": payment_dummy.created,
+            "modified": payment_dummy.modified,
+            "charge_status": payment_dummy.charge_status,
+            "total": payment_dummy.total,
+            "captured_amount": payment_dummy.captured_amount,
+            "currency": payment_dummy.currency,
+        },
+        "site_name": "Saleor",
+        "domain": "localhost:8000",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_payment_confirmation(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(payment_confirmation_template=""),
+    )
+    assert not mocked_email_task.called
+
+
+@mock.patch(
     "saleor.plugins.user_email.notify_events.send_order_canceled_email_task.delay"
 )
 def test_send_order_canceled(mocked_email_task, order, user_email_plugin):
@@ -273,6 +522,27 @@ def test_send_order_canceled(mocked_email_task, order, user_email_plugin):
     mocked_email_task.assert_called_with(
         payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
+
+
+@mock.patch(
+    "saleor.plugins.user_email.notify_events.send_order_canceled_email_task.delay"
+)
+def test_send_order_canceled_empty_template(
+    mocked_email_task, order, user_email_plugin
+):
+    payload = {
+        "order": get_default_order_payload(order, "http://localhost:8000/redirect"),
+        "recipient_email": "user@example.com",
+        "site_name": "Saleor",
+        "domain": "localhost:8000",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_order_canceled(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(order_cancel_template=""),
+    )
+    assert not mocked_email_task.called
 
 
 @mock.patch(
@@ -295,6 +565,29 @@ def test_send_order_refund(mocked_email_task, order, user_email_plugin):
 
 
 @mock.patch(
+    "saleor.plugins.user_email.notify_events.send_order_refund_email_task.delay"
+)
+def test_send_order_refund_with_empty_template(
+    mocked_email_task, order, user_email_plugin
+):
+    payload = {
+        "order": get_default_order_payload(order, "http://localhost:8000/redirect"),
+        "recipient_email": "user@example.com",
+        "amount": order.total_gross_amount,
+        "currency": order.currency,
+        "site_name": "Saleor",
+        "domain": "localhost:8000",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_order_refund(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(order_refund_template=""),
+    )
+    assert not mocked_email_task.called
+
+
+@mock.patch(
     "saleor.plugins.user_email.notify_events.send_order_confirmed_email_task.delay"
 )
 def test_send_order_confirmed(mocked_email_task, order, user_email_plugin):
@@ -309,3 +602,24 @@ def test_send_order_confirmed(mocked_email_task, order, user_email_plugin):
     mocked_email_task.assert_called_with(
         payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
+
+
+@mock.patch(
+    "saleor.plugins.user_email.notify_events.send_order_confirmed_email_task.delay"
+)
+def test_send_order_confirmed_empty_template(
+    mocked_email_task, order, user_email_plugin
+):
+    payload = {
+        "order": get_default_order_payload(order, "http://localhost:8000/redirect"),
+        "recipient_email": "user@example.com",
+        "site_name": "Saleor",
+        "domain": "localhost:8000",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_order_confirmed(
+        payload=payload,
+        config=config,
+        plugin=user_email_plugin(order_confirmed_template=""),
+    )
+    assert not mocked_email_task.called


### PR DESCRIPTION
I want to merge this change because it fixes an issue that Saleor sends empty emails.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
