### PR TITLE
Attach transactions to checkout type

### DIFF
--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -336,4 +336,4 @@ class TransactionItemsByCheckoutIDLoader(DataLoader):
         transactions_map = defaultdict(list)
         for transaction in transactions:
             transactions_map[transaction.checkout_id].append(transaction)
-        return [transactions_map.get(checkout_id, []) for checkout_id in keys]
+        return [transactions_map[checkout_id] for checkout_id in keys]

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -10,6 +10,7 @@ from ...checkout.fetch import (
     update_delivery_method_lists_for_checkout_info,
 )
 from ...checkout.models import Checkout, CheckoutLine
+from ...payment.models import TransactionItem
 from ..account.dataloaders import AddressByIdLoader, UserByUserIdLoader
 from ..core.dataloaders import DataLoader
 from ..discount.dataloaders import VoucherByCodeLoader
@@ -323,3 +324,16 @@ class CheckoutLinesByCheckoutTokenLoader(DataLoader):
         for line in lines.iterator():
             line_map[line.checkout_id].append(line)
         return [line_map.get(checkout_id, []) for checkout_id in keys]
+
+
+class TransactionItemsByCheckoutIDLoader(DataLoader):
+    context_key = "transaction_items_by_checkout_id"
+
+    def batch_load(self, keys):
+        transactions = TransactionItem.objects.filter(checkout_id__in=keys).order_by(
+            "pk"
+        )
+        transactions_map = defaultdict(list)
+        for transaction in transactions:
+            transactions_map[transaction.checkout_id].append(transaction)
+        return [transactions_map.get(checkout_id, []) for checkout_id in keys]

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -36,7 +36,7 @@ from ....checkout.utils import (
     calculate_checkout_quantity,
 )
 from ....core.payments import PaymentInterface
-from ....payment import TransactionKind
+from ....payment import TransactionAction, TransactionKind
 from ....payment.interface import GatewayResponse
 from ....plugins.base_plugin import ExcludedShippingMethod
 from ....plugins.manager import get_plugins_manager
