### PR TITLE
Event category_delete added to category bulk_delete mutation

### DIFF
--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -85,9 +85,6 @@ class CategoryBulkDelete(ModelBulkDeleteMutation):
     def bulk_action(cls, info, queryset):
         delete_categories(queryset.values_list("pk", flat=True), info.context.plugins)
 
-        for instance in queryset:
-            info.context.plugins.category_deleted(instance)
-
 
 class CollectionBulkDelete(ModelBulkDeleteMutation):
     class Arguments:

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -85,6 +85,9 @@ class CategoryBulkDelete(ModelBulkDeleteMutation):
     def bulk_action(cls, info, queryset):
         delete_categories(queryset.values_list("pk", flat=True), info.context.plugins)
 
+        for instance in queryset:
+            info.context.plugins.category_deleted(instance)
+
 
 class CollectionBulkDelete(ModelBulkDeleteMutation):
     class Arguments:

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -192,7 +192,6 @@ class CategoryDelete(ModelDeleteMutation):
         delete_categories([db_id], manager=info.context.plugins)
 
         instance.id = db_id
-        info.context.plugins.category_deleted(instance)
         return cls.success_response(instance)
 
 

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -80,6 +80,41 @@ def test_delete_categories(staff_api_client, category_list, permission_manage_pr
     ).exists()
 
 
+@patch("saleor.plugins.webhook.plugin._get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
+def test_delete_categories_trigger_webhook(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    staff_api_client,
+    category_list,
+    permission_manage_products,
+    settings,
+):
+    # given
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("Category", category.id)
+            for category in category_list
+        ]
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION_CATEGORY_BULK_DELETE,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["categoryBulkDelete"]["count"] == 3
+    mocked_webhook_trigger.call_count = len(category_list)
+
+
 @patch("saleor.product.signals.delete_versatile_image")
 def test_delete_categories_with_images(
     delete_versatile_image_mock,

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -112,7 +112,7 @@ def test_delete_categories_trigger_webhook(
 
     # then
     assert content["data"]["categoryBulkDelete"]["count"] == 3
-    mocked_webhook_trigger.call_count = len(category_list)
+    assert mocked_webhook_trigger.call_count == len(category_list)
 
 
 @patch("saleor.product.signals.delete_versatile_image")

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -59,7 +59,7 @@ def test_category_deleted(category, subscription_category_deleted_webhook):
 
     # then
     expected_payload = json.dumps({"category": {"id": category_id}, "meta": None})
-    assert graphene.Node.from_global_id(category_id)[1] != "None"
+    assert category_instances[0].id is not None
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import graphene
 
 from .....graphql.webhook.subscription_payload import validate_subscription_query
+from .....product.models import Category
 from .....webhook.event_types import WebhookEventAsyncType
 from ...tasks import create_deliveries_for_subscriptions, logger
 
@@ -43,14 +44,22 @@ def test_category_updated(category, subscription_category_updated_webhook):
 def test_category_deleted(category, subscription_category_deleted_webhook):
     # given
     webhooks = [subscription_category_deleted_webhook]
+
+    category_query = Category.objects.filter(pk=category.id)
+    category_instances = [cat for cat in category_query]
+    category_query.delete()
+
     event_type = WebhookEventAsyncType.CATEGORY_DELETED
-    category_id = graphene.Node.to_global_id("Category", category.id)
+    category_id = graphene.Node.to_global_id("Category", category_instances[0].id)
 
     # when
-    deliveries = create_deliveries_for_subscriptions(event_type, category, webhooks)
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, category_instances[0], webhooks
+    )
 
     # then
     expected_payload = json.dumps({"category": {"id": category_id}, "meta": None})
+    assert graphene.Node.from_global_id(category_id)[1] != "None"
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]

--- a/saleor/product/utils/__init__.py
+++ b/saleor/product/utils/__init__.py
@@ -53,12 +53,18 @@ def delete_categories(categories_ids: List[str], manager):
     )
     products = list(products)
 
+    category_instances = [cat for cat in categories]
     categories.delete()
-    product_ids = [product.id for product in products]
+
+    for category in category_instances:
+        manager.category_deleted(category)
+
     for product in products:
         manager.product_updated(product)
 
-    update_products_discounted_prices_task.delay(product_ids=product_ids)
+    update_products_discounted_prices_task.delay(
+        product_ids=[product.id for product in products]
+    )
 
 
 def collect_categories_tree_products(category: "Category") -> "QuerySet[Product]":


### PR DESCRIPTION
I want to merge this change because it adds sending `category_delete` webhook event to category `bulk_delete` mutation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
