### PR TITLE
Use event.reference instead of event.payment_id for transactions

### DIFF
--- a/saleor/graphql/order/tests/test_fulfillment_refund_products.py
+++ b/saleor/graphql/order/tests/test_fulfillment_refund_products.py
@@ -98,7 +98,7 @@ def test_fulfillment_refund_products_with_transaction_action_request(
     event = fulfilled_order.events.first()
     assert event.type == OrderEvents.TRANSACTION_REFUND_REQUESTED
     assert Decimal(event.parameters["amount"]) == amount_to_refund
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
 
 
 @patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")

--- a/saleor/graphql/order/tests/test_fulfillment_return_products.py
+++ b/saleor/graphql/order/tests/test_fulfillment_return_products.py
@@ -123,7 +123,7 @@ def test_fulfillment_return_products_with_transaction_action_request(
     event = fulfilled_order.events.first()
     assert event.type == OrderEvents.TRANSACTION_REFUND_REQUESTED
     assert Decimal(event.parameters["amount"]) == amount_to_refund
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
 
 
 @patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -5614,7 +5614,7 @@ def test_order_capture_with_transaction_action_request(
     event = order.events.first()
     assert event.type == OrderEvents.TRANSACTION_CAPTURE_REQUESTED
     assert Decimal(event.parameters["amount"]) == capture_value
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
 
 
 @patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
@@ -5881,7 +5881,7 @@ def test_order_void_with_transaction_action_request(
 
     event = order.events.first()
     assert event.type == OrderEvents.TRANSACTION_VOID_REQUESTED
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
 
 
 @patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
@@ -6038,7 +6038,7 @@ def test_order_refund_with_transaction_action_request(
     event = order.events.first()
     assert event.type == OrderEvents.TRANSACTION_REFUND_REQUESTED
     assert Decimal(event.parameters["amount"]) == refund_value
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
 
 
 @patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")

--- a/saleor/graphql/payment/tests/mutations/test_transaction_request_action.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_request_action.py
@@ -119,7 +119,7 @@ def test_transaction_request_capture_action_for_order(
     event = order_with_lines.events.first()
     assert event.type == OrderEvents.TRANSACTION_CAPTURE_REQUESTED
     assert Decimal(event.parameters["amount"]) == expected_called_capture_amount
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
 
 
 @pytest.mark.parametrize(
@@ -183,7 +183,7 @@ def test_transaction_request_refund_action_for_order(
     event = order_with_lines.events.first()
     assert event.type == OrderEvents.TRANSACTION_REFUND_REQUESTED
     assert Decimal(event.parameters["amount"]) == expected_called_refund_amount
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
 
 
 @patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
@@ -234,7 +234,7 @@ def test_transaction_request_void_action_for_order(
 
     event = order_with_lines.events.first()
     assert event.type == OrderEvents.TRANSACTION_VOID_REQUESTED
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
 
 
 @patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -52,7 +52,7 @@ def event_transaction_capture_requested(
         app=app,
         parameters={
             "amount": amount,
-            "payment_id": reference,
+            "reference": reference,
         },
     )
 
@@ -69,7 +69,7 @@ def event_transaction_refund_requested(
         app=app,
         parameters={
             "amount": amount,
-            "payment_id": reference,
+            "reference": reference,
         },
     )
 
@@ -85,7 +85,7 @@ def event_transaction_void_requested(
         user=user,
         app=app,
         parameters={
-            "payment_id": reference,
+            "reference": reference,
         },
     )
 

--- a/saleor/payment/tests/test_gateway.py
+++ b/saleor/payment/tests/test_gateway.py
@@ -399,7 +399,7 @@ def test_request_capture_action_on_order(
     event = order.events.first()
     assert event.type == OrderEvents.TRANSACTION_CAPTURE_REQUESTED
     assert Decimal(event.parameters["amount"]) == action_value
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
     assert event.user == staff_user
 
 
@@ -445,7 +445,7 @@ def test_request_capture_action_by_app(
     event = order.events.first()
     assert event.type == OrderEvents.TRANSACTION_CAPTURE_REQUESTED
     assert Decimal(event.parameters["amount"]) == action_value
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
     assert event.app == app
 
 
@@ -560,7 +560,7 @@ def test_request_refund_action_on_order(
     event = order.events.first()
     assert event.type == OrderEvents.TRANSACTION_REFUND_REQUESTED
     assert Decimal(event.parameters["amount"]) == action_value
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
     assert event.user == staff_user
 
 
@@ -606,7 +606,7 @@ def test_request_refund_action_by_app(
     event = order.events.first()
     assert event.type == OrderEvents.TRANSACTION_REFUND_REQUESTED
     assert Decimal(event.parameters["amount"]) == action_value
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
     assert event.app == app
     assert not event.user
 
@@ -715,7 +715,7 @@ def test_request_void_action_on_order(
 
     event = order.events.first()
     assert event.type == OrderEvents.TRANSACTION_VOID_REQUESTED
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
     assert event.user == staff_user
 
 
@@ -758,7 +758,7 @@ def test_request_void_action_by_app(
 
     event = order.events.first()
     assert event.type == OrderEvents.TRANSACTION_VOID_REQUESTED
-    assert event.parameters["payment_id"] == transaction.reference
+    assert event.parameters["reference"] == transaction.reference
     assert event.app == app
     assert not event.user
 


### PR DESCRIPTION
I want to merge this change because by mistake I used incorrect field for storing received transaction reference

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
