### PR TITLE
Fix #9174

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -91,6 +91,16 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             shipping_method_id=shipping_method_id,
         )
 
+        if delivery_method is None and shipping_method_id:
+            raise ValidationError(
+                {
+                    "delivery_method_id": ValidationError(
+                        f"Couldn't resolve to a node: ${shipping_method_id}",
+                        code=CheckoutErrorCode.NOT_FOUND,
+                    )
+                }
+            )
+
         cls._check_delivery_method(
             checkout_info, lines, shipping_method=delivery_method, collection_point=None
         )


### PR DESCRIPTION
Setting external methods did not throw an error when that method didn't exist.
This commit updates the code to throw a not found error.

I want to merge this change to fix an open issue and contribute to a project I may use.

Fixes #9174.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
