### PR TITLE
Use error code checkout_not_found for mutation order create from checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable, unreleased changes to this project will be documented in this file.
 # Unreleased
 
 ### Breaking changes
-- PREVIEW_FEATURE: replace error code `NOT_FOUND` with `CHECKOUT_NOT_FOUND` for mutation `OrderCreateFromCheckout`
+- PREVIEW_FEATURE: replace error code `NOT_FOUND` with `CHECKOUT_NOT_FOUND` for mutation `OrderCreateFromCheckout` - #9569 by @korycins
 - Convert IDs from DB to Graphql format in all notification payloads (email plugins and webhook.NOTIFY)- #9388 by @L3str4nge
 - Migrate order id from int to UUID - #9324 by @IKarbowiak
   - Changed the order `id` changed from `int` to `UUID`, the old ids still can be used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable, unreleased changes to this project will be documented in this file.
 # Unreleased
 
 ### Breaking changes
+- PREVIEW_FEATURE: replace error code `NOT_FOUND` with `CHECKOUT_NOT_FOUND` for mutation `OrderCreateFromCheckout`
 - Convert IDs from DB to Graphql format in all notification payloads (email plugins and webhook.NOTIFY)- #9388 by @L3str4nge
 - Migrate order id from int to UUID - #9324 by @IKarbowiak
   - Changed the order `id` changed from `int` to `UUID`, the old ids still can be used

--- a/saleor/checkout/error_codes.py
+++ b/saleor/checkout/error_codes.py
@@ -33,7 +33,7 @@ class CheckoutErrorCode(Enum):
 
 class OrderCreateFromCheckoutErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
-    NOT_FOUND = "not_found"
+    CHECKOUT_NOT_FOUND = "checkout_not_found"
     CHANNEL_INACTIVE = "channel_inactive"
     INSUFFICIENT_STOCK = "insufficient_stock"
     VOUCHER_NOT_APPLICABLE = "voucher_not_applicable"

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -70,7 +70,11 @@ class OrderCreateFromCheckout(BaseMutation):
     def perform_mutation(cls, root, info, **data):
         checkout_id = data.get("id")
         checkout = cls.get_node_or_error(
-            info, checkout_id, field="id", only_type=Checkout
+            info,
+            checkout_id,
+            field="id",
+            only_type=Checkout,
+            code=OrderCreateFromCheckoutErrorCode.CHECKOUT_NOT_FOUND.value,
         )
         tracking_code = analytics.get_client_id(info.context)
 

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -218,7 +218,9 @@ class BaseMutation(graphene.Mutation):
         return pk
 
     @classmethod
-    def get_node_or_error(cls, info, node_id, field="id", only_type=None, qs=None):
+    def get_node_or_error(
+        cls, info, node_id, field="id", only_type=None, qs=None, code="not_found"
+    ):
         if not node_id:
             return None
 
@@ -240,7 +242,7 @@ class BaseMutation(graphene.Mutation):
                 raise ValidationError(
                     {
                         field: ValidationError(
-                            "Couldn't resolve to a node: %s" % node_id, code="not_found"
+                            "Couldn't resolve to a node: %s" % node_id, code=code
                         )
                     }
                 )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15246,7 +15246,7 @@ type OrderCreateFromCheckoutError {
 """An enumeration."""
 enum OrderCreateFromCheckoutErrorCode {
   GRAPHQL_ERROR
-  NOT_FOUND
+  CHECKOUT_NOT_FOUND
   CHANNEL_INACTIVE
   INSUFFICIENT_STOCK
   VOUCHER_NOT_APPLICABLE


### PR DESCRIPTION
I want to merge this change because it replaces the used `NOT_FOUND` error code with `CHECKOUT_NOT_FOUND`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
