### PR TITLE
Add subscription for transaction action request

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16902,7 +16902,7 @@ type Subscription {
   event: Event
 }
 
-union Event = CategoryCreated | CategoryUpdated | CategoryDeleted | OrderCreated | OrderUpdated | OrderConfirmed | OrderFullyPaid | OrderCancelled | OrderFulfilled | DraftOrderCreated | DraftOrderUpdated | DraftOrderDeleted | ProductCreated | ProductUpdated | ProductDeleted | ProductVariantCreated | ProductVariantUpdated | ProductVariantOutOfStock | ProductVariantBackInStock | ProductVariantDeleted | SaleCreated | SaleUpdated | SaleDeleted | InvoiceRequested | InvoiceDeleted | InvoiceSent | FulfillmentCreated | FulfillmentCanceled | CustomerCreated | CustomerUpdated | CollectionCreated | CollectionUpdated | CollectionDeleted | CheckoutCreated | CheckoutUpdated | PageCreated | PageUpdated | PageDeleted | ShippingPriceCreated | ShippingPriceUpdated | ShippingPriceDeleted | ShippingZoneCreated | ShippingZoneUpdated | ShippingZoneDeleted | TranslationCreated | TranslationUpdated
+union Event = CategoryCreated | CategoryUpdated | CategoryDeleted | OrderCreated | OrderUpdated | OrderConfirmed | OrderFullyPaid | OrderCancelled | OrderFulfilled | DraftOrderCreated | DraftOrderUpdated | DraftOrderDeleted | ProductCreated | ProductUpdated | ProductDeleted | ProductVariantCreated | ProductVariantUpdated | ProductVariantOutOfStock | ProductVariantBackInStock | ProductVariantDeleted | SaleCreated | SaleUpdated | SaleDeleted | InvoiceRequested | InvoiceDeleted | InvoiceSent | FulfillmentCreated | FulfillmentCanceled | CustomerCreated | CustomerUpdated | CollectionCreated | CollectionUpdated | CollectionDeleted | CheckoutCreated | CheckoutUpdated | PageCreated | PageUpdated | PageDeleted | ShippingPriceCreated | ShippingPriceUpdated | ShippingPriceDeleted | ShippingZoneCreated | ShippingZoneUpdated | ShippingZoneDeleted | TransactionActionRequest | TranslationCreated | TranslationUpdated
 
 type CategoryCreated {
   """
@@ -17319,6 +17319,26 @@ type ShippingZoneDeleted {
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ShippingZone
+}
+
+type TransactionActionRequest {
+  """
+  New in Saleor 3.2. Look up a transaction. Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  transaction: TransactionItem
+
+  """
+  New in Saleor 3.2. Requested action data. Note: this feature is in a preview state and can be subject to changes at later point.
+  """
+  action: TransactionAction!
+}
+
+type TransactionAction {
+  """Determines the action type."""
+  actionType: TransactionActionEnum!
+
+  """Transaction request amount. Null when action type is VOID."""
+  amount: PositiveDecimal
 }
 
 type TranslationCreated {

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -3,9 +3,11 @@ from graphene import AbstractType, ObjectType, Union
 from rx import Observable
 
 from ...attribute.models import AttributeTranslation, AttributeValueTranslation
+from ...core.prices import quantize_price
 from ...discount.models import SaleTranslation, VoucherTranslation
 from ...menu.models import MenuItemTranslation
 from ...page.models import PageTranslation
+from ...payment.interface import TransactionActionData
 from ...product.models import (
     CategoryTranslation,
     CollectionTranslation,
@@ -16,6 +18,9 @@ from ...shipping.models import ShippingMethodTranslation
 from ...webhook.event_types import WebhookEventAsyncType
 from ..channel import ChannelContext
 from ..core.descriptions import ADDED_IN_32, PREVIEW_FEATURE
+from ..core.scalars import PositiveDecimal
+from ..payment.enums import TransactionActionEnum
+from ..payment.types import TransactionItem
 from ..translations import types as translation_types
 
 TRANSLATIONS_TYPES_MAP = {
@@ -432,6 +437,47 @@ class ShippingZoneDeleted(ObjectType, ShippingZoneBase):
     ...
 
 
+class TransactionAction(ObjectType):
+    action_type = graphene.Field(
+        TransactionActionEnum,
+        required=True,
+        description="Determines the action type.",
+    )
+    amount = PositiveDecimal(
+        description="Transaction request amount. Null when action type is VOID.",
+    )
+
+    @staticmethod
+    def resolve_amount(root: TransactionActionData, _info):
+        if root.action_value:
+            return quantize_price(root.action_value, root.transaction.currency)
+        return None
+
+
+class TransactionActionRequest(ObjectType):
+    transaction = graphene.Field(
+        TransactionItem,
+        description=f"{ADDED_IN_32} Look up a transaction. {PREVIEW_FEATURE}",
+    )
+    action = graphene.Field(
+        TransactionAction,
+        required=True,
+        description=f"{ADDED_IN_32} Requested action data. {PREVIEW_FEATURE}",
+    )
+
+    @staticmethod
+    def resolve_transaction(root, _info):
+        _, transaction_action_data = root
+        transaction_action_data: TransactionActionData
+        return transaction_action_data.transaction
+
+    @staticmethod
+    def resolve_action(root, _info):
+        _, transaction_action_data = root
+        transaction_action_data: TransactionActionData
+        return transaction_action_data
+
+
 class TranslationTypes(Union):
     class Meta:
         types = tuple(TRANSLATIONS_TYPES_MAP.values())
@@ -512,6 +558,7 @@ class Event(Union):
             ShippingZoneCreated,
             ShippingZoneUpdated,
             ShippingZoneDeleted,
+            TransactionActionRequest,
             TranslationCreated,
             TranslationUpdated,
         )
@@ -567,6 +614,7 @@ class Event(Union):
             WebhookEventAsyncType.SHIPPING_ZONE_CREATED: ShippingZoneCreated,
             WebhookEventAsyncType.SHIPPING_ZONE_UPDATED: ShippingZoneUpdated,
             WebhookEventAsyncType.SHIPPING_ZONE_DELETED: ShippingZoneDeleted,
+            WebhookEventAsyncType.TRANSACTION_ACTION_REQUEST: TransactionActionRequest,
             WebhookEventAsyncType.TRANSLATION_CREATED: TranslationCreated,
             WebhookEventAsyncType.TRANSLATION_UPDATED: TranslationUpdated,
         }

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -681,7 +681,13 @@ class WebhookPlugin(BasePlugin):
             payload = generate_transaction_action_request_payload(
                 transaction_data, self.requestor
             )
-            trigger_webhooks_async(payload, event_type, webhooks)
+            trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                subscribable_object=transaction_data,
+                requestor=self.requestor,
+            )
 
     def __run_payment_webhook(
         self,

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_action_request_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_action_request_subscription.py
@@ -1,0 +1,238 @@
+import json
+from decimal import Decimal
+
+import graphene
+from freezegun import freeze_time
+
+from .....core.prices import quantize_price
+from .....payment import TransactionAction
+from .....payment.interface import TransactionActionData
+from .....payment.models import TransactionItem
+from .....webhook.event_types import WebhookEventAsyncType
+from .....webhook.models import Webhook
+from ...tasks import create_deliveries_for_subscriptions
+
+TRANSACTION_ACTION_REQUEST_SUBSCRIPTION_QUERY = """
+subscription{
+  event{
+    ... on TransactionActionRequest{
+      transaction{
+        id
+        createdAt
+        actions
+        authorizedAmount{
+          currency
+          amount
+        }
+        refundedAmount{
+          currency
+          amount
+        }
+        voidedAmount{
+          currency
+          amount
+        }
+        capturedAmount{
+          currency
+          amount
+        }
+        events{
+          id
+        }
+        status
+        type
+        reference
+      }
+      action{
+        actionType
+        amount
+      }
+    }
+  }
+}
+"""
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_transaction_refund_action_request(
+    order, webhook_app, permission_manage_payments
+):
+    # given
+    captured_value = Decimal("10")
+    webhook_app.permissions.add(permission_manage_payments)
+    transaction = TransactionItem.objects.create(
+        status="Captured",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        order_id=order.pk,
+        captured_value=captured_value,
+    )
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TRANSACTION_ACTION_REQUEST_SUBSCRIPTION_QUERY,
+    )
+    event_type = WebhookEventAsyncType.TRANSACTION_ACTION_REQUEST
+    webhook.events.create(event_type=event_type)
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.id)
+    action_value = Decimal("5.00")
+    transaction_data = TransactionActionData(
+        transaction=transaction,
+        action_type=TransactionAction.REFUND,
+        action_value=action_value,
+    )
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, transaction_data, [webhook]
+    )
+
+    # then
+    assert json.loads(deliveries[0].payload.payload) == {
+        "transaction": {
+            "id": transaction_id,
+            "createdAt": "2020-03-18T12:00:00+00:00",
+            "actions": ["REFUND"],
+            "authorizedAmount": {"currency": "USD", "amount": 0.0},
+            "refundedAmount": {"currency": "USD", "amount": 0.0},
+            "voidedAmount": {"currency": "USD", "amount": 0.0},
+            "capturedAmount": {
+                "currency": "USD",
+                "amount": quantize_price(captured_value, "USD"),
+            },
+            "events": [],
+            "status": "Captured",
+            "type": "Credit card",
+            "reference": "PSP ref",
+        },
+        "action": {
+            "actionType": "REFUND",
+            "amount": quantize_price(action_value, "USD"),
+        },
+        "meta": None,
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_transaction_capture_action_request(
+    order, webhook_app, permission_manage_payments
+):
+    # given
+    authorized_value = Decimal("10")
+    webhook_app.permissions.add(permission_manage_payments)
+    transaction = TransactionItem.objects.create(
+        status="Authorized",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["capture"],
+        currency="USD",
+        order_id=order.pk,
+        authorized_value=authorized_value,
+    )
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TRANSACTION_ACTION_REQUEST_SUBSCRIPTION_QUERY,
+    )
+    event_type = WebhookEventAsyncType.TRANSACTION_ACTION_REQUEST
+    webhook.events.create(event_type=event_type)
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.id)
+    action_value = Decimal("5.00")
+    transaction_data = TransactionActionData(
+        transaction=transaction,
+        action_type=TransactionAction.CAPTURE,
+        action_value=action_value,
+    )
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, transaction_data, [webhook]
+    )
+
+    # then
+    assert json.loads(deliveries[0].payload.payload) == {
+        "transaction": {
+            "id": transaction_id,
+            "createdAt": "2020-03-18T12:00:00+00:00",
+            "actions": ["CAPTURE"],
+            "authorizedAmount": {
+                "currency": "USD",
+                "amount": quantize_price(authorized_value, "USD"),
+            },
+            "refundedAmount": {"currency": "USD", "amount": 0.0},
+            "voidedAmount": {"currency": "USD", "amount": 0.0},
+            "capturedAmount": {"currency": "USD", "amount": 0.0},
+            "events": [],
+            "status": "Authorized",
+            "type": "Credit card",
+            "reference": "PSP ref",
+        },
+        "action": {
+            "actionType": "CAPTURE",
+            "amount": quantize_price(action_value, "USD"),
+        },
+        "meta": None,
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_transaction_void_action_request(
+    order, webhook_app, permission_manage_payments
+):
+    # given
+    authorized_value = Decimal("10")
+    webhook_app.permissions.add(permission_manage_payments)
+    transaction = TransactionItem.objects.create(
+        status="Captured",
+        type="Credit card",
+        reference="PSP ref",
+        available_actions=["void"],
+        currency="USD",
+        order_id=order.pk,
+        authorized_value=authorized_value,
+    )
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TRANSACTION_ACTION_REQUEST_SUBSCRIPTION_QUERY,
+    )
+    event_type = WebhookEventAsyncType.TRANSACTION_ACTION_REQUEST
+    webhook.events.create(event_type=event_type)
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.id)
+
+    transaction_data = TransactionActionData(
+        transaction=transaction,
+        action_type=TransactionAction.VOID,
+    )
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, transaction_data, [webhook]
+    )
+
+    # then
+    assert json.loads(deliveries[0].payload.payload) == {
+        "transaction": {
+            "id": transaction_id,
+            "createdAt": "2020-03-18T12:00:00+00:00",
+            "actions": ["VOID"],
+            "authorizedAmount": {
+                "currency": "USD",
+                "amount": quantize_price(authorized_value, "USD"),
+            },
+            "refundedAmount": {"currency": "USD", "amount": 0.0},
+            "voidedAmount": {"currency": "USD", "amount": 0.0},
+            "capturedAmount": {"currency": "USD", "amount": 0.0},
+            "events": [],
+            "status": "Captured",
+            "type": "Credit card",
+            "reference": "PSP ref",
+        },
+        "action": {"actionType": "VOID", "amount": None},
+        "meta": None,
+    }

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1102,7 +1102,11 @@ def test_transaction_action_request(
         transaction_action_data,
     )
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.TRANSACTION_ACTION_REQUEST, [any_webhook]
+        expected_data,
+        WebhookEventAsyncType.TRANSACTION_ACTION_REQUEST,
+        [any_webhook],
+        subscribable_object=transaction_action_data,
+        requestor=ANY,
     )
 
 

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -354,6 +354,7 @@ SUBSCRIBABLE_EVENTS = [
     WebhookEventAsyncType.SHIPPING_ZONE_CREATED,
     WebhookEventAsyncType.SHIPPING_ZONE_UPDATED,
     WebhookEventAsyncType.SHIPPING_ZONE_DELETED,
+    WebhookEventAsyncType.TRANSACTION_ACTION_REQUEST,
     WebhookEventAsyncType.TRANSLATION_CREATED,
     WebhookEventAsyncType.TRANSLATION_UPDATED,
 ]


### PR DESCRIPTION
I want to merge this change because it adds a possibility to build a webhook subscription query for a new webhook TRANSACTION_ACTION_REQUEST

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
