### PR TITLE
Add anonymization of user email. Enable accountRegister mutation for demo mode

### DIFF
--- a/saleor/demo/settings.py
+++ b/saleor/demo/settings.py
@@ -52,6 +52,7 @@ ROOT_EMAIL = os.environ.get("ROOT_EMAIL")
 # (see saleor.demo.management.commands.populatedb).
 INSTALLED_APPS.remove("saleor.core")
 INSTALLED_APPS += ["saleor.demo", "saleor.core"]
+ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL = False
 
 
 def _get_project_name_from_url(url: str) -> str:

--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -6,6 +6,7 @@ from .views import GraphQLView
 
 class ReadOnlyMiddleware:
     ALLOWED_MUTATIONS = [
+        "accountRegister",
         "checkoutAddPromoCode",
         "checkoutBillingAddressUpdate",
         "checkoutComplete",

--- a/saleor/plugins/anonymize/plugin.py
+++ b/saleor/plugins/anonymize/plugin.py
@@ -1,12 +1,17 @@
 from typing import TYPE_CHECKING, Any, Optional
 
-from ...core.anonymize import obfuscate_address, obfuscate_email
+from django.utils.crypto import get_random_string
+from faker import Faker
+
+from ...core.anonymize import obfuscate_address
 from ..base_plugin import BasePlugin
 from . import obfuscate_order
 
 if TYPE_CHECKING:
     from ...account.models import Address, User
     from ...order.models import Order
+
+faker = Faker()
 
 
 class AnonymizePlugin(BasePlugin):
@@ -43,5 +48,8 @@ class AnonymizePlugin(BasePlugin):
         order.save()
 
     def customer_created(self, customer: "User", previous_value: Any) -> Any:
-        customer.email = obfuscate_email(customer.email)
+
+        customer.first_name = faker.first_name()
+        customer.last_name = faker.last_name()
+        customer.email = f"{get_random_string(25)}@anonymous-demo-email"
         customer.save()


### PR DESCRIPTION
I want to merge this change because:
- disable account email confirmation for demo instance
- anonymize email, first_name, last_name provided when user is created 
- enable accountRegister mutation for `Read Only` mode.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
