### PR TITLE
Add benchmark tests for Webhooks events resolvers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,5 +6,6 @@ pytest_plugins = [
     "saleor.graphql.account.tests.benchmark.fixtures",
     "saleor.graphql.order.tests.benchmark.fixtures",
     "saleor.graphql.giftcard.tests.benchmark.fixtures",
+    "saleor.graphql.webhook.tests.benchmark.fixtures",
     "saleor.plugins.webhook.tests.subscription_webhooks.fixtures",
 ]

--- a/saleor/graphql/webhook/tests/benchmark/fixtures.py
+++ b/saleor/graphql/webhook/tests/benchmark/fixtures.py
@@ -1,0 +1,85 @@
+from itertools import cycle
+
+import pytest
+
+from .....app.models import App
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
+from .....webhook.models import Webhook, WebhookEvent
+
+NUMBER_OF_WEBHOOKS_PER_APP = 6
+
+
+def _prepare_async_and_sync_events(webhook):
+    return [
+        WebhookEvent(
+            webhook=webhook, event_type=WebhookEventSyncType.PAYMENT_AUTHORIZE
+        ),
+        WebhookEvent(webhook=webhook, event_type=WebhookEventAsyncType.ANY),
+    ]
+
+
+def _prepare_sync_event(webhook):
+    return [
+        WebhookEvent(
+            webhook=webhook,
+            event_type=WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+        )
+    ]
+
+
+def _prepare_async_event(webhook):
+    return [
+        WebhookEvent(webhook=webhook, event_type=WebhookEventAsyncType.CHANNEL_CREATED)
+    ]
+
+
+@pytest.fixture
+def events_cycle():
+    return cycle(
+        (
+            _prepare_async_and_sync_events,
+            _prepare_sync_event,
+            _prepare_async_event,
+            lambda x: [],
+            lambda x: [],
+        )
+    )
+
+
+@pytest.fixture
+def webhook_events(webhooks_without_events, events_cycle):
+    webhook_events = []
+
+    for webhook in webhooks_without_events:
+        webhook_events.extend(next(events_cycle)(webhook))
+
+    return WebhookEvent.objects.bulk_create(webhook_events)
+
+
+@pytest.fixture
+def apps_without_webhooks(db):
+    return App.objects.bulk_create(
+        [
+            App(name="App1", is_active=True),
+            App(name="App2", is_active=False),
+            App(name="App3", is_active=True),
+            App(name="App4", is_active=False),
+        ]
+    )
+
+
+@pytest.fixture
+def webhooks_without_events(apps_without_webhooks):
+    webhooks = []
+
+    for app in apps_without_webhooks[:2]:
+        for index in range(NUMBER_OF_WEBHOOKS_PER_APP):
+            webhook = Webhook(
+                name=f"Webhook_{index}",
+                app=app,
+                target_url=f"http://localhost/test_{index}",
+                is_active=index % 2,
+            )
+            webhooks.append(webhook)
+
+    return Webhook.objects.bulk_create(webhooks)

--- a/saleor/graphql/webhook/tests/benchmark/test_webhook_events.py
+++ b/saleor/graphql/webhook/tests/benchmark/test_webhook_events.py
@@ -1,0 +1,44 @@
+import pytest
+
+from ....tests.utils import get_graphql_content
+
+WEBHOOKS_QUERY = """
+query {
+    apps(first:100) {
+        edges {
+            node {
+                webhooks {
+                    id
+                    name
+                    targetUrl
+                    isActive
+                    asyncEvents {
+                        name
+                    }
+                    syncEvents {
+                        name
+                    }
+                    events {
+                        name
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_webhooks(
+    staff_api_client, webhook_events, permission_manage_apps, count_queries
+):
+    content = get_graphql_content(
+        staff_api_client.post_graphql(
+            WEBHOOKS_QUERY,
+            permissions=[permission_manage_apps],
+            check_no_permissions=False,
+        )
+    )
+    assert len(content["data"]["apps"]["edges"]) == 4


### PR DESCRIPTION
I want to merge this change because I want add benchmark for webhook resolvers


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
