### PR TITLE
Fix events deletion in 3.3

### DIFF
--- a/saleor/plugins/webhook/utils.py
+++ b/saleor/plugins/webhook/utils.py
@@ -197,4 +197,7 @@ def delivery_update(delivery: "EventDelivery", status: str):
 
 def clear_successful_delivery(delivery: "EventDelivery"):
     if delivery.status == EventDeliveryStatus.SUCCESS:
+        payload_id = delivery.payload_id
         delivery.delete()
+        if payload_id:
+            EventPayload.objects.filter(pk=payload_id, deliveries__isnull=True).delete()


### PR DESCRIPTION
I want to merge this change because it is a port of #9650 and #9806 to 3.3

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
