### PR TITLE
Add python3-psycopg2 module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
   libgdk-pixbuf2.0-0 \
   shared-mime-info \
   mime-support \
+  python3-psycopg2 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I want to merge this change because it fixed exception ImportError throw after running ```RUN ... python3 manage.py collectstatic```.

<!-- Please mention all relevant issue numbers. -->

[#7856](https://github.com/saleor/saleor/issues/7856)

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
