### PR TITLE
Always cast database ID to int in dataloader

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -134,7 +134,7 @@ class ShippingMethodInfo(DeliveryMethodBase):
     @property
     def delivery_method_order_field(self) -> dict:
         if not self.delivery_method.is_external:
-            return {"shipping_method_id": self.delivery_method.id}
+            return {"shipping_method_id": int(self.delivery_method.id)}
         return {}
 
     def is_valid_delivery_method(self) -> bool:

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -33,11 +33,19 @@ MUTATION_CHECKOUT_COMPLETE = """
     mutation checkoutComplete($token: UUID, $redirectUrl: String) {
         checkoutComplete(token: $token, redirectUrl: $redirectUrl) {
             order {
-                id,
+                id
                 token
                 original
                 origin
-            },
+                deliveryMethod {
+                    ... on Warehouse {
+                        id
+                    }
+                    ... on ShippingMethod {
+                        id
+                    }
+                }
+            }
             errors {
                 field,
                 message,


### PR DESCRIPTION
Shipping methods ID can be of two types:
- int - when a shipping method from Saleor is used 
- string - when an eternal shipping method is used.

Internally string is used to pass the ID between functions, but when this happens the `ShippingMethodByIdLoader` fails to resolve the shipping method, as it uses integers internally. This quick-fix casts IDs to int inside the data loader, which should always resolve shipping methods from Saleor DB.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