@@ -4442,3 +4442,92 @@ def test_get_checkout_with_vatlayer_set(
     # then
     content = get_graphql_content(response)
     assert content["data"]["checkout"]["token"] == str(checkout.token)
+
+
+QUERY_CHECKOUT_TRANSACTIONS = """
+    query getCheckout($token: UUID!) {
+        checkout(token: $token) {
+           transactions {
+               id
+           }
+        }
+    }
+    """
+
+
+def test_checkout_transactions_missing_permission(api_client, checkout):
+    # given
+    checkout.payment_transactions.create(
+        status="Authorized",
+        type="Credit card",
+        reference="123",
+        currency="USD",
+        authorized_value=Decimal("15"),
+        available_actions=[TransactionAction.CAPTURE, TransactionAction.VOID],
+    )
+    query = QUERY_CHECKOUT_TRANSACTIONS
+    variables = {"token": str(checkout.token)}
+
+    # when
+    response = api_client.post_graphql(query, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_checkout_transactions_with_manage_checkouts(
+    staff_api_client, checkout, permission_manage_checkouts
+):
+    # given
+    transaction = checkout.payment_transactions.create(
+        status="Authorized",
+        type="Credit card",
+        reference="123",
+        currency="USD",
+        authorized_value=Decimal("15"),
+        available_actions=[TransactionAction.CAPTURE, TransactionAction.VOID],
+    )
+    query = QUERY_CHECKOUT_TRANSACTIONS
+    variables = {"token": str(checkout.token)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_checkouts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["checkout"]["transactions"]) == 1
+    transaction_id = content["data"]["checkout"]["transactions"][0]["id"]
+    assert transaction_id == graphene.Node.to_global_id(
+        "TransactionItem", transaction.id
+    )
+
+
+def test_checkout_transactions_with_handle_payments(
+    staff_api_client, checkout, permission_manage_payments
+):
+    # given
+    transaction = checkout.payment_transactions.create(
+        status="Authorized",
+        type="Credit card",
+        reference="123",
+        currency="USD",
+        authorized_value=Decimal("15"),
+        available_actions=[TransactionAction.CAPTURE, TransactionAction.VOID],
+    )
+    query = QUERY_CHECKOUT_TRANSACTIONS
+    variables = {"token": str(checkout.token)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["checkout"]["transactions"]) == 1
+    transaction_id = content["data"]["checkout"]["transactions"][0]["id"]
+    assert transaction_id == graphene.Node.to_global_id(
+        "TransactionItem", transaction.id
+    )

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -3,7 +3,11 @@ from promise import Promise
 
 from ...checkout import calculations, models
 from ...checkout.utils import get_valid_collection_points_for_checkout
-from ...core.permissions import AccountPermissions
+from ...core.permissions import (
+    AccountPermissions,
+    CheckoutPermissions,
+    PaymentPermissions,
+)
 from ...core.taxes import zero_taxed_money
 from ...core.tracing import traced_resolver
 from ...shipping.interface import ShippingMethodData
@@ -15,14 +19,21 @@ from ..channel import ChannelContext
 from ..channel.dataloaders import ChannelByCheckoutLineIDLoader, ChannelByIdLoader
 from ..channel.types import Channel
 from ..core.connection import CountableConnection
-from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_FIELD, PREVIEW_FEATURE
+from ..core.descriptions import (
+    ADDED_IN_31,
+    ADDED_IN_32,
+    DEPRECATED_IN_3X_FIELD,
+    PREVIEW_FEATURE,
+)
 from ..core.enums import LanguageCodeEnum
 from ..core.scalars import UUID
 from ..core.types import ModelObjectType, Money, NonNullList, TaxedMoney
 from ..core.utils import str_to_enum
+from ..decorators import one_of_permissions_required
 from ..discount.dataloaders import DiscountsByDateTimeLoader
 from ..giftcard.types import GiftCard
 from ..meta.types import ObjectWithMetadata
+from ..payment.types import TransactionItem
 from ..product.dataloaders import (
     ProductTypeByProductIdLoader,
     ProductTypeByVariantIdLoader,
@@ -37,6 +48,7 @@ from .dataloaders import (
     CheckoutInfoByCheckoutTokenLoader,
     CheckoutLinesByCheckoutTokenLoader,
     CheckoutLinesInfoByCheckoutTokenLoader,
+    TransactionItemsByCheckoutIDLoader,
 )
 
 
@@ -273,6 +285,15 @@ class Checkout(ModelObjectType):
     )
     language_code = graphene.Field(
         LanguageCodeEnum, required=True, description="Checkout language code."
+    )
+
+    transactions = NonNullList(
+        TransactionItem,
+        description=(
+            f"{ADDED_IN_32} List of transactions for the checkout. Requires one of the "
+            f"following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS. "
+            f"{PREVIEW_FEATURE}"
+        ),
     )
 
     class Meta:
@@ -529,6 +550,13 @@ class Checkout(ModelObjectType):
             .load(root.token)
             .then(get_oldest_stock_reservation_expiration_date)
         )
+
+    @staticmethod
+    @one_of_permissions_required(
+        [CheckoutPermissions.MANAGE_CHECKOUTS, PaymentPermissions.HANDLE_PAYMENTS]
+    )
+    def resolve_transactions(root: models.Checkout, info):
+        return TransactionItemsByCheckoutIDLoader(info.context).load(root.pk)
 
 
 class CheckoutCountableConnection(CountableConnection):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5577,6 +5577,11 @@ type Checkout implements Node & ObjectWithMetadata {
 
   """Checkout language code."""
   languageCode: LanguageCodeEnum!
+
+  """
+  New in Saleor 3.2. List of transactions for the checkout. Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS. Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  transactions: [TransactionItem!]
 }
 
 """
@@ -5774,6 +5779,90 @@ type CheckoutLine implements Node {
 New in Saleor 3.1. Represents a delivery method chosen for the checkout. `Warehouse` type is used when checkout is marked as "click and collect" and `ShippingMethod` otherwise. Note: this feature is in a preview state and can be subject to changes at later point.
 """
 union DeliveryMethod = Warehouse | ShippingMethod
+
+"""
+New in Saleor 3.2. Represents a payment transaction. Note: this feature is in a preview state and can be subject to changes at later point.
+"""
+type TransactionItem implements Node & ObjectWithMetadata {
+  """The ID of the object."""
+  id: ID!
+
+  """
+  List of private metadata items. Requires proper staff permissions to access.
+  """
+  privateMetadata: [MetadataItem!]!
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+  createdAt: DateTime!
+  modifiedAt: DateTime!
+
+  """
+  List of actions that can be performed in the current state of a payment.
+  """
+  actions: [TransactionActionEnum!]!
+
+  """Total amount authorized for this payment."""
+  authorizedAmount: Money!
+
+  """Total amount refunded for this payment."""
+  refundedAmount: Money!
+
+  """Total amount voided for this payment."""
+  voidedAmount: Money!
+
+  """Total amount captured for this payment."""
+  capturedAmount: Money!
+
+  """Status of transaction."""
+  status: String!
+
+  """Type of transaction."""
+  type: String!
+
+  """Reference of transaction."""
+  reference: String!
+
+  """List of all transaction's events."""
+  events: [TransactionEvent!]!
+}
+
+"""
+Represents possible actions on payment transaction.
+
+    The following actions are possible:
+    CAPTURE - Represents the capture action.
+    REFUND - Represents a refund action.
+    VOID - Represents a void action.
+"""
+enum TransactionActionEnum {
+  CAPTURE
+  REFUND
+  VOID
+}
+
+"""Represents transaction's event."""
+type TransactionEvent implements Node {
+  """The ID of the object."""
+  id: ID!
+  createdAt: DateTime!
+
+  """Status of transaction's event."""
+  status: TransactionStatus!
+
+  """Reference of transaction's event."""
+  reference: String!
+
+  """Name of the transaction's event."""
+  name: String
+}
+
+"""An enumeration."""
+enum TransactionStatus {
+  PENDING
+  SUCCESS
+  FAILURE
+}
 
 type GiftCardCountableConnection {
   """Pagination data for this connection."""
@@ -6262,90 +6351,6 @@ type CreditCard {
 
   """Four-digit number representing the card’s expiration year."""
   expYear: Int
-}
-
-"""
-New in Saleor 3.2. Represents a payment transaction. Note: this feature is in a preview state and can be subject to changes at later point.
-"""
-type TransactionItem implements Node & ObjectWithMetadata {
-  """The ID of the object."""
-  id: ID!
-
-  """
-  List of private metadata items. Requires proper staff permissions to access.
-  """
-  privateMetadata: [MetadataItem!]!
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-  createdAt: DateTime!
-  modifiedAt: DateTime!
-
-  """
-  List of actions that can be performed in the current state of a payment.
-  """
-  actions: [TransactionActionEnum!]!
-
-  """Total amount authorized for this payment."""
-  authorizedAmount: Money!
-
-  """Total amount refunded for this payment."""
-  refundedAmount: Money!
-
-  """Total amount voided for this payment."""
-  voidedAmount: Money!
-
-  """Total amount captured for this payment."""
-  capturedAmount: Money!
-
-  """Status of transaction."""
-  status: String!
-
-  """Type of transaction."""
-  type: String!
-
-  """Reference of transaction."""
-  reference: String!
-
-  """List of all transaction's events."""
-  events: [TransactionEvent!]!
-}
-
-"""
-Represents possible actions on payment transaction.
-
-    The following actions are possible:
-    CAPTURE - Represents the capture action.
-    REFUND - Represents a refund action.
-    VOID - Represents a void action.
-"""
-enum TransactionActionEnum {
-  CAPTURE
-  REFUND
-  VOID
-}
-
-"""Represents transaction's event."""
-type TransactionEvent implements Node {
-  """The ID of the object."""
-  id: ID!
-  createdAt: DateTime!
-
-  """Status of transaction's event."""
-  status: TransactionStatus!
-
-  """Reference of transaction's event."""
-  reference: String!
-
-  """Name of the transaction's event."""
-  name: String
-}
-
-"""An enumeration."""
-enum TransactionStatus {
-  PENDING
-  SUCCESS
-  FAILURE
 }
 
 """History log of the order."""


### PR DESCRIPTION
I want to merge this change because it adds `transactions` field to `Checkout` type

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
