### PR TITLE
Allow fetching by id all order data for new orders

### DIFF
--- a/saleor/graphql/meta/tests/test_meta_queries.py
+++ b/saleor/graphql/meta/tests/test_meta_queries.py
@@ -408,13 +408,18 @@ QUERY_ORDER_PUBLIC_META = """
 
 def test_query_public_meta_for_order_as_anonymous_user(api_client, order):
     # given
+    order.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
+    order.save(update_fields=["user", "metadata"])
     variables = {"id": graphene.Node.to_global_id("Order", order.pk)}
 
     # when
     response = api_client.post_graphql(QUERY_ORDER_PUBLIC_META, variables)
+    content = get_graphql_content(response)
 
     # then
-    assert_no_permission(response)
+    metadata = content["data"]["order"]["metadata"][0]
+    assert metadata["key"] == PUBLIC_KEY
+    assert metadata["value"] == PUBLIC_VALUE
 
 
 def test_query_public_meta_for_order_as_customer(user_api_client, order):
@@ -426,9 +431,12 @@ def test_query_public_meta_for_order_as_customer(user_api_client, order):
 
     # when
     response = user_api_client.post_graphql(QUERY_ORDER_PUBLIC_META, variables)
+    content = get_graphql_content(response)
 
     # then
-    assert_no_permission(response)
+    metadata = content["data"]["order"]["metadata"][0]
+    assert metadata["key"] == PUBLIC_KEY
+    assert metadata["value"] == PUBLIC_VALUE
 
 
 def test_query_public_meta_for_order_as_staff(
@@ -493,13 +501,18 @@ QUERY_DRAFT_ORDER_PUBLIC_META = """
 
 def test_query_public_meta_for_draft_order_as_anonymous_user(api_client, draft_order):
     # given
+    draft_order.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
+    draft_order.save(update_fields=["user", "metadata"])
     variables = {"id": graphene.Node.to_global_id("Order", draft_order.pk)}
 
     # when
     response = api_client.post_graphql(QUERY_DRAFT_ORDER_PUBLIC_META, variables)
+    content = get_graphql_content(response)
 
     # then
-    assert_no_permission(response)
+    metadata = content["data"]["order"]["metadata"][0]
+    assert metadata["key"] == PUBLIC_KEY
+    assert metadata["value"] == PUBLIC_VALUE
 
 
 def test_query_public_meta_for_draft_order_as_customer(user_api_client, draft_order):
@@ -511,9 +524,12 @@ def test_query_public_meta_for_draft_order_as_customer(user_api_client, draft_or
 
     # when
     response = user_api_client.post_graphql(QUERY_DRAFT_ORDER_PUBLIC_META, variables)
+    content = get_graphql_content(response)
 
     # then
-    assert_no_permission(response)
+    metadata = content["data"]["order"]["metadata"][0]
+    assert metadata["key"] == PUBLIC_KEY
+    assert metadata["value"] == PUBLIC_VALUE
 
 
 def test_query_public_meta_for_draft_order_as_staff(

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -79,13 +79,10 @@ class OrderQueries(graphene.ObjectType):
             OrderPermissions.MANAGE_ORDERS,
         ],
     )
