### PR TITLE
Add support for refund action request to fulfillment mutation related to return&refund

### DIFF
--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -531,16 +531,19 @@ class FulfillmentRefundAndReturnProductBase(BaseMutation):
 
     @classmethod
     def clean_order_payment(cls, payment, cleaned_input):
-        if not payment or not payment.can_refund():
-            raise ValidationError(
-                {
-                    "order": ValidationError(
-                        "Order cannot be refunded.",
-                        code=OrderErrorCode.CANNOT_REFUND.value,
-                    )
-                }
-            )
-        cleaned_input["payment"] = payment
+        if payment:
+            if not payment.gateway or payment.can_refund():
+                cleaned_input["payment"] = payment
+                return
+
+        raise ValidationError(
+            {
+                "order": ValidationError(
+                    "Order cannot be refunded.",
+                    code=OrderErrorCode.CANNOT_REFUND.value,
+                )
+            }
+        )
 
     @classmethod
     def clean_amount_to_refund(cls, order, amount_to_refund, payment, cleaned_input):
@@ -557,7 +560,11 @@ class FulfillmentRefundAndReturnProductBase(BaseMutation):
                         )
                     }
                 )
-            if amount_to_refund > payment.captured_amount:
+            # FIXME this will be cleaned up with cleaning up Payment model
+            captured_value = (
+                payment.captured_amount if payment.gateway else payment.captured_value
+            )
+            if amount_to_refund > captured_value:
                 raise ValidationError(
                     {
                         "amount_to_refund": ValidationError(

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -531,10 +531,9 @@ class FulfillmentRefundAndReturnProductBase(BaseMutation):
 
     @classmethod
     def clean_order_payment(cls, payment, cleaned_input):
-        if payment:
-            if not payment.gateway or payment.can_refund():
-                cleaned_input["payment"] = payment
-                return
+        if payment and (not payment.gateway or payment.can_refund()):
+            cleaned_input["payment"] = payment
+            return
 
         raise ValidationError(
             {

--- a/saleor/graphql/order/tests/test_fulfillment_refund_products.py
+++ b/saleor/graphql/order/tests/test_fulfillment_refund_products.py
@@ -5,13 +5,15 @@ import graphene
 from prices import Money, TaxedMoney
 
 from ....core.prices import quantize_price
-from ....order import FulfillmentLineData
+from ....order import FulfillmentLineData, OrderEvents
 from ....order.error_codes import OrderErrorCode
 from ....order.fetch import OrderLineInfo
 from ....order.models import FulfillmentLine, FulfillmentStatus
-from ....payment import ChargeStatus, PaymentError
-from ....payment.interface import RefundData
+from ....payment import ChargeStatus, PaymentAction, PaymentError
+from ....payment.interface import PaymentActionData, RefundData
+from ....payment.models import Payment
 from ....warehouse.models import Allocation, Stock
+from ...core.utils import to_global_id_or_none
 from ...tests.utils import get_graphql_content
 
 ORDER_FULFILL_REFUND_MUTATION = """
@@ -43,6 +45,102 @@ mutation OrderFulfillmentRefundProducts(
     }
 }
 """
+
+
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.payment_action_request")
+def test_fulfillment_refund_products_with_payment_action_request(
+    mocked_payment_action_request,
+    mocked_is_active,
+    staff_api_client,
+    permission_manage_orders,
+    fulfilled_order,
+):
+    # given
+    mocked_is_active.return_value = True
+
+    captured_value = Decimal("20.0")
+    payment = Payment.objects.create(
+        status="Captured",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        order_id=fulfilled_order.pk,
+        captured_value=captured_value,
+    )
+
+    order_id = to_global_id_or_none(fulfilled_order)
+    amount_to_refund = Decimal("11.00")
+    variables = {
+        "order": order_id,
+        "input": {"amountToRefund": amount_to_refund, "includeShippingCosts": True},
+    }
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_FULFILL_REFUND_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfillmentRefundProducts"]
+    errors = data["errors"]
+    assert not errors
+
+    mocked_payment_action_request.assert_called_once_with(
+        PaymentActionData(
+            payment=payment,
+            action_type=PaymentAction.REFUND,
+            action_value=amount_to_refund,
+        ),
+        channel_slug=fulfilled_order.channel.slug,
+    )
+    event = fulfilled_order.events.first()
+    assert event.type == OrderEvents.PAYMENT_REFUND_REQUESTED
+    assert Decimal(event.parameters["amount"]) == amount_to_refund
+    assert event.parameters["payment_id"] == payment.reference
+
+
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+def test_fulfillment_refund_products_with_missing_payment_action_hook(
+    mocked_is_active,
+    staff_api_client,
+    permission_manage_orders,
+    fulfilled_order,
+):
+    # given
+    mocked_is_active.return_value = False
+
+    captured_value = Decimal("20.0")
+    Payment.objects.create(
+        status="Captured",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        order_id=fulfilled_order.pk,
+        captured_value=captured_value,
+    )
+
+    order_id = to_global_id_or_none(fulfilled_order)
+    amount_to_refund = Decimal("11.00")
+    variables = {
+        "order": order_id,
+        "input": {"amountToRefund": amount_to_refund, "includeShippingCosts": True},
+    }
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_FULFILL_REFUND_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfillmentRefundProducts"]
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["code"] == (
+        OrderErrorCode.MISSING_PAYMENT_ACTION_REQUEST_WEBHOOK.name
+    )
+    assert mocked_is_active.called
 
 
 @patch("saleor.order.actions.gateway.refund")

--- a/saleor/graphql/order/tests/test_fulfillment_return_products.py
+++ b/saleor/graphql/order/tests/test_fulfillment_return_products.py
@@ -5,13 +5,15 @@ import graphene
 from prices import Money, TaxedMoney
 
 from ....core.prices import quantize_price
-from ....order import FulfillmentLineData, OrderOrigin, OrderStatus
+from ....order import FulfillmentLineData, OrderEvents, OrderOrigin, OrderStatus
 from ....order.error_codes import OrderErrorCode
 from ....order.fetch import OrderLineInfo
 from ....order.models import FulfillmentStatus, Order
-from ....payment import ChargeStatus, PaymentError
-from ....payment.interface import RefundData
+from ....payment import ChargeStatus, PaymentAction, PaymentError
+from ....payment.interface import PaymentActionData, RefundData
+from ....payment.models import Payment
 from ....warehouse.models import Stock
+from ...core.utils import to_global_id_or_none
 from ...tests.utils import get_graphql_content
 
 ORDER_FULFILL_RETURN_MUTATION = """
@@ -64,6 +66,110 @@ mutation OrderFulfillmentReturnProducts(
     }
 }
 """
+
+
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.payment_action_request")
+def test_fulfillment_return_products_with_payment_action_request(
+    mocked_payment_action_request,
+    mocked_is_active,
+    staff_api_client,
+    permission_manage_orders,
+    fulfilled_order,
+):
+    # given
+    mocked_is_active.return_value = True
+
+    captured_value = Decimal("20.0")
+    payment = Payment.objects.create(
+        status="Captured",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        order_id=fulfilled_order.pk,
+        captured_value=captured_value,
+    )
+
+    order_id = to_global_id_or_none(fulfilled_order)
+    amount_to_refund = Decimal("11.00")
+    variables = {
+        "order": order_id,
+        "input": {
+            "refund": True,
+            "amountToRefund": amount_to_refund,
+            "includeShippingCosts": True,
+        },
+    }
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_FULFILL_RETURN_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfillmentReturnProducts"]
+    errors = data["errors"]
+    assert not errors
+
+    mocked_payment_action_request.assert_called_once_with(
+        PaymentActionData(
+            payment=payment,
+            action_type=PaymentAction.REFUND,
+            action_value=amount_to_refund,
+        ),
+        channel_slug=fulfilled_order.channel.slug,
+    )
+    event = fulfilled_order.events.first()
+    assert event.type == OrderEvents.PAYMENT_REFUND_REQUESTED
+    assert Decimal(event.parameters["amount"]) == amount_to_refund
+    assert event.parameters["payment_id"] == payment.reference
+
+
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+def test_fulfillment_return_products_with_missing_payment_action_hook(
+    mocked_is_active,
+    staff_api_client,
+    permission_manage_orders,
+    fulfilled_order,
+):
+    # given
+    mocked_is_active.return_value = False
+
+    captured_value = Decimal("20.0")
+    Payment.objects.create(
+        status="Captured",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        order_id=fulfilled_order.pk,
+        captured_value=captured_value,
+    )
+
+    order_id = to_global_id_or_none(fulfilled_order)
+    amount_to_refund = Decimal("11.00")
+    variables = {
+        "order": order_id,
+        "input": {
+            "refund": True,
+            "amountToRefund": amount_to_refund,
+            "includeShippingCosts": True,
+        },
+    }
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_FULFILL_RETURN_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfillmentReturnProducts"]
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["code"] == (
+        OrderErrorCode.MISSING_PAYMENT_ACTION_REQUEST_WEBHOOK.name
+    )
+    assert mocked_is_active.called
 
 
 def test_fulfillment_return_products_order_without_payment(


### PR DESCRIPTION
I want to merge this change because it adds a handler to process a refund in a new way by calling the hook payment action request.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
