### PR TITLE
Extra benchmark tests for order type

### DIFF
--- a/saleor/graphql/order/tests/benchmark/test_order.py
+++ b/saleor/graphql/order/tests/benchmark/test_order.py
@@ -46,6 +46,15 @@ FRAGMENT_ORDER_DETAILS = (
         canFinalize
         isShippingRequired
         id
+        giftCards {
+          id
+        }
+        invoices {
+          id
+        }
+        payments {
+          id
+        }
         number
         shippingAddress {
           ...Address


### PR DESCRIPTION
I want to merge this change because it adds a few benchmarks to order type:
- giftCards
- invoices
- payments

which apparently were missing dataloaders.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
