### PR TITLE
Add more types and fields to the cost map

### DIFF
--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -124,6 +124,14 @@ COST_MAP = {
         "warehouses": {"complexity": 1, "multipliers": ["first", "last"]},
         "webhook": {"complexity": 1},
     },
+    "Allocation": {
+        "warehouse": {"complexity": 1},
+    },
+    "App": {
+        "extensions": {"complexity": 1},
+        "tokens": {"complexity": 1},
+        "webhooks": {"complexity": 1},
+    },
     "Attribute": {
         "choices": {"complexity": 1, "multipliers": ["first", "last"]},
         "productTypes": {"complexity": 1, "multipliers": ["first", "last"]},
@@ -136,12 +144,93 @@ COST_MAP = {
         "parent": {"complexity": 1},
         "products": {"complexity": 1, "multipliers": ["first", "last"]},
     },
+    "Checkout": {
+        "availableCollectionPoints": {"complexity": 1},
+        "availablePaymentGateways": {"complexity": 1},
+        "availableShippingMethods": {"complexity": 1},
+        "billingAddress": {"complexity": 1},
+        "channel": {"complexity": 1},
+        "giftCards": {"complexity": 1},
+        "lines": {"complexity": 1},
+        "shippingAddress": {"complexity": 1},
+        "shippingMethod": {"complexity": 1},
+        "shippingMethods": {"complexity": 1},
+        "transactions": {"complexity": 1},
+        "user": {"complexity": 1},
+    },
     "Collection": {
         "channelListings": {"complexity": 1},
         "products": {"complexity": 1, "multipliers": ["first", "last"]},
     },
+    "CollectionChannelListing": {
+        "channel": {"complexity": 1},
+    },
+    "Fulfillment": {
+        "lines": {"complexity": 1},
+        "warehouse": {"complexity": 1},
+    },
+    "FulfillmentLine": {
+        "orderLine": {"complexity": 1},
+    },
+    "GiftCard": {
+        "app": {"complexity": 1},
+        "createdBy": {"complexity": 1},
+        "events": {"complexity": 1},
+        "product": {"complexity": 1},
+        "usedBy": {"complexity": 1},
+        "user": {"complexity": 1},
+    },
+    "Group": {
+        "permissions": {"complexity": 1},
+        "users": {"complexity": 1},
+    },
+    "Menu": {
+        "items": {"complexity": 1},
+    },
+    "MenuItem": {
+        "category": {"complexity": 1},
+        "children": {"complexity": 1},
+        "collection": {"complexity": 1},
+        "menu": {"complexity": 1},
+        "page": {"complexity": 1},
+        "parent": {"complexity": 1},
+    },
+    "Order": {
+        "availableCollectionPoints": {"complexity": 1},
+        "availableShippingMethods": {"complexity": 1},
+        "billingAddress": {"complexity": 1},
+        "channel": {"complexity": 1},
+        "deliveryMethod": {"complexity": 1},
+        "discounts": {"complexity": 1},
+        "events": {"complexity": 1},
+        "fulfillments": {"complexity": 1},
+        "giftCards": {"complexity": 1},
+        "invoices": {"complexity": 1},
+        "lines": {"complexity": 1},
+        "payments": {"complexity": 1},
+        "shippingAddress": {"complexity": 1},
+        "shippingMethod": {"complexity": 1},
+        "shippingMethods": {"complexity": 1},
+        "transactions": {"complexity": 1},
+        "user": {"complexity": 1},
+        "voucher": {"complexity": 1},
+    },
     "OrderLine": {
+        "allocations": {"complexity": 1},
+        "thumbnail": {"complexity": 1},
         "variant": {"complexity": 1},
+    },
+    "Page": {
+        "attributes": {"complexity": 1},
+        "pageType": {"complexity": 1},
+    },
+    "PageType": {
+        "attributes": {"complexity": 1},
+        "availableAttributes": {"complexity": 1, "multipliers": ["first", "last"]},
+    },
+    "Payment": {
+        "order": {"complexity": 1},
+        "transactions": {"complexity": 1},
     },
     "Product": {
         "attributes": {"complexity": 1},
@@ -159,6 +248,21 @@ COST_MAP = {
         "thumbnail": {"complexity": 1},
         "variants": {"complexity": 1},
     },
+    "ProductChannelListing": {
+        "channel": {"complexity": 1},
+        "pricing": {"complexity": 1},
+    },
+    "ProductImage": {
+        "url": {"complexity": 1},
+    },
+    "ProductMedia": {
+        "url": {"complexity": 1},
+    },
+    "ProductType": {
+        "availableAttributes": {"complexity": 1, "multipliers": ["first", "last"]},
+        "productAttributes": {"complexity": 1},
+        "products": {"complexity": 1, "multipliers": ["first", "last"]},
+    },
     "ProductVariant": {
         "attributes": {"complexity": 1},
         "channelListings": {"complexity": 1},
@@ -168,7 +272,60 @@ COST_MAP = {
         "product": {"complexity": 1},
         "revenue": {"complexity": 1},
     },
+    "ProductVariantChannelListing": {
+        "channel": {"complexity": 1},
+    },
+    "Sale": {
+        "categories": {"complexity": 1, "multipliers": ["first", "last"]},
+        "channelListings": {"complexity": 1},
+        "collections": {"complexity": 1, "multipliers": ["first", "last"]},
+        "products": {"complexity": 1, "multipliers": ["first", "last"]},
+        "translation": {"complexity": 1},
+        "variants": {"complexity": 1, "multipliers": ["first", "last"]},
+    },
+    "SaleChannelListing": {
+        "channel": {"complexity": 1},
+    },
     "SelectedAttribute": {
         "attribute": {"complexity": 1},
+    },
+    "ShippingMethodChannelListing": {
+        "channel": {"complexity": 1},
+    },
+    "ShippingZone": {
+        "channels": {"complexity": 1},
+        "countries": {"complexity": 1},
+        "warehouses": {"complexity": 1},
+    },
+    "Shop": {
+        "availableExternalAuthentications": {"complexity": 1},
+        "availablePaymentGateways": {"complexity": 1},
+        "availableShippingMethods": {"complexity": 1},
+        "countries": {"complexity": 1},
+    },
+    "Stock": {
+        "productVariant": {"complexity": 1},
+    },
+    "User": {
+        "avatar": {"complexity": 1},
+        "checkout": {"complexity": 1},
+        "editableGroups": {"complexity": 1},
+        "events": {"complexity": 1},
+        "giftCards": {"complexity": 1, "multipliers": ["first", "last"]},
+        "orders": {"complexity": 1, "multipliers": ["first", "last"]},
+        "permissionGroups": {"complexity": 1},
+        "storedPaymentSources": {"complexity": 1},
+        "userPermissions": {"complexity": 1},
+    },
+    "Voucher": {
+        "categories": {"complexity": 1, "multipliers": ["first", "last"]},
+        "channelListings": {"complexity": 1},
+        "collections": {"complexity": 1, "multipliers": ["first", "last"]},
+        "countries": {"complexity": 1},
+        "products": {"complexity": 1, "multipliers": ["first", "last"]},
+        "variants": {"complexity": 1, "multipliers": ["first", "last"]},
+    },
+    "VoucherChannelListing": {
+        "channel": {"complexity": 1},
     },
 }


### PR DESCRIPTION
This PR makes query cost calculation more accurate by adding more types and fields to the cost map

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
