### PR TITLE
Drop distinct and icontains in favor of ilike in apps filtering

### DIFF
--- a/saleor/graphql/app/filters.py
+++ b/saleor/graphql/app/filters.py
@@ -3,13 +3,12 @@ import django_filters
 from ...app import models
 from ...app.types import AppExtensionTarget, AppType
 from ..core.filters import EnumFilter, ListObjectTypeFilter
-from ..utils.filters import filter_by_query_param
 from .enums import AppExtensionMountEnum, AppExtensionTargetEnum, AppTypeEnum
 
 
 def filter_app_search(qs, _, value):
     if value:
-        qs = filter_by_query_param(qs, value, ("name",))
+        qs = qs.filter(name__ilike=value)
     return qs
 
 


### PR DESCRIPTION
I want to merge this change because it replaces usage of `filter_by_query_param` in favor of `.filter` with `ilike` to improve performance of apps filtering.

Previous sql:
```
SELECT DISTINCT "app_app"."id", ... WHERE UPPER("app_app"."name"::text) LIKE UPPER('%test%')
```

New SQL:
```
SELECT "app_app"."id", ... WHERE "app_app"."name" ILIKE '%test%'
```


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
