### PR TITLE
Anonymise search payload for order/user in demo mode

### DIFF
--- a/saleor/plugins/anonymize/plugin.py
+++ b/saleor/plugins/anonymize/plugin.py
@@ -4,7 +4,9 @@ from django.utils import timezone
 from django.utils.crypto import get_random_string
 from faker import Faker
 
+from ...account import search
 from ...core.anonymize import obfuscate_address
+from ...order.search import prepare_order_search_document_value
 from ..base_plugin import BasePlugin
 from . import obfuscate_order
 
@@ -46,6 +48,7 @@ class AnonymizePlugin(BasePlugin):
 
     def order_created(self, order: "Order", previous_value: Any):
         order = obfuscate_order(order)
+        order.search_document = prepare_order_search_document_value(order)
         order.save()
 
     def customer_created(self, customer: "User", previous_value: Any) -> Any:
@@ -54,4 +57,7 @@ class AnonymizePlugin(BasePlugin):
         timestamp = str(timezone.now())
         email = f"{hash(timestamp + get_random_string(5))}@anonymous-demo-email.com"
         customer.email = email
+        customer.search_document = search.prepare_user_search_document_value(
+            customer, attach_addresses_data=False
+        )
         customer.save()


### PR DESCRIPTION
I want to merge this change because it runs a logic responsible for re-generate a search payload stored in DB object.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
