### PR TITLE
Fix for raising Permission Denied when Anonymous user calls checkout.customer field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Refactor app tokens - #9438 by @IKarbowiak
   - Store app tokens hashes instead of plain text.
 - Save images to product media from external URLs - #9329 by @krzysztofwolski
-
+- Fix for raising Permission Denied when anonymous user calls `checkout.customer` field - #9573 by @korycins
 
 # 3.1.7
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -3363,11 +3363,36 @@ QUERY_CHECKOUT_USER_ID = """
     """
 
 
-def test_anonymous_client_cant_fetch_checkout_user(api_client, checkout):
+def test_anonymous_client_can_fetch_anonymoues_checkout_user(api_client, checkout):
+    # given
     query = QUERY_CHECKOUT_USER_ID
     variables = {"token": str(checkout.token)}
+
+    # when
     response = api_client.post_graphql(query, variables)
-    assert_no_permission(response)
+
+    # then
+
+    content = get_graphql_content(response)
+    assert not content["data"]["checkout"]["user"]
+
+
+def test_anonymous_client_cant_fetch_checkout_with_attached_user(
+    api_client, checkout, customer_user
+):
+    # given
+    checkout.user = customer_user
+    checkout.save()
+
+    query = QUERY_CHECKOUT_USER_ID
+    variables = {"token": str(checkout.token)}
+
+    # when
+    response = api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["checkout"]
 
 
 def test_authorized_access_to_checkout_user_as_customer(

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -302,6 +302,8 @@ class Checkout(ModelObjectType):
 
     @staticmethod
     def resolve_user(root: models.Checkout, info):
+        if not root.user_id:
+            return None
         requestor = get_user_or_app_from_context(info.context)
         check_requestor_access(requestor, root.user, AccountPermissions.MANAGE_USERS)
         return root.user


### PR DESCRIPTION
I want to merge this change because it fixes a raised `PermissionDenied`, when query for anonymous checkout contains `user` field, and it is called as an `anonymous` user. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
