### PR TITLE
Fix invoice template

### DIFF
--- a/templates/invoices/invoice.html
+++ b/templates/invoices/invoice.html
@@ -212,7 +212,7 @@
             <div class="padded-font"></div>
             <span class="header-category">Order:</span>
             <div class="padded-font-sm"></div>
-            <span class="header-item">{{ order.id }}</span>
+            <span class="header-item">{{ order.number }}</span>
             <div class="padded-font"></div>
             <span class="header-category">Date:</span>
             <div class="padded-font-sm"></div>


### PR DESCRIPTION
Change from `order.id` to `order.number` in the invoice template.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
