### PR TITLE
Fix parse_tax_data not handling invalid JSON types

### DIFF
--- a/saleor/plugins/webhook/tests/test_tax_webhook_utils.py
+++ b/saleor/plugins/webhook/tests/test_tax_webhook_utils.py
@@ -130,6 +130,27 @@ def test_parse_tax_data_decimalexception(tax_data_response):
     assert tax_data is None
 
 
+@pytest.mark.parametrize(
+    "response_data",
+    [
+        [],
+        1.0,
+        "text",
+        None,
+        {"lines": {}},
+        {"lines": 1.0},
+        {"lines": "text"},
+        {"lines": None},
+        {"lines": [[]]},
+        {"lines": [1.0]},
+        {"lines": ["text"]},
+        {"lines": [None]},
+    ],
+)
+def test_parse_tax_data_malformed(response_data):
+    assert parse_tax_data(response_data) is None
+
+
 def test_parse_tax_codes_success(tax_codes_response):
     assert parse_tax_codes(tax_codes_response) == {
         tax["code"]: tax["description"] for tax in tax_codes_response

--- a/saleor/plugins/webhook/utils.py
+++ b/saleor/plugins/webhook/utils.py
@@ -194,7 +194,7 @@ def parse_tax_data(
 ) -> Optional[TaxData]:
     try:
         return _unsafe_parse_tax_data(response_data)
-    except (KeyError, decimal.DecimalException):
+    except (TypeError, KeyError, decimal.DecimalException):
         return None
 
 


### PR DESCRIPTION
I want to merge this change because prior to this PR, `parse_tax_data` would crash when passing  invalid JSON types (eg. top-level array, `"lines": null`).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
