### PR TITLE
Optimize memory usage on update products search vector - 3.3

### DIFF
--- a/saleor/core/search_tasks.py
+++ b/saleor/core/search_tasks.py
@@ -15,7 +15,11 @@ from ..product.search import (
 
 task_logger = get_task_logger(__name__)
 
-BATCH_SIZE = 1000
+BATCH_SIZE = 500
+# Based on local testing, 500 should be a good ballance between performance
+# total time and memory usage. Should be tested after some time and adjusted by
+# running the task on different thresholds and measure memory usage, total time
+# and execution time of an single SQL statement.
 
 
 @app.task


### PR DESCRIPTION
3.3 port of #9789

I want to merge this change because it optimizes update_products_search_vector to work in batches.
Also reduces batch size for orders so it doesn't time out.

Local testing of update_products_search_vector

Memory usage (1137 products)
before : 101MB (python) 1.51GB postgres
after: 32MB (python) 371MB postgres

Memory usage (10000 products)
before: 1.25GB (python) 29.8GB postgres (oom kill)
after: 34MB (python) 396MB postgres

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
