### PR TITLE
Rename initialize_context and remove get_response.

### DIFF
--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, Optional
 
 from celery.utils.log import get_task_logger
-from django.core.handlers.base import BaseHandler
+from django.conf import settings
+from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpRequest
-from django.test.client import RequestFactory
 from django.utils.functional import SimpleLazyObject
 from graphql import GraphQLDocument, get_default_backend, parse
 from graphql.error import GraphQLSyntaxError
@@ -48,27 +48,35 @@ def check_document_is_single_subscription(document: GraphQLDocument) -> bool:
     return len(subscriptions) == 1
 
 
-def initialize_context() -> HttpRequest:
+def initialize_request() -> HttpRequest:
     """Prepare a request object for webhook subscription.
 
-    It creates a dummy request object and initialize middleware on it. It is required
-    to process a request in the same way as API logic does.
+    It creates a dummy request object.
     return: HttpRequest
     """
-    handler = BaseHandler()
-    context = RequestFactory().request(SERVER_NAME=SimpleLazyObject(get_host))
-    handler.load_middleware()
-    response = handler.get_response(context)
-    if response.status_code not in [200, 301]:
-        raise Exception("Unable to initialize context for webhook.")
-    return context
+
+    environ = {
+        "REQUEST_METHOD": "GET",
+        "SERVER_NAME": SimpleLazyObject(get_host),
+        "REMOTE_ADDR": "127.0.0.1",
+        "SERVER_PORT": 80,
+        "PATH_INFO": "/graphql/",
+        "wsgi.input": b"",
+        "wsgi.multiprocess": True,
+        "wsgi.url_scheme": "http",
+    }
+
+    if settings.ENABLE_SSL:
+        environ["wsgi.url_scheme"] = "https"
+
+    return WSGIRequest(environ)
 
 
 def generate_payload_from_subscription(
     event_type: str,
     subscribable_object,
     subscription_query: Optional[str],
-    context: HttpRequest,
+    request: HttpRequest,
     app: Optional[App] = None,
 ) -> Optional[Dict[str, Any]]:
     """Generate webhook payload from subscription query.
@@ -98,12 +106,12 @@ def generate_payload_from_subscription(
     )
     app_id = app.pk if app else None
 
-    context.app = app  # type: ignore
+    request.app = app  # type: ignore
 
     results = document.execute(
         allow_subscriptions=True,
         root=(event_type, subscribable_object),
-        context=get_context_value(context),
+        context=get_context_value(request),
     )
     if hasattr(results, "errors"):
         logger.warning(

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -20,7 +20,7 @@ from ...core.models import EventDelivery, EventPayload
 from ...core.tracing import webhooks_opentracing_trace
 from ...graphql.webhook.subscription_payload import (
     generate_payload_from_subscription,
-    initialize_context,
+    initialize_request,
 )
 from ...payment import PaymentError
 from ...settings import WEBHOOK_SYNC_TIMEOUT, WEBHOOK_TIMEOUT
@@ -80,7 +80,6 @@ def create_deliveries_for_subscriptions(
         )
         return []
 
-    context = initialize_context()
     event_payloads = []
     event_deliveries = []
     for webhook in webhooks:
@@ -88,7 +87,7 @@ def create_deliveries_for_subscriptions(
             event_type=event_type,
             subscribable_object=subscribable_object,
             subscription_query=webhook.subscription_query,
-            context=context,
+            request=initialize_request(),
             app=webhook.app,
         )
         if not data:


### PR DESCRIPTION
I want to merge this change because it renames `initialize_context` function to be more accurate.  Additionally removes loading middleware and getting response from function.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
