### PR TITLE
Handle ValidationError in metadata mutations

### DIFF
--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -174,8 +174,8 @@ class BaseMetadataMutation(BaseMutation):
 
     @classmethod
     def mutate(cls, root, info, **data):
-        type_name, object_pk = cls.get_object_type_name_and_pk(data)
         try:
+            type_name, object_pk = cls.get_object_type_name_and_pk(data)
             permissions = cls.get_permissions(info, type_name, object_pk, **data)
         except GraphQLError as e:
             error = ValidationError(
@@ -184,8 +184,10 @@ class BaseMetadataMutation(BaseMutation):
             return cls.handle_errors(error)
         except ValidationError as e:
             return cls.handle_errors(e)
+
         if not cls.check_permissions(info.context, permissions):
             raise PermissionDenied(permissions=permissions)
+
         try:
             result = super().mutate(root, info, **data)
             if not result.errors:

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -128,6 +128,21 @@ def item_contains_multiple_proper_public_metadata(
     )
 
 
+def test_meta_mutations_handle_validation_errors(staff_api_client):
+    invalid_id = "6QjoLs5LIqb3At7hVKKcUlqXceKkFK"
+    variables = {
+        "id": invalid_id,
+        "input": [{"key": "year", "value": "of-saleor"}],
+    }
+    response = staff_api_client.post_graphql(
+        UPDATE_PUBLIC_METADATA_MUTATION % "Checkout", variables
+    )
+    content = get_graphql_content(response)
+    errors = content["data"]["updateMetadata"]["errors"]
+    assert errors
+    assert errors[0]["code"] == MetadataErrorCode.INVALID.name
+
+
 @patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_base_metadata_mutation_handles_errors_from_extra_action(
     mock_checkout_updated, api_client, checkout


### PR DESCRIPTION
Fix handling ValidationError in metadata mutations.

Before:
```json
"errors": [
    {
      "message": "['“6QjoLs5LIqb3At7hVKKcUlqXceKkFK” is not a valid UUID.']",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "updateMetadata"
      ],
      "extensions": {
        "exception": {
          "code": "ValidationError",
          "stacktrace": [
            "Traceback (most recent call last):",
            "  File \"/Users/marcin/mirumee/saleor-platform/saleor/saleor/graphql/core/utils/__init__.py\", line 170, in from_global_id_or_error",
            "    type_, id_ = graphene.Node.from_global_id(global_id)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/graphene/relay/node.py\", line 115, in from_global_id",
            "    return from_global_id(global_id)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/graphql_relay/node/node.py\", line 66, in from_global_id",
            "    unbased_global_id = unbase64(global_id)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/graphql_relay/utils.py\", line 11, in unbase64",
            "    return _unbase64(s).decode('utf-8')",
            "  File \"/Users/marcin/.pyenv/versions/3.9.1/lib/python3.9/base64.py\", line 87, in b64decode",
            "    return binascii.a2b_base64(s)",
            "binascii.Error: Incorrect padding",
            "",
            "During handling of the above exception, another exception occurred:",
            "Traceback (most recent call last):",
            "  File \"/Users/marcin/mirumee/saleor-platform/saleor/saleor/graphql/meta/mutations.py\", line 203, in get_object_type_name_and_pk",
            "    return from_global_id_or_error(object_id)",
            "  File \"/Users/marcin/mirumee/saleor-platform/saleor/saleor/graphql/core/utils/__init__.py\", line 172, in from_global_id_or_error",
            "    raise GraphQLError(f\"Couldn't resolve id: {global_id}.\")",
            "graphql.error.base.GraphQLError: Couldn't resolve id: 6QjoLs5LIqb3At7hVKKcUlqXceKkFK.",
            "",
            "During handling of the above exception, another exception occurred:",
            "Traceback (most recent call last):",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/fields/__init__.py\", line 2434, in to_python",
            "    return uuid.UUID(**{input_form: value})",
            "  File \"/Users/marcin/.pyenv/versions/3.9.1/lib/python3.9/uuid.py\", line 177, in __init__",
            "    raise ValueError('badly formed hexadecimal UUID string')",
            "ValueError: badly formed hexadecimal UUID string",
            "",
            "During handling of the above exception, another exception occurred:",
            "Traceback (most recent call last):",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/graphql/execution/executor.py\", line 452, in resolve_or_error",
            "    return executor.execute(resolve_fn, source, info, **args)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/graphql/execution/executors/sync.py\", line 16, in execute",
            "    return fn(*args, **kwargs)",
            "  File \"/Users/marcin/mirumee/saleor-platform/saleor/saleor/graphql/meta/mutations.py\", line 177, in mutate",
            "    type_name, object_pk = cls.get_object_type_name_and_pk(data)",
            "  File \"/Users/marcin/mirumee/saleor-platform/saleor/saleor/graphql/meta/mutations.py\", line 207, in get_object_type_name_and_pk",
            "    if checkout := checkout_models.Checkout.objects.filter(",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/manager.py\", line 85, in manager_method",
            "    return getattr(self.get_queryset(), name)(*args, **kwargs)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/query.py\", line 941, in filter",
            "    return self._filter_or_exclude(False, args, kwargs)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/query.py\", line 961, in _filter_or_exclude",
            "    clone._filter_or_exclude_inplace(negate, args, kwargs)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/query.py\", line 968, in _filter_or_exclude_inplace",
            "    self._query.add_q(Q(*args, **kwargs))",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/sql/query.py\", line 1393, in add_q",
            "    clause, _ = self._add_q(q_object, self.used_aliases)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/sql/query.py\", line 1412, in _add_q",
            "    child_clause, needed_inner = self.build_filter(",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/sql/query.py\", line 1347, in build_filter",
            "    condition = self.build_lookup(lookups, col, value)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/sql/query.py\", line 1193, in build_lookup",
            "    lookup = lookup_class(lhs, rhs)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/lookups.py\", line 25, in __init__",
            "    self.rhs = self.get_prep_lookup()",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/lookups.py\", line 77, in get_prep_lookup",
            "    return self.lhs.output_field.get_prep_value(self.rhs)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/fields/__init__.py\", line 2418, in get_prep_value",
            "    return self.to_python(value)",
            "  File \"/Users/marcin/.pyenv/versions/saleor/lib/python3.9/site-packages/django/db/models/fields/__init__.py\", line 2436, in to_python",
            "    raise exceptions.ValidationError(",
            "django.core.exceptions.ValidationError: ['“6QjoLs5LIqb3At7hVKKcUlqXceKkFK” is not a valid UUID.']"
          ]
        }
      }
    }
```

After:
```json
"data": {
    "updateMetadata": {
      "errors": [
        {
          "field": null,
          "message": "“6QjoLs5LIqb3At7hVKKcUlqXceKkFK” is not a valid UUID."
        }
      ],
      "__typename": "UpdateMetadata"
    }
  },
```


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
