### PR TITLE
Skip event delivery attempt in celery task when webhook is disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable, unreleased changes to this project will be documented in this file.
 
 # Unreleased
 
+### Other changes
+
+- Fix sending webhook request in Celery task when webhook is disabled.
+
 # 3.3.0
 
 ### Breaking changes

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -320,8 +320,15 @@ def send_webhook_request_async(self, event_delivery_id):
     except EventDelivery.DoesNotExist:
         logger.error("Event delivery id: %r not found", event_delivery_id)
         return
-    data = delivery.payload.payload
+
+    if not delivery.webhook.is_active:
+        delivery_update(delivery=delivery, status=EventDeliveryStatus.FAILED)
+        logger.info("Event delivery id: %r webhook is disabled.", event_delivery_id)
+        return
+
     webhook = delivery.webhook
+    data = delivery.payload.payload
+
     domain = Site.objects.get_current().domain
     attempt = create_attempt(delivery, self.request.id)
     delivery_status = EventDeliveryStatus.SUCCESS

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1057,6 +1057,23 @@ def test_send_webhook_request_async(
     assert delivery.status == EventDeliveryStatus.SUCCESS
 
 
+@mock.patch("saleor.plugins.webhook.tasks.clear_successful_delivery")
+def test_send_webhook_request_async_when_webhook_is_disabled(
+    mocked_clear_delivery, event_delivery
+):
+    # given
+    event_delivery.webhook.is_active = False
+    event_delivery.webhook.save(update_fields=["is_active"])
+
+    # when
+    send_webhook_request_async(event_delivery.pk)
+    event_delivery.refresh_from_db()
+
+    # then
+    mocked_clear_delivery.not_called()
+    assert event_delivery.status == EventDeliveryStatus.FAILED
+
+
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_using_scheme_method")
 def test_send_webhook_request_async_when_delivery_attempt_failed(
     mocked_send_response,


### PR DESCRIPTION
I want to merge this change because it prevents Celery workers to send webhook requests when webhook is disabled. Additionally, it will set `EventDelivery` status to `failed`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
