### PR TITLE
Fix creating dummy context for subscription webhooks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix sending webhook request in Celery task when webhook is disabled.
 - Fix for multiplied line prices passed to Avatax - #9699 by @korycins
 - Fix max_length for voucher_code in Checkout model - #9794 by @SzymJ
+- Fix creating dummy context for subscription webhooks - #9798 by @SzymJ
 
 # 3.3.0
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -261,6 +261,7 @@ def site_settings(db, settings) -> SiteSettings:
         default_mail_sender_address="mirumee@example.com",
     )[0]
     settings.SITE_ID = site.pk
+    settings.ALLOWED_HOSTS += [site.domain]
 
     main_menu = Menu.objects.get_or_create(
         name=settings.DEFAULT_MENUS["top_menu_name"],


### PR DESCRIPTION
I want to merge this change because it fixes creating context used in subscription webhooks.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
