### PR TITLE
APP_CREAED event renamed to APP_INSTALLED.

### DIFF
--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -68,5 +68,5 @@ def install_app(app_installation: AppInstallation, activate: bool = False):
     except requests.RequestException as e:
         app.delete()
         raise e
-    PluginsManager(plugins=settings.PLUGINS).app_created(app)
+    PluginsManager(plugins=settings.PLUGINS).app_installed(app)
     return app, token

--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -67,7 +67,7 @@ def test_install_app_created_app_trigger_webhook(
             "is_active": app.is_active,
             "name": app.name,
         },
-        WebhookEventAsyncType.APP_CREATED,
+        WebhookEventAsyncType.APP_INSTALLED,
         [any_webhook],
         app,
         None,

--- a/saleor/graphql/app/mutations.py
+++ b/saleor/graphql/app/mutations.py
@@ -177,7 +177,7 @@ class AppCreate(ModelMutation):
         cls._save_m2m(info, instance, cleaned_input)
         response = cls.success_response(instance)
         response.auth_token = auth_token
-        info.context.plugins.app_created(instance)
+        info.context.plugins.app_installed(instance)
         return response
 
     @classmethod

--- a/saleor/graphql/app/tests/mutations/test_app_create.py
+++ b/saleor/graphql/app/tests/mutations/test_app_create.py
@@ -105,7 +105,7 @@ def test_app_create_trigger_webhook(
             "is_active": app.is_active,
             "name": app.name,
         },
