### PR TITLE
Use the human-readable order number in notification payloads

### DIFF
--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -244,7 +244,7 @@ def get_default_order_payload(order: "Order", redirect_url: str = ""):
         {
             "id": to_global_id_or_none(order),
             "token": order.id,  # DEPRECATED: will be removed in Saleor 4.0.
-            "number": order.id,
+            "number": order.number,
             "channel_slug": order.channel.slug,
             "created": str(order.created_at),
             "shipping_price_net_amount": order.shipping_price_net_amount,

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -29,7 +29,7 @@ def test_get_custom_order_payload(order):
     assert expected_payload == {
         "order": {
             "id": to_global_id_or_none(order),
-            "number": order.id,
+            "number": order.number,
             "private_metadata": {},
             "metadata": order.metadata,
             "status": "unfulfilled",
@@ -237,7 +237,7 @@ def test_get_default_order_payload(order_line):
         ],
         "channel_slug": order.channel.slug,
         "id": to_global_id_or_none(order),
-        "number": order.id,
+        "number": order.number,
         "token": order.id,
         "created": str(order.created_at),
         "display_gross_prices": order.display_gross_prices,


### PR DESCRIPTION
I want to merge this change because customers are seeing the UUID instead of the human-readable order number in Sendgrid dynamic templates.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
