### PR TITLE
Rename initialize_context and remove get_response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Refactor app tokens - #9438 by @IKarbowiak
   - Store app tokens hashes instead of plain text.
 - Save images to product media from external URLs - #9329 by @krzysztofwolski
-
+- Fix and rename initialize_context for subscription webhooks - #9846 by @SzymJ
 
 # 3.1.7
 

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -1,15 +1,16 @@
 from typing import Any, Dict, Optional
 
 from celery.utils.log import get_task_logger
-from django.core.handlers.base import BaseHandler
+from django.conf import settings
 from django.http import HttpRequest
-from django.test.client import RequestFactory
+from django.utils.functional import SimpleLazyObject
 from graphql import GraphQLDocument, get_default_backend, parse
 from graphql.error import GraphQLSyntaxError
 from graphql.language.ast import FragmentDefinition, OperationDefinition
 from promise import Promise
 
 from ...app.models import App
+from ...settings import get_host
 
 logger = get_task_logger(__name__)
 
@@ -46,26 +47,31 @@ def check_document_is_single_subscription(document: GraphQLDocument) -> bool:
     return len(subscriptions) == 1
 
 
-def initialize_context() -> HttpRequest:
+def initialize_request() -> HttpRequest:
     """Prepare a request object for webhook subscription.
 
-    It creates a dummy request object and initialize middleware on it. It is required
-    to process a request in the same way as API logic does.
+    It creates a dummy request object.
+
     return: HttpRequest
     """
-    handler = BaseHandler()
-    context = RequestFactory().request()
-    handler.load_middleware()
-    response = handler.get_response(context)
-    assert response.status_code == 200
-    return context
+
+    request = HttpRequest()
+    request.path = "/graphql/"
+    request.path_info = "/graphql/"
+    request.method = "GET"
+    request.META = {"SERVER_NAME": SimpleLazyObject(get_host), "SERVER_PORT": "80"}
+    if settings.ENABLE_SSL:
+        request.META["HTTP_X_FORWARDED_PROTO"] = "https"
+        request.META["SERVER_PORT"] = "443"
+
+    return request
 
 
 def generate_payload_from_subscription(
     event_type: str,
     subscribable_object,
     subscription_query: Optional[str],
-    context: HttpRequest,
+    request: HttpRequest,
     app: Optional[App] = None,
 ) -> Optional[Dict[str, Any]]:
     """Generate webhook payload from subscription query.
@@ -77,7 +83,7 @@ def generate_payload_from_subscription(
     subscribable_object: is a object which have a dedicated own type in Subscription
     definition.
     subscription_query: query used to prepare a payload via graphql engine.
-    context: A dummy request used to share context between apps in order to use
+    request: A dummy request used to share context between apps in order to use
     dataloaders benefits.
     app: the owner of the given payload. Required in case when webhook contains
     protected fields.
@@ -95,12 +101,12 @@ def generate_payload_from_subscription(
     )
     app_id = app.pk if app else None
 
-    context.app = app  # type: ignore
+    request.app = app  # type: ignore
 
     results = document.execute(
         allow_subscriptions=True,
         root=(event_type, subscribable_object),
-        context=get_context_value(context),
+        context=get_context_value(request),
     )
     if hasattr(results, "errors"):
         logger.warning(

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -20,7 +20,7 @@ from ...core.models import EventDelivery, EventPayload
 from ...core.tracing import webhooks_opentracing_trace
 from ...graphql.webhook.subscription_payload import (
     generate_payload_from_subscription,
-    initialize_context,
+    initialize_request,
 )
 from ...payment import PaymentError
 from ...settings import WEBHOOK_SYNC_TIMEOUT, WEBHOOK_TIMEOUT
@@ -110,7 +110,6 @@ def create_deliveries_for_subscriptions(
         )
         return []
 
-    context = initialize_context()
     event_payloads = []
     event_deliveries = []
     for webhook in webhooks:
@@ -118,7 +117,7 @@ def create_deliveries_for_subscriptions(
             event_type=event_type,
             subscribable_object=subscribable_object,
             subscription_query=webhook.subscription_query,
-            context=context,
+            request=initialize_request(),
             app=webhook.app,
         )
         if not data:

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -261,6 +261,7 @@ def site_settings(db, settings) -> SiteSettings:
         default_mail_sender_address="mirumee@example.com",
     )[0]
     settings.SITE_ID = site.pk
+    settings.ALLOWED_HOSTS += [site.domain]
 
     main_menu = Menu.objects.get_or_create(
         name=settings.DEFAULT_MENUS["top_menu_name"],


### PR DESCRIPTION
 want to merge this change because it renames initialize_context function to be more accurate. Additionally removes loading middleware and getting response from function.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
