### PR TITLE
FIX product_media delete when products are deleted

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -8,7 +8,7 @@ import requests
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files import File
 from django.db import transaction
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Exists, F, OuterRef, Q
 from django.utils.text import slugify
 
 from ....attribute import AttributeInputType, AttributeType
@@ -1806,8 +1806,7 @@ class ProductMediaDelete(BaseMutation):
                 }
             )
         media_id = media_obj.id
-        media_obj.to_remove = True
-        media_obj.save(update_fields=["to_remove"])
+        media_obj.set_to_remove()
         delete_product_media_task.delay(media_id)
         media_obj.id = media_id
         product = models.Product.objects.prefetched_for_webhook().get(

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -8,7 +8,7 @@ import requests
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files import File
 from django.db import transaction
-from django.db.models import Exists, F, OuterRef, Q
+from django.db.models import Exists, OuterRef, Q
 from django.utils.text import slugify
 
 from ....attribute import AttributeInputType, AttributeType

--- a/saleor/product/signals.py
+++ b/saleor/product/signals.py
@@ -14,6 +14,6 @@ def delete_digital_content_file(sender, instance, **kwargs):
 
 def delete_product_all_media(sender, instance, **kwargs):
     if all_media := instance.media.all():
-        all_media.update(to_remove=True)
         for media in all_media:
+            media.set_to_remove()
             delete_product_media_task.delay(media.id)


### PR DESCRIPTION
I want to merge this change because it fixes problem when product medias are deleted after deleting a product. 

Before the `get_ordering_queryset` method were called with every `delete()` on ProductMedia. It was referring to `self.product.media.all()` - in case of deleting product first, the product was None so task would fail.
This caused  multiple retries on many tasks - which, in large numbers, caused queues backlog overgrowth.

The fix moves  ordering queryset logic from `delete()` to `set_to_remove`. 
Now this logic is used before product is deleted from db.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
