### PR TITLE
Expose order alongside fulfillment in fulfillment-based subscriptions used by webhooks

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -21507,6 +21507,15 @@ type FulfillmentCreated implements Event {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   fulfillment: Fulfillment
+
+  """
+  Order connected with looked up fulfillment.
+  
+  Added in Saleor 3.4.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  order: Order
 }
 
 type FulfillmentCanceled implements Event {
@@ -21530,6 +21539,15 @@ type FulfillmentCanceled implements Event {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   fulfillment: Fulfillment
+
+  """
+  Order connected with looked up fulfillment.
+  
+  Added in Saleor 3.4.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  order: Order
 }
 
 type CustomerCreated implements Event {

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -584,11 +584,20 @@ class FulfillmentBase(AbstractType):
         "saleor.graphql.order.types.Fulfillment",
         description="Look up a Fulfillment." + ADDED_IN_32 + PREVIEW_FEATURE,
     )
+    order = graphene.Field(
+        "saleor.graphql.order.types.Order",
+        description="Order connected with looked up fulfillment." + ADDED_IN_34 + PREVIEW_FEATURE,
+    )
 
     @staticmethod
     def resolve_fulfillment(root, _info):
-        _, invoice = root
-        return invoice
+        _, fulfillment = root
+        return fulfillment
+
+    @staticmethod
+    def resolve_order(root, info):
+        _, fulfillment = root
+        return fulfillment.order
 
 
 class FulfillmentCreated(ObjectType, FulfillmentBase):

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -586,7 +586,9 @@ class FulfillmentBase(AbstractType):
     )
     order = graphene.Field(
         "saleor.graphql.order.types.Order",
-        description="Order connected with looked up fulfillment." + ADDED_IN_34 + PREVIEW_FEATURE,
+        description="Order connected with looked up fulfillment."
+        + ADDED_IN_34
+        + PREVIEW_FEATURE,
     )
 
     @staticmethod

--- a/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
@@ -64,7 +64,10 @@ def generate_fulfillment_payload(fulfillment):
             "trackingNumber": fulfillment.tracking_number,
             "status": fulfillment.status.upper(),
             "lines": generate_fulfillment_lines_payload(fulfillment),
-        }
+        },
+        "order": {
+            "id": graphene.Node.to_global_id("Order", fulfillment.order.pk),
+        },
     }
 
 

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -706,6 +706,9 @@ FULFILLMENT_CREATED = (
           fulfillment{
             ...FulfillmentDetails
           }
+          order{
+            id
+          }
         }
       }
     }
@@ -720,6 +723,9 @@ FULFILLMENT_CANCELED = (
         ...on FulfillmentCanceled{
           fulfillment{
             ...FulfillmentDetails
+          }
+          order{
+            id
           }
         }
       }


### PR DESCRIPTION
I want to merge this change because I need access to data stored in `Order` when serving subscription-powered `FULFILLMENT_CREATED` webhook type.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [X] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
