### PR TITLE
Custom prices API preview

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1191,6 +1191,7 @@ type CheckoutLineDelete {
 input CheckoutLineInput {
   quantity: Int!
   variantId: ID!
+  price: PositiveDecimal
 }
 
 type CheckoutLinesAdd {
@@ -5198,6 +5199,7 @@ enum PermissionEnum {
   MANAGE_SETTINGS
   MANAGE_TRANSLATIONS
   MANAGE_CHECKOUTS
+  HANDLE_CHECKOUTS
 }
 
 type PermissionGroupCreate {


### PR DESCRIPTION
This is a preview of the custom prices feature in Saleor.

The feature will allow defining your own prices for product variants added to the checkout. Below you can find main assumptions:
- The price changes will be allowed only for apps with new `HANDLE_CHECKOUT` permission. Other users will get the `PermissionDenied` error when trying to provide the custom price.
- The new permission will be granted to all apps that already have `MANAGE_CHECKOUT`. 
- The `CheckoutLineInput` will be extended with the optional price field `price: PositiveDecimal`, so the custom price could be set in the following mutations:
  - `checkoutCreate`
  - `checkoutLinesAdd` - when adding a variant that is already added to checkout, don't create any new line, but override the already existing one - increment the quantity and update the price.
  - `checkoutLinesUpdate` - will override the existing line with the price provided in the mutation
- Whether the given price is net or gross should depend on the shop settings (the same settings that decide whether variant.get_price is considered net or gross.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
