### PR TITLE
Add required dependencies to 0040_add_handle_checkouts_permission migration

### DIFF
--- a/saleor/checkout/migrations/0040_add_handle_checkouts_permission.py
+++ b/saleor/checkout/migrations/0040_add_handle_checkouts_permission.py
@@ -35,6 +35,8 @@ def assing_permissions(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
+        ("product", "0159_auto_20220209_1501"),
+        ("order", "0131_rename_order_token_id"),
         ("checkout", "0039_alter_checkout_email"),
     ]
 


### PR DESCRIPTION
Fixes when running migrations on fresh database locally
```
 Applying checkout.0040_add_handle_checkouts_permission...Running post-migrate handlers for application contenttypes
ERROR celery.app.trace Task saleor.core.search_tasks.set_order_search_document_values[9fbe4617-4add-4033-b31b-6af5868c5ea2] raised unexpected: ProgrammingError('column order_order.id does not exist\nLINE 1: ...er"."private_metadata", "order_order"."metadata", "order_ord...\n                                                             ^\n') [PID:24884:MainThread]
Traceback (most recent call last):
  File "/Users/xxx/Documents/projects/xxxx/saleor/saleor_venv/lib/python3.9/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.UndefinedColumn: column order_order.id does not exist
LINE 1: ...er"."private_metadata", "order_order"."metadata", "order_ord...
```
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
