### PR TITLE
Fix using enum values in permission descriptions

### DIFF
--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -262,7 +262,8 @@ class User(ModelObjectType):
         "saleor.graphql.order.types.OrderCountableConnection",
         description=(
             "List of user's orders. Requires one of the following permissions: "
-            f"{AccountPermissions.MANAGE_STAFF}, {AuthorizationFilters.OWNER}"
+            f"{AccountPermissions.MANAGE_STAFF.name}, "
+            f"{AuthorizationFilters.OWNER.name}."
         ),
     )
     user_permissions = NonNullList(

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -72,7 +72,7 @@ class AppQueries(graphene.ObjectType):
         description=(
             "Look up an app by ID. If ID is not provided, return the currently "
             "authenticated app. Requires one of the following permissions: "
-            f"{AuthorizationFilters.OWNER}, {AppPermission.MANAGE_APPS}."
+            f"{AuthorizationFilters.OWNER.name}, {AppPermission.MANAGE_APPS.name}."
         ),
     )
     app_extensions = FilterConnectionField(

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -159,60 +159,60 @@ class Attribute(ModelObjectType):
     value_required = graphene.Boolean(
         description=(
             f"{AttributeDescriptions.VALUE_REQUIRED} Requires one of the following "
-            f"permissions: {PagePermissions.MANAGE_PAGES}, "
-            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES}, "
-            f"{ProductPermissions.MANAGE_PRODUCTS}, "
-            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES}."
+            f"permissions: {PagePermissions.MANAGE_PAGES.name}, "
+            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES.name}, "
+            f"{ProductPermissions.MANAGE_PRODUCTS.name}, "
+            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.name}."
         ),
         required=True,
     )
     visible_in_storefront = graphene.Boolean(
         description=(
             f"{AttributeDescriptions.VISIBLE_IN_STOREFRONT} Requires one of the "
-            f"following permissions: {PagePermissions.MANAGE_PAGES}, "
-            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES}, "
-            f"{ProductPermissions.MANAGE_PRODUCTS}, "
-            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES}."
+            f"following permissions: {PagePermissions.MANAGE_PAGES.name}, "
+            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES.name}, "
+            f"{ProductPermissions.MANAGE_PRODUCTS.name}, "
+            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.name}."
         ),
         required=True,
     )
     filterable_in_storefront = graphene.Boolean(
         description=(
             f"{AttributeDescriptions.FILTERABLE_IN_STOREFRONT} Requires one of the "
-            f"following permissions: {PagePermissions.MANAGE_PAGES}, "
-            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES}, "
-            f"{ProductPermissions.MANAGE_PRODUCTS}, "
-            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES}."
+            f"following permissions: {PagePermissions.MANAGE_PAGES.name}, "
+            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES.name}, "
+            f"{ProductPermissions.MANAGE_PRODUCTS.name}, "
+            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.name}."
         ),
         required=True,
     )
     filterable_in_dashboard = graphene.Boolean(
         description=(
             f"{AttributeDescriptions.FILTERABLE_IN_DASHBOARD} Requires one of the "
-            f"following permissions: {PagePermissions.MANAGE_PAGES}, "
-            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES}, "
-            f"{ProductPermissions.MANAGE_PRODUCTS}, "
-            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES}."
+            f"following permissions: {PagePermissions.MANAGE_PAGES.name}, "
+            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES.name}, "
+            f"{ProductPermissions.MANAGE_PRODUCTS.name}, "
+            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.name}."
         ),
         required=True,
     )
     available_in_grid = graphene.Boolean(
         description=(
             f"{AttributeDescriptions.AVAILABLE_IN_GRID} Requires one of the following "
-            f"permissions: {PagePermissions.MANAGE_PAGES}, "
-            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES}, "
-            f"{ProductPermissions.MANAGE_PRODUCTS}, "
-            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES}."
+            f"permissions: {PagePermissions.MANAGE_PAGES.name}, "
+            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES.name}, "
+            f"{ProductPermissions.MANAGE_PRODUCTS.name}, "
+            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.name}."
         ),
         required=True,
     )
     storefront_search_position = graphene.Int(
         description=(
             f"{AttributeDescriptions.STOREFRONT_SEARCH_POSITION} Requires one of the "
-            f"following permissions: {PagePermissions.MANAGE_PAGES}, "
-            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES}, "
-            f"{ProductPermissions.MANAGE_PRODUCTS}, "
-            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES}."
+            f"following permissions: {PagePermissions.MANAGE_PAGES.name}, "
+            f"{PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES.name}, "
+            f"{ProductPermissions.MANAGE_PRODUCTS.name}, "
+            f"{ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.name}."
         ),
         required=True,
     )

