### PR TITLE
Improved metadata permissions for apps

### DIFF
--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -21,6 +21,7 @@ JWT_THIRDPARTY_ACCESS_TYPE = "thirdparty"
 JWT_REFRESH_TOKEN_COOKIE_NAME = "refreshToken"
 
 PERMISSIONS_FIELD = "permissions"
+USER_PERMISSION_FIELD = "user_permissions"
 JWT_SALEOR_OWNER_NAME = "saleor"
 JWT_OWNER_FIELD = "owner"
 
@@ -170,6 +171,7 @@ def _create_access_token_for_third_party_actions(
     additional_payload = {
         object_payload_key: graphene.Node.to_global_id(type, object_id),
         PERMISSIONS_FIELD: list(app_permission_enums & user_permission_enums),
+        USER_PERMISSION_FIELD: list(user_permission_enums),
     }
 
     payload = jwt_user_payload(

--- a/saleor/core/tests/test_jwt.py
+++ b/saleor/core/tests/test_jwt.py
@@ -33,6 +33,9 @@ def test_create_access_token_for_app_extension_staff_user_with_more_permissions(
     _, decode_extension_id = graphene.Node.from_global_id(
         decoded_token["app_extension"]
     )
+    assert set(decoded_token["user_permissions"]) == set(
+        ["MANAGE_CHANNELS", "MANAGE_APPS", "MANAGE_PRODUCTS"]
+    )
     assert int(decode_extension_id) == extension.id
 
 
@@ -64,6 +67,7 @@ def test_create_access_token_for_app_extension_with_more_permissions(
     _, decode_extension_id = graphene.Node.from_global_id(
         decoded_token["app_extension"]
     )
+    assert decoded_token["user_permissions"] == ["MANAGE_PRODUCTS"]
     assert int(decode_extension_id) == extension.id
 
 

--- a/saleor/graphql/app/resolvers.py
+++ b/saleor/graphql/app/resolvers.py
@@ -6,10 +6,8 @@ from ...core.jwt import (
     create_access_token_for_app,
     create_access_token_for_app_extension,
 )
-from ...core.permissions import AppPermission
 from ...core.utils.validators import user_is_valid
 from ..core.utils import from_global_id_or_error
-from ..decorators import permission_required
 from .enums import AppTypeEnum
 
 
@@ -26,7 +24,7 @@ def resolve_access_token_for_app(info, root):
         return None
 
     user = info.context.user
-    if user.is_anonymous:
+    if user.is_anonymous or not user.is_staff:
         return None
     return create_access_token_for_app(root, user)
 
@@ -44,7 +42,7 @@ def resolve_access_token_for_app_extension(info, root):
     return None
 
 
-@permission_required(AppPermission.MANAGE_APPS)
+# @permission_required(AppPermission.MANAGE_APPS)
 def resolve_app(_info, id):
     if not id:
         return None

--- a/saleor/graphql/app/resolvers.py
+++ b/saleor/graphql/app/resolvers.py
@@ -42,7 +42,6 @@ def resolve_access_token_for_app_extension(info, root):
     return None
 
 
-# @permission_required(AppPermission.MANAGE_APPS)
 def resolve_app(_info, id):
     if not id:
         return None

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -1,5 +1,6 @@
 import graphene
 
+from ...core.exceptions import PermissionDenied
 from ...core.permissions import AppPermission, AuthorizationFilters
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
@@ -63,17 +64,26 @@ class AppQueries(graphene.ObjectType):
         sort_by=AppSortingInput(description="Sort apps."),
         description="List of the apps.",
         permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
             AppPermission.MANAGE_APPS,
         ],
     )
-    app = graphene.Field(
+    app = PermissionsField(
         App,
         id=graphene.Argument(graphene.ID, description="ID of the app.", required=False),
         description=(
             "Look up an app by ID. If ID is not provided, return the currently "
-            "authenticated app. Requires one of the following permissions: "
-            f"{AuthorizationFilters.OWNER.name}, {AppPermission.MANAGE_APPS.name}."
+            "authenticated app. \n\nRequires one of the following permissions: "
+            f"{AuthorizationFilters.AUTHENTICATED_STAFF_USER}"
+            f"{AuthorizationFilters.AUTHENTICATED_APP}. The authenticated app has "
+            f"access to its resources. Fetching different apps requires "
+            f"{AppPermission.MANAGE_APPS.name} permission."
         ),
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        ],
+        auto_permission_message=False,
     )
     app_extensions = FilterConnectionField(
         AppExtensionCountableConnection,
@@ -110,9 +120,14 @@ class AppQueries(graphene.ObjectType):
 
     @staticmethod
     def resolve_app(_root, info, *, id=None):
-        app = info.context.app
-        if not id and app:
-            return app
+        if app := info.context.app:
+            if not id:
+                return app
+            _, app_id = from_global_id_or_error(id, only_type="App")
+            if int(app_id) == app.id:
+                return app
+            elif not app.has_perm(AppPermission.MANAGE_APPS):
+                raise PermissionDenied(permissions=[AppPermission.MANAGE_APPS])
         return resolve_app(info, id)
 
     @staticmethod

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -74,8 +74,8 @@ class AppQueries(graphene.ObjectType):
         description=(
             "Look up an app by ID. If ID is not provided, return the currently "
             "authenticated app. \n\nRequires one of the following permissions: "
-            f"{AuthorizationFilters.AUTHENTICATED_STAFF_USER} "
-            f"{AuthorizationFilters.AUTHENTICATED_APP}. The authenticated app has "
+            f"{AuthorizationFilters.AUTHENTICATED_STAFF_USER.name} "
+            f"{AuthorizationFilters.AUTHENTICATED_APP.name}. The authenticated app has "
             f"access to its resources. Fetching different apps requires "
             f"{AppPermission.MANAGE_APPS.name} permission."
         ),

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -74,7 +74,7 @@ class AppQueries(graphene.ObjectType):
         description=(
             "Look up an app by ID. If ID is not provided, return the currently "
             "authenticated app. \n\nRequires one of the following permissions: "
-            f"{AuthorizationFilters.AUTHENTICATED_STAFF_USER}"
+            f"{AuthorizationFilters.AUTHENTICATED_STAFF_USER} "
             f"{AuthorizationFilters.AUTHENTICATED_APP}. The authenticated app has "
             f"access to its resources. Fetching different apps requires "
             f"{AppPermission.MANAGE_APPS.name} permission."

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -73,7 +73,7 @@ class AppQueries(graphene.ObjectType):
         id=graphene.Argument(graphene.ID, description="ID of the app.", required=False),
         description=(
             "Look up an app by ID. If ID is not provided, return the currently "
-            "authenticated app. \n\nRequires one of the following permissions: "
+            "authenticated app.\n\nRequires one of the following permissions: "
             f"{AuthorizationFilters.AUTHENTICATED_STAFF_USER.name} "
             f"{AuthorizationFilters.AUTHENTICATED_APP.name}. The authenticated app has "
             f"access to its resources. Fetching different apps requires "

--- a/saleor/graphql/app/tests/queries/test_app.py
+++ b/saleor/graphql/app/tests/queries/test_app.py
@@ -112,10 +112,10 @@ def test_app_query(
     else:
         assert app_data["accessToken"] is None
 
-    assert app_data["metadata"]["key"] == "test"
-    assert app_data["metadata"]["value"] == "123"
-    assert app_data["metafield"] == {"test": "123"}
-    assert app_data["metadields"] == [{"test": "123"}]
+    assert app_data["metadata"][0]["key"] == "test"
+    assert app_data["metadata"][0]["value"] == "123"
+    assert app_data["metafield"] == "123"
+    assert app_data["metafields"] == {"test": "123"}
 
 
 def test_app_query_no_permission(

--- a/saleor/graphql/app/tests/queries/test_app.py
+++ b/saleor/graphql/app/tests/queries/test_app.py
@@ -2,6 +2,8 @@ import graphene
 import pytest
 from freezegun import freeze_time
 
+from .....app.models import App
+from .....app.types import AppType
 from .....core.jwt import create_access_token_for_app
 from ....tests.utils import assert_no_permission, get_graphql_content
 
@@ -40,6 +42,8 @@ QUERY_APP = """
                     code
                 }
             }
+            metafield(key: "test")
+            metafields(keys: ["test"])
             metadata{
                 key
                 value
@@ -50,7 +54,7 @@ QUERY_APP = """
             }
         }
     }
-    """
+"""
 
 
 @freeze_time("2012-01-14 11:00:00")
@@ -67,6 +71,8 @@ def test_app_query(
     app = app_with_token
     app = app if app_type == "custom" else external_app
     app.permissions.add(permission_manage_staff)
+    app.store_value_in_metadata({"test": "123"})
+    app.save()
 
     webhook = webhook
     webhook.app = app
@@ -105,6 +111,11 @@ def test_app_query(
         )
     else:
         assert app_data["accessToken"] is None
+
+    assert app_data["metadata"]["key"] == "test"
+    assert app_data["metadata"]["value"] == "123"
+    assert app_data["metafield"] == {"test": "123"}
+    assert app_data["metadields"] == [{"test": "123"}]
 
 
 def test_app_query_no_permission(
@@ -153,9 +164,12 @@ def test_app_with_access_to_resources(
 def test_app_without_id_as_staff(
     staff_api_client, app, permission_manage_apps, order_with_lines, webhook
 ):
+    # when
     response = staff_api_client.post_graphql(
-        QUERY_APP, permissions=[permission_manage_apps]
+        QUERY_APP, permissions=[permission_manage_apps], check_no_permissions=False
     )
+
+    # then
     content = get_graphql_content(response)
     assert content["data"]["app"] is None
 
@@ -207,24 +221,35 @@ def test_app_query_without_permission(
     app,
     order_with_lines,
 ):
-    id = graphene.Node.to_global_id("App", app.id)
+    # given
+    second_app = App.objects.create(name="Sample app", is_active=True)
+    id = graphene.Node.to_global_id("App", second_app.id)
     variables = {"id": id}
+
+    # when
     response = app_api_client.post_graphql(
         QUERY_APP,
         variables,
     )
+
+    # then
     assert_no_permission(response)
 
 
 def test_app_query_without_permission_and_id(
-    staff_api_client,
-    app,
-    order_with_lines,
+    staff_api_client, app, order_with_lines, webhook
 ):
+    # given
+    App.objects.create(name="Sample app", is_active=True)
+
+    # when
     response = staff_api_client.post_graphql(
         QUERY_APP,
     )
-    assert_no_permission(response)
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["app"]
 
 
 def test_app_query_with_permission(
@@ -289,3 +314,190 @@ def test_app_with_extensions_query(
         assigned_permissions = [p.codename for p in app_extension.permissions.all()]
         assigned_permissions = [{"code": p.upper()} for p in assigned_permissions]
         assert assigned_permissions in returned_permission_codes
+
+
+QUERY_APP_AVAILABLE_FOR_STAFF_WITHOUT_MANAGE_APPS = """
+    query ($id: ID){
+        app(id: $id){
+            id
+            created
+            isActive
+            permissions{
+                code
+            }
+            name
+            type
+            aboutApp
+            dataPrivacy
+            dataPrivacyUrl
+            homepageUrl
+            supportUrl
+            configurationUrl
+            appUrl
+            accessToken
+            extensions{
+                id
+                label
+                url
+                mount
+                target
+                permissions{
+                    code
+                }
+            }
+        }
+    }
+"""
+
+
+@freeze_time("2012-01-14 11:00:00")
+@pytest.mark.parametrize("app_type", ("external", "custom"))
+def test_app_query_for_staff_without_manage_apps(
+    app_type,
+    staff_api_client,
+    permission_manage_staff,
+    app_with_token,
+    external_app,
+    webhook,
+):
+    app = app_with_token
+    app = app if app_type == "custom" else external_app
+    app.permissions.add(permission_manage_staff)
+
+    webhook = webhook
+    webhook.app = app
+    webhook.save()
+
+    id = graphene.Node.to_global_id("App", app.id)
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(
+        QUERY_APP_AVAILABLE_FOR_STAFF_WITHOUT_MANAGE_APPS,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    app_data = content["data"]["app"]
+
+    assert app_data["isActive"] == app.is_active
+    assert app_data["permissions"] == [{"code": "MANAGE_STAFF"}]
+    assert app_data["type"] == app.type.upper()
+    assert app_data["aboutApp"] == app.about_app
+    assert app_data["dataPrivacy"] == app.data_privacy
+    assert app_data["dataPrivacyUrl"] == app.data_privacy_url
+    assert app_data["homepageUrl"] == app.homepage_url
+    assert app_data["supportUrl"] == app.support_url
+    assert app_data["configurationUrl"] == app.configuration_url
+    assert app_data["appUrl"] == app.app_url
+    if app_type == "external":
+        assert app_data["accessToken"] == create_access_token_for_app(
+            app, staff_api_client.user
+        )
+    else:
+        assert app_data["accessToken"] is None
+
+
+def test_app_query_for_normal_user(
+    user_api_client, permission_manage_users, permission_manage_staff, app
+):
+    # when
+    response = user_api_client.post_graphql(
+        QUERY_APP_AVAILABLE_FOR_STAFF_WITHOUT_MANAGE_APPS,
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+#
+QUERY_APP_WITH_METADATA = """
+    query ($id: ID){
+        app(id: $id){
+            id
+            metadata{
+                key
+                value
+            }
+        }
+    }
+"""
+
+
+def test_app_query_with_metadata_staff_user_without_permissions(
+    staff_api_client,
+    staff_user,
+    app,
+):
+    # given
+    app.type = AppType.THIRDPARTY
+    app.store_value_in_metadata({"test": "123"})
+    app.save()
+
+    id = graphene.Node.to_global_id("App", app.id)
+    variables = {"id": id}
+
+    # when
+    response = staff_api_client.post_graphql(QUERY_APP_WITH_METADATA, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+QUERY_APP_WITH_METAFIELD = """
+    query ($id: ID){
+        app(id: $id){
+            id
+            metafield(key: "test")
+        }
+    }
+"""
+
+
+def test_app_query_with_metafield_staff_user_without_permissions(
+    staff_api_client,
+    staff_user,
+    app,
+):
+    # given
+    app.type = AppType.THIRDPARTY
+    app.store_value_in_metadata({"test": "123"})
+    app.save()
+
+    id = graphene.Node.to_global_id("App", app.id)
+    variables = {"id": id}
+
+    # when
+    response = staff_api_client.post_graphql(QUERY_APP_WITH_METAFIELD, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+QUERY_APP_WITH_METAFIELDS = """
+    query ($id: ID){
+        app(id: $id){
+            id
+            metafields(keys: ["test"])
+        }
+    }
+"""
+
+
+def test_app_query_with_metafields_staff_user_without_permissions(
+    staff_api_client,
+    staff_user,
+    app,
+):
+    # given
+    app.type = AppType.THIRDPARTY
+    app.store_value_in_metadata({"test": "123"})
+    app.save()
+
+    id = graphene.Node.to_global_id("App", app.id)
+    variables = {"id": id}
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_APP_WITH_METAFIELDS, variables=variables
+    )
+
+    # then
+    assert_no_permission(response)

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -212,23 +212,19 @@ class App(ModelObjectType):
     tokens = NonNullList(
         AppToken,
         description=(
-            f"""Last 4 characters of the tokens.{
-                message_one_of_permissions_required(
-                    [AppPermission.MANAGE_APPS, AuthorizationFilters.OWNER]
-                )
-            }
-            """
+            "Last 4 characters of the tokens."
+            + message_one_of_permissions_required(
+                [AppPermission.MANAGE_APPS, AuthorizationFilters.OWNER]
+            )
         ),
     )
     webhooks = NonNullList(
         Webhook,
         description=(
-            f"""List of webhooks assigned to this app.{
-                message_one_of_permissions_required(
-                    [AppPermission.MANAGE_APPS, AuthorizationFilters.OWNER]
-                )
-            }
-            """
+            "List of webhooks assigned to this app."
+            + message_one_of_permissions_required(
+                [AppPermission.MANAGE_APPS, AuthorizationFilters.OWNER]
+            )
         ),
     )
 

--- a/saleor/graphql/context.py
+++ b/saleor/graphql/context.py
@@ -9,12 +9,14 @@ from django.utils.functional import SimpleLazyObject
 from ..account.models import User
 from ..app.models import App, AppToken
 from ..core.auth import get_token_from_request
+from ..core.jwt import jwt_decode_with_exception_handler
 from .api import API_PATH
 
 
 def get_context_value(request):
     set_app_on_context(request)
     set_auth_on_context(request)
+    set_decoded_auth_token(request)
     return request
 
 
@@ -37,6 +39,12 @@ def get_app(raw_auth_token) -> Optional[App]:
     return App.objects.filter(
         Exists(tokens.filter(id__in=token_ids, app_id=OuterRef("pk"))), is_active=True
     ).first()
+
+
+def set_decoded_auth_token(request):
+    token = get_token_from_request(request)
+    decoded_auth_token = jwt_decode_with_exception_handler(token)
+    request.decoded_auth_token = decoded_auth_token
 
 
 def set_app_on_context(request):

--- a/saleor/graphql/core/fields.py
+++ b/saleor/graphql/core/fields.py
@@ -13,14 +13,14 @@ from .connection import FILTERS_NAME, FILTERSET_CLASS
 class PermissionsField(graphene.Field):
     def __init__(self, *args, **kwargs):
         self.permissions = kwargs.pop("permissions", [])
+        auto_permission_message = kwargs.pop("auto_permission_message", True)
         assert isinstance(self.permissions, list), (
             "FieldWithPermissions `permissions` argument must be a list: "
             f"{self.permissions}"
         )
 
         super(PermissionsField, self).__init__(*args, **kwargs)
-
-        if self.permissions:
+        if auto_permission_message and self.permissions:
             permissions_msg = message_one_of_permissions_required(self.permissions)
             description = self.description or ""
             self.description = description + permissions_msg

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1077,7 +1077,7 @@ type Query {
   ): AppCountableConnection
 
   """
-  Look up an app by ID. If ID is not provided, return the currently authenticated app. 
+  Look up an app by ID. If ID is not provided, return the currently authenticated app.
   
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER AUTHENTICATED_APP. The authenticated app has access to its resources. Fetching different apps requires MANAGE_APPS permission.
   """
@@ -1793,12 +1793,16 @@ type App implements Node & ObjectWithMetadata {
   type: AppTypeEnum
 
   """
-  Last 4 characters of the tokens. Requires one of the following permissions: AppPermission.MANAGE_APPS
+  Last 4 characters of the tokens.
+  
+  Requires one of the following permissions: MANAGE_APPS, OWNER.
   """
   tokens: [AppToken!]
 
   """
-  List of webhooks assigned to this app. Requires one of the following permissions: AppPermission.MANAGE_APPS
+  List of webhooks assigned to this app.
+  
+  Requires one of the following permissions: MANAGE_APPS, OWNER.
   """
   webhooks: [Webhook!]
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1054,7 +1054,7 @@ type Query {
   """
   List of the apps.
   
-  Requires one of the following permissions: MANAGE_APPS.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, MANAGE_APPS.
   """
   apps(
     """Filtering options for apps."""
@@ -1077,7 +1077,9 @@ type Query {
   ): AppCountableConnection
 
   """
-  Look up an app by ID. If ID is not provided, return the currently authenticated app. Requires one of the following permissions: OWNER, MANAGE_APPS.
+  Look up an app by ID. If ID is not provided, return the currently authenticated app. 
+  
+  Requires one of the following permissions: AuthorizationFilters.AUTHENTICATED_STAFF_USERAuthorizationFilters.AUTHENTICATED_APP. The authenticated app has access to its resources. Fetching different apps requires MANAGE_APPS permission.
   """
   app(
     """ID of the app."""
@@ -1790,10 +1792,14 @@ type App implements Node & ObjectWithMetadata {
   """Type of the app."""
   type: AppTypeEnum
 
-  """Last 4 characters of the tokens."""
+  """
+  Last 4 characters of the tokens. Requires one of the following permissions: AppPermission.MANAGE_APPS
+  """
   tokens: [AppToken!]
 
-  """List of webhooks assigned to this app."""
+  """
+  List of webhooks assigned to this app. Requires one of the following permissions: AppPermission.MANAGE_APPS
+  """
   webhooks: [Webhook!]
 
   """Description of this app."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1079,7 +1079,7 @@ type Query {
   """
   Look up an app by ID. If ID is not provided, return the currently authenticated app. 
   
-  Requires one of the following permissions: AuthorizationFilters.AUTHENTICATED_STAFF_USER AuthorizationFilters.AUTHENTICATED_APP. The authenticated app has access to its resources. Fetching different apps requires MANAGE_APPS permission.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER AUTHENTICATED_APP. The authenticated app has access to its resources. Fetching different apps requires MANAGE_APPS permission.
   """
   app(
     """ID of the app."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1079,7 +1079,7 @@ type Query {
   """
   Look up an app by ID. If ID is not provided, return the currently authenticated app. 
   
-  Requires one of the following permissions: AuthorizationFilters.AUTHENTICATED_STAFF_USERAuthorizationFilters.AUTHENTICATED_APP. The authenticated app has access to its resources. Fetching different apps requires MANAGE_APPS permission.
+  Requires one of the following permissions: AuthorizationFilters.AUTHENTICATED_STAFF_USER AuthorizationFilters.AUTHENTICATED_APP. The authenticated app has access to its resources. Fetching different apps requires MANAGE_APPS permission.
   """
   app(
     """ID of the app."""


### PR DESCRIPTION
I want to merge this change because:
- all users with a valid app user token (the UI one, currently everyone with staff status should be able to obtain such a token) can read and write the metadata of the app they are using (including through { app { metadata {...}}} )
- no app user tokens can read or write the private metadata of any apps, including the app they are using
-  every app can read and write its own private metadata (including through { app { privateMetadata {...}}} ) using the app token (the token assigned during app installation)
- Add a new field to the app user token (the UI one) that contains a list of all permissions the user would normally hold (we already list the effective permissions of the current token, we want to tell the app what the user is capable of outside of the app context)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
