### PR TITLE
Remove settings seconds in migrations

### DIFF
--- a/saleor/checkout/migrations/0044_fulfill_checkout_line_new_fields.py
+++ b/saleor/checkout/migrations/0044_fulfill_checkout_line_new_fields.py
@@ -19,9 +19,7 @@ def set_checkout_line_token_and_created_at(apps, _schema_editor):
         )
         for checkout_line in checkout_lines:
             checkout = checkout_in_bulk.get(checkout_line.checkout_id)
-            checkout_line.created_at = checkout.created_at.replace(
-                second=checkout_line.pk
-            )
+            checkout_line.created_at = checkout.created_at
             checkout_line.token = uuid.uuid4()
 
         CheckoutLine.objects.bulk_update(checkout_lines, ["token", "created_at"])

--- a/saleor/order/migrations/0139_fulfil_orderline_token_old_id_created_at.py
+++ b/saleor/order/migrations/0139_fulfil_orderline_token_old_id_created_at.py
@@ -19,7 +19,7 @@ def set_order_line_token_and_created_at(apps, _schema_editor):
         )
         for order_line in order_lines:
             order = order_in_bulk.get(order_line.order_id)
-            order_line.created_at = order.created_at.replace(second=order_line.pk)
+            order_line.created_at = order.created_at
             order_line.token = uuid.uuid4()
 
         OrderLine.objects.bulk_update(order_lines, ["token", "created_at"])


### PR DESCRIPTION
Remove settings seconds in migrations.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
