### PR TITLE
Move get_webhooks_for_event to webhook utils

### DIFF
--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -157,7 +157,7 @@ MUTATION_CHECKOUT_CREATE = """
 """
 
 
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_checkout_create_triggers_webhooks(
     mocked_webhook_trigger,

--- a/saleor/graphql/page/tests/mutations/test_page_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_create.py
@@ -114,7 +114,7 @@ def test_page_create_mutation(staff_api_client, permission_manage_pages, page_ty
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_create_trigger_page_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/page/tests/mutations/test_page_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_delete.py
@@ -41,7 +41,7 @@ def test_page_delete_mutation(staff_api_client, page, permission_manage_pages):
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_delete_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -122,7 +122,7 @@ def test_update_page(staff_api_client, permission_manage_pages, page):
         assert attr_data in expected_attributes
 
 
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 @freeze_time("2020-03-18 12:00:00")
 def test_update_page_trigger_webhook(

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -80,7 +80,7 @@ def test_delete_categories(staff_api_client, category_list, permission_manage_pr
     ).exists()
 
 
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_delete_categories_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -545,7 +545,7 @@ def test_delete_products_with_images(
     mocked_recalculate_orders_task.assert_not_called()
 
 
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
 def test_delete_products_trigger_webhook(
@@ -580,7 +580,7 @@ def test_delete_products_trigger_webhook(
     mocked_recalculate_orders_task.assert_not_called()
 
 
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_delete_products_without_variants(
     mocked_webhook_trigger,

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -446,7 +446,7 @@ def test_category_create_mutation(
     assert data["category"]["parent"]["id"] == parent_id
 
 
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_category_create_trigger_webhook(
     mocked_webhook_trigger,
@@ -667,7 +667,7 @@ def test_category_update_mutation(
     assert data["category"]["backgroundImage"]["alt"] == image_alt
 
 
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_category_update_trigger_webhook(
     mocked_webhook_trigger,
@@ -989,7 +989,7 @@ def test_category_delete_mutation(
 
 
 @patch("saleor.product.signals.delete_versatile_image")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_category_delete_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -7963,7 +7963,7 @@ def test_delete_product_with_image(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
 def test_delete_product_trigger_webhook(

--- a/saleor/graphql/shipping/tests/mutations/test_bulk_delete.py
+++ b/saleor/graphql/shipping/tests/mutations/test_bulk_delete.py
@@ -60,7 +60,7 @@ def test_delete_shipping_methods(
     ).exists()
 
 
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_delete_shipping_methods_trigger_multiple_webhook_events(
     mocked_webhook_trigger,
@@ -127,7 +127,7 @@ def test_delete_shipping_zones(
     ).exists()
 
 
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_delete_shipping_zones_trigger_multiple_webhook_events(
     mocked_webhook_trigger,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_method_channel_listing_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_method_channel_listing_update.py
@@ -103,7 +103,7 @@ def test_shipping_method_channel_listing_create_as_staff_user(
     )
 
 
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_shipping_method_channel_listing_create_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_create.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_create.py
@@ -115,7 +115,7 @@ def test_create_shipping_method(
     assert data["shippingMethod"]["postalCodeRules"] == postal_code_rules
 
 
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_create_shipping_method_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_delete.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_delete.py
@@ -49,7 +49,7 @@ def test_delete_shipping_method(
     assert data["shippingZone"]["id"] == shipping_zone_id
 
 
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_delete_shipping_method_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_exclude_products.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_exclude_products.py
@@ -93,7 +93,7 @@ def test_exclude_products_for_shipping_method_already_has_excluded_products(
 
 
 @pytest.mark.parametrize("requestor", ["staff", "app"])
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_exclude_products_for_shipping_method_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_remove_product_from_exclude.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_remove_product_from_exclude.py
@@ -110,7 +110,7 @@ def test_remove_products_from_excluded_products_for_shipping_method(
 
 
 @pytest.mark.parametrize("requestor", ["staff", "app"])
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_remove_products_from_excluded_products_for_shipping_method_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_update.py
@@ -91,7 +91,7 @@ def test_update_shipping_method(
     assert data["shippingMethod"]["maximumDeliveryDays"] == max_del_days
 
 
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_update_shipping_method_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_create.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_create.py
@@ -84,7 +84,7 @@ def test_create_shipping_zone(
     assert zone["default"] is False
 
 
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_create_shipping_zone_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_delete.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_delete.py
@@ -46,7 +46,7 @@ def test_delete_shipping_zone(
         shipping_zone.refresh_from_db()
 
 
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_delete_shipping_zone_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
@@ -81,7 +81,7 @@ def test_update_shipping_zone(
     assert data["description"] == description
 
 
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_update_shipping_zone_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -829,7 +829,7 @@ PRODUCT_TRANSLATE_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_create_translation(
     mocked_webhook_trigger,
@@ -980,7 +980,7 @@ def test_product_create_translation_by_invalid_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_update_translation(
     mocked_webhook_trigger,
@@ -1043,7 +1043,7 @@ mutation productVariantTranslate(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_variant_create_translation(
     mocked_webhook_trigger,
@@ -1100,7 +1100,7 @@ def test_product_variant_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_variant_update_translation(
     mocked_webhook_trigger,
@@ -1189,7 +1189,7 @@ mutation collectionTranslate($collectionId: ID!, $input: TranslationInput!) {
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_collection_create_translation(
     mocked_webhook_trigger,
@@ -1281,7 +1281,7 @@ def test_collection_create_translation_for_description_name_as_null(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_collection_update_translation(
     mocked_webhook_trigger,
@@ -1360,7 +1360,7 @@ mutation categoryTranslate($categoryId: ID!, $input: TranslationInput!) {
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_category_create_translation(
     mocked_webhook_trigger,
@@ -1452,7 +1452,7 @@ def test_category_create_translation_for_description_name_as_null(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_category_update_translation(
     mocked_webhook_trigger,
@@ -1509,7 +1509,7 @@ VOUCHER_TRANSLATE_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_voucher_create_translation(
     mocked_webhook_trigger,
@@ -1564,7 +1564,7 @@ def test_voucher_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_voucher_update_translation(
     mocked_webhook_trigger,
@@ -1620,7 +1620,7 @@ SALE_TRANSLATION_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_sale_create_translation(
     mocked_webhook_trigger,
@@ -1675,7 +1675,7 @@ def test_sale_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_sale_update_translation(
     mocked_webhook_trigger,
@@ -1733,7 +1733,7 @@ mutation pageTranslate($pageId: ID!, $input: PageTranslationInput!) {
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_create_translation(
     mocked_webhook_trigger,
@@ -1822,7 +1822,7 @@ def test_page_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_update_translation(
     mocked_webhook_trigger,
@@ -1880,7 +1880,7 @@ ATTRIBUTE_TRANSLATE_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_attribute_create_translation(
     mocked_webhook_trigger,
@@ -1935,7 +1935,7 @@ def test_attribute_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_attribute_update_translation(
     mocked_webhook_trigger,
@@ -1994,7 +1994,7 @@ ATTRIBUTE_VALUE_TRANSLATE_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_attribute_value_create_translation(
     mocked_webhook_trigger,
@@ -2049,7 +2049,7 @@ def test_attribute_value_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_attribute_value_update_translation(
     mocked_webhook_trigger,
@@ -2119,7 +2119,7 @@ SHIPPING_PRICE_TRANSLATE = """
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_shipping_method_create_translation(
     mocked_webhook_trigger,
@@ -2188,7 +2188,7 @@ def test_shipping_method_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_shipping_method_update_translation(
     mocked_webhook_trigger,
@@ -2265,7 +2265,7 @@ MENU_ITEM_TRANSLATE = """
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_menu_item_update_translation(
     mocked_webhook_trigger,
@@ -2322,7 +2322,7 @@ def test_menu_item_create_translation_by_translatable_content_id(
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_shop_create_translation(
     mocked_webhook_trigger,
@@ -2393,7 +2393,7 @@ SHOP_SETTINGS_TRANSLATE_MUTATION = """
 
 
 @freeze_time("1914-06-28 10:50")
-@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_shop_update_translation(
     mocked_webhook_trigger,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -32,11 +32,11 @@ from ...webhook.payloads import (
     generate_sale_payload,
     generate_translation_payload,
 )
+from ...webhook.utils import get_webhooks_for_event
 from ..base_plugin import BasePlugin, ExcludedShippingMethod
 from .const import CACHE_EXCLUDED_SHIPPING_KEY
 from .shipping import get_excluded_shipping_data, parse_list_shipping_methods_response
 from .tasks import (
-    _get_webhooks_for_event,
     send_webhook_request_async,
     trigger_webhook_sync,
     trigger_webhooks_async,
@@ -118,7 +118,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             order_data = generate_order_payload(order, self.requestor)
             trigger_webhooks_async(
                 order_data, event_type, webhooks, order, self.requestor
@@ -128,7 +128,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_CONFIRMED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             order_data = generate_order_payload(order, self.requestor)
             trigger_webhooks_async(
                 order_data, event_type, webhooks, order, self.requestor
@@ -138,7 +138,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_FULLY_PAID
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             order_data = generate_order_payload(order, self.requestor)
             trigger_webhooks_async(
                 order_data, event_type, webhooks, order, self.requestor
@@ -148,7 +148,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             order_data = generate_order_payload(order, self.requestor)
             trigger_webhooks_async(
                 order_data, event_type, webhooks, order, self.requestor
@@ -160,7 +160,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.SALE_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             sale_data = generate_sale_payload(
                 sale,
                 previous_catalogue=None,
@@ -181,7 +181,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.SALE_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             sale_data = generate_sale_payload(
                 sale, previous_catalogue, current_catalogue, self.requestor
             )
@@ -195,7 +195,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.SALE_DELETED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             sale_data = generate_sale_payload(
                 sale, previous_catalogue=previous_catalogue, requestor=self.requestor
             )
@@ -213,7 +213,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.INVOICE_REQUESTED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             invoice_data = generate_invoice_payload(invoice, self.requestor)
             trigger_webhooks_async(
                 invoice_data, event_type, webhooks, invoice, self.requestor
@@ -223,7 +223,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.INVOICE_DELETED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             invoice_data = generate_invoice_payload(invoice, self.requestor)
             trigger_webhooks_async(
                 invoice_data, event_type, webhooks, invoice, self.requestor
@@ -233,7 +233,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.INVOICE_SENT
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             invoice_data = generate_invoice_payload(invoice, self.requestor)
             trigger_webhooks_async(
                 invoice_data, event_type, webhooks, invoice, self.requestor
@@ -243,7 +243,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_CANCELLED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             order_data = generate_order_payload(order, self.requestor)
             trigger_webhooks_async(
                 order_data, event_type, webhooks, order, self.requestor
@@ -253,7 +253,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_FULFILLED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             order_data = generate_order_payload(order, self.requestor)
             trigger_webhooks_async(
                 order_data, event_type, webhooks, order, self.requestor
@@ -263,7 +263,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             order_data = generate_order_payload(order, self.requestor)
             trigger_webhooks_async(
                 order_data, event_type, webhooks, order, self.requestor
@@ -273,7 +273,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             order_data = generate_order_payload(order, self.requestor)
             trigger_webhooks_async(
                 order_data, event_type, webhooks, order, self.requestor
@@ -283,7 +283,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_DELETED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             order_data = generate_order_payload(order, self.requestor)
             trigger_webhooks_async(
                 order_data, event_type, webhooks, order, self.requestor
@@ -293,7 +293,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.FULFILLMENT_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
             trigger_webhooks_async(
                 fulfillment_data, event_type, webhooks, fulfillment, self.requestor
@@ -303,7 +303,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.FULFILLMENT_CANCELED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
             trigger_webhooks_async(
                 fulfillment_data, event_type, webhooks, fulfillment, self.requestor
@@ -313,7 +313,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.CUSTOMER_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             customer_data = generate_customer_payload(customer, self.requestor)
             trigger_webhooks_async(
                 customer_data, event_type, webhooks, customer, self.requestor
@@ -323,7 +323,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.CUSTOMER_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             customer_data = generate_customer_payload(customer, self.requestor)
             trigger_webhooks_async(
                 customer_data, event_type, webhooks, customer, self.requestor
@@ -333,7 +333,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.COLLECTION_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             collection_data = generate_collection_payload(collection, self.requestor)
             trigger_webhooks_async(
                 collection_data, event_type, webhooks, collection, self.requestor
@@ -343,7 +343,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.COLLECTION_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             collection_data = generate_collection_payload(collection, self.requestor)
             trigger_webhooks_async(
                 collection_data, event_type, webhooks, collection, self.requestor
@@ -353,7 +353,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.COLLECTION_DELETED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             collection_data = generate_collection_payload(collection, self.requestor)
             trigger_webhooks_async(
                 collection_data, event_type, webhooks, collection, self.requestor
@@ -363,7 +363,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             product_data = generate_product_payload(product, self.requestor)
             trigger_webhooks_async(
                 product_data, event_type, webhooks, product, self.requestor
@@ -373,7 +373,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             product_data = generate_product_payload(product, self.requestor)
             trigger_webhooks_async(
                 product_data, event_type, webhooks, product, self.requestor
@@ -385,7 +385,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_DELETED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             product_data = generate_product_deleted_payload(
                 product, variants, self.requestor
             )
@@ -403,7 +403,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             product_variant_data = generate_product_variant_payload(
                 [product_variant], self.requestor
             )
@@ -421,7 +421,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             product_variant_data = generate_product_variant_payload(
                 [product_variant], self.requestor
             )
@@ -439,7 +439,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_DELETED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             product_variant_data = generate_product_variant_payload(
                 [product_variant], self.requestor
             )
@@ -455,7 +455,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             product_variant_data = generate_product_variant_with_stock_payload([stock])
             trigger_webhooks_async(
                 product_variant_data, event_type, webhooks, stock, self.requestor
@@ -465,7 +465,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             product_variant_data = generate_product_variant_with_stock_payload(
                 [stock], self.requestor
             )
@@ -477,7 +477,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.CHECKOUT_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             checkout_data = generate_checkout_payload(checkout, self.requestor)
             trigger_webhooks_async(
                 checkout_data, event_type, webhooks, checkout, self.requestor
@@ -487,7 +487,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.CHECKOUT_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             checkout_data = generate_checkout_payload(checkout, self.requestor)
             trigger_webhooks_async(
                 checkout_data, event_type, webhooks, checkout, self.requestor
@@ -499,7 +499,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.NOTIFY_USER
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             data = {
                 "notify_event": event,
                 "payload": payload,
@@ -517,7 +517,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PAGE_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             page_data = generate_page_payload(page, self.requestor)
             trigger_webhooks_async(
                 page_data, event_type, webhooks, page, self.requestor
@@ -527,7 +527,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PAGE_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             page_data = generate_page_payload(page, self.requestor)
             trigger_webhooks_async(
                 page_data, event_type, webhooks, page, self.requestor
@@ -537,7 +537,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.PAGE_DELETED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             page_data = generate_page_payload(page, self.requestor)
             trigger_webhooks_async(
                 page_data, event_type, webhooks, page, self.requestor
@@ -643,7 +643,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.TRANSLATION_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             translation_data = generate_translation_payload(translation, self.requestor)
             trigger_webhooks_async(
                 translation_data, event_type, webhooks, translation, self.requestor
@@ -653,7 +653,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.TRANSLATION_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             translation_data = generate_translation_payload(translation, self.requestor)
             trigger_webhooks_async(
                 translation_data, event_type, webhooks, translation, self.requestor
@@ -866,5 +866,5 @@ class WebhookPlugin(BasePlugin):
 
     def is_event_active(self, event: str, channel=Optional[str]):
         map_event = {"invoice_request": WebhookEventAsyncType.INVOICE_REQUESTED}
-        webhooks = _get_webhooks_for_event(event_type=map_event[event])
+        webhooks = get_webhooks_for_event(event_type=map_event[event])
         return any(webhooks)

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -550,7 +550,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
 
         event_type = WebhookEventAsyncType.SHIPPING_PRICE_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             payload = {
                 "id": graphene.Node.to_global_id(
                     "ShippingMethodType", shipping_method.id
@@ -567,7 +567,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
 
         event_type = WebhookEventAsyncType.SHIPPING_PRICE_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             payload = {
                 "id": graphene.Node.to_global_id(
                     "ShippingMethodType", shipping_method.id
@@ -584,7 +584,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
 
         event_type = WebhookEventAsyncType.SHIPPING_PRICE_DELETED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             payload = {
                 "id": graphene.Node.to_global_id(
                     "ShippingMethodType", shipping_method.id
@@ -601,7 +601,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
 
         event_type = WebhookEventAsyncType.SHIPPING_ZONE_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             payload = {
                 "id": graphene.Node.to_global_id("ShippingZone", shipping_zone.id)
             }
@@ -616,7 +616,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
 
         event_type = WebhookEventAsyncType.SHIPPING_ZONE_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             payload = {
                 "id": graphene.Node.to_global_id("ShippingZone", shipping_zone.id)
             }
@@ -631,7 +631,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
 
         event_type = WebhookEventAsyncType.SHIPPING_ZONE_DELETED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             payload = {
                 "id": graphene.Node.to_global_id("ShippingZone", shipping_zone.id)
             }

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -88,7 +88,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.CATEGORY_CREATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             payload = {"id": graphene.Node.to_global_id("Category", category.id)}
             trigger_webhooks_async(
                 payload, event_type, webhooks, category, self.requestor
@@ -98,7 +98,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.CATEGORY_UPDATED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             payload = {"id": graphene.Node.to_global_id("Category", category.id)}
             trigger_webhooks_async(
                 payload, event_type, webhooks, category, self.requestor
@@ -108,7 +108,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.CATEGORY_DELETED
-        if webhooks := _get_webhooks_for_event(event_type):
+        if webhooks := get_webhooks_for_event(event_type):
             payload = {"id": graphene.Node.to_global_id("Category", category.id)}
             trigger_webhooks_async(
                 payload, event_type, webhooks, category, self.requestor

--- a/saleor/plugins/webhook/shipping.py
+++ b/saleor/plugins/webhook/shipping.py
@@ -12,9 +12,10 @@ from prices import Money
 from ...graphql.core.utils import from_global_id_or_error
 from ...graphql.shipping.types import ShippingMethod
 from ...shipping.interface import ShippingMethodData
+from ...webhook.utils import get_webhooks_for_event
 from ..base_plugin import ExcludedShippingMethod
 from .const import CACHE_EXCLUDED_SHIPPING_TIME, EXCLUDED_SHIPPING_REQUEST_TIMEOUT
-from .tasks import _get_webhooks_for_event, trigger_webhook_sync
+from .tasks import trigger_webhook_sync
 from .utils import APP_ID_PREFIX
 
 if TYPE_CHECKING:
@@ -120,7 +121,7 @@ def get_excluded_shipping_data(
     """
 
     excluded_methods_map: Dict[str, List[ExcludedShippingMethod]] = defaultdict(list)
-    webhooks = _get_webhooks_for_event(event_type)
+    webhooks = get_webhooks_for_event(event_type)
     if webhooks:
         payload = payload_fun()
 

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -29,7 +29,6 @@ from ....core.notify_events import NotifyEventType
 from ....core.utils.url import prepare_url
 from ....discount.utils import fetch_catalogue_info
 from ....graphql.discount.mutations import convert_catalogue_info_to_global_ids
-from ....plugins.webhook.tasks import _get_webhooks_for_event
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.payloads import (
     generate_checkout_payload,
@@ -44,6 +43,7 @@ from ....webhook.payloads import (
     generate_product_variant_with_stock_payload,
     generate_sale_payload,
 )
+from ....webhook.utils import get_webhooks_for_event
 from ...manager import get_plugins_manager
 from ...webhook.tasks import send_webhook_request_async, trigger_webhooks_async
 
@@ -102,7 +102,7 @@ def test_trigger_webhooks_for_event_calls_expected_events(
     third_webhook.events.create(event_type=WebhookEventAsyncType.ANY)
     event_payload = EventPayload.objects.create()
     trigger_webhooks_async(
-        event_payload, event_name, _get_webhooks_for_event(event_name)
+        event_payload, event_name, get_webhooks_for_event(event_name)
     )
     deliveries_called = {
         EventDelivery.objects.get(id=delivery_id[0][0])
@@ -114,7 +114,7 @@ def test_trigger_webhooks_for_event_calls_expected_events(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_order_created(
     mocked_webhook_trigger,
@@ -139,7 +139,7 @@ def test_order_created(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_order_confirmed(
     mocked_webhook_trigger,
@@ -164,7 +164,7 @@ def test_order_confirmed(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_draft_order_created(
     mocked_webhook_trigger,
@@ -189,7 +189,7 @@ def test_draft_order_created(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_draft_order_deleted(
     mocked_webhook_trigger,
@@ -214,7 +214,7 @@ def test_draft_order_deleted(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_draft_order_updated(
     mocked_webhook_trigger,
@@ -239,7 +239,7 @@ def test_draft_order_updated(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_customer_created(
     mocked_webhook_trigger,
@@ -264,7 +264,7 @@ def test_customer_created(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_customer_updated(
     mocked_webhook_trigger,
@@ -289,7 +289,7 @@ def test_customer_updated(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_order_fully_paid(
     mocked_webhook_trigger,
@@ -314,7 +314,7 @@ def test_order_fully_paid(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_collection_created(
     mocked_webhook_trigger,
@@ -339,7 +339,7 @@ def test_collection_created(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_collection_updated(
     mocked_webhook_trigger,
@@ -364,7 +364,7 @@ def test_collection_updated(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_collection_deleted(
     mocked_webhook_trigger,
@@ -389,7 +389,7 @@ def test_collection_deleted(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_created(
     mocked_webhook_trigger,
@@ -414,7 +414,7 @@ def test_product_created(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_updated(
     mocked_webhook_trigger,
@@ -439,7 +439,7 @@ def test_product_updated(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_deleted(
     mocked_webhook_trigger,
@@ -479,7 +479,7 @@ def test_product_deleted(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_variant_created(
     mocked_webhook_trigger,
@@ -504,7 +504,7 @@ def test_product_variant_created(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_variant_updated(
     mocked_webhook_trigger,
@@ -529,7 +529,7 @@ def test_product_variant_updated(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_variant_deleted(
     mocked_webhook_trigger,
@@ -554,7 +554,7 @@ def test_product_variant_deleted(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_variant_out_of_stock(
     mocked_webhook_trigger,
@@ -580,7 +580,7 @@ def test_product_variant_out_of_stock(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_product_variant_back_in_stock(
     mocked_webhook_trigger,
@@ -606,7 +606,7 @@ def test_product_variant_back_in_stock(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_order_updated(
     mocked_webhook_trigger,
@@ -631,7 +631,7 @@ def test_order_updated(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_order_cancelled(
     mocked_webhook_trigger,
@@ -656,7 +656,7 @@ def test_order_cancelled(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_checkout_created(
     mocked_webhook_trigger,
@@ -703,7 +703,7 @@ def test_checkout_payload_includes_sales(checkout_with_item, sale, discount_info
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_checkout_updated(
     mocked_webhook_trigger,
@@ -728,7 +728,7 @@ def test_checkout_updated(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_created(
     mocked_webhook_trigger, mocked_get_webhooks_for_event, any_webhook, settings, page
@@ -745,7 +745,7 @@ def test_page_created(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_updated(
     mocked_webhook_trigger, mocked_get_webhooks_for_event, any_webhook, settings, page
@@ -762,7 +762,7 @@ def test_page_updated(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_page_deleted(
     mocked_webhook_trigger, mocked_get_webhooks_for_event, any_webhook, settings, page
@@ -782,7 +782,7 @@ def test_page_deleted(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_invoice_request(
     mocked_webhook_trigger,
@@ -808,7 +808,7 @@ def test_invoice_request(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_invoice_delete(
     mocked_webhook_trigger,
@@ -834,7 +834,7 @@ def test_invoice_delete(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_invoice_sent(
     mocked_webhook_trigger,
@@ -856,7 +856,7 @@ def test_invoice_sent(
 
 
 @freeze_time("2020-03-18 12:00:00")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_notify_user(
     mocked_webhook_trigger,
@@ -943,7 +943,7 @@ def test_create_event_payload_reference_with_error(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_sale_created(
     mocked_webhook_trigger, mocked_get_webhooks_for_event, any_webhook, settings, sale
@@ -962,7 +962,7 @@ def test_sale_created(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_sale_updated(
     mocked_webhook_trigger,
@@ -999,7 +999,7 @@ def test_sale_updated(
 
 
 @freeze_time("1914-06-28 10:50")
-@mock.patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_sale_deleted(
     mocked_webhook_trigger, mocked_get_webhooks_for_event, any_webhook, settings, sale

--- a/saleor/webhook/tests/test_utils.py
+++ b/saleor/webhook/tests/test_utils.py
@@ -1,4 +1,4 @@
-from ..event_types import WebhookEventAsyncType
+from ..event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..models import Webhook
 from ..utils import get_webhooks_for_event
 
@@ -37,3 +37,14 @@ def test_get_webhook_for_event_no_duplicates(app, webhook, permission_manage_ord
     webhooks = get_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED)
 
     assert webhooks.count() == 1
+
+
+def test_get_webhook_for_event_not_returning_any_webhook_for_sync_event_types(
+    app, any_webhook, payment_app, permission_manage_payments
+):
+    app.permissions.add(permission_manage_payments)
+
+    webhooks = get_webhooks_for_event(WebhookEventSyncType.PAYMENT_AUTHORIZE)
+
+    assert webhooks.count() == 1
+    assert webhooks[0] != any_webhook

--- a/saleor/webhook/tests/test_utils.py
+++ b/saleor/webhook/tests/test_utils.py
@@ -28,3 +28,12 @@ def test_get_webhooks_for_event_when_app_has_no_permissions(app, webhook):
     webhooks = get_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED)
 
     assert webhooks.exists() is False
+
+
+def test_get_webhook_for_event_no_duplicates(app, webhook, permission_manage_orders):
+    app.permissions.add(permission_manage_orders)
+    webhook.events.create(event_type=WebhookEventAsyncType.ANY)
+
+    webhooks = get_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED)
+
+    assert webhooks.count() == 1

--- a/saleor/webhook/tests/test_utils.py
+++ b/saleor/webhook/tests/test_utils.py
@@ -1,0 +1,30 @@
+from ..event_types import WebhookEventAsyncType
+from ..models import Webhook
+from ..utils import get_webhooks_for_event
+
+
+def test_get_webhooks_for_event(app, webhook, any_webhook, permission_manage_orders):
+    app.permissions.add(permission_manage_orders)
+
+    webhooks = get_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED)
+
+    assert set(webhooks) == {webhook, any_webhook}
+
+
+def test_get_webhooks_for_event_when_webhooks_provided(
+    app, webhook, any_webhook, permission_manage_orders
+):
+    app.permissions.add(permission_manage_orders)
+
+    webhooks = get_webhooks_for_event(
+        WebhookEventAsyncType.ORDER_CREATED, Webhook.objects.filter(id=webhook.id)
+    )
+
+    assert webhooks.count() == 1
+    assert webhooks.first() == webhook
+
+
+def test_get_webhooks_for_event_when_app_has_no_permissions(app, webhook):
+    webhooks = get_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED)
+
+    assert webhooks.exists() is False

--- a/saleor/webhook/tests/test_utils.py
+++ b/saleor/webhook/tests/test_utils.py
@@ -1,50 +1,108 @@
+import pytest
+
+from ...app.models import App
 from ..event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..models import Webhook
 from ..utils import get_webhooks_for_event
 
 
-def test_get_webhooks_for_event(app, webhook, any_webhook, permission_manage_orders):
-    app.permissions.add(permission_manage_orders)
-
-    webhooks = get_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED)
-
-    assert set(webhooks) == {webhook, any_webhook}
+@pytest.fixture
+def sync_type():
+    return WebhookEventSyncType.PAYMENT_AUTHORIZE
 
 
-def test_get_webhooks_for_event_when_webhooks_provided(
-    app, webhook, any_webhook, permission_manage_orders
+@pytest.fixture
+def async_type():
+    return WebhookEventAsyncType.ORDER_CREATED
+
+
+@pytest.fixture
+def sync_webhook(db, permission_manage_payments, sync_type):
+    app = App.objects.create(name="Sync App", is_active=True)
+    app.tokens.create(name="Default")
+    app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(name="sync-webhook", app=app)
+    webhook.events.create(event_type=sync_type, webhook=webhook)
+    return webhook
+
+
+@pytest.fixture
+def async_app_factory(db, permission_manage_orders, async_type):
+    def create_app(active_app=True, active_webhook=True, any_webhook=False):
+        app = App.objects.create(name="Async App", is_active=active_app)
+        app.tokens.create(name="Default")
+        app.permissions.add(permission_manage_orders)
+        webhook = Webhook.objects.create(
+            name="async-webhook", app=app, is_active=active_webhook
+        )
+        event_type = WebhookEventAsyncType.ANY if any_webhook else async_type
+        webhook.events.create(event_type=event_type, webhook=webhook)
+        return app, webhook
+
+    return create_app
+
+
+def test_get_webhooks_for_event(sync_webhook, async_app_factory, async_type):
+    _, async_webhook = async_app_factory()
+    _, any_webhook = async_app_factory(any_webhook=True)
+
+    webhooks = get_webhooks_for_event(async_type)
+
+    assert set(webhooks) == {async_webhook, any_webhook}
+
+
+def test_get_webhooks_for_event_when_app_webhook_inactive(
+    sync_webhook, async_app_factory, async_type
 ):
-    app.permissions.add(permission_manage_orders)
+    async_app_factory(active_app=False, active_webhook=True)
+    async_app_factory(active_app=True, active_webhook=False)
+    _, any_webhook = async_app_factory()
+
+    webhooks = get_webhooks_for_event(async_type)
+
+    assert set(webhooks) == {any_webhook}
+
+
+def test_get_webhooks_for_event_when_webhooks_provided(async_app_factory, async_type):
+    _, async_webhook_a = async_app_factory()
+    _, async_webhook_b = async_app_factory(any_webhook=True)
+    _, _ = async_app_factory()
+    webhooks_ids = [async_webhook_a.id, async_webhook_b.id]
 
     webhooks = get_webhooks_for_event(
-        WebhookEventAsyncType.ORDER_CREATED, Webhook.objects.filter(id=webhook.id)
+        async_type, Webhook.objects.filter(id__in=webhooks_ids)
     )
 
-    assert webhooks.count() == 1
-    assert webhooks.first() == webhook
+    assert set(webhooks) == {async_webhook_a, async_webhook_b}
 
 
-def test_get_webhooks_for_event_when_app_has_no_permissions(app, webhook):
-    webhooks = get_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED)
+def test_get_webhooks_for_event_when_app_has_no_permissions(
+    async_app_factory, async_type
+):
+    _, async_webhook_a = async_app_factory()
+    app, _ = async_app_factory(any_webhook=True)
+    app.permissions.clear()
 
-    assert webhooks.exists() is False
+    webhooks = get_webhooks_for_event(async_type)
+
+    assert set(webhooks) == {async_webhook_a}
 
 
-def test_get_webhook_for_event_no_duplicates(app, webhook, permission_manage_orders):
-    app.permissions.add(permission_manage_orders)
-    webhook.events.create(event_type=WebhookEventAsyncType.ANY)
+def test_get_webhook_for_event_no_duplicates(async_app_factory, async_type):
+    _, async_webhook = async_app_factory()
+    async_webhook.events.create(event_type=WebhookEventAsyncType.ANY)
 
-    webhooks = get_webhooks_for_event(WebhookEventAsyncType.ORDER_CREATED)
+    webhooks = get_webhooks_for_event(async_type)
 
     assert webhooks.count() == 1
 
 
 def test_get_webhook_for_event_not_returning_any_webhook_for_sync_event_types(
-    app, any_webhook, payment_app, permission_manage_payments
+    sync_webhook, async_app_factory, sync_type, permission_manage_payments
 ):
-    app.permissions.add(permission_manage_payments)
+    any_app, _ = async_app_factory(any_webhook=True)
+    any_app.permissions.add(permission_manage_payments)
 
-    webhooks = get_webhooks_for_event(WebhookEventSyncType.PAYMENT_AUTHORIZE)
+    webhooks = get_webhooks_for_event(sync_type)
 
-    assert webhooks.count() == 1
-    assert webhooks[0] != any_webhook
+    assert set(webhooks) == {sync_webhook}

--- a/saleor/webhook/utils.py
+++ b/saleor/webhook/utils.py
@@ -27,11 +27,11 @@ def get_webhooks_for_event(
     event_types = [event_type]
     if event_type in WebhookEventAsyncType.ALL:
         event_types.append(WebhookEventAsyncType.ANY)
-    event_type_webhooks = Webhook.objects.filter(
-        is_active=True, events__event_type__in=event_types
-    )
     webhooks = (
-        webhooks.filter(id__in=event_type_webhooks, app__in=apps)
+        webhooks.filter(
+            is_active=True, events__event_type__in=event_types, app__in=apps
+        )
+        .distinct()
         .select_related("app")
         .prefetch_related("app__permissions__content_type")
     )

--- a/saleor/webhook/utils.py
+++ b/saleor/webhook/utils.py
@@ -1,0 +1,35 @@
+from typing import TYPE_CHECKING, Optional
+
+from .event_types import WebhookEventAsyncType, WebhookEventSyncType
+from .models import Webhook
+
+if TYPE_CHECKING:
+    from django.db.models import QuerySet
+
+
+def get_webhooks_for_event(
+    event_type: str, webhooks: Optional["QuerySet[Webhook]"] = None
+) -> "QuerySet[Webhook]":
+    """Get active webhooks from the database for an event."""
+    permissions = {}
+    required_permission = WebhookEventAsyncType.PERMISSIONS.get(
+        event_type, WebhookEventSyncType.PERMISSIONS.get(event_type)
+    )
+    if required_permission:
+        app_label, codename = required_permission.value.split(".")
+        permissions["app__permissions__content_type__app_label"] = app_label
+        permissions["app__permissions__codename"] = codename
+
+    if webhooks is None:
+        webhooks = Webhook.objects.all()
+    webhooks = (
+        webhooks.filter(
+            is_active=True,
+            app__is_active=True,
+            events__event_type__in=[event_type, WebhookEventAsyncType.ANY],
+            **permissions,
+        )
+        .select_related("app")
+        .prefetch_related("app__permissions__content_type")
+    )
+    return webhooks

--- a/saleor/webhook/utils.py
+++ b/saleor/webhook/utils.py
@@ -24,11 +24,14 @@ def get_webhooks_for_event(
     if webhooks is None:
         webhooks = Webhook.objects.all()
     apps = App.objects.filter(is_active=True, **permissions)
+    event_types = [event_type]
+    if event_type in WebhookEventAsyncType.ALL:
+        event_types.append(WebhookEventAsyncType.ANY)
     event_type_webhooks = Webhook.objects.filter(
-        events__event_type__in=[event_type, WebhookEventAsyncType.ANY]
+        is_active=True, events__event_type__in=event_types
     )
     webhooks = (
-        webhooks.filter(is_active=True, app__in=apps, id__in=event_type_webhooks)
+        webhooks.filter(id__in=event_type_webhooks, app__in=apps)
         .select_related("app")
         .prefetch_related("app__permissions__content_type")
     )


### PR DESCRIPTION
I want to merge this change because it moves `get_webhooks_for_event` to webhook utils, where it is placed better for reuse. Resolves #8990 and #9138 by changing ANY webhooks to catch only async events.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
