### PR TITLE
Fix payment flow

### DIFF
--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -18,6 +18,7 @@ from ...graphql.checkout.tests.test_checkout_complete import (
 from ...order import OrderEvents
 from ...order.models import OrderEvent
 from ...order.notifications import get_default_order_payload
+from ...payment import TransactionKind
 from ...payment.models import Payment
 from ...plugins.manager import get_plugins_manager
 from ...product.models import ProductTranslation, ProductVariantTranslation
@@ -1253,4 +1254,55 @@ def test_complete_checkout_action_required_voucher_once_per_customer(
     assert not order
     assert action_required is True
     assert not voucher_customer.exists()
+    mocked_create_order.assert_not_called()
+
+
+@mock.patch("saleor.checkout.complete_checkout._create_order")
+def test_complete_checkout_order_not_created_when_the_refund_is_ongoing(
+    mocked_create_order,
+    customer_user,
+    checkout,
+    payment_txn_to_confirm,
+):
+    # given
+    payment = Payment.objects.create(
+        gateway="mirumee.payments.dummy", is_active=True, checkout=checkout
+    )
+    payment.to_confirm = False
+    payment.save()
+    payment.transactions.create(
+        is_success=True,
+        action_required=False,
+        kind=TransactionKind.REFUND_ONGOING,
+        amount=payment.total,
+        currency=payment.currency,
+        token="test",
+        gateway_response={},
+    )
+
+    checkout.user = customer_user
+    checkout.billing_address = customer_user.default_billing_address
+    checkout.shipping_address = customer_user.default_billing_address
+    checkout.tracking_code = ""
+    checkout.redirect_url = "https://www.example.com"
+    checkout.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+
+    # when
+    order, _, _ = complete_checkout(
+        checkout_info=checkout_info,
+        manager=manager,
+        lines=lines,
+        payment_data={},
+        store_source=False,
+        discounts=None,
+        user=customer_user,
+        app=None,
+    )
+
+    # then
+    assert not order
     mocked_create_order.assert_not_called()

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -201,13 +201,11 @@ def test_try_void_or_refund_inactive_payment_failed_transaction(
     assert not refund_or_void_mock.called
 
 
-@patch("saleor.payment.utils.update_payment_charge_status")
 @patch("saleor.payment.utils.get_channel_slug_from_payment")
 @patch("saleor.payment.gateway.payment_refund_or_void")
 def test_try_void_or_refund_inactive_payment_transaction_success(
     refund_or_void_mock,
     get_channel_slug_from_payment_mock,
-    update_payment_charge_status_mock,
     payment_txn_captured,
 ):
     transaction = payment_txn_captured.transactions.first()
@@ -215,6 +213,5 @@ def test_try_void_or_refund_inactive_payment_transaction_success(
     assert not try_void_or_refund_inactive_payment(
         payment_txn_captured, transaction, None
     )
-    assert update_payment_charge_status_mock.called
     assert get_channel_slug_from_payment_mock.called
     assert refund_or_void_mock.called

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -594,10 +594,14 @@ def try_void_or_refund_inactive_payment(
     webhook when we have order already paid.
     """
     if transaction.is_success:
-        update_payment_charge_status(payment, transaction)
         channel_slug = get_channel_slug_from_payment(payment)
         try:
-            gateway.payment_refund_or_void(payment, manager, channel_slug=channel_slug)
+            gateway.payment_refund_or_void(
+                payment,
+                manager,
+                channel_slug=channel_slug,
+                transaction_id=transaction.token,
+            )
         except PaymentError:
             logger.exception(
                 "Unable to void/refund an inactive payment %s, %s.",


### PR DESCRIPTION
### This PR fixes two issues:

### First problem:
Sometimes we can have situations when something went wrong during order creation (i.e. tax plugin raises an error)  and the refund process is started. In the meantime, we got a notification from the payment gateway with confirmation that the payment was captured. At this step, we usually have an order, but if there isn't we call the method for creating the order. As a result, we're ending with an order, which is refunded just after creation. 
Fix: before order creation, I'm checking if there is any ongoing refund for a given payment.

### Second problem:
The order has two payments:
- first was created, and we get a proper response from the gateway, but again something went wrong, during order creation, so we started the refund process. 
- because of the problems somebody run the payment creation process again, this time everything goes well, and the order was created. The first payment was deactivated
- then we got some notification from getaway regarding the first payment, but this payment was deactivated, so again we run the refund process. But before that, we handled the notification and doubled captured amount
- after that, the first refund was properly performed, and we received a notification about that, so the captured amount was reduced, but just before the amount was doubled, so we ended with two payments, both of them with a captured amount equal to the total value of the order. 

So in the second scenario, we have two problems:
1. we shouldn't captured the payment again, if it was already captured
2. the refund should be started if there is any already ongoing

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