--- a/saleor/graphql/csv/types.py
+++ b/saleor/graphql/csv/types.py
@@ -22,8 +22,8 @@ class ExportEvent(ModelObjectType):
         User,
         description=(
             "User who performed the action. Requires one of the following "
-            f"permissions: {AuthorizationFilters.OWNER}, "
-            f"{AccountPermissions.MANAGE_STAFF}."
+            f"permissions: {AuthorizationFilters.OWNER.name}, "
+            f"{AccountPermissions.MANAGE_STAFF.name}."
         ),
         required=False,
     )
@@ -31,7 +31,8 @@ class ExportEvent(ModelObjectType):
         App,
         description=(
             "App which performed the action. Requires one of the following "
-            f"permissions: {AuthorizationFilters.OWNER}, {AppPermission.MANAGE_APPS}."
+            f"permissions: {AuthorizationFilters.OWNER.name}, "
+            f"{AppPermission.MANAGE_APPS.name}."
         ),
         required=False,
     )

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -73,15 +73,16 @@ class GiftCardEvent(ModelObjectType):
         "saleor.graphql.account.types.User",
         description=(
             "User who performed the action. Requires one of the following "
-            f"permissions: {AccountPermissions.MANAGE_USERS}, "
-            f"{AccountPermissions.MANAGE_STAFF}, {AuthorizationFilters.OWNER}."
+            f"permissions: {AccountPermissions.MANAGE_USERS.name}, "
+            f"{AccountPermissions.MANAGE_STAFF.name}, "
+            f"{AuthorizationFilters.OWNER.name}."
         ),
     )
     app = graphene.Field(
         App,
         description=(
             "App that performed the action. Requires one of the following permissions: "
-            f"{AppPermission.MANAGE_APPS}, {AuthorizationFilters.OWNER}."
+            f"{AppPermission.MANAGE_APPS.name}, {AuthorizationFilters.OWNER.name}."
         ),
     )
     message = graphene.String(description="Content of the event.")
@@ -237,8 +238,8 @@ class GiftCard(ModelObjectType):
     code = graphene.String(
         description=(
             "Gift card code. Can be fetched by a staff member with "
-            f"{GiftcardPermissions.MANAGE_GIFT_CARD} when gift card wasn't yet used "
-            "and by the gift card owner."
+            f"{GiftcardPermissions.MANAGE_GIFT_CARD.name} when gift card wasn't yet "
+            "used and by the gift card owner."
         ),
         required=True,
     )
@@ -262,7 +263,8 @@ class GiftCard(ModelObjectType):
             + ADDED_IN_31
             + PREVIEW_FEATURE
             + "\n\nRequires one of the following permissions: "
-            f"{AccountPermissions.MANAGE_USERS}, {AuthorizationFilters.OWNER}."
+            f"{AccountPermissions.MANAGE_USERS.name}, "
+            f"{AuthorizationFilters.OWNER.name}."
         ),
     )
     used_by_email = graphene.String(
@@ -282,7 +284,7 @@ class GiftCard(ModelObjectType):
             + ADDED_IN_31
             + PREVIEW_FEATURE
             + "\n\nRequires one of the following permissions: "
-            f"{AppPermission.MANAGE_APPS}, {AuthorizationFilters.OWNER}."
+            f"{AppPermission.MANAGE_APPS.name}, {AuthorizationFilters.OWNER.name}."
         ),
     )
     product = graphene.Field(

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -81,7 +81,8 @@ class MenuItem(ChannelContextTypeWithMetadata, ModelObjectType):
         Page,
         description=(
             "A page associated with this menu item. Requires one of the following "
-            f"permissions to include unpublished items: {PagePermissions.MANAGE_PAGES}."
+            f"permissions to include unpublished items: "
+            f"{PagePermissions.MANAGE_PAGES.name}."
         ),
     )
     level = graphene.Int(required=True)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -216,8 +216,8 @@ class OrderEvent(ModelObjectType):
         App,
         description=(
             "App that performed the action. Requires of of the following permissions: "
-            f"{AppPermission.MANAGE_APPS}, {OrderPermissions.MANAGE_ORDERS}, "
-            f"{AuthorizationFilters.OWNER}."
+            f"{AppPermission.MANAGE_APPS.name}, {OrderPermissions.MANAGE_ORDERS.name}, "
+            f"{AuthorizationFilters.OWNER.name}."
         ),
     )
     message = graphene.String(description="Content of the event.")
