### PR TITLE
Fix product media delete ordering queryset in 3.2

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1800,8 +1800,7 @@ class ProductMediaDelete(BaseMutation):
                 }
             )
         media_id = media_obj.id
-        media_obj.to_remove = True
-        media_obj.save(update_fields=["to_remove"])
+        media_obj.set_to_remove()
         delete_product_media_task.delay(media_id)
         media_obj.id = media_id
         product = models.Product.objects.prefetched_for_webhook().get(

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -8,7 +8,7 @@ from django.contrib.postgres.aggregates import StringAgg
 from django.contrib.postgres.indexes import BTreeIndex, GinIndex
 from django.contrib.postgres.search import SearchVectorField
 from django.core.validators import MinValueValidator
-from django.db import models
+from django.db import models, transaction
 from django.db.models import JSONField  # type: ignore
 from django.db.models import (
     BooleanField,
@@ -812,6 +812,20 @@ class ProductMedia(SortableModel):
 
     def get_ordering_queryset(self):
         return self.product.media.all()
+
+    @transaction.atomic
+    def delete(self, *args, **kwargs):
+        super(SortableModel, self).delete(*args, **kwargs)
+
+    @transaction.atomic
+    def set_to_remove(self):
+        self.to_remove = True
+        self.save(update_fields=["to_remove"])
+        if self.sort_order is not None:
+            qs = self.get_ordering_queryset()
+            qs.filter(sort_order__gt=self.sort_order).update(
+                sort_order=F("sort_order") - 1
+            )
 
 
 class VariantMedia(models.Model):

--- a/saleor/product/signals.py
+++ b/saleor/product/signals.py
@@ -14,6 +14,6 @@ def delete_digital_content_file(sender, instance, **kwargs):
 
 def delete_product_all_media(sender, instance, **kwargs):
     if all_media := instance.media.all():
-        all_media.update(to_remove=True)
         for media in all_media:
+            media.set_to_remove()
             delete_product_media_task.delay(media.id)


### PR DESCRIPTION
patch with fix from #9703

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
