### PR TITLE
Observability reporter

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -889,6 +889,23 @@ python-versions = ">=3.6"
 python-dateutil = ">=2.4"
 
 [[package]]
+name = "fakeredis"
+version = "1.8"
+description = "Fake implementation of redis API for testing purposes."
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+redis = "<=4.3.1"
+six = ">=1.16.0,<2.0.0"
+sortedcontainers = ">=2.4.0,<3.0.0"
+
+[package.extras]
+aioredis = ["aioredis (>=2.0.1,<3.0.0)"]
+lua = ["lupa (>=1.13,<2.0)"]
+
+[[package]]
 name = "filelock"
 version = "3.7.0"
 description = "A platform independent file lock."
@@ -2390,6 +2407,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "soupsieve"
 version = "2.3.2.post1"
 description = "A modern CSS selector implementation for Beautiful Soup."
@@ -2798,7 +2823,7 @@ test = ["pytest"]
 [metadata]
 lock-version = "1.1"
   python-versions = "~3.9"
-content-hash = "49c5267a6d585df393705bc434f9497f0b621a064dba6e8fc1541fa163a7950f"
+content-hash = "14661cfb9f2b517bb4b21b6ec07df499d90352d85d59c66eef13c928dd6da1f9"
 
 [metadata.files]
 adyen = [
@@ -3293,6 +3318,10 @@ execnet = [
 faker = [
     {file = "Faker-13.12.0-py3-none-any.whl", hash = "sha256:5cbb89fc6a16793b2bd98252c03a86098c7426beab0a20382709a815651b8804"},
     {file = "Faker-13.12.0.tar.gz", hash = "sha256:1f6478011ac8a8273e0f9cd6da03d9ea6391c622db340eca015339512e9cde29"},
+]
+fakeredis = [
+    {file = "fakeredis-1.8-py3-none-any.whl", hash = "sha256:65dcd78c0cd29d17daccce9f58698f6ab61ad7a404eab373fcad2b76fe8db03d"},
+    {file = "fakeredis-1.8.tar.gz", hash = "sha256:cbf8d74ae06672d40b2fa88b9ee4f1d6efd56b06b2e7f0be2c639647f00643f1"},
 ]
 filelock = [
     {file = "filelock-3.7.0-py3-none-any.whl", hash = "sha256:c7b5fdb219b398a5b28c8e4c1893ef5f98ece6a38c6ab2c22e26ec161556fed6"},
@@ -4212,6 +4241,10 @@ sniffio = [
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
+]
+sortedcontainers = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 soupsieve = [
     {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -2597,6 +2597,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "types-redis"
+version = "4.2.6"
+description = "Typing stubs for redis"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "types-requests"
 version = "2.27.29"
 description = "Typing stubs for requests"
@@ -2823,7 +2831,7 @@ test = ["pytest"]
 [metadata]
 lock-version = "1.1"
   python-versions = "~3.9"
-content-hash = "14661cfb9f2b517bb4b21b6ec07df499d90352d85d59c66eef13c928dd6da1f9"
+content-hash = "203c89136a886e6de47588c7755bbf14590c279789a57b9e73a8b39ea3679545"
 
 [metadata.files]
 adyen = [
@@ -4354,6 +4362,10 @@ types-python-dateutil = [
 types-pytz = [
     {file = "types-pytz-2021.3.8.tar.gz", hash = "sha256:41253a3a2bf028b6a3f17b58749a692d955af0f74e975de94f6f4d2d3cd01dbd"},
     {file = "types_pytz-2021.3.8-py3-none-any.whl", hash = "sha256:aef4a917ab28c585d3f474bfce4f4b44b91e95d9d47d4de29dd845e0db8e3910"},
+]
+types-redis = [
+    {file = "types-redis-4.2.6.tar.gz", hash = "sha256:d6adc77185cf40b300816767a64c0ee9ee0b21dc174e8e5c23b7e83d43189cb8"},
+    {file = "types_redis-4.2.6-py3-none-any.whl", hash = "sha256:1136af954ade0be33b487f440c8cbcbee29f089a83e685484ec91f363c6c69fe"},
 ]
 types-requests = [
     {file = "types-requests-2.27.29.tar.gz", hash = "sha256:fb453b3a76a48eca66381cea8004feaaea12835e838196f5c7ac87c75c5c19ef"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ documentation = "https://docs.saleor.io/"
   types-freezegun = "^1.1.7"
   types-six = "^1.16.12"
   fakeredis = "^1.8"
+  types-redis = "^4.2.6"
 
 [tool.black]
 target_version = [ "py35", "py36", "py37", "py38" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ documentation = "https://docs.saleor.io/"
   types-certifi = "^2021.10.8"
   types-freezegun = "^1.1.7"
   types-six = "^1.16.12"
+  fakeredis = "^1.8"
 
 [tool.black]
 target_version = [ "py35", "py36", "py37", "py38" ]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ aniso8601==7.0.0; python_version >= "3.6" and python_version < "4.0"
 anyio==3.6.1; python_version >= "3.7" and python_full_version >= "3.6.2"
 asgiref==3.5.2; python_version >= "3.7" and python_version < "4.0"
 astroid==2.11.5; python_full_version >= "3.6.2"
-async-timeout==4.0.2; python_version >= "3.7"
+async-timeout==4.0.2; python_version >= "3.7" and python_version < "4.0"
 atomicwrites==1.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" and python_version < "4.0" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.4.0" and python_version < "4.0"
 attrs==21.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.7" and python_version < "4.0"
 authlib==1.0.1
@@ -35,7 +35,7 @@ colorama==0.4.4; sys_platform == "win32" and python_version >= "3.7" and python_
 coverage==6.4; python_version >= "3.7"
 cryptography==37.0.2; python_version >= "3.6"
 cssselect2==0.6.0; python_version >= "3.7"
-deprecated==1.2.13; python_version >= "3.7" and python_full_version < "3.0.0" or python_version >= "3.7" and python_full_version >= "3.4.0"
+deprecated==1.2.13; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.7" and python_version < "4.0" and python_full_version >= "3.4.0"
 dill==0.3.5.1; python_full_version >= "3.7.0"
 distlib==0.3.4; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 dj-database-url==0.5.0
@@ -68,6 +68,7 @@ enmerkar==0.7.1
 et-xmlfile==1.1.0; python_version >= "3.6"
 execnet==1.9.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 faker==13.12.0; python_version >= "3.6"
+fakeredis==1.8; python_version >= "3.7" and python_version < "4.0"
 filelock==3.7.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 flake8==4.0.1; python_version >= "3.6"
 fonttools==4.33.3; python_version >= "3.7"
@@ -152,7 +153,7 @@ pylint-django==2.5.3
 pylint-plugin-utils==0.7; python_full_version >= "3.6.2"
 pylint==2.13.9; python_full_version >= "3.6.2"
 pymeta3==0.5.1
-pyparsing==3.0.9; python_full_version >= "3.6.8" and python_version >= "3.7"
+pyparsing==3.0.9; python_full_version >= "3.6.8" and python_version >= "3.7" and python_version < "4.0"
 pyphen==0.12.0; python_version >= "3.7"
 pytest-celery==0.0.0
 pytest-cov==3.0.0; python_version >= "3.6"
@@ -177,7 +178,7 @@ pywatchman==1.4.1
 pyxb==1.2.5
 pyyaml==6.0; python_version >= "3.7"
 razorpay==1.3.0
-redis==4.3.1; python_version >= "3.7"
+redis==4.3.1; python_version >= "3.7" and python_version < "4.0"
 requests==2.27.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 rsa==4.8; python_version >= "3.6" and python_version < "4" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 rx==1.6.1
@@ -185,9 +186,10 @@ s3transfer==0.5.2; python_version >= "3.6"
 sendgrid==6.9.7; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 sentry-sdk==1.5.12
 singledispatch==3.7.0; python_version >= "3.6" and python_version < "4.0"
-six==1.16.0; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.6.0" and python_version >= "3.7" and python_version < "4.0"
+six==1.16.0; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.7" and python_version < "4.0" and python_full_version >= "3.6.0"
 sniffio==1.2.0; python_version >= "3.7" and python_full_version >= "3.6.2"
 snowballstemmer==2.2.0; python_version >= "3.6"
+sortedcontainers==2.4.0; python_version >= "3.7" and python_version < "4.0"
 soupsieve==2.3.2.post1; python_version >= "3.6"
 sqlparse==0.4.2; python_version >= "3.7" and python_version < "4.0"
 starkbank-ecdsa==2.0.3; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
@@ -221,7 +223,7 @@ wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.7"
 weasyprint==55.0; python_version >= "3.7"
 webencodings==0.5.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 websockets==10.3; python_version >= "3.7"
-wrapt==1.14.1; python_full_version >= "3.6.2" and python_version >= "3.5" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_version >= "3.7" and python_full_version >= "3.5.0")
+wrapt==1.14.1; python_full_version >= "3.6.2" and python_version >= "3.5" and (python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.7" and python_version < "4.0" and python_full_version >= "3.5.0")
 yarl==1.7.2; python_version >= "3.6"
 zipp==3.8.0; python_version < "3.10" and python_version >= "3.7"
 zopfli==0.2.1; python_version >= "3.7"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -208,6 +208,7 @@ types-freezegun==1.1.9
 types-pkg-resources==0.1.3
 types-python-dateutil==2.8.17
 types-pytz==2021.3.8
+types-redis==4.2.6
 types-requests==2.27.29
 types-six==1.16.15
 types-urllib3==1.26.15

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -101,7 +101,7 @@ class GraphQLView(View):
                 "Cannot import '%s' graphene middleware!" % middleware_name
             )
 
-    @observability.dispatch_decorator
+    @observability.report_view
     def dispatch(self, request, *args, **kwargs):
         # Handle options method the GraphQlView restricts it.
         if request.method == "GET":

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -25,6 +25,7 @@ from jwt.exceptions import PyJWTError
 from .. import __version__ as saleor_version
 from ..core.exceptions import PermissionDenied, ReadOnlyException
 from ..core.utils import is_valid_ipv4, is_valid_ipv6
+from ..webhook import observability
 from .api import API_PATH, schema
 from .context import get_context_value
 from .core.validators.query_cost import validate_query_cost
@@ -100,6 +101,7 @@ class GraphQLView(View):
                 "Cannot import '%s' graphene middleware!" % middleware_name
             )
 
+    @observability.dispatch_decorator
     def dispatch(self, request, *args, **kwargs):
         # Handle options method the GraphQlView restricts it.
         if request.method == "GET":
@@ -197,30 +199,34 @@ class GraphQLView(View):
             # we can calculate the RAW UTF-8 size using the length of
             # response.content of type 'bytes'
             span.set_tag("http.content_length", len(response.content))
-
+            with observability.report_api_call(request) as api_call:
+                api_call.response = response
+                api_call.report()
             return response
 
     def get_response(
         self, request: HttpRequest, data: dict
     ) -> Tuple[Optional[Dict[str, List[Any]]], int]:
-        execution_result = self.execute_graphql_request(request, data)
-        status_code = 200
-        if execution_result:
-            response = {}
-            if execution_result.errors:
-                response["errors"] = [
-                    self.format_error(e) for e in execution_result.errors
-                ]
-            if execution_result.invalid:
-                status_code = 400
+        with observability.report_gql_operation() as operation:
+            execution_result = self.execute_graphql_request(request, data)
+            status_code = 200
+            if execution_result:
+                response = {}
+                if execution_result.errors:
+                    response["errors"] = [
+                        self.format_error(e) for e in execution_result.errors
+                    ]
+                if execution_result.invalid:
+                    status_code = 400
+                else:
+                    response["data"] = execution_result.data
+                if execution_result.extensions:
+                    response["extensions"] = execution_result.extensions
+                result: Optional[Dict[str, List[Any]]] = response
             else:
-                response["data"] = execution_result.data
-            if execution_result.extensions:
-                response["extensions"] = execution_result.extensions
-            result: Optional[Dict[str, List[Any]]] = response
-        else:
-            result = None
-
+                result = None
+            operation.result = result
+            operation.result_invalid = execution_result.invalid
         return result, status_code
 
     def get_root_value(self):
@@ -279,6 +285,10 @@ class GraphQLView(View):
             query_cost = 0
 
             document, error = self.parse_query(query)
+            with observability.report_gql_operation() as operation:
+                operation.query = document
+                operation.name = operation_name
+                operation.variables = variables
             if error:
                 return error
 

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -468,9 +468,10 @@ def send_webhook_request_sync(
 
 @app.task
 def observability_send_events():
-    events = get_buffer().pop_events(get_buffer_name())
-    if not events:
+    events_data = get_buffer().pop_events(get_buffer_name())
+    if not events_data:
         return
+    events = [json.loads(event) for event in events_data]
     domain = Site.objects.get_current().domain
     event_type = WebhookEventAsyncType.OBSERVABILITY
     for webhook in get_webhooks_for_event(event_type):

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -26,6 +26,7 @@ from ...payment import PaymentError
 from ...settings import WEBHOOK_SYNC_TIMEOUT, WEBHOOK_TIMEOUT
 from ...site.models import Site
 from ...webhook.event_types import SUBSCRIBABLE_EVENTS
+from ...webhook.observability.utils import report_webhook_event_delivery
 from ...webhook.utils import get_webhooks_for_event
 from . import signature_for_payload
 from .utils import (
@@ -337,6 +338,7 @@ def send_webhook_request_async(self, event_delivery_id):
                 data,
             )
         attempt_update(attempt, response)
+        report_webhook_event_delivery(attempt)
         if response.status == EventDeliveryStatus.FAILED:
             task_logger.info(
                 "[Webhook ID: %r] Failed request to %r: %r for event: %r."

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -30,7 +30,6 @@ from ...site.models import Site
 from ...webhook import observability
 from ...webhook.event_types import SUBSCRIBABLE_EVENTS, WebhookEventAsyncType
 from ...webhook.observability import WebhookData
-from ...webhook.payloads import generate_meta, generate_requestor
 from ...webhook.utils import get_webhooks_for_event
 from . import signature_for_payload
 from .utils import (

--- a/saleor/plugins/webhook/tests/test_observability.py
+++ b/saleor/plugins/webhook/tests/test_observability.py
@@ -110,3 +110,19 @@ def test_send_observability_events_to_google_pub_sub(
         WebhookEventAsyncType.OBSERVABILITY,
         dump_payload(events[-1]),
     )
+
+
+@patch("saleor.plugins.webhook.tasks.send_webhook_using_scheme_method")
+def test_send_observability_events_to_google_pub_sub_when_reposnse_failed(
+    mock_send_webhook_using_scheme_method, observability_webhook_data
+):
+    observability_webhook_data.target_url = (
+        "gcpubsub://cloud.google.com/projects/saleor/topics/test"
+    )
+    events = [{"event": "data"}, {"event": "data"}]
+    response = Mock()
+    response.status = EventDeliveryStatus.FAILED
+    mock_send_webhook_using_scheme_method.return_value = response
+
+    send_observability_events([observability_webhook_data], events)
+    assert mock_send_webhook_using_scheme_method.call_count == len(events)

--- a/saleor/plugins/webhook/tests/test_observability.py
+++ b/saleor/plugins/webhook/tests/test_observability.py
@@ -1,0 +1,99 @@
+from unittest.mock import patch
+
+from celery.canvas import Signature
+
+from ....webhook.event_types import WebhookEventAsyncType
+from ....webhook.observability import dump_payload
+from ..tasks import (
+    observability_reporter_task,
+    observability_send_events,
+    send_observability_events,
+)
+
+
+@patch("saleor.plugins.webhook.tasks.group")
+@patch("saleor.plugins.webhook.tasks.send_observability_events")
+@patch("saleor.plugins.webhook.tasks.observability.get_webhooks")
+@patch("saleor.plugins.webhook.tasks.observability.buffer_pop_events")
+def test_observability_reporter_task(
+    mock_buffer_pop_events,
+    mock_get_webhooks,
+    mock_send_observability_events,
+    mock_celery_group,
+    observability_webhook_data,
+    settings,
+):
+    events, batch_count = ["event", "event"], 5
+    webhooks = [observability_webhook_data]
+    mock_buffer_pop_events.return_value = events, batch_count
+    mock_get_webhooks.return_value = webhooks
+
+    observability_reporter_task()
+
+    mock_celery_group.assert_called_once()
+    tasks = mock_celery_group.call_args.args[0]
+    for task in tasks:
+        assert isinstance(task, Signature)
+    assert len(tasks) == batch_count
+    expires = settings.OBSERVABILITY_REPORT_PERIOD.total_seconds()
+    mock_celery_group.return_value.apply_async.assert_called_once_with(expires=expires)
+    mock_send_observability_events.assert_called_once_with(webhooks, events)
+
+
+@patch("saleor.plugins.webhook.tasks.send_observability_events")
+@patch("saleor.plugins.webhook.tasks.observability.get_webhooks")
+@patch("saleor.plugins.webhook.tasks.observability.buffer_pop_events")
+def test_observability_send_events(
+    mock_buffer_pop_events,
+    mock_get_webhooks,
+    mock_send_observability_events,
+    observability_webhook_data,
+):
+    events, batch_count = ["event", "event"], 5
+    webhooks = [observability_webhook_data]
+    mock_buffer_pop_events.return_value = events, batch_count
+    mock_get_webhooks.return_value = webhooks
+
+    observability_send_events()
+
+    mock_send_observability_events.assert_called_once_with(webhooks, events)
+
+
+@patch("saleor.plugins.webhook.tasks.send_webhook_using_scheme_method")
+def test_send_observability_events(
+    mock_send_webhook_using_scheme_method, observability_webhook_data
+):
+    webhooks = [observability_webhook_data]
+    events = [{"event": "data"}, {"event": "data"}]
+
+    send_observability_events(webhooks, events)
+
+    mock_send_webhook_using_scheme_method.assert_called_once_with(
+        observability_webhook_data.target_url,
+        observability_webhook_data.saleor_domain,
+        observability_webhook_data.secret_key,
+        WebhookEventAsyncType.OBSERVABILITY,
+        dump_payload(events),
+    )
+
+
+@patch("saleor.plugins.webhook.tasks.send_webhook_using_scheme_method")
+def test_send_observability_events_to_google_pub_sub(
+    mock_send_webhook_using_scheme_method, observability_webhook_data
+):
+    observability_webhook_data.target_url = (
+        "gcpubsub://cloud.google.com/projects/saleor/topics/test"
+    )
+    webhooks = [observability_webhook_data]
+    events = [{"event": "data"}, {"event": "data"}]
+
+    send_observability_events(webhooks, events)
+
+    assert mock_send_webhook_using_scheme_method.call_count == len(events)
+    mock_send_webhook_using_scheme_method.assert_called_with(
+        observability_webhook_data.target_url,
+        observability_webhook_data.saleor_domain,
+        observability_webhook_data.secret_key,
+        WebhookEventAsyncType.OBSERVABILITY,
+        dump_payload(events[-1]),
+    )

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -553,6 +553,30 @@ EVENT_PAYLOAD_DELETE_PERIOD = timedelta(
     seconds=parse(os.environ.get("EVENT_PAYLOAD_DELETE_PERIOD", "14 days"))
 )
 
+# Observability settings
+OBSERVABILITY_BROKER_URL = os.environ.get("OBSERVABILITY_BROKER_URL")
+OBSERVABILITY_ACTIVE = bool(OBSERVABILITY_BROKER_URL)
+OBSERVABILITY_REPORT_ALL_API_CALLS = get_bool_from_env(
+    "OBSERVABILITY_REPORT_ALL_API_CALLS", False
+)
+OBSERVABILITY_MAX_PAYLOAD_SIZE = int(
+    os.environ.get("OBSERVABILITY_MAX_PAYLOAD_SIZE", 128 * 1024)
+)
+OBSERVABILITY_BUFFER_SIZE_LIMIT = int(
+    os.environ.get("OBSERVABILITY_BUFFER_SIZE_LIMIT", 1000)
+)
+OBSERVABILITY_BUFFER_BATCH_SIZE = int(
+    os.environ.get("OBSERVABILITY_BUFFER_BATCH_SIZE", 100)
+)
+OBSERVABILITY_REPORT_PERIOD = timedelta(
+    seconds=parse(os.environ.get("OBSERVABILITY_REPORT_PERIOD", "20 seconds"))
+)
+# if OBSERVABILITY_ACTIVE:
+#     CELERY_BEAT_SCHEDULE["observability-reporter"] = {
+#         "task": "saleor.plugins.webhook.tasks.observability_reporter_task",
+#         "schedule": OBSERVABILITY_REPORT_PERIOD,
+#     }
+
 # Change this value if your application is running behind a proxy,
 # e.g. HTTP_CF_Connecting_IP for Cloudflare or X_FORWARDED_FOR
 REAL_IP_ENVIRON = os.environ.get("REAL_IP_ENVIRON", "REMOTE_ADDR")

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -571,11 +571,11 @@ OBSERVABILITY_BUFFER_BATCH_SIZE = int(
 OBSERVABILITY_REPORT_PERIOD = timedelta(
     seconds=parse(os.environ.get("OBSERVABILITY_REPORT_PERIOD", "20 seconds"))
 )
-# if OBSERVABILITY_ACTIVE:
-#     CELERY_BEAT_SCHEDULE["observability-reporter"] = {
-#         "task": "saleor.plugins.webhook.tasks.observability_reporter_task",
-#         "schedule": OBSERVABILITY_REPORT_PERIOD,
-#     }
+if OBSERVABILITY_ACTIVE:
+    CELERY_BEAT_SCHEDULE["observability-reporter"] = {
+        "task": "saleor.plugins.webhook.tasks.observability_reporter_task",
+        "schedule": OBSERVABILITY_REPORT_PERIOD,
+    }
 
 # Change this value if your application is running behind a proxy,
 # e.g. HTTP_CF_Connecting_IP for Cloudflare or X_FORWARDED_FOR

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -128,6 +128,7 @@ from ..warehouse.models import (
 )
 from ..webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..webhook.models import Webhook, WebhookEvent
+from ..webhook.observability import WebhookData
 from .utils import dummy_editorjs
 
 
@@ -5258,7 +5259,7 @@ def shipping_app(db, permission_manage_shipping):
 
 
 @pytest.fixture
-def observability_app(db, permission_manage_observability):
+def observability_webhook(db, permission_manage_observability):
     app = App.objects.create(name="Observability App", is_active=True)
     app.tokens.create(name="Default")
     app.permissions.add(permission_manage_observability)
@@ -5269,7 +5270,17 @@ def observability_app(db, permission_manage_observability):
         target_url="https://observability-app.com/api/",
     )
     webhook.events.create(event_type=WebhookEventAsyncType.OBSERVABILITY)
-    return app
+    return webhook
+
+
+@pytest.fixture
+def observability_webhook_data(observability_webhook):
+    return WebhookData(
+        id=observability_webhook.id,
+        saleor_domain="mirumee.com",
+        target_url=observability_webhook.target_url,
+        secret_key=observability_webhook.secret_key,
+    )
 
 
 @pytest.fixture

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1786,6 +1786,11 @@ def permission_manage_apps():
 
 
 @pytest.fixture
+def permission_manage_observability():
+    return Permission.objects.get(codename="manage_observability")
+
+
+@pytest.fixture
 def product_type(color_attribute, size_attribute):
     product_type = ProductType.objects.create(
         name="Default Type",
@@ -5249,6 +5254,21 @@ def shipping_app(db, permission_manage_shipping):
             ]
         ]
     )
+    return app
+
+
+@pytest.fixture
+def observability_app(db, permission_manage_observability):
+    app = App.objects.create(name="Observability App", is_active=True)
+    app.tokens.create(name="Default")
+    app.permissions.add(permission_manage_observability)
+
+    webhook = Webhook.objects.create(
+        name="observability-webhook-1",
+        app=app,
+        target_url="https://observability-app.com/api/",
+    )
+    webhook.events.create(event_type=WebhookEventAsyncType.OBSERVABILITY)
     return app
 
 

--- a/saleor/webhook/observability/__init__.py
+++ b/saleor/webhook/observability/__init__.py
@@ -1,14 +1,29 @@
 import functools
 
 from .buffers import get_buffer
-from .utils import get_observability_webhooks, report_api_call, report_gql_operation
+from .exceptions import ObservabilityError
+from .payloads import dump_payload
+from .utils import (
+    WebhookData,
+    get_buffer_name,
+    get_observability_webhooks,
+    report_api_call,
+    report_gql_operation,
+    report_webhook_event_delivery,
+    task_next_retry_date,
+)
 
 __all__ = [
+    "get_buffer",
+    "ObservabilityError",
+    "dump_payload",
+    "WebhookData",
+    "get_buffer_name",
+    "get_observability_webhooks",
     "report_api_call",
     "report_gql_operation",
-    "dispatch_decorator",
-    "get_buffer",
-    "get_observability_webhooks",
+    "report_webhook_event_delivery",
+    "task_next_retry_date",
 ]
 
 

--- a/saleor/webhook/observability/__init__.py
+++ b/saleor/webhook/observability/__init__.py
@@ -1,8 +1,15 @@
 import functools
 
-from .utils import report_api_call, report_gql_operation
+from .buffers import get_buffer
+from .utils import get_observability_webhooks, report_api_call, report_gql_operation
 
-__all__ = ["report_api_call", "report_gql_operation", "dispatch_decorator"]
+__all__ = [
+    "report_api_call",
+    "report_gql_operation",
+    "dispatch_decorator",
+    "get_buffer",
+    "get_observability_webhooks",
+]
 
 
 def dispatch_decorator(method):

--- a/saleor/webhook/observability/__init__.py
+++ b/saleor/webhook/observability/__init__.py
@@ -3,9 +3,9 @@ from .exceptions import ObservabilityError
 from .payloads import dump_payload
 from .utils import (
     WebhookData,
-    buffer_pop_events,
     get_buffer_name,
     get_webhooks,
+    pop_events_with_remaining_size,
     report_api_call,
     report_event_delivery_attempt,
     report_gql_operation,
@@ -15,7 +15,7 @@ from .utils import (
 
 __all__ = [
     "get_buffer",
-    "buffer_pop_events",
+    "pop_events_with_remaining_size",
     "ObservabilityError",
     "dump_payload",
     "WebhookData",

--- a/saleor/webhook/observability/__init__.py
+++ b/saleor/webhook/observability/__init__.py
@@ -1,6 +1,7 @@
 from .buffers import get_buffer
 from .exceptions import ObservabilityError
 from .payloads import dump_payload
+from .tracing import opentracing_trace
 from .utils import (
     WebhookData,
     get_buffer_name,
@@ -26,4 +27,5 @@ __all__ = [
     "report_event_delivery_attempt",
     "task_next_retry_date",
     "report_view",
+    "opentracing_trace",
 ]

--- a/saleor/webhook/observability/__init__.py
+++ b/saleor/webhook/observability/__init__.py
@@ -3,8 +3,9 @@ from .exceptions import ObservabilityError
 from .payloads import dump_payload
 from .utils import (
     WebhookData,
+    buffer_pop_events,
     get_buffer_name,
-    get_observability_webhooks,
+    get_webhooks,
     report_api_call,
     report_event_delivery_attempt,
     report_gql_operation,
@@ -14,11 +15,12 @@ from .utils import (
 
 __all__ = [
     "get_buffer",
+    "buffer_pop_events",
     "ObservabilityError",
     "dump_payload",
     "WebhookData",
     "get_buffer_name",
-    "get_observability_webhooks",
+    "get_webhooks",
     "report_api_call",
     "report_gql_operation",
     "report_event_delivery_attempt",

--- a/saleor/webhook/observability/__init__.py
+++ b/saleor/webhook/observability/__init__.py
@@ -1,5 +1,3 @@
-import functools
-
 from .buffers import get_buffer
 from .exceptions import ObservabilityError
 from .payloads import dump_payload
@@ -8,8 +6,9 @@ from .utils import (
     get_buffer_name,
     get_observability_webhooks,
     report_api_call,
+    report_event_delivery_attempt,
     report_gql_operation,
-    report_webhook_event_delivery,
+    report_view,
     task_next_retry_date,
 )
 
@@ -22,17 +21,7 @@ __all__ = [
     "get_observability_webhooks",
     "report_api_call",
     "report_gql_operation",
-    "report_webhook_event_delivery",
+    "report_event_delivery_attempt",
     "task_next_retry_date",
+    "report_view",
 ]
-
-
-def dispatch_decorator(method):
-    @functools.wraps(method)
-    def wrapper(self, request, *args, **kwargs):
-        with report_api_call(request) as api_call:
-            response = method(self, request, *args, **kwargs)
-            api_call.response = response
-            return response
-
-    return wrapper

--- a/saleor/webhook/observability/__init__.py
+++ b/saleor/webhook/observability/__init__.py
@@ -1,0 +1,16 @@
+import functools
+
+from .utils import report_api_call, report_gql_operation
+
+__all__ = ["report_api_call", "report_gql_operation", "dispatch_decorator"]
+
+
+def dispatch_decorator(method):
+    @functools.wraps(method)
+    def wrapper(self, request, *args, **kwargs):
+        with report_api_call(request) as api_call:
+            response = method(self, request, *args, **kwargs)
+            api_call.response = response
+            return response
+
+    return wrapper

--- a/saleor/webhook/observability/buffers.py
+++ b/saleor/webhook/observability/buffers.py
@@ -1,0 +1,159 @@
+import zlib
+from typing import Dict, List, Optional
+
+from asgiref.local import Local
+from django.conf import settings
+from redis import ConnectionPool, Redis
+
+from .exceptions import ConnectionDoesNotExist
+
+_local = Local()
+
+
+class BaseBuffer:
+    _compressor_preset = 6
+
+    def __init__(self, broker_url: str, max_size: int, batch_size: int):
+        self._broker_url = broker_url
+        self._max_size = max_size
+        self._batch_size = batch_size
+
+    def decode(self, value: bytes) -> str:
+        return zlib.decompress(value).decode()
+
+    def encode(self, value: str) -> bytes:
+        return zlib.compress(value.encode(), self._compressor_preset)
+
+    def put_event(self, key: str, event: str, retry=False):
+        raise NotImplementedError(
+            "subclasses of BaseBuffer must provide a put_event() method"
+        )
+
+    def put_events(self, key: str, events: List[str], retry=False) -> int:
+        raise NotImplementedError(
+            "subclasses of BaseBuffer must provide a put_events() method"
+        )
+
+    def put_events_multi_buffer(
+        self, events_dict: Dict[str, List[str]], retry=False
+    ) -> Dict[str, int]:
+        raise NotImplementedError(
+            "subclasses of BaseBuffer must provide a put_events_multi_buffer() method"
+        )
+
+    def pop_event(self, key) -> Optional[str]:
+        raise NotImplementedError(
+            "subclasses of BaseBuffer must provide a pop_events() method"
+        )
+
+    def pop_events(self, key, batch_size=100) -> List[str]:
+        raise NotImplementedError(
+            "subclasses of BaseBuffer must provide a pop_events() method"
+        )
+
+    def size(self, key: str) -> int:
+        raise NotImplementedError(
+            "subclasses of BaseBuffer must provide a size() method"
+        )
+
+
+class RedisBuffer(BaseBuffer):
+    _pools: Dict[str, ConnectionPool] = {}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._client: Optional[Redis] = None
+
+    def get_connection_pool(self):
+        return ConnectionPool.from_url(self._broker_url)
+
+    def get_or_create_connection_pool(self):
+        if self._broker_url not in self._pools:
+            self._pools[self._broker_url] = self.get_connection_pool()
+        return self._pools[self._broker_url]
+
+    def connect(self) -> Redis:
+        pool = self.get_or_create_connection_pool()
+        return Redis(connection_pool=pool)
+
+    @property
+    def client(self) -> Redis:
+        if not self._client:
+            self._client = self.connect()
+        return self._client
+
+    def _put_events(
+        self, key: str, events: List[bytes], client: Optional[Redis] = None
+    ):
+        if client is None:
+            client = self.client
+        client.lpush(key, *events)
+        client.ltrim(key, 0, max(0, self._max_size - 1))
+
+    def put_events(self, key: str, events: List[str], retry=False) -> int:
+        events_data = [self.encode(event) for event in events]
+        with self.client.pipeline(transaction=False) as pipe:
+            self._put_events(key, events_data, client=pipe)
+            result = pipe.execute()
+        return max(0, result[0] - self._max_size)
+
+    def put_event(self, key: str, event: str, retry=False):
+        return self.put_events(key, [event])
+
+    def put_events_multi_buffer(
+        self, events_dict: Dict[str, List[str]], retry=False
+    ) -> Dict[str, int]:
+        keys = list(events_dict.keys())
+        trimmed: Dict[str, int] = {}
+        if not keys:
+            return trimmed
+        with self.client.pipeline(transaction=False) as pipe:
+            for key in keys:
+                events_data = [self.encode(event) for event in events_dict[key]]
+                self._put_events(key, events_data, client=pipe)
+            result = pipe.execute()
+        for key in keys:
+            buffer_len, _ = result.pop(0), result.pop(0)
+            trimmed[key] = max(0, buffer_len - self._max_size)
+        return trimmed
+
+    def pop_events(self, key, batch_size=100) -> List[str]:
+        events = []
+        with self.client.pipeline(transaction=False) as pipe:
+            for i in range(max(1, batch_size)):
+                pipe.rpop(key)
+            result = pipe.execute()
+        for elem in result:
+            if elem is None:
+                break
+            events.append(self.decode(elem))
+        return events
+
+    def pop_event(self, key) -> Optional[str]:
+        events = self.pop_events(key, batch_size=1)
+        return events[0] if events else None
+
+    def size(self, key: str) -> int:
+        return self.client.llen(key)
+
+
+def buffer_factory(broker_url: str, max_size: int, batch_size: int) -> BaseBuffer:
+    return RedisBuffer(broker_url, max_size, batch_size)
+
+
+def get_buffer() -> BaseBuffer:
+    attr_name = "observability_buffer"
+    if hasattr(_local, attr_name):
+        return _local.observability_buffer
+    try:
+        return getattr(_local, "observability_buffer")
+    except AttributeError:
+        pass
+    if not settings.OBSERVABILITY_BROKER_URL:
+        raise ConnectionDoesNotExist("The observability broker url not set")
+    broker_url = settings.OBSERVABILITY_BROKER_URL
+    max_size = settings.OBSERVABILITY_BUFFER_SIZE_LIMIT
+    batch_size = settings.OBSERVABILITY_BUFFER_BATCH_SIZE
+    buffer = buffer_factory(broker_url, max_size, batch_size)
+    setattr(_local, attr_name, buffer)
+    return buffer

--- a/saleor/webhook/observability/buffers.py
+++ b/saleor/webhook/observability/buffers.py
@@ -84,9 +84,6 @@ class BaseBuffer:
     def in_batches(self, size: int) -> int:
         return math.ceil(size / self.batch_size)
 
-    def batch_count(self) -> int:
-        return self.in_batches(self.size())
-
 
 class RedisBuffer(BaseBuffer):
     _pools: Dict[str, ConnectionPool] = {}

--- a/saleor/webhook/observability/buffers.py
+++ b/saleor/webhook/observability/buffers.py
@@ -88,6 +88,7 @@ class BaseBuffer:
 class RedisBuffer(BaseBuffer):
     _pools: Dict[str, ConnectionPool] = {}
     _socket_connect_timeout = 0.25
+    _client_name = "observability_buffer"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -98,6 +99,7 @@ class RedisBuffer(BaseBuffer):
             self.broker_url,
             socket_connect_timeout=self._socket_connect_timeout,
             socket_timeout=self.connection_timeout,
+            client_name=self._client_name,
         )
 
     def get_or_create_connection_pool(self):

--- a/saleor/webhook/observability/buffers.py
+++ b/saleor/webhook/observability/buffers.py
@@ -187,7 +187,7 @@ class RedisBuffer(BaseBuffer):
         return self.client.llen(self.key)
 
 
-def buffer_factory(key: KEY_TYPE) -> BaseBuffer:
+def get_buffer(key: KEY_TYPE) -> BaseBuffer:
     if not settings.OBSERVABILITY_BROKER_URL:
         raise ConnectionNotConfigured("The observability broker url not set")
     broker_url = settings.OBSERVABILITY_BROKER_URL
@@ -197,11 +197,3 @@ def buffer_factory(key: KEY_TYPE) -> BaseBuffer:
     return RedisBuffer(
         broker_url, key, max_size, batch_size, connection_timeout=connection_timeout
     )
-
-
-def get_buffer(key: KEY_TYPE) -> BaseBuffer:
-    if buffer := getattr(_local, key, None):
-        return buffer
-    buffer = buffer_factory(key)
-    setattr(_local, key, buffer)
-    return buffer

--- a/saleor/webhook/observability/buffers.py
+++ b/saleor/webhook/observability/buffers.py
@@ -1,57 +1,67 @@
+import pickle
 import zlib
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from asgiref.local import Local
 from django.conf import settings
 from redis import ConnectionPool, Redis
 
-from .exceptions import ConnectionDoesNotExist
+from .exceptions import ConnectionNotConfigured
 
+KEY_TYPE = str
 _local = Local()
 
 
 class BaseBuffer:
     _compressor_preset = 6
+    _pickle_version = 5
 
     def __init__(self, broker_url: str, max_size: int, batch_size: int):
-        self._broker_url = broker_url
-        self._max_size = max_size
-        self._batch_size = batch_size
+        self.broker_url = broker_url
+        self.max_size = max_size
+        self.batch_size = batch_size
 
-    def decode(self, value: bytes) -> str:
-        return zlib.decompress(value).decode()
+    def decode(self, value: bytes) -> Any:
+        return pickle.loads(zlib.decompress(value))
 
-    def encode(self, value: str) -> bytes:
-        return zlib.compress(value.encode(), self._compressor_preset)
+    def encode(self, value: Any) -> bytes:
+        return zlib.compress(
+            pickle.dumps(value, self._pickle_version), self._compressor_preset
+        )
 
-    def put_event(self, key: str, event: str, retry=False):
+    def put_event(self, key: KEY_TYPE, event: Any):
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a put_event() method"
         )
 
-    def put_events(self, key: str, events: List[str], retry=False) -> int:
+    def put_events(self, key: KEY_TYPE, events: List[Any]) -> int:
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a put_events() method"
         )
 
-    def put_events_multi_buffer(
-        self, events_dict: Dict[str, List[str]], retry=False
-    ) -> Dict[str, int]:
+    def put_multi_key_events(
+        self, events_dict: Dict[KEY_TYPE, List[Any]]
+    ) -> Dict[KEY_TYPE, int]:
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a put_events_multi_buffer() method"
         )
 
-    def pop_event(self, key) -> Optional[str]:
+    def pop_event(self, key: KEY_TYPE) -> Any:
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a pop_events() method"
         )
 
-    def pop_events(self, key, batch_size=100) -> List[str]:
+    def pop_events(self, key: KEY_TYPE) -> List[Any]:
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a pop_events() method"
         )
 
-    def size(self, key: str) -> int:
+    def clear(self, key: KEY_TYPE):
+        raise NotImplementedError(
+            "subclasses of BaseBuffer must provide a clear() method"
+        )
+
+    def size(self, key: KEY_TYPE) -> int:
         raise NotImplementedError(
             "subclasses of BaseBuffer must provide a size() method"
         )
@@ -65,12 +75,12 @@ class RedisBuffer(BaseBuffer):
         self._client: Optional[Redis] = None
 
     def get_connection_pool(self):
-        return ConnectionPool.from_url(self._broker_url)
+        return ConnectionPool.from_url(self.broker_url)
 
     def get_or_create_connection_pool(self):
-        if self._broker_url not in self._pools:
-            self._pools[self._broker_url] = self.get_connection_pool()
-        return self._pools[self._broker_url]
+        if self.broker_url not in self._pools:
+            self._pools[self.broker_url] = self.get_connection_pool()
+        return self._pools[self.broker_url]
 
     def connect(self) -> Redis:
         pool = self.get_or_create_connection_pool()
@@ -83,28 +93,28 @@ class RedisBuffer(BaseBuffer):
         return self._client
 
     def _put_events(
-        self, key: str, events: List[bytes], client: Optional[Redis] = None
+        self, key: KEY_TYPE, events: List[bytes], client: Optional[Redis] = None
     ):
         if client is None:
             client = self.client
         client.lpush(key, *events)
-        client.ltrim(key, 0, max(0, self._max_size - 1))
+        client.ltrim(key, 0, max(0, self.max_size - 1))
 
-    def put_events(self, key: str, events: List[str], retry=False) -> int:
+    def put_events(self, key: KEY_TYPE, events: List[Any]) -> int:
         events_data = [self.encode(event) for event in events]
         with self.client.pipeline(transaction=False) as pipe:
             self._put_events(key, events_data, client=pipe)
             result = pipe.execute()
-        return max(0, result[0] - self._max_size)
+        return max(0, result[0] - self.max_size)
 
-    def put_event(self, key: str, event: str, retry=False):
-        return self.put_events(key, [event])
+    def put_event(self, key: KEY_TYPE, event: Any):
+        self.put_events(key, [event])
 
-    def put_events_multi_buffer(
-        self, events_dict: Dict[str, List[str]], retry=False
-    ) -> Dict[str, int]:
+    def put_multi_key_events(
+        self, events_dict: Dict[KEY_TYPE, List[Any]]
+    ) -> Dict[KEY_TYPE, int]:
         keys = list(events_dict.keys())
-        trimmed: Dict[str, int] = {}
+        trimmed: Dict[KEY_TYPE, int] = {}
         if not keys:
             return trimmed
         with self.client.pipeline(transaction=False) as pipe:
@@ -114,10 +124,10 @@ class RedisBuffer(BaseBuffer):
             result = pipe.execute()
         for key in keys:
             buffer_len, _ = result.pop(0), result.pop(0)
-            trimmed[key] = max(0, buffer_len - self._max_size)
+            trimmed[key] = max(0, buffer_len - self.max_size)
         return trimmed
 
-    def pop_events(self, key, batch_size=100) -> List[str]:
+    def _pop_events(self, key: KEY_TYPE, batch_size: int) -> List[Any]:
         events = []
         with self.client.pipeline(transaction=False) as pipe:
             for i in range(max(1, batch_size)):
@@ -129,11 +139,21 @@ class RedisBuffer(BaseBuffer):
             events.append(self.decode(elem))
         return events
 
-    def pop_event(self, key) -> Optional[str]:
-        events = self.pop_events(key, batch_size=1)
+    def pop_event(self, key: KEY_TYPE) -> Any:
+        events = self._pop_events(key, batch_size=1)
         return events[0] if events else None
 
-    def size(self, key: str) -> int:
+    def pop_events(self, key: KEY_TYPE) -> List[Any]:
+        return self._pop_events(key, self.batch_size)
+
+    def clear(self, key: KEY_TYPE) -> int:
+        with self.client.pipeline(transaction=False) as pipe:
+            pipe.llen(key)
+            pipe.delete(key)
+            result = pipe.execute()
+        return result[0]
+
+    def size(self, key: KEY_TYPE) -> int:
         return self.client.llen(key)
 
 
@@ -150,7 +170,7 @@ def get_buffer() -> BaseBuffer:
     except AttributeError:
         pass
     if not settings.OBSERVABILITY_BROKER_URL:
-        raise ConnectionDoesNotExist("The observability broker url not set")
+        raise ConnectionNotConfigured("The observability broker url not set")
     broker_url = settings.OBSERVABILITY_BROKER_URL
     max_size = settings.OBSERVABILITY_BUFFER_SIZE_LIMIT
     batch_size = settings.OBSERVABILITY_BUFFER_BATCH_SIZE

--- a/saleor/webhook/observability/exceptions.py
+++ b/saleor/webhook/observability/exceptions.py
@@ -6,9 +6,5 @@ class ConnectionNotConfigured(ObservabilityError):
     pass
 
 
-class ConnectionInterrupted(ObservabilityError):
-    pass
-
-
-class CompressorError(ObservabilityError):
+class TruncationError(ObservabilityError):
     pass

--- a/saleor/webhook/observability/exceptions.py
+++ b/saleor/webhook/observability/exceptions.py
@@ -1,0 +1,14 @@
+class ObservabilityError(Exception):
+    pass
+
+
+class ConnectionDoesNotExist(ObservabilityError):
+    pass
+
+
+class ConnectionInterrupted(ObservabilityError):
+    pass
+
+
+class CompressorError(ObservabilityError):
+    pass

--- a/saleor/webhook/observability/exceptions.py
+++ b/saleor/webhook/observability/exceptions.py
@@ -2,7 +2,7 @@ class ObservabilityError(Exception):
     pass
 
 
-class ConnectionDoesNotExist(ObservabilityError):
+class ConnectionNotConfigured(ObservabilityError):
     pass
 
 

--- a/saleor/webhook/observability/obfuscation.py
+++ b/saleor/webhook/observability/obfuscation.py
@@ -181,13 +181,13 @@ def anonymize_gql_operation_response(
 def anonymize_event_payload(
     subscription_query: Optional[str],
     event_type: str,  # pylint: disable=unused-argument
-    payload: List,
+    payload: Any,
     sensitive_fields: SensitiveFieldsMap,
-) -> List:
+) -> Any:
     if not subscription_query:
         return payload
     graphql_backend = get_default_backend()
     document = graphql_backend.document_from_string(schema, subscription_query)
     if _contain_sensitive_field(document, sensitive_fields):
-        return [MASK]
+        return MASK
     return payload

--- a/saleor/webhook/observability/obfuscation.py
+++ b/saleor/webhook/observability/obfuscation.py
@@ -1,0 +1,193 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union, cast
+
+from graphql import (
+    GraphQLError,
+    GraphQLInterfaceType,
+    GraphQLObjectType,
+    GraphQLSchema,
+    get_default_backend,
+    get_named_type,
+)
+from graphql.language.ast import (
+    Field,
+    FragmentDefinition,
+    FragmentSpread,
+    InlineFragment,
+    OperationDefinition,
+)
+from graphql.type import GraphQLField
+from graphql.validation import validate
+from graphql.validation.rules.base import ValidationRule
+from graphql.validation.validation import ValidationContext
+
+from ...graphql.api import schema
+from .sensitive_data import SENSITIVE_HEADERS, SensitiveFieldsMap
+
+if TYPE_CHECKING:
+    from graphql import GraphQLDocument
+
+    from .utils import GraphQLOperationResponse
+
+GraphQLNode = Union[
+    Field,
+    FragmentDefinition,
+    FragmentSpread,
+    InlineFragment,
+    OperationDefinition,
+]
+MASK = "***"
+
+
+def hide_sensitive_headers(
+    headers: Dict[str, str], sensitive_headers: Tuple[str, ...] = SENSITIVE_HEADERS
+) -> Dict[str, str]:
+    return {
+        key: val if key.upper().replace("-", "_") not in sensitive_headers else MASK
+        for key, val in headers.items()
+    }
+
+
+class SensitiveFieldError(GraphQLError):
+    pass
+
+
+class ContainSensitiveField(ValidationRule):
+    def __init__(
+        self, sensitive_fields: SensitiveFieldsMap
+    ):  # pylint: disable=super-init-not-called
+        self.sensitive_fields = sensitive_fields
+
+    def __call__(self, context: ValidationContext):
+        self.context = context
+        return self
+
+    def is_sensitive_field(self, node: Field, parent_type: str):
+        if fields := self.sensitive_fields.get(parent_type):
+            node_name = node.name.value
+            if node_name in fields:
+                raise SensitiveFieldError(
+                    "The query contains sensitive field "
+                    f"{node_name} of type {parent_type}."
+                )
+
+    def contain_sensitive_field(self, node: GraphQLNode, type_def) -> bool:
+        if isinstance(node, FragmentSpread) or not node.selection_set:
+            return False
+        fields: Dict[str, GraphQLField] = {}
+        if isinstance(type_def, (GraphQLObjectType, GraphQLInterfaceType)):
+            fields = type_def.fields
+        for child_node in node.selection_set.selections:
+            if isinstance(child_node, Field):
+                field = fields.get(child_node.name.value)
+                if not field:
+                    continue
+                field_type = get_named_type(field.type)
+                if type_def and type_def.name:
+                    self.is_sensitive_field(child_node, type_def.name)
+                self.contain_sensitive_field(child_node, field_type)
+            if isinstance(child_node, FragmentSpread):
+                fragment = self.context.get_fragment(child_node.name.value)
+                if fragment:
+                    fragment_type = self.context.get_schema().get_type(
+                        fragment.type_condition.name.value
+                    )
+                    self.contain_sensitive_field(fragment, fragment_type)
+            if isinstance(child_node, InlineFragment):
+                inline_fragment_type = type_def
+                if child_node.type_condition and child_node.type_condition.name:
+                    inline_fragment_type = self.context.get_schema().get_type(
+                        child_node.type_condition.name.value
+                    )
+                self.contain_sensitive_field(child_node, inline_fragment_type)
+        return False
+
+    def enter_operation_definition(
+        self, node, key, parent, path, ancestors
+    ):  # pylint: disable=unused-argument
+        validate_sensitive_fields_map(self.sensitive_fields, self.context.get_schema())
+        if node.operation == "query":
+            self.contain_sensitive_field(
+                node, self.context.get_schema().get_query_type()
+            )
+        elif node.operation == "mutation":
+            self.contain_sensitive_field(
+                node, self.context.get_schema().get_mutation_type()
+            )
+        elif node.operation == "subscription":
+            self.contain_sensitive_field(
+                node, self.context.get_schema().get_subscription_type()
+            )
+
+    def enter(
+        self,
+        node: Any,
+        key: Optional[Union[int, str]],
+        parent: Any,
+        path: List[Union[int, str]],
+        ancestors: List[Any],
+    ):
+        if isinstance(node, OperationDefinition):
+            self.enter_operation_definition(node, key, parent, path, ancestors)
+
+
+def validate_sensitive_fields_map(
+    sensitive_fields: SensitiveFieldsMap, schema: GraphQLSchema
+):
+    type_map = schema.get_type_map()
+    for type_name, type_fields in sensitive_fields.items():
+        if type_name not in type_map:
+            raise GraphQLError(
+                "The query anonymization could not be performed "
+                f"because a type {type_name} that is not defined "
+                "is specified as sensitive."
+            )
+        if not isinstance(type_map[type_name], GraphQLObjectType):
+            raise GraphQLError(
+                "The query anonymization could not be performed because a type "
+                f"{type_name} specified as sensitive is not an object type."
+            )
+        for field_name in type_fields:
+            graphql_type = cast(GraphQLObjectType, type_map[type_name])
+            if field_name not in graphql_type.fields:
+                raise GraphQLError(
+                    "The query anonymization could not be performed because a field "
+                    f"{field_name} specified as sensitive is not "
+                    f"defined by the {type_name} type."
+                )
+
+
+def _contain_sensitive_field(
+    document: "GraphQLDocument", sensitive_fields: SensitiveFieldsMap
+):
+    validator = cast(
+        Type[ValidationRule], ContainSensitiveField(sensitive_fields=sensitive_fields)
+    )
+    try:
+        validate(document.schema, document.document_ast, [validator])
+    except SensitiveFieldError:
+        return True
+    return False
+
+
+def anonymize_gql_operation_response(
+    operation: "GraphQLOperationResponse", sensitive_fields: SensitiveFieldsMap
+):
+    if not operation.query or not operation.result:
+        return
+    if _contain_sensitive_field(operation.query, sensitive_fields):
+        operation.result["data"] = MASK
+
+
+def anonymize_event_payload(
+    subscription_query: Optional[str],
+    event_type: str,  # pylint: disable=unused-argument
+    payload: List,
+    sensitive_fields: SensitiveFieldsMap,
+) -> List:
+    if not subscription_query:
+        return payload
+    graphql_backend = get_default_backend()
+    document = graphql_backend.document_from_string(schema, subscription_query)
+    if _contain_sensitive_field(document, sensitive_fields):
+        return [MASK]
+    return payload

--- a/saleor/webhook/observability/payload_schema.py
+++ b/saleor/webhook/observability/payload_schema.py
@@ -11,7 +11,7 @@ class JsonTruncText:
         self._added_bytes = max(0, added_bytes)
 
     def __eq__(self, other):
-        if not isinstance(self, JsonTruncText):
+        if not isinstance(other, JsonTruncText):
             return False
         return (self.text, self.truncated) == (other.text, other.truncated)
 

--- a/saleor/webhook/observability/payload_schema.py
+++ b/saleor/webhook/observability/payload_schema.py
@@ -1,0 +1,151 @@
+from datetime import datetime
+from enum import Enum
+from json.encoder import ESCAPE_ASCII, ESCAPE_DCT  # type: ignore
+from typing import List, Optional, Tuple, TypedDict
+
+
+class JsonTruncText:
+    def __init__(self, text="", truncated=False, added_bytes=0):
+        self.text = text
+        self.truncated = truncated
+        self._added_bytes = max(0, added_bytes)
+
+    def __eq__(self, other):
+        if not isinstance(self, JsonTruncText):
+            return False
+        return (self.text, self.truncated) == (other.text, other.truncated)
+
+    def __repr__(self):
+        return f'JsonTruncText(text="{self.text}", truncated={self.truncated})'
+
+    @property
+    def byte_size(self) -> int:
+        return len(self.text) + self._added_bytes
+
+    @staticmethod
+    def json_char_len(char: str) -> int:
+        try:
+            return len(ESCAPE_DCT[char])
+        except KeyError:
+            return 6 if ord(char) < 0x10000 else 12
+
+    @classmethod
+    def truncate(cls, s: str, limit: int):
+        limit = max(limit, 0)
+        s_init_len = len(s)
+        s = s[:limit]
+        added_bytes = 0
+
+        for match in ESCAPE_ASCII.finditer(s):
+            start, end = match.span(0)
+            markup = cls.json_char_len(match.group(0)) - 1
+            added_bytes += markup
+            if end + added_bytes > limit:
+                return cls(
+                    text=s[:start],
+                    truncated=True,
+                    added_bytes=added_bytes - markup,
+                )
+            if end + added_bytes == limit:
+                s = s[:end]
+                return cls(
+                    text=s,
+                    truncated=len(s) < s_init_len,
+                    added_bytes=added_bytes,
+                )
+        return cls(
+            text=s,
+            truncated=len(s) < s_init_len,
+            added_bytes=added_bytes,
+        )
+
+
+class ObservabilityEventTypes(str, Enum):
+    API_CALL = "api_call"
+    EVENT_DELIVERY_ATTEMPT = "event_delivery_attempt"
+
+
+HttpHeaders = List[Tuple[str, str]]
+
+
+class App(TypedDict):
+    id: str
+    name: str
+
+
+class Webhook(TypedDict):
+    id: str
+    name: str
+    target_url: str
+    subscription_query: Optional[JsonTruncText]
+
+
+class ObservabilityEventBase(TypedDict):
+    event_type: ObservabilityEventTypes
+
+
+class GraphQLOperation(TypedDict):
+    name: Optional[JsonTruncText]
+    operation_type: Optional[str]
+    query: Optional[JsonTruncText]
+    result: Optional[JsonTruncText]
+    result_invalid: bool
+
+
+class ApiCallRequest(TypedDict):
+    id: str
+    method: str
+    url: str
+    time: float
+    headers: HttpHeaders
+    content_length: int
+
+
+class ApiCallResponse(TypedDict):
+    headers: HttpHeaders
+    status_code: Optional[int]
+    content_length: int
+
+
+class ApiCallPayload(ObservabilityEventBase):
+    request: ApiCallRequest
+    response: ApiCallResponse
+    app: Optional[App]
+    gql_operations: List[GraphQLOperation]
+
+
+class EventDeliveryPayload(TypedDict):
+    content_length: int
+    body: JsonTruncText
+
+
+class EventDelivery(TypedDict):
+    id: str
+    status: str
+    event_type: str
+    event_sync: bool
+    payload: EventDeliveryPayload
+
+
+class EventDeliveryAttemptRequest(TypedDict):
+    headers: HttpHeaders
+
+
+class EventDeliveryAttemptResponse(TypedDict):
+    headers: HttpHeaders
+    status_code: Optional[int]
+    content_length: int
+    body: JsonTruncText
+
+
+class EventDeliveryAttemptPayload(ObservabilityEventBase):
+    id: str
+    time: datetime
+    duration: Optional[float]
+    status: str
+    next_retry: Optional[datetime]
+    request: EventDeliveryAttemptRequest
+    response: EventDeliveryAttemptResponse
+    event_delivery: EventDelivery
+    webhook: Webhook
+    app: App

--- a/saleor/webhook/observability/payloads.py
+++ b/saleor/webhook/observability/payloads.py
@@ -2,23 +2,38 @@ import json
 import uuid
 from collections.abc import Mapping
 from datetime import datetime
-from enum import Enum
-from json.encoder import ESCAPE_ASCII, ESCAPE_DCT  # type: ignore
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import graphene
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
-from graphene.utils.str_converters import to_camel_case
+from graphene.utils.str_converters import to_camel_case as str_to_camel_case
 from graphql import get_operation_ast
 
 from .. import traced_payload_generator
 from ..event_types import WebhookEventSyncType
+from .exceptions import TruncationError
 from .obfuscation import (
     anonymize_event_payload,
     anonymize_gql_operation_response,
     hide_sensitive_headers,
+)
+from .payload_schema import (
+    ApiCallPayload,
+    ApiCallRequest,
+    ApiCallResponse,
+    App,
+    EventDelivery,
+    EventDeliveryAttemptPayload,
+    EventDeliveryAttemptRequest,
+    EventDeliveryAttemptResponse,
+    EventDeliveryPayload,
+    GraphQLOperation,
+    HttpHeaders,
+    JsonTruncText,
+    ObservabilityEventTypes,
+    Webhook,
 )
 from .sensitive_data import SENSITIVE_GQL_FIELDS
 
@@ -34,184 +49,49 @@ class CustomJsonEncoder(DjangoJSONEncoder):
         return super().default(o)
 
 
-class JsonTruncText:
-    def __init__(self, text="", truncated=False, added_bytes=0):
-        self.text = text
-        self.truncated = truncated
-        self._added_bytes = max(0, added_bytes)
-
-    def __eq__(self, other):
-        if not isinstance(self, JsonTruncText):
-            return False
-        return (self.text, self.truncated) == (other.text, other.truncated)
-
-    def __repr__(self):
-        return f'JsonTruncText(text="{self.text}", truncated={self.truncated})'
-
-    @property
-    def byte_size(self) -> int:
-        return len(self.text) + self._added_bytes
-
-    @staticmethod
-    def json_char_len(char: str) -> int:
-        try:
-            return len(ESCAPE_DCT[char])
-        except KeyError:
-            return 6 if ord(char) < 0x10000 else 12
-
-    @classmethod
-    def truncate(cls, s: str, limit: int):
-        limit = max(limit, 0)
-        s_init_len = len(s)
-        s = s[:limit]
-        added_bytes = 0
-
-        for match in ESCAPE_ASCII.finditer(s):
-            start, end = match.span(0)
-            markup = cls.json_char_len(match.group(0)) - 1
-            added_bytes += markup
-            if end + added_bytes > limit:
-                return cls(
-                    text=s[:start],
-                    truncated=True,
-                    added_bytes=added_bytes - markup,
-                )
-            if end + added_bytes == limit:
-                s = s[:end]
-                return cls(
-                    text=s,
-                    truncated=len(s) < s_init_len,
-                    added_bytes=added_bytes,
-                )
-        return cls(
-            text=s,
-            truncated=len(s) < s_init_len,
-            added_bytes=added_bytes,
-        )
+def to_camel_case(obj: Any) -> Any:
+    if isinstance(obj, Mapping):
+        data = {}
+        for k, v in obj.items():
+            data[str_to_camel_case(k)] = to_camel_case(v)
+        return data
+    if isinstance(obj, list):
+        return [to_camel_case(i) for i in obj]
+    return obj
 
 
-class ObservabilityEventTypes(str, Enum):
-    API_CALL = "observability_api_call"
-    EVENT_DELIVERY_ATTEMPT = "observability_event_delivery_attempt"
+def pretty_json(obj: Any) -> str:
+    return json.dumps(obj, indent=2, ensure_ascii=True)
 
 
-class ObservabilityEventPayload(TypedDict):
-    event_type: ObservabilityEventTypes
-
-
-class GraphQLOperationPayload(TypedDict):
-    name: Optional[JsonTruncText]
-    operation_type: Optional[str]
-    query: Optional[JsonTruncText]
-    result: Optional[JsonTruncText]
-    result_invalid: bool
-
-
-class RequestPayload(TypedDict):
-    id: str
-    method: str
-    url: str
-    time: float
-    headers: Dict[str, str]
-    content_length: int
-
-
-class ResponsePayload(TypedDict):
-    headers: Dict[str, str]
-    status_code: Optional[int]
-    content_length: int
-
-
-class AppPayload(TypedDict):
-    id: str
-    name: str
-
-
-class GraphQLOperationsPayload(TypedDict):
-    count: int
-    operations: List[GraphQLOperationPayload]
-
-
-class ApiCallPayload(ObservabilityEventPayload):
-    request: RequestPayload
-    response: ResponsePayload
-    app: Optional[AppPayload]
-    gql_operations: GraphQLOperationsPayload
-
-
-class EventDeliveryDataPayload(TypedDict):
-    content_length: int
-    body: JsonTruncText
-
-
-class EventDeliveryPayload(TypedDict):
-    id: str
-    status: str
-    event_type: str
-    event_sync: bool
-    payload: EventDeliveryDataPayload
-
-
-class WebhookPayload(TypedDict):
-    id: str
-    name: str
-    target_url: str
-    subscription_query: Optional[JsonTruncText]
-
-
-class AttemptPayload(TypedDict):
-    id: str
-    time: datetime
-    duration: Optional[float]
-    status: str
-    next_retry: Optional[datetime]
-
-
-class RequestHeadersPayload(TypedDict):
-    headers: Dict[str, str]
-
-
-class ResponseWithBodyPayload(ResponsePayload):
-    body: JsonTruncText
-
-
-class EventDeliveryAttemptPayload(ObservabilityEventPayload):
-    event_delivery_attempt: AttemptPayload
-    request: RequestHeadersPayload
-    response: ResponseWithBodyPayload
-    event_delivery: EventDeliveryPayload
-    webhook: WebhookPayload
-    app: AppPayload
-
-
-def _json_serialize(obj: Any, pretty=False):
-    if pretty:
-        return json.dumps(obj, indent=2, ensure_ascii=True, cls=CustomJsonEncoder)
-    return json.dumps(obj, ensure_ascii=True, cls=CustomJsonEncoder)
+def dump_payload(payload: Any) -> str:
+    return json.dumps(to_camel_case(payload), ensure_ascii=True, cls=CustomJsonEncoder)
 
 
 TRUNC_PLACEHOLDER = JsonTruncText(truncated=False)
 EMPTY_TRUNC = JsonTruncText(truncated=True)
-
-
-GQL_OPERATION_PLACEHOLDER = GraphQLOperationPayload(
+GQL_OPERATION_PLACEHOLDER = GraphQLOperation(
     name=TRUNC_PLACEHOLDER,
     operation_type="subscription",
     query=TRUNC_PLACEHOLDER,
     result=TRUNC_PLACEHOLDER,
     result_invalid=False,
 )
-GQL_OPERATION_PLACEHOLDER_SIZE = len(_json_serialize(GQL_OPERATION_PLACEHOLDER))
+GQL_OPERATION_PLACEHOLDER_SIZE = len(dump_payload(GQL_OPERATION_PLACEHOLDER))
+
+
+def serialize_headers(headers: Dict[str, str]) -> HttpHeaders:
+    return [(k, v) for k, v in hide_sensitive_headers(headers).items()]
 
 
 def serialize_gql_operation_result(
     operation: "GraphQLOperationResponse", bytes_limit: int
-) -> Tuple[GraphQLOperationPayload, int]:
+) -> Tuple[GraphQLOperation, int]:
     bytes_limit -= GQL_OPERATION_PLACEHOLDER_SIZE
     if bytes_limit < 0:
-        raise ValueError()
+        raise TruncationError()
     anonymize_gql_operation_response(operation, SENSITIVE_GQL_FIELDS)
-    payload = GraphQLOperationPayload(
+    payload = GraphQLOperation(
         name=None,
         operation_type=None,
         query=None,
@@ -219,31 +99,32 @@ def serialize_gql_operation_result(
         result_invalid=operation.result_invalid,
     )
     if operation.name:
-        payload["name"] = JsonTruncText.truncate(operation.name, bytes_limit // 3)
-        bytes_limit -= cast(JsonTruncText, payload["name"]).byte_size
+        name = JsonTruncText.truncate(operation.name, bytes_limit)
+        bytes_limit -= name.byte_size
+        payload["name"] = name
     if operation.query:
-        payload["query"] = JsonTruncText.truncate(
+        query = JsonTruncText.truncate(
             operation.query.document_string, bytes_limit // 2
         )
-        bytes_limit -= cast(JsonTruncText, payload["query"]).byte_size
+        bytes_limit -= query.byte_size
+        payload["query"] = query
         if definition := get_operation_ast(
             operation.query.document_ast, operation.name
         ):
             payload["operation_type"] = definition.operation
     if operation.result:
-        payload["result"] = JsonTruncText.truncate(
-            _json_serialize(operation.result, pretty=True), bytes_limit
-        )
-        bytes_limit -= cast(JsonTruncText, payload["result"]).byte_size
+        result = JsonTruncText.truncate(pretty_json(operation.result), bytes_limit)
+        bytes_limit -= result.byte_size
+        payload["result"] = result
     return payload, max(0, bytes_limit)
 
 
 def serialize_gql_operation_results(
     operations: List["GraphQLOperationResponse"], bytes_limit: int
-) -> List[GraphQLOperationPayload]:
+) -> List[GraphQLOperation]:
     if bytes_limit - len(operations) * GQL_OPERATION_PLACEHOLDER_SIZE < 0:
-        raise ValueError()
-    payloads: List[GraphQLOperationPayload] = []
+        raise TruncationError()
+    payloads: List[GraphQLOperation] = []
     for i, operation in enumerate(operations):
         payload_limit = bytes_limit // (len(operations) - i)
         payload, left_bytes = serialize_gql_operation_result(operation, payload_limit)
@@ -252,61 +133,43 @@ def serialize_gql_operation_results(
     return payloads
 
 
-def payload_to_camel_case(d: Mapping) -> Dict:
-    data = {}
-    for k, v in d.items():
-        if isinstance(v, Mapping):
-            v = payload_to_camel_case(v)
-        elif isinstance(v, list):
-            v = [payload_to_camel_case(i) for i in v]
-        new_key = to_camel_case(k)
-        data[new_key] = v
-    return data
-
-
 @traced_payload_generator
 def generate_api_call_payload(
     request: HttpRequest,
     response: HttpResponse,
     gql_operations: List["GraphQLOperationResponse"],
     bytes_limit: int,
-) -> str:
+) -> ApiCallPayload:
     payload = ApiCallPayload(
         event_type=ObservabilityEventTypes.API_CALL,
-        request=RequestPayload(
+        request=ApiCallRequest(
             id=str(uuid.uuid4()),
             method=request.method or "",
             url=request.build_absolute_uri(request.get_full_path()),
             time=getattr(request, "request_time", timezone.now()).timestamp(),
-            headers=hide_sensitive_headers(dict(request.headers)),
+            headers=serialize_headers(dict(request.headers)),
             content_length=int(request.headers.get("Content-Length") or 0),
         ),
-        response=ResponsePayload(
-            headers=hide_sensitive_headers(dict(response.headers)),
+        response=ApiCallResponse(
+            headers=serialize_headers(dict(response.headers)),
             status_code=response.status_code,
             content_length=len(response.content),
         ),
         app=None,
-        gql_operations=GraphQLOperationsPayload(
-            count=len(gql_operations), operations=[]
-        ),
+        gql_operations=[],
     )
     if app := getattr(request, "app", None):
-        payload["app"] = AppPayload(
+        payload["app"] = App(
             id=graphene.Node.to_global_id("App", app.id),
             name=app.name,
         )
-    initial_dump = _json_serialize(payload)
-    remaining_bytes = bytes_limit - len(initial_dump)
+    remaining_bytes = bytes_limit - len(dump_payload(payload))
     if remaining_bytes < 0:
-        raise ValueError(f"Payload too big. Can't truncate to {bytes_limit}")
-    try:
-        payload["gql_operations"]["operations"] = serialize_gql_operation_results(
-            gql_operations, remaining_bytes
-        )
-    except ValueError:
-        pass
-    return _json_serialize(payload_to_camel_case(payload))
+        raise TruncationError()
+    payload["gql_operations"] = serialize_gql_operation_results(
+        gql_operations, remaining_bytes
+    )
+    return payload
 
 
 @traced_payload_generator
@@ -314,82 +177,77 @@ def generate_event_delivery_attempt_payload(
     attempt: "EventDeliveryAttempt",
     next_retry: Optional["datetime"],
     bytes_limit: int,
-) -> str:
+) -> EventDeliveryAttemptPayload:
     if not attempt.delivery:
         raise ValueError(
             f"EventDeliveryAttempt {attempt.id} is not assigned to delivery."
             "Can't generate payload."
         )
-    if not attempt.delivery.payload or not attempt.delivery.webhook:
+    if not attempt.delivery.payload:
         raise ValueError(
             f"EventDelivery {attempt.delivery.id} do not have "
-            "payload or webhook set. Can't generate payload."
+            "payload set. Can't generate payload."
         )
     response_body = attempt.response or ""
-    data = EventDeliveryAttemptPayload(
+    payload = EventDeliveryAttemptPayload(
+        id=graphene.Node.to_global_id("EventDeliveryAttempt", attempt.pk),
         event_type=ObservabilityEventTypes.EVENT_DELIVERY_ATTEMPT,
-        event_delivery_attempt=AttemptPayload(
-            id=graphene.Node.to_global_id("EventDeliveryAttempt", attempt.pk),
-            time=attempt.created_at,
-            duration=attempt.duration,
-            status=attempt.status,
-            next_retry=next_retry,
+        time=attempt.created_at,
+        duration=attempt.duration,
+        status=attempt.status,
+        next_retry=next_retry,
+        request=EventDeliveryAttemptRequest(
+            headers=serialize_headers(json.loads(attempt.request_headers or "{}")),
         ),
-        request=RequestHeadersPayload(
-            headers=json.loads(attempt.request_headers or "{}")
-        ),
-        response=ResponseWithBodyPayload(
-            headers=json.loads(attempt.response_headers or "{}"),
+        response=EventDeliveryAttemptResponse(
+            headers=serialize_headers(json.loads(attempt.response_headers or "{}")),
             content_length=len(response_body.encode("utf-8")),
             body=TRUNC_PLACEHOLDER,
             status_code=attempt.response_status_code,
         ),
-        event_delivery=EventDeliveryPayload(
+        event_delivery=EventDelivery(
             id=graphene.Node.to_global_id("EventDelivery", attempt.delivery.pk),
             status=attempt.delivery.status,
             event_type=attempt.delivery.event_type,
             event_sync=attempt.delivery.event_type in WebhookEventSyncType.ALL,
-            payload=EventDeliveryDataPayload(
-                content_length=len(attempt.delivery.payload.payload),
+            payload=EventDeliveryPayload(
+                content_length=len(attempt.delivery.payload.payload.encode("utf-8")),
                 body=TRUNC_PLACEHOLDER,
             ),
         ),
-        webhook=WebhookPayload(
+        webhook=Webhook(
             id=graphene.Node.to_global_id("Webhook", attempt.delivery.webhook.pk),
             name=attempt.delivery.webhook.name or "",
             target_url=attempt.delivery.webhook.target_url,
             subscription_query=TRUNC_PLACEHOLDER,
         ),
-        app=AppPayload(
+        app=App(
             id=graphene.Node.to_global_id("App", attempt.delivery.webhook.app.pk),
             name=attempt.delivery.webhook.app.name,
         ),
     )
-    initial_dump = _json_serialize(data)
-    remaining_bytes = bytes_limit - len(initial_dump)
-    if remaining_bytes < 0:
-        raise ValueError(f"Payload too big. Can't truncate to {bytes_limit}")
-    trunc_resp_body = JsonTruncText.truncate(response_body, remaining_bytes // 3)
-    remaining_bytes -= trunc_resp_body.byte_size
-    data["response"]["body"] = trunc_resp_body
+    if (remaining := bytes_limit - len(dump_payload(payload))) < 0:
+        raise TruncationError()
 
     subscription_query = attempt.delivery.webhook.subscription_query
-    data["webhook"]["subscription_query"] = None
     if subscription_query:
-        trunc_subscription_query = JsonTruncText.truncate(
-            subscription_query, remaining_bytes // 2
-        )
-        remaining_bytes -= trunc_subscription_query.byte_size
-        data["webhook"]["subscription_query"] = trunc_subscription_query
+        trunc_sub_query = JsonTruncText.truncate(subscription_query, remaining // 4)
+        remaining -= trunc_sub_query.byte_size
+        payload["webhook"]["subscription_query"] = trunc_sub_query
+    else:
+        payload["webhook"]["subscription_query"] = None
 
-    payload = anonymize_event_payload(
+    payload["response"]["body"] = JsonTruncText.truncate(response_body, remaining // 2)
+    remaining -= payload["response"]["body"].byte_size
+
+    event_delivery_payload = json.loads(attempt.delivery.payload.payload)
+    event_delivery_payload = anonymize_event_payload(
         subscription_query,
         attempt.delivery.event_type,
-        cast(List, json.loads(attempt.delivery.payload.payload)),
+        event_delivery_payload,
         SENSITIVE_GQL_FIELDS,
     )
-    trunc_payload = JsonTruncText.truncate(
-        _json_serialize(payload, True), remaining_bytes
+    payload["event_delivery"]["payload"]["body"] = JsonTruncText.truncate(
+        pretty_json(event_delivery_payload), remaining
     )
-    data["event_delivery"]["payload"]["body"] = trunc_payload
-    return _json_serialize(payload_to_camel_case(data))
+    return payload

--- a/saleor/webhook/observability/payloads.py
+++ b/saleor/webhook/observability/payloads.py
@@ -1,0 +1,381 @@
+import json
+import uuid
+from datetime import datetime
+from enum import Enum
+from json.encoder import ESCAPE_ASCII, ESCAPE_DCT  # type: ignore
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypedDict, cast
+
+import graphene
+from django.core.serializers.json import DjangoJSONEncoder
+from django.http import HttpRequest, HttpResponse
+from django.utils import timezone
+from graphql import get_operation_ast
+
+from .. import traced_payload_generator
+from ..event_types import WebhookEventSyncType
+from .obfuscation import (
+    anonymize_event_payload,
+    anonymize_gql_operation_response,
+    hide_sensitive_headers,
+)
+from .sensitive_data import SENSITIVE_GQL_FIELDS
+
+if TYPE_CHECKING:
+    from ...core.models import EventDeliveryAttempt
+    from .utils import GraphQLOperationResponse
+
+
+class CustomJsonEncoder(DjangoJSONEncoder):
+    def default(self, o):
+        if isinstance(o, JsonTruncText):
+            return {"text": o.text, "truncated": o.truncated}
+        return super().default(o)
+
+
+class JsonTruncText:
+    def __init__(self, text="", truncated=False, added_bytes=0):
+        self.text = text
+        self.truncated = truncated
+        self._added_bytes = max(0, added_bytes)
+
+    def __eq__(self, other):
+        if not isinstance(self, JsonTruncText):
+            return False
+        return (self.text, self.truncated) == (other.text, other.truncated)
+
+    def __repr__(self):
+        return f'JsonTruncText(text="{self.text}", truncated={self.truncated})'
+
+    @property
+    def byte_size(self) -> int:
+        return len(self.text) + self._added_bytes
+
+    @staticmethod
+    def json_char_len(char: str) -> int:
+        try:
+            return len(ESCAPE_DCT[char])
+        except KeyError:
+            return 6 if ord(char) < 0x10000 else 12
+
+    @classmethod
+    def truncate(cls, s: str, limit: int):
+        limit = max(limit, 0)
+        s_init_len = len(s)
+        s = s[:limit]
+        added_bytes = 0
+
+        for match in ESCAPE_ASCII.finditer(s):
+            start, end = match.span(0)
+            markup = cls.json_char_len(match.group(0)) - 1
+            added_bytes += markup
+            if end + added_bytes > limit:
+                return cls(
+                    text=s[:start],
+                    truncated=True,
+                    added_bytes=added_bytes - markup,
+                )
+            if end + added_bytes == limit:
+                s = s[:end]
+                return cls(
+                    text=s,
+                    truncated=len(s) < s_init_len,
+                    added_bytes=added_bytes,
+                )
+        return cls(
+            text=s,
+            truncated=len(s) < s_init_len,
+            added_bytes=added_bytes,
+        )
+
+
+class ObservabilityEventTypes(str, Enum):
+    API_CALL = "observability_api_call"
+    EVENT_DELIVERY_ATTEMPT = "observability_event_delivery_attempt"
+
+
+class ObservabilityEventPayload(TypedDict):
+    event_type: ObservabilityEventTypes
+
+
+class GraphQLOperationPayload(TypedDict):
+    name: Optional[JsonTruncText]
+    operation_type: Optional[str]
+    query: Optional[JsonTruncText]
+    result: Optional[JsonTruncText]
+    result_invalid: bool
+
+
+class RequestPayload(TypedDict):
+    id: str
+    method: str
+    url: str
+    time: float
+    headers: Dict[str, str]
+    content_length: int
+
+
+class ResponsePayload(TypedDict):
+    headers: Dict[str, str]
+    status_code: Optional[int]
+    content_length: int
+
+
+class AppPayload(TypedDict):
+    id: str
+    name: str
+
+
+class GraphQLOperationsPayload(TypedDict):
+    count: int
+    operations: List[GraphQLOperationPayload]
+
+
+class ApiCallPayload(ObservabilityEventPayload):
+    request: RequestPayload
+    response: ResponsePayload
+    app: Optional[AppPayload]
+    gql_operations: GraphQLOperationsPayload
+
+
+class EventDeliveryDataPayload(TypedDict):
+    content_length: int
+    body: JsonTruncText
+
+
+class EventDeliveryPayload(TypedDict):
+    id: str
+    status: str
+    event_type: str
+    event_sync: bool
+    payload: EventDeliveryDataPayload
+
+
+class WebhookPayload(TypedDict):
+    id: str
+    name: str
+    target_url: str
+    subscription_query: Optional[JsonTruncText]
+
+
+class AttemptPayload(TypedDict):
+    id: str
+    time: datetime
+    duration: Optional[float]
+    status: str
+    next_retry: Optional[datetime]
+
+
+class RequestHeadersPayload(TypedDict):
+    headers: Dict[str, str]
+
+
+class ResponseWithBodyPayload(ResponsePayload):
+    body: JsonTruncText
+
+
+class EventDeliveryAttemptPayload(ObservabilityEventPayload):
+    event_delivery_attempt: AttemptPayload
+    request: RequestHeadersPayload
+    response: ResponseWithBodyPayload
+    event_delivery: EventDeliveryPayload
+    webhook: WebhookPayload
+    app: AppPayload
+
+
+def _json_serialize(obj: Any, pretty=False):
+    if pretty:
+        return json.dumps(obj, indent=2, ensure_ascii=True, cls=CustomJsonEncoder)
+    return json.dumps(obj, ensure_ascii=True, cls=CustomJsonEncoder)
+
+
+TRUNC_PLACEHOLDER = JsonTruncText(truncated=False)
+EMPTY_TRUNC = JsonTruncText(truncated=True)
+
+
+GQL_OPERATION_PLACEHOLDER = GraphQLOperationPayload(
+    name=TRUNC_PLACEHOLDER,
+    operation_type="subscription",
+    query=TRUNC_PLACEHOLDER,
+    result=TRUNC_PLACEHOLDER,
+    result_invalid=False,
+)
+GQL_OPERATION_PLACEHOLDER_SIZE = len(_json_serialize(GQL_OPERATION_PLACEHOLDER))
+
+
+def serialize_gql_operation_result(
+    operation: "GraphQLOperationResponse", bytes_limit: int
+) -> Tuple[GraphQLOperationPayload, int]:
+    bytes_limit -= GQL_OPERATION_PLACEHOLDER_SIZE
+    if bytes_limit < 0:
+        raise ValueError()
+    anonymize_gql_operation_response(operation, SENSITIVE_GQL_FIELDS)
+    payload = GraphQLOperationPayload(
+        name=None,
+        operation_type=None,
+        query=None,
+        result=None,
+        result_invalid=operation.result_invalid,
+    )
+    if operation.name:
+        payload["name"] = JsonTruncText.truncate(operation.name, bytes_limit // 3)
+        bytes_limit -= cast(JsonTruncText, payload["name"]).byte_size
+    if operation.query:
+        payload["query"] = JsonTruncText.truncate(
+            operation.query.document_string, bytes_limit // 2
+        )
+        bytes_limit -= cast(JsonTruncText, payload["query"]).byte_size
+        if definition := get_operation_ast(
+            operation.query.document_ast, operation.name
+        ):
+            payload["operation_type"] = definition.operation
+    if operation.result:
+        payload["result"] = JsonTruncText.truncate(
+            _json_serialize(operation.result, pretty=True), bytes_limit
+        )
+        bytes_limit -= cast(JsonTruncText, payload["result"]).byte_size
+    return payload, max(0, bytes_limit)
+
+
+def serialize_gql_operation_results(
+    operations: List["GraphQLOperationResponse"], bytes_limit: int
+) -> List[GraphQLOperationPayload]:
+    if bytes_limit - len(operations) * GQL_OPERATION_PLACEHOLDER_SIZE < 0:
+        raise ValueError()
+    payloads: List[GraphQLOperationPayload] = []
+    for i, operation in enumerate(operations):
+        payload_limit = bytes_limit // (len(operations) - i)
+        payload, left_bytes = serialize_gql_operation_result(operation, payload_limit)
+        payloads.append(payload)
+        bytes_limit -= payload_limit - left_bytes
+    return payloads
+
+
+@traced_payload_generator
+def generate_api_call_payload(
+    request: HttpRequest,
+    response: HttpResponse,
+    gql_operations: List["GraphQLOperationResponse"],
+    bytes_limit: int,
+) -> str:
+    payload = ApiCallPayload(
+        event_type=ObservabilityEventTypes.API_CALL,
+        request=RequestPayload(
+            id=str(uuid.uuid4()),
+            method=request.method or "",
+            url=request.build_absolute_uri(request.get_full_path()),
+            time=getattr(request, "request_time", timezone.now()).timestamp(),
+            headers=hide_sensitive_headers(dict(request.headers)),
+            content_length=int(request.headers.get("Content-Length") or 0),
+        ),
+        response=ResponsePayload(
+            headers=hide_sensitive_headers(dict(response.headers)),
+            status_code=response.status_code,
+            content_length=len(response.content),
+        ),
+        app=None,
+        gql_operations=GraphQLOperationsPayload(
+            count=len(gql_operations), operations=[]
+        ),
+    )
+    if app := getattr(request, "app", None):
+        payload["app"] = AppPayload(
+            id=graphene.Node.to_global_id("App", app.id),
+            name=app.name,
+        )
+    initial_dump = _json_serialize(payload)
+    remaining_bytes = bytes_limit - len(initial_dump)
+    if remaining_bytes < 0:
+        raise ValueError(f"Payload too big. Can't truncate to {bytes_limit}")
+    try:
+        payload["gql_operations"]["operations"] = serialize_gql_operation_results(
+            gql_operations, remaining_bytes
+        )
+    except ValueError:
+        pass
+    return _json_serialize(payload)
+
+
+@traced_payload_generator
+def generate_event_delivery_attempt_payload(
+    attempt: "EventDeliveryAttempt",
+    next_retry: Optional["datetime"],
+    bytes_limit: int,
+) -> str:
+    if not attempt.delivery:
+        raise ValueError(
+            f"EventDeliveryAttempt {attempt.id} is not assigned to delivery."
+            "Can't generate payload."
+        )
+    if not attempt.delivery.payload or not attempt.delivery.webhook:
+        raise ValueError(
+            f"EventDelivery {attempt.delivery.id} do not have "
+            "payload or webhook set. Can't generate payload."
+        )
+    response_body = attempt.response or ""
+    data = EventDeliveryAttemptPayload(
+        event_type=ObservabilityEventTypes.EVENT_DELIVERY_ATTEMPT,
+        event_delivery_attempt=AttemptPayload(
+            id=graphene.Node.to_global_id("EventDeliveryAttempt", attempt.pk),
+            time=attempt.created_at,
+            duration=attempt.duration,
+            status=attempt.status,
+            next_retry=next_retry,
+        ),
+        request=RequestHeadersPayload(
+            headers=json.loads(attempt.request_headers or "{}")
+        ),
+        response=ResponseWithBodyPayload(
+            headers=json.loads(attempt.response_headers or "{}"),
+            content_length=len(response_body.encode("utf-8")),
+            body=TRUNC_PLACEHOLDER,
+            status_code=attempt.response_status_code,
+        ),
+        event_delivery=EventDeliveryPayload(
+            id=graphene.Node.to_global_id("EventDelivery", attempt.delivery.pk),
+            status=attempt.delivery.status,
+            event_type=attempt.delivery.event_type,
+            event_sync=attempt.delivery.event_type in WebhookEventSyncType.ALL,
+            payload=EventDeliveryDataPayload(
+                content_length=len(attempt.delivery.payload.payload),
+                body=TRUNC_PLACEHOLDER,
+            ),
+        ),
+        webhook=WebhookPayload(
+            id=graphene.Node.to_global_id("Webhook", attempt.delivery.webhook.pk),
+            name=attempt.delivery.webhook.name or "",
+            target_url=attempt.delivery.webhook.target_url,
+            subscription_query=TRUNC_PLACEHOLDER,
+        ),
+        app=AppPayload(
+            id=graphene.Node.to_global_id("App", attempt.delivery.webhook.app.pk),
+            name=attempt.delivery.webhook.app.name,
+        ),
+    )
+    initial_dump = _json_serialize(data)
+    remaining_bytes = bytes_limit - len(initial_dump)
+    if remaining_bytes < 0:
+        raise ValueError(f"Payload too big. Can't truncate to {bytes_limit}")
+    trunc_resp_body = JsonTruncText.truncate(response_body, remaining_bytes // 3)
+    remaining_bytes -= trunc_resp_body.byte_size
+    data["response"]["body"] = trunc_resp_body
+
+    subscription_query = attempt.delivery.webhook.subscription_query
+    data["webhook"]["subscription_query"] = None
+    if subscription_query:
+        trunc_subscription_query = JsonTruncText.truncate(
+            subscription_query, remaining_bytes // 2
+        )
+        remaining_bytes -= trunc_subscription_query.byte_size
+        data["webhook"]["subscription_query"] = trunc_subscription_query
+
+    payload = anonymize_event_payload(
+        subscription_query,
+        attempt.delivery.event_type,
+        cast(List, json.loads(attempt.delivery.payload.payload)),
+        SENSITIVE_GQL_FIELDS,
+    )
+    trunc_payload = JsonTruncText.truncate(
+        _json_serialize(payload, True), remaining_bytes
+    )
+    data["event_delivery"]["payload"]["body"] = trunc_payload
+    return _json_serialize(data)

--- a/saleor/webhook/observability/sensitive_data.py
+++ b/saleor/webhook/observability/sensitive_data.py
@@ -13,6 +13,7 @@ from ...core.auth import DEFAULT_AUTH_HEADER, SALEOR_AUTH_HEADER
 SENSITIVE_HEADERS = (
     SALEOR_AUTH_HEADER,
     DEFAULT_AUTH_HEADER,
+    "COOKIE",
 )
 SENSITIVE_HEADERS = tuple(
     x[5:] if x.startswith("HTTP_") else x for x in SENSITIVE_HEADERS

--- a/saleor/webhook/observability/sensitive_data.py
+++ b/saleor/webhook/observability/sensitive_data.py
@@ -1,0 +1,40 @@
+"""Definitions of sensitive data for observability obfuscation methods.
+
+SENSITIVE_HEADERS is a tuple of sensitive HTTP headers to anonymize before reporting.
+
+SENSITIVE_GQL_FIELDS is a dict of sets representing fields of GraphGL types to anonymize
+- Type
+- Fields
+"""
+from typing import Dict, Set
+
+from ...core.auth import DEFAULT_AUTH_HEADER, SALEOR_AUTH_HEADER
+
+SENSITIVE_HEADERS = (
+    SALEOR_AUTH_HEADER,
+    DEFAULT_AUTH_HEADER,
+)
+SENSITIVE_HEADERS = tuple(
+    x[5:] if x.startswith("HTTP_") else x for x in SENSITIVE_HEADERS
+)
+
+SensitiveFieldsMap = Dict[str, Set[str]]
+SENSITIVE_GQL_FIELDS: SensitiveFieldsMap = {
+    "RefreshToken": {"token"},
+    "CreateToken": {"token", "refreshToken", "csrfToken"},
+    "User": {"email", "firstName", "lastName"},
+    "Address": {
+        "firstName",
+        "lastName",
+        "companyName",
+        "streetAddress1",
+        "streetAddress2",
+        "phone",
+    },
+    "AppTokenCreate": {"authToken"},
+    "AppToken": {"authToken"},
+    "App": {"accessToken"},
+    "Order": {"userEmail"},
+    "Payment": {"creditCard"},
+    "Checkout": {"email"},
+}

--- a/saleor/webhook/observability/tests/conftest.py
+++ b/saleor/webhook/observability/tests/conftest.py
@@ -1,0 +1,30 @@
+from typing import Dict, Optional
+
+import pytest
+from graphql import get_default_backend
+
+from ....graphql.api import schema
+from ..utils import GraphQLOperationResponse
+
+backend = get_default_backend()
+
+
+@pytest.fixture
+def gql_operation_factory():
+    def factory(
+        query_string: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict] = None,
+        result: Optional[Dict] = None,
+        result_invalid=False,
+    ) -> GraphQLOperationResponse:
+        query = backend.document_from_string(schema, query_string)
+        return GraphQLOperationResponse(
+            name=operation_name,
+            query=query,
+            variables=variables,
+            result=result,
+            result_invalid=result_invalid,
+        )
+
+    return factory

--- a/saleor/webhook/observability/tests/conftest.py
+++ b/saleor/webhook/observability/tests/conftest.py
@@ -1,12 +1,19 @@
 from typing import Dict, Optional
+from unittest.mock import patch
 
+import fakeredis
 import pytest
 from graphql import get_default_backend
+from redis import ConnectionPool
 
 from ....graphql.api import schema
-from ..utils import GraphQLOperationResponse
+from ..buffers import RedisBuffer
+from ..utils import GraphQLOperationResponse, get_buffer_name
 
 backend = get_default_backend()
+
+BROKER_URL = "redis://fake-redis"
+KEY, MAX_SIZE, BATCH_SIZE = get_buffer_name(), 10, 5
 
 
 @pytest.fixture
@@ -28,3 +35,32 @@ def gql_operation_factory():
         )
 
     return factory
+
+
+@pytest.fixture
+def redis_server(settings):
+    settings.OBSERVABILITY_BROKER_URL = BROKER_URL
+    settings.OBSERVABILITY_BUFFER_SIZE_LIMIT = MAX_SIZE
+    settings.OBSERVABILITY_BUFFER_BATCH_SIZE = BATCH_SIZE
+    server = fakeredis.FakeServer()
+    server.connected = True
+    yield server
+
+
+@pytest.fixture
+def patch_redis(redis_server):
+    with patch(
+        "saleor.webhook.observability.buffers.RedisBuffer.get_connection_pool",
+        lambda x: ConnectionPool(
+            connection_class=fakeredis.FakeConnection, server=redis_server
+        ),
+    ):
+        yield redis_server
+
+
+@pytest.fixture
+def buffer(redis_server, patch_redis):
+    buffer = RedisBuffer(BROKER_URL, KEY, max_size=MAX_SIZE, batch_size=BATCH_SIZE)
+    yield buffer
+    redis_server.connected = True
+    buffer.clear()

--- a/saleor/webhook/observability/tests/conftest.py
+++ b/saleor/webhook/observability/tests/conftest.py
@@ -56,11 +56,10 @@ def patch_redis(redis_server):
         ),
     ):
         yield redis_server
+        RedisBuffer._pools = {}
 
 
 @pytest.fixture
 def buffer(redis_server, patch_redis):
     buffer = RedisBuffer(BROKER_URL, KEY, max_size=MAX_SIZE, batch_size=BATCH_SIZE)
     yield buffer
-    redis_server.connected = True
-    buffer.clear()

--- a/saleor/webhook/observability/tests/conftest.py
+++ b/saleor/webhook/observability/tests/conftest.py
@@ -56,10 +56,11 @@ def patch_redis(redis_server):
         ),
     ):
         yield redis_server
-        RedisBuffer._pools = {}
 
 
 @pytest.fixture
 def buffer(redis_server, patch_redis):
     buffer = RedisBuffer(BROKER_URL, KEY, max_size=MAX_SIZE, batch_size=BATCH_SIZE)
     yield buffer
+    redis_server.connected = True
+    buffer.clear()

--- a/saleor/webhook/observability/tests/test_buffer.py
+++ b/saleor/webhook/observability/tests/test_buffer.py
@@ -1,30 +1,21 @@
 import pytest
 
-from ..buffers import RedisBuffer, buffer_factory, get_buffer
+from ..buffers import RedisBuffer, get_buffer
 from ..exceptions import ConnectionNotConfigured
 from ..tests.conftest import BATCH_SIZE, KEY, MAX_SIZE
 
 
-def test_buffer_factory(redis_server, settings):
-    buffer = buffer_factory(KEY)
+def test_get_buffer(redis_server, settings):
+    buffer = get_buffer(KEY)
     assert isinstance(buffer, RedisBuffer)
     assert buffer.max_size == settings.OBSERVABILITY_BUFFER_SIZE_LIMIT
     assert buffer.batch_size == settings.OBSERVABILITY_BUFFER_BATCH_SIZE
 
 
-def test_get_buffer_when_no_configured(settings):
+def test_get_buffer_with_no_config(settings):
     settings.OBSERVABILITY_BROKER_URL = None
     with pytest.raises(ConnectionNotConfigured):
         get_buffer(KEY)
-
-
-def test_get_buffer(redis_server, settings):
-    buffer = get_buffer(KEY)
-    buffer_bis = get_buffer(KEY)
-    assert id(buffer) == id(buffer_bis)
-    assert buffer.broker_url == settings.OBSERVABILITY_BROKER_URL
-    assert buffer.max_size == settings.OBSERVABILITY_BUFFER_SIZE_LIMIT
-    assert buffer.batch_size == settings.OBSERVABILITY_BUFFER_BATCH_SIZE
 
 
 def test_in_batches(buffer):

--- a/saleor/webhook/observability/tests/test_buffer.py
+++ b/saleor/webhook/observability/tests/test_buffer.py
@@ -29,7 +29,8 @@ def test_get_connection_pool(buffer):
     assert pool.connection_kwargs["client_name"] == buffer._client_name
 
 
-def test_get_or_create_connection_pool(buffer):
+def test_get_or_create_connection_pool(redis_server):
+    buffer = get_buffer(KEY)
     pool_a = buffer.get_or_create_connection_pool()
     pool_b = buffer.get_or_create_connection_pool()
     assert pool_a == pool_b

--- a/saleor/webhook/observability/tests/test_obfuscation.py
+++ b/saleor/webhook/observability/tests/test_obfuscation.py
@@ -1,0 +1,166 @@
+import pytest
+from graphql import GraphQLError
+
+from ....graphql.api import schema
+from ..obfuscation import (
+    MASK,
+    anonymize_event_payload,
+    anonymize_gql_operation_response,
+    hide_sensitive_headers,
+    validate_sensitive_fields_map,
+)
+
+
+@pytest.mark.parametrize(
+    "headers,sensitive,expected",
+    [
+        (
+            {"header1": "text", "header2": "text"},
+            ("AUTHORIZATION", "AUTHORIZATION_BEARER"),
+            {"header1": "text", "header2": "text"},
+        ),
+        (
+            {"header1": "text", "authorization": "secret"},
+            ("AUTHORIZATION", "AUTHORIZATION_BEARER"),
+            {"header1": "text", "authorization": MASK},
+        ),
+        (
+            {"HEADER1": "text", "authorization-bearer": "secret"},
+            ("AUTHORIZATION", "AUTHORIZATION_BEARER"),
+            {"HEADER1": "text", "authorization-bearer": MASK},
+        ),
+    ],
+)
+def test_hide_sensitive_headers(headers, sensitive, expected):
+    assert hide_sensitive_headers(headers, sensitive_headers=sensitive) == expected
+
+
+def test_anonymize_gql_operation_response(gql_operation_factory):
+    query = "query FirstQuery { shop { name } }"
+    result = {"data": "result"}
+    sensitive_fields = {"Shop": {"name"}}
+    operation_result = gql_operation_factory(query, result=result)
+
+    anonymize_gql_operation_response(operation_result, sensitive_fields)
+
+    assert operation_result.result["data"] == MASK
+
+
+def test_anonymize_gql_operation_with_mutation_in_query(gql_operation_factory):
+    query = """
+    mutation tokenRefresh($token: String){
+        tokenRefresh(refreshToken: $token){
+            token
+        }
+    }"""
+    result = {"data": {"tokenRefresh": {"token": "SECRET TOKEN"}}}
+    sensitive_fields = {"RefreshToken": {"token"}}
+    operation_result = gql_operation_factory(query, result=result)
+
+    anonymize_gql_operation_response(operation_result, sensitive_fields)
+
+    assert operation_result.result["data"] == MASK
+
+
+def test_anonymize_gql_operation_with_subscription_in_query(gql_operation_factory):
+    query = """
+    subscription{
+      event{
+        ...on ProductUpdated{
+          product{
+            id
+            name
+          }
+        }
+      }
+    }
+    """
+    result = {"data": "secret data"}
+    sensitive_fields = {"Product": {"name"}}
+    operation_result = gql_operation_factory(query, result=result)
+
+    anonymize_gql_operation_response(operation_result, sensitive_fields)
+
+    assert operation_result.result["data"] == MASK
+
+
+def test_anonymize_gql_operation_response_with_empty_sensitive_fields_map(
+    gql_operation_factory,
+):
+    query = "query FirstQuery { shop { name } }"
+    result = {"data": "result"}
+    operation_result = gql_operation_factory(query, result=result)
+
+    anonymize_gql_operation_response(operation_result, {})
+
+    assert operation_result.result == result
+
+
+def test_anonymize_gql_operation_response_with_fragment_spread(gql_operation_factory):
+    query = """
+    fragment ProductFragment on Product {
+      id
+      name
+    }
+    query products($first: Int){
+      products(channel: "channel-pln", first:$first){
+        edges{
+          node{
+            ... ProductFragment
+            variants {
+                variantName: name
+            }
+          }
+        }
+      }
+    }"""
+    result = {"data": "result"}
+    sensitive_fields = {"Product": {"name"}}
+    operation_result = gql_operation_factory(query, result=result)
+
+    anonymize_gql_operation_response(operation_result, sensitive_fields)
+
+    assert operation_result.result["data"] == MASK
+
+
+@pytest.mark.parametrize(
+    "sensitive_fields",
+    [
+        {"NonExistingType": {}},
+        {"Product": {"nonExistingField"}},
+        {"Node": {"id"}},
+    ],
+)
+def test_validate_sensitive_fields_map(sensitive_fields):
+    with pytest.raises(GraphQLError):
+        validate_sensitive_fields_map(sensitive_fields, schema)
+
+
+def test_anonymize_event_payload():
+    query = """
+        subscription{
+          event{
+            ...on ProductUpdated{
+              product{
+                id
+                name
+              }
+            }
+          }
+        }
+        """
+    payload = [{"sensitive": "data"}]
+    sensitive_fields = {"Product": {"name"}}
+
+    anonymized = anonymize_event_payload(query, "any_type", payload, sensitive_fields)
+
+    assert anonymized == MASK
+
+
+def test_anonymize_event_delivery_payload_when_empty_subscription_query():
+    payload = [{"sensitive": "data"}]
+    sensitive_fields = {"Product": {"name"}}
+
+    anonymized = anonymize_event_payload(None, "any_type", payload, sensitive_fields)
+
+    assert anonymized == payload

--- a/saleor/webhook/observability/tests/test_payloads.py
+++ b/saleor/webhook/observability/tests/test_payloads.py
@@ -1,0 +1,412 @@
+import json
+from datetime import datetime
+from uuid import UUID
+
+import graphene
+import pytest
+from django.http import JsonResponse
+from django.utils import timezone
+
+from ....core import EventDeliveryStatus
+from ....webhook.event_types import WebhookEventAsyncType
+from ..exceptions import TruncationError
+from ..payload_schema import (
+    ApiCallPayload,
+    ApiCallRequest,
+    ApiCallResponse,
+    App,
+    EventDelivery,
+    EventDeliveryAttemptPayload,
+    EventDeliveryAttemptRequest,
+    EventDeliveryAttemptResponse,
+    EventDeliveryPayload,
+    GraphQLOperation,
+    ObservabilityEventTypes,
+    Webhook,
+)
+from ..payloads import (
+    GQL_OPERATION_PLACEHOLDER_SIZE,
+    JsonTruncText,
+    dump_payload,
+    generate_api_call_payload,
+    generate_event_delivery_attempt_payload,
+    pretty_json,
+    serialize_gql_operation_result,
+    serialize_gql_operation_results,
+    to_camel_case,
+)
+from ..utils import GraphQLOperationResponse
+
+
+@pytest.mark.parametrize(
+    "snake_payload,expected_camel",
+    [
+        (
+            ApiCallRequest(
+                id="id",
+                method="GET",
+                url="http://example.com",
+                time=123456.2,
+                headers=[("snake_header_1", "val"), ("snake_header_2", "val")],
+                content_length=1024,
+            ),
+            {
+                "id": "id",
+                "method": "GET",
+                "url": "http://example.com",
+                "time": 123456.2,
+                "headers": [("snake_header_1", "val"), ("snake_header_2", "val")],
+                "contentLength": 1024,
+            },
+        ),
+        (
+            {
+                "key_a": {"sub_key_a": "val", "sub_key_b": "val"},
+                "key_b": [{"list_key_a": "val"}, {"list_key_b": "val"}],
+            },
+            {
+                "keyA": {"subKeyA": "val", "subKeyB": "val"},
+                "keyB": [{"listKeyA": "val"}, {"listKeyB": "val"}],
+            },
+        ),
+    ],
+)
+def test_to_camel_case(snake_payload, expected_camel):
+    assert to_camel_case(snake_payload) == expected_camel
+
+
+def test_serialize_gql_operation_result(gql_operation_factory):
+    bytes_limit = 1024
+    query = "query FirstQuery { shop { name } }"
+    result = {"data": "result"}
+    operation_result = gql_operation_factory(query, "FirstQuery", None, result)
+    payload, _ = serialize_gql_operation_result(operation_result, bytes_limit)
+    assert payload == GraphQLOperation(
+        name=JsonTruncText("FirstQuery", False),
+        operation_type="query",
+        query=JsonTruncText(query, False),
+        result=JsonTruncText(pretty_json(result), False),
+        result_invalid=False,
+    )
+    assert len(dump_payload(payload)) <= bytes_limit
+
+
+def test_serialize_gql_operation_result_when_no_operation_data():
+    bytes_limit = 1024
+    result = GraphQLOperationResponse()
+    payload, _ = serialize_gql_operation_result(result, bytes_limit)
+    assert payload == GraphQLOperation(
+        name=None, operation_type=None, query=None, result=None, result_invalid=False
+    )
+    assert len(dump_payload(payload)) <= bytes_limit
+
+
+def test_serialize_gql_operation_result_when_too_low_bytes_limit():
+    result = GraphQLOperationResponse()
+    with pytest.raises(TruncationError):
+        serialize_gql_operation_result(result, GQL_OPERATION_PLACEHOLDER_SIZE - 1)
+
+
+def test_serialize_gql_operation_result_when_minimal_bytes_limit(gql_operation_factory):
+    query = "query FirstQuery { shop { name } }"
+    operation_result = gql_operation_factory(
+        query, "FirstQuery", None, {"data": "result"}
+    )
+    payload, left_bytes = serialize_gql_operation_result(
+        operation_result, GQL_OPERATION_PLACEHOLDER_SIZE
+    )
+    assert payload == GraphQLOperation(
+        name=JsonTruncText("", True),
+        operation_type="query",
+        query=JsonTruncText("", True),
+        result=JsonTruncText("", True),
+        result_invalid=False,
+    )
+    assert left_bytes == 0
+    assert len(dump_payload(payload)) <= GQL_OPERATION_PLACEHOLDER_SIZE
+
+
+def test_serialize_gql_operation_result_when_truncated(gql_operation_factory):
+    query = "query FirstQuery { shop { name } }"
+    operation_result = gql_operation_factory(
+        query, "FirstQuery", None, {"data": "result"}
+    )
+    bytes_limit = 225
+    payload, left_bytes = serialize_gql_operation_result(operation_result, bytes_limit)
+    assert payload == GraphQLOperation(
+        name=JsonTruncText("FirstQuery", False),
+        operation_type="query",
+        query=JsonTruncText("query FirstQue", True),
+        result=JsonTruncText('{\n  "data": ', True),
+        result_invalid=False,
+    )
+    assert left_bytes == 0
+    assert len(dump_payload(payload)) <= bytes_limit
+
+
+def test_serialize_gql_operation_results(gql_operation_factory):
+    query = "query FirstQuery { shop { name } } query SecondQuery { shop { name } }"
+    result = {"data": "result"}
+    first_result = gql_operation_factory(query, "FirstQuery", None, result)
+    second_result = gql_operation_factory(query, "SecondQuery", None, result)
+    payloads = serialize_gql_operation_results([first_result, second_result], 1024)
+    assert payloads == [
+        GraphQLOperation(
+            name=JsonTruncText("FirstQuery", False),
+            operation_type="query",
+            query=JsonTruncText(query, False),
+            result=JsonTruncText(pretty_json(result), False),
+            result_invalid=False,
+        ),
+        GraphQLOperation(
+            name=JsonTruncText("SecondQuery", False),
+            operation_type="query",
+            query=JsonTruncText(query, False),
+            result=JsonTruncText(pretty_json(result), False),
+            result_invalid=False,
+        ),
+    ]
+
+
+def test_serialize_gql_operation_results_when_minimal_bytes_limit(
+    gql_operation_factory,
+):
+    query = "query FirstQuery { shop { name } } query SecondQuery { shop { name } }"
+    result = {"data": "result"}
+    first_result = gql_operation_factory(query, "FirstQuery", None, result)
+    second_result = gql_operation_factory(query, "SecondQuery", None, result)
+    payloads = serialize_gql_operation_results(
+        [first_result, second_result], 2 * GQL_OPERATION_PLACEHOLDER_SIZE
+    )
+    assert payloads == [
+        GraphQLOperation(
+            name=JsonTruncText("", True),
+            operation_type="query",
+            query=JsonTruncText("", True),
+            result=JsonTruncText("", True),
+            result_invalid=False,
+        ),
+        GraphQLOperation(
+            name=JsonTruncText("", True),
+            operation_type="query",
+            query=JsonTruncText("", True),
+            result=JsonTruncText("", True),
+            result_invalid=False,
+        ),
+    ]
+    assert len(dump_payload(payloads)) <= 2 * GQL_OPERATION_PLACEHOLDER_SIZE
+
+
+def test_serialize_gql_operation_results_when_too_low_bytes_limit(
+    gql_operation_factory,
+):
+    query = "query FirstQuery { shop { name } } query SecondQuery { shop { name } }"
+    result = {"data": "result"}
+    first_result = gql_operation_factory(query, "FirstQuery", None, result)
+    second_result = gql_operation_factory(query, "SecondQuery", None, result)
+    with pytest.raises(TruncationError):
+        serialize_gql_operation_results(
+            [first_result, second_result], 2 * GQL_OPERATION_PLACEHOLDER_SIZE - 1
+        )
+
+
+def test_generate_api_call_payload(app, rf, gql_operation_factory):
+    request = rf.post(
+        "/graphql", data={"request": "data"}, content_type="application/json"
+    )
+    request.request_time = datetime(1914, 6, 28, 10, 50, tzinfo=timezone.utc)
+    request.app = app
+    response = JsonResponse({"response": "data"})
+    query_a = "query FirstQuery { shop { name } }"
+    query_b = "query SecondQuery { shop { name } }"
+    result_a = {"data": "result A"}
+    result_b = {"data": "result B"}
+    first_result = gql_operation_factory(query_a, "FirstQuery", None, result_a)
+    second_result = gql_operation_factory(query_b, "SecondQuery", None, result_b)
+
+    payload = generate_api_call_payload(
+        request, response, [first_result, second_result], 2048
+    )
+    request_id = payload["request"]["id"]
+
+    assert UUID(request_id, version=4)
+    assert payload == ApiCallPayload(
+        event_type=ObservabilityEventTypes.API_CALL,
+        request=ApiCallRequest(
+            id=request_id,
+            method="POST",
+            url="http://testserver/graphql",
+            time=request.request_time.timestamp(),
+            content_length=19,
+            headers=[
+                ("Cookie", ""),
+                ("Content-Length", "19"),
+                ("Content-Type", "application/json"),
+            ],
+        ),
+        app=App(
+            id=graphene.Node.to_global_id("App", app.pk), name="Sample app objects"
+        ),
+        response=ApiCallResponse(
+            headers=[
+                ("Content-Type", "application/json"),
+            ],
+            status_code=200,
+            content_length=20,
+        ),
+        gql_operations=[
+            GraphQLOperation(
+                name=JsonTruncText("FirstQuery", False),
+                operation_type="query",
+                query=JsonTruncText(query_a, False),
+                result=JsonTruncText(pretty_json(result_a), False),
+                result_invalid=False,
+            ),
+            GraphQLOperation(
+                name=JsonTruncText("SecondQuery", False),
+                operation_type="query",
+                query=JsonTruncText(query_b, False),
+                result=JsonTruncText(pretty_json(result_b), False),
+                result_invalid=False,
+            ),
+        ],
+    )
+
+
+def test_generate_api_call_payload_request_not_from_app(rf):
+    request = rf.post(
+        "/graphql", data={"request": "data"}, content_type="application/json"
+    )
+    request.app = None
+    response = JsonResponse({"response": "data"})
+    payload = generate_api_call_payload(request, response, [], 1024)
+
+    assert payload["app"] is None
+
+
+def test_generate_api_call_payload_skip_operations_when_size_limit_too_low(
+    app, rf, gql_operation_factory
+):
+    request = rf.post(
+        "/graphql", data={"request": "data"}, content_type="application/json"
+    )
+    request.request_time = datetime(1914, 6, 28, 10, 50, tzinfo=timezone.utc)
+    request.app = app
+    response = JsonResponse({"response": "data"})
+    query = "query FirstQuery { shop { name } } query SecondQuery { shop { name } }"
+    result = {"data": "result A"}
+    first_result = gql_operation_factory(query, "FirstQuery", None, result)
+    second_result = gql_operation_factory(query, "SecondQuery", None, result)
+    payload_without_operations = generate_api_call_payload(request, response, [], 1024)
+    bytes_limit = (
+        len(dump_payload(payload_without_operations))
+        + GQL_OPERATION_PLACEHOLDER_SIZE * 2
+    )
+    operation_trunc_payload = GraphQLOperation(
+        name=JsonTruncText("", True),
+        operation_type="query",
+        query=JsonTruncText("", True),
+        result=JsonTruncText("", True),
+        result_invalid=False,
+    )
+
+    payload = generate_api_call_payload(
+        request, response, [first_result, second_result], bytes_limit
+    )
+
+    assert payload["gql_operations"] == [operation_trunc_payload] * 2
+
+
+def test_generate_api_call_payload_when_too_low_bytes_limit(app, rf):
+    request = rf.post(
+        "/graphql", data={"request": "data"}, content_type="application/json"
+    )
+    request.request_time = datetime(1914, 6, 28, 10, 50, tzinfo=timezone.utc)
+    request.app = app
+    response = JsonResponse({"response": "data"})
+    payload = generate_api_call_payload(request, response, [], 1024)
+
+    with pytest.raises(TruncationError):
+        generate_api_call_payload(request, response, [], len(payload) - 1)
+
+
+def test_generate_event_delivery_attempt_payload(event_attempt):
+    created_at = datetime(1914, 6, 28, 10, 50, tzinfo=timezone.utc)
+    event_attempt.created_at = created_at
+    delivery = event_attempt.delivery
+    webhook = delivery.webhook
+    app = webhook.app
+
+    payload = generate_event_delivery_attempt_payload(event_attempt, None, 1024)
+
+    assert payload == EventDeliveryAttemptPayload(
+        id=graphene.Node.to_global_id("EventDeliveryAttempt", event_attempt.pk),
+        time=created_at,
+        duration=None,
+        status=EventDeliveryStatus.PENDING,
+        next_retry=None,
+        event_type=ObservabilityEventTypes.EVENT_DELIVERY_ATTEMPT,
+        request=EventDeliveryAttemptRequest(
+            headers=[],
+        ),
+        response=EventDeliveryAttemptResponse(
+            headers=[],
+            content_length=16,
+            status_code=None,
+            body=JsonTruncText("example_response", False),
+        ),
+        event_delivery=EventDelivery(
+            id=graphene.Node.to_global_id("EventDelivery", delivery.pk),
+            status=EventDeliveryStatus.PENDING,
+            event_type=WebhookEventAsyncType.ANY,
+            event_sync=False,
+            payload=EventDeliveryPayload(
+                content_length=32,
+                body=JsonTruncText(
+                    pretty_json(json.loads(delivery.payload.payload)), False
+                ),
+            ),
+        ),
+        webhook=Webhook(
+            id=graphene.Node.to_global_id("Webhook", webhook.pk),
+            name="Simple webhook",
+            target_url="http://www.example.com/test",
+            subscription_query=None,
+        ),
+        app=App(
+            id=graphene.Node.to_global_id("App", app.pk), name="Sample app objects"
+        ),
+    )
+
+
+def test_generate_event_delivery_attempt_payload_failed(event_attempt):
+    too_small_bytes_limit = 10
+    with pytest.raises(TruncationError):
+        generate_event_delivery_attempt_payload(
+            event_attempt, None, too_small_bytes_limit
+        )
+
+
+def test_generate_event_delivery_attempt_payload_with_next_retry_date(
+    event_attempt,
+):
+    next_retry_date = datetime(1914, 6, 28, 10, 50, tzinfo=timezone.utc)
+    payload = generate_event_delivery_attempt_payload(
+        event_attempt, next_retry_date, 1024
+    )
+
+    assert payload["next_retry"] == next_retry_date
+
+
+def test_generate_event_delivery_attempt_payload_with_empty_headers(
+    event_attempt,
+):
+    headers = {"Content-Length": "19", "Content-Type": "application/json"}
+    headers_list = [("Content-Length", "19"), ("Content-Type", "application/json")]
+    event_attempt.request_headers = json.dumps(headers)
+    event_attempt.response_headers = json.dumps(headers)
+
+    payload = generate_event_delivery_attempt_payload(event_attempt, None, 1024)
+
+    assert payload["request"]["headers"] == headers_list
+    assert payload["response"]["headers"] == headers_list

--- a/saleor/webhook/observability/tests/test_payloads.py
+++ b/saleor/webhook/observability/tests/test_payloads.py
@@ -239,7 +239,7 @@ def test_generate_api_call_payload(app, rf, gql_operation_factory):
             time=request.request_time.timestamp(),
             content_length=19,
             headers=[
-                ("Cookie", ""),
+                ("Cookie", "***"),
                 ("Content-Length", "19"),
                 ("Content-Type", "application/json"),
             ],

--- a/saleor/webhook/observability/tests/test_payloads.py
+++ b/saleor/webhook/observability/tests/test_payloads.py
@@ -381,12 +381,28 @@ def test_generate_event_delivery_attempt_payload(event_attempt):
     )
 
 
-def test_generate_event_delivery_attempt_payload_failed(event_attempt):
+def test_generate_event_delivery_attempt_payload_raises_truncation_error(event_attempt):
     too_small_bytes_limit = 10
     with pytest.raises(TruncationError):
         generate_event_delivery_attempt_payload(
             event_attempt, None, too_small_bytes_limit
         )
+
+
+def test_generate_event_delivery_attempt_payload_raises_error_when_no_delivery(
+    event_attempt,
+):
+    event_attempt.delivery = None
+    with pytest.raises(ValueError):
+        generate_event_delivery_attempt_payload(event_attempt, None, 1024)
+
+
+def test_generate_event_delivery_attempt_payload_raises_error_when_no_payload(
+    event_attempt,
+):
+    event_attempt.delivery.payload = None
+    with pytest.raises(ValueError):
+        generate_event_delivery_attempt_payload(event_attempt, None, 1024)
 
 
 def test_generate_event_delivery_attempt_payload_with_next_retry_date(

--- a/saleor/webhook/observability/tests/test_redis_buffer.py
+++ b/saleor/webhook/observability/tests/test_redis_buffer.py
@@ -120,6 +120,16 @@ def test_pop_events(buffer):
     assert buffer.size() == MAX_SIZE - BATCH_SIZE
 
 
+def test_pop_events_get_size(buffer):
+    events = [{"event": f"data{i}"} for i in range(MAX_SIZE)]
+    buffer.put_events(events)
+    popped_events, size = buffer.pop_events_get_size()
+    assert len(popped_events) == BATCH_SIZE
+    assert popped_events == events[:BATCH_SIZE]
+    assert size == MAX_SIZE - BATCH_SIZE
+    assert buffer.size() == size
+
+
 def test_clear(buffer):
     events = [{"event": "data"}] * 2
     buffer.put_events(events)

--- a/saleor/webhook/observability/tests/test_redis_buffer.py
+++ b/saleor/webhook/observability/tests/test_redis_buffer.py
@@ -1,0 +1,122 @@
+from unittest.mock import patch
+
+import fakeredis
+import pytest
+from redis import ConnectionPool
+
+from ..buffers import RedisBuffer, buffer_factory, get_buffer
+from ..exceptions import ConnectionNotConfigured
+
+BROKER_URL = "redis://fake-redis"
+MAX_SIZE, BATCH_SIZE = 10, 5
+
+
+@pytest.fixture
+def redis_server(settings):
+    settings.OBSERVABILITY_BROKER_URL = BROKER_URL
+    server = fakeredis.FakeServer()
+    server.connected = True
+    yield server
+
+
+@pytest.fixture
+def patch_redis(redis_server):
+    with patch(
+        "saleor.webhook.observability.buffers.RedisBuffer.get_connection_pool",
+        lambda x: ConnectionPool(
+            connection_class=fakeredis.FakeConnection, server=redis_server
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+def buffer(patch_redis):
+    buffer = buffer_factory(BROKER_URL, max_size=MAX_SIZE, batch_size=BATCH_SIZE)
+    yield buffer
+    buffer.client.flushall()
+
+
+def test_buffer_factory():
+    max_size, batch_size = 10, 10
+    buffer = buffer_factory(BROKER_URL, max_size=max_size, batch_size=batch_size)
+    assert isinstance(buffer, RedisBuffer)
+    assert (buffer.max_size, buffer.batch_size) == (max_size, batch_size)
+
+
+def test_get_buffer_when_no_configured(settings):
+    settings.OBSERVABILITY_BROKER_URL = None
+    with pytest.raises(ConnectionNotConfigured):
+        get_buffer()
+
+
+def test_get_buffer(settings):
+    settings.OBSERVABILITY_BROKER_URL = "redis://fake-redis"
+    buffer = get_buffer()
+    buffer_bis = get_buffer()
+    assert id(buffer) == id(buffer_bis)
+    assert buffer.broker_url == settings.OBSERVABILITY_BROKER_URL
+    assert buffer.max_size == settings.OBSERVABILITY_BUFFER_SIZE_LIMIT
+    assert buffer.batch_size == settings.OBSERVABILITY_BUFFER_BATCH_SIZE
+
+
+def test_buffer_put_events(buffer):
+    key, event = "buffer", {"event": "data"}
+    buffer.put_event(key, event)
+    assert buffer.size(key) == 1
+
+
+def test_buffer_put_events_max_size(buffer):
+    key, event = "buffer", {"event": "data"}
+    for i in range(MAX_SIZE * 2):
+        buffer.put_event(key, event)
+    assert buffer.size(key) == MAX_SIZE
+
+
+def test_put_events(buffer):
+    key, events = "buffer", [{"event": "data"}] * 2
+    buffer.put_events(key, events)
+    assert buffer.size(key) == 2
+
+
+def test_put_events_max_size(buffer):
+    key, events = "buffer", [{"event": "data"}] * MAX_SIZE * 2
+    buffer.put_events(key, events)
+    assert buffer.size(key) == MAX_SIZE
+
+
+def test_put_multi_key_events(buffer):
+    key_a, events_a = "buffer_a", [{"event": "data"}] * 2
+    key_b, events_b = "buffer_b", [{"event": "data"}] * MAX_SIZE
+    key_c, events_c = "buffer_c", [{"event": "data"}] * MAX_SIZE * 2
+    buffer.put_multi_key_events({key_a: events_a, key_b: events_b, key_c: events_c})
+    assert buffer.size(key_a) == 2
+    assert buffer.size(key_b) == MAX_SIZE
+    assert buffer.size(key_c) == MAX_SIZE
+
+
+def test_pop_event(buffer):
+    key, event = "buffer", {"event": "data"}
+    buffer.put_event(key, event)
+    popped_event = buffer.pop_event(key)
+    assert id(event) != id(popped_event)
+    assert event == popped_event
+    assert buffer.size(key) == 0
+    assert buffer.pop_event(key) is None
+
+
+def test_pop_events(buffer):
+    key, events = "buffer", [{"event": f"data{i}"} for i in range(MAX_SIZE)]
+    buffer.put_events(key, events)
+    popped_events = buffer.pop_events(key)
+    assert len(popped_events) == BATCH_SIZE
+    assert popped_events == events[:BATCH_SIZE]
+    assert buffer.size(key) == MAX_SIZE - BATCH_SIZE
+
+
+def test_clear(buffer):
+    key, events = "buffer", [{"event": "data"}] * 2
+    buffer.put_events(key, events)
+    assert buffer.size(key) == 2
+    assert buffer.clear(key) == 2
+    assert buffer.size(key) == 0

--- a/saleor/webhook/observability/tests/test_redis_buffer.py
+++ b/saleor/webhook/observability/tests/test_redis_buffer.py
@@ -8,12 +8,14 @@ from ..buffers import RedisBuffer, buffer_factory, get_buffer
 from ..exceptions import ConnectionNotConfigured
 
 BROKER_URL = "redis://fake-redis"
-MAX_SIZE, BATCH_SIZE = 10, 5
+KEY, MAX_SIZE, BATCH_SIZE = "observability_buffer", 10, 5
 
 
 @pytest.fixture
 def redis_server(settings):
     settings.OBSERVABILITY_BROKER_URL = BROKER_URL
+    settings.OBSERVABILITY_BUFFER_SIZE_LIMIT = MAX_SIZE
+    settings.OBSERVABILITY_BUFFER_BATCH_SIZE = BATCH_SIZE
     server = fakeredis.FakeServer()
     server.connected = True
     yield server
@@ -32,14 +34,14 @@ def patch_redis(redis_server):
 
 @pytest.fixture
 def buffer(patch_redis):
-    buffer = buffer_factory(BROKER_URL, max_size=MAX_SIZE, batch_size=BATCH_SIZE)
+    buffer = buffer_factory(BROKER_URL, KEY, max_size=MAX_SIZE, batch_size=BATCH_SIZE)
     yield buffer
     buffer.client.flushall()
 
 
 def test_buffer_factory():
     max_size, batch_size = 10, 10
-    buffer = buffer_factory(BROKER_URL, max_size=max_size, batch_size=batch_size)
+    buffer = buffer_factory(BROKER_URL, KEY, max_size=max_size, batch_size=batch_size)
     assert isinstance(buffer, RedisBuffer)
     assert (buffer.max_size, buffer.batch_size) == (max_size, batch_size)
 
@@ -47,13 +49,13 @@ def test_buffer_factory():
 def test_get_buffer_when_no_configured(settings):
     settings.OBSERVABILITY_BROKER_URL = None
     with pytest.raises(ConnectionNotConfigured):
-        get_buffer()
+        get_buffer(KEY)
 
 
 def test_get_buffer(settings):
     settings.OBSERVABILITY_BROKER_URL = "redis://fake-redis"
-    buffer = get_buffer()
-    buffer_bis = get_buffer()
+    buffer = get_buffer(KEY)
+    buffer_bis = get_buffer(KEY)
     assert id(buffer) == id(buffer_bis)
     assert buffer.broker_url == settings.OBSERVABILITY_BROKER_URL
     assert buffer.max_size == settings.OBSERVABILITY_BUFFER_SIZE_LIMIT
@@ -61,62 +63,67 @@ def test_get_buffer(settings):
 
 
 def test_buffer_put_events(buffer):
-    key, event = "buffer", {"event": "data"}
-    buffer.put_event(key, event)
-    assert buffer.size(key) == 1
+    event = {"event": "data"}
+    buffer.put_event(event)
+    assert buffer.size() == 1
 
 
 def test_buffer_put_events_max_size(buffer):
-    key, event = "buffer", {"event": "data"}
+    event = {"event": "data"}
     for i in range(MAX_SIZE * 2):
-        buffer.put_event(key, event)
-    assert buffer.size(key) == MAX_SIZE
+        buffer.put_event(event)
+    assert buffer.size() == MAX_SIZE
 
 
 def test_put_events(buffer):
-    key, events = "buffer", [{"event": "data"}] * 2
-    buffer.put_events(key, events)
-    assert buffer.size(key) == 2
+    events = [{"event": "data"}] * 2
+    buffer.put_events(events)
+    assert buffer.size() == 2
 
 
 def test_put_events_max_size(buffer):
-    key, events = "buffer", [{"event": "data"}] * MAX_SIZE * 2
-    buffer.put_events(key, events)
-    assert buffer.size(key) == MAX_SIZE
+    events = [{"event": "data"}] * MAX_SIZE * 2
+    buffer.put_events(events)
+    assert buffer.size() == MAX_SIZE
 
 
-def test_put_multi_key_events(buffer):
+def test_put_multi_key_events(patch_redis):
     key_a, events_a = "buffer_a", [{"event": "data"}] * 2
     key_b, events_b = "buffer_b", [{"event": "data"}] * MAX_SIZE
     key_c, events_c = "buffer_c", [{"event": "data"}] * MAX_SIZE * 2
-    buffer.put_multi_key_events({key_a: events_a, key_b: events_b, key_c: events_c})
-    assert buffer.size(key_a) == 2
-    assert buffer.size(key_b) == MAX_SIZE
-    assert buffer.size(key_c) == MAX_SIZE
+    buffer_a, buffer_b, buffer_c = (
+        get_buffer(key_a),
+        get_buffer(key_b),
+        get_buffer(key_c),
+    )
+    buffer_a.put_multi_key_events({key_a: events_a, key_b: events_b, key_c: events_c})
+    assert buffer_a.size() == 2
+    assert buffer_b.size() == MAX_SIZE
+    assert buffer_c.size() == MAX_SIZE
 
 
 def test_pop_event(buffer):
-    key, event = "buffer", {"event": "data"}
-    buffer.put_event(key, event)
-    popped_event = buffer.pop_event(key)
+    event = "buffer", {"event": "data"}
+    buffer.put_event(event)
+    popped_event = buffer.pop_event()
     assert id(event) != id(popped_event)
     assert event == popped_event
-    assert buffer.size(key) == 0
-    assert buffer.pop_event(key) is None
+    assert buffer.size() == 0
+    assert buffer.pop_event() is None
 
 
 def test_pop_events(buffer):
-    key, events = "buffer", [{"event": f"data{i}"} for i in range(MAX_SIZE)]
-    buffer.put_events(key, events)
-    popped_events = buffer.pop_events(key)
+    events = [{"event": f"data{i}"} for i in range(MAX_SIZE)]
+    buffer.put_events(events)
+    popped_events = buffer.pop_events()
     assert len(popped_events) == BATCH_SIZE
     assert popped_events == events[:BATCH_SIZE]
-    assert buffer.size(key) == MAX_SIZE - BATCH_SIZE
+    assert buffer.size() == MAX_SIZE - BATCH_SIZE
 
 
 def test_clear(buffer):
-    key, events = "buffer", [{"event": "data"}] * 2
-    buffer.put_events(key, events)
-    assert buffer.size(key) == 2
-    assert buffer.clear(key) == 2
-    assert buffer.size(key) == 0
+    events = [{"event": "data"}] * 2
+    buffer.put_events(events)
+    assert buffer.size() == 2
+    assert buffer.clear() == 2
+    assert buffer.size() == 0

--- a/saleor/webhook/observability/tests/test_utils.py
+++ b/saleor/webhook/observability/tests/test_utils.py
@@ -18,6 +18,7 @@ from ..utils import (
     pop_events_with_remaining_size,
     put_event,
     report_api_call,
+    report_event_delivery_attempt,
     report_gql_operation,
     task_next_retry_date,
 )
@@ -197,6 +198,38 @@ def test_api_call_response_report_when_request_not_from_app(
     api_call.report()
 
     mock_get_webhooks.assert_not_called()
+    mock_put_event.assert_not_called()
+
+
+@patch("saleor.webhook.observability.utils.put_event")
+@patch("saleor.webhook.observability.utils.get_webhooks")
+def test_report_event_delivery_attempt(
+    mock_get_webhooks,
+    mock_put_event,
+    observability_enabled,
+    event_attempt,
+    observability_webhook_data,
+):
+    mock_get_webhooks.return_value = [observability_webhook_data]
+
+    report_event_delivery_attempt(event_attempt)
+
+    mock_put_event.assert_called_once()
+
+
+@patch("saleor.webhook.observability.utils.put_event")
+@patch("saleor.webhook.observability.utils.get_webhooks")
+def test_report_event_delivery_attempt_not_active(
+    mock_get_webhooks,
+    mock_put_event,
+    observability_disabled,
+    event_attempt,
+    observability_webhook_data,
+):
+    mock_get_webhooks.return_value = [observability_webhook_data]
+
+    report_event_delivery_attempt(event_attempt)
+
     mock_put_event.assert_not_called()
 
 

--- a/saleor/webhook/observability/tests/test_utils.py
+++ b/saleor/webhook/observability/tests/test_utils.py
@@ -120,6 +120,13 @@ def test_json_truncate_text_to_byte_limit(
     assert len(json.dumps(truncated.text)) == expected_size + len('""')
 
 
+def test_json_truncate_text_comparison():
+    truncated_a = JsonTruncText("content", truncated=True)
+    truncated_b = JsonTruncText("content", truncated=True)
+    assert truncated_a != "content"
+    assert truncated_a == truncated_b
+
+
 @pytest.mark.parametrize(
     "retry, next_retry_date",
     [

--- a/saleor/webhook/observability/tests/test_utils.py
+++ b/saleor/webhook/observability/tests/test_utils.py
@@ -1,0 +1,121 @@
+import json
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+import pytz
+from celery.exceptions import Retry
+from django.core.cache import cache
+from freezegun import freeze_time
+
+from ..payload_schema import JsonTruncText
+from ..payloads import CustomJsonEncoder
+from ..utils import (
+    WebhookData,
+    _webhooks_active_cache,
+    get_observability_webhooks,
+    observability_webhooks_active,
+    task_next_retry_date,
+)
+
+
+@pytest.fixture
+def reset_cache():
+    yield
+    cache.clear()
+
+
+def test_get_observability_webhooks(reset_cache, observability_app):
+    webhook = observability_app.webhooks.first()
+    observability_webhooks = get_observability_webhooks()
+    assert observability_webhooks == [
+        WebhookData(
+            id=webhook.id,
+            saleor_domain="mirumee.com",
+            target_url=webhook.target_url,
+            secret_key=webhook.secret_key,
+        )
+    ]
+
+
+@patch("saleor.webhook.observability.utils.get_webhooks_for_event")
+def test_get_observability_webhooks_cache(
+    mocked_get_webhooks_for_event, reset_cache, observability_app
+):
+    webhook = observability_app.webhooks.first()
+    mocked_get_webhooks_for_event.return_value = [webhook]
+    get_observability_webhooks(), get_observability_webhooks()
+
+    mocked_get_webhooks_for_event.assert_called_once()
+
+
+def test_observability_webhooks_active(reset_cache, observability_app):
+    _webhooks_active_cache.clear()
+    assert observability_webhooks_active() is True
+
+
+def test_observability_webhooks_active_when_app_deactivated(
+    reset_cache, observability_app
+):
+    _webhooks_active_cache.clear()
+    observability_app.is_active = False
+    observability_app.save()
+
+    assert observability_webhooks_active() is False
+
+
+@patch("saleor.webhook.observability.utils.get_observability_webhooks")
+def test_observability_webhooks_active_cache(
+    mocked_get_observability_webhooks, reset_cache, observability_app
+):
+    _webhooks_active_cache.clear()
+    mocked_get_observability_webhooks.return_value = []
+    observability_webhooks_active(), observability_webhooks_active()
+
+    mocked_get_observability_webhooks.assert_called_once()
+
+
+def test_custom_json_encoder_dumps_json_trunc_text():
+    input_data = {"body": JsonTruncText("content", truncated=True)}
+
+    serialized_data = json.dumps(input_data, cls=CustomJsonEncoder)
+
+    data = json.loads(serialized_data)
+    assert data["body"]["text"] == "content"
+    assert data["body"]["truncated"] is True
+
+
+@pytest.mark.parametrize(
+    "text,limit,expected_size,expected_text,expected_truncated",
+    [
+        ("abcde", 5, 5, "abcde", False),
+        ("abó", 3, 2, "ab", True),
+        ("abó", 8, 8, "abó", False),
+        ("abó", 12, 8, "abó", False),
+        ("a\nc𐀁d", 17, 17, "a\nc𐀁d", False),
+        ("a\nc𐀁d", 10, 4, "a\nc", True),
+        ("a\nc𐀁d", 16, 16, "a\nc𐀁", True),
+        ("abcd", 0, 0, "", True),
+    ],
+)
+def test_json_truncate_text_to_byte_limit(
+    text, limit, expected_size, expected_text, expected_truncated
+):
+    truncated = JsonTruncText.truncate(text, limit)
+    assert truncated.text == expected_text
+    assert truncated.byte_size == expected_size
+    assert truncated.truncated == expected_truncated
+    assert len(json.dumps(truncated.text)) == expected_size + len('""')
+
+
+@pytest.mark.parametrize(
+    "retry, next_retry_date",
+    [
+        (Retry(), None),
+        (Retry(when=60 * 10), datetime(1914, 6, 28, 11, tzinfo=pytz.utc)),
+        (Retry(when=datetime(1914, 6, 28, 11)), datetime(1914, 6, 28, 11)),
+    ],
+)
+@freeze_time("1914-06-28 10:50")
+def test_task_next_retry_date(retry, next_retry_date):
+    assert task_next_retry_date(retry) == next_retry_date

--- a/saleor/webhook/observability/tests/test_utils.py
+++ b/saleor/webhook/observability/tests/test_utils.py
@@ -233,17 +233,23 @@ def test_report_event_delivery_attempt_not_active(
     mock_put_event.assert_not_called()
 
 
-def test_put_event(buffer):
+@patch("saleor.webhook.observability.utils.get_buffer")
+def test_put_event(mock_get_buffer, buffer):
+    mock_get_buffer.return_value = buffer
     put_event(lambda: {"payload": "data"})
     assert buffer.size() == 1
 
 
-def test_put_event_catch_exceptions(buffer):
+@patch("saleor.webhook.observability.utils.get_buffer")
+def test_put_event_catch_exceptions(mock_get_buffer, buffer):
+    mock_get_buffer.return_value = buffer
     put_event(lambda: 1 / 0)
     assert buffer.size() == 0
 
 
-def test_pop_events_with_remaining_size(buffer):
+@patch("saleor.webhook.observability.utils.get_buffer")
+def test_pop_events_with_remaining_size(mock_get_buffer, buffer):
+    mock_get_buffer.return_value = buffer
     payload = "payload-{}"
     buffer.put_events([payload.format(i) for i in range(BATCH_SIZE + BATCH_SIZE // 2)])
 
@@ -253,7 +259,11 @@ def test_pop_events_with_remaining_size(buffer):
     assert batch_count == 1
 
 
-def test_pop_events_with_remaining_size_catch_exceptions(redis_server, buffer):
+@patch("saleor.webhook.observability.utils.get_buffer")
+def test_pop_events_with_remaining_size_catch_exceptions(
+    mock_get_buffer, redis_server, buffer
+):
+    mock_get_buffer.return_value = buffer
     redis_server.connected = False
 
     assert pop_events_with_remaining_size() == ([], 0)

--- a/saleor/webhook/observability/tests/test_utils.py
+++ b/saleor/webhook/observability/tests/test_utils.py
@@ -6,26 +6,30 @@ import pytest
 import pytz
 from celery.exceptions import Retry
 from django.core.cache import cache
+from django.http import HttpResponse
 from freezegun import freeze_time
 
 from ..payload_schema import JsonTruncText
 from ..payloads import CustomJsonEncoder
 from ..utils import (
+    ApiCall,
     WebhookData,
-    _webhooks_active_cache,
+    active_webhooks_exists,
+    active_webhooks_exists_clear_cache,
     get_observability_webhooks,
-    observability_webhooks_active,
+    report_api_call,
+    report_gql_operation,
     task_next_retry_date,
 )
 
 
 @pytest.fixture
-def reset_cache():
+def clear_cache():
     yield
     cache.clear()
 
 
-def test_get_observability_webhooks(reset_cache, observability_app):
+def test_get_observability_webhooks(clear_cache, observability_app):
     webhook = observability_app.webhooks.first()
     observability_webhooks = get_observability_webhooks()
     assert observability_webhooks == [
@@ -40,7 +44,7 @@ def test_get_observability_webhooks(reset_cache, observability_app):
 
 @patch("saleor.webhook.observability.utils.get_webhooks_for_event")
 def test_get_observability_webhooks_cache(
-    mocked_get_webhooks_for_event, reset_cache, observability_app
+    mocked_get_webhooks_for_event, clear_cache, observability_app
 ):
     webhook = observability_app.webhooks.first()
     mocked_get_webhooks_for_event.return_value = [webhook]
@@ -49,30 +53,30 @@ def test_get_observability_webhooks_cache(
     mocked_get_webhooks_for_event.assert_called_once()
 
 
-def test_observability_webhooks_active(reset_cache, observability_app):
-    _webhooks_active_cache.clear()
-    assert observability_webhooks_active() is True
+def test_observability_webhooks_active(clear_cache, observability_app):
+    active_webhooks_exists_clear_cache()
+    assert active_webhooks_exists() is True
 
 
 def test_observability_webhooks_active_when_app_deactivated(
-    reset_cache, observability_app
+    clear_cache, observability_app
 ):
-    _webhooks_active_cache.clear()
+    active_webhooks_exists_clear_cache()
     observability_app.is_active = False
     observability_app.save()
 
-    assert observability_webhooks_active() is False
+    assert active_webhooks_exists() is False
 
 
 @patch("saleor.webhook.observability.utils.get_observability_webhooks")
 def test_observability_webhooks_active_cache(
-    mocked_get_observability_webhooks, reset_cache, observability_app
+    mock_get_observability_webhooks, clear_cache, observability_app
 ):
-    _webhooks_active_cache.clear()
-    mocked_get_observability_webhooks.return_value = []
-    observability_webhooks_active(), observability_webhooks_active()
+    active_webhooks_exists_clear_cache()
+    mock_get_observability_webhooks.return_value = []
+    active_webhooks_exists(), active_webhooks_exists()
 
-    mocked_get_observability_webhooks.assert_called_once()
+    mock_get_observability_webhooks.assert_called_once()
 
 
 def test_custom_json_encoder_dumps_json_trunc_text():
@@ -119,3 +123,90 @@ def test_json_truncate_text_to_byte_limit(
 @freeze_time("1914-06-28 10:50")
 def test_task_next_retry_date(retry, next_retry_date):
     assert task_next_retry_date(retry) == next_retry_date
+
+
+@pytest.fixture
+def test_request(rf):
+    return rf.post("/graphql", data={"request": "data"})
+
+
+@pytest.fixture
+def observability_enabled(settings):
+    settings.OBSERVABILITY_ACTIVE = True
+    settings.OBSERVABILITY_REPORT_ALL_API_CALLS = False
+    yield
+
+
+@pytest.fixture
+def observability_disabled(settings):
+    settings.OBSERVABILITY_ACTIVE = False
+    settings.OBSERVABILITY_REPORT_ALL_API_CALLS = False
+    yield
+
+
+@patch("saleor.webhook.observability.utils.ApiCall.report")
+def test_report_api_call_scope(mocked_api_call_report, test_request):
+    with report_api_call(test_request) as level_1:
+        with report_api_call(test_request) as level_2:
+            with report_api_call(test_request) as level_3:
+                assert level_1 == level_2
+                assert level_1 == level_3
+                assert level_2 == level_3
+                level_3.report()
+    assert mocked_api_call_report.call_count == 2
+    with report_api_call(test_request) as diff_scope:
+        assert diff_scope != level_1
+
+
+def test_report_gql_operation_scope(test_request):
+    with report_api_call(test_request) as api_call:
+        assert len(api_call.gql_operations) == 0
+        with report_gql_operation() as operation_a:
+            with report_gql_operation() as operation_a_l2:
+                assert operation_a == operation_a_l2
+        with report_gql_operation() as operation_b:
+            pass
+        assert len(api_call.gql_operations) == 2
+        assert api_call.gql_operations == [operation_a, operation_b]
+
+
+@pytest.fixture
+def api_call(test_request):
+    api_call = ApiCall(request=test_request)
+    api_call.response = HttpResponse({"response": "data"})
+    return api_call
+
+
+@patch("saleor.webhook.observability.utils.put_to_buffer")
+@patch("saleor.webhook.observability.utils.active_webhooks_exists")
+def test_api_call_report(
+    mock_active_webhooks_exists,
+    mock_put_to_buffer,
+    observability_enabled,
+    app,
+    api_call,
+    test_request,
+):
+    mock_active_webhooks_exists.return_value = True
+    test_request.app = app
+    api_call.report(), api_call.report()
+
+    mock_put_to_buffer.assert_called_once()
+
+
+@patch("saleor.webhook.observability.utils.active_webhooks_exists")
+def test_api_call_response_report_when_observability_not_active(
+    mock_active_webhooks_exists, observability_disabled, api_call
+):
+    api_call.report()
+
+    mock_active_webhooks_exists.assert_not_called()
+
+
+@patch("saleor.webhook.observability.utils.active_webhooks_exists")
+def test_api_call_response_report_when_request_not_from_app(
+    mock_active_webhooks_exists, observability_enabled, api_call
+):
+    api_call.report()
+
+    mock_active_webhooks_exists.assert_not_called()

--- a/saleor/webhook/observability/tracing.py
+++ b/saleor/webhook/observability/tracing.py
@@ -1,0 +1,14 @@
+from contextlib import contextmanager
+
+import opentracing
+
+
+@contextmanager
+def opentracing_trace(span_name, component):
+    with opentracing.global_tracer().start_active_span(
+        f"observability.{span_name}"
+    ) as scope:
+        span = scope.span
+        span.set_tag("service.name", "observability")
+        span.set_tag(opentracing.tags.COMPONENT, component)
+        yield

--- a/saleor/webhook/observability/utils.py
+++ b/saleor/webhook/observability/utils.py
@@ -93,7 +93,8 @@ def put_event(generate_payload: Callable[[], Any]):
     try:
         payload = generate_payload()
         with opentracing_trace("put_event", "buffer"):
-            get_buffer(get_buffer_name()).put_event(payload)
+            if get_buffer(get_buffer_name()).put_event(payload):
+                logger.warning("[Observability] Buffer full, event dropped")
     except Exception:
         logger.error("[Observability] Event dropped", exc_info=True)
 

--- a/saleor/webhook/observability/utils.py
+++ b/saleor/webhook/observability/utils.py
@@ -100,14 +100,14 @@ def put_event(generate_payload: Callable[[], Any]):
 
 
 def pop_events_with_remaining_size() -> Tuple[List[Any], int]:
-    try:
-        buffer = get_buffer(get_buffer_name())
-        with opentracing_trace("pop_events", "buffer"):
+    with opentracing_trace("pop_events", "buffer"):
+        try:
+            buffer = get_buffer(get_buffer_name())
             events, remaining = buffer.pop_events_get_size()
             batch_count = buffer.in_batches(remaining)
-    except Exception:
-        logger.error("[Observability] Could not pop events batch", exc_info=True)
-        events, batch_count = [], 0
+        except Exception:
+            logger.error("[Observability] Could not pop events batch", exc_info=True)
+            events, batch_count = [], 0
     return events, batch_count
 
 

--- a/saleor/webhook/observability/utils.py
+++ b/saleor/webhook/observability/utils.py
@@ -1,0 +1,202 @@
+import logging
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from functools import partial
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    TypedDict,
+)
+
+import opentracing
+import opentracing.tags
+from asgiref.local import Local
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.core.cache import cache
+from django.utils import timezone
+from graphql import GraphQLDocument
+from pytimeparse import parse
+
+from ..event_types import WebhookEventAsyncType
+from ..utils import get_webhooks_for_event
+from .buffers import get_buffer
+from .exceptions import ObservabilityError
+from .payloads import generate_api_call_payload, generate_event_delivery_attempt_payload
+
+if TYPE_CHECKING:
+
+    from celery.exceptions import Retry
+    from django.http import HttpRequest, HttpResponse
+
+    from ...core.models import EventDeliveryAttempt
+
+logger = logging.getLogger(__name__)
+OBSERVABILITY_EVENT_TYPE = WebhookEventAsyncType.OBSERVABILITY
+WEBHOOKS_CACHE_TIMEOUT = parse("5 minutes")
+BUFFER_KEY = "observability_buffer"
+WEBHOOKS_KEY = "observability_webhooks"
+_IS_ACTIVE_CACHE: Dict[str, Tuple[bool, float]] = {}
+_context = Local()
+
+
+class WebhookData(TypedDict):
+    saleor_domain: str
+    target_url: str
+    secret_key: Optional[str]
+
+
+def get_buffer_name() -> str:
+    return cache.make_key(BUFFER_KEY)
+
+
+def get_observability_webhooks() -> List[WebhookData]:
+    webhooks_data = cache.get(WEBHOOKS_KEY)
+    if webhooks_data is None:
+        webhooks_data = []
+        if webhooks := get_webhooks_for_event(OBSERVABILITY_EVENT_TYPE):
+            domain = Site.objects.get_current().domain
+            for webhook in webhooks:
+                webhooks_data.append(
+                    WebhookData(
+                        saleor_domain=domain,
+                        target_url=webhook.target_url,
+                        secret_key=webhook.secret_key,
+                    )
+                )
+        cache.set(WEBHOOKS_KEY, webhooks_data, timeout=WEBHOOKS_CACHE_TIMEOUT)
+    return webhooks_data
+
+
+def is_observability_active(timeout=WEBHOOKS_CACHE_TIMEOUT) -> bool:
+    key = get_buffer_name()
+    if (cached := _IS_ACTIVE_CACHE.get(key, None)) is not None:
+        is_active, check_time = cached
+        if time.monotonic() - check_time <= timeout:
+            return is_active
+    is_active = bool(get_observability_webhooks())
+    _IS_ACTIVE_CACHE[key] = (is_active, time.monotonic())
+    return is_active
+
+
+def task_next_retry_date(retry_error: "Retry") -> Optional[datetime]:
+    if isinstance(retry_error.when, (int, float)):
+        return timezone.now() + timedelta(seconds=retry_error.when)
+    if isinstance(retry_error.when, datetime):
+        return retry_error.when
+    return None
+
+
+def put_to_buffer(event_payload: Callable[[], str], sync=True):
+    if not sync:
+        raise NotImplementedError(
+            "[Observability] Async upload to buffer not implemented"
+        )
+    try:
+        payload = event_payload()
+        get_buffer().put_event(get_buffer_name(), payload)
+    except ObservabilityError:
+        logger.error("[Observability] Event dropped", exc_info=True)
+
+
+@dataclass
+class GraphQLOperationResponse:
+    name: Optional[str] = None
+    query: Optional[GraphQLDocument] = None
+    variables: Optional[Dict] = None
+    result: Optional[Dict] = None
+    result_invalid: bool = False
+
+
+class ApiCallContext:
+    def __init__(self, request: "HttpRequest"):
+        self.gql_operations: List[GraphQLOperationResponse] = []
+        self.response: Optional["HttpResponse"] = None
+        self._reported = False
+        self.request = request
+
+    def report(self):
+        if (
+            self._reported
+            or not settings.OBSERVABILITY_ACTIVE
+            or (
+                not getattr(self.request, "app", None)
+                and not settings.OBSERVABILITY_REPORT_ALL_API_CALLS
+            )
+        ):
+            return
+        self._reported = True
+        tracer = opentracing.global_tracer()
+        with tracer.start_active_span("observability_report_api_call") as scope:
+            scope.span.set_tag(opentracing.tags.COMPONENT, "observability")
+            if self.response is None:
+                logger.error("[Observability] HttpResponse not provided, event dropped")
+                return
+            if is_observability_active():
+                put_to_buffer(
+                    partial(
+                        generate_api_call_payload,
+                        self.request,
+                        self.response,
+                        self.gql_operations,
+                        settings.OBSERVABILITY_MAX_PAYLOAD_SIZE,
+                    )
+                )
+
+
+@contextmanager
+def report_api_call(request: "HttpRequest") -> Generator[ApiCallContext, None, None]:
+    root = False
+    if not hasattr(_context, "api_call"):
+        _context.api_call, root = ApiCallContext(request), True
+    yield _context.api_call
+    if root:
+        _context.api_call.report()
+        del _context.api_call
+
+
+@contextmanager
+def report_gql_operation() -> Generator[GraphQLOperationResponse, None, None]:
+    root = False
+    if not hasattr(_context, "gql_operation"):
+        _context.gql_operation, root = GraphQLOperationResponse(), True
+    yield _context.gql_operation
+    if root:
+        if hasattr(_context, "api_call"):
+            _context.api_call.gql_operations.append(_context.gql_operation)
+        del _context.gql_operation
+
+
+def report_webhook_event_delivery(
+    attempt: "EventDeliveryAttempt", next_retry: Optional["datetime"] = None
+):
+    if not settings.OBSERVABILITY_ACTIVE:
+        return
+    tracer = opentracing.global_tracer()
+    with tracer.start_active_span(
+        "observability_report_event_delivery_attempt"
+    ) as scope:
+        scope.span.set_tag(opentracing.tags.COMPONENT, "observability")
+        if is_observability_active():
+            if attempt.delivery is None:
+                logger.error(
+                    "[Observability] Event delivery not assigned to attempt: %r. "
+                    "Event dropped",
+                    attempt,
+                )
+                return
+            put_to_buffer(
+                partial(
+                    generate_event_delivery_attempt_payload,
+                    attempt,
+                    next_retry,
+                    settings.OBSERVABILITY_MAX_PAYLOAD_SIZE,
+                )
+            )

--- a/saleor/webhook/observability/utils.py
+++ b/saleor/webhook/observability/utils.py
@@ -45,6 +45,8 @@ BUFFER_KEY = "observability_buffer"
 WEBHOOKS_KEY = "observability_webhooks"
 _IS_ACTIVE_CACHE: Dict[str, Tuple[bool, float]] = {}
 _context = Local()
+_api_call_attr = "api_call"
+_gql_operation_attr = "gql_operation"
 
 
 class WebhookData(TypedDict):


### PR DESCRIPTION
I want to merge this change because it adds an observability reporter to Saleor. This PR will be followed by another one, moving uploading observability tasks to Redis buffer using background worker (working in a separate thread).

- Activate Observability reporter by setting `OBSERVABILITY_BROKER_URL`. Right now, only Redis is supported.
- The reporter gathers two observability event types: API calls and event delivery attempts. It collects API calls only from apps by default, but the `OBSERVABILITY_REPORT_ALL_API_CALLS` setting can change this (useful for debugging).
- Observability events are buffered, and the buffer size is configurable using the `OBSERVABILITY_BUFFER_SIZE_LIMIT` setting. Events put to the full buffer are skipped. In addition, the payload of the observability event is truncated during creation to the maximum size specified by `OBSERVABILITY_MAX_PAYLOAD_SIZE`.
- A Celery background task periodically empties the buffer. `OBSERVABILITY_REPORT_PERIOD` can regulate the frequency of emptying the buffer (every 20s by default). Reporter sends observability events to all webhooks, listening for `OBSERVABILITY` event types. Events are sent in batches. Batch size is configured using `OBSERVABILITY_BUFFER_BATCH_SIZE`.

During the observability event payload creation, all data coming from the Graphql backend is anonymized. Right now, the presence of any sensitive field in the query results in anonymizing the whole response. It will be improved in future PR.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
