### PR TITLE
Pass the Saleor version string to Sentry as release number

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -19,6 +19,7 @@ from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 
+from . import __version__
 from .core.languages import LANGUAGES as CORE_LANGUAGES
 
 
@@ -575,7 +576,7 @@ def SENTRY_INIT(dsn: str, sentry_opts: dict):
     Will only be called if SENTRY_DSN is not None, during core start, can be
     overriden in separate settings file.
     """
-    sentry_sdk.init(dsn, **sentry_opts)
+    sentry_sdk.init(dsn, release=__version__, **sentry_opts)
     ignore_logger("graphql.execution.utils")
     ignore_logger("graphql.execution.executor")
 


### PR DESCRIPTION
This should make it easier to track releases

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
