### PR TITLE
Make quantity optional in `CheckoutLinesUpdate` mutation

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_lines_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_update.py
@@ -3,9 +3,9 @@ from django.forms import ValidationError
 
 from ....checkout.error_codes import CheckoutErrorCode
 from ....warehouse.reservations import is_reservation_enabled
-from ...core.types import CheckoutError, NonNullList
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.scalars import UUID
+from ...core.types import CheckoutError, NonNullList
 from ..types import Checkout
 from .checkout_create import CheckoutLineInput
 from .checkout_lines_add import CheckoutLinesAdd

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -13,7 +13,7 @@ from .....plugins.manager import get_plugins_manager
 from .....product.models import ProductVariant, ProductVariantChannelListing
 from .....warehouse.models import Stock
 from ....tests.utils import get_graphql_content
-from ...mutations.utils import CustomPrice
+from ...mutations.utils import CheckoutLineData
 
 FRAGMENT_PRICE = """
     fragment Price on TaxedMoney {
@@ -580,7 +580,7 @@ def test_add_billing_address_to_checkout(
 MUTATION_CHECKOUT_LINES_UPDATE = (
     FRAGMENT_CHECKOUT_LINE
     + """
-        mutation updateCheckoutLine($token: UUID, $lines: [CheckoutLineInput!]!){
+        mutation updateCheckoutLine($token: UUID, $lines: [CheckoutLineUpdateInput!]!){
           checkoutLinesUpdate(token: $token, lines: $lines) {
             checkout {
               id
@@ -701,8 +701,15 @@ def test_update_checkout_lines_with_reservations(
     add_variants_to_checkout(
         checkout,
         variants,
-        [2] * 10,
-        [CustomPrice(to_update=False, value=None)] * 10,
+        [
+            CheckoutLineData(
+                quantity=2,
+                quantity_to_update=True,
+                custom_price=None,
+                custom_price_to_update=False,
+            )
+        ]
+        * 10,
         channel_USD.slug,
         replace_reservations=True,
         reservation_length=5,

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_update.py
@@ -11,7 +11,7 @@ from ...mutations.utils import update_checkout_shipping_method_if_invalid
 
 MUTATION_CHECKOUT_LINES_UPDATE = """
     mutation checkoutLinesUpdate(
-            $checkoutId: ID, $token: UUID, $lines: [CheckoutLineInput!]!) {
+            $checkoutId: ID, $token: UUID, $lines: [CheckoutLineUpdateInput!]!) {
         checkoutLinesUpdate(checkoutId: $checkoutId, token: $token, lines: $lines) {
             checkout {
                 token

--- a/saleor/graphql/checkout/tests/test_checkout_lines.py
+++ b/saleor/graphql/checkout/tests/test_checkout_lines.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
-from ....checkout.models import Checkout
+from ....checkout.models import Checkout, CheckoutLine
 from ....checkout.utils import add_variant_to_checkout, calculate_checkout_quantity
 from ....plugins.manager import get_plugins_manager
 from ....product.models import ProductChannelListing
@@ -18,7 +18,7 @@ from ....warehouse.models import Reservation, Stock
 from ....warehouse.tests.utils import get_available_quantity_for_stock
 from ...tests.utils import assert_no_permission, get_graphql_content
 from ..mutations.utils import (
-    CustomPrice,
+    CheckoutLineData,
     group_quantity_and_custom_prices_by_variants,
     update_checkout_shipping_method_if_invalid,
 )
@@ -744,7 +744,7 @@ def test_checkout_lines_invalid_variant_id(user_api_client, checkout, stock):
 
 MUTATION_CHECKOUT_LINES_UPDATE = """
     mutation checkoutLinesUpdate(
-            $token: UUID, $lines: [CheckoutLineInput!]!) {
+            $token: UUID, $lines: [CheckoutLineUpdateInput!]!) {
         checkoutLinesUpdate(token: $token, lines: $lines) {
             checkout {
                 id
@@ -898,11 +898,11 @@ def test_checkout_lines_update_against_reserved_stock(
     assert data["errors"][0]["field"] == "quantity"
 
     checkout.refresh_from_db()
-    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     assert line.variant == variant
     assert line.quantity == 3
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 3
     reservation.refresh_from_db()
     assert Reservation.objects.count() == 1
@@ -969,7 +969,7 @@ def test_checkout_lines_update_other_lines_reservations_expirations(
         reservation.refresh_from_db()
 
 
-def test_checkout_lines_update_with_custom_price(
+def test_checkout_lines_update_quantity_and_custom_price(
     app_api_client, checkout_with_item, permission_handle_checkouts
 ):
     checkout = checkout_with_item
@@ -997,13 +997,50 @@ def test_checkout_lines_update_with_custom_price(
     data = content["data"]["checkoutLinesUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     assert line.variant == variant
     assert line.quantity == 1
     assert line.price_override == price
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 1
+
+
+def test_checkout_lines_update_custom_price(
+    app_api_client, checkout_with_item, permission_handle_checkouts
+):
+    checkout = checkout_with_item
+    lines, _ = fetch_checkout_lines(checkout)
+    assert checkout.lines.count() == 1
+    assert calculate_checkout_quantity(lines) == 3
+    line = checkout.lines.first()
+    variant = line.variant
+    previous_quantity = line.quantity
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    price = Decimal("22.22")
+
+    variables = {
+        "token": checkout_with_item.token,
+        "lines": [{"variantId": variant_id, "price": price}],
+    }
+    response = app_api_client.post_graphql(
+        MUTATION_CHECKOUT_LINES_UPDATE,
+        variables,
+        permissions=[permission_handle_checkouts],
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["checkoutLinesUpdate"]
+    assert not data["errors"]
+    checkout.refresh_from_db()
+    assert checkout.lines.count() == 1
+    line = checkout.lines.first()
+    assert line.variant == variant
+    assert line.quantity == previous_quantity
+    assert line.price_override == price
+    lines, _ = fetch_checkout_lines(checkout)
+    assert calculate_checkout_quantity(lines) == 3
 
 
 def test_checkout_lines_update_with_custom_price_override_existing_price(
@@ -1036,12 +1073,12 @@ def test_checkout_lines_update_with_custom_price_override_existing_price(
     data = content["data"]["checkoutLinesUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     assert line.variant == variant
     assert line.quantity == 1
     assert line.price_override == price
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 1
 
 
@@ -1074,13 +1111,53 @@ def test_checkout_lines_update_clear_custom_price(
     data = content["data"]["checkoutLinesUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
-    lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     assert line.variant == variant
     assert line.quantity == 1
     assert line.price_override is None
+    lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 1
+
+
+def test_checkout_lines_update_set_quantity_to_0_then_update_customer_price(
+    app_api_client, checkout_with_item, permission_handle_checkouts
+):
+    """Ensure an error is not raised and the line is deleted when the line quantity
+    is set to 0 firstly and then the custom price is changed."""
+
+    checkout = checkout_with_item
+    lines, _ = fetch_checkout_lines(checkout)
+    assert checkout.lines.count() == 1
+    assert calculate_checkout_quantity(lines) == 3
+    line = checkout.lines.first()
+    line.price_override = Decimal("10.12")
+    line.save(update_fields=["price_override"])
+    variant = line.variant
+    assert line.quantity == 3
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    variables = {
+        "token": checkout_with_item.token,
+        "lines": [
+            {"variantId": variant_id, "quantity": 0},
+            {"variantId": variant_id, "price": 10},
+        ],
+    }
+    response = app_api_client.post_graphql(
+        MUTATION_CHECKOUT_LINES_UPDATE,
+        variables,
+        permissions=[permission_handle_checkouts],
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["checkoutLinesUpdate"]
+    assert not data["errors"]
+    checkout.refresh_from_db()
+    assert checkout.lines.count() == 0
+    with pytest.raises(CheckoutLine.DoesNotExist):
+        line.refresh_from_db()
 
 
 def test_checkout_lines_update_with_custom_price_by_app_no_perm(
@@ -1129,6 +1206,33 @@ def test_checkout_lines_update_with_custom_price_raise_permission_denied_for_sta
         permissions=[permission_handle_checkouts],
     )
     assert_no_permission(response)
+
+
+def test_checkout_lines_update_no_quantity_provided(
+    user_api_client, checkout_with_item
+):
+    checkout = checkout_with_item
+    lines, _ = fetch_checkout_lines(checkout)
+    assert checkout.lines.count() == 1
+    assert calculate_checkout_quantity(lines) == 3
+    line = checkout.lines.first()
+    variant = line.variant
+    assert line.quantity == 3
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    variables = {
+        "token": checkout_with_item.token,
+        "lines": [{"variantId": variant_id}],
+    }
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
+    content = get_graphql_content(response)
+
+    data = content["data"]["checkoutLinesUpdate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == CheckoutErrorCode.REQUIRED.name
+    assert errors[0]["field"] == "quantity"
 
 
 def test_checkout_lines_update_with_unavailable_variant(
@@ -1580,18 +1684,25 @@ def tests_checkout_lines_delete_invalid_lines_ids(user_api_client, checkout_with
     [
         (
             [
-                {"quantity": 6, "variant_id": "abc", "price": "1.22"},
+                {"quantity": 6, "variant_id": "abc", "price": 1.22},
                 {"quantity": 6, "variant_id": "abc"},
-                {"quantity": 1, "variant_id": "def", "price": "33.2"},
-                {"quantity": 1, "variant_id": "def", "price": "10"},
+                {"quantity": 1, "variant_id": "def", "price": 33.2},
+                {"quantity": 1, "variant_id": "def", "price": 10},
             ],
-            (
-                [12, 2],
-                [
-                    CustomPrice(to_update=False, value=None),
-                    CustomPrice(to_update=True, value="10"),
-                ],
-            ),
+            [
+                CheckoutLineData(
+                    quantity=12,
+                    quantity_to_update=True,
+                    custom_price=1.22,
+                    custom_price_to_update=True,
+                ),
+                CheckoutLineData(
+                    quantity=2,
+                    quantity_to_update=True,
+                    custom_price=10,
+                    custom_price_to_update=True,
+                ),
+            ],
         ),
         (
             [
@@ -1611,17 +1722,30 @@ def tests_checkout_lines_delete_invalid_lines_ids(user_api_client, checkout_with
                 {"quantity": 1000, "variant_id": "jkl"},
                 {"quantity": 999, "variant_id": "zzz"},
             ],
-            (
-                [20, 24, 4, 922, 1000, 999],
-                [CustomPrice(to_update=False, value=None)] * 6,
-            ),
+            [
+                CheckoutLineData(
+                    quantity=quantity,
+                    quantity_to_update=True,
+                    custom_price=None,
+                    custom_price_to_update=False,
+                )
+                for quantity in [20, 24, 4, 922, 1000, 999]
+            ],
         ),
         (
             [
                 {"quantity": 100, "variant_id": name}
                 for name in (l1 + l2 for l1 in "abcdef" for l2 in "ghijkl")
             ],
-            ([100] * 36, [CustomPrice(to_update=False, value=None)] * 36),
+            [
+                CheckoutLineData(
+                    quantity=100,
+                    quantity_to_update=True,
+                    custom_price=None,
+                    custom_price_to_update=False,
+                )
+            ]
+            * 36,
         ),
     ],
 )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9801,7 +9801,7 @@ type Mutation {
     """
     A list of checkout lines, each containing information about an item in the checkout.
     """
-    lines: [CheckoutLineInput!]!
+    lines: [CheckoutLineUpdateInput!]!
 
     """Checkout token."""
     token: UUID
@@ -14931,6 +14931,19 @@ type CheckoutLinesUpdate {
   checkout: Checkout
   checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
+}
+
+input CheckoutLineUpdateInput {
+  """The number of items purchased. Required for not app requestor."""
+  quantity: Int
+
+  """ID of the product variant."""
+  variantId: ID!
+
+  """
+  New in Saleor 3.1. Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used. Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  price: PositiveDecimal
 }
 
 """Remove a gift card or a voucher from a checkout."""


### PR DESCRIPTION
Make `quantity` optional in `CheckoutLinesUpdate` mutation.

Copy of PR: https://github.com/saleor/saleor/pull/9418

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
