### PR TITLE
Add missing update_products_discounted_prices in pupulatedb command

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -87,6 +87,7 @@ from ...product.thumbnails import (
     create_collection_background_image_thumbnails,
     create_product_thumbnails,
 )
+from ...product.utils.variant_prices import update_products_discounted_prices
 from ...shipping.models import (
     ShippingMethod,
     ShippingMethodChannelListing,
@@ -470,7 +471,9 @@ def create_products_by_schema(placeholder_dir, create_images):
     )
     assign_products_to_collections(associations=types["product.collectionproduct"])
 
-    update_products_search_document(Product.objects.all())
+    all_products_qs = Product.objects.all()
+    update_products_search_document(all_products_qs)
+    update_products_discounted_prices(all_products_qs)
 
 
 class SaleorProvider(BaseProvider):


### PR DESCRIPTION
There are lot of `"discountedPrice": null` when you execute following query. 
```
{
  products(
    first: 10
    channel: "channel-pln"
    sortBy: { field: PRICE, direction: DESC }
  ) {
    edges {
      node {
        id
        channelListings {
          discountedPrice {
            amount
          }
        }
      }
    }
  }
}
```
This pull request fixes populating data. In addition I've checked places in the codebase when update_products_discounted_prices should be triggered:

- [x] Price changed manually in dashboard
- [x] Sale added/removed/updated

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
