### PR TITLE
Add mutation to call transaction action

### DIFF
--- a/saleor/graphql/payment/enums.py
+++ b/saleor/graphql/payment/enums.py
@@ -12,7 +12,7 @@ TransactionKindEnum = to_enum(TransactionKind, type_name="TransactionKind")
 PaymentChargeStatusEnum = to_enum(ChargeStatus, type_name="PaymentChargeStatusEnum")
 TransactionActionEnum = to_enum(
     TransactionAction,
-    type_name="PaymentActionEnum",
+    type_name="TransactionActionEnum",
     description=TransactionAction.__doc__,
 )
 TransactionStatusEnum = to_enum(TransactionStatus, type_name="TransactionStatus")

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1,4 +1,5 @@
-from typing import List, Union
+from decimal import Decimal
+from typing import List, Optional, Union
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -15,12 +16,18 @@ from ...core.utils import get_client_ip
 from ...core.utils.url import validate_storefront_url
 from ...order import models as order_models
 from ...order.events import transaction_event
-from ...payment import PaymentError, StorePaymentMethod, gateway
+from ...payment import PaymentError, StorePaymentMethod, TransactionAction, gateway
 from ...payment import models as payment_models
 from ...payment.error_codes import (
     PaymentErrorCode,
     TransactionCreateErrorCode,
+    TransactionRequestActionErrorCode,
     TransactionUpdateErrorCode,
+)
+from ...payment.gateway import (
+    request_capture_action,
+    request_refund_action,
+    request_void_action,
 )
 from ...payment.utils import create_payment, is_currency_supported
 from ..account.i18n import I18nMixin
@@ -40,6 +47,7 @@ from ..core.scalars import UUID, PositiveDecimal
 from ..core.types import common as common_types
 from ..core.validators import validate_one_of_args_is_in_mutation
 from ..meta.mutations import MetadataInput
+from ..utils import get_user_or_app_from_context
 from .enums import TransactionActionEnum, TransactionStatusEnum
 from .types import Payment, PaymentInitialized, TransactionItem
 from .utils import metadata_contains_empty_key
@@ -839,3 +847,87 @@ class TransactionUpdate(TransactionCreate):
                 name=transaction_event_data.get("name", ""),
             )
         return TransactionUpdate(transaction=instance)
+
+
+class TransactionRequestAction(BaseMutation):
+    transaction = graphene.Field(TransactionItem)
+
+    class Arguments:
+        id = graphene.ID(
+            description="The ID of the transaction.",
+            required=True,
+        )
+        action_type = graphene.Argument(
+            TransactionActionEnum,
+            required=True,
+            description="Determines the action type.",
+        )
+        amount = PositiveDecimal(
+            description=(
+                "Transaction request amount. If empty for refund or capture, maximal "
+                "possible amount will be used."
+            )
+        )
+
+    class Meta:
+        description = f"{PREVIEW_FEATURE} Request an action for payment transaction."
+        error_type_class = common_types.TransactionRequestActionError
+        permissions = (
+            PaymentPermissions.HANDLE_PAYMENTS,
+            OrderPermissions.MANAGE_ORDERS,
+        )
+
+    @classmethod
+    def check_permissions(cls, context, permissions=None):
+        required_permissions = permissions or cls._meta.permissions
+        requestor = get_user_or_app_from_context(context)
+        for required_permission in required_permissions:
+            # We want to allow to call this mutation for requestor with one of following
+            # permission: manage_orders, manager_payments
+            if requestor.has_perm(required_permission):
+                return True
+        return False
+
+    @classmethod
+    def handle_transaction_action(
+        cls, action, action_kwargs, action_value: Optional[Decimal]
+    ):
+        if action == TransactionAction.VOID:
+            request_void_action(**action_kwargs)
+        elif action == TransactionAction.CAPTURE:
+            transaction = action_kwargs["transaction"]
+            action_value = action_value or transaction.authorized_value
+            action_value = min(action_value, transaction.authorized_value)
+            request_capture_action(**action_kwargs, capture_value=action_value)
+        elif action == TransactionAction.REFUND:
+            transaction = action_kwargs["transaction"]
+            action_value = action_value or transaction.captured_value
+            action_value = min(action_value, transaction.captured_value)
+            request_refund_action(**action_kwargs, refund_value=action_value)
+
+    @classmethod
+    def perform_mutation(cls, root, info, **data):
+        id = data["id"]
+        action_type = data["action_type"]
+        action_value = data.get("amount")
+        transaction = cls.get_node_or_error(info, id, only_type=TransactionItem)
+        channel_slug = (
+            transaction.order.channel.slug
+            if transaction.order_id
+            else transaction.checkout.channel.slug
+        )
+        action_kwargs = {
+            "channel_slug": channel_slug,
+            "user": info.context.user,
+            "app": info.context.app,
+            "transaction": transaction,
+            "manager": info.context.plugins,
+        }
+
+        try:
+            cls.handle_transaction_action(action_type, action_kwargs, action_value)
+        except PaymentError as e:
+            error_enum = TransactionRequestActionErrorCode
+            code = error_enum.MISSING_TRANSACTION_ACTION_REQUEST_WEBHOOK.value
+            raise ValidationError(str(e), code=code)
+        return TransactionRequestAction(transaction=transaction)

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -36,6 +36,7 @@ from ..checkout.mutations.utils import get_checkout_by_token
 from ..checkout.types import Checkout
 from ..core.descriptions import (
     ADDED_IN_31,
+    ADDED_IN_32,
     DEPRECATED_IN_3X_INPUT,
     DEPRECATED_IN_3X_MUTATION,
     PREVIEW_FEATURE,
@@ -798,7 +799,9 @@ class TransactionUpdate(TransactionCreate):
         )
 
     class Meta:
-        description = f"{PREVIEW_FEATURE} Create transaction for checkout or order."
+        description = (
+            f"{ADDED_IN_32} Create transaction for checkout or order. {PREVIEW_FEATURE}"
+        )
         error_type_class = common_types.TransactionUpdateError
         permissions = (PaymentPermissions.HANDLE_PAYMENTS,)
         object_type = TransactionItem
@@ -883,7 +886,7 @@ class TransactionRequestAction(BaseMutation):
         requestor = get_user_or_app_from_context(context)
         for required_permission in required_permissions:
             # We want to allow to call this mutation for requestor with one of following
-            # permission: manage_orders, manager_payments
+            # permission: manage_orders, handle_payments
             if requestor.has_perm(required_permission):
                 return True
         return False

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -873,7 +873,10 @@ class TransactionRequestAction(BaseMutation):
         )
 
     class Meta:
-        description = f"{PREVIEW_FEATURE} Request an action for payment transaction."
+        description = (
+            f"{ADDED_IN_32} Request an action for payment transaction. "
+            f"{PREVIEW_FEATURE}"
+        )
         error_type_class = common_types.TransactionRequestActionError
         permissions = (
             PaymentPermissions.HANDLE_PAYMENTS,

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -13,6 +13,7 @@ from .mutations import (
     PaymentRefund,
     PaymentVoid,
     TransactionCreate,
+    TransactionRequestAction,
     TransactionUpdate,
 )
 from .resolvers import resolve_payment_by_id, resolve_payments
@@ -54,3 +55,4 @@ class PaymentMutations(graphene.ObjectType):
 
     transaction_create = TransactionCreate.Field()
     transaction_update = TransactionUpdate.Field()
+    transaction_request_action = TransactionRequestAction.Field()

--- a/saleor/graphql/payment/tests/mutations/test_transaction_request_action.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_request_action.py
@@ -1,0 +1,574 @@
+from decimal import Decimal
+
+import graphene
+import pytest
+from mock import patch
+
+from .....order import OrderEvents
+from .....payment import TransactionAction
+from .....payment.interface import TransactionActionData
+from .....payment.models import TransactionItem
+from ....core.enums import TransactionRequestActionErrorCode
+from ....tests.utils import assert_no_permission, get_graphql_content
+from ...enums import TransactionActionEnum
+
+MUTATION_TRANSACTION_REQUEST_ACTION = """
+mutation TransactionRequestAction(
+    $id: ID!,
+    $action_type: TransactionActionEnum!,
+    $amount: PositiveDecimal
+    ){
+    transactionRequestAction(
+            id: $id,
+            actionType: $action_type,
+            amount: $amount
+        ){
+        transaction{
+                id
+                actions
+                reference
+                type
+                status
+                modifiedAt
+                createdAt
+                authorizedAmount{
+                    amount
+                    currency
+                }
+                voidedAmount{
+                    currency
+                    amount
+                }
+                capturedAmount{
+                    currency
+                    amount
+                }
+                refundedAmount{
+                    currency
+                    amount
+                }
+        }
+        errors{
+            field
+            message
+            code
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "capture_amount, expected_called_capture_amount",
+    [
+        (Decimal("8.00"), Decimal("8.00")),
+        (None, Decimal("10.00")),
+        (Decimal("100"), Decimal("10.00")),
+    ],
+)
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.transaction_action_request")
+def test_transaction_request_capture_action_for_order(
+    mocked_payment_action_request,
+    mocked_is_active,
+    capture_amount,
+    expected_called_capture_amount,
+    order_with_lines,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    mocked_is_active.return_value = True
+
+    transaction = TransactionItem.objects.create(
+        status="Authorized",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["capture", "void"],
+        currency="USD",
+        order_id=order_with_lines.pk,
+        authorized_value=Decimal("10"),
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
+        "action_type": TransactionActionEnum.CAPTURE.name,
+        "amount": capture_amount,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_REQUEST_ACTION,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    get_graphql_content(response)
+
+    assert mocked_is_active.called
+    mocked_payment_action_request.assert_called_once_with(
+        TransactionActionData(
+            transaction=transaction,
+            action_type=TransactionAction.CAPTURE,
+            action_value=expected_called_capture_amount,
+        ),
+        channel_slug=order_with_lines.channel.slug,
+    )
+
+    event = order_with_lines.events.first()
+    assert event.type == OrderEvents.TRANSACTION_CAPTURE_REQUESTED
+    assert Decimal(event.parameters["amount"]) == expected_called_capture_amount
+    assert event.parameters["payment_id"] == transaction.reference
+
+
+@pytest.mark.parametrize(
+    "refund_amount, expected_called_refund_amount",
+    [
+        (Decimal("8.00"), Decimal("8.00")),
+        (None, Decimal("10.00")),
+        (Decimal("100"), Decimal("10.00")),
+    ],
+)
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.transaction_action_request")
+def test_transaction_request_refund_action_for_order(
+    mocked_payment_action_request,
+    mocked_is_active,
+    refund_amount,
+    expected_called_refund_amount,
+    order_with_lines,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    mocked_is_active.return_value = True
+
+    transaction = TransactionItem.objects.create(
+        status="Captured",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        order_id=order_with_lines.pk,
+        captured_value=Decimal("10"),
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
+        "action_type": TransactionActionEnum.REFUND.name,
+        "amount": refund_amount,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_REQUEST_ACTION,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    get_graphql_content(response)
+
+    assert mocked_is_active.called
+    mocked_payment_action_request.assert_called_once_with(
+        TransactionActionData(
+            transaction=transaction,
+            action_type=TransactionAction.REFUND,
+            action_value=expected_called_refund_amount,
+        ),
+        channel_slug=order_with_lines.channel.slug,
+    )
+
+    event = order_with_lines.events.first()
+    assert event.type == OrderEvents.TRANSACTION_REFUND_REQUESTED
+    assert Decimal(event.parameters["amount"]) == expected_called_refund_amount
+    assert event.parameters["payment_id"] == transaction.reference
+
+
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.transaction_action_request")
+def test_transaction_request_void_action_for_order(
+    mocked_payment_action_request,
+    mocked_is_active,
+    order_with_lines,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    mocked_is_active.return_value = True
+
+    transaction = TransactionItem.objects.create(
+        status="Authorized",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["capture", "void"],
+        currency="USD",
+        order_id=order_with_lines.pk,
+        authorized_value=Decimal("10"),
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
+        "action_type": TransactionActionEnum.VOID.name,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_REQUEST_ACTION,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    get_graphql_content(response)
+
+    assert mocked_is_active.called
+    mocked_payment_action_request.assert_called_once_with(
+        TransactionActionData(
+            transaction=transaction,
+            action_type=TransactionAction.VOID,
+            action_value=None,
+        ),
+        channel_slug=order_with_lines.channel.slug,
+    )
+
+    event = order_with_lines.events.first()
+    assert event.type == OrderEvents.TRANSACTION_VOID_REQUESTED
+    assert event.parameters["payment_id"] == transaction.reference
+
+
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.transaction_action_request")
+def test_transaction_request_void_action_for_checkout(
+    mocked_payment_action_request,
+    mocked_is_active,
+    checkout,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    mocked_is_active.return_value = True
+
+    transaction = TransactionItem.objects.create(
+        status="Authorized",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["capture", "void"],
+        currency="USD",
+        checkout_id=checkout.pk,
+        authorized_value=Decimal("10"),
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
+        "action_type": TransactionActionEnum.VOID.name,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_REQUEST_ACTION,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    get_graphql_content(response)
+
+    assert mocked_is_active.called
+    mocked_payment_action_request.assert_called_once_with(
+        TransactionActionData(
+            transaction=transaction,
+            action_type=TransactionAction.VOID,
+            action_value=None,
+        ),
+        channel_slug=checkout.channel.slug,
+    )
+
+
+@pytest.mark.parametrize(
+    "capture_amount, expected_called_capture_amount",
+    [
+        (Decimal("8.00"), Decimal("8.00")),
+        (None, Decimal("10.00")),
+        (Decimal("100"), Decimal("10.00")),
+    ],
+)
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.transaction_action_request")
+def test_transaction_request_capture_action_for_checkout(
+    mocked_payment_action_request,
+    mocked_is_active,
+    capture_amount,
+    expected_called_capture_amount,
+    checkout,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    mocked_is_active.return_value = True
+
+    transaction = TransactionItem.objects.create(
+        status="Authorized",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["capture", "void"],
+        currency="USD",
+        checkout_id=checkout.pk,
+        authorized_value=Decimal("10"),
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
+        "action_type": TransactionActionEnum.CAPTURE.name,
+        "amount": capture_amount,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_REQUEST_ACTION,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    get_graphql_content(response)
+
+    assert mocked_is_active.called
+    mocked_payment_action_request.assert_called_once_with(
+        TransactionActionData(
+            transaction=transaction,
+            action_type=TransactionAction.CAPTURE,
+            action_value=expected_called_capture_amount,
+        ),
+        channel_slug=checkout.channel.slug,
+    )
+
+
+@pytest.mark.parametrize(
+    "refund_amount, expected_called_refund_amount",
+    [
+        (Decimal("8.00"), Decimal("8.00")),
+        (None, Decimal("10.00")),
+        (Decimal("100"), Decimal("10.00")),
+    ],
+)
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.transaction_action_request")
+def test_transaction_request_refund_action_for_checkout(
+    mocked_payment_action_request,
+    mocked_is_active,
+    refund_amount,
+    expected_called_refund_amount,
+    checkout,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    mocked_is_active.return_value = True
+
+    transaction = TransactionItem.objects.create(
+        status="Captured",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        checkout_id=checkout.pk,
+        captured_value=Decimal("10"),
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
+        "action_type": TransactionActionEnum.REFUND.name,
+        "amount": refund_amount,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_REQUEST_ACTION,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    get_graphql_content(response)
+
+    assert mocked_is_active.called
+    mocked_payment_action_request.assert_called_once_with(
+        TransactionActionData(
+            transaction=transaction,
+            action_type=TransactionAction.REFUND,
+            action_value=expected_called_refund_amount,
+        ),
+        channel_slug=checkout.channel.slug,
+    )
+
+
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.transaction_action_request")
+def test_transaction_request_uses_handle_payment_permission(
+    mocked_payment_action_request,
+    mocked_is_active,
+    checkout,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    mocked_is_active.return_value = True
+
+    transaction = TransactionItem.objects.create(
+        status="Captured",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        checkout_id=checkout.pk,
+        captured_value=Decimal("10"),
+    )
+    refund_amount = Decimal("1")
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
+        "action_type": TransactionActionEnum.REFUND.name,
+        "amount": refund_amount,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_REQUEST_ACTION,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    get_graphql_content(response)
+
+    assert mocked_is_active.called
+    mocked_payment_action_request.assert_called_once_with(
+        TransactionActionData(
+            transaction=transaction,
+            action_type=TransactionAction.REFUND,
+            action_value=refund_amount,
+        ),
+        channel_slug=checkout.channel.slug,
+    )
+
+
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.transaction_action_request")
+def test_transaction_request_uses_manage_orders_permission(
+    mocked_payment_action_request,
+    mocked_is_active,
+    order,
+    app_api_client,
+    permission_manage_orders,
+):
+    # given
+    mocked_is_active.return_value = True
+
+    transaction = TransactionItem.objects.create(
+        status="Captured",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        order_id=order.pk,
+        captured_value=Decimal("10"),
+    )
+    refund_amount = Decimal("1")
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
+        "action_type": TransactionActionEnum.REFUND.name,
+        "amount": refund_amount,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_REQUEST_ACTION,
+        variables,
+        permissions=[permission_manage_orders],
+    )
+
+    # then
+    get_graphql_content(response)
+
+    assert mocked_is_active.called
+    mocked_payment_action_request.assert_called_once_with(
+        TransactionActionData(
+            transaction=transaction,
+            action_type=TransactionAction.REFUND,
+            action_value=refund_amount,
+        ),
+        channel_slug=order.channel.slug,
+    )
+
+
+def test_transaction_request_action_missing_permission(
+    app_api_client, order_with_lines
+):
+    # given
+
+    transaction = TransactionItem.objects.create(
+        status="Authorized",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["capture", "void"],
+        currency="USD",
+        order_id=order_with_lines.pk,
+        authorized_value=Decimal("10"),
+    )
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
+        "action_type": TransactionActionEnum.VOID.name,
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_TRANSACTION_REQUEST_ACTION, variables, permissions=[]
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+def test_transaction_request_action_missing_event(
+    mocked_is_active, staff_api_client, permission_manage_payments, order
+):
+    # given
+    authorization_value = Decimal("10")
+    transaction = TransactionItem.objects.create(
+        status="Authorized",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["capture", "void"],
+        currency="USD",
+        order_id=order.pk,
+        authorized_value=authorization_value,
+    )
+    mocked_is_active.return_value = False
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
+        "action_type": TransactionActionEnum.VOID.name,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION_TRANSACTION_REQUEST_ACTION,
+        variables,
+        permissions=[
+            permission_manage_payments,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["transactionRequestAction"]
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["message"] == (
+        "No app or plugin is configured to handle payment action requests."
+    )
+    code_enum = TransactionRequestActionErrorCode
+    assert data["errors"][0]["code"] == (
+        code_enum.MISSING_TRANSACTION_ACTION_REQUEST_WEBHOOK.name
+    )
+
+    assert mocked_is_active.called

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -8768,7 +8768,7 @@ type Mutation {
   ): TransactionCreate
 
   """
-  Note: this feature is in a preview state and can be subject to changes at later point. Create transaction for checkout or order. Requires one of the following permissions: HANDLE_PAYMENTS.
+  New in Saleor 3.2. Create transaction for checkout or order. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: HANDLE_PAYMENTS.
   """
   transactionUpdate(
     """The ID of the transaction."""
@@ -12968,7 +12968,7 @@ input TransactionEventInput {
 }
 
 """
-Note: this feature is in a preview state and can be subject to changes at later point. Create transaction for checkout or order. Requires one of the following permissions: HANDLE_PAYMENTS.
+New in Saleor 3.2. Create transaction for checkout or order. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: HANDLE_PAYMENTS.
 """
 type TransactionUpdate {
   transaction: TransactionItem

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -8782,7 +8782,7 @@ type Mutation {
   ): TransactionUpdate
 
   """
-  Note: this feature is in a preview state and can be subject to changes at later point. Request an action for payment transaction. Requires one of the following permissions: HANDLE_PAYMENTS, MANAGE_ORDERS.
+  New in Saleor 3.2. Request an action for payment transaction. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: HANDLE_PAYMENTS, MANAGE_ORDERS.
   """
   transactionRequestAction(
     """Determines the action type."""
@@ -13030,7 +13030,7 @@ input TransactionUpdateInput {
 }
 
 """
-Note: this feature is in a preview state and can be subject to changes at later point. Request an action for payment transaction. Requires one of the following permissions: HANDLE_PAYMENTS, MANAGE_ORDERS.
+New in Saleor 3.2. Request an action for payment transaction. Note: this feature is in a preview state and can be subject to changes at later point. Requires one of the following permissions: HANDLE_PAYMENTS, MANAGE_ORDERS.
 """
 type TransactionRequestAction {
   transaction: TransactionItem

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6282,7 +6282,7 @@ type TransactionItem implements Node & ObjectWithMetadata {
   """
   List of actions that can be performed in the current state of a payment.
   """
-  actions: [PaymentActionEnum!]!
+  actions: [TransactionActionEnum!]!
 
   """Total amount authorized for this payment."""
   authorizedAmount: Money!
@@ -6314,7 +6314,7 @@ Represents possible actions on payment transaction.
     REFUND - Represents a refund action.
     VOID - Represents a void action.
 """
-enum PaymentActionEnum {
+enum TransactionActionEnum {
   CAPTURE
   REFUND
   VOID
@@ -8780,6 +8780,22 @@ type Mutation {
     """Data that defines a transaction transaction."""
     transactionEvent: TransactionEventInput
   ): TransactionUpdate
+
+  """
+  Note: this feature is in a preview state and can be subject to changes at later point. Request an action for payment transaction. Requires one of the following permissions: HANDLE_PAYMENTS, MANAGE_ORDERS.
+  """
+  transactionRequestAction(
+    """Determines the action type."""
+    actionType: TransactionActionEnum!
+
+    """
+    Transaction request amount. If empty for refund or capture, maximal possible amount will be used.
+    """
+    amount: PositiveDecimal
+
+    """The ID of the transaction."""
+    id: ID!
+  ): TransactionRequestAction
 
   """
   Creates a new page. Requires one of the following permissions: MANAGE_PAGES.
@@ -12911,7 +12927,7 @@ input TransactionCreateInput {
   reference: String
 
   """List of all possible actions for the transaction"""
-  availableActions: [PaymentActionEnum!]
+  availableActions: [TransactionActionEnum!]
 
   """Amount authorized by this transaction."""
   amountAuthorized: MoneyInput
@@ -12992,7 +13008,7 @@ input TransactionUpdateInput {
   reference: String
 
   """List of all possible actions for the transaction"""
-  availableActions: [PaymentActionEnum!]
+  availableActions: [TransactionActionEnum!]
 
   """Amount authorized by this transaction."""
   amountAuthorized: MoneyInput
@@ -13011,6 +13027,35 @@ input TransactionUpdateInput {
 
   """Payment private metadata."""
   privateMetadata: [MetadataInput!]
+}
+
+"""
+Note: this feature is in a preview state and can be subject to changes at later point. Request an action for payment transaction. Requires one of the following permissions: HANDLE_PAYMENTS, MANAGE_ORDERS.
+"""
+type TransactionRequestAction {
+  transaction: TransactionItem
+  errors: [TransactionRequestActionError!]!
+}
+
+type TransactionRequestActionError {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: TransactionRequestActionErrorCode!
+}
+
+"""An enumeration."""
+enum TransactionRequestActionErrorCode {
+  INVALID
+  GRAPHQL_ERROR
+  NOT_FOUND
+  MISSING_TRANSACTION_ACTION_REQUEST_WEBHOOK
 }
 
 """

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -41,6 +41,6 @@ class TransactionRequestActionErrorCode(Enum):
     INVALID = "invalid"
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
-    MISSING_PAYMENT_ACTION_REQUEST_WEBHOOK = (
+    MISSING_TRANSACTION_ACTION_REQUEST_WEBHOOK = (
         "missing_transaction_action_request_webhook"
     )


### PR DESCRIPTION
I want to merge this change because it adds a mutation that allows triggering a request for action on a transaction

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
