### PR TITLE
Ensure initialization of the dummy context succeeded

### DIFF
--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -56,7 +56,8 @@ def initialize_context() -> HttpRequest:
     handler = BaseHandler()
     context = RequestFactory().request()
     handler.load_middleware()
-    handler.get_response(context)
+    response = handler.get_response(context)
+    assert response.status_code == 200
     return context
 
 


### PR DESCRIPTION
Saleor tests introduced by aca6418d6c36956bc1ab530e6ef7e146ec9df90c were not picking up if unexpected error happened when creating the dummy context (e.g. middleware caused HTTP 500 or HTTP 404) which can cause unexpected results or behaviors


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
