### PR TITLE
Fix invalid ADDED_PRODUCTS event parameter for OrderLinesCreate mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
 # Unreleased
+- Fix invalid `ADDED_PRODUCTS` event parameter for `OrderLinesCreate` mutation - #9653 by @IKarbowiak
 
 # 3.3.1
 

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -1,3 +1,5 @@
+from typing import List, Tuple
+
 import graphene
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -829,9 +831,10 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
     def add_lines_to_order(
         order, lines_to_add, user, app, manager, settings, discounts
     ):
+        added_lines: List[Tuple[int, OrderLine]] = []
         try:
-            return [
-                add_variant_to_order(
+            for quantity, variant in lines_to_add:
+                line = add_variant_to_order(
                     order,
                     variant,
                     quantity,
@@ -842,13 +845,13 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
                     discounts=discounts,
                     allocate_stock=order.is_unconfirmed(),
                 )
-                for quantity, variant in lines_to_add
-            ]
+                added_lines.append((quantity, line))
         except TaxError as tax_error:
             raise ValidationError(
                 "Unable to calculate taxes - %s" % str(tax_error),
                 code=OrderErrorCode.TAX_ERROR.value,
             )
+        return added_lines
 
     @classmethod
     @traced_atomic_transaction()
@@ -859,7 +862,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         variants = [line[1] for line in lines_to_add]
         cls.validate_variants(order, variants)
 
-        lines = cls.add_lines_to_order(
+        added_lines = cls.add_lines_to_order(
             order,
             lines_to_add,
             info.context.user,
@@ -874,8 +877,10 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             order=order,
             user=info.context.user,
             app=info.context.app,
-            order_lines=lines_to_add,
+            order_lines=added_lines,
         )
+
+        lines = [line for _, line in added_lines]
 
         recalculate_order(order)
         update_order_search_document(order)

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -4106,7 +4106,14 @@ def test_order_lines_create(
         order, status, draft_order_updated_webhook_mock, order_updated_webhook_mock
     )
     assert OrderEvent.objects.count() == 1
-    assert OrderEvent.objects.last().type == order_events.OrderEvents.ADDED_PRODUCTS
+    event = OrderEvent.objects.last()
+    assert event.type == order_events.OrderEvents.ADDED_PRODUCTS
+    assert len(event.parameters["lines"]) == 1
+    line = OrderLine.objects.last()
+    assert event.parameters["lines"] == [
+        {"item": str(line), "line_pk": line.pk, "quantity": quantity}
+    ]
+
     content = get_graphql_content(response)
     data = content["data"]["orderLinesCreate"]
     assert data["orderLines"][0]["productSku"] == variant.sku


### PR DESCRIPTION
Fix invalid `ADDED_PRODUCTS` event parameter for `OrderLinesCreate` mutation. Previously as `line` the `ProductVariant` object was provided and variant `id` was saved as `line_id`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
