### PR TITLE
Switch payload ids from DB's to Graphql 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable, unreleased changes to this project will be documented in this file.
 # Unreleased
 
 ### Breaking changes
+- Convert IDs from DB to Graphql format in Email Payload - #9388 by @L3str4nge
 
 - Migrate order id from int to UUID - #9324 by @IKarbowiak
   - Changed the order `id` changed from `int` to `UUID`, the old ids still can be used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable, unreleased changes to this project will be documented in this file.
 # Unreleased
 
 ### Breaking changes
-- Convert IDs from DB to Graphql format in Email Payload - #9388 by @L3str4nge
+- Convert IDs from DB to Graphql format in all notification payloads (email plugins and webhook.NOTIFY)- #9388 by @L3str4nge
 
 - Migrate order id from int to UUID - #9324 by @IKarbowiak
   - Changed the order `id` changed from `int` to `UUID`, the old ids still can be used

--- a/saleor/account/notifications.py
+++ b/saleor/account/notifications.py
@@ -6,13 +6,14 @@ from django.contrib.auth.tokens import default_token_generator
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
 from ..core.tokens import account_delete_token_generator
+from ..core.utils import graphql_id
 from ..core.utils.url import prepare_url
 from .models import User
 
 
 def get_default_user_payload(user: User):
     return {
-        "id": user.id,
+        "id": graphql_id(user),
         "email": user.email,
         "first_name": user.first_name,
         "last_name": user.last_name,

--- a/saleor/account/notifications.py
+++ b/saleor/account/notifications.py
@@ -6,14 +6,14 @@ from django.contrib.auth.tokens import default_token_generator
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
 from ..core.tokens import account_delete_token_generator
-from ..core.utils import graphql_id
 from ..core.utils.url import prepare_url
+from ..graphql.core.utils import to_global_id_or_none
 from .models import User
 
 
 def get_default_user_payload(user: User):
     return {
-        "id": graphql_id(user),
+        "id": to_global_id_or_none(user),
         "email": user.email,
         "first_name": user.first_name,
         "last_name": user.last_name,

--- a/saleor/account/tests/test_notifications.py
+++ b/saleor/account/tests/test_notifications.py
@@ -5,6 +5,7 @@ import pytest
 from freezegun import freeze_time
 
 from ...core.notify_events import NotifyEventType, UserNotifyEvent
+from ...core.utils import graphql_id
 from ...core.utils.url import prepare_url
 from ...plugins.manager import get_plugins_manager
 from .. import notifications
@@ -13,7 +14,7 @@ from ..notifications import get_default_user_payload
 
 def test_get_default_user_payload(customer_user):
     assert get_default_user_payload(customer_user) == {
-        "id": customer_user.id,
+        "id": graphql_id(customer_user),
         "email": customer_user.email,
         "first_name": customer_user.first_name,
         "last_name": customer_user.last_name,

--- a/saleor/account/tests/test_notifications.py
+++ b/saleor/account/tests/test_notifications.py
@@ -5,8 +5,8 @@ import pytest
 from freezegun import freeze_time
 
 from ...core.notify_events import NotifyEventType, UserNotifyEvent
-from ...core.utils import graphql_id
 from ...core.utils.url import prepare_url
+from ...graphql.core.utils import to_global_id_or_none
 from ...plugins.manager import get_plugins_manager
 from .. import notifications
 from ..notifications import get_default_user_payload
@@ -14,7 +14,7 @@ from ..notifications import get_default_user_payload
 
 def test_get_default_user_payload(customer_user):
     assert get_default_user_payload(customer_user) == {
-        "id": graphql_id(customer_user),
+        "id": to_global_id_or_none(customer_user),
         "email": customer_user.email,
         "first_name": customer_user.first_name,
         "last_name": customer_user.last_name,

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -3,7 +3,6 @@ import socket
 from typing import TYPE_CHECKING, Optional, Type, Union
 from urllib.parse import urljoin
 
-import graphene
 from babel.numbers import get_territory_currencies
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -157,19 +156,3 @@ def generate_unique_slug(
 def delete_versatile_image(image):
     image.delete_all_created_images()
     image.delete(save=False)
-
-
-def graphql_id(instance):
-    class_name = instance.__class__.__name__
-    if instance.id is None:
-        return None
-    return graphene.Node.to_global_id(class_name, instance.id)
-
-
-def get_id_from_graphql_id(_id):
-    if not _id:
-        return _id
-
-    values = graphene.Node.from_global_id(_id)
-    assert len(values) == 2
-    return values[1]

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -3,6 +3,7 @@ import socket
 from typing import TYPE_CHECKING, Optional, Type, Union
 from urllib.parse import urljoin
 
+import graphene
 from babel.numbers import get_territory_currencies
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -156,3 +157,19 @@ def generate_unique_slug(
 def delete_versatile_image(image):
     image.delete_all_created_images()
     image.delete(save=False)
+
+
+def graphql_id(instance):
+    class_name = instance.__class__.__name__
+    if instance.id is None:
+        return None
+    return graphene.Node.to_global_id(class_name, instance.id)
+
+
+def get_id_from_graphql_id(_id):
+    if not _id:
+        return _id
+
+    values = graphene.Node.from_global_id(_id)
+    assert len(values) == 2
+    return values[1]

--- a/saleor/csv/notifications.py
+++ b/saleor/csv/notifications.py
@@ -2,7 +2,8 @@ from typing import TYPE_CHECKING
 
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
-from ..core.utils import build_absolute_uri, graphql_id
+from ..core.utils import build_absolute_uri
+from ..graphql.core.utils import to_global_id_or_none
 from ..plugins.manager import get_plugins_manager
 
 if TYPE_CHECKING:
@@ -10,14 +11,14 @@ if TYPE_CHECKING:
 
 
 def get_default_export_payload(export_file: "ExportFile") -> dict:
-    user_id = graphql_id(export_file.user) if export_file.user else None
+    user_id = to_global_id_or_none(export_file.user) if export_file.user else None
     user_email = export_file.user.email if export_file.user else None
-    app_id = graphql_id(export_file.app) if export_file.app else None
+    app_id = to_global_id_or_none(export_file.app) if export_file.app else None
     return {
         "user_id": user_id,
         "user_email": user_email,
         "app_id": app_id,
-        "id": graphql_id(export_file),
+        "id": to_global_id_or_none(export_file),
         "status": export_file.status,
         "message": export_file.message,
         "created_at": export_file.created_at,

--- a/saleor/csv/notifications.py
+++ b/saleor/csv/notifications.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
-from ..core.utils import build_absolute_uri
+from ..core.utils import build_absolute_uri, graphql_id
 from ..plugins.manager import get_plugins_manager
 
 if TYPE_CHECKING:
@@ -10,14 +10,14 @@ if TYPE_CHECKING:
 
 
 def get_default_export_payload(export_file: "ExportFile") -> dict:
-    user_id = export_file.user.id if export_file.user else None
+    user_id = graphql_id(export_file.user) if export_file.user else None
     user_email = export_file.user.email if export_file.user else None
-    app_id = export_file.app.id if export_file.app else None
+    app_id = graphql_id(export_file.app) if export_file.app else None
     return {
         "user_id": user_id,
         "user_email": user_email,
         "app_id": app_id,
-        "id": export_file.id,
+        "id": graphql_id(export_file),
         "status": export_file.status,
         "message": export_file.message,
         "created_at": export_file.created_at,

--- a/saleor/giftcard/notifications.py
+++ b/saleor/giftcard/notifications.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from ..account.notifications import get_default_user_payload
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
-from ..core.utils import graphql_id
+from ..graphql.core.utils import to_global_id_or_none
 
 if TYPE_CHECKING:
     from .models import GiftCard
@@ -24,8 +24,10 @@ def send_gift_card_notification(
     payload = {
         "gift_card": get_default_gift_card_payload(gift_card),
         "user": get_default_user_payload(customer_user) if customer_user else None,
-        "requester_user_id": graphql_id(requester_user) if requester_user else None,
-        "requester_app_id": graphql_id(app) if app else None,
+        "requester_user_id": to_global_id_or_none(requester_user)
+        if requester_user
+        else None,
+        "requester_app_id": to_global_id_or_none(app) if app else None,
         "recipient_email": email,
         "resending": resending,
         **get_site_context(),
@@ -37,7 +39,7 @@ def send_gift_card_notification(
 
 def get_default_gift_card_payload(gift_card: "GiftCard"):
     return {
-        "id": graphql_id(gift_card),
+        "id": to_global_id_or_none(gift_card),
         "code": gift_card.code,
         "balance": gift_card.current_balance_amount,
         "currency": gift_card.currency,

--- a/saleor/giftcard/notifications.py
+++ b/saleor/giftcard/notifications.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from ..account.notifications import get_default_user_payload
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
+from ..core.utils import graphql_id
 
 if TYPE_CHECKING:
     from .models import GiftCard
@@ -23,8 +24,8 @@ def send_gift_card_notification(
     payload = {
         "gift_card": get_default_gift_card_payload(gift_card),
         "user": get_default_user_payload(customer_user) if customer_user else None,
-        "requester_user_id": requester_user.id if requester_user else None,
-        "requester_app_id": app.id if app else None,
+        "requester_user_id": graphql_id(requester_user) if requester_user else None,
+        "requester_app_id": graphql_id(app) if app else None,
         "recipient_email": email,
         "resending": resending,
         **get_site_context(),
@@ -36,7 +37,7 @@ def send_gift_card_notification(
 
 def get_default_gift_card_payload(gift_card: "GiftCard"):
     return {
-        "id": gift_card.id,
+        "id": graphql_id(gift_card),
         "code": gift_card.code,
         "balance": gift_card.current_balance_amount,
         "currency": gift_card.currency,

--- a/saleor/giftcard/tests/test_notifications.py
+++ b/saleor/giftcard/tests/test_notifications.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from ...account.notifications import get_default_user_payload
 from ...core.notify_events import NotifyEventType
+from ...core.utils import graphql_id
 from ...plugins.manager import get_plugins_manager
 from ..notifications import get_default_gift_card_payload, send_gift_card_notification
 
@@ -9,7 +10,7 @@ from ..notifications import get_default_gift_card_payload, send_gift_card_notifi
 def test_get_default_gift_card_payload(gift_card):
     payload = get_default_gift_card_payload(gift_card)
     assert payload == {
-        "id": gift_card.id,
+        "id": graphql_id(gift_card),
         "code": gift_card.code,
         "balance": gift_card.current_balance_amount,
         "currency": gift_card.currency,
@@ -36,7 +37,7 @@ def test_send_gift_card_notification(
     expected_payload = {
         "gift_card": get_default_gift_card_payload(gift_card),
         "user": get_default_user_payload(customer_user) if customer_user else None,
-        "requester_user_id": staff_user.id,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
         "recipient_email": customer_user.email,
         "resending": resending,

--- a/saleor/giftcard/tests/test_notifications.py
+++ b/saleor/giftcard/tests/test_notifications.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from ...account.notifications import get_default_user_payload
 from ...core.notify_events import NotifyEventType
-from ...core.utils import graphql_id
+from ...graphql.core.utils import to_global_id_or_none
 from ...plugins.manager import get_plugins_manager
 from ..notifications import get_default_gift_card_payload, send_gift_card_notification
 
@@ -10,7 +10,7 @@ from ..notifications import get_default_gift_card_payload, send_gift_card_notifi
 def test_get_default_gift_card_payload(gift_card):
     payload = get_default_gift_card_payload(gift_card)
     assert payload == {
-        "id": graphql_id(gift_card),
+        "id": to_global_id_or_none(gift_card),
         "code": gift_card.code,
         "balance": gift_card.current_balance_amount,
         "currency": gift_card.currency,
@@ -37,7 +37,7 @@ def test_send_gift_card_notification(
     expected_payload = {
         "gift_card": get_default_gift_card_payload(gift_card),
         "user": get_default_user_payload(customer_user) if customer_user else None,
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
         "recipient_email": customer_user.email,
         "resending": resending,

--- a/saleor/graphql/core/utils/__init__.py
+++ b/saleor/graphql/core/utils/__init__.py
@@ -183,6 +183,22 @@ def from_global_id_or_error(
     return type_, id_
 
 
+def from_global_id_or_none(
+    global_id, only_type: Union[ObjectType, str] = None, raise_error: bool = False
+):
+    if not global_id:
+        return None
+
+    return from_global_id_or_error(global_id, only_type, raise_error)[1]
+
+
+def to_global_id_or_none(instance):
+    class_name = instance.__class__.__name__
+    if instance.id is None:
+        return None
+    return graphene.Node.to_global_id(class_name, instance.id)
+
+
 def add_hash_to_file_name(file):
     """Add unique text fragment to the file name to prevent file overriding."""
     file_name, format = os.path.splitext(file._name)

--- a/saleor/graphql/invoice/tests/test_send_invoice_notification.py
+++ b/saleor/graphql/invoice/tests/test_send_invoice_notification.py
@@ -4,6 +4,7 @@ import graphene
 
 from ....core import JobStatus
 from ....core.notify_events import NotifyEventType
+from ....core.utils import graphql_id
 from ....graphql.tests.utils import get_graphql_content
 from ....invoice.models import Invoice
 from ....invoice.notifications import get_invoice_payload
@@ -38,7 +39,7 @@ def test_invoice_send_notification_by_user(
     )
     content = get_graphql_content(response)
     expected_payload = {
-        "requester_user_id": staff_api_client.user.id,
+        "requester_user_id": graphql_id(staff_api_client.user),
         "requester_app_id": None,
         "invoice": get_invoice_payload(invoice),
         "recipient_email": invoice.order.get_customer_email(),
@@ -70,7 +71,7 @@ def test_invoice_send_notification_by_app(
     content = get_graphql_content(response)
     expected_payload = {
         "requester_user_id": None,
-        "requester_app_id": app_api_client.app.pk,
+        "requester_app_id": graphql_id(app_api_client.app),
         "invoice": get_invoice_payload(invoice),
         "recipient_email": invoice.order.get_customer_email(),
         "domain": "mirumee.com",

--- a/saleor/graphql/invoice/tests/test_send_invoice_notification.py
+++ b/saleor/graphql/invoice/tests/test_send_invoice_notification.py
@@ -4,11 +4,11 @@ import graphene
 
 from ....core import JobStatus
 from ....core.notify_events import NotifyEventType
-from ....core.utils import graphql_id
 from ....graphql.tests.utils import get_graphql_content
 from ....invoice.models import Invoice
 from ....invoice.notifications import get_invoice_payload
 from ....order import OrderEvents
+from ...core.utils import to_global_id_or_none
 
 INVOICE_SEND_EMAIL_MUTATION = """
     mutation invoiceSendNotification($id: ID!) {
@@ -39,7 +39,7 @@ def test_invoice_send_notification_by_user(
     )
     content = get_graphql_content(response)
     expected_payload = {
-        "requester_user_id": graphql_id(staff_api_client.user),
+        "requester_user_id": to_global_id_or_none(staff_api_client.user),
         "requester_app_id": None,
         "invoice": get_invoice_payload(invoice),
         "recipient_email": invoice.order.get_customer_email(),
@@ -71,7 +71,7 @@ def test_invoice_send_notification_by_app(
     content = get_graphql_content(response)
     expected_payload = {
         "requester_user_id": None,
-        "requester_app_id": graphql_id(app_api_client.app),
+        "requester_app_id": to_global_id_or_none(app_api_client.app),
         "invoice": get_invoice_payload(invoice),
         "recipient_email": invoice.order.get_customer_email(),
         "domain": "mirumee.com",

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -21,7 +21,6 @@ from ....core.anonymize import obfuscate_email
 from ....core.notify_events import NotifyEventType
 from ....core.prices import quantize_price
 from ....core.taxes import TaxError, zero_taxed_money
-from ....core.utils import graphql_id
 from ....discount.models import OrderDiscount
 from ....giftcard import GiftCardEvents
 from ....giftcard.events import gift_cards_bought_event, gift_cards_used_in_order_event
@@ -43,6 +42,7 @@ from ....product.models import ProductVariant, ProductVariantChannelListing
 from ....shipping.models import ShippingMethod, ShippingMethodChannelListing
 from ....warehouse.models import Allocation, PreorderAllocation, Stock, Warehouse
 from ....warehouse.tests.utils import get_available_quantity_for_stock
+from ...core.utils import to_global_id_or_none
 from ...order.mutations.orders import (
     clean_order_cancel,
     clean_order_capture,
@@ -1035,7 +1035,7 @@ def test_order_confirm(
     expected_payload = {
         "order": get_default_order_payload(order_unconfirmed, ""),
         "recipient_email": order_unconfirmed.user.email,
-        "requester_user_id": graphql_id(staff_api_client.user),
+        "requester_user_id": to_global_id_or_none(staff_api_client.user),
         "requester_app_id": None,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
@@ -1093,7 +1093,7 @@ def test_order_confirm_without_sku(
     expected_payload = {
         "order": get_default_order_payload(order_unconfirmed, ""),
         "recipient_email": order_unconfirmed.user.email,
-        "requester_user_id": graphql_id(staff_api_client.user),
+        "requester_user_id": to_global_id_or_none(staff_api_client.user),
         "requester_app_id": None,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -21,6 +21,7 @@ from ....core.anonymize import obfuscate_email
 from ....core.notify_events import NotifyEventType
 from ....core.prices import quantize_price
 from ....core.taxes import TaxError, zero_taxed_money
+from ....core.utils import graphql_id
 from ....discount.models import OrderDiscount
 from ....giftcard import GiftCardEvents
 from ....giftcard.events import gift_cards_bought_event, gift_cards_used_in_order_event
@@ -1034,7 +1035,7 @@ def test_order_confirm(
     expected_payload = {
         "order": get_default_order_payload(order_unconfirmed, ""),
         "recipient_email": order_unconfirmed.user.email,
-        "requester_user_id": staff_api_client.user.id,
+        "requester_user_id": graphql_id(staff_api_client.user),
         "requester_app_id": None,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
@@ -1092,7 +1093,7 @@ def test_order_confirm_without_sku(
     expected_payload = {
         "order": get_default_order_payload(order_unconfirmed, ""),
         "recipient_email": order_unconfirmed.user.email,
-        "requester_user_id": staff_api_client.user.id,
+        "requester_user_id": graphql_id(staff_api_client.user),
         "requester_app_id": None,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",

--- a/saleor/invoice/notifications.py
+++ b/saleor/invoice/notifications.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Optional
 
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
-from ..core.utils import graphql_id
+from ..graphql.core.utils import to_global_id_or_none
 
 if TYPE_CHECKING:
     from ..account.models import User
@@ -13,10 +13,10 @@ if TYPE_CHECKING:
 
 def get_invoice_payload(invoice):
     return {
-        "id": graphql_id(invoice),
+        "id": to_global_id_or_none(invoice),
         "number": invoice.number,
         "download_url": invoice.url,
-        "order_id": graphql_id(invoice.order),
+        "order_id": to_global_id_or_none(invoice.order),
     }
 
 
@@ -30,8 +30,8 @@ def send_invoice(
     payload = {
         "invoice": get_invoice_payload(invoice),
         "recipient_email": invoice.order.get_customer_email(),  # type: ignore
-        "requester_user_id": graphql_id(staff_user),
-        "requester_app_id": graphql_id(app) if app else None,
+        "requester_user_id": to_global_id_or_none(staff_user),
+        "requester_app_id": to_global_id_or_none(app) if app else None,
         **get_site_context(),
     }
 

--- a/saleor/invoice/notifications.py
+++ b/saleor/invoice/notifications.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Optional
 
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
+from ..core.utils import graphql_id
 
 if TYPE_CHECKING:
     from ..account.models import User
@@ -12,10 +13,10 @@ if TYPE_CHECKING:
 
 def get_invoice_payload(invoice):
     return {
-        "id": invoice.id,
+        "id": graphql_id(invoice),
         "number": invoice.number,
         "download_url": invoice.url,
-        "order_id": invoice.order_id,
+        "order_id": graphql_id(invoice.order),
     }
 
 
@@ -29,8 +30,8 @@ def send_invoice(
     payload = {
         "invoice": get_invoice_payload(invoice),
         "recipient_email": invoice.order.get_customer_email(),  # type: ignore
-        "requester_user_id": staff_user.id,
-        "requester_app_id": app.id if app else None,
+        "requester_user_id": graphql_id(staff_user),
+        "requester_app_id": graphql_id(app) if app else None,
         **get_site_context(),
     }
 

--- a/saleor/invoice/tests/test_notifications.py
+++ b/saleor/invoice/tests/test_notifications.py
@@ -1,4 +1,4 @@
-from ...core.utils import graphql_id
+from ...graphql.core.utils import to_global_id_or_none
 from ..models import Invoice
 from ..notifications import get_invoice_payload
 
@@ -8,6 +8,6 @@ def test_collect_invoice_data_for_email(order):
     url = "http://www.example.com"
     invoice = Invoice.objects.create(number=number, url=url, order=order)
     payload = get_invoice_payload(invoice)
-    assert payload["id"] == graphql_id(invoice)
+    assert payload["id"] == to_global_id_or_none(invoice)
     assert payload["number"] == number
     assert payload["download_url"] == url

--- a/saleor/invoice/tests/test_notifications.py
+++ b/saleor/invoice/tests/test_notifications.py
@@ -1,3 +1,4 @@
+from ...core.utils import graphql_id
 from ..models import Invoice
 from ..notifications import get_invoice_payload
 
@@ -7,6 +8,6 @@ def test_collect_invoice_data_for_email(order):
     url = "http://www.example.com"
     invoice = Invoice.objects.create(number=number, url=url, order=order)
     payload = get_invoice_payload(invoice)
-    assert payload["id"] == invoice.id
+    assert payload["id"] == graphql_id(invoice)
     assert payload["number"] == number
     assert payload["download_url"] == url

--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -243,7 +243,7 @@ def get_default_order_payload(order: "Order", redirect_url: str = ""):
     order_payload.update(
         {
             "id": to_global_id_or_none(order),
-            "token": to_global_id_or_none(order),
+            "token": order.id,  # DEPRECATED: will be removed in Saleor 4.0.
             "number": order.id,
             "channel_slug": order.channel.slug,
             "created": str(order.created),

--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -8,6 +8,7 @@ from ..account.models import StaffNotificationRecipient
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
 from ..core.prices import quantize_price, quantize_price_fields
+from ..core.utils import graphql_id
 from ..core.utils.url import prepare_url
 from ..discount import OrderDiscountType
 from ..product import ProductMediaTypes
@@ -69,7 +70,7 @@ def get_product_payload(product: Product):
     all_media = product.media.all()
     images = [media for media in all_media if media.type == ProductMediaTypes.IMAGE]
     return {
-        "id": product.id,
+        "id": graphql_id(product),
         "attributes": get_product_attributes(product),
         "weight": str(product.weight or ""),
         **get_default_images_payload(images),
@@ -80,7 +81,7 @@ def get_product_variant_payload(variant: ProductVariant):
     all_media = variant.media.all()
     images = [media for media in all_media if media.type == ProductMediaTypes.IMAGE]
     return {
-        "id": variant.id,
+        "id": graphql_id(variant),
         "weight": str(variant.weight or ""),
         "is_preorder": variant.is_preorder_active(),
         "preorder_global_threshold": variant.preorder_global_threshold,
@@ -103,7 +104,7 @@ def get_order_line_payload(line: "OrderLine"):
     currency = line.currency
 
     return {
-        "id": line.id,
+        "id": graphql_id(line),
         "product": variant_dependent_fields.get("product"),  # type: ignore
         "product_name": line.product_name,
         "translated_product_name": line.translated_product_name or line.product_name,
@@ -241,9 +242,9 @@ def get_default_order_payload(order: "Order", redirect_url: str = ""):
     order_payload = model_to_dict(order, fields=ORDER_MODEL_FIELDS)
     order_payload.update(
         {
-            "id": order.id,
-            "token": order.id,  # DEPRECATED: will be removed in Saleor 4.0.
-            "number": order.number,
+            "id": graphql_id(order),
+            "token": graphql_id(order),
+            "number": graphql_id(order),
             "channel_slug": order.channel.slug,
             "created": str(order.created),
             "shipping_price_net_amount": order.shipping_price_net_amount,
@@ -266,7 +267,7 @@ def get_default_order_payload(order: "Order", redirect_url: str = ""):
 
 def get_default_fulfillment_line_payload(line: "FulfillmentLine"):
     return {
-        "id": line.id,
+        "id": graphql_id(line),
         "order_line": get_order_line_payload(line.order_line),
         "quantity": line.quantity,
     }
@@ -427,5 +428,5 @@ def send_order_refunded_confirmation(
 def attach_requester_payload_data(
     payload: dict, user: Optional["User"], app: Optional["App"]
 ):
-    payload["requester_user_id"] = user.id if user else None
-    payload["requester_app_id"] = app.id if app else None
+    payload["requester_user_id"] = graphql_id(user) if user else None
+    payload["requester_app_id"] = graphql_id(app) if app else None

--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -243,8 +243,8 @@ def get_default_order_payload(order: "Order", redirect_url: str = ""):
     order_payload.update(
         {
             "id": to_global_id_or_none(order),
-            "token": to_global_id_or_none(order), # DEPRECATED: will be removed in Saleor 4.0.
-            "number": to_global_id_or_none(order),
+            "token": to_global_id_or_none(order),
+            "number": order.id,
             "channel_slug": order.channel.slug,
             "created": str(order.created),
             "shipping_price_net_amount": order.shipping_price_net_amount,

--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -8,9 +8,9 @@ from ..account.models import StaffNotificationRecipient
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
 from ..core.prices import quantize_price, quantize_price_fields
-from ..core.utils import graphql_id
 from ..core.utils.url import prepare_url
 from ..discount import OrderDiscountType
+from ..graphql.core.utils import to_global_id_or_none
 from ..product import ProductMediaTypes
 from ..product.models import DigitalContentUrl, Product, ProductMedia, ProductVariant
 from ..product.product_images import AVAILABLE_PRODUCT_SIZES, get_thumbnail
@@ -70,7 +70,7 @@ def get_product_payload(product: Product):
     all_media = product.media.all()
     images = [media for media in all_media if media.type == ProductMediaTypes.IMAGE]
     return {
-        "id": graphql_id(product),
+        "id": to_global_id_or_none(product),
         "attributes": get_product_attributes(product),
         "weight": str(product.weight or ""),
         **get_default_images_payload(images),
@@ -81,7 +81,7 @@ def get_product_variant_payload(variant: ProductVariant):
     all_media = variant.media.all()
     images = [media for media in all_media if media.type == ProductMediaTypes.IMAGE]
     return {
-        "id": graphql_id(variant),
+        "id": to_global_id_or_none(variant),
         "weight": str(variant.weight or ""),
         "is_preorder": variant.is_preorder_active(),
         "preorder_global_threshold": variant.preorder_global_threshold,
@@ -104,7 +104,7 @@ def get_order_line_payload(line: "OrderLine"):
     currency = line.currency
 
     return {
-        "id": graphql_id(line),
+        "id": to_global_id_or_none(line),
         "product": variant_dependent_fields.get("product"),  # type: ignore
         "product_name": line.product_name,
         "translated_product_name": line.translated_product_name or line.product_name,
@@ -242,9 +242,9 @@ def get_default_order_payload(order: "Order", redirect_url: str = ""):
     order_payload = model_to_dict(order, fields=ORDER_MODEL_FIELDS)
     order_payload.update(
         {
-            "id": graphql_id(order),
-            "token": graphql_id(order),
-            "number": graphql_id(order),
+            "id": to_global_id_or_none(order),
+            "token": to_global_id_or_none(order), # DEPRECATED: will be removed in Saleor 4.0.
+            "number": to_global_id_or_none(order),
             "channel_slug": order.channel.slug,
             "created": str(order.created),
             "shipping_price_net_amount": order.shipping_price_net_amount,
@@ -267,7 +267,7 @@ def get_default_order_payload(order: "Order", redirect_url: str = ""):
 
 def get_default_fulfillment_line_payload(line: "FulfillmentLine"):
     return {
-        "id": graphql_id(line),
+        "id": to_global_id_or_none(line),
         "order_line": get_order_line_payload(line.order_line),
         "quantity": line.quantity,
     }
@@ -428,5 +428,5 @@ def send_order_refunded_confirmation(
 def attach_requester_payload_data(
     payload: dict, user: Optional["User"], app: Optional["App"]
 ):
-    payload["requester_user_id"] = graphql_id(user) if user else None
-    payload["requester_app_id"] = graphql_id(app) if app else None
+    payload["requester_user_id"] = to_global_id_or_none(user) if user else None
+    payload["requester_app_id"] = to_global_id_or_none(app) if app else None

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -29,7 +29,7 @@ def test_get_custom_order_payload(order):
     assert expected_payload == {
         "order": {
             "id": to_global_id_or_none(order),
-            "number": to_global_id_or_none(order),
+            "number": order.id,
             "private_metadata": {},
             "metadata": {},
             "status": "unfulfilled",
@@ -237,7 +237,7 @@ def test_get_default_order_payload(order_line):
         ],
         "channel_slug": order.channel.slug,
         "id": to_global_id_or_none(order),
-        "number": to_global_id_or_none(order),
+        "number": order.id,
         "token": order.token,
         "created": str(order.created),
         "display_gross_prices": order.display_gross_prices,

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -7,8 +7,8 @@ from prices import Money, fixed_discount
 
 from ...core.notify_events import NotifyEventType
 from ...core.prices import quantize_price
-from ...core.utils import graphql_id
 from ...discount import DiscountValueType
+from ...graphql.core.utils import to_global_id_or_none
 from ...order import notifications
 from ...order.fetch import fetch_order_info
 from ...plugins.manager import get_plugins_manager
@@ -28,8 +28,8 @@ def test_get_custom_order_payload(order):
     expected_payload = get_custom_order_payload(order)
     assert expected_payload == {
         "order": {
-            "id": graphql_id(order),
-            "number": graphql_id(order),
+            "id": to_global_id_or_none(order),
+            "number": to_global_id_or_none(order),
             "private_metadata": {},
             "metadata": {},
             "status": "unfulfilled",
@@ -126,7 +126,7 @@ def test_get_order_line_payload(order_line):
     currency = order_line.currency
     assert payload == {
         "variant": {
-            "id": graphql_id(order_line.variant),
+            "id": to_global_id_or_none(order_line.variant),
             "first_image": None,
             "images": None,
             "weight": "",
@@ -139,17 +139,17 @@ def test_get_order_line_payload(order_line):
             "first_image": None,
             "images": None,
             "weight": "5.0 kg",
-            "id": graphql_id(order_line.variant.product),
+            "id": to_global_id_or_none(order_line.variant.product),
         },
         "translated_product_name": order_line.translated_product_name
         or order_line.product_name,
         "translated_variant_name": order_line.translated_variant_name
         or order_line.variant_name,
-        "id": graphql_id(order_line),
+        "id": to_global_id_or_none(order_line),
         "product_name": order_line.product_name,
         "variant_name": order_line.variant_name,
         "product_sku": order_line.product_sku,
-        "product_variant_id": graphql_id(order_line.variant),
+        "product_variant_id": to_global_id_or_none(order_line.variant),
         "is_shipping_required": order_line.is_shipping_required,
         "quantity": order_line.quantity,
         "quantity_fulfilled": order_line.quantity_fulfilled,
@@ -236,9 +236,9 @@ def test_get_default_order_payload(order_line):
             }
         ],
         "channel_slug": order.channel.slug,
-        "id": graphql_id(order),
-        "number": graphql_id(order),
-        "token": order.id,
+        "id": to_global_id_or_none(order),
+        "number": to_global_id_or_none(order),
+        "token": order.token,
         "created": str(order.created),
         "display_gross_prices": order.display_gross_prices,
         "currency": order.currency,
@@ -487,7 +487,7 @@ def test_send_fulfillment_confirmation_by_user(
     )
 
     expected_payload = get_default_fulfillment_payload(fulfilled_order, fulfillment)
-    expected_payload["requester_user_id"] = graphql_id(staff_user)
+    expected_payload["requester_user_id"] = to_global_id_or_none(staff_user)
     expected_payload["requester_app_id"] = None
     mocked_notify.assert_called_once_with(
         NotifyEventType.ORDER_FULFILLMENT_CONFIRMATION,
@@ -515,7 +515,7 @@ def test_send_fulfillment_confirmation_by_app(
 
     expected_payload = get_default_fulfillment_payload(fulfilled_order, fulfillment)
     expected_payload["requester_user_id"] = None
-    expected_payload["requester_app_id"] = graphql_id(app)
+    expected_payload["requester_app_id"] = to_global_id_or_none(app)
     mocked_notify.assert_called_once_with(
         NotifyEventType.ORDER_FULFILLMENT_CONFIRMATION,
         payload=expected_payload,
@@ -559,7 +559,7 @@ def test_send_email_order_canceled_by_user(
         "recipient_email": order.get_customer_email(),
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
     }
     mocked_notify.assert_called_once_with(
@@ -584,7 +584,7 @@ def test_send_email_order_canceled_by_app(mocked_notify, order, site_settings, a
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
         "requester_user_id": None,
-        "requester_app_id": graphql_id(app),
+        "requester_app_id": to_global_id_or_none(app),
     }
     mocked_notify.assert_called_once_with(
         NotifyEventType.ORDER_CANCELED,
@@ -608,7 +608,7 @@ def test_send_email_order_refunded_by_user(
 
     # then
     expected_payload = {
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
         "order": get_default_order_payload(order),
         "amount": amount,
@@ -639,7 +639,7 @@ def test_send_email_order_refunded_by_app(mocked_notify, order, site_settings, a
     # then
     expected_payload = {
         "requester_user_id": None,
-        "requester_app_id": graphql_id(app),
+        "requester_app_id": to_global_id_or_none(app),
         "order": get_default_order_payload(order),
         "amount": amount,
         "currency": order.currency,

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -238,7 +238,7 @@ def test_get_default_order_payload(order_line):
         "channel_slug": order.channel.slug,
         "id": to_global_id_or_none(order),
         "number": order.id,
-        "token": order.token,
+        "token": order.id,
         "created": str(order.created),
         "display_gross_prices": order.display_gross_prices,
         "currency": order.currency,

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -7,6 +7,7 @@ from prices import Money, fixed_discount
 
 from ...core.notify_events import NotifyEventType
 from ...core.prices import quantize_price
+from ...core.utils import graphql_id
 from ...discount import DiscountValueType
 from ...order import notifications
 from ...order.fetch import fetch_order_info
@@ -27,8 +28,8 @@ def test_get_custom_order_payload(order):
     expected_payload = get_custom_order_payload(order)
     assert expected_payload == {
         "order": {
-            "id": expected_payload["order"]["id"],
-            "number": expected_payload["order"]["number"],
+            "id": graphql_id(order),
+            "number": graphql_id(order),
             "private_metadata": {},
             "metadata": {},
             "status": "unfulfilled",
@@ -125,7 +126,7 @@ def test_get_order_line_payload(order_line):
     currency = order_line.currency
     assert payload == {
         "variant": {
-            "id": order_line.variant_id,
+            "id": graphql_id(order_line.variant),
             "first_image": None,
             "images": None,
             "weight": "",
@@ -138,17 +139,17 @@ def test_get_order_line_payload(order_line):
             "first_image": None,
             "images": None,
             "weight": "5.0 kg",
-            "id": order_line.variant.product.id,
+            "id": graphql_id(order_line.variant.product),
         },
         "translated_product_name": order_line.translated_product_name
         or order_line.product_name,
         "translated_variant_name": order_line.translated_variant_name
         or order_line.variant_name,
-        "id": order_line.id,
+        "id": graphql_id(order_line),
         "product_name": order_line.product_name,
         "variant_name": order_line.variant_name,
         "product_sku": order_line.product_sku,
-        "product_variant_id": order_line.product_variant_id,
+        "product_variant_id": graphql_id(order_line.variant),
         "is_shipping_required": order_line.is_shipping_required,
         "quantity": order_line.quantity,
         "quantity_fulfilled": order_line.quantity_fulfilled,
@@ -235,8 +236,8 @@ def test_get_default_order_payload(order_line):
             }
         ],
         "channel_slug": order.channel.slug,
-        "id": order.id,
-        "number": order.number,
+        "id": graphql_id(order),
+        "number": graphql_id(order),
         "token": order.id,
         "created": str(order.created),
         "display_gross_prices": order.display_gross_prices,
@@ -486,7 +487,7 @@ def test_send_fulfillment_confirmation_by_user(
     )
 
     expected_payload = get_default_fulfillment_payload(fulfilled_order, fulfillment)
-    expected_payload["requester_user_id"] = staff_user.id
+    expected_payload["requester_user_id"] = graphql_id(staff_user)
     expected_payload["requester_app_id"] = None
     mocked_notify.assert_called_once_with(
         NotifyEventType.ORDER_FULFILLMENT_CONFIRMATION,
@@ -514,7 +515,7 @@ def test_send_fulfillment_confirmation_by_app(
 
     expected_payload = get_default_fulfillment_payload(fulfilled_order, fulfillment)
     expected_payload["requester_user_id"] = None
-    expected_payload["requester_app_id"] = app.id
+    expected_payload["requester_app_id"] = graphql_id(app)
     mocked_notify.assert_called_once_with(
         NotifyEventType.ORDER_FULFILLMENT_CONFIRMATION,
         payload=expected_payload,
@@ -558,7 +559,7 @@ def test_send_email_order_canceled_by_user(
         "recipient_email": order.get_customer_email(),
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
-        "requester_user_id": staff_user.id,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
     }
     mocked_notify.assert_called_once_with(
@@ -583,7 +584,7 @@ def test_send_email_order_canceled_by_app(mocked_notify, order, site_settings, a
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
         "requester_user_id": None,
-        "requester_app_id": app.id,
+        "requester_app_id": graphql_id(app),
     }
     mocked_notify.assert_called_once_with(
         NotifyEventType.ORDER_CANCELED,
@@ -607,7 +608,7 @@ def test_send_email_order_refunded_by_user(
 
     # then
     expected_payload = {
-        "requester_user_id": staff_user.id,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
         "order": get_default_order_payload(order),
         "amount": amount,
@@ -638,7 +639,7 @@ def test_send_email_order_refunded_by_app(mocked_notify, order, site_settings, a
     # then
     expected_payload = {
         "requester_user_id": None,
-        "requester_app_id": app.id,
+        "requester_app_id": graphql_id(app),
         "order": get_default_order_payload(order),
         "amount": amount,
         "currency": order.currency,

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -5,7 +5,6 @@ import graphene
 import pytest
 from prices import Money, TaxedMoney
 
-from ...core.utils import graphql_id
 from ...core.weight import zero_weight
 from ...discount import OrderDiscountType
 from ...discount.models import (
@@ -16,6 +15,7 @@ from ...discount.models import (
     VoucherType,
 )
 from ...discount.utils import validate_voucher_in_order
+from ...graphql.core.utils import to_global_id_or_none
 from ...graphql.tests.utils import get_graphql_content
 from ...order.interface import OrderTaxedPricesData
 from ...payment import ChargeStatus
@@ -1070,7 +1070,7 @@ def test_send_fulfillment_order_lines_mails_by_user(
         order=order, fulfillment=fulfillment, user=staff_user, app=None, manager=manager
     )
     expected_payload = get_default_fulfillment_payload(order, fulfillment)
-    expected_payload["requester_user_id"] = graphql_id(staff_user)
+    expected_payload["requester_user_id"] = to_global_id_or_none(staff_user)
     expected_payload["requester_app_id"] = None
     mocked_notify.assert_called_once_with(
         "order_fulfillment_confirmation",
@@ -1115,7 +1115,7 @@ def test_send_fulfillment_order_lines_mails_by_app(
     )
     expected_payload = get_default_fulfillment_payload(order, fulfillment)
     expected_payload["requester_user_id"] = None
-    expected_payload["requester_app_id"] = graphql_id(app)
+    expected_payload["requester_app_id"] = to_global_id_or_none(app)
     mocked_notify.assert_called_once_with(
         "order_fulfillment_confirmation",
         payload=expected_payload,

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -5,6 +5,7 @@ import graphene
 import pytest
 from prices import Money, TaxedMoney
 
+from ...core.utils import graphql_id
 from ...core.weight import zero_weight
 from ...discount import OrderDiscountType
 from ...discount.models import (
@@ -1069,7 +1070,7 @@ def test_send_fulfillment_order_lines_mails_by_user(
         order=order, fulfillment=fulfillment, user=staff_user, app=None, manager=manager
     )
     expected_payload = get_default_fulfillment_payload(order, fulfillment)
-    expected_payload["requester_user_id"] = staff_user.id
+    expected_payload["requester_user_id"] = graphql_id(staff_user)
     expected_payload["requester_app_id"] = None
     mocked_notify.assert_called_once_with(
         "order_fulfillment_confirmation",
@@ -1114,7 +1115,7 @@ def test_send_fulfillment_order_lines_mails_by_app(
     )
     expected_payload = get_default_fulfillment_payload(order, fulfillment)
     expected_payload["requester_user_id"] = None
-    expected_payload["requester_app_id"] = app.id
+    expected_payload["requester_app_id"] = graphql_id(app)
     mocked_notify.assert_called_once_with(
         "order_fulfillment_confirmation",
         payload=expected_payload,

--- a/saleor/plugins/admin_email/tasks.py
+++ b/saleor/plugins/admin_email/tasks.py
@@ -1,6 +1,6 @@
 from ...celeryconf import app
-from ...core.utils import get_id_from_graphql_id
 from ...csv.events import export_failed_info_sent_event, export_file_sent_event
+from ...graphql.core.utils import from_global_id_or_none
 from ..email_common import EmailConfig, send_email
 
 
@@ -31,8 +31,8 @@ def send_email_with_link_to_download_file_task(
         context=payload,
     )
     export_file_sent_event(
-        export_file_id=get_id_from_graphql_id(payload["export"]["id"]),
-        user_id=get_id_from_graphql_id(payload["export"].get("user_id")),
+        export_file_id=from_global_id_or_none(payload["export"]["id"]),
+        user_id=from_global_id_or_none(payload["export"].get("user_id")),
     )
 
 
@@ -49,8 +49,8 @@ def send_export_failed_email_task(
         context=payload,
     )
     export_failed_info_sent_event(
-        export_file_id=get_id_from_graphql_id(payload["export"]["id"]),
-        user_id=get_id_from_graphql_id(payload["export"].get("user_id")),
+        export_file_id=from_global_id_or_none(payload["export"]["id"]),
+        user_id=from_global_id_or_none(payload["export"].get("user_id")),
     )
 
 

--- a/saleor/plugins/admin_email/tasks.py
+++ b/saleor/plugins/admin_email/tasks.py
@@ -1,4 +1,5 @@
 from ...celeryconf import app
+from ...core.utils import get_id_from_graphql_id
 from ...csv.events import export_failed_info_sent_event, export_file_sent_event
 from ..email_common import EmailConfig, send_email
 
@@ -30,7 +31,8 @@ def send_email_with_link_to_download_file_task(
         context=payload,
     )
     export_file_sent_event(
-        export_file_id=payload["export"]["id"], user_id=payload["export"].get("user_id")
+        export_file_id=get_id_from_graphql_id(payload["export"]["id"]),
+        user_id=get_id_from_graphql_id(payload["export"].get("user_id")),
     )
 
 
@@ -47,7 +49,8 @@ def send_export_failed_email_task(
         context=payload,
     )
     export_failed_info_sent_event(
-        export_file_id=payload["export"]["id"], user_id=payload["export"].get("user_id")
+        export_file_id=get_id_from_graphql_id(payload["export"]["id"]),
+        user_id=get_id_from_graphql_id(payload["export"].get("user_id")),
     )
 
 

--- a/saleor/plugins/sendgrid/tasks.py
+++ b/saleor/plugins/sendgrid/tasks.py
@@ -5,8 +5,8 @@ from sendgrid.helpers.mail import Mail
 
 from ...account import events as account_events
 from ...celeryconf import app
-from ...core.utils import get_id_from_graphql_id
 from ...giftcard import events as gift_card_events
+from ...graphql.core.utils import from_global_id_or_none
 from ...invoice import events as invoice_events
 from ...order import events as order_events
 from . import SendgridConfiguration
@@ -52,7 +52,7 @@ def send_password_reset_email_task(payload: dict, configuration: dict):
     configuration = SendgridConfiguration(**configuration)
     user_id = payload.get("user", {}).get("id")
 
-    user_id = get_id_from_graphql_id(user_id)
+    user_id = from_global_id_or_none(user_id)
     send_email(
         configuration=configuration,
         template_id=configuration.account_password_reset_template_id,
@@ -76,7 +76,7 @@ def send_request_email_change_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     account_events.customer_email_change_request_event(
-        user_id=get_id_from_graphql_id(user_id),
+        user_id=from_global_id_or_none(user_id),
         parameters={
             "old_email": payload.get("old_email"),
             "new_email": payload["recipient_email"],
@@ -104,7 +104,7 @@ def send_user_change_email_notification_task(payload: dict, configuration: dict)
     }
 
     account_events.customer_email_changed_event(
-        user_id=get_id_from_graphql_id(user_id), parameters=event_parameters
+        user_id=from_global_id_or_none(user_id), parameters=event_parameters
     )
 
 
@@ -181,8 +181,8 @@ def send_order_confirmation_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     order_events.event_order_confirmation_notification(
-        order_id=get_id_from_graphql_id(payload["order"]["id"]),
-        user_id=get_id_from_graphql_id(payload["order"].get("user_id")),
+        order_id=from_global_id_or_none(payload["order"]["id"]),
+        user_id=from_global_id_or_none(payload["order"].get("user_id")),
         customer_email=payload["recipient_email"],
     )
 
@@ -201,17 +201,17 @@ def send_fulfillment_confirmation_email_task(payload: dict, configuration: dict)
         payload=payload,
     )
     order_events.event_fulfillment_confirmed_notification(
-        order_id=get_id_from_graphql_id(payload["order"]["id"]),
-        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
-        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+        order_id=from_global_id_or_none(payload["order"]["id"]),
+        user_id=from_global_id_or_none(payload["requester_user_id"]),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
         customer_email=payload["recipient_email"],
     )
 
     if payload.get("digital_lines"):
         order_events.event_fulfillment_digital_links_notification(
-            order_id=get_id_from_graphql_id(payload["order"]["id"]),
-            user_id=get_id_from_graphql_id(payload["requester_user_id"]),
-            app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+            order_id=from_global_id_or_none(payload["order"]["id"]),
+            user_id=from_global_id_or_none(payload["requester_user_id"]),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
             customer_email=payload["recipient_email"],
         )
 
@@ -245,8 +245,8 @@ def send_payment_confirmation_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     order_events.event_payment_confirmed_notification(
-        order_id=get_id_from_graphql_id(payload["order"]["id"]),
-        user_id=get_id_from_graphql_id(payload["order"].get("user_id")),
+        order_id=from_global_id_or_none(payload["order"]["id"]),
+        user_id=from_global_id_or_none(payload["order"].get("user_id")),
         customer_email=payload["recipient_email"],
     )
 
@@ -265,9 +265,9 @@ def send_order_canceled_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     order_events.event_order_cancelled_notification(
-        order_id=get_id_from_graphql_id(payload["order"]["id"]),
-        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
-        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+        order_id=from_global_id_or_none(payload["order"]["id"]),
+        user_id=from_global_id_or_none(payload["requester_user_id"]),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
         customer_email=payload["recipient_email"],
     )
 
@@ -286,9 +286,9 @@ def send_order_refund_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     order_events.event_order_refunded_notification(
-        order_id=get_id_from_graphql_id(payload["order"]["id"]),
-        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
-        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+        order_id=from_global_id_or_none(payload["order"]["id"]),
+        user_id=from_global_id_or_none(payload["requester_user_id"]),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
         customer_email=payload["recipient_email"],
     )
 
@@ -307,9 +307,9 @@ def send_gift_card_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     email_data = {
-        "gift_card_id": get_id_from_graphql_id(payload["gift_card"]["id"]),
-        "user_id": get_id_from_graphql_id(payload["requester_user_id"]),
-        "app_id": get_id_from_graphql_id(payload["requester_app_id"]),
+        "gift_card_id": from_global_id_or_none(payload["gift_card"]["id"]),
+        "user_id": from_global_id_or_none(payload["requester_user_id"]),
+        "app_id": from_global_id_or_none(payload["requester_app_id"]),
         "email": payload["recipient_email"],
     }
     if payload["resending"] is True:
@@ -332,9 +332,9 @@ def send_order_confirmed_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     order_events.event_order_confirmed_notification(
-        order_id=get_id_from_graphql_id(payload.get("order", {}).get("id")),
-        user_id=get_id_from_graphql_id(payload.get("requester_user_id")),
-        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+        order_id=from_global_id_or_none(payload.get("order", {}).get("id")),
+        user_id=from_global_id_or_none(payload.get("requester_user_id")),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
         customer_email=payload["recipient_email"],
     )
 

--- a/saleor/plugins/sendgrid/tasks.py
+++ b/saleor/plugins/sendgrid/tasks.py
@@ -5,6 +5,7 @@ from sendgrid.helpers.mail import Mail
 
 from ...account import events as account_events
 from ...celeryconf import app
+from ...core.utils import get_id_from_graphql_id
 from ...giftcard import events as gift_card_events
 from ...invoice import events as invoice_events
 from ...order import events as order_events
@@ -50,6 +51,8 @@ def send_account_confirmation_email_task(payload: dict, configuration: dict):
 def send_password_reset_email_task(payload: dict, configuration: dict):
     configuration = SendgridConfiguration(**configuration)
     user_id = payload.get("user", {}).get("id")
+
+    user_id = get_id_from_graphql_id(user_id)
     send_email(
         configuration=configuration,
         template_id=configuration.account_password_reset_template_id,
@@ -73,7 +76,7 @@ def send_request_email_change_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     account_events.customer_email_change_request_event(
-        user_id=user_id,
+        user_id=get_id_from_graphql_id(user_id),
         parameters={
             "old_email": payload.get("old_email"),
             "new_email": payload["recipient_email"],
@@ -101,7 +104,7 @@ def send_user_change_email_notification_task(payload: dict, configuration: dict)
     }
 
     account_events.customer_email_changed_event(
-        user_id=user_id, parameters=event_parameters
+        user_id=get_id_from_graphql_id(user_id), parameters=event_parameters
     )
 
 
@@ -178,8 +181,8 @@ def send_order_confirmation_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     order_events.event_order_confirmation_notification(
-        order_id=payload["order"]["id"],
-        user_id=payload["order"].get("user_id"),
+        order_id=get_id_from_graphql_id(payload["order"]["id"]),
+        user_id=get_id_from_graphql_id(payload["order"].get("user_id")),
         customer_email=payload["recipient_email"],
     )
 
@@ -198,17 +201,17 @@ def send_fulfillment_confirmation_email_task(payload: dict, configuration: dict)
         payload=payload,
     )
     order_events.event_fulfillment_confirmed_notification(
-        order_id=payload["order"]["id"],
-        user_id=payload["requester_user_id"],
-        app_id=payload["requester_app_id"],
+        order_id=get_id_from_graphql_id(payload["order"]["id"]),
+        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
+        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
         customer_email=payload["recipient_email"],
     )
 
     if payload.get("digital_lines"):
         order_events.event_fulfillment_digital_links_notification(
-            order_id=payload["order"]["id"],
-            user_id=payload["requester_user_id"],
-            app_id=payload["requester_app_id"],
+            order_id=get_id_from_graphql_id(payload["order"]["id"]),
+            user_id=get_id_from_graphql_id(payload["requester_user_id"]),
+            app_id=get_id_from_graphql_id(payload["requester_app_id"]),
             customer_email=payload["recipient_email"],
         )
 
@@ -242,8 +245,8 @@ def send_payment_confirmation_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     order_events.event_payment_confirmed_notification(
-        order_id=payload["order"]["id"],
-        user_id=payload["order"].get("user_id"),
+        order_id=get_id_from_graphql_id(payload["order"]["id"]),
+        user_id=get_id_from_graphql_id(payload["order"].get("user_id")),
         customer_email=payload["recipient_email"],
     )
 
@@ -262,9 +265,9 @@ def send_order_canceled_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     order_events.event_order_cancelled_notification(
-        order_id=payload["order"]["id"],
-        user_id=payload["requester_user_id"],
-        app_id=payload["requester_app_id"],
+        order_id=get_id_from_graphql_id(payload["order"]["id"]),
+        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
+        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
         customer_email=payload["recipient_email"],
     )
 
@@ -283,9 +286,9 @@ def send_order_refund_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     order_events.event_order_refunded_notification(
-        order_id=payload["order"]["id"],
-        user_id=payload["requester_user_id"],
-        app_id=payload["requester_app_id"],
+        order_id=get_id_from_graphql_id(payload["order"]["id"]),
+        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
+        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
         customer_email=payload["recipient_email"],
     )
 
@@ -304,9 +307,9 @@ def send_gift_card_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     email_data = {
-        "gift_card_id": payload["gift_card"]["id"],
-        "user_id": payload["requester_user_id"],
-        "app_id": payload["requester_app_id"],
+        "gift_card_id": get_id_from_graphql_id(payload["gift_card"]["id"]),
+        "user_id": get_id_from_graphql_id(payload["requester_user_id"]),
+        "app_id": get_id_from_graphql_id(payload["requester_app_id"]),
         "email": payload["recipient_email"],
     }
     if payload["resending"] is True:
@@ -329,9 +332,9 @@ def send_order_confirmed_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     order_events.event_order_confirmed_notification(
-        order_id=payload.get("order", {}).get("id"),
-        user_id=payload.get("requester_user_id"),
-        app_id=payload["requester_app_id"],
+        order_id=get_id_from_graphql_id(payload.get("order", {}).get("id")),
+        user_id=get_id_from_graphql_id(payload.get("requester_user_id")),
+        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
         customer_email=payload["recipient_email"],
     )
 

--- a/saleor/plugins/sendgrid/tests/test_tasks.py
+++ b/saleor/plugins/sendgrid/tests/test_tasks.py
@@ -6,9 +6,9 @@ import pytest
 from ....account import CustomerEvents
 from ....account.models import CustomerEvent
 from ....account.notifications import get_default_user_payload
-from ....core.utils import graphql_id
 from ....giftcard import GiftCardEvents
 from ....giftcard.models import GiftCardEvent
+from ....graphql.core.utils import to_global_id_or_none
 from ....invoice import InvoiceEvents
 from ....invoice.models import Invoice, InvoiceEvent
 from ....order import OrderEvents, OrderEventsEmails
@@ -429,7 +429,7 @@ def test_send_fulfillment_confirmation_email_task_by_user(
     template_id = "ABC1"
 
     payload = get_default_fulfillment_payload(order, fulfillment)
-    payload["requester_user_id"] = graphql_id(staff_user)
+    payload["requester_user_id"] = to_global_id_or_none(staff_user)
     payload["requester_app_id"] = None
 
     plugin = sendgrid_email_plugin(
@@ -465,7 +465,7 @@ def test_send_fulfillment_confirmation_email_task_by_app(
 
     payload = get_default_fulfillment_payload(order, fulfillment)
     payload["requester_user_id"] = None
-    payload["requester_app_id"] = graphql_id(app)
+    payload["requester_app_id"] = to_global_id_or_none(app)
 
     plugin = sendgrid_email_plugin(
         api_key="A12",
@@ -573,7 +573,7 @@ def test_send_order_canceled_email_task_by_user(
         "recipient_email": recipient_email,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
     }
 
@@ -615,7 +615,7 @@ def test_send_order_canceled_email_task_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": graphql_id(app),
+        "requester_app_id": to_global_id_or_none(app),
     }
 
     plugin = sendgrid_email_plugin(
@@ -657,7 +657,7 @@ def test_send_order_refund_email_task_by_user(
         "currency": order.currency,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
     }
 
@@ -701,7 +701,7 @@ def test_send_order_refund_email_task_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": graphql_id(app),
+        "requester_app_id": to_global_id_or_none(app),
     }
 
     plugin = sendgrid_email_plugin(
@@ -738,12 +738,12 @@ def test_send_gift_card_email_task_by_user(
 
     payload = {
         "user": get_default_user_payload(staff_user),
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
         "recipient_email": recipient_email,
         "resending": False,
         "gift_card": {
-            "id": graphql_id(gift_card),
+            "id": to_global_id_or_none(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,
@@ -783,12 +783,12 @@ def test_send_gift_card_email_task_by_user_resending(
 
     payload = {
         "user": get_default_user_payload(staff_user),
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
         "recipient_email": recipient_email,
         "resending": True,
         "gift_card": {
-            "id": graphql_id(gift_card),
+            "id": to_global_id_or_none(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,
@@ -829,11 +829,11 @@ def test_send_gift_card_email_task_by_app(
     payload = {
         "user": None,
         "requester_user_id": None,
-        "requester_app_id": graphql_id(app),
+        "requester_app_id": to_global_id_or_none(app),
         "recipient_email": recipient_email,
         "resending": False,
         "gift_card": {
-            "id": graphql_id(gift_card),
+            "id": to_global_id_or_none(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,
@@ -878,7 +878,7 @@ def test_send_order_confirmed_email_task_by_user(
         "currency": order.currency,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
     }
 
@@ -922,7 +922,7 @@ def test_send_order_confirmed_email_task_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": graphql_id(app),
+        "requester_app_id": to_global_id_or_none(app),
     }
 
     plugin = sendgrid_email_plugin(

--- a/saleor/plugins/sendgrid/tests/test_tasks.py
+++ b/saleor/plugins/sendgrid/tests/test_tasks.py
@@ -6,6 +6,7 @@ import pytest
 from ....account import CustomerEvents
 from ....account.models import CustomerEvent
 from ....account.notifications import get_default_user_payload
+from ....core.utils import graphql_id
 from ....giftcard import GiftCardEvents
 from ....giftcard.models import GiftCardEvent
 from ....invoice import InvoiceEvents
@@ -428,7 +429,7 @@ def test_send_fulfillment_confirmation_email_task_by_user(
     template_id = "ABC1"
 
     payload = get_default_fulfillment_payload(order, fulfillment)
-    payload["requester_user_id"] = staff_user.pk
+    payload["requester_user_id"] = graphql_id(staff_user)
     payload["requester_app_id"] = None
 
     plugin = sendgrid_email_plugin(
@@ -464,7 +465,7 @@ def test_send_fulfillment_confirmation_email_task_by_app(
 
     payload = get_default_fulfillment_payload(order, fulfillment)
     payload["requester_user_id"] = None
-    payload["requester_app_id"] = app.pk
+    payload["requester_app_id"] = graphql_id(app)
 
     plugin = sendgrid_email_plugin(
         api_key="A12",
@@ -572,7 +573,7 @@ def test_send_order_canceled_email_task_by_user(
         "recipient_email": recipient_email,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": staff_user.pk,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
     }
 
@@ -614,7 +615,7 @@ def test_send_order_canceled_email_task_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": app.pk,
+        "requester_app_id": graphql_id(app),
     }
 
     plugin = sendgrid_email_plugin(
@@ -656,7 +657,7 @@ def test_send_order_refund_email_task_by_user(
         "currency": order.currency,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": staff_user.pk,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
     }
 
@@ -700,7 +701,7 @@ def test_send_order_refund_email_task_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": app.pk,
+        "requester_app_id": graphql_id(app),
     }
 
     plugin = sendgrid_email_plugin(
@@ -737,13 +738,12 @@ def test_send_gift_card_email_task_by_user(
 
     payload = {
         "user": get_default_user_payload(staff_user),
-        "requester_user_id": staff_user.id,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
         "recipient_email": recipient_email,
         "resending": False,
-        "recipient_email": recipient_email,
         "gift_card": {
-            "id": gift_card.id,
+            "id": graphql_id(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,
@@ -783,13 +783,12 @@ def test_send_gift_card_email_task_by_user_resending(
 
     payload = {
         "user": get_default_user_payload(staff_user),
-        "requester_user_id": staff_user.id,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
         "recipient_email": recipient_email,
         "resending": True,
-        "recipient_email": recipient_email,
         "gift_card": {
-            "id": gift_card.id,
+            "id": graphql_id(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,
@@ -830,17 +829,15 @@ def test_send_gift_card_email_task_by_app(
     payload = {
         "user": None,
         "requester_user_id": None,
-        "requester_app_id": app.id,
+        "requester_app_id": graphql_id(app),
         "recipient_email": recipient_email,
         "resending": False,
-        "recipient_email": recipient_email,
         "gift_card": {
-            "id": gift_card.id,
+            "id": graphql_id(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,
         },
-        "recipient_email": recipient_email,
     }
 
     plugin = sendgrid_email_plugin(
@@ -881,7 +878,7 @@ def test_send_order_confirmed_email_task_by_user(
         "currency": order.currency,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": staff_user.pk,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
     }
 
@@ -925,7 +922,7 @@ def test_send_order_confirmed_email_task_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": app.pk,
+        "requester_app_id": graphql_id(app),
     }
 
     plugin = sendgrid_email_plugin(

--- a/saleor/plugins/user_email/tasks.py
+++ b/saleor/plugins/user_email/tasks.py
@@ -1,5 +1,6 @@
 from ...account import events as account_events
 from ...celeryconf import app
+from ...core.utils import get_id_from_graphql_id
 from ...giftcard import events as gift_card_events
 from ...invoice import events as invoice_events
 from ...order import events as order_events
@@ -33,7 +34,9 @@ def send_password_reset_email_task(recipient_email, payload, config, subject, te
         subject=subject,
         template_str=template,
     )
-    account_events.customer_password_reset_link_sent_event(user_id=user_id)
+    account_events.customer_password_reset_link_sent_event(
+        user_id=get_id_from_graphql_id(user_id)
+    )
 
 
 @app.task(compression="zlib")
@@ -51,7 +54,7 @@ def send_request_email_change_email_task(
         template_str=template,
     )
     account_events.customer_email_change_request_event(
-        user_id=user_id,
+        user_id=get_id_from_graphql_id(user_id),
         parameters={
             "old_email": payload.get("old_email"),
             "new_email": recipient_email,
@@ -79,7 +82,7 @@ def send_user_change_email_notification_task(
     }
 
     account_events.customer_email_changed_event(
-        user_id=user_id, parameters=event_parameters
+        user_id=get_id_from_graphql_id(user_id), parameters=event_parameters
     )
 
 
@@ -125,9 +128,9 @@ def send_gift_card_email_task(recipient_email, payload, config, subject, templat
         template_str=template,
     )
     email_data = {
-        "gift_card_id": payload["gift_card"]["id"],
-        "user_id": payload["requester_user_id"],
-        "app_id": payload["requester_app_id"],
+        "gift_card_id": get_id_from_graphql_id(payload["gift_card"]["id"]),
+        "user_id": get_id_from_graphql_id(payload["requester_user_id"]),
+        "app_id": get_id_from_graphql_id(payload["requester_app_id"]),
         "email": payload["recipient_email"],
     }
     if payload["resending"] is True:
@@ -149,15 +152,15 @@ def send_invoice_email_task(recipient_email, payload, config, subject, template)
         template_str=template,
     )
     invoice_events.notification_invoice_sent_event(
-        user_id=payload["requester_user_id"],
-        app_id=payload["requester_app_id"],
-        invoice_id=payload["invoice"]["id"],
+        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
+        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+        invoice_id=get_id_from_graphql_id(payload["invoice"]["id"]),
         customer_email=payload["recipient_email"],
     )
     order_events.event_invoice_sent_notification(
-        order_id=payload["invoice"]["order_id"],
-        user_id=payload["requester_user_id"],
-        app_id=payload["requester_app_id"],
+        order_id=get_id_from_graphql_id(payload["invoice"]["order_id"]),
+        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
+        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
         email=payload["recipient_email"],
     )
 
@@ -177,8 +180,8 @@ def send_order_confirmation_email_task(
         template_str=template,
     )
     order_events.event_order_confirmation_notification(
-        order_id=payload["order"]["id"],
-        user_id=payload["order"].get("user_id"),
+        order_id=get_id_from_graphql_id(payload["order"]["id"]),
+        user_id=get_id_from_graphql_id(payload["order"].get("user_id")),
         customer_email=recipient_email,
     )
 
@@ -197,17 +200,17 @@ def send_fulfillment_confirmation_email_task(
         template_str=template,
     )
     order_events.event_fulfillment_confirmed_notification(
-        order_id=payload["order"]["id"],
-        user_id=payload["requester_user_id"],
-        app_id=payload["requester_app_id"],
+        order_id=get_id_from_graphql_id(payload["order"]["id"]),
+        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
+        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
         customer_email=recipient_email,
     )
 
     if payload.get("digital_lines"):
         order_events.event_fulfillment_digital_links_notification(
-            order_id=payload["order"]["id"],
-            user_id=payload["requester_user_id"],
-            app_id=payload["requester_app_id"],
+            order_id=get_id_from_graphql_id(payload["order"]["id"]),
+            user_id=get_id_from_graphql_id(payload["requester_user_id"]),
+            app_id=get_id_from_graphql_id(payload["requester_app_id"]),
             customer_email=recipient_email,
         )
 
@@ -241,8 +244,8 @@ def send_payment_confirmation_email_task(
         template_str=template,
     )
     order_events.event_payment_confirmed_notification(
-        order_id=payload["order"]["id"],
-        user_id=payload["order"].get("user_id"),
+        order_id=get_id_from_graphql_id(payload["order"]["id"]),
+        user_id=get_id_from_graphql_id(payload["order"].get("user_id")),
         customer_email=recipient_email,
     )
 
@@ -259,9 +262,9 @@ def send_order_canceled_email_task(recipient_email, payload, config, subject, te
         template_str=template,
     )
     order_events.event_order_cancelled_notification(
-        order_id=payload["order"]["id"],
-        user_id=payload["requester_user_id"],
-        app_id=payload["requester_app_id"],
+        order_id=get_id_from_graphql_id(payload["order"]["id"]),
+        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
+        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
         customer_email=recipient_email,
     )
 
@@ -278,9 +281,9 @@ def send_order_refund_email_task(recipient_email, payload, config, subject, temp
         template_str=template,
     )
     order_events.event_order_refunded_notification(
-        order_id=payload["order"]["id"],
-        user_id=payload["requester_user_id"],
-        app_id=payload["requester_app_id"],
+        order_id=get_id_from_graphql_id(payload["order"]["id"]),
+        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
+        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
         customer_email=recipient_email,
     )
 
@@ -299,8 +302,8 @@ def send_order_confirmed_email_task(
         template_str=template,
     )
     order_events.event_order_confirmed_notification(
-        order_id=payload.get("order", {}).get("id"),
-        user_id=payload.get("requester_user_id"),
-        app_id=payload["requester_app_id"],
+        order_id=get_id_from_graphql_id(payload.get("order", {}).get("id")),
+        user_id=get_id_from_graphql_id(payload.get("requester_user_id")),
+        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
         customer_email=recipient_email,
     )

--- a/saleor/plugins/user_email/tasks.py
+++ b/saleor/plugins/user_email/tasks.py
@@ -1,7 +1,7 @@
 from ...account import events as account_events
 from ...celeryconf import app
-from ...core.utils import get_id_from_graphql_id
 from ...giftcard import events as gift_card_events
+from ...graphql.core.utils import from_global_id_or_none
 from ...invoice import events as invoice_events
 from ...order import events as order_events
 from ..email_common import EmailConfig, send_email
@@ -35,7 +35,7 @@ def send_password_reset_email_task(recipient_email, payload, config, subject, te
         template_str=template,
     )
     account_events.customer_password_reset_link_sent_event(
-        user_id=get_id_from_graphql_id(user_id)
+        user_id=from_global_id_or_none(user_id)
     )
 
 
@@ -54,7 +54,7 @@ def send_request_email_change_email_task(
         template_str=template,
     )
     account_events.customer_email_change_request_event(
-        user_id=get_id_from_graphql_id(user_id),
+        user_id=from_global_id_or_none(user_id),
         parameters={
             "old_email": payload.get("old_email"),
             "new_email": recipient_email,
@@ -82,7 +82,7 @@ def send_user_change_email_notification_task(
     }
 
     account_events.customer_email_changed_event(
-        user_id=get_id_from_graphql_id(user_id), parameters=event_parameters
+        user_id=from_global_id_or_none(user_id), parameters=event_parameters
     )
 
 
@@ -128,9 +128,9 @@ def send_gift_card_email_task(recipient_email, payload, config, subject, templat
         template_str=template,
     )
     email_data = {
-        "gift_card_id": get_id_from_graphql_id(payload["gift_card"]["id"]),
-        "user_id": get_id_from_graphql_id(payload["requester_user_id"]),
-        "app_id": get_id_from_graphql_id(payload["requester_app_id"]),
+        "gift_card_id": from_global_id_or_none(payload["gift_card"]["id"]),
+        "user_id": from_global_id_or_none(payload["requester_user_id"]),
+        "app_id": from_global_id_or_none(payload["requester_app_id"]),
         "email": payload["recipient_email"],
     }
     if payload["resending"] is True:
@@ -152,15 +152,15 @@ def send_invoice_email_task(recipient_email, payload, config, subject, template)
         template_str=template,
     )
     invoice_events.notification_invoice_sent_event(
-        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
-        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
-        invoice_id=get_id_from_graphql_id(payload["invoice"]["id"]),
+        user_id=from_global_id_or_none(payload["requester_user_id"]),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
+        invoice_id=from_global_id_or_none(payload["invoice"]["id"]),
         customer_email=payload["recipient_email"],
     )
     order_events.event_invoice_sent_notification(
-        order_id=get_id_from_graphql_id(payload["invoice"]["order_id"]),
-        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
-        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+        order_id=from_global_id_or_none(payload["invoice"]["order_id"]),
+        user_id=from_global_id_or_none(payload["requester_user_id"]),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
         email=payload["recipient_email"],
     )
 
@@ -180,8 +180,8 @@ def send_order_confirmation_email_task(
         template_str=template,
     )
     order_events.event_order_confirmation_notification(
-        order_id=get_id_from_graphql_id(payload["order"]["id"]),
-        user_id=get_id_from_graphql_id(payload["order"].get("user_id")),
+        order_id=from_global_id_or_none(payload["order"]["id"]),
+        user_id=from_global_id_or_none(payload["order"].get("user_id")),
         customer_email=recipient_email,
     )
 
@@ -200,17 +200,17 @@ def send_fulfillment_confirmation_email_task(
         template_str=template,
     )
     order_events.event_fulfillment_confirmed_notification(
-        order_id=get_id_from_graphql_id(payload["order"]["id"]),
-        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
-        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+        order_id=from_global_id_or_none(payload["order"]["id"]),
+        user_id=from_global_id_or_none(payload["requester_user_id"]),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
         customer_email=recipient_email,
     )
 
     if payload.get("digital_lines"):
         order_events.event_fulfillment_digital_links_notification(
-            order_id=get_id_from_graphql_id(payload["order"]["id"]),
-            user_id=get_id_from_graphql_id(payload["requester_user_id"]),
-            app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+            order_id=from_global_id_or_none(payload["order"]["id"]),
+            user_id=from_global_id_or_none(payload["requester_user_id"]),
+            app_id=from_global_id_or_none(payload["requester_app_id"]),
             customer_email=recipient_email,
         )
 
@@ -244,8 +244,8 @@ def send_payment_confirmation_email_task(
         template_str=template,
     )
     order_events.event_payment_confirmed_notification(
-        order_id=get_id_from_graphql_id(payload["order"]["id"]),
-        user_id=get_id_from_graphql_id(payload["order"].get("user_id")),
+        order_id=from_global_id_or_none(payload["order"]["id"]),
+        user_id=from_global_id_or_none(payload["order"].get("user_id")),
         customer_email=recipient_email,
     )
 
@@ -262,9 +262,9 @@ def send_order_canceled_email_task(recipient_email, payload, config, subject, te
         template_str=template,
     )
     order_events.event_order_cancelled_notification(
-        order_id=get_id_from_graphql_id(payload["order"]["id"]),
-        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
-        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+        order_id=from_global_id_or_none(payload["order"]["id"]),
+        user_id=from_global_id_or_none(payload["requester_user_id"]),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
         customer_email=recipient_email,
     )
 
@@ -281,9 +281,9 @@ def send_order_refund_email_task(recipient_email, payload, config, subject, temp
         template_str=template,
     )
     order_events.event_order_refunded_notification(
-        order_id=get_id_from_graphql_id(payload["order"]["id"]),
-        user_id=get_id_from_graphql_id(payload["requester_user_id"]),
-        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+        order_id=from_global_id_or_none(payload["order"]["id"]),
+        user_id=from_global_id_or_none(payload["requester_user_id"]),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
         customer_email=recipient_email,
     )
 
@@ -302,8 +302,8 @@ def send_order_confirmed_email_task(
         template_str=template,
     )
     order_events.event_order_confirmed_notification(
-        order_id=get_id_from_graphql_id(payload.get("order", {}).get("id")),
-        user_id=get_id_from_graphql_id(payload.get("requester_user_id")),
-        app_id=get_id_from_graphql_id(payload["requester_app_id"]),
+        order_id=from_global_id_or_none(payload.get("order", {}).get("id")),
+        user_id=from_global_id_or_none(payload.get("requester_user_id")),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
         customer_email=recipient_email,
     )

--- a/saleor/plugins/user_email/tests/test_tasks.py
+++ b/saleor/plugins/user_email/tests/test_tasks.py
@@ -1,9 +1,9 @@
 from unittest import mock
 
 from ....account.notifications import get_default_user_payload
-from ....core.utils import graphql_id
 from ....giftcard import GiftCardEvents
 from ....giftcard.models import GiftCardEvent
+from ....graphql.core.utils import to_global_id_or_none
 from ....invoice import InvoiceEvents
 from ....invoice.models import Invoice, InvoiceEvent
 from ....order import OrderEvents, OrderEventsEmails
@@ -416,15 +416,15 @@ def test_send_invoice_email_task_default_template_by_user(
     recipient_email = "user@example.com"
     payload = {
         "invoice": {
-            "id": graphql_id(invoice),
-            "order_id": graphql_id(order),
+            "id": to_global_id_or_none(invoice),
+            "order_id": to_global_id_or_none(order),
             "number": 999,
             "download_url": "http://localhost:8000/download",
         },
         "recipient_email": recipient_email,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
     }
 
@@ -459,8 +459,8 @@ def test_send_invoice_email_task_default_template_by_app(
     recipient_email = "user@example.com"
     payload = {
         "invoice": {
-            "id": graphql_id(invoice),
-            "order_id": graphql_id(order),
+            "id": to_global_id_or_none(invoice),
+            "order_id": to_global_id_or_none(order),
             "number": 999,
             "download_url": "http://localhost:8000/download",
         },
@@ -468,7 +468,7 @@ def test_send_invoice_email_task_default_template_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": graphql_id(app),
+        "requester_app_id": to_global_id_or_none(app),
     }
 
     send_invoice_email_task(
@@ -505,15 +505,15 @@ def test_send_invoice_email_task_custom_template(
     recipient_email = "user@example.com"
     payload = {
         "invoice": {
-            "id": graphql_id(invoice),
+            "id": to_global_id_or_none(invoice),
             "number": 999,
-            "order_id": graphql_id(order),
+            "order_id": to_global_id_or_none(order),
             "download_url": "http://localhost:8000/download",
         },
         "recipient_email": recipient_email,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
     }
 
@@ -608,7 +608,7 @@ def test_send_fulfillment_confirmation_email_task_default_template(
     mocked_send_mail, user_email_dict_config, order, fulfillment, staff_user
 ):
     payload = get_default_fulfillment_payload(order, fulfillment)
-    payload["requester_user_id"] = graphql_id(staff_user)
+    payload["requester_user_id"] = to_global_id_or_none(staff_user)
     payload["requester_app_id"] = None
 
     send_fulfillment_confirmation_email_task(
@@ -646,7 +646,7 @@ def test_send_fulfillment_confirmation_email_task_custom_template_by_user(
         fulfillment_confirmation_subject=expected_subject,
     )
     payload = get_default_fulfillment_payload(order, fulfillment)
-    payload["requester_user_id"] = graphql_id(staff_user)
+    payload["requester_user_id"] = to_global_id_or_none(staff_user)
     payload["requester_app_id"] = None
     payload["digital_lines"] = [{"fulfillmentLine": {"id": 1}}]
     recipient_email = payload["recipient_email"]
@@ -700,7 +700,7 @@ def test_send_fulfillment_confirmation_email_task_custom_template_by_app(
     )
     payload = get_default_fulfillment_payload(order, fulfillment)
     payload["requester_user_id"] = None
-    payload["requester_app_id"] = graphql_id(app)
+    payload["requester_app_id"] = to_global_id_or_none(app)
     payload["digital_lines"] = [{"fulfillmentLine": {"id": 1}}]
     recipient_email = payload["recipient_email"]
 
@@ -876,7 +876,7 @@ def test_send_order_canceled_email_task_default_template_by_user(
         "recipient_email": recipient_email,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
     }
 
@@ -899,7 +899,7 @@ def test_send_order_canceled_email_task_default_template_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": graphql_id(app),
+        "requester_app_id": to_global_id_or_none(app),
     }
 
     send_order_canceled_email_task(
@@ -926,7 +926,7 @@ def test_send_order_canceled_email_task_custom_template(
         "recipient_email": recipient_email,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
     }
     send_order_canceled_email_task(
@@ -959,7 +959,7 @@ def test_send_order_refund_email_task_default_template_by_user(
         "currency": order.currency,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
     }
 
@@ -990,7 +990,7 @@ def test_send_order_refund_email_task_default_template_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": graphql_id(app),
+        "requester_app_id": to_global_id_or_none(app),
     }
 
     send_order_refund_email_task(
@@ -1025,7 +1025,7 @@ def test_send_order_refund_email_task_custom_template(
         "currency": order.currency,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
     }
     send_order_refund_email_task(
@@ -1059,7 +1059,7 @@ def test_send_order_confirmed_email_task_default_template_by_user(
     payload = {
         "order": get_default_order_payload(order, "http://localhost:8000/redirect"),
         "recipient_email": recipient_email,
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
         "site_name": "Saleor",
         "domain": "localhost:8000",
@@ -1089,7 +1089,7 @@ def test_send_order_confirmed_email_task_default_template_by_app(
     payload = {
         "order": get_default_order_payload(order, "http://localhost:8000/redirect"),
         "recipient_email": recipient_email,
-        "requester_app_id": graphql_id(app),
+        "requester_app_id": to_global_id_or_none(app),
         "requester_user_id": None,
         "site_name": "Saleor",
         "domain": "localhost:8000",
@@ -1125,7 +1125,7 @@ def test_send_order_confirmed_email_task_custom_template(
     payload = {
         "order": get_default_order_payload(order, "http://localhost:8000/redirect"),
         "recipient_email": recipient_email,
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
         "site_name": "Saleor",
         "domain": "localhost:8000",
@@ -1166,12 +1166,12 @@ def test_send_gift_card_email_task_by_user(
 
     payload = {
         "user": get_default_user_payload(staff_user),
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
         "recipient_email": recipient_email,
         "resending": False,
         "gift_card": {
-            "id": graphql_id(gift_card),
+            "id": to_global_id_or_none(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,
@@ -1219,13 +1219,13 @@ def test_send_gift_card_email_task_by_user_resending(
 
     payload = {
         "user": get_default_user_payload(staff_user),
-        "requester_user_id": graphql_id(staff_user),
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
         "recipient_email": recipient_email,
         "resending": True,
         "recipient_email": recipient_email,
         "gift_card": {
-            "id": graphql_id(gift_card),
+            "id": to_global_id_or_none(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,
@@ -1273,12 +1273,12 @@ def test_send_gift_card_email_task_by_app(
     payload = {
         "user": None,
         "requester_user_id": None,
-        "requester_app_id": graphql_id(app),
+        "requester_app_id": to_global_id_or_none(app),
         "recipient_email": recipient_email,
         "resending": False,
         "recipient_email": recipient_email,
         "gift_card": {
-            "id": graphql_id(gift_card),
+            "id": to_global_id_or_none(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,

--- a/saleor/plugins/user_email/tests/test_tasks.py
+++ b/saleor/plugins/user_email/tests/test_tasks.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from ....account.notifications import get_default_user_payload
+from ....core.utils import graphql_id
 from ....giftcard import GiftCardEvents
 from ....giftcard.models import GiftCardEvent
 from ....invoice import InvoiceEvents
@@ -415,15 +416,15 @@ def test_send_invoice_email_task_default_template_by_user(
     recipient_email = "user@example.com"
     payload = {
         "invoice": {
-            "id": invoice.id,
-            "order_id": order.id,
+            "id": graphql_id(invoice),
+            "order_id": graphql_id(order),
             "number": 999,
             "download_url": "http://localhost:8000/download",
         },
         "recipient_email": recipient_email,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": staff_user.id,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
     }
 
@@ -458,8 +459,8 @@ def test_send_invoice_email_task_default_template_by_app(
     recipient_email = "user@example.com"
     payload = {
         "invoice": {
-            "id": invoice.id,
-            "order_id": order.id,
+            "id": graphql_id(invoice),
+            "order_id": graphql_id(order),
             "number": 999,
             "download_url": "http://localhost:8000/download",
         },
@@ -467,7 +468,7 @@ def test_send_invoice_email_task_default_template_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": app.pk,
+        "requester_app_id": graphql_id(app),
     }
 
     send_invoice_email_task(
@@ -504,15 +505,15 @@ def test_send_invoice_email_task_custom_template(
     recipient_email = "user@example.com"
     payload = {
         "invoice": {
-            "id": invoice.id,
+            "id": graphql_id(invoice),
             "number": 999,
-            "order_id": order.id,
+            "order_id": graphql_id(order),
             "download_url": "http://localhost:8000/download",
         },
         "recipient_email": recipient_email,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": staff_user.id,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
     }
 
@@ -607,7 +608,7 @@ def test_send_fulfillment_confirmation_email_task_default_template(
     mocked_send_mail, user_email_dict_config, order, fulfillment, staff_user
 ):
     payload = get_default_fulfillment_payload(order, fulfillment)
-    payload["requester_user_id"] = staff_user.pk
+    payload["requester_user_id"] = graphql_id(staff_user)
     payload["requester_app_id"] = None
 
     send_fulfillment_confirmation_email_task(
@@ -645,7 +646,7 @@ def test_send_fulfillment_confirmation_email_task_custom_template_by_user(
         fulfillment_confirmation_subject=expected_subject,
     )
     payload = get_default_fulfillment_payload(order, fulfillment)
-    payload["requester_user_id"] = staff_user.pk
+    payload["requester_user_id"] = graphql_id(staff_user)
     payload["requester_app_id"] = None
     payload["digital_lines"] = [{"fulfillmentLine": {"id": 1}}]
     recipient_email = payload["recipient_email"]
@@ -699,7 +700,7 @@ def test_send_fulfillment_confirmation_email_task_custom_template_by_app(
     )
     payload = get_default_fulfillment_payload(order, fulfillment)
     payload["requester_user_id"] = None
-    payload["requester_app_id"] = app.pk
+    payload["requester_app_id"] = graphql_id(app)
     payload["digital_lines"] = [{"fulfillmentLine": {"id": 1}}]
     recipient_email = payload["recipient_email"]
 
@@ -875,7 +876,7 @@ def test_send_order_canceled_email_task_default_template_by_user(
         "recipient_email": recipient_email,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": staff_user.pk,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
     }
 
@@ -898,7 +899,7 @@ def test_send_order_canceled_email_task_default_template_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": app.pk,
+        "requester_app_id": graphql_id(app),
     }
 
     send_order_canceled_email_task(
@@ -925,7 +926,7 @@ def test_send_order_canceled_email_task_custom_template(
         "recipient_email": recipient_email,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": staff_user.pk,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
     }
     send_order_canceled_email_task(
@@ -958,7 +959,7 @@ def test_send_order_refund_email_task_default_template_by_user(
         "currency": order.currency,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": staff_user.pk,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
     }
 
@@ -989,7 +990,7 @@ def test_send_order_refund_email_task_default_template_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": app.pk,
+        "requester_app_id": graphql_id(app),
     }
 
     send_order_refund_email_task(
@@ -1024,7 +1025,7 @@ def test_send_order_refund_email_task_custom_template(
         "currency": order.currency,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": staff_user.pk,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
     }
     send_order_refund_email_task(
@@ -1058,7 +1059,7 @@ def test_send_order_confirmed_email_task_default_template_by_user(
     payload = {
         "order": get_default_order_payload(order, "http://localhost:8000/redirect"),
         "recipient_email": recipient_email,
-        "requester_user_id": staff_user.id,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
         "site_name": "Saleor",
         "domain": "localhost:8000",
@@ -1088,7 +1089,7 @@ def test_send_order_confirmed_email_task_default_template_by_app(
     payload = {
         "order": get_default_order_payload(order, "http://localhost:8000/redirect"),
         "recipient_email": recipient_email,
-        "requester_app_id": app.id,
+        "requester_app_id": graphql_id(app),
         "requester_user_id": None,
         "site_name": "Saleor",
         "domain": "localhost:8000",
@@ -1124,7 +1125,7 @@ def test_send_order_confirmed_email_task_custom_template(
     payload = {
         "order": get_default_order_payload(order, "http://localhost:8000/redirect"),
         "recipient_email": recipient_email,
-        "requester_user_id": staff_user.id,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
         "site_name": "Saleor",
         "domain": "localhost:8000",
@@ -1165,13 +1166,12 @@ def test_send_gift_card_email_task_by_user(
 
     payload = {
         "user": get_default_user_payload(staff_user),
-        "requester_user_id": staff_user.id,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
         "recipient_email": recipient_email,
         "resending": False,
-        "recipient_email": recipient_email,
         "gift_card": {
-            "id": gift_card.id,
+            "id": graphql_id(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,
@@ -1219,13 +1219,13 @@ def test_send_gift_card_email_task_by_user_resending(
 
     payload = {
         "user": get_default_user_payload(staff_user),
-        "requester_user_id": staff_user.id,
+        "requester_user_id": graphql_id(staff_user),
         "requester_app_id": None,
         "recipient_email": recipient_email,
         "resending": True,
         "recipient_email": recipient_email,
         "gift_card": {
-            "id": gift_card.id,
+            "id": graphql_id(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,
@@ -1273,12 +1273,12 @@ def test_send_gift_card_email_task_by_app(
     payload = {
         "user": None,
         "requester_user_id": None,
-        "requester_app_id": app.id,
+        "requester_app_id": graphql_id(app),
         "recipient_email": recipient_email,
         "resending": False,
         "recipient_email": recipient_email,
         "gift_card": {
-            "id": gift_card.id,
+            "id": graphql_id(gift_card),
             "code": gift_card.code,
             "balance": gift_card.current_balance_amount,
             "currency": gift_card.currency,


### PR DESCRIPTION
Switches all DB ids in email payload to graphql.  For creating events we still need db ids so there is a function to get db id from graphql (kinda revert).

[DOCS PR](https://github.com/saleor/saleor-docs/pull/387)
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
