### PR TITLE
chore: consolidate isort configuration

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,16 @@
 [settings]
+profile = black
+skip =
+    .direnv
+    .tox
+    .venv
+    migrations
+    node_modules
+
+# Vertical Hanging Indent
+multi_line_output = 3
+include_trailing_comma = True
+
+line_length = 88
+known_first_party = saleor
 known_third_party = Adyen,PIL,authorizenet,babel,before_after,boto3,botocore,braintree,celery,cryptography,dateutil,dj_database_url,dj_email_url,django,django_cache_url,django_countries,django_filters,django_measurement,django_prices,django_prices_openexchangerates,django_prices_vatlayer,draftjs_sanitizer,faker,freezegun,google,google_measurement_protocol,graphene,graphql,graphql_relay,html2text,html_to_draftjs,i18naddress,jaeger_client,jwt,kombu,lxml,markdown,measurement,micawber,mptt,oauthlib,openpyxl,opentracing,petl,phonenumber_field,phonenumbers,pkg_resources,posuto,prices,promise,pybars,pytest,pythonjsonlogger,pytimeparse,pytz,razorpay,requests,sendgrid,sentry_sdk,storages,stripe,urllib3,uvicorn,versatileimagefield,weasyprint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,16 +20,10 @@ repos:
     hooks:
       - id: flake8
 
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
     hooks:
       - id: isort
-        args: ["--profile", "black"]
 
   - repo: https://github.com/pycqa/pydocstyle
     rev: 6.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,24 +48,6 @@ ignore = D100, D101, D102, D103, D104, D105, D106, D107, D203, D213, D407, D202
 inherit = false
 match-dir = saleor
 
-[isort]
-skip =
-    .direnv
-    .tox
-    .venv
-    migrations
-    node_modules
-not_skip = __init__.py
-
-# Vertical Hanging Indent
-multi_line_output = 3
-include_trailing_comma: True
-
-line_length = 88
-known_first_party = saleor
-known_third_party =Adyen,PIL,authorizenet,babel,boto3,braintree,celery,dateutil,dj_database_url,dj_email_url,django,django_cache_url,django_countries,django_filters,django_measurement,django_prices,django_prices_openexchangerates,django_prices_vatlayer,draftjs_sanitizer,faker,freezegun,google,google_measurement_protocol,graphene,graphene_django,graphene_federation,graphql,graphql_relay,html2text,html_to_draftjs,i18naddress,jaeger_client,jwt,kombu,lxml,markdown,measurement,mptt,oauthlib,openpyxl,opentracing,petl,phonenumber_field,phonenumbers,pkg_resources,prices,promise,pybars,pytest,pythonjsonlogger,pytimeparse,pytz,razorpay,requests,sendgrid,sentry_sdk,storages,stripe,tqdm,urllib3,versatileimagefield,weasyprint
-
-
 [mypy]
 ignore_missing_imports = True
 allow_untyped_globals = True


### PR DESCRIPTION
While setting up my editor to better integrating the linter environment, me and my co-workers noticed that the linter settings for isort was not applied consistently. This PR attempts to fix it.

# Description

isort makes a point about [not merging configs][1] which seems to happen in Saleor
due to having configuration in `.isort.cfg`, `setup.cfg` and finally through `pre-commit` configuration.

Solve this by moving all configs into the first existing config file.

Also, as part of the [5.x upgrade guide][2]:
- remove a deprecated setting for not skipping `__init__.py` which is now scanned by default
- update the pre-commit step to remove `seed-isort-config` and use the newer version for `pre-commit`

[1]: https://pycqa.github.io/isort/docs/configuration/config_files.html
[2]: https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
