### PR TITLE
Fix flaky order payload serializer test

### DIFF
--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -54,6 +54,10 @@ def parse_django_datetime(date):
     return json.loads(json.dumps(date, cls=DjangoJSONEncoder))
 
 
+def sort_by_id(dicts):
+    return sorted(dicts, key=lambda d: d["id"])
+
+
 @freeze_time()
 @mock.patch("saleor.webhook.payloads.generate_order_lines_payload")
 @mock.patch("saleor.webhook.payloads.generate_fulfillment_lines_payload")
@@ -196,28 +200,7 @@ def test_generate_order_payload(
             "country_area": order.billing_address.country_area,
             "phone": str(order.billing_address.phone),
         },
-        "discounts": [
-            {
-                "id": graphene.Node.to_global_id("OrderDiscount", discount_1.pk),
-                "type": discount_1.type,
-                "value_type": discount_1.value_type,
-                "value": ANY,
-                "amount_value": str(quantize_price(discount_1.amount_value, currency)),
-                "name": discount_1.name,
-                "translated_name": discount_1.translated_name,
-                "reason": discount_1.reason,
-            },
-            {
-                "id": graphene.Node.to_global_id("OrderDiscount", discount_2.pk),
-                "type": discount_2.type,
-                "value_type": discount_2.value_type,
-                "value": ANY,
-                "amount_value": str(quantize_price(discount_2.amount_value, currency)),
-                "name": discount_2.name,
-                "translated_name": discount_2.translated_name,
-                "reason": discount_2.reason,
-            },
-        ],
+        "discounts": ANY,
         "original": graphene.Node.to_global_id("Order", order.original_id),
         "lines": json.loads(order_lines),
         "fulfillments": [
@@ -250,6 +233,31 @@ def test_generate_order_payload(
         ),
         "meta": generate_meta(requestor_data=generate_requestor(customer_user)),
     }
+
+    assert sort_by_id(payload["discounts"]) == sort_by_id(
+        [
+            {
+                "id": graphene.Node.to_global_id("OrderDiscount", discount_1.pk),
+                "type": discount_1.type,
+                "value_type": discount_1.value_type,
+                "value": ANY,
+                "amount_value": str(quantize_price(discount_1.amount_value, currency)),
+                "name": discount_1.name,
+                "translated_name": discount_1.translated_name,
+                "reason": discount_1.reason,
+            },
+            {
+                "id": graphene.Node.to_global_id("OrderDiscount", discount_2.pk),
+                "type": discount_2.type,
+                "value_type": discount_2.value_type,
+                "value": ANY,
+                "amount_value": str(quantize_price(discount_2.amount_value, currency)),
+                "name": discount_2.name,
+                "translated_name": discount_2.translated_name,
+                "reason": discount_2.reason,
+            },
+        ],
+    )
 
     mocked_fulfillment_lines.assert_called_with(fulfillment)
 


### PR DESCRIPTION
I want to merge this change because `test_generate_order_payload` is sometimes failing.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
