### PR TITLE
Fix incorect price send to avatax

### DIFF
--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -365,16 +365,20 @@ def get_order_lines_data(
             "name": line.variant.product.name,
             "tax_included": tax_included,
         }
-        append_line_to_data(
-            **append_line_to_data_kwargs,
-            amount=undiscounted_amount,
-        )
+        if not invoice_transaction_type:
+            append_line_to_data(
+                **append_line_to_data_kwargs,
+                amount=undiscounted_amount,
+            )
 
-        # for invoice transaction we want to include only final price
-        if (
-            not invoice_transaction_type
-            and undiscounted_amount != price_with_discounts_amount
-        ):
+            # for invoice transaction we want to include only final price
+            if undiscounted_amount != price_with_discounts_amount:
+                append_line_to_data(
+                    **append_line_to_data_kwargs,
+                    amount=price_with_discounts_amount,
+                    ref1=line.variant.sku,
+                )
+        else:
             append_line_to_data(
                 **append_line_to_data_kwargs,
                 amount=price_with_discounts_amount,


### PR DESCRIPTION
I want to merge this change because it sends to Avatax price with discounts instead of undiscounted_price

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
