### PR TITLE
Fix countries resolver performance

### DIFF
--- a/saleor/graphql/shop/resolvers.py
+++ b/saleor/graphql/shop/resolvers.py
@@ -38,6 +38,7 @@ def resolve_countries(**kwargs):
     attached_to_shipping_zones = countries_filter.get("attached_to_shipping_zones")
     language_code = kwargs.get("language_code")
     taxes = {vat.country_code: vat for vat in VAT.objects.all()}
+    codes_list = get_countries_codes_list(attached_to_shipping_zones)
     # DEPRECATED: translation.override will be dropped in Saleor 4.0
     with translation.override(language_code):
         return [
@@ -45,7 +46,7 @@ def resolve_countries(**kwargs):
                 code=country[0], country=country[1], vat=taxes.get(country[0])
             )
             for country in countries
-            if country[0] in get_countries_codes_list(attached_to_shipping_zones)
+            if country[0] in codes_list
         ]
 
 


### PR DESCRIPTION
I want to merge this change because it fixes performance of countries resolver when `attachedToShippingZones` is active.
Local DB:
![image](https://user-images.githubusercontent.com/12252472/157042603-82721501-5251-4c8b-af31-189ecbc48675.png)
Before: **251 SQL queries / 1.21s**
After: **2 SQL queries / 45.07ms**

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