@@ -701,8 +701,9 @@ class Order(ModelObjectType):
         description=(
             "User who placed the order. This field is set only for orders placed by "
             "authenticated users. Requires one of the following permissions: "
-            f"{AccountPermissions.MANAGE_USERS}, {OrderPermissions.MANAGE_ORDERS}, "
-            f"{AuthorizationFilters.OWNER}."
+            f"{AccountPermissions.MANAGE_USERS.name}, "
+            f"{OrderPermissions.MANAGE_ORDERS.name}, "
+            f"{AuthorizationFilters.OWNER.name}."
         ),
     )
     tracking_client_id = graphene.String(required=True)
@@ -710,16 +711,16 @@ class Order(ModelObjectType):
         "saleor.graphql.account.types.Address",
         description=(
             "Billing address. Requires one of the following permissions to view the "
-            f"full data: {OrderPermissions.MANAGE_ORDERS}, "
-            f"{AuthorizationFilters.OWNER}."
+            f"full data: {OrderPermissions.MANAGE_ORDERS.name}, "
+            f"{AuthorizationFilters.OWNER.name}."
         ),
     )
     shipping_address = graphene.Field(
         "saleor.graphql.account.types.Address",
         description=(
             "Shipping address. Requires one of the following permissions to view the "
-            f"full data: {OrderPermissions.MANAGE_ORDERS}, "
-            f"{AuthorizationFilters.OWNER}."
+            f"full data: {OrderPermissions.MANAGE_ORDERS.name}, "
+            f"{AuthorizationFilters.OWNER.name}."
         ),
     )
     shipping_method_name = graphene.String()
@@ -762,7 +763,7 @@ class Order(ModelObjectType):
         Invoice,
         description=(
             "List of order invoices. Requires one of the following permissions: "
-            f"{OrderPermissions.MANAGE_ORDERS}, {AuthorizationFilters.OWNER}."
+            f"{OrderPermissions.MANAGE_ORDERS.name}, {AuthorizationFilters.OWNER.name}."
         ),
         required=True,
     )
