### PR TITLE
Update `user_email` field in order payload

### DIFF
--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -72,7 +72,6 @@ ORDER_FIELDS = (
     "created",
     "status",
     "origin",
-    "user_email",
     "shipping_method_name",
     "collection_point_name",
     "shipping_price_net_amount",
@@ -282,6 +281,7 @@ def generate_order_payload(
     extra_dict_data = {
         "id": graphene.Node.to_global_id("Order", order.id),
         "token": str(order.id),
+        "user_email": lambda o: o.user.email if o.user_id else o.user_email,
         "original": graphene.Node.to_global_id("Order", order.original_id),
         "lines": json.loads(generate_order_lines_payload(lines)),
         "fulfillments": json.loads(fulfillments_data),
@@ -409,6 +409,7 @@ def _generate_order_payload_for_invoice(order: "Order"):
         fields=ORDER_FIELDS,
         extra_dict_data={
             "token": lambda o: o.id,
+            "user_email": lambda o: o.user.email if o.user_id else o.user_email,
         },
     )
     return payload


### PR DESCRIPTION
Return `order.user_email` or order user's email in order payload `user_email` field.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
