### PR TITLE
Fix Braintree error "91584: Merchant account must match ... authorization merchant account"

### DIFF
--- a/saleor/payment/gateways/braintree/__init__.py
+++ b/saleor/payment/gateways/braintree/__init__.py
@@ -118,17 +118,23 @@ def get_client_token(
         span = scope.span
         span.set_tag(opentracing.tags.COMPONENT, "payment")
         span.set_tag("service.name", "braintree")
-        if not token_config:
-            return gateway.client_token.generate()
         parameters = create_token_params(config, token_config)
         return gateway.client_token.generate(parameters)
 
 
-def create_token_params(config: GatewayConfig, token_config: TokenConfig) -> dict:
+def create_token_params(
+    config: GatewayConfig, token_config: Optional[TokenConfig] = None
+) -> dict:
     params = {}
-    customer_id = token_config.customer_id
-    if customer_id and config.store_customer:
-        params["customer_id"] = customer_id
+    if "merchant_account_id" in config.connection_params:
+        merchant_account_id = config.connection_params["merchant_account_id"]
+        if merchant_account_id:
+            params["merchant_account_id"] = merchant_account_id
+
+    if token_config:
+        customer_id = token_config.customer_id
+        if customer_id and config.store_customer:
+            params["customer_id"] = customer_id
     return params
 
 


### PR DESCRIPTION
In case when Braintree is configured to have multiple accounts for different currencies, unless a relevant merchant account ID is used to generate a client token before 3D Secure flow is completed, transaction will fail with the following error:

code `91584`: `Merchant account must match the 3D Secure authorization merchant account`



<!-- Please mention all relevant issue numbers. -->
This issue is most likely related: https://github.com/saleor/saleor/issues/4604

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
