### PR TITLE
Assign missing user to context

### DIFF
--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Optional
 
 from celery.utils.log import get_task_logger
-from django.contrib.auth.models import AnonymousUser
 from django.core.handlers.base import BaseHandler
 from django.http import HttpRequest
 from django.test.client import RequestFactory
@@ -86,6 +85,7 @@ def generate_payload_from_subscription(
     generate a payload
     """
     from ..api import schema
+    from ..context import get_context_value
 
     graphql_backend = get_default_backend()
     ast = parse(subscription_query)  # type: ignore
@@ -96,12 +96,11 @@ def generate_payload_from_subscription(
     app_id = app.pk if app else None
 
     context.app = app  # type: ignore
-    context.user = AnonymousUser()
 
     results = document.execute(
         allow_subscriptions=True,
         root=(event_type, subscribable_object),
-        context=context,
+        context=get_context_value(context),
     )
     if hasattr(results, "errors"):
         logger.warning(

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional
 
 from celery.utils.log import get_task_logger
+from django.contrib.auth.models import AnonymousUser
 from django.core.handlers.base import BaseHandler
 from django.http import HttpRequest
 from django.test.client import RequestFactory
@@ -95,6 +96,7 @@ def generate_payload_from_subscription(
     app_id = app.pk if app else None
 
     context.app = app  # type: ignore
+    context.user = AnonymousUser()
 
     results = document.execute(
         allow_subscriptions=True,

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -127,7 +127,7 @@ def create_deliveries_for_subscriptions(
             )
             continue
 
-        event_payload = EventPayload(payload=json.dumps([{**data, "meta": meta}]))
+        event_payload = EventPayload(payload=json.dumps({**data, "meta": meta}))
         event_payloads.append(event_payload)
         event_deliveries.append(
             EventDelivery(
@@ -167,7 +167,9 @@ def trigger_webhooks_async(
     if subscription_webhooks:
         meta = {}
         if requestor:
-            meta = generate_meta(requestor_data=generate_requestor(requestor))
+            meta = generate_meta(
+                requestor_data=generate_requestor(requestor), camel_case=True
+            )
         deliveries.extend(
             create_deliveries_for_subscriptions(
                 event_type=event_type,

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -18,7 +18,7 @@ def test_category_created(category, subscription_category_created_webhook):
     deliveries = create_deliveries_for_subscriptions(event_type, category, webhooks)
 
     # then
-    expected_payload = json.dumps([{"category": {"id": category_id}, "meta": None}])
+    expected_payload = json.dumps({"category": {"id": category_id}, "meta": None})
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
@@ -34,7 +34,7 @@ def test_category_updated(category, subscription_category_updated_webhook):
     deliveries = create_deliveries_for_subscriptions(event_type, category, webhooks)
 
     # then
-    expected_payload = json.dumps([{"category": {"id": category_id}, "meta": None}])
+    expected_payload = json.dumps({"category": {"id": category_id}, "meta": None})
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
@@ -50,7 +50,7 @@ def test_category_deleted(category, subscription_category_deleted_webhook):
     deliveries = create_deliveries_for_subscriptions(event_type, category, webhooks)
 
     # then
-    expected_payload = json.dumps([{"category": {"id": category_id}, "meta": None}])
+    expected_payload = json.dumps({"category": {"id": category_id}, "meta": None})
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
@@ -61,7 +61,7 @@ def test_product_created(product, subscription_product_created_webhook):
     event_type = WebhookEventAsyncType.PRODUCT_CREATED
     product_id = graphene.Node.to_global_id("Product", product.id)
     deliveries = create_deliveries_for_subscriptions(event_type, product, webhooks)
-    expected_payload = json.dumps([{"product": {"id": product_id}, "meta": None}])
+    expected_payload = json.dumps({"product": {"id": product_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -73,7 +73,7 @@ def test_product_updated(product, subscription_product_updated_webhook):
     event_type = WebhookEventAsyncType.PRODUCT_UPDATED
     product_id = graphene.Node.to_global_id("Product", product.id)
     deliveries = create_deliveries_for_subscriptions(event_type, product, webhooks)
-    expected_payload = json.dumps([{"product": {"id": product_id}, "meta": None}])
+    expected_payload = json.dumps({"product": {"id": product_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -85,7 +85,7 @@ def test_product_deleted(product, subscription_product_deleted_webhook):
     event_type = WebhookEventAsyncType.PRODUCT_DELETED
     product_id = graphene.Node.to_global_id("Product", product.id)
     deliveries = create_deliveries_for_subscriptions(event_type, product, webhooks)
-    expected_payload = json.dumps([{"product": {"id": product_id}, "meta": None}])
+    expected_payload = json.dumps({"product": {"id": product_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -97,9 +97,7 @@ def test_product_variant_created(variant, subscription_product_variant_created_w
     event_type = WebhookEventAsyncType.PRODUCT_VARIANT_CREATED
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
     deliveries = create_deliveries_for_subscriptions(event_type, variant, webhooks)
-    expected_payload = json.dumps(
-        [{"productVariant": {"id": variant_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"productVariant": {"id": variant_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -111,9 +109,7 @@ def test_product_variant_updated(variant, subscription_product_variant_updated_w
     event_type = WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
     deliveries = create_deliveries_for_subscriptions(event_type, variant, webhooks)
-    expected_payload = json.dumps(
-        [{"productVariant": {"id": variant_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"productVariant": {"id": variant_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -125,9 +121,7 @@ def test_product_variant_deleted(variant, subscription_product_variant_deleted_w
     event_type = WebhookEventAsyncType.PRODUCT_VARIANT_DELETED
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
     deliveries = create_deliveries_for_subscriptions(event_type, variant, webhooks)
-    expected_payload = json.dumps(
-        [{"productVariant": {"id": variant_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"productVariant": {"id": variant_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -141,9 +135,7 @@ def test_product_variant_out_of_stock(
     event_type = WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK
     variant_id = graphene.Node.to_global_id("ProductVariant", stock.product_variant.id)
     deliveries = create_deliveries_for_subscriptions(event_type, stock, webhooks)
-    expected_payload = json.dumps(
-        [{"productVariant": {"id": variant_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"productVariant": {"id": variant_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -157,9 +149,7 @@ def test_product_variant_back_in_stock(
     event_type = WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK
     variant_id = graphene.Node.to_global_id("ProductVariant", stock.product_variant.id)
     deliveries = create_deliveries_for_subscriptions(event_type, stock, webhooks)
-    expected_payload = json.dumps(
-        [{"productVariant": {"id": variant_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"productVariant": {"id": variant_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -171,7 +161,7 @@ def test_order_created(order, subscription_order_created_webhook):
     event_type = WebhookEventAsyncType.ORDER_CREATED
     order_id = graphene.Node.to_global_id("Order", order.id)
     deliveries = create_deliveries_for_subscriptions(event_type, order, webhooks)
-    expected_payload = json.dumps([{"order": {"id": order_id}, "meta": None}])
+    expected_payload = json.dumps({"order": {"id": order_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -183,7 +173,7 @@ def test_order_confirmed(order, subscription_order_confirmed_webhook):
     event_type = WebhookEventAsyncType.ORDER_CONFIRMED
     order_id = graphene.Node.to_global_id("Order", order.id)
     deliveries = create_deliveries_for_subscriptions(event_type, order, webhooks)
-    expected_payload = json.dumps([{"order": {"id": order_id}, "meta": None}])
+    expected_payload = json.dumps({"order": {"id": order_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -195,7 +185,7 @@ def test_order_fully_paid(order, subscription_order_fully_paid_webhook):
     event_type = WebhookEventAsyncType.ORDER_FULLY_PAID
     order_id = graphene.Node.to_global_id("Order", order.id)
     deliveries = create_deliveries_for_subscriptions(event_type, order, webhooks)
-    expected_payload = json.dumps([{"order": {"id": order_id}, "meta": None}])
+    expected_payload = json.dumps({"order": {"id": order_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -207,7 +197,7 @@ def test_order_updated(order, subscription_order_updated_webhook):
     event_type = WebhookEventAsyncType.ORDER_UPDATED
     order_id = graphene.Node.to_global_id("Order", order.id)
     deliveries = create_deliveries_for_subscriptions(event_type, order, webhooks)
-    expected_payload = json.dumps([{"order": {"id": order_id}, "meta": None}])
+    expected_payload = json.dumps({"order": {"id": order_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -219,7 +209,7 @@ def test_order_cancelled(order, subscription_order_cancelled_webhook):
     event_type = WebhookEventAsyncType.ORDER_CANCELLED
     order_id = graphene.Node.to_global_id("Order", order.id)
     deliveries = create_deliveries_for_subscriptions(event_type, order, webhooks)
-    expected_payload = json.dumps([{"order": {"id": order_id}, "meta": None}])
+    expected_payload = json.dumps({"order": {"id": order_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -231,7 +221,7 @@ def test_order_fulfilled(order, subscription_order_fulfilled_webhook):
     event_type = WebhookEventAsyncType.ORDER_FULFILLED
     order_id = graphene.Node.to_global_id("Order", order.id)
     deliveries = create_deliveries_for_subscriptions(event_type, order, webhooks)
-    expected_payload = json.dumps([{"order": {"id": order_id}, "meta": None}])
+    expected_payload = json.dumps({"order": {"id": order_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -243,7 +233,7 @@ def test_draft_order_created(order, subscription_draft_order_created_webhook):
     event_type = WebhookEventAsyncType.DRAFT_ORDER_CREATED
     order_id = graphene.Node.to_global_id("Order", order.id)
     deliveries = create_deliveries_for_subscriptions(event_type, order, webhooks)
-    expected_payload = json.dumps([{"order": {"id": order_id}, "meta": None}])
+    expected_payload = json.dumps({"order": {"id": order_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -255,7 +245,7 @@ def test_draft_order_updated(order, subscription_draft_order_updated_webhook):
     event_type = WebhookEventAsyncType.DRAFT_ORDER_UPDATED
     order_id = graphene.Node.to_global_id("Order", order.id)
     deliveries = create_deliveries_for_subscriptions(event_type, order, webhooks)
-    expected_payload = json.dumps([{"order": {"id": order_id}, "meta": None}])
+    expected_payload = json.dumps({"order": {"id": order_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -267,7 +257,7 @@ def test_draft_order_deleted(order, subscription_draft_order_deleted_webhook):
     event_type = WebhookEventAsyncType.DRAFT_ORDER_DELETED
     order_id = graphene.Node.to_global_id("Order", order.id)
     deliveries = create_deliveries_for_subscriptions(event_type, order, webhooks)
-    expected_payload = json.dumps([{"order": {"id": order_id}, "meta": None}])
+    expected_payload = json.dumps({"order": {"id": order_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -279,7 +269,7 @@ def test_sale_created(sale, subscription_sale_created_webhook):
     event_type = WebhookEventAsyncType.SALE_CREATED
     sale_id = graphene.Node.to_global_id("Sale", sale.id)
     deliveries = create_deliveries_for_subscriptions(event_type, sale, webhooks)
-    expected_payload = json.dumps([{"sale": {"id": sale_id}, "meta": None}])
+    expected_payload = json.dumps({"sale": {"id": sale_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -291,7 +281,7 @@ def test_sale_updated(sale, subscription_sale_updated_webhook):
     event_type = WebhookEventAsyncType.SALE_UPDATED
     sale_id = graphene.Node.to_global_id("Sale", sale.id)
     deliveries = create_deliveries_for_subscriptions(event_type, sale, webhooks)
-    expected_payload = json.dumps([{"sale": {"id": sale_id}, "meta": None}])
+    expected_payload = json.dumps({"sale": {"id": sale_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -303,7 +293,7 @@ def test_sale_deleted(sale, subscription_sale_deleted_webhook):
     event_type = WebhookEventAsyncType.SALE_DELETED
     sale_id = graphene.Node.to_global_id("Sale", sale.id)
     deliveries = create_deliveries_for_subscriptions(event_type, sale, webhooks)
-    expected_payload = json.dumps([{"sale": {"id": sale_id}, "meta": None}])
+    expected_payload = json.dumps({"sale": {"id": sale_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -316,7 +306,7 @@ def test_invoice_requested(fulfilled_order, subscription_invoice_requested_webho
     invoice = fulfilled_order.invoices.first()
     invoice_id = graphene.Node.to_global_id("Invoice", invoice.id)
     deliveries = create_deliveries_for_subscriptions(event_type, invoice, webhooks)
-    expected_payload = json.dumps([{"invoice": {"id": invoice_id}, "meta": None}])
+    expected_payload = json.dumps({"invoice": {"id": invoice_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -329,7 +319,7 @@ def test_invoice_deleted(fulfilled_order, subscription_invoice_deleted_webhook):
     invoice = fulfilled_order.invoices.first()
     invoice_id = graphene.Node.to_global_id("Invoice", invoice.id)
     deliveries = create_deliveries_for_subscriptions(event_type, invoice, webhooks)
-    expected_payload = json.dumps([{"invoice": {"id": invoice_id}, "meta": None}])
+    expected_payload = json.dumps({"invoice": {"id": invoice_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -342,7 +332,7 @@ def test_invoice_sent(fulfilled_order, subscription_invoice_sent_webhook):
     invoice = fulfilled_order.invoices.first()
     invoice_id = graphene.Node.to_global_id("Invoice", invoice.id)
     deliveries = create_deliveries_for_subscriptions(event_type, invoice, webhooks)
-    expected_payload = json.dumps([{"invoice": {"id": invoice_id}, "meta": None}])
+    expected_payload = json.dumps({"invoice": {"id": invoice_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -354,9 +344,7 @@ def test_fulfillment_created(fulfillment, subscription_fulfillment_created_webho
     event_type = WebhookEventAsyncType.FULFILLMENT_CREATED
     fulfillment_id = graphene.Node.to_global_id("Fulfillment", fulfillment.id)
     deliveries = create_deliveries_for_subscriptions(event_type, fulfillment, webhooks)
-    expected_payload = json.dumps(
-        [{"fulfillment": {"id": fulfillment_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"fulfillment": {"id": fulfillment_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -368,9 +356,7 @@ def test_fulfillment_canceled(fulfillment, subscription_fulfillment_canceled_web
     event_type = WebhookEventAsyncType.FULFILLMENT_CANCELED
     fulfillment_id = graphene.Node.to_global_id("Fulfillment", fulfillment.id)
     deliveries = create_deliveries_for_subscriptions(event_type, fulfillment, webhooks)
-    expected_payload = json.dumps(
-        [{"fulfillment": {"id": fulfillment_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"fulfillment": {"id": fulfillment_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
 
@@ -385,7 +371,7 @@ def test_customer_created(customer_user, subscription_customer_created_webhook):
     deliveries = create_deliveries_for_subscriptions(
         event_type, customer_user, webhooks
     )
-    expected_payload = json.dumps([{"user": {"id": user_id}, "meta": None}])
+    expected_payload = json.dumps({"user": {"id": user_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -399,7 +385,7 @@ def test_customer_updated(customer_user, subscription_customer_updated_webhook):
     deliveries = create_deliveries_for_subscriptions(
         event_type, customer_user, webhooks
     )
-    expected_payload = json.dumps([{"user": {"id": user_id}, "meta": None}])
+    expected_payload = json.dumps({"user": {"id": user_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -411,7 +397,7 @@ def test_collection_created(collection, subscription_collection_created_webhook)
     event_type = WebhookEventAsyncType.COLLECTION_CREATED
     collection_id = graphene.Node.to_global_id("Collection", collection.pk)
     deliveries = create_deliveries_for_subscriptions(event_type, collection, webhooks)
-    expected_payload = json.dumps([{"collection": {"id": collection_id}, "meta": None}])
+    expected_payload = json.dumps({"collection": {"id": collection_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -423,7 +409,7 @@ def test_collection_updated(collection, subscription_collection_updated_webhook)
     event_type = WebhookEventAsyncType.COLLECTION_UPDATED
     collection_id = graphene.Node.to_global_id("Collection", collection.id)
     deliveries = create_deliveries_for_subscriptions(event_type, collection, webhooks)
-    expected_payload = json.dumps([{"collection": {"id": collection_id}, "meta": None}])
+    expected_payload = json.dumps({"collection": {"id": collection_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -435,7 +421,7 @@ def test_collection_deleted(collection, subscription_collection_deleted_webhook)
     event_type = WebhookEventAsyncType.COLLECTION_DELETED
     collection_id = graphene.Node.to_global_id("Collection", collection.id)
     deliveries = create_deliveries_for_subscriptions(event_type, collection, webhooks)
-    expected_payload = json.dumps([{"collection": {"id": collection_id}, "meta": None}])
+    expected_payload = json.dumps({"collection": {"id": collection_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -447,7 +433,7 @@ def test_checkout_create(checkout, subscription_checkout_created_webhook):
     event_type = WebhookEventAsyncType.CHECKOUT_CREATED
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     deliveries = create_deliveries_for_subscriptions(event_type, checkout, webhooks)
-    expected_payload = json.dumps([{"checkout": {"id": checkout_id}, "meta": None}])
+    expected_payload = json.dumps({"checkout": {"id": checkout_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -459,7 +445,7 @@ def test_checkout_update(checkout, subscription_checkout_updated_webhook):
     event_type = WebhookEventAsyncType.CHECKOUT_UPDATED
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     deliveries = create_deliveries_for_subscriptions(event_type, checkout, webhooks)
-    expected_payload = json.dumps([{"checkout": {"id": checkout_id}, "meta": None}])
+    expected_payload = json.dumps({"checkout": {"id": checkout_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -471,7 +457,7 @@ def test_page_created(page, subscription_page_created_webhook):
     event_type = WebhookEventAsyncType.PAGE_CREATED
     page_id = graphene.Node.to_global_id("Page", page.pk)
     deliveries = create_deliveries_for_subscriptions(event_type, page, webhooks)
-    expected_payload = json.dumps([{"page": {"id": page_id}, "meta": None}])
+    expected_payload = json.dumps({"page": {"id": page_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -483,7 +469,7 @@ def test_page_updated(page, subscription_page_updated_webhook):
     event_type = WebhookEventAsyncType.PAGE_UPDATED
     page_id = graphene.Node.to_global_id("Page", page.pk)
     deliveries = create_deliveries_for_subscriptions(event_type, page, webhooks)
-    expected_payload = json.dumps([{"page": {"id": page_id}, "meta": None}])
+    expected_payload = json.dumps({"page": {"id": page_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -495,7 +481,7 @@ def test_page_deleted(page, subscription_page_deleted_webhook):
     event_type = WebhookEventAsyncType.PAGE_DELETED
     page_id = graphene.Node.to_global_id("Page", page.pk)
     deliveries = create_deliveries_for_subscriptions(event_type, page, webhooks)
-    expected_payload = json.dumps([{"page": {"id": page_id}, "meta": None}])
+    expected_payload = json.dumps({"page": {"id": page_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -509,7 +495,7 @@ def test_product_created_multiple_events_in_subscription(
     event_type = WebhookEventAsyncType.PRODUCT_CREATED
     product_id = graphene.Node.to_global_id("Product", product.id)
     deliveries = create_deliveries_for_subscriptions(event_type, product, webhooks)
-    expected_payload = json.dumps([{"product": {"id": product_id}, "meta": None}])
+    expected_payload = json.dumps({"product": {"id": product_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_translation_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_translation_subscription.py
@@ -18,9 +18,7 @@ def test_translation_created_product(
         event_type, product_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -39,9 +37,7 @@ def test_translation_created_product_variant(
         event_type, variant_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -60,9 +56,7 @@ def test_translation_created_collection(
         event_type, collection_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -81,9 +75,7 @@ def test_translation_created_category(
         event_type, category_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -102,9 +94,7 @@ def test_translation_created_attribute(
         event_type, translated_attribute, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -123,9 +113,7 @@ def test_translation_created_attribute_value(
         event_type, translated_attribute_value, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -144,9 +132,7 @@ def test_translation_created_page(
         event_type, page_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -165,9 +151,7 @@ def test_translation_created_shipping_method(
         event_type, shipping_method_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -186,9 +170,7 @@ def test_translation_created_sale(
         event_type, sale_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -207,9 +189,7 @@ def test_translation_created_voucher(
         event_type, voucher_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -228,9 +208,7 @@ def test_translation_created_menu_item(
         event_type, menu_item_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -249,9 +227,7 @@ def test_translation_updated_product(
         event_type, product_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -270,9 +246,7 @@ def test_translation_updated_product_variant(
         event_type, variant_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -291,9 +265,7 @@ def test_translation_updated_collection(
         event_type, collection_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -312,9 +284,7 @@ def test_translation_updated_category(
         event_type, category_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -333,9 +303,7 @@ def test_translation_updated_attribute(
         event_type, translated_attribute, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -354,9 +322,7 @@ def test_translation_updated_attribute_value(
         event_type, translated_attribute_value, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -375,9 +341,7 @@ def test_translation_updated_page(
         event_type, page_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -396,9 +360,7 @@ def test_translation_updated_shipping_method(
         event_type, shipping_method_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -417,9 +379,7 @@ def test_translation_updated_sale(
         event_type, sale_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -438,9 +398,7 @@ def test_translation_updated_voucher(
         event_type, voucher_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
@@ -459,9 +417,7 @@ def test_translation_updated_menu_item(
         event_type, menu_item_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps(
-        [{"translation": {"id": translation_id}, "meta": None}]
-    )
+    expected_payload = json.dumps({"translation": {"id": translation_id}, "meta": None})
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
@@ -58,7 +58,9 @@ def test_trigger_webhooks_async_with_meta(
         event_type=webhook_type,
         subscribable_object=order,
         webhooks=[webhook],
-        meta=generate_meta(requestor_data=generate_requestor(staff_user)),
+        meta=generate_meta(
+            requestor_data=generate_requestor(staff_user), camel_case=True
+        ),
     )
     mocked_send_webhook_request.assert_called_once_with(TEST_ID)
 

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -8,6 +8,7 @@ import graphene
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import F, QuerySet, Sum
 from django.utils import timezone
+from graphene.utils.str_converters import to_camel_case
 
 from .. import __version__
 from ..account.models import User
@@ -105,7 +106,7 @@ def generate_requestor(requestor: Optional["RequestorOrLazyObject"] = None):
     return {"id": requestor.name, "type": "app"}  # type: ignore
 
 
-def generate_meta(*, requestor_data: Dict[str, Any], **kwargs):
+def generate_meta(*, requestor_data: Dict[str, Any], camel_case=False, **kwargs):
     meta_result = {
         "issued_at": timezone.now().isoformat(),
         "version": __version__,
@@ -114,7 +115,14 @@ def generate_meta(*, requestor_data: Dict[str, Any], **kwargs):
 
     meta_result.update(kwargs)
 
-    return meta_result
+    if camel_case:
+        meta = {}
+        for key, value in meta_result.items():
+            meta[to_camel_case(key)] = value
+    else:
+        meta = meta_result
+
+    return meta
 
 
 def prepare_order_lines_allocations_payload(line):


### PR DESCRIPTION
I want to merge this change because the context used in the subscription query doesn't have an expected user field

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
