### PR TITLE
Fix unhandled graphql errors after removing graphene-django

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -578,6 +578,7 @@ def SENTRY_INIT(dsn: str, sentry_opts: dict):
     """
     sentry_sdk.init(dsn, **sentry_opts)
     ignore_logger("graphql.execution.utils")
+    ignore_logger("graphql.execution.executor")
 
 
 GRAPHENE = {


### PR DESCRIPTION
I want to merge this change because it silences `graphql.execution.executor` from entering sentry. Important errors still come in as unhandled by different logger.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
