### PR TITLE
Cast shipping_method_id to int

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1108,7 +1108,7 @@ class Order(ModelObjectType):
             return listing.then(calculate_price)
 
         shipping_method = ShippingMethodByIdLoader(info.context).load(
-            root.shipping_method_id
+            int(root.shipping_method_id)
         )
         channel = ChannelByIdLoader(info.context).load(root.channel_id)
 


### PR DESCRIPTION
Cast `root.shipping_method_id` to `int` because passing it as `str` causes unexpected returning `None` from `ShippingMethodByIdLoader`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
