### PR TITLE
Fix logging of excessive logger informations

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -356,6 +356,7 @@ LOGGING = {
             "propagate": False,
         },
         "graphql.execution.utils": {"propagate": False, "handlers": ["null"]},
+        "graphql.execution.executor": {"propagate": False, "handlers": ["null"]},
     },
 }
 


### PR DESCRIPTION
I want to merge this change because it silences logging from `graphql.execution.executor`
Previously we merged a solution in #9398 which prevented such logging channel from impacting sentry, it should be silenced in loggers as well, which we missed.

- errors like PermissionDenied goes through by `saleor.graphql.errors.handled`
- errors like DivisionByZero goes in as `saleor.graphql.errors.unhandled`
- with this PR neither of above gets duplicated by `graphql.execution.executor`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
