### PR TITLE
Allow to access to app's resources when app is an owner

### DIFF
--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -464,7 +464,7 @@ def look_for_permission_in_users_with_manage_staff(
 
 
 def requestor_has_access(
-    requestor: Union["User", "App"], owner: Optional["User"], *perms
+    requestor: Union["User", "App"], owner: Optional[Union["User", "App"]], *perms
 ) -> bool:
     """Check if requestor can access data.
 

--- a/saleor/graphql/app/mutations.py
+++ b/saleor/graphql/app/mutations.py
@@ -16,6 +16,7 @@ from ..core import types as grapqhl_types
 from ..core.enums import PermissionEnum
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types import AppError, NonNullList
+from ..decorators import staff_member_required
 from ..utils import get_user_or_app_from_context, requestor_is_superuser
 from .types import App, AppInstallation, AppToken, Manifest
 from .utils import ensure_can_manage_permissions
@@ -154,6 +155,11 @@ class AppCreate(ModelMutation):
             cleaned_input["permissions"] = get_permissions(permissions)
             ensure_can_manage_permissions(requestor, permissions)
         return cleaned_input
+
+    @classmethod
+    @staff_member_required
+    def perform_mutation(cls, root, info, **data):
+        return super().perform_mutation(root, info, **data)
 
     @classmethod
     def save(cls, info, instance, cleaned_input):
@@ -370,6 +376,11 @@ class AppInstall(ModelMutation):
             cleaned_input["permissions"] = get_permissions(permissions)
             ensure_can_manage_permissions(requestor, permissions)
         return cleaned_input
+
+    @classmethod
+    @staff_member_required
+    def perform_mutation(cls, root, info, **data):
+        return super().perform_mutation(root, info, **data)
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):

--- a/saleor/graphql/app/tests/mutations/test_app_install.py
+++ b/saleor/graphql/app/tests/mutations/test_app_install.py
@@ -5,7 +5,7 @@ import graphene
 from .....app.models import AppInstallation
 from .....core import JobStatus
 from ....core.enums import AppErrorCode, PermissionEnum
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_no_permission, get_graphql_content
 
 INSTALL_APP_MUTATION = """
     mutation AppInstall(
@@ -62,13 +62,10 @@ def test_install_app_mutation(
     mocked_task.assert_called_with(app_installation.pk, True)
 
 
-def test_install_app_mutation_by_app(
+def test_app_is_not_allowed_to_install_app(
     permission_manage_apps, permission_manage_orders, app_api_client, monkeypatch
 ):
-    mocked_task = Mock()
-    monkeypatch.setattr(
-        "saleor.graphql.app.mutations.install_app_task.delay", mocked_task
-    )
+    # given
     query = INSTALL_APP_MUTATION
     app_api_client.app.permissions.set(
         [permission_manage_apps, permission_manage_orders]
@@ -78,18 +75,15 @@ def test_install_app_mutation_by_app(
         "manifest_url": "http://localhost:3000/manifest",
         "permissions": [PermissionEnum.MANAGE_ORDERS.name],
     }
+
+    # when
     response = app_api_client.post_graphql(
         query,
         variables=variables,
     )
-    content = get_graphql_content(response)
-    app_installation = AppInstallation.objects.get()
-    app_installation_data = content["data"]["appInstall"]["appInstallation"]
-    _, app_id = graphene.Node.from_global_id(app_installation_data["id"])
-    assert int(app_id) == app_installation.id
-    assert app_installation_data["status"] == JobStatus.PENDING.upper()
-    assert app_installation_data["manifestUrl"] == app_installation.manifest_url
-    mocked_task.assert_called_with(app_installation.pk, True)
+
+    # then
+    assert_no_permission(response)
 
 
 def test_app_install_mutation_out_of_scope_permissions(
@@ -106,33 +100,6 @@ def test_app_install_mutation_out_of_scope_permissions(
         query,
         variables=variables,
     )
-    content = get_graphql_content(response)
-    data = content["data"]["appInstall"]
-
-    errors = data["errors"]
-    assert not data["appInstallation"]
-    assert len(errors) == 1
-    error = errors[0]
-    assert error["field"] == "permissions"
-    assert error["code"] == AppErrorCode.OUT_OF_SCOPE_PERMISSION.name
-    assert error["permissions"] == [PermissionEnum.MANAGE_ORDERS.name]
-
-
-def test_install_app_mutation_by_app_out_of_scope_permissions(
-    permission_manage_apps, app_api_client
-):
-    query = INSTALL_APP_MUTATION
-    app_api_client.app.permissions.set([permission_manage_apps])
-    variables = {
-        "app_name": "New external integration",
-        "manifest_url": "http://localhost:3000/manifest",
-        "permissions": [PermissionEnum.MANAGE_ORDERS.name],
-    }
-    response = app_api_client.post_graphql(
-        query,
-        variables=variables,
-    )
-
     content = get_graphql_content(response)
     data = content["data"]["appInstall"]
 

--- a/saleor/graphql/meta/permissions.py
+++ b/saleor/graphql/meta/permissions.py
@@ -82,7 +82,10 @@ def menu_permissions(_info, _object_pk: Any) -> List[BasePermissionEnum]:
     return [MenuPermissions.MANAGE_MENUS]
 
 
-def app_permissions(_info, _object_pk: int) -> List[BasePermissionEnum]:
+def app_permissions(info, object_pk: int) -> List[BasePermissionEnum]:
+    app = info.context.app
+    if app and app.pk == int(object_pk):
+        return []
     return [AppPermission.MANAGE_APPS]
 
 

--- a/saleor/graphql/meta/resolvers.py
+++ b/saleor/graphql/meta/resolvers.py
@@ -94,7 +94,7 @@ def resolve_private_metadata(root: ModelWithMetadata, info):
 
     required_permissions = get_required_permission(info, item_id)
 
-    if not required_permissions:
+    if not isinstance(required_permissions, list):
         raise PermissionDenied()
 
     requester = get_user_or_app_from_context(info.context)

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -665,6 +665,48 @@ def test_add_public_metadata_for_app(staff_api_client, permission_manage_apps, a
     )
 
 
+def test_add_public_metadata_for_app_by_different_app(
+    app_api_client, permission_manage_apps, app, payment_app
+):
+    # given
+    app_id = graphene.Node.to_global_id("App", payment_app.pk)
+    app_api_client.app = app
+
+    # when
+    response = execute_update_public_metadata_for_item(
+        app_api_client,
+        permission_manage_apps,
+        app_id,
+        "App",
+    )
+
+    # then
+    assert item_contains_proper_public_metadata(
+        response["data"]["updateMetadata"]["item"], payment_app, app_id
+    )
+
+
+def test_add_public_metadata_for_app_that_is_owner(
+    app_api_client, permission_manage_apps, app
+):
+    # given
+    app_id = graphene.Node.to_global_id("App", app.pk)
+    app_api_client.app = app
+
+    # when
+    response = execute_update_public_metadata_for_item(
+        app_api_client,
+        None,
+        app_id,
+        "App",
+    )
+
+    # then
+    assert item_contains_proper_public_metadata(
+        response["data"]["updateMetadata"]["item"], app, app_id
+    )
+
+
 def test_add_public_metadata_for_page(staff_api_client, permission_manage_pages, page):
     # given
     page_id = graphene.Node.to_global_id("Page", page.pk)
@@ -2279,6 +2321,52 @@ def test_add_private_metadata_for_app(staff_api_client, permission_manage_apps, 
     response = execute_update_private_metadata_for_item(
         staff_api_client,
         permission_manage_apps,
+        app_id,
+        "App",
+    )
+
+    # then
+    assert item_contains_proper_private_metadata(
+        response["data"]["updatePrivateMetadata"]["item"],
+        app,
+        app_id,
+    )
+
+
+def test_add_private_metadata_for_app_by_different_app(
+    app_api_client, permission_manage_apps, app, payment_app
+):
+    # given
+    app_id = graphene.Node.to_global_id("App", payment_app.pk)
+    app_api_client.app = app
+
+    # when
+    response = execute_update_private_metadata_for_item(
+        app_api_client,
+        permission_manage_apps,
+        app_id,
+        "App",
+    )
+
+    # then
+    assert item_contains_proper_private_metadata(
+        response["data"]["updatePrivateMetadata"]["item"],
+        payment_app,
+        app_id,
+    )
+
+
+def test_add_private_metadata_by_app_that_is_owner(
+    app_api_client, permission_manage_apps, app
+):
+    # given
+    app_id = graphene.Node.to_global_id("App", app.pk)
+    app_api_client.app = app
+
+    # when
+    response = execute_update_private_metadata_for_item(
+        app_api_client,
+        None,
         app_id,
         "App",
     )


### PR DESCRIPTION
- it allows an app to access to own data, like webhooks, tokens, public/private metadata. 
- It also allows using `UpdateMetadata` and `UpdatePrivateMetadata` to update App's metadata fields, when app from the request is an owner. 
- It blocks creating a new App by a different App with `MANAGE_APPS` permission


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
