### PR TITLE
Fix migration issue between 3.0 and main

### DIFF
--- a/saleor/attribute/migrations/0017_auto_20210811_0701.py
+++ b/saleor/attribute/migrations/0017_auto_20210811_0701.py
@@ -33,6 +33,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="attributevalue",
             name="value",
-            field=models.CharField(blank=True, default="", max_length=9),
+            field=models.CharField(blank=True, default="", max_length=100),
         ),
     ]

--- a/saleor/attribute/models/base.py
+++ b/saleor/attribute/models/base.py
@@ -208,7 +208,7 @@ class AttributeTranslation(Translation):
 class AttributeValue(SortableModel):
     name = models.CharField(max_length=250)
     # keeps hex code color value in #RRGGBBAA format
-    value = models.CharField(max_length=9, blank=True, default="")
+    value = models.CharField(max_length=100, blank=True, default="")
     slug = models.SlugField(max_length=255, allow_unicode=True)
     file_url = models.URLField(null=True, blank=True)
     content_type = models.CharField(max_length=50, null=True, blank=True)


### PR DESCRIPTION
I want to merge this change because in 3.0 we already had value length limit of 100 which might cause colissions between versions.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