@@ -863,8 +864,8 @@ class Order(ModelObjectType):
     user_email = graphene.String(
         description=(
             "Email address of the customer. Requires the following permissions to "
-            f"access the full data: {OrderPermissions.MANAGE_ORDERS}, "
-            f"{AuthorizationFilters.OWNER}"
+            f"access the full data: {OrderPermissions.MANAGE_ORDERS.name}, "
+            f"{AuthorizationFilters.OWNER.name}."
         ),
         required=False,
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6,7 +6,7 @@ schema {
 
 type Query {
   """
-  Look up a webhook by ID. Requires one of the following permissions: AppPermission.MANAGE_APPS, AuthorizationFilters.OWNER
+  Look up a webhook by ID. Requires one of the following permissions: MANAGE_APPS, OWNER.
   """
   webhook(
     """ID of the webhook."""
@@ -1077,7 +1077,7 @@ type Query {
   ): AppCountableConnection
 
   """
-  Look up an app by ID. If ID is not provided, return the currently authenticated app. Requires one of the following permissions: AuthorizationFilters.OWNER, AppPermission.MANAGE_APPS.
+  Look up an app by ID. If ID is not provided, return the currently authenticated app. Requires one of the following permissions: OWNER, MANAGE_APPS.
   """
   app(
     """ID of the app."""
@@ -3828,32 +3828,32 @@ type Attribute implements Node & ObjectWithMetadata {
   ): AttributeValueCountableConnection
 
   """
-  Whether the attribute requires values to be passed or not. Requires one of the following permissions: PagePermissions.MANAGE_PAGES, PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES, ProductPermissions.MANAGE_PRODUCTS, ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Whether the attribute requires values to be passed or not. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   valueRequired: Boolean!
 
   """
-  Whether the attribute should be visible or not in storefront. Requires one of the following permissions: PagePermissions.MANAGE_PAGES, PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES, ProductPermissions.MANAGE_PRODUCTS, ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Whether the attribute should be visible or not in storefront. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   visibleInStorefront: Boolean!
 
   """
-  Whether the attribute can be filtered in storefront. Requires one of the following permissions: PagePermissions.MANAGE_PAGES, PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES, ProductPermissions.MANAGE_PRODUCTS, ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Whether the attribute can be filtered in storefront. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   filterableInStorefront: Boolean!
 
   """
-  Whether the attribute can be filtered in dashboard. Requires one of the following permissions: PagePermissions.MANAGE_PAGES, PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES, ProductPermissions.MANAGE_PRODUCTS, ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Whether the attribute can be filtered in dashboard. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   filterableInDashboard: Boolean!
 
   """
-  Whether the attribute can be displayed in the admin product list. Requires one of the following permissions: PagePermissions.MANAGE_PAGES, PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES, ProductPermissions.MANAGE_PRODUCTS, ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Whether the attribute can be displayed in the admin product list. Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   availableInGrid: Boolean!
 
   """
-  The position of the attribute in the storefront navigation (0 by default). Requires one of the following permissions: PagePermissions.MANAGE_PAGES, PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES, ProductPermissions.MANAGE_PRODUCTS, ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  The position of the attribute in the storefront navigation (0 by default). Requires one of the following permissions: MANAGE_PAGES, MANAGE_PAGE_TYPES_AND_ATTRIBUTES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
   """
   storefrontSearchPosition: Int!
 
@@ -6340,7 +6340,7 @@ type MenuItem implements Node & ObjectWithMetadata {
   collection: Collection
 
   """
-  A page associated with this menu item. Requires one of the following permissions to include unpublished items: PagePermissions.MANAGE_PAGES.
+  A page associated with this menu item. Requires one of the following permissions to include unpublished items: MANAGE_PAGES.
   """
   page: Page
   level: Int!
@@ -6915,7 +6915,7 @@ type User implements Node & ObjectWithMetadata {
   note: String
 
   """
-  List of user's orders. Requires one of the following permissions: AccountPermissions.MANAGE_STAFF, AuthorizationFilters.OWNER
+  List of user's orders. Requires one of the following permissions: MANAGE_STAFF, OWNER.
   """
   orders(
     """Return the elements in the list that come before the specified cursor."""
@@ -7167,7 +7167,7 @@ type GiftCard implements Node & ObjectWithMetadata {
   last4CodeChars: String!
 
   """
-  Gift card code. Can be fetched by a staff member with GiftcardPermissions.MANAGE_GIFT_CARD when gift card wasn't yet used and by the gift card owner.
+  Gift card code. Can be fetched by a staff member with MANAGE_GIFT_CARD when gift card wasn't yet used and by the gift card owner.
   """
   code: String!
   created: DateTime!
@@ -7197,7 +7197,7 @@ type GiftCard implements Node & ObjectWithMetadata {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires one of the following permissions: AccountPermissions.MANAGE_USERS, AuthorizationFilters.OWNER.
+  Requires one of the following permissions: MANAGE_USERS, OWNER.
   """
   createdByEmail: String
 
@@ -7219,7 +7219,7 @@ type GiftCard implements Node & ObjectWithMetadata {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires one of the following permissions: AppPermission.MANAGE_APPS, AuthorizationFilters.OWNER.
+  Requires one of the following permissions: MANAGE_APPS, OWNER.
   """
   app: App
 
@@ -7296,12 +7296,12 @@ type GiftCardEvent implements Node {
   type: GiftCardEventsEnum
 
   """
-  User who performed the action. Requires one of the following permissions: AccountPermissions.MANAGE_USERS, AccountPermissions.MANAGE_STAFF, AuthorizationFilters.OWNER.
+  User who performed the action. Requires one of the following permissions: MANAGE_USERS, MANAGE_STAFF, OWNER.
   """
   user: User
 
   """
-  App that performed the action. Requires one of the following permissions: AppPermission.MANAGE_APPS, AuthorizationFilters.OWNER.
+  App that performed the action. Requires one of the following permissions: MANAGE_APPS, OWNER.
   """
   app: App
 
@@ -7616,18 +7616,18 @@ type Order implements Node & ObjectWithMetadata {
   status: OrderStatus!
 
   """
-  User who placed the order. This field is set only for orders placed by authenticated users. Requires one of the following permissions: AccountPermissions.MANAGE_USERS, OrderPermissions.MANAGE_ORDERS, AuthorizationFilters.OWNER.
+  User who placed the order. This field is set only for orders placed by authenticated users. Requires one of the following permissions: MANAGE_USERS, MANAGE_ORDERS, OWNER.
   """
   user: User
   trackingClientId: String!
 
   """
-  Billing address. Requires one of the following permissions to view the full data: OrderPermissions.MANAGE_ORDERS, AuthorizationFilters.OWNER.
+  Billing address. Requires one of the following permissions to view the full data: MANAGE_ORDERS, OWNER.
   """
   billingAddress: Address
 
   """
-  Shipping address. Requires one of the following permissions to view the full data: OrderPermissions.MANAGE_ORDERS, AuthorizationFilters.OWNER.
+  Shipping address. Requires one of the following permissions to view the full data: MANAGE_ORDERS, OWNER.
   """
   shippingAddress: Address
   shippingMethodName: String
@@ -7661,7 +7661,7 @@ type Order implements Node & ObjectWithMetadata {
   availableCollectionPoints: [Warehouse!]!
 
   """
-  List of order invoices. Requires one of the following permissions: OrderPermissions.MANAGE_ORDERS, AuthorizationFilters.OWNER.
+  List of order invoices. Requires one of the following permissions: MANAGE_ORDERS, OWNER.
   """
   invoices: [Invoice!]!
 
@@ -7745,7 +7745,7 @@ type Order implements Node & ObjectWithMetadata {
   totalBalance: Money!
 
   """
-  Email address of the customer. Requires the following permissions to access the full data: OrderPermissions.MANAGE_ORDERS, AuthorizationFilters.OWNER
+  Email address of the customer. Requires the following permissions to access the full data: MANAGE_ORDERS, OWNER.
   """
   userEmail: String
 
@@ -8251,7 +8251,7 @@ type OrderEvent implements Node {
   user: User
 
   """
-  App that performed the action. Requires of of the following permissions: AppPermission.MANAGE_APPS, OrderPermissions.MANAGE_ORDERS, AuthorizationFilters.OWNER.
+  App that performed the action. Requires of of the following permissions: MANAGE_APPS, MANAGE_ORDERS, OWNER.
   """
   app: App
 
@@ -9459,12 +9459,12 @@ type ExportEvent implements Node {
   type: ExportEventsEnum!
 
   """
-  User who performed the action. Requires one of the following permissions: AuthorizationFilters.OWNER, AccountPermissions.MANAGE_STAFF.
+  User who performed the action. Requires one of the following permissions: OWNER, MANAGE_STAFF.
   """
   user: User
 
   """
-  App which performed the action. Requires one of the following permissions: AuthorizationFilters.OWNER, AppPermission.MANAGE_APPS.
+  App which performed the action. Requires one of the following permissions: OWNER, MANAGE_APPS.
   """
   app: App
 

--- a/saleor/graphql/webhook/schema.py
+++ b/saleor/graphql/webhook/schema.py
@@ -18,7 +18,7 @@ class WebhookQueries(graphene.ObjectType):
         ),
         description=(
             "Look up a webhook by ID. Requires one of the following permissions: "
-            f"{AppPermission.MANAGE_APPS}, {AuthorizationFilters.OWNER}"
+            f"{AppPermission.MANAGE_APPS.name}, {AuthorizationFilters.OWNER.name}."
         ),
     )
     webhook_events = PermissionsField(


### PR DESCRIPTION
To represent permissions in the schema we should only use their names, without the internal enum's class name. This PR unifies some missed cases that are incorrect.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
