### PR TITLE
Merge `main` into `taxes-by-sync-webhooks`

### DIFF
--- a/saleor/graphql/core/utils/error_codes.py
+++ b/saleor/graphql/core/utils/error_codes.py
@@ -1,30 +1,5 @@
 from enum import Enum
 
-from ....account.error_codes import AccountErrorCode, PermissionGroupErrorCode
-from ....app.error_codes import AppErrorCode
-from ....attribute.error_codes import AttributeErrorCode
-from ....channel.error_codes import ChannelErrorCode
-from ....checkout.error_codes import CheckoutErrorCode
-from ....core.error_codes import (
-    MetadataErrorCode,
-    ShopErrorCode,
-    TranslationErrorCode,
-    UploadErrorCode,
-)
-from ....csv.error_codes import ExportErrorCode
-from ....discount.error_codes import DiscountErrorCode
-from ....giftcard.error_codes import GiftCardErrorCode
-from ....invoice.error_codes import InvoiceErrorCode
-from ....menu.error_codes import MenuErrorCode
-from ....order.error_codes import OrderErrorCode
-from ....page.error_codes import PageErrorCode
-from ....payment.error_codes import PaymentErrorCode
-from ....plugins.error_codes import PluginErrorCode
-from ....product.error_codes import ProductErrorCode
-from ....shipping.error_codes import ShippingErrorCode
-from ....site.error_codes import GiftCardSettingsErrorCode, OrderSettingsErrorCode
-from ...notifications.error_codes import ExternalNotificationErrorCodes
-
 DJANGO_VALIDATORS_ERROR_CODES = [
     "invalid",
     "invalid_extension",
@@ -53,38 +28,6 @@ DJANGO_FORM_FIELDS_ERROR_CODES = [
 ]
 
 
-SALEOR_ERROR_CODE_ENUMS = [
-    AccountErrorCode,
-    AppErrorCode,
-    AttributeErrorCode,
-    ChannelErrorCode,
-    CheckoutErrorCode,
-    ExportErrorCode,
-    DiscountErrorCode,
-    GiftCardSettingsErrorCode,
-    ExternalNotificationErrorCodes,
-    PluginErrorCode,
-    GiftCardErrorCode,
-    InvoiceErrorCode,
-    MenuErrorCode,
-    MetadataErrorCode,
-    OrderErrorCode,
-    PageErrorCode,
-    PaymentErrorCode,
-    OrderSettingsErrorCode,
-    PermissionGroupErrorCode,
-    ProductErrorCode,
-    ShippingErrorCode,
-    ShopErrorCode,
-    TranslationErrorCode,
-    UploadErrorCode,
-]
-
-saleor_error_codes = []
-for enum in SALEOR_ERROR_CODE_ENUMS:
-    saleor_error_codes.extend([code.value for code in enum])
-
-
 def get_error_code_from_error(error) -> str:
     """Return valid error code from ValidationError.
 
@@ -96,10 +39,12 @@ def get_error_code_from_error(error) -> str:
         return "required"
     if code in ["unique", "unique_for_date"]:
         return "unique"
-    if code in DJANGO_VALIDATORS_ERROR_CODES or code in DJANGO_FORM_FIELDS_ERROR_CODES:
+    if (
+        code is None
+        or code in DJANGO_VALIDATORS_ERROR_CODES
+        or code in DJANGO_FORM_FIELDS_ERROR_CODES
+    ):
         return "invalid"
     if isinstance(code, Enum):
         code = code.value
-    if code not in saleor_error_codes:
-        return "invalid"
     return code

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -174,8 +174,8 @@ class BaseMetadataMutation(BaseMutation):
 
     @classmethod
     def mutate(cls, root, info, **data):
-        type_name, object_pk = cls.get_object_type_name_and_pk(data)
         try:
+            type_name, object_pk = cls.get_object_type_name_and_pk(data)
             permissions = cls.get_permissions(info, type_name, object_pk, **data)
         except GraphQLError as e:
             error = ValidationError(
@@ -184,8 +184,10 @@ class BaseMetadataMutation(BaseMutation):
             return cls.handle_errors(error)
         except ValidationError as e:
             return cls.handle_errors(e)
+
         if not cls.check_permissions(info.context, permissions):
             raise PermissionDenied(permissions=permissions)
+
         try:
             result = super().mutate(root, info, **data)
             if not result.errors:

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -128,6 +128,21 @@ def item_contains_multiple_proper_public_metadata(
     )
 
 
+def test_meta_mutations_handle_validation_errors(staff_api_client):
+    invalid_id = "6QjoLs5LIqb3At7hVKKcUlqXceKkFK"
+    variables = {
+        "id": invalid_id,
+        "input": [{"key": "year", "value": "of-saleor"}],
+    }
+    response = staff_api_client.post_graphql(
+        UPDATE_PUBLIC_METADATA_MUTATION % "Checkout", variables
+    )
+    content = get_graphql_content(response)
+    errors = content["data"]["updateMetadata"]["errors"]
+    assert errors
+    assert errors[0]["code"] == MetadataErrorCode.INVALID.name
+
+
 @patch("saleor.plugins.manager.PluginsManager.checkout_updated")
 def test_base_metadata_mutation_handles_errors_from_extra_action(
     mock_checkout_updated, api_client, checkout

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -18,8 +18,8 @@ from prices import Money, TaxedMoney, TaxedMoneyRange
 from ...checkout import base_calculations, calculations
 from ...checkout.interface import CheckoutTaxedPricesData
 from ...core.taxes import TaxType
-from ...graphql.core.utils.error_codes import PluginErrorCode
 from ...order.interface import OrderTaxedPricesData
+from ...plugins.error_codes import PluginErrorCode
 from ...product.models import ProductType
 from ..base_plugin import BasePlugin, ConfigurationTypeField
 from ..manager import get_plugins_manager


### PR DESCRIPTION
I want to merge this change because I want to merge fix for order serializer test from `main` into `taxes-by-sync-webhooks`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
