### PR TITLE
Fix product media delete ordering queryset in 3.3

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1806,8 +1806,7 @@ class ProductMediaDelete(BaseMutation):
                 }
             )
         media_id = media_obj.id
-        media_obj.to_remove = True
-        media_obj.save(update_fields=["to_remove"])
+        media_obj.set_to_remove()
         delete_product_media_task.delay(media_id)
         media_obj.id = media_id
         product = models.Product.objects.prefetched_for_webhook().get(

--- a/saleor/product/signals.py
+++ b/saleor/product/signals.py
@@ -14,6 +14,6 @@ def delete_digital_content_file(sender, instance, **kwargs):
 
 def delete_product_all_media(sender, instance, **kwargs):
     if all_media := instance.media.all():
-        all_media.update(to_remove=True)
         for media in all_media:
+            media.set_to_remove()
             delete_product_media_task.delay(media.id)


### PR DESCRIPTION
patch with fix from #9703

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
