### PR TITLE
Fix sorting by publication date with pagination

### DIFF
--- a/saleor/graphql/product/sorters.py
+++ b/saleor/graphql/product/sorters.py
@@ -2,7 +2,7 @@ import graphene
 from django.db.models import (
     BooleanField,
     Count,
-    DateField,
+    DateTimeField,
     ExpressionWrapper,
     F,
     IntegerField,
@@ -121,7 +121,7 @@ class CollectionSortField(graphene.Enum):
             ).values_list("published_at")[:1]
         )
         return queryset.annotate(
-            published_at=ExpressionWrapper(subquery, output_field=DateField())
+            published_at=ExpressionWrapper(subquery, output_field=DateTimeField())
         )
 
 
@@ -226,7 +226,7 @@ class ProductOrderField(graphene.Enum):
             ).values_list("published_at")[:1]
         )
         return queryset.annotate(
-            published_at=ExpressionWrapper(subquery, output_field=DateField())
+            published_at=ExpressionWrapper(subquery, output_field=DateTimeField())
         )
 
     @staticmethod


### PR DESCRIPTION
Fix sorting products and collections by `PUBLISHED_AT` and `PUBLICATION_DATE` with pagination.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
