### PR TITLE
chore: ensure graphql schema has LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,6 @@ package-lock.json linguist-generated -diff -merge
 
 # Automatically resolve changelog conflicts
 CHANGELOG.md merge=union
+
+# Make sure that the schema uses LF line endings
+saleor/graphql/schema.graphql text=auto


### PR DESCRIPTION
When generating the graphql schema through docker you will end up with a file containing CRLF line endings, due to the nature of how TTY's work:

```console
$ mv saleor/graphql/schema.graphql{,.old} && \
  docker-compose run --rm saleor \
    python manage.py get_graphql_schema > saleor/graphql/schema.graphql
$ file saleor/graphql/schema.graphql saleor/graphql/schema.graphql.old
saleor/graphql/schema.graphql:     ASCII text, with CRLF, CR line terminators
saleor/graphql/schema.graphql.old: ASCII text
```

We tell git to ignore this and stick with LF line endings and avoid `~7000` line diffs.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
