### PR TITLE
Add subscription_query to Webhook type and tests

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1065,6 +1065,7 @@ type Webhook implements Node {
   targetUrl: String!
   isActive: Boolean!
   secretKey: String
+  subscriptionQuery: String
 }
 
 """An object with an ID"""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1062,9 +1062,17 @@ type Webhook implements Node {
     """Return the last n elements from the list."""
     last: Int
   ): EventDeliveryCountableConnection
+
+  """Target URL for webhook."""
   targetUrl: String!
+
+  """Informs if webhook is activated."""
   isActive: Boolean!
+
+  """Used to create a hash signature with each payload."""
   secretKey: String
+
+  """Used to define payloads for specific events."""
   subscriptionQuery: String
 }
 
@@ -1566,11 +1574,23 @@ type EventDeliveryAttempt implements Node {
 
   """Event delivery creation date and time."""
   createdAt: DateTime!
+
+  """Task id for delivery attempt."""
   taskId: String
+
+  """Delivery attempt duration."""
   duration: Float
+
+  """Delivery attempt response content."""
   response: String
+
+  """Response headers for delivery attempt."""
   responseHeaders: String
+
+  """Delivery attempt response status code."""
   responseStatusCode: Int
+
+  """Request headers for delivery attempt."""
   requestHeaders: String
 
   """Event delivery status."""

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -20,6 +20,7 @@ def validate_subscription_query(query: str) -> bool:
     graphql_backend = get_default_backend()
     try:
         document = graphql_backend.document_from_string(schema, query)
+        print(document.document_ast.definitions)
     except (ValueError, GraphQLSyntaxError):
         return False
     if not check_document_is_single_subscription(document):

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -20,7 +20,6 @@ def validate_subscription_query(query: str) -> bool:
     graphql_backend = get_default_backend()
     try:
         document = graphql_backend.document_from_string(schema, query)
-        print(document.document_ast.definitions)
     except (ValueError, GraphQLSyntaxError):
         return False
     if not check_document_is_single_subscription(document):

--- a/saleor/graphql/webhook/tests/test_webhook.py
+++ b/saleor/graphql/webhook/tests/test_webhook.py
@@ -15,7 +15,6 @@ from ..enums import (
     WebhookEventTypeSyncEnum,
     WebhookSampleEventTypeEnum,
 )
-from ..subscription_payload import generate_payload_from_subscription
 
 WEBHOOK_CREATE = """
     mutation webhookCreate($input: WebhookCreateInput!){
@@ -580,7 +579,3 @@ def test_sample_payload_query_by_staff(
     else:
         get_graphql_content(response)
         mock_generate_sample_payload.assert_called_with(event_type.value)
-
-
-def test_generate_payload_from_subscription():
-    generate_payload_from_subscription()

--- a/saleor/graphql/webhook/tests/test_webhook.py
+++ b/saleor/graphql/webhook/tests/test_webhook.py
@@ -349,6 +349,7 @@ QUERY_WEBHOOK = """
       webhook(id: $id) {
         id
         isActive
+        subscriptionQuery
         asyncEvents {
           eventType
         }
@@ -372,6 +373,27 @@ def test_query_webhook_by_staff(staff_api_client, webhook, permission_manage_app
     webhook_response = content["data"]["webhook"]
     assert webhook_response["id"] == webhook_id
     assert webhook_response["isActive"] == webhook.is_active
+    assert webhook_response["subscriptionQuery"] is None
+    events = webhook.events.all()
+    assert len(events) == 1
+    assert events[0].event_type == WebhookEventTypeAsyncEnum.ORDER_CREATED.value
+
+
+def test_query_webhook_with_subscription_query_by_staff(
+    staff_api_client, subscription_order_created_webhook, permission_manage_apps
+):
+    query = QUERY_WEBHOOK
+    webhook = subscription_order_created_webhook
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {"id": webhook_id}
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
+    response = staff_api_client.post_graphql(query, variables=variables)
+
+    content = get_graphql_content(response)
+    webhook_response = content["data"]["webhook"]
+    assert webhook_response["id"] == webhook_id
+    assert webhook_response["isActive"] == webhook.is_active
+    assert webhook_response["subscriptionQuery"] == webhook.subscription_query
     events = webhook.events.all()
     assert len(events) == 1
     assert events[0].event_type == WebhookEventTypeAsyncEnum.ORDER_CREATED.value

--- a/saleor/graphql/webhook/types.py
+++ b/saleor/graphql/webhook/types.py
@@ -167,6 +167,7 @@ class Webhook(ModelObjectType):
     target_url = graphene.String(required=True)
     is_active = graphene.Boolean(required=True)
     secret_key = graphene.String()
+    subscription_query = graphene.String()
 
     class Meta:
         description = "Webhook."

--- a/saleor/graphql/webhook/types.py
+++ b/saleor/graphql/webhook/types.py
@@ -76,12 +76,18 @@ class EventDeliveryAttempt(ModelObjectType):
     created_at = graphene.DateTime(
         description="Event delivery creation date and time.", required=True
     )
-    task_id = graphene.String()
-    duration = graphene.Float()
-    response = graphene.String()
-    response_headers = graphene.String()
-    response_status_code = graphene.Int()
-    request_headers = graphene.String()
+    task_id = graphene.String(description="Task id for delivery attempt.")
+    duration = graphene.Float(description="Delivery attempt duration.")
+    response = graphene.String(description="Delivery attempt response content.")
+    response_headers = graphene.String(
+        description="Response headers for delivery attempt."
+    )
+    response_status_code = graphene.Int(
+        description="Delivery attempt response status code."
+    )
+    request_headers = graphene.String(
+        description="Request headers for delivery attempt."
+    )
     status = EventDeliveryStatusEnum(
         description="Event delivery status.", required=True
     )
@@ -164,10 +170,16 @@ class Webhook(ModelObjectType):
         filter=EventDeliveryFilterInput(description="Event delivery filter options."),
         description="Event deliveries.",
     )
-    target_url = graphene.String(required=True)
-    is_active = graphene.Boolean(required=True)
-    secret_key = graphene.String()
-    subscription_query = graphene.String()
+    target_url = graphene.String(required=True, description="Target URL for webhook.")
+    is_active = graphene.Boolean(
+        required=True, description="Informs if webhook is activated."
+    )
+    secret_key = graphene.String(
+        description="Used to create a hash signature with each payload."
+    )
+    subscription_query = graphene.String(
+        description="Used to define payloads for specific events."
+    )
 
     class Meta:
         description = "Webhook."

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -3,13 +3,9 @@ from unittest.mock import patch
 
 import graphene
 
-from .....graphql.webhook.subscription_payload import (
-    logger,
-    validate_subscription_query,
-)
+from .....graphql.webhook.subscription_payload import validate_subscription_query
 from .....webhook.event_types import WebhookEventAsyncType
-from ...tasks import create_deliveries_for_subscriptions
-from ...tasks import logger as task_logger
+from ...tasks import create_deliveries_for_subscriptions, logger
 
 
 def test_product_created(product, subscription_product_created_webhook):
@@ -488,7 +484,7 @@ def test_create_deliveries_for_subscriptions_unsubscribable_event(
 
 
 @patch("saleor.graphql.webhook.subscription_payload.get_default_backend")
-@patch.object(task_logger, "warning")
+@patch.object(logger, "warning")
 def test_create_deliveries_for_subscriptions_document_executed_with_error(
     mocked_task_logger,
     mocked_backend,


### PR DESCRIPTION
I want to merge this change because it adds `subscription_query` field to Webhook type and adds some tests to raise coverage of subscription payloads.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