-        WebhookEventAsyncType.APP_CREATED,
+        WebhookEventAsyncType.APP_INSTALLED,
         [any_webhook],
         app,
         SimpleLazyObject(lambda: staff_api_client.user),

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1314,8 +1314,8 @@ enum WebhookEventTypeEnum {
   """All the events."""
   ANY_EVENTS
 
-  """A new app created."""
-  APP_CREATED
+  """A new app installed."""
+  APP_INSTALLED
 
   """An app updated."""
   APP_UPDATED
@@ -1553,8 +1553,8 @@ enum WebhookEventTypeAsyncEnum {
   """All the events."""
   ANY_EVENTS
 
-  """A new app created."""
-  APP_CREATED
+  """A new app installed."""
+  APP_INSTALLED
 
   """An app updated."""
   APP_UPDATED
@@ -2199,7 +2199,7 @@ scalar JSONString
 
 """An enumeration."""
 enum WebhookSampleEventTypeEnum {
-  APP_CREATED
+  APP_INSTALLED
   APP_UPDATED
   APP_DELETED
   APP_STATUS_CHANGED
@@ -20074,9 +20074,9 @@ type Subscription {
   event: Event
 }
 
-union Event = AppCreated | AppUpdated | AppDeleted | AppStatusChanged | CategoryCreated | CategoryUpdated | CategoryDeleted | ChannelCreated | ChannelUpdated | ChannelDeleted | ChannelStatusChanged | GiftCardCreated | GiftCardUpdated | GiftCardDeleted | GiftCardStatusChanged | MenuCreated | MenuUpdated | MenuDeleted | MenuItemCreated | MenuItemUpdated | MenuItemDeleted | OrderCreated | OrderUpdated | OrderConfirmed | OrderFullyPaid | OrderCancelled | OrderFulfilled | DraftOrderCreated | DraftOrderUpdated | DraftOrderDeleted | ProductCreated | ProductUpdated | ProductDeleted | ProductVariantCreated | ProductVariantUpdated | ProductVariantOutOfStock | ProductVariantBackInStock | ProductVariantDeleted | SaleCreated | SaleUpdated | SaleDeleted | InvoiceRequested | InvoiceDeleted | InvoiceSent | FulfillmentCreated | FulfillmentCanceled | CustomerCreated | CustomerUpdated | CollectionCreated | CollectionUpdated | CollectionDeleted | CheckoutCreated | CheckoutUpdated | PageCreated | PageUpdated | PageDeleted | ShippingPriceCreated | ShippingPriceUpdated | ShippingPriceDeleted | ShippingZoneCreated | ShippingZoneUpdated | ShippingZoneDeleted | TransactionActionRequest | TranslationCreated | TranslationUpdated | VoucherCreated | VoucherUpdated | VoucherDeleted
+union Event = AppInstalled | AppUpdated | AppDeleted | AppStatusChanged | CategoryCreated | CategoryUpdated | CategoryDeleted | ChannelCreated | ChannelUpdated | ChannelDeleted | ChannelStatusChanged | GiftCardCreated | GiftCardUpdated | GiftCardDeleted | GiftCardStatusChanged | MenuCreated | MenuUpdated | MenuDeleted | MenuItemCreated | MenuItemUpdated | MenuItemDeleted | OrderCreated | OrderUpdated | OrderConfirmed | OrderFullyPaid | OrderCancelled | OrderFulfilled | DraftOrderCreated | DraftOrderUpdated | DraftOrderDeleted | ProductCreated | ProductUpdated | ProductDeleted | ProductVariantCreated | ProductVariantUpdated | ProductVariantOutOfStock | ProductVariantBackInStock | ProductVariantDeleted | SaleCreated | SaleUpdated | SaleDeleted | InvoiceRequested | InvoiceDeleted | InvoiceSent | FulfillmentCreated | FulfillmentCanceled | CustomerCreated | CustomerUpdated | CollectionCreated | CollectionUpdated | CollectionDeleted | CheckoutCreated | CheckoutUpdated | PageCreated | PageUpdated | PageDeleted | ShippingPriceCreated | ShippingPriceUpdated | ShippingPriceDeleted | ShippingZoneCreated | ShippingZoneUpdated | ShippingZoneDeleted | TransactionActionRequest | TranslationCreated | TranslationUpdated | VoucherCreated | VoucherUpdated | VoucherDeleted
 
-type AppCreated {
+type AppInstalled {
   """
   Look up a app.
   

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -23,7 +23,7 @@ order_updated_event_enum_description = (
 
 
 WEBHOOK_EVENT_DESCRIPTION = {
-    WebhookEventAsyncType.APP_CREATED: "A new app created.",
+    WebhookEventAsyncType.APP_INSTALLED: "A new app installed.",
     WebhookEventAsyncType.APP_UPDATED: "An app updated.",
     WebhookEventAsyncType.APP_DELETED: "An app deleted.",
     WebhookEventAsyncType.APP_STATUS_CHANGED: "An app status is changed.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -50,7 +50,7 @@ class AppBase(AbstractType):
         return app
 
 
-class AppCreated(ObjectType, AppBase):
+class AppInstalled(ObjectType, AppBase):
     ...
 
 
@@ -679,7 +679,7 @@ class VoucherDeleted(ObjectType, VoucherBase):
 class Event(Union):
     class Meta:
         types = (
-            AppCreated,
+            AppInstalled,
             AppUpdated,
             AppDeleted,
             AppStatusChanged,
@@ -752,7 +752,7 @@ class Event(Union):
     @classmethod
     def get_type(cls, object_type: str):
         types = {
-            WebhookEventAsyncType.APP_CREATED: AppCreated,
+            WebhookEventAsyncType.APP_INSTALLED: AppInstalled,
             WebhookEventAsyncType.APP_UPDATED: AppUpdated,
             WebhookEventAsyncType.APP_DELETED: AppDeleted,
             WebhookEventAsyncType.APP_STATUS_CHANGED: AppStatusChanged,

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -133,11 +133,11 @@ class BasePlugin:
     def __str__(self):
         return self.PLUGIN_NAME
 
-    #  Trigger when app is created.
+    #  Trigger when app is installed.
     #
     #  Overwrite this method if you need to trigger specific logic after an app is
-    #  created.
-    app_created: Callable[["App", None], None]
+    #  installed.
+    app_installed: Callable[["App", None], None]
 
     #  Trigger when app is deleted.
     #

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -808,9 +808,9 @@ class PluginsManager(PaymentInterface):
             channel_slug=channel_slug,
         )
 
-    def app_created(self, app: "App"):
+    def app_installed(self, app: "App"):
         default_value = None
-        return self.__run_method_on_plugins("app_created", default_value, app)
+        return self.__run_method_on_plugins("app_installed", default_value, app)
 
     def app_updated(self, app: "App"):
         default_value = None

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -102,10 +102,10 @@ class WebhookPlugin(BasePlugin):
             }
             trigger_webhooks_async(payload, event_type, webhooks, app, self.requestor)
 
-    def app_created(self, app: "App", previous_value: None) -> None:
+    def app_installed(self, app: "App", previous_value: None) -> None:
         if not self.active:
             return previous_value
-        self._trigger_app_event(WebhookEventAsyncType.APP_CREATED, app)
+        self._trigger_app_event(WebhookEventAsyncType.APP_INSTALLED, app)
 
     def app_updated(self, app: "App", previous_value: None) -> None:
         if not self.active:

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -30,12 +30,12 @@ APP_DETAILS_FRAGMENT = """
 """
 
 
-APP_CREATED_SUBSCRIPTION_QUERY = (
+APP_INSTALLED_SUBSCRIPTION_QUERY = (
     APP_DETAILS_FRAGMENT
     + """
     subscription{
       event{
-        ...on AppCreated{
+        ...on AppInstalled{
           app{
             ...AppDetails
           }
@@ -47,9 +47,9 @@ APP_CREATED_SUBSCRIPTION_QUERY = (
 
 
 @pytest.fixture
-def subscription_app_created_webhook(subscription_webhook):
+def subscription_app_installed_webhook(subscription_webhook):
     return subscription_webhook(
-        APP_CREATED_SUBSCRIPTION_QUERY, WebhookEventAsyncType.APP_CREATED
+        APP_INSTALLED_SUBSCRIPTION_QUERY, WebhookEventAsyncType.APP_INSTALLED
     )
 
 

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -43,10 +43,10 @@ def generate_expected_payload_for_app(app, app_global_id):
     )
 
 
-def test_app_created(app, subscription_app_created_webhook):
+def test_app_installed(app, subscription_app_installed_webhook):
     # given
-    webhooks = [subscription_app_created_webhook]
-    event_type = WebhookEventAsyncType.APP_CREATED
+    webhooks = [subscription_app_installed_webhook]
+    event_type = WebhookEventAsyncType.APP_INSTALLED
     app_id = graphene.Node.to_global_id("App", app.id)
 
     # when

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -18,7 +18,7 @@ from ..core.permissions import (
 class WebhookEventAsyncType:
     ANY = "any_events"
 
-    APP_CREATED = "app_created"
+    APP_INSTALLED = "app_installed"
     APP_UPDATED = "app_updated"
     APP_DELETED = "app_deleted"
     APP_STATUS_CHANGED = "app_status_changed"
@@ -112,7 +112,7 @@ class WebhookEventAsyncType:
 
     DISPLAY_LABELS = {
         ANY: "Any events",
-        APP_CREATED: "App created",
+        APP_INSTALLED: "App created",
         APP_UPDATED: "App updated",
         APP_DELETED: "App deleted",
         APP_STATUS_CHANGED: "App status changed",
@@ -185,7 +185,7 @@ class WebhookEventAsyncType:
 
     CHOICES = [
         (ANY, DISPLAY_LABELS[ANY]),
-        (APP_CREATED, DISPLAY_LABELS[APP_CREATED]),
+        (APP_INSTALLED, DISPLAY_LABELS[APP_INSTALLED]),
         (APP_UPDATED, DISPLAY_LABELS[APP_UPDATED]),
         (APP_DELETED, DISPLAY_LABELS[APP_DELETED]),
         (APP_STATUS_CHANGED, DISPLAY_LABELS[APP_STATUS_CHANGED]),
@@ -259,7 +259,7 @@ class WebhookEventAsyncType:
     ALL = [event[0] for event in CHOICES]
 
     PERMISSIONS = {
-        APP_CREATED: AppPermission.MANAGE_APPS,
+        APP_INSTALLED: AppPermission.MANAGE_APPS,
         APP_UPDATED: AppPermission.MANAGE_APPS,
         APP_DELETED: AppPermission.MANAGE_APPS,
         APP_STATUS_CHANGED: AppPermission.MANAGE_APPS,
@@ -403,7 +403,7 @@ class WebhookEventSyncType:
 
 
 SUBSCRIBABLE_EVENTS = [
-    WebhookEventAsyncType.APP_CREATED,
+    WebhookEventAsyncType.APP_INSTALLED,
     WebhookEventAsyncType.APP_UPDATED,
     WebhookEventAsyncType.APP_DELETED,
     WebhookEventAsyncType.APP_STATUS_CHANGED,


### PR DESCRIPTION
I want to merge this change because it renames `APP_CREATED` event to `APP_INSTALLED`.

New event:
- `APP_INSTALLED`

Removed event:
- `APP_CREATED`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
