### PR TITLE
Handle https protocol in initialize_context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix max_length for voucher_code in Checkout model - #9794 by @SzymJ
 - Fix creating dummy context for subscription webhooks - #9798 by @SzymJ
 - Missing fields added to payment webhooks events payload - #9825 by @SzymJ
+- Fix handling https protocol in initialize_context - #9840 by @SzymJ
 
 # 3.3.0
 

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -59,7 +59,7 @@ def initialize_context() -> HttpRequest:
     context = RequestFactory().request(SERVER_NAME=SimpleLazyObject(get_host))
     handler.load_middleware()
     response = handler.get_response(context)
-    if not response.status_code == 200:
+    if response.status_code not in [200, 301]:
         raise Exception("Unable to initialize context for webhook.")
     return context
 


### PR DESCRIPTION
I want to merge this change because it fixes initialize_context when `SERVER_NAME` uses https protocol.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
