### PR TITLE
feat: expose a way to override `X-Forwarded-Host`

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -408,6 +408,7 @@ ALLOWED_HOSTS = get_list(os.environ.get("ALLOWED_HOSTS", "localhost,127.0.0.1"))
 ALLOWED_GRAPHQL_ORIGINS = get_list(os.environ.get("ALLOWED_GRAPHQL_ORIGINS", "*"))
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = get_bool_from_env("USE_X_FORWARDED_HOST", False)
 
 # Amazon S3 configuration
 # See https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html


### PR DESCRIPTION
The proxy flag allows us to override `host:port` for Django which is very
common when you put something in front of it. More so; while developing locally
you'd most often expose your instance through ephemeral ports (Django defaults to `8000`).

While visiting the GraphQL playground, your browser will pass the `Origin` header with
said port to the playground, which will create CORS issues since Saleor/Django will return it sans port in the reverse lookup: https://github.com/saleor/saleor/blob/f81b2f347e4c7a624cd68a1eca3b0a5611498f6e/saleor/graphql/api.py#L31

Here is a minimal caddy server config that sits in front of Saleor and:
1. Listens on the default Django port,
1. terminates TLS, and
2. passes a minimal proxy config to Saleor

```caddy
{
	auto_https off
	https_port 8000
}

:8000 {
	tls /etc/caddy/cert.pem /etc/caddy/cert.key {
		protocols tls1.3
	}
	reverse_proxy http://saleor:80 {
		header_up Host "saleor"
		header_up X-Forwarded-Host "saleor:8000"
		header_up X-Forwarded-Proto "https"
	}
}
```

By passing `USE_X_FORWARDED_HOST=1` through your environment and a config like above,
you should be able to visit the playground without issues.

This PR intentionally skips exposing `USE_X_FORWARDED_HOST` since there is [a known bug][1]
in Django with regards to overriding port behavior, yet to be fixed (with a closed PR).

The [HTTP host defintition RFC 7230][2] optionally allows to pass port through the `Host` proxy header, which suffices to cover both scenarios.

A PR in the documentation repo will follow if this lands. I chose to not add a test since this is
only exposing Django behavior, not anything specific to Saleor.

[1]: https://code.djangoproject.com/ticket/31354
[2]: https://datatracker.ietf.org/doc/html/rfc7230#section-5.4

---

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [x] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
