### PR TITLE
Improve shipping zone filters performance

### DIFF
--- a/saleor/graphql/shipping/filters.py
+++ b/saleor/graphql/shipping/filters.py
@@ -5,7 +5,6 @@ from ..channel.types import Channel
 from ..core.filters import GlobalIDMultipleChoiceFilter
 from ..core.types import FilterInputObjectType
 from ..utils import resolve_global_ids_to_primary_keys
-from ..utils.filters import filter_fields_containing_value
 
 
 def filter_channels(qs, _, values):
@@ -15,8 +14,12 @@ def filter_channels(qs, _, values):
     return qs
 
 
+def filter_shipping_zones_search(qs, _, value):
+    return qs.filter(name__ilike=value)
+
+
 class ShippingZoneFilter(django_filters.FilterSet):
-    search = django_filters.CharFilter(method=filter_fields_containing_value("name"))
+    search = django_filters.CharFilter(method=filter_shipping_zones_search)
     channels = GlobalIDMultipleChoiceFilter(method=filter_channels)
 
     class Meta:


### PR DESCRIPTION
I want to merge this change because it improves performance of shipping zones filtering.

Previous SQL (search filter):
```
SELECT DISTINCT "shipping_shippingzone"."id", ... FROM "shipping_shippingzone" WHERE UPPER("shipping_shippingzone"."name"::text) LIKE UPPER('%test%')
```

New SQL (search filter):
```
SELECT "shipping_shippingzone"."id", ... FROM "shipping_shippingzone" WHERE "shipping_shippingzone"."name" ILIKE '%test%'
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
