### PR TITLE
Add missing shipping method data in order and checkout events payloads.

### DIFF
--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -208,6 +208,29 @@ def _generate_collection_point_payload(warehouse: "Warehouse"):
     return collection_point_data
 
 
+def _generate_shipping_method_payload(shipping_method, channel):
+    if not shipping_method:
+        return None
+
+    serializer = PayloadSerializer()
+    shipping_method_fields = ("name", "type")
+
+    shipping_method_channel_listing = shipping_method.channel_listings.filter(
+        channel=channel,
+    ).first()
+
+    payload = serializer.serialize(
+        [shipping_method],
+        fields=shipping_method_fields,
+        extra_dict_data={
+            "currency": shipping_method_channel_listing.currency,
+            "price_amount": shipping_method_channel_listing.price_amount,
+        },
+    )
+
+    return json.loads(payload)[0]
+
+
 @traced_payload_generator
 def generate_order_payload(
     order: "Order",
@@ -235,7 +258,6 @@ def generate_order_payload(
     discount_price_fields = ("amount_value",)
 
     channel_fields = ("slug", "currency_code")
-    shipping_method_fields = ("name", "type", "currency", "price_amount")
 
     lines = order.lines.all()
     fulfillments = order.fulfillments.all()
@@ -276,6 +298,9 @@ def generate_order_payload(
         if order.collection_point
         else None,
         "payments": json.loads(_generate_order_payment_payload(payments)),
+        "shipping_method": _generate_shipping_method_payload(
+            order.shipping_method, order.channel
+        ),
     }
     if with_meta:
         extra_dict_data["meta"] = generate_meta(
@@ -287,7 +312,6 @@ def generate_order_payload(
         fields=ORDER_FIELDS,
         additional_fields={
             "channel": (lambda o: o.channel, channel_fields),
-            "shipping_method": (lambda o: o.shipping_method, shipping_method_fields),
             "shipping_address": (lambda o: o.shipping_address, ADDRESS_FIELDS),
             "billing_address": (lambda o: o.billing_address, ADDRESS_FIELDS),
             "discounts": (lambda _: discounts, discount_fields),
@@ -458,7 +482,6 @@ def generate_checkout_payload(
     quantize_price_fields(checkout, checkout_price_fields, checkout.currency)
     user_fields = ("email", "first_name", "last_name")
     channel_fields = ("slug", "currency_code")
-    shipping_method_fields = ("name", "type", "currency", "price_amount")
 
     discounts = fetch_active_discounts()
     lines_dict_data = serialize_checkout_lines(checkout, discounts)
@@ -479,7 +502,6 @@ def generate_checkout_payload(
             "user": (lambda c: c.user, user_fields),
             "billing_address": (lambda c: c.billing_address, ADDRESS_FIELDS),
             "shipping_address": (lambda c: c.shipping_address, ADDRESS_FIELDS),
-            "shipping_method": (lambda c: c.shipping_method, shipping_method_fields),
             "warehouse_address": (
                 lambda c: warehouse.address if warehouse else None,
                 ADDRESS_FIELDS,
@@ -487,6 +509,9 @@ def generate_checkout_payload(
         },
         extra_dict_data={
             # Casting to list to make it json-serializable
+            "shipping_method": _generate_shipping_method_payload(
+                checkout.shipping_method, checkout.channel
+            ),
             "lines": list(lines_dict_data),
             "collection_point": json.loads(
                 _generate_collection_point_payload(checkout.collection_point)

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -224,7 +224,10 @@ def _generate_shipping_method_payload(shipping_method, channel):
         fields=shipping_method_fields,
         extra_dict_data={
             "currency": shipping_method_channel_listing.currency,
-            "price_amount": shipping_method_channel_listing.price_amount,
+            "price_amount": quantize_price(
+                shipping_method_channel_listing.price_amount,
+                shipping_method_channel_listing.currency,
+            ),
         },
     )
 

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -111,6 +111,9 @@ def test_generate_order_payload(
     assert order.fulfillments.count() == 1
 
     fulfillment = order.fulfillments.first()
+    shipping_method_channel_listing = order.shipping_method.channel_listings.filter(
+        channel=order.channel,
+    ).first()
 
     # when
     payload = json.loads(generate_order_payload(order, customer_user))[0]
@@ -143,6 +146,8 @@ def test_generate_order_payload(
             ),
             "name": order.shipping_method.name,
             "type": order.shipping_method.type,
+            "currency": shipping_method_channel_listing.currency,
+            "price_amount": str(shipping_method_channel_listing.price_amount),
         },
         "payments": [
             {
@@ -1115,6 +1120,10 @@ def test_generate_checkout_payload(
     # when
     payload = json.loads(generate_checkout_payload(checkout, customer_user))[0]
 
+    shipping_method_channel_listing = checkout.shipping_method.channel_listings.filter(
+        channel=checkout.channel,
+    ).first()
+
     # then
     assert payload == {
         "type": "Checkout",
@@ -1179,6 +1188,8 @@ def test_generate_checkout_payload(
             ),
             "name": checkout.shipping_method.name,
             "type": checkout.shipping_method.type,
+            "currency": shipping_method_channel_listing.currency,
+            "price_amount": str(shipping_method_channel_listing.price_amount),
         },
         "lines": serialize_checkout_lines(checkout),
         "collection_point": json.loads(

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -147,7 +147,12 @@ def test_generate_order_payload(
             "name": order.shipping_method.name,
             "type": order.shipping_method.type,
             "currency": shipping_method_channel_listing.currency,
-            "price_amount": str(shipping_method_channel_listing.price_amount),
+            "price_amount": str(
+                quantize_price(
+                    shipping_method_channel_listing.price_amount,
+                    shipping_method_channel_listing.currency,
+                )
+            ),
         },
         "payments": [
             {
@@ -1189,7 +1194,12 @@ def test_generate_checkout_payload(
             "name": checkout.shipping_method.name,
             "type": checkout.shipping_method.type,
             "currency": shipping_method_channel_listing.currency,
-            "price_amount": str(shipping_method_channel_listing.price_amount),
+            "price_amount": str(
+                quantize_price(
+                    shipping_method_channel_listing.price_amount,
+                    shipping_method_channel_listing.currency,
+                )
+            ),
         },
         "lines": serialize_checkout_lines(checkout),
         "collection_point": json.loads(


### PR DESCRIPTION
I want to merge this change because it adds missing `shipping method` data in payloads related to `Order` and `Checkout` webhook events.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
