### PR TITLE
Only run pytest if Python code is affected

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - main
       - ci/*
+    paths:
+      - "**.py"
+      - Dockerfile
+      - requirements_dev.txt
+      - "saleor/**"
 
 env:
   BENCH_PATH: ./queries-results.json
@@ -31,13 +36,12 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
 
       - name: Install system dependencies
         run: apt-get install -y libpq-dev
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements_dev.txt') }}
@@ -56,7 +60,7 @@ jobs:
             --junitxml=junit/test-results.xml \
             --django-db-bench=${{ env.BENCH_PATH }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
@@ -64,8 +68,9 @@ jobs:
             ${{ runner.os }}-pre-commit-
 
       # Publish coverage and test results
-      - uses: codecov/codecov-action@v1
-      - uses: actions/upload-artifact@v1
+      - uses: codecov/codecov-action@v2
+
+      - uses: actions/upload-artifact@v3
         with:
           name: pytest-results
           path: junit/test-results.xml


### PR DESCRIPTION
Currently, Pytest is run even if all you change is the README file, this PR makes it so Pytest is only run if Python code is affected.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
