### PR TITLE
Fix invalid email domain in demo mode

### DIFF
--- a/saleor/plugins/anonymize/plugin.py
+++ b/saleor/plugins/anonymize/plugin.py
@@ -52,6 +52,6 @@ class AnonymizePlugin(BasePlugin):
         customer.first_name = faker.first_name()
         customer.last_name = faker.last_name()
         timestamp = str(timezone.now())
-        email = f"{hash(timestamp + get_random_string(5))}@anonymous-demo-email"
+        email = f"{hash(timestamp + get_random_string(5))}@anonymous-demo-email.com"
         customer.email = email
         customer.save()


### PR DESCRIPTION
I want to merge this change because the previous dummy user email's domain was invalid

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
