### PR TITLE
Fix clear_successful_delivery to remove payload

### DIFF
--- a/saleor/plugins/webhook/tests/test_payment_webhook_utils.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook_utils.py
@@ -178,11 +178,12 @@ def test_parse_payment_action_response_parse_amount(
     assert gateway_response.amount == dummy_webhook_app_payment_data.amount
 
 
-def test_clear_successful_delivery(event_delivery, event_payload):
+def test_clear_successful_delivery(event_delivery):
     # given
     assert EventDelivery.objects.filter(pk=event_delivery.pk).exists()
     event_delivery.status = EventDeliveryStatus.SUCCESS
     event_delivery.save()
+    event_payload = event_delivery.payload
     # when
     clear_successful_delivery(event_delivery)
     # then
@@ -190,17 +191,13 @@ def test_clear_successful_delivery(event_delivery, event_payload):
     assert not EventPayload.objects.filter(pk=event_payload.pk).exists()
 
 
-def test_clear_successful_delivery_when_payload_in_multiple_deliveries(
-    event_delivery, event_payload
-):
+def test_clear_successful_delivery_when_payload_in_multiple_deliveries(event_delivery):
     # given
     assert EventDelivery.objects.filter(pk=event_delivery.pk).exists()
     event_delivery.status = EventDeliveryStatus.SUCCESS
     event_delivery.save()
-    EventDelivery.objects.create(
-        payload=event_delivery.payload,
-        webhook=event_delivery.webhook,
-    )
+    event_payload = event_delivery.payload
+    EventDelivery.objects.create(payload=event_payload, webhook=event_delivery.webhook)
     # when
     clear_successful_delivery(event_delivery)
     # then

--- a/saleor/plugins/webhook/utils.py
+++ b/saleor/plugins/webhook/utils.py
@@ -197,7 +197,7 @@ def delivery_update(delivery: "EventDelivery", status: str):
 
 def clear_successful_delivery(delivery: "EventDelivery"):
     if delivery.status == EventDeliveryStatus.SUCCESS:
-        payload = delivery.payload
+        payload_id = delivery.payload_id
         delivery.delete()
-        if payload:
-            EventPayload.objects.filter(pk=payload.pk, deliveries__isnull=True).delete()
+        if payload_id:
+            EventPayload.objects.filter(pk=payload_id, deliveries__isnull=True).delete()

--- a/saleor/plugins/webhook/utils.py
+++ b/saleor/plugins/webhook/utils.py
@@ -197,4 +197,7 @@ def delivery_update(delivery: "EventDelivery", status: str):
 
 def clear_successful_delivery(delivery: "EventDelivery"):
     if delivery.status == EventDeliveryStatus.SUCCESS:
+        payload = delivery.payload
         delivery.delete()
+        if payload:
+            EventPayload.objects.filter(pk=payload.pk, deliveries__isnull=True).delete()


### PR DESCRIPTION
I want to merge this change because it fixes removing payload while cleaning successful deliveries.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
