### PR TITLE
Handle pagination with invalid cursor that is valid base64

### DIFF
--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -235,7 +235,10 @@ def connection_from_queryset_slice(
     filter_kwargs = (
         _prepare_filter(cursor, sorting_fields, sorting_direction) if cursor else Q()
     )
-    filtered_qs = qs.filter(filter_kwargs)
+    try:
+        filtered_qs = qs.filter(filter_kwargs)
+    except ValueError:
+        raise GraphQLError("Received cursor is invalid.")
     filtered_qs = filtered_qs[:end_margin]
     edges, page_info = _get_edges_for_connection(
         edge_type, filtered_qs, args, sorting_fields

--- a/saleor/graphql/core/tests/test_pagination.py
+++ b/saleor/graphql/core/tests/test_pagination.py
@@ -241,6 +241,7 @@ def test_pagination_invalid_cursor(books):
 
 
 def test_pagination_invalid_cursor_and_valid_base64(books):
+    """This cursor should have int value, in this test we pass string value"""
     cursor = base64.b64encode(str.encode(f"{['Test']}")).decode("utf-8")
     variables = {"first": 5, "after": cursor}
 

--- a/saleor/graphql/core/tests/test_pagination.py
+++ b/saleor/graphql/core/tests/test_pagination.py
@@ -241,13 +241,12 @@ def test_pagination_invalid_cursor(books):
 
 
 def test_pagination_invalid_cursor_and_valid_base64(books):
-    """This cursor should have int value, in this test we pass string value"""
+    """This cursor should have int value, in this test we pass string value."""
     cursor = base64.b64encode(str.encode(f"{['Test']}")).decode("utf-8")
     variables = {"first": 5, "after": cursor}
 
     result = schema.execute(QUERY_PAGINATION_TEST, variables=variables)
 
-    assert result.errors
     assert len(result.errors) == 1
     assert str(result.errors[0]) == "Received cursor is invalid."
 

--- a/saleor/graphql/core/tests/test_pagination.py
+++ b/saleor/graphql/core/tests/test_pagination.py
@@ -1,3 +1,4 @@
+import base64
 import math
 
 import graphene
@@ -230,6 +231,17 @@ def test_pagination_backward_last_page_info(books):
 
 def test_pagination_invalid_cursor(books):
     cursor = graphene.Node.to_global_id("BookType", -1)
+    variables = {"first": 5, "after": cursor}
+
+    result = schema.execute(QUERY_PAGINATION_TEST, variables=variables)
+
+    assert result.errors
+    assert len(result.errors) == 1
+    assert str(result.errors[0]) == "Received cursor is invalid."
+
+
+def test_pagination_invalid_cursor_and_valid_base64(books):
+    cursor = base64.b64encode(str.encode(f"{['Test']}")).decode("utf-8")
     variables = {"first": 5, "after": cursor}
 
     result = schema.execute(QUERY_PAGINATION_TEST, variables=variables)


### PR DESCRIPTION
I want to merge this change because it adds error handling when pagination input parameter is a valid base64 but has invalid value

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
