### PR TITLE
Add language_code to webhook payloads for Order, Checkout and Customer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Other changes
 - Fix failing `checkoutCustomerAttach` mutation - #9401 by @IKarbowiak
 - Add new mutation `orderCreateFromCheckout` - #9343 by @korycins
+- Add `language_code` field to webhook payload for `Order`, `Checkout` and `Customer` - #9433 by @rafalp
+
 
 # 3.1.7
 

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -79,6 +79,7 @@ ORDER_FIELDS = (
     "shipping_price_gross_amount",
     "shipping_tax_rate",
     "weight",
+    "language_code",
     "private_metadata",
     "metadata",
     "total_net_amount",
@@ -428,6 +429,7 @@ def generate_checkout_payload(
         "currency",
         "discount_amount",
         "discount_name",
+        "language_code",
         "private_metadata",
         "metadata",
     )
@@ -490,6 +492,7 @@ def generate_customer_payload(
             "last_name",
             "is_active",
             "date_joined",
+            "language_code",
             "private_metadata",
             "metadata",
         ],

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -124,6 +124,7 @@ def test_generate_order_payload(
         "shipping_method_name": order.shipping_method_name,
         "collection_point_name": None,
         "weight": f"{order.weight.value}:{order.weight.unit}",
+        "language_code": order.language_code,
         "metadata": order.metadata,
         "private_metadata": order.private_metadata,
         "channel": {
@@ -671,6 +672,7 @@ def test_generate_invoice_payload(fulfilled_order):
             "type": "Order",
             "token": str(invoice.order.id),
             "id": graphene.Node.to_global_id("Order", invoice.order.id),
+            "language_code": "en",
             "private_metadata": {},
             "metadata": {},
             "created": ANY,
@@ -927,6 +929,7 @@ def test_generate_customer_payload(customer_user, address_other_country, address
                 "phone": customer.default_shipping_address.phone,
             }
         ],
+        "language_code": customer.language_code,
         "private_metadata": customer.private_metadata,
         "metadata": customer.metadata,
         "email": customer.email,
@@ -1072,6 +1075,7 @@ def test_generate_checkout_payload(
             quantize_price(checkout.discount_amount, checkout.currency)
         ),
         "discount_name": checkout.discount_name,
+        "language_code": checkout.language_code,
         "private_metadata": checkout.private_metadata,
         "metadata": checkout.metadata,
         "channel": {


### PR DESCRIPTION
This PR adds `language_code` field to webhook payloads for `Order`, `Checkout` and `Customer`. This field is useful for scenarios when webhook handler needs to display localized messages to the user.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
