### PR TITLE
Add unit price to checkout line resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Migrate order discount id from int to UUID - #9729 by @IKarbowiak
   - Changed the order discount `id` from `int` to `UUID`, the old ids still can be used
   for old order discounts.
+- Add `unitPrice`, `undiscountedUnitPrice`, `undiscountedTotalPrice` fields to `CheckoutLine` type - #9821 by @fowczarek
 
 ### Other changes
 - Fix for sending incorrect prices to Avatax - #9633 by @korycins

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -484,7 +484,7 @@ def _create_order(
         voucher = order_data.get("voucher")
         # When we have a voucher for specific products we track it directly in the
         # Orderline. Voucher with 'apply_once_per_order' is handled in the same way
-        # as we apply it only for single quantity of the cheapest line.
+        # as we apply it only for single quantity of the cheapest item.
         if not voucher or (
             voucher.type != VoucherType.SPECIFIC_PRODUCT
             and not voucher.apply_once_per_order
@@ -907,7 +907,7 @@ def _handle_checkout_discount(
 
         # When we have a voucher for specific products we track it directly in the
         # Orderline. Voucher with 'apply_once_per_order' is handled in the same way
-        # as we apply it only for single quantity of the cheapest line.
+        # as we apply it only for single quantity of the cheapest item.
         if not voucher or (
             voucher.type != VoucherType.SPECIFIC_PRODUCT
             and not voucher.apply_once_per_order

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -331,7 +331,7 @@ def apply_voucher_to_checkout_line(
     """Attach voucher to valid checkout lines info.
 
     Apply a voucher to checkout line info when the voucher has the type
-    SPECIFIC_PRODUCTS or is applied only to the cheapest line.
+    SPECIFIC_PRODUCTS or is applied only to the cheapest item.
     """
     from .utils import get_discounted_lines
 

--- a/saleor/checkout/tests/test_base_calculations.py
+++ b/saleor/checkout/tests/test_base_calculations.py
@@ -336,10 +336,10 @@ def test_calculate_base_line_unit_price_with_discounts_apply_once_per_order(
         channel_listing=checkout_line_info.channel_listing,
         discounts=[],
     )
+    expected_voucher_amount = expected_price * voucher_percent_value / 100
     assert prices_data.undiscounted_price == expected_price
     assert prices_data.price_with_sale == expected_price
-    # apply once per order is applied when calculating line total.
-    assert prices_data.price_with_discounts == expected_price
+    assert prices_data.price_with_discounts == expected_price - expected_voucher_amount
 
 
 def test_calculate_base_line_unit_price_with_discounts_once_per_order_custom_prices(
@@ -375,10 +375,10 @@ def test_calculate_base_line_unit_price_with_discounts_once_per_order_custom_pri
     # then
     currency = checkout_line_info.channel_listing.currency
     expected_price = Money(price_override, currency)
+    expected_voucher_amount = expected_price * voucher_percent_value / 100
     assert prices_data.undiscounted_price == expected_price
     assert prices_data.price_with_sale == expected_price
-    # apply once per order is applied when calculating line total.
-    assert prices_data.price_with_discounts == expected_price
+    assert prices_data.price_with_discounts == expected_price - expected_voucher_amount
 
 
 def test_calculate_base_line_unit_price_with_variant_on_sale_and_voucher(

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -3644,10 +3644,14 @@ QUERY_CHECKOUT_PRICES = """
                 }
             }
            lines {
-                unitPrice{
-                    gross{
+                unitPrice {
+                    gross {
                         amount
                     }
+                }
+                undiscountedUnitPice {
+                    amount
+                    currency
                 }
                 totalPrice {
                     currency
@@ -3712,6 +3716,18 @@ def test_checkout_prices(user_api_client, checkout_with_item):
         data["lines"][0]["totalPrice"]["gross"]["amount"]
         == line_total_price.gross.amount
     )
+    undiscounted_unit_price = line_info.variant.get_price(
+        line_info.product,
+        line_info.collections,
+        checkout_info.channel,
+        line_info.channel_listing,
+        [],
+        line_info.line.price_override,
+    )
+    assert (
+        data["lines"][0]["undiscountedUnitPice"]["amount"]
+        == undiscounted_unit_price.amount
+    )
 
 
 def test_checkout_prices_checkout_with_custom_prices(
@@ -3756,6 +3772,7 @@ def test_checkout_prices_checkout_with_custom_prices(
         data["lines"][0]["totalPrice"]["gross"]["amount"]
         == checkout_line.quantity * price_override
     )
+    assert data["lines"][0]["undiscountedUnitPice"]["amount"] == price_override
 
 
 def test_checkout_prices_with_sales(user_api_client, checkout_with_item, discount_info):
@@ -3808,6 +3825,18 @@ def test_checkout_prices_with_sales(user_api_client, checkout_with_item, discoun
     assert (
         data["lines"][0]["totalPrice"]["gross"]["amount"]
         == line_total_price.gross.amount
+    )
+    undiscounted_unit_price = line_info.variant.get_price(
+        line_info.product,
+        line_info.collections,
+        checkout_info.channel,
+        line_info.channel_listing,
+        [],
+        line_info.line.price_override,
+    )
+    assert (
+        data["lines"][0]["undiscountedUnitPice"]["amount"]
+        == undiscounted_unit_price.amount
     )
 
 
@@ -3867,6 +3896,18 @@ def test_checkout_prices_with_specific_voucher(
         data["lines"][0]["totalPrice"]["gross"]["amount"]
         == line_total_price.gross.amount
     )
+    undiscounted_unit_price = line_info.variant.get_price(
+        line_info.product,
+        line_info.collections,
+        checkout_info.channel,
+        line_info.channel_listing,
+        [],
+        line_info.line.price_override,
+    )
+    assert (
+        data["lines"][0]["undiscountedUnitPice"]["amount"]
+        == undiscounted_unit_price.amount
+    )
 
 
 def test_checkout_prices_with_voucher_once_per_order(
@@ -3923,6 +3964,18 @@ def test_checkout_prices_with_voucher_once_per_order(
     assert (
         data["lines"][0]["totalPrice"]["gross"]["amount"]
         == line_total_price.gross.amount
+    )
+    undiscounted_unit_price = line_info.variant.get_price(
+        line_info.product,
+        line_info.collections,
+        checkout_info.channel,
+        line_info.channel_listing,
+        [],
+        line_info.line.price_override,
+    )
+    assert (
+        data["lines"][0]["undiscountedUnitPice"]["amount"]
+        == undiscounted_unit_price.amount
     )
 
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -3649,7 +3649,7 @@ QUERY_CHECKOUT_PRICES = """
                         amount
                     }
                 }
-                undiscountedUnitPice {
+                undiscountedUnitPrice {
                     amount
                     currency
                 }
@@ -3658,6 +3658,10 @@ QUERY_CHECKOUT_PRICES = """
                     gross {
                         amount
                     }
+                }
+                undiscountedTotalPrice {
+                    amount
+                    currency
                 }
            }
         }
@@ -3725,8 +3729,12 @@ def test_checkout_prices(user_api_client, checkout_with_item):
         line_info.line.price_override,
     )
     assert (
-        data["lines"][0]["undiscountedUnitPice"]["amount"]
+        data["lines"][0]["undiscountedUnitPrice"]["amount"]
         == undiscounted_unit_price.amount
+    )
+    assert (
+        data["lines"][0]["undiscountedTotalPrice"]["amount"]
+        == undiscounted_unit_price.amount * line_info.line.quantity
     )
 
 
@@ -3772,7 +3780,11 @@ def test_checkout_prices_checkout_with_custom_prices(
         data["lines"][0]["totalPrice"]["gross"]["amount"]
         == checkout_line.quantity * price_override
     )
-    assert data["lines"][0]["undiscountedUnitPice"]["amount"] == price_override
+    assert data["lines"][0]["undiscountedUnitPrice"]["amount"] == price_override
+    assert (
+        data["lines"][0]["undiscountedTotalPrice"]["amount"]
+        == price_override * line_info.line.quantity
+    )
 
 
 def test_checkout_prices_with_sales(user_api_client, checkout_with_item, discount_info):
@@ -3835,8 +3847,12 @@ def test_checkout_prices_with_sales(user_api_client, checkout_with_item, discoun
         line_info.line.price_override,
     )
     assert (
-        data["lines"][0]["undiscountedUnitPice"]["amount"]
+        data["lines"][0]["undiscountedUnitPrice"]["amount"]
         == undiscounted_unit_price.amount
+    )
+    assert (
+        data["lines"][0]["undiscountedTotalPrice"]["amount"]
+        == undiscounted_unit_price.amount * line_info.line.quantity
     )
 
 
@@ -3905,8 +3921,12 @@ def test_checkout_prices_with_specific_voucher(
         line_info.line.price_override,
     )
     assert (
-        data["lines"][0]["undiscountedUnitPice"]["amount"]
+        data["lines"][0]["undiscountedUnitPrice"]["amount"]
         == undiscounted_unit_price.amount
+    )
+    assert (
+        data["lines"][0]["undiscountedTotalPrice"]["amount"]
+        == undiscounted_unit_price.amount * line_info.line.quantity
     )
 
 
@@ -3974,8 +3994,12 @@ def test_checkout_prices_with_voucher_once_per_order(
         line_info.line.price_override,
     )
     assert (
-        data["lines"][0]["undiscountedUnitPice"]["amount"]
+        data["lines"][0]["undiscountedUnitPrice"]["amount"]
         == undiscounted_unit_price.amount
+    )
+    assert (
+        data["lines"][0]["undiscountedTotalPrice"]["amount"]
+        == undiscounted_unit_price.amount * line_info.line.quantity
     )
 
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -37,6 +37,7 @@ from ....checkout.utils import (
     calculate_checkout_quantity,
 )
 from ....core.payments import PaymentInterface
+from ....core.prices import quantize_price
 from ....payment import TransactionAction, TransactionKind
 from ....payment.interface import GatewayResponse
 from ....plugins.base_plugin import ExcludedShippingMethod
@@ -3914,12 +3915,11 @@ def test_checkout_prices_with_voucher_once_per_order(
     )
     assert line_total_prices.price_with_discounts != line_total_prices.price_with_sale
     line_total_price = line_total_prices.price_with_discounts
-    # TODO:
-    # fix it currently Voucher applied once per order are only calculated in line total
-    # assert (
-    #     data["lines"][0]["unitPrice"]["gross"]["amount"]
-    #     == line_total_price.gross.amount / line_info.line.quantity
-    # )
+    assert data["lines"][0]["unitPrice"]["gross"]["amount"] == float(
+        quantize_price(
+            line_total_price.gross.amount / line_info.line.quantity, checkout.currency
+        )
+    )
     assert (
         data["lines"][0]["totalPrice"]["gross"]["amount"]
         == line_total_price.gross.amount

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -94,6 +94,13 @@ class CheckoutLine(ModelObjectType):
         ),
         required=True,
     )
+    undiscounted_unit_pice = graphene.Field(
+        Money,
+        description=(
+            "The unit price of the checkout line, without discounts included."
+        ),
+        required=True,
+    )
     total_price = graphene.Field(
         TaxedMoney,
         description="The sum of the checkout line price, taxes and discounts.",
@@ -160,6 +167,64 @@ class CheckoutLine(ModelObjectType):
                     lines,
                 ]
             ).then(calculate_line_unit_price)
+
+        return (
+            CheckoutByTokenLoader(info.context)
+            .load(root.checkout_id)
+            .then(with_checkout)
+        )
+
+    @staticmethod
+    def resolve_undiscounted_unit_pice(root, info):
+        def with_checkout(checkout):
+            discounts = DiscountsByDateTimeLoader(info.context).load(
+                info.context.request_time
+            )
+            checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(
+                checkout.token
+            )
+            lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(
+                checkout.token
+            )
+
+            def calculate_undiscounted_unit_price(data):
+                (
+                    discounts,
+                    checkout_info,
+                    lines,
+                ) = data
+                for line_info in lines:
+                    if line_info.line.pk == root.pk:
+                        address = (
+                            checkout_info.shipping_address
+                            or checkout_info.billing_address
+                        )
+                        include_taxes_in_prices = (
+                            info.context.site.settings.include_taxes_in_prices
+                        )
+                        undiscounted_price = (
+                            info.context.plugins.calculate_checkout_line_unit_price(
+                                checkout_info=checkout_info,
+                                lines=lines,
+                                checkout_line_info=line_info,
+                                address=address,
+                                discounts=discounts,
+                            ).undiscounted_price
+                        )
+                        return (
+                            undiscounted_price.gross
+                            if include_taxes_in_prices
+                            else undiscounted_price.net
+                        )
+                return None
+
+            return Promise.all(
+                [
+                    discounts,
+                    checkout_info,
+                    lines,
+                ]
+            ).then(calculate_undiscounted_unit_price)
 
         return (
             CheckoutByTokenLoader(info.context)

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -89,21 +89,22 @@ class CheckoutLine(ModelObjectType):
     quantity = graphene.Int(required=True)
     unit_price = graphene.Field(
         TaxedMoney,
-        description=(
-            "The unit price of the checkout line, with taxes and discounts included."
-        ),
+        description="The unit price of the checkout line, with taxes and discounts.",
         required=True,
     )
-    undiscounted_unit_pice = graphene.Field(
+    undiscounted_unit_price = graphene.Field(
         Money,
-        description=(
-            "The unit price of the checkout line, without discounts included."
-        ),
+        description="The unit price of the checkout line, without discounts.",
         required=True,
     )
     total_price = graphene.Field(
         TaxedMoney,
         description="The sum of the checkout line price, taxes and discounts.",
+        required=True,
+    )
+    undiscounted_total_price = graphene.Field(
+        Money,
+        description="The sum of the checkout line price, without discounts.",
         required=True,
     )
     requires_shipping = graphene.Boolean(
@@ -126,8 +127,9 @@ class CheckoutLine(ModelObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_unit_price(root, info):
+        # Temporary solution in new tax interface introduced in PR#9526
+        # this value will be denormalized and store in checkout line.
         def with_checkout(checkout):
             discounts = DiscountsByDateTimeLoader(info.context).load(
                 info.context.request_time
@@ -175,7 +177,9 @@ class CheckoutLine(ModelObjectType):
         )
 
     @staticmethod
-    def resolve_undiscounted_unit_pice(root, info):
+    def resolve_undiscounted_unit_price(root, info):
+        # Temporary solution in new tax interface introduced in PR#9526
+        # this value will be denormalized and store in checkout line.
         def with_checkout(checkout):
             discounts = DiscountsByDateTimeLoader(info.context).load(
                 info.context.request_time
@@ -274,6 +278,66 @@ class CheckoutLine(ModelObjectType):
                     lines,
                 ]
             ).then(calculate_line_total_price)
+
+        return (
+            CheckoutByTokenLoader(info.context)
+            .load(root.checkout_id)
+            .then(with_checkout)
+        )
+
+    @staticmethod
+    def resolve_undiscounted_total_price(root, info):
+        # Temporary solution in new tax interface introduced in PR#9526
+        # this value will be denormalized and store in checkout line.
+        def with_checkout(checkout):
+            discounts = DiscountsByDateTimeLoader(info.context).load(
+                info.context.request_time
+            )
+            checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(
+                checkout.token
+            )
+            lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(
+                checkout.token
+            )
+
+            def calculate_undiscounted_total_price(data):
+                (
+                    discounts,
+                    checkout_info,
+                    lines,
+                ) = data
+                for line_info in lines:
+                    if line_info.line.pk == root.pk:
+                        address = (
+                            checkout_info.shipping_address
+                            or checkout_info.billing_address
+                        )
+                        include_taxes_in_prices = (
+                            info.context.site.settings.include_taxes_in_prices
+                        )
+                        undiscounted_price = (
+                            info.context.plugins.calculate_checkout_line_total(
+                                checkout_info=checkout_info,
+                                lines=lines,
+                                checkout_line_info=line_info,
+                                address=address,
+                                discounts=discounts,
+                            ).undiscounted_price
+                        )
+                        return (
+                            undiscounted_price.gross
+                            if include_taxes_in_prices
+                            else undiscounted_price.net
+                        )
+                return None
+
+            return Promise.all(
+                [
+                    discounts,
+                    checkout_info,
+                    lines,
+                ]
+            ).then(calculate_undiscounted_total_price)
 
         return (
             CheckoutByTokenLoader(info.context)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7696,6 +7696,9 @@ type CheckoutLine implements Node {
   """
   unitPrice: TaxedMoney!
 
+  """The unit price of the checkout line, without discounts included."""
+  undiscountedUnitPice: Money!
+
   """The sum of the checkout line price, taxes and discounts."""
   totalPrice: TaxedMoney!
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7691,16 +7691,17 @@ type CheckoutLine implements Node {
   variant: ProductVariant!
   quantity: Int!
 
-  """
-  The unit price of the checkout line, with taxes and discounts included.
-  """
+  """The unit price of the checkout line, with taxes and discounts."""
   unitPrice: TaxedMoney!
 
-  """The unit price of the checkout line, without discounts included."""
-  undiscountedUnitPice: Money!
+  """The unit price of the checkout line, without discounts."""
+  undiscountedUnitPrice: Money!
 
   """The sum of the checkout line price, taxes and discounts."""
   totalPrice: TaxedMoney!
+
+  """The sum of the checkout line price, without discounts."""
+  undiscountedTotalPrice: Money!
 
   """Indicates whether the item need to be delivered."""
   requiresShipping: Boolean!

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7691,6 +7691,11 @@ type CheckoutLine implements Node {
   variant: ProductVariant!
   quantity: Int!
 
+  """
+  The unit price of the checkout line, with taxes and discounts included.
+  """
+  unitPrice: TaxedMoney!
+
   """The sum of the checkout line price, taxes and discounts."""
   totalPrice: TaxedMoney!
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -40,7 +40,7 @@ from ..attribute.models import (
 from ..attribute.utils import associate_attribute_values_to_instance
 from ..checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ..checkout.models import Checkout, CheckoutLine
-from ..checkout.utils import add_variant_to_checkout
+from ..checkout.utils import add_variant_to_checkout, add_voucher_to_checkout
 from ..core import EventDeliveryStatus, JobStatus, TimePeriodType
 from ..core.models import EventDelivery, EventDeliveryAttempt, EventPayload
 from ..core.payments import PaymentInterface
@@ -310,6 +310,32 @@ def checkout_with_item(checkout, product):
     add_variant_to_checkout(checkout_info, variant, 3)
     checkout.save()
     return checkout
+
+
+@pytest.fixture
+def checkout_with_item_and_voucher_specific_products(
+    checkout_with_item, voucher_specific_product_type
+):
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
+    add_voucher_to_checkout(
+        manager, checkout_info, lines, voucher_specific_product_type
+    )
+    checkout_with_item.refresh_from_db()
+    return checkout_with_item
+
+
+@pytest.fixture
+def checkout_with_item_and_voucher_once_per_order(checkout_with_item, voucher):
+    voucher.apply_once_per_order = True
+    voucher.save()
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
+    add_voucher_to_checkout(manager, checkout_info, lines, voucher)
+    checkout_with_item.refresh_from_db()
+    return checkout_with_item
 
 
 @pytest.fixture
@@ -3058,7 +3084,8 @@ def voucher_percentage(channel_USD):
 
 
 @pytest.fixture
-def voucher_specific_product_type(voucher_percentage):
+def voucher_specific_product_type(voucher_percentage, product):
+    voucher_percentage.products.add(product)
     voucher_percentage.type = VoucherType.SPECIFIC_PRODUCT
     voucher_percentage.save()
     return voucher_percentage


### PR DESCRIPTION
I want to merge this change because adding unit pice to checkout lines. 

Extend checkout line type for:
```graphql
type CheckoutLine implements Node {
   ...
   unitPrice: TaxedMoney!
   undiscountedUnitPrice: Money!
   undiscountedTotalPrice: Money!
}
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
