### PR TITLE
Update `orderNumber` field in `OrderEvent` type

### DIFF
--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -1319,7 +1319,7 @@ def test_nested_order_events_query(
     assert data["user"]["email"] == staff_user.email
     assert data["type"] == "FULFILLMENT_FULFILLED_ITEMS"
     assert data["date"] == event.date.isoformat()
-    assert data["orderNumber"] == str(fulfilled_order.pk)
+    assert data["orderNumber"] == str(fulfilled_order.number)
     assert data["fulfilledItems"] == [
         {
             "quantity": line.quantity,
@@ -1379,7 +1379,7 @@ def test_nested_order_events_query_for_app(
     assert data["app"]["name"] == app.name
     assert data["type"] == "FULFILLMENT_FULFILLED_ITEMS"
     assert data["date"] == event.date.isoformat()
-    assert data["orderNumber"] == str(fulfilled_order.pk)
+    assert data["orderNumber"] == str(fulfilled_order.number)
     assert data["fulfilledItems"] == [
         {
             "quantity": line.quantity,
@@ -1578,7 +1578,7 @@ def test_payment_information_order_events_query(
     assert data["user"]["email"] == staff_user.email
     assert data["app"] is None
     assert data["type"] == "PAYMENT_CAPTURED"
-    assert data["orderNumber"] == str(order.pk)
+    assert data["orderNumber"] == str(order.number)
     assert data["paymentId"] == payment_dummy.token
     assert data["paymentGateway"] == payment_dummy.gateway
 
@@ -1614,7 +1614,7 @@ def test_payment_information_order_events_query_for_app(
     assert data["lines"] is None
     assert data["app"]["name"] == app.name
     assert data["type"] == "PAYMENT_CAPTURED"
-    assert data["orderNumber"] == str(order.pk)
+    assert data["orderNumber"] == str(order.number)
     assert data["paymentId"] == payment_dummy.token
     assert data["paymentGateway"] == payment_dummy.gateway
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -289,8 +289,15 @@ class OrderEvent(ModelObjectType):
         return root.parameters.get("oversold_items", None)
 
     @staticmethod
-    def resolve_order_number(root: models.OrderEvent, _info):
-        return root.order_id
+    def resolve_order_number(root: models.OrderEvent, info):
+        def _resolve_order_number(order: models.Order):
+            return order.number
+
+        return (
+            OrderByIdLoader(info.context)
+            .load(root.order_id)
+            .then(_resolve_order_number)
+        )
 
     @staticmethod
     def resolve_invoice_number(root: models.OrderEvent, _info):

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3978,8 +3978,12 @@ def order_with_preorder_lines(
 
 @pytest.fixture
 def order_events(order):
-    for event_type, _ in OrderEvents.CHOICES:
-        OrderEvent.objects.create(type=event_type, order=order)
+    order_events = [
+        OrderEvent(type=event_type, order=order)
+        for event_type, _ in OrderEvents.CHOICES
+    ]
+    OrderEvent.objects.bulk_create(order_events)
+    return order_events
 
 
 @pytest.fixture


### PR DESCRIPTION
Update `orderNumber` field in `OrderEvent` type - return `number` instead of `id`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
