### PR TITLE
Missing fields added to payment webhooks event payload.

### DIFF
--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -20,6 +20,15 @@ class TransactionActionData:
 
 
 @dataclass
+class TransactionData:
+    token: str
+    is_success: bool
+    kind: str
+    gateway_response: JSONType
+    amount: Dict[str, str]
+
+
+@dataclass
 class PaymentMethodInfo:
     """Uniform way to represent payment method information."""
 
@@ -120,6 +129,7 @@ class PaymentData:
     order_id: Optional[int]
     customer_ip_address: Optional[str]
     customer_email: str
+    order_channel_slug: Optional[str] = None
     token: Optional[str] = None
     customer_id: Optional[str] = None  # stores payment gateway customer ID
     reuse_source: bool = False  # Note: this field will be removed in 4.0.
@@ -131,6 +141,7 @@ class PaymentData:
     payment_metadata: Dict[str, str] = field(default_factory=dict)
     psp_reference: Optional[str] = None
     refund_data: Optional[RefundData] = None
+    transactions: List[TransactionData] = field(default_factory=list)
     # Optional, lazy-evaluated gateway arguments
     _resolve_lines_data: InitVar[Callable[[], PaymentLinesData]] = None
 

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import AnonymousUser
 
 from ...checkout.calculations import checkout_total
 from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from ...core.prices import quantize_price
 from ...plugins.manager import PluginsManager, get_plugins_manager
 from .. import (
     ChargeStatus,
@@ -17,7 +18,7 @@ from .. import (
     gateway,
 )
 from ..error_codes import PaymentErrorCode
-from ..interface import GatewayResponse, PaymentMethodInfo
+from ..interface import GatewayResponse, PaymentMethodInfo, TransactionData
 from ..models import Payment
 from ..utils import (
     ALLOWED_GATEWAY_KINDS,
@@ -257,6 +258,38 @@ def test_create_payment_information_for_checkout_metadata(payment_dummy, checkou
 
     payment_info = create_payment_information(payment_dummy)
     assert payment_info.checkout_metadata == metadata
+
+
+def test_create_payment_information_for_payment_with_transactions(payment_dummy):
+    # given
+    payment_dummy.transactions.create(
+        amount=payment_dummy.total,
+        currency=payment_dummy.currency,
+        kind=TransactionKind.AUTH,
+        gateway_response={"status": "SUCCESS"},
+        is_success=True,
+    )
+
+    # when
+    payment_info = create_payment_information(payment_dummy)
+
+    # then
+    for transaction in payment_dummy.transactions.all():
+        assert (
+            TransactionData(
+                token=transaction.token,
+                is_success=transaction.is_success,
+                kind=transaction.kind,
+                gateway_response=transaction.gateway_response,
+                amount={
+                    "amount": str(
+                        quantize_price(transaction.amount, transaction.currency)
+                    ),
+                    "currency": transaction.currency,
+                },
+            )
+            in payment_info.transactions
+        )
 
 
 def test_create_payment_information_for_draft_order(draft_order):

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -24,7 +24,7 @@ from ...order.actions import fulfill_order_lines
 from ...order.fetch import OrderLineInfo
 from ...order.models import Order
 from ...payment import TransactionAction
-from ...payment.interface import TransactionActionData
+from ...payment.interface import TransactionActionData, TransactionData
 from ...payment.models import TransactionItem
 from ...plugins.manager import get_plugins_manager
 from ...plugins.webhook.utils import from_payment_app_id
@@ -765,6 +765,42 @@ def test_generate_payment_payload(dummy_webhook_app_payment_data):
     ).name
     expected_payload["meta"] = generate_meta(requestor_data=generate_requestor())
 
+    assert payload == json.dumps(expected_payload, cls=CustomJsonEncoder)
+
+
+@freeze_time("1914-06-28 10:50")
+def test_generate_payment_with_transactions_payload(dummy_webhook_app_payment_data):
+    transaction_data = {
+        "token": "token",
+        "is_success": True,
+        "kind": "auth",
+        "gateway_response": {"status": "SUCCESS"},
+        "amount": {
+            "amount": str(
+                quantize_price(
+                    dummy_webhook_app_payment_data.amount,
+                    dummy_webhook_app_payment_data.currency,
+                )
+            ),
+            "currency": dummy_webhook_app_payment_data.currency,
+        },
+    }
+
+    dummy_webhook_app_payment_data.transactions = [TransactionData(**transaction_data)]
+
+    payload = generate_payment_payload(dummy_webhook_app_payment_data)
+    expected_payload = asdict(dummy_webhook_app_payment_data)
+
+    expected_payload["amount"] = Decimal(expected_payload["amount"]).quantize(
+        Decimal("0.01")
+    )
+    expected_payload["payment_method"] = from_payment_app_id(
+        dummy_webhook_app_payment_data.gateway
+    ).name
+
+    expected_payload["meta"] = generate_meta(requestor_data=generate_requestor())
+
+    assert expected_payload["transactions"]
     assert payload == json.dumps(expected_payload, cls=CustomJsonEncoder)
 
 


### PR DESCRIPTION
I want to merge this change because it adds missing fields in the payment webhooks events payload.

New fields:

- `order_channel_slug` - channel slug from order
- `transactions` - list of dictionaries with transaction data:
  - `token`
  - `is_success`
  - `kind`
  - `gateway_response`
  - `amount`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