-    order = PermissionsField(
+    order = graphene.Field(
         Order,
         description="Look up an order by ID.",
         id=graphene.Argument(graphene.ID, description="ID of an order.", required=True),
-        permissions=[
-            OrderPermissions.MANAGE_ORDERS,
-        ],
     )
     orders = FilterConnectionField(
         OrderCountableConnection,

--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -2146,16 +2146,21 @@ def test_fulfillment_query(
     warehouse,
     permission_manage_orders,
 ):
+    # given
     order = fulfilled_order
     order_line_1, order_line_2 = order.lines.all()
     order_id = graphene.Node.to_global_id("Order", order.pk)
     order_line_1_id = graphene.Node.to_global_id("OrderLine", order_line_1.pk)
     order_line_2_id = graphene.Node.to_global_id("OrderLine", order_line_2.pk)
     warehose_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
+    staff_user = staff_api_client.user
+    staff_user.user_permissions.add(permission_manage_orders)
     variables = {"id": order_id}
-    response = staff_api_client.post_graphql(
-        QUERY_FULFILLMENT, variables, permissions=[permission_manage_orders]
-    )
+
+    # when
+    response = staff_api_client.post_graphql(QUERY_FULFILLMENT, variables)
+
+    # then
     content = get_graphql_content(response)
     data = content["data"]["order"]["fulfillments"]
     assert len(data) == 1

--- a/saleor/graphql/order/tests/test_order_invoices.py
+++ b/saleor/graphql/order/tests/test_order_invoices.py
@@ -72,7 +72,7 @@ def test_order_query_invoices_customer_user_by_token(api_client, fulfilled_order
     query OrderByToken($token: UUID!) {
         orderByToken(token: $token) {
             invoices {
-                id
+                status
                 number
                 externalUrl
             }
@@ -80,4 +80,12 @@ def test_order_query_invoices_customer_user_by_token(api_client, fulfilled_order
     }
     """
     response = api_client.post_graphql(query, {"token": fulfilled_order.id})
-    assert_no_permission(response)
+    content = get_graphql_content(response)
+    data = content["data"]["orderByToken"]
+    assert data["invoices"] == [
+        {
+            "status": JobStatus.SUCCESS.upper(),
+            "externalUrl": "http://www.example.com/invoice.pdf",
+            "number": "01/12/2020/TEST",
+        }
+    ]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -526,11 +526,7 @@ type Query {
     last: Int
   ): OrderEventCountableConnection
 
-  """
-  Look up an order by ID.
-  
-  Requires one of the following permissions: MANAGE_ORDERS.
-  """
+  """Look up an order by ID."""
   order(
     """ID of an order."""
     id: ID!
@@ -7732,18 +7728,18 @@ type Order implements Node & ObjectWithMetadata {
   status: OrderStatus!
 
   """
-  User who placed the order. This field is set only for orders placed by authenticated users. Requires one of the following permissions: MANAGE_USERS, MANAGE_ORDERS, OWNER.
+  User who placed the order. This field is set only for orders placed by authenticated users. Can be fetched for orders created in Saleor 3.2 and later, for other orders requires one of the following permissions: MANAGE_USERS, MANAGE_ORDERS, OWNER.
   """
   user: User
   trackingClientId: String!
 
   """
-  Billing address. Requires one of the following permissions to view the full data: MANAGE_ORDERS, OWNER.
+  Billing address. The full data can be access for orders created in Saleor 3.2 and later, for other orders requires one of the following permissions: MANAGE_ORDERS, OWNER.
   """
   billingAddress: Address
 
   """
-  Shipping address. Requires one of the following permissions to view the full data: MANAGE_ORDERS, OWNER.
+  Shipping address. The full data can be access for orders created in Saleor 3.2 and later, for other orders requires one of the following permissions: MANAGE_ORDERS, OWNER.
   """
   shippingAddress: Address
   shippingMethodName: String
@@ -7777,7 +7773,7 @@ type Order implements Node & ObjectWithMetadata {
   availableCollectionPoints: [Warehouse!]!
 
   """
-  List of order invoices. Requires one of the following permissions: MANAGE_ORDERS, OWNER.
+  List of order invoices. Can be fetched for orders created in Saleor 3.2 and later, for other orders requires one of the following permissions: MANAGE_ORDERS, OWNER.
   """
   invoices: [Invoice!]!
 
@@ -7861,7 +7857,7 @@ type Order implements Node & ObjectWithMetadata {
   totalBalance: Money!
 
   """
-  Email address of the customer. Requires the following permissions to access the full data: MANAGE_ORDERS, OWNER.
+  Email address of the customer. The full data can be access for orders created in Saleor 3.2 and later, for other orders requires one of the following permissions: MANAGE_ORDERS, OWNER.
   """
   userEmail: String
 

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -1278,7 +1278,7 @@ GET_ORDER_AVAILABLE_COLLECTION_POINTS = """
 
 
 def test_available_collection_points_for_preorders_variants_in_order(
-    api_client, staff_api_client, order_with_preorder_lines, permission_manage_orders
+    api_client, staff_api_client, order_with_preorder_lines
 ):
     expected_collection_points = list(
         Warehouse.objects.for_country("US")
@@ -1292,7 +1292,6 @@ def test_available_collection_points_for_preorders_variants_in_order(
         variables={
             "id": graphene.Node.to_global_id("Order", order_with_preorder_lines.id)
         },
-        permissions=[permission_manage_orders],
     )
     response_content = get_graphql_content(response)
     assert (
@@ -1305,7 +1304,6 @@ def test_available_collection_points_for_preorders_and_regular_variants_in_order
     api_client,
     staff_api_client,
     order_with_preorder_lines,
-    permission_manage_orders,
 ):
     expected_collection_points = list(
         Warehouse.objects.for_country("US")
@@ -1320,7 +1318,6 @@ def test_available_collection_points_for_preorders_and_regular_variants_in_order
         variables={
             "id": graphene.Node.to_global_id("Order", order_with_preorder_lines.id)
         },
-        permissions=[permission_manage_orders],
     )
     response_content = get_graphql_content(response)
     assert (


### PR DESCRIPTION
Allow fetching full data for new orders - orders created in version 3.2 or later, that cannot be fetched by the old id. For older orders, only anonymized data are returned for users without proper permissions.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
