### PR TITLE
Fix memory consumption of delete_event_payloads_task

### DIFF
--- a/saleor/core/tests/test_tasks.py
+++ b/saleor/core/tests/test_tasks.py
@@ -1,10 +1,19 @@
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 from django.core.files.storage import default_storage
+from django.utils import timezone
+from freezegun import freeze_time
 
 from ...product.models import ProductMedia
-from ..tasks import delete_from_storage_task, delete_product_media_task
+from ...webhook.event_types import WebhookEventAsyncType
+from ..models import EventDelivery, EventDeliveryAttempt, EventPayload
+from ..tasks import (
+    delete_event_payloads_task,
+    delete_from_storage_task,
+    delete_product_media_task,
+)
 
 
 def test_delete_from_storage_task(product_with_image, media_root):
@@ -60,3 +69,24 @@ def test_delete_product_media_task_product_media_to_remove(
     delete_versatile_img_mock.assert_called_once_with(media.image)
     with pytest.raises(media._meta.model.DoesNotExist):
         media.refresh_from_db()
+
+
+def test_delete_event_payloads_task(webhook, settings):
+    delete_period = settings.EVENT_PAYLOAD_DELETE_PERIOD
+    before_delete_period = timezone.now() - delete_period - timedelta(hours=12)
+    after_delete_period = timezone.now() - delete_period + timedelta(hours=12)
+    for creation_time in [before_delete_period, after_delete_period]:
+        with freeze_time(creation_time):
+            payload = EventPayload.objects.create(payload='{"key": "data"}')
+            delivery = EventDelivery.objects.create(
+                event_type=WebhookEventAsyncType.ANY,
+                payload=payload,
+                webhook=webhook,
+            )
+            EventDeliveryAttempt.objects.create(delivery=delivery)
+
+    delete_event_payloads_task()
+
+    assert EventPayload.objects.count() == 1
+    assert EventDelivery.objects.count() == 1
+    assert EventDeliveryAttempt.objects.count() == 1


### PR DESCRIPTION
I want to merge this change because it optimizes memory consumption of `delete_event_payloads_task` by switching to raw SQL queries to delete event data.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
