### PR TITLE
enable list client sources in production

### DIFF
--- a/saleor/payment/gateways/authorize_net/__init__.py
+++ b/saleor/payment/gateways/authorize_net/__init__.py
@@ -254,7 +254,7 @@ def list_client_sources(
     get_customer_profile.customerProfileId = customer_id
     get_customer_profile.unmaskExpirationDate = True
     controller = getCustomerProfileController(get_customer_profile)
-    if config.connection_params.get("use_sandbox") is False:
+    if not config.connection_params.get("use_sandbox"):
         controller.setenvironment(constants.PRODUCTION)
     controller.execute()
 

--- a/saleor/payment/gateways/authorize_net/__init__.py
+++ b/saleor/payment/gateways/authorize_net/__init__.py
@@ -254,6 +254,8 @@ def list_client_sources(
     get_customer_profile.customerProfileId = customer_id
     get_customer_profile.unmaskExpirationDate = True
     controller = getCustomerProfileController(get_customer_profile)
+    if config.connection_params.get("use_sandbox") is False:
+        controller.setenvironment(constants.PRODUCTION)
     controller.execute()
 
     response = controller.getresponse()


### PR DESCRIPTION
get client sources is not adapted to production environment, and always set to the default: sandbox environment

I want to merge this change because:
**It was not possible to get client data in production environment, and the client had to re-enter the details and credit details each time**

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
