### PR TITLE
Skip event delivery attempt in celery task when webhook is disabled.

### DIFF
--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -320,8 +320,14 @@ def send_webhook_request_async(self, event_delivery_id):
     except EventDelivery.DoesNotExist:
         logger.error("Event delivery id: %r not found", event_delivery_id)
         return
-    data = delivery.payload.payload
+
+    if not delivery.webhook.is_active:
+        delivery_update(delivery=delivery, status=EventDeliveryStatus.FAILED)
+        logger.error("Event delivery id: %r webhook is disabled.", event_delivery_id)
+        return
+
     webhook = delivery.webhook
+    data = delivery.payload.payload
     domain = Site.objects.get_current().domain
     attempt = create_attempt(delivery, self.request.id)
     delivery_status = EventDeliveryStatus.SUCCESS

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1061,6 +1061,23 @@ def test_send_webhook_request_async(
     assert delivery.status == EventDeliveryStatus.SUCCESS
 
 
+@mock.patch("saleor.plugins.webhook.tasks.clear_successful_delivery")
+def test_send_webhook_request_async_when_webhook_is_disabled(
+    mocked_clear_delivery, event_delivery
+):
+    # given
+    event_delivery.webhook.is_active = False
+    event_delivery.webhook.save(update_fields=["is_active"])
+
+    # when
+    send_webhook_request_async(event_delivery.pk)
+    event_delivery.refresh_from_db()
+
+    # then
+    mocked_clear_delivery.not_called()
+    assert event_delivery.status == EventDeliveryStatus.FAILED
+
+
 @freeze_time("1914-06-28 10:50")
 @mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")


### PR DESCRIPTION
I want to merge this change because it prevents Celery workers to send webhook requests when webhook is disabled. Additionally, it will set`EventDelivery` status to `failed`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
