### PR TITLE
Fix checkout 0040 migrations dependencies

### DIFF
--- a/saleor/checkout/migrations/0040_add_handle_checkouts_permission.py
+++ b/saleor/checkout/migrations/0040_add_handle_checkouts_permission.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("product", "0159_auto_20220209_1501"),
-        ("order", "0131_rename_order_token_id"),
+        ("order", "0133_rename_order_token_id"),
         ("checkout", "0039_alter_checkout_email"),
     ]
 


### PR DESCRIPTION
Fix `0040_add_handle_checkouts_permission` dependencies

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
