### PR TITLE
Errors handling fix for orderFulfillApprove mutation

### DIFF
--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -188,10 +188,10 @@ def test_order_fulfill_with_stock_exceeded_with_flag_disabled(
 
     errors = data["errors"]
     assert errors[0]["code"] == "INSUFFICIENT_STOCK"
-    assert errors[0]["message"] == "Insufficient product stock: SKU_AA"
+    assert errors[0]["message"] == f"Insufficient product stock: {order_line}"
 
     assert errors[1]["code"] == "INSUFFICIENT_STOCK"
-    assert errors[1]["message"] == "Insufficient product stock: SKU_B"
+    assert errors[1]["message"] == f"Insufficient product stock: {order_line2}"
 
 
 def test_order_fulfill_with_stock_exceeded_with_flag_enabled(
@@ -1817,6 +1817,7 @@ def test_fulfillment_approve_delete_products_before_approval_allow_stock_exceede
     errors = content["data"]["orderFulfillmentApprove"]["errors"]
 
     assert len(errors) == 2
+
     error_field_and_code = {
         "field": "stocks",
         "code": "INSUFFICIENT_STOCK",
@@ -1824,12 +1825,9 @@ def test_fulfillment_approve_delete_products_before_approval_allow_stock_exceede
     expected_errors = [
         {
             **error_field_and_code,
-            "message": "Insufficient product stock: Test product (SKU_AA)",
-        },
-        {
-            **error_field_and_code,
-            "message": "Insufficient product stock: Test product 2 (SKU_B)",
-        },
+            "message": f"Insufficient product stock: {line.order_line}",
+        }
+        for line in fulfillment.lines.all()
     ]
 
     for expected_error in expected_errors:
@@ -1989,9 +1987,13 @@ def test_fulfillment_approve_when_stock_is_exceeded_and_flag_disabled(
         "field": "stocks",
         "code": "INSUFFICIENT_STOCK",
     }
+
     expected_errors = [
-        {**error_field_and_code, "message": "Insufficient product stock: SKU_AA"},
-        {**error_field_and_code, "message": "Insufficient product stock: SKU_B"},
+        {
+            **error_field_and_code,
+            "message": f"Insufficient product stock: {line.order_line}",
+        }
+        for line in fulfillment.lines.all()
     ]
 
     for expected_error in expected_errors:

--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -1817,11 +1817,23 @@ def test_fulfillment_approve_delete_products_before_approval_allow_stock_exceede
     errors = content["data"]["orderFulfillmentApprove"]["errors"]
 
     assert len(errors) == 2
-    assert errors[0]["code"] == "INSUFFICIENT_STOCK"
-    assert errors[0]["message"] == "Insufficient product stock: Test product (SKU_AA)"
+    error_field_and_code = {
+        "field": "stocks",
+        "code": "INSUFFICIENT_STOCK",
+    }
+    expected_errors = [
+        {
+            **error_field_and_code,
+            "message": "Insufficient product stock: Test product (SKU_AA)",
+        },
+        {
+            **error_field_and_code,
+            "message": "Insufficient product stock: Test product 2 (SKU_B)",
+        },
+    ]
 
-    assert errors[1]["code"] == "INSUFFICIENT_STOCK"
-    assert errors[1]["message"] == "Insufficient product stock: Test product 2 (SKU_B)"
+    for expected_error in expected_errors:
+        assert expected_error in errors
 
     fulfillment.refresh_from_db()
     assert fulfillment.status == FulfillmentStatus.WAITING_FOR_APPROVAL
@@ -1972,11 +1984,18 @@ def test_fulfillment_approve_when_stock_is_exceeded_and_flag_disabled(
     errors = content["data"]["orderFulfillmentApprove"]["errors"]
 
     assert len(errors) == 2
-    assert errors[0]["code"] == "INSUFFICIENT_STOCK"
-    assert errors[0]["message"] == "Insufficient product stock: SKU_AA"
 
-    assert errors[1]["code"] == "INSUFFICIENT_STOCK"
-    assert errors[1]["message"] == "Insufficient product stock: SKU_B"
+    error_field_and_code = {
+        "field": "stocks",
+        "code": "INSUFFICIENT_STOCK",
+    }
+    expected_errors = [
+        {**error_field_and_code, "message": "Insufficient product stock: SKU_AA"},
+        {**error_field_and_code, "message": "Insufficient product stock: SKU_B"},
+    ]
+
+    for expected_error in expected_errors:
+        assert expected_error in errors
 
 
 @patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -289,7 +289,7 @@ def prepare_insufficient_stock_order_validation_errors(exc):
         )
         errors.append(
             ValidationError(
-                f"Insufficient product stock: {item.variant or item.order_line}",
+                f"Insufficient product stock: {item.order_line or item.variant}",
                 code=OrderErrorCode.INSUFFICIENT_STOCK,
                 params={
                     "order_lines": [order_line_global_id]

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -289,7 +289,7 @@ def prepare_insufficient_stock_order_validation_errors(exc):
         )
         errors.append(
             ValidationError(
-                f"Insufficient product stock: {item.variant}",
+                f"Insufficient product stock: {item.variant or item.order_line}",
                 code=OrderErrorCode.INSUFFICIENT_STOCK,
                 params={
                     "order_lines": [order_line_global_id]


### PR DESCRIPTION
I want to merge this change because it fixes returning `InsufficientStock` error as a backend error instead GraphQL error.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
