### PR TITLE
Allow to use apps in the demo mode

### DIFF
--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -40,6 +40,10 @@ class ReadOnlyMiddleware:
             if root_email and user_email == root_email:
                 return next_(root, info, **kwargs)
 
+        # Bypass authenticated app as to create an app, root user is required
+        if request.app:
+            return next_(root, info, **kwargs)
+
         for selection in info.operation.selection_set.selections:
             selection_name = str(selection.name.value)
             blocked = selection_name not in ReadOnlyMiddleware.ALLOWED_MUTATIONS


### PR DESCRIPTION
I want to merge this change because it allows using apps in demo mode. To create an app in demo mode, the whitelisted user is required.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
