### PR TITLE
Observability background worker

### DIFF
--- a/saleor/webhook/__init__.py
+++ b/saleor/webhook/__init__.py
@@ -1,5 +1,7 @@
 import opentracing
 
+default_app_config = "saleor.webhook.app.WebhookAppConfig"
+
 
 def traced_payload_generator(func):
     def wrapper(*args, **kwargs):

--- a/saleor/webhook/app.py
+++ b/saleor/webhook/app.py
@@ -1,0 +1,13 @@
+from django.apps import AppConfig
+
+
+class WebhookAppConfig(AppConfig):
+    name = "saleor.webhook"
+
+    def ready(self):
+        from django.conf import settings
+
+        from .observability.worker import init
+
+        if settings.OBSERVABILITY_ACTIVE:
+            init()

--- a/saleor/webhook/observability/tests/conftest.py
+++ b/saleor/webhook/observability/tests/conftest.py
@@ -72,3 +72,10 @@ def patch_connection_pool(redis_server):
 def buffer(patch_connection_pool):
     buffer = RedisBuffer(BROKER_URL, KEY, max_size=MAX_SIZE, batch_size=BATCH_SIZE)
     return buffer
+
+
+@pytest.fixture
+def buffer_full(buffer):
+    for _ in range(MAX_SIZE):
+        buffer.put_event("payload")
+    return buffer

--- a/saleor/webhook/observability/tests/test_utils.py
+++ b/saleor/webhook/observability/tests/test_utils.py
@@ -12,6 +12,7 @@ from ..payload_schema import JsonTruncText
 from ..payloads import CustomJsonEncoder
 from ..utils import (
     ApiCall,
+    get_buffer_name,
     get_webhooks,
     get_webhooks_clear_mem_cache,
     pop_events_with_remaining_size,
@@ -229,9 +230,13 @@ def test_report_event_delivery_attempt_not_active(
     mock_put_event.assert_not_called()
 
 
-def test_put_event(patch_get_buffer, buffer):
-    put_event(lambda: {"payload": "data"})
-    assert buffer.size() == 1
+@patch("saleor.webhook.observability.utils.worker.put_event")
+def test_put_event(mock_put_event, patch_get_buffer):
+    def generate_payload():
+        return {"payload": "data"}
+
+    put_event(generate_payload)
+    mock_put_event.assert_called_once_with(get_buffer_name(), generate_payload)
 
 
 def test_put_event_catch_exceptions(patch_get_buffer, buffer):

--- a/saleor/webhook/observability/tests/test_worker.py
+++ b/saleor/webhook/observability/tests/test_worker.py
@@ -1,0 +1,82 @@
+from datetime import timedelta
+from functools import partial
+from unittest.mock import patch
+
+import pytest
+
+from .. import worker
+
+BATCH_SIZE = 10
+REPORT_PERIOD = timedelta(seconds=1)
+
+
+@pytest.fixture
+def worker_settings(settings):
+    settings.OBSERVABILITY_BUFFER_BATCH_SIZE = BATCH_SIZE
+    settings.OBSERVABILITY_REPORT_PERIOD = REPORT_PERIOD
+
+
+@pytest.fixture
+def init(worker_settings):
+    worker.init()
+
+
+def test_init(init):
+    assert isinstance(worker._worker, worker.BackgroundWorker)
+
+
+def test_put_event_when_worker_not_initialized():
+    worker.shutdown_worker()
+    assert worker.put_event("buffer", "payload") is False
+
+
+@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
+def test_background_worker(mock_buffer_put_multi_key_events, init):
+    buffer_name = "buffer_a"
+    payload = "payload-{}"
+    for i in range(BATCH_SIZE):
+        worker.put_event(buffer_name, partial(payload.format, i))
+    worker.shutdown_worker()
+    mock_buffer_put_multi_key_events.assert_called_once_with(
+        {buffer_name: [payload.format(i) for i in range(BATCH_SIZE)]}
+    )
+
+
+@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
+def test_background_worker_put_multi_buffer(mock_buffer_put_multi_key_events, init):
+    buffer_a, buffer_b = "buffer_a", "buffer_b"
+    payload = "payload-{}"
+    for i in range(BATCH_SIZE // 2):
+        worker.put_event(buffer_a, partial(payload.format, i))
+        worker.put_event(buffer_b, partial(payload.format, i))
+    worker.shutdown_worker()
+    mock_buffer_put_multi_key_events.assert_called_once_with(
+        {
+            buffer_a: [payload.format(i) for i in range(BATCH_SIZE // 2)],
+            buffer_b: [payload.format(i) for i in range(BATCH_SIZE // 2)],
+        }
+    )
+
+
+@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
+def test_background_worker_queue_full(mock_buffer_put_multi_key_events, init):
+    buffer_name, payload = "buffer_a", "payload-{}"
+    for i in range(BATCH_SIZE):
+        worker.put_event(buffer_name, partial(payload.format, i))
+    assert worker.put_event(buffer_name, partial(payload.format, BATCH_SIZE)) is False
+    worker.shutdown_worker()
+    mock_buffer_put_multi_key_events.assert_called_once()
+
+
+@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
+def test_background_worker_with_generate_payload_exception(
+    mock_buffer_put_multi_key_events, init
+):
+    buffer_name, payload = "buffer_a", "payload-{}"
+    worker.put_event(buffer_name, lambda: 1 / 0)
+    for i in range(BATCH_SIZE - 1):
+        worker.put_event(buffer_name, partial(payload.format, i))
+    worker.shutdown_worker()
+    mock_buffer_put_multi_key_events.assert_called_once_with(
+        {buffer_name: [payload.format(i) for i in range(BATCH_SIZE - 1)]}
+    )

--- a/saleor/webhook/observability/tests/test_worker.py
+++ b/saleor/webhook/observability/tests/test_worker.py
@@ -1,7 +1,7 @@
 import time
 from datetime import timedelta
 from functools import partial
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 from redis.exceptions import RedisError
@@ -10,87 +10,87 @@ from .. import worker
 from .conftest import KEY, MAX_SIZE
 
 BATCH_SIZE = 10
+QUEUE_SIZE = worker.BackgroundWorker.queue_size(BATCH_SIZE)
 REPORT_PERIOD = timedelta(seconds=0.01)
-timeout = REPORT_PERIOD.total_seconds()
-safe_delay = timeout * 2
+JOIN_TIMEOUT = REPORT_PERIOD.total_seconds() * 2
 
 
 @pytest.fixture
-def init_worker(settings):
+def mock_buffer_put_multi_key_events():
+    target = "saleor.webhook.observability.worker.buffer_put_multi_key_events"
+    with patch(target) as mock:
+        yield mock
+
+
+@pytest.fixture
+def init_worker(settings, mock_buffer_put_multi_key_events):
     settings.OBSERVABILITY_BUFFER_BATCH_SIZE = BATCH_SIZE
     settings.OBSERVABILITY_REPORT_PERIOD = REPORT_PERIOD
     worker.init()
     yield
-    worker.shutdown_worker()
-
-
-def test_init(init_worker):
-    assert isinstance(worker._worker, worker.BackgroundWorker)
-
-
-def test_put_event_when_worker_not_initialized():
-    worker.shutdown_worker()
-    assert worker.put_event("buffer", "payload") is False
+    worker.shutdown()
 
 
 @patch("saleor.webhook.observability.worker.get_buffer")
 def test_buffer_put_multi_key_events(mock_get_buffer, buffer):
     mock_get_buffer.return_value = buffer
     events = {KEY: ["payload"], "buffer_b": ["payload"]}
+
     assert worker.buffer_put_multi_key_events(events) is True
 
 
 @patch("saleor.webhook.observability.worker.get_buffer")
 def test_buffer_put_multi_key_events_when_buffer_is_full(mock_get_buffer, buffer):
     mock_get_buffer.return_value = buffer
-    for i in range(MAX_SIZE):
+    for _ in range(MAX_SIZE):
         buffer.put_event("payload")
     assert buffer.size() == MAX_SIZE
     events = {KEY: ["payload"], "buffer_b": ["payload"]}
+
     assert worker.buffer_put_multi_key_events(events) is False
 
 
-@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
-def test_background_worker(mock_buffer_put_multi_key_events, init_worker):
-    buffer_name, payload = "buffer_a", "payload-{}"
+def test_put_event_when_worker_not_initialized():
+    worker.shutdown()
+
+    assert worker.put_event("buffer", lambda: "payload") is False
+    assert worker.queue_join(JOIN_TIMEOUT) is False
+
+
+def test_background_worker(init_worker, mock_buffer_put_multi_key_events):
+    payload = "buffer_a", "payload"
+
+    worker.put_event(KEY, lambda: payload)
+
+    assert worker.queue_join(JOIN_TIMEOUT) is True
+    mock_buffer_put_multi_key_events.assert_called_once_with({KEY: [payload]})
+
+
+def test_background_worker_put_multiple_events(
+    init_worker, mock_buffer_put_multi_key_events
+):
+    payload = "payload-{}"
     for i in range(BATCH_SIZE + 1):
-        worker.put_event(buffer_name, partial(payload.format, i))
-    mock_buffer_put_multi_key_events.assert_called_once_with(
-        {buffer_name: [payload.format(i) for i in range(BATCH_SIZE)]}
+        worker.put_event(KEY, partial(payload.format, i))
+
+    assert worker.queue_join(JOIN_TIMEOUT) is True
+    mock_buffer_put_multi_key_events.assert_has_calls(
+        [
+            call({KEY: [payload.format(i) for i in range(BATCH_SIZE)]}),
+            call({KEY: [payload.format(BATCH_SIZE)]}),
+        ]
     )
 
 
-@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
-def test_background_worker_put_to_buffer_exception(
-    mock_buffer_put_multi_key_events, init_worker
+def test_background_worker_put_events_multi_buffer(
+    init_worker, mock_buffer_put_multi_key_events
 ):
-    mock_buffer_put_multi_key_events.side_effect = [RedisError, True]
-    for i in range(BATCH_SIZE * 2):
-        worker.put_event("buffer_a", lambda: "payload")
-    time.sleep(safe_delay)
-    mock_buffer_put_multi_key_events.call_count == 2
-
-
-@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
-def test_background_worker_put_to_buffer_on_timeout(
-    mock_buffer_put_multi_key_events, init_worker
-):
-    buffer_name, payload = "buffer_a", "payload"
-    worker.put_event(buffer_name, lambda: payload)
-    time.sleep(safe_delay)
-    mock_buffer_put_multi_key_events.assert_called_once_with({buffer_name: [payload]})
-
-
-@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
-def test_background_worker_put_multi_buffer(
-    mock_buffer_put_multi_key_events, init_worker
-):
-    buffer_a, buffer_b = "buffer_a", "buffer_b"
-    payload = "payload-{}"
+    buffer_a, buffer_b, payload = "buffer_a", "buffer_b", "payload-{}"
     for i in range(BATCH_SIZE // 2):
         worker.put_event(buffer_a, partial(payload.format, i))
         worker.put_event(buffer_b, partial(payload.format, i))
-    time.sleep(safe_delay)
+
+    assert worker.queue_join(JOIN_TIMEOUT) is True
     mock_buffer_put_multi_key_events.assert_called_once_with(
         {
             buffer_a: [payload.format(i) for i in range(BATCH_SIZE // 2)],
@@ -99,53 +99,69 @@ def test_background_worker_put_multi_buffer(
     )
 
 
-@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
-def test_background_worker_queue_full(mock_buffer_put_multi_key_events, init_worker):
-    buffer_name, payload = "buffer_a", "payload-{}"
+def test_background_worker_when_queue_is_full(
+    init_worker, mock_buffer_put_multi_key_events
+):
+    for _ in range(QUEUE_SIZE):
+        worker.put_event(KEY, lambda: "payload")
+
+    assert worker.put_event(KEY, lambda: "payload") is False
+    mock_buffer_put_multi_key_events.assert_called()
+
+
+def test_background_worker_exception_raised_while_put_to_buffer_dont_stop_worker(
+    init_worker, mock_buffer_put_multi_key_events
+):
+    put_buffer_side_effects = [RedisError, True]
+    mock_buffer_put_multi_key_events.side_effect = put_buffer_side_effects
+    for _ in range(len(put_buffer_side_effects)):
+        for _ in range(BATCH_SIZE):
+            worker.put_event(KEY, lambda: "payload")
+        assert worker.queue_join(JOIN_TIMEOUT) is True
+
+    assert mock_buffer_put_multi_key_events.call_count == len(put_buffer_side_effects)
+
+
+def test_background_worker_when_generate_payload_raises_exception(
+    init_worker, mock_buffer_put_multi_key_events
+):
+    payload = "payload-{}"
+    worker.put_event(KEY, lambda: 1 / 0)
     for i in range(BATCH_SIZE):
-        worker.put_event(buffer_name, partial(payload.format, i))
-    assert worker.put_event(buffer_name, partial(payload.format, BATCH_SIZE)) is False
+        worker.put_event(KEY, partial(payload.format, i))
+
+    assert worker.queue_join(JOIN_TIMEOUT) is True
     mock_buffer_put_multi_key_events.assert_called_once_with(
-        {buffer_name: [payload.format(i) for i in range(BATCH_SIZE)]}
+        {KEY: [payload.format(i) for i in range(BATCH_SIZE)]}
     )
 
 
-@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
-def test_background_worker_with_generate_payload_exception(
-    mock_buffer_put_multi_key_events, init_worker
-):
-    buffer_name, payload = "buffer_a", "payload"
-    worker.put_event(buffer_name, lambda: 1 / 0)
-    worker.put_event(buffer_name, lambda: payload)
-    time.sleep(safe_delay)
-    mock_buffer_put_multi_key_events.assert_called_once_with({buffer_name: [payload]})
-
-
-@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
-def test_background_worker_shutdown(mock_buffer_put_multi_key_events, init_worker):
-    buffer_a, buffer_b = "buffer_a", "buffer_b"
+def test_background_worker_shutdown(init_worker, mock_buffer_put_multi_key_events):
     payload = "payload-{}"
-    for i in range(BATCH_SIZE // 2):
-        worker.put_event(buffer_a, partial(payload.format, i))
-        worker.put_event(buffer_b, partial(payload.format, i))
-    worker.shutdown_worker()
+    for i in range(BATCH_SIZE):
+        worker.put_event(KEY, partial(payload.format, i))
+    worker.shutdown()
     mock_buffer_put_multi_key_events.assert_called_once_with(
-        {
-            buffer_a: [payload.format(i) for i in range(BATCH_SIZE // 2)],
-            buffer_b: [payload.format(i) for i in range(BATCH_SIZE // 2)],
-        }
+        {KEY: [payload.format(i) for i in range(BATCH_SIZE)]}
     )
 
 
-@patch("saleor.webhook.observability.worker.buffer_put_multi_key_events")
+def test_background_worker_shutdown_when_queue_full(
+    init_worker, mock_buffer_put_multi_key_events
+):
+    for _ in range(QUEUE_SIZE):
+        worker.put_event(KEY, lambda: "payload")
+    worker.shutdown()
+    mock_buffer_put_multi_key_events.assert_called()
+
+
 def test_background_worker_failed_flush_on_shutdown(
-    mock_buffer_put_multi_key_events, init_worker
+    init_worker, mock_buffer_put_multi_key_events
 ):
     def generate_payload():
-        time.sleep(safe_delay)
+        time.sleep(JOIN_TIMEOUT * 2)
         return "payload"
 
-    worker.put_event("buffer_a", generate_payload)
-    worker.shutdown_worker(timeout)
+    worker.put_event(KEY, generate_payload)
+    worker.shutdown(JOIN_TIMEOUT)
     mock_buffer_put_multi_key_events.assert_not_called()
-    time.sleep(safe_delay)

--- a/saleor/webhook/observability/worker.py
+++ b/saleor/webhook/observability/worker.py
@@ -44,7 +44,14 @@ def put_event(buffer_name: str, generate_payload: Callable[[], Any]) -> bool:
 
 
 def buffer_put_multi_key_events(events: Dict[str, List]):
-    return get_buffer("").put_multi_key_events(events)
+    dropped_events = get_buffer("").put_multi_key_events(events)
+    for buffer_name, events_count in dropped_events.items():
+        if events_count:
+            logging.warning(
+                "[Observability] Buffer %s full, %s event(s) dropped",
+                buffer_name,
+                events_count,
+            )
 
 
 class BackgroundWorker:
@@ -57,7 +64,7 @@ class BackgroundWorker:
         self._timeout = timeout
 
     def _target(self):
-        logger.info("[Observability] Background worker started")
+        logger.debug("[Observability] Background worker started")
         working = True
         while working:
             with opentracing_trace("background_worker", "background_worker"):

--- a/saleor/webhook/observability/worker.py
+++ b/saleor/webhook/observability/worker.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 
 def shutdown_worker(timeout=FLUSH_TIMEOUT):
     global _worker
-    logger.debug("[Observability] Atexit shutdown signal")
     if _worker:
+        logger.debug("[Observability] Background worker shutdown")
         _worker.flush(timeout)
         _worker = None
 

--- a/saleor/webhook/observability/worker.py
+++ b/saleor/webhook/observability/worker.py
@@ -4,7 +4,7 @@ import os
 from queue import Empty, Full, Queue
 from threading import Lock, Thread
 from time import monotonic
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from django.conf import settings
 
@@ -18,10 +18,12 @@ FLUSH_TIMEOUT = 2.0
 logger = logging.getLogger(__name__)
 
 
-def _shutdown_worker():
+def shutdown_worker(timeout=FLUSH_TIMEOUT):
+    global _worker
     logger.debug("[Observability] Atexit shutdown signal")
     if _worker:
-        _worker.close()
+        _worker.flush(timeout)
+        _worker = None
 
 
 def init():
@@ -31,7 +33,7 @@ def init():
             batch_size=settings.OBSERVABILITY_BUFFER_BATCH_SIZE,
             timeout=settings.OBSERVABILITY_REPORT_PERIOD.total_seconds(),
         )
-        atexit.register(_shutdown_worker)
+        atexit.register(shutdown_worker)
 
 
 def put_event(buffer_name: str, generate_payload: Callable[[], Any]) -> bool:
@@ -39,6 +41,10 @@ def put_event(buffer_name: str, generate_payload: Callable[[], Any]) -> bool:
         return _worker.submit_event(buffer_name, generate_payload)
     logger.warning("[Observability] Worker not initialized, event dropped")
     return False
+
+
+def buffer_put_multi_key_events(events: Dict[str, List]):
+    return get_buffer("").put_multi_key_events(events)
 
 
 class BackgroundWorker:
@@ -80,7 +86,7 @@ class BackgroundWorker:
                 if events_count:
                     with opentracing_trace("put_events", "buffer"):
                         try:
-                            get_buffer("").put_multi_key_events(events)
+                            buffer_put_multi_key_events(events)
                         except Exception:
                             logger.error(
                                 "[Observability] Buffer error, dropped %s events",
@@ -137,30 +143,21 @@ class BackgroundWorker:
     def _wait_flush(self, timeout: float):
         initial_timeout = min(0.1, timeout)
         if not self._timed_queue_join(initial_timeout):
-            pending = self._queue.qsize() + 1
+            pending = self._queue.qsize()
             logger.debug("[Observability] %d events pending on flush", pending)
             if not self._timed_queue_join(timeout - initial_timeout):
-                pending = self._queue.qsize() + 1
+                pending = self._queue.qsize()
                 logger.error(
                     "[Observability] Flush timed out, dropped %s events", pending
                 )
 
     def flush(self, timeout: float):
         with self._lock:
+            try:
+                self._queue.put_nowait(_TERMINATOR)
+            except Full:
+                logger.debug("[Observability] Worker queue full, flush failed")
             if self.is_alive and timeout > 0.0:
                 self._wait_flush(timeout)
-
-    def kill(self):
-        logger.debug("[Observability] Worker got kill request")
-        with self._lock:
-            if self._thread:
-                try:
-                    self._queue.put_nowait(_TERMINATOR)
-                except Full:
-                    logger.debug("[Observability] Worker queue full, kill failed")
-                self._thread = None
-                self._thread_for_pid = None
-
-    def close(self):
-        self.flush(FLUSH_TIMEOUT)
-        self.kill()
+            self._thread = None
+            self._thread_for_pid = None

--- a/saleor/webhook/observability/worker.py
+++ b/saleor/webhook/observability/worker.py
@@ -1,0 +1,160 @@
+import atexit
+import logging
+import os
+from queue import Empty, Full, Queue
+from threading import Lock, Thread
+from time import monotonic
+from typing import Any, Callable, Optional
+
+from django.conf import settings
+
+from .buffers import get_buffer
+
+_worker: Optional["BackgroundWorker"] = None
+_TERMINATOR = object()
+FLUSH_TIMEOUT = 2.0
+
+logger = logging.getLogger(__name__)
+
+
+def _shutdown_worker():
+    logger.debug("[Observability] Atexit shutdown signal")
+    if _worker:
+        _worker.close()
+
+
+def init():
+    global _worker
+    if _worker is None:
+        _worker = BackgroundWorker(
+            batch_size=settings.OBSERVABILITY_BUFFER_BATCH_SIZE,
+            timeout=settings.OBSERVABILITY_REPORT_PERIOD.total_seconds(),
+        )
+        atexit.register(_shutdown_worker)
+
+
+def put_event(buffer_name: str, generate_payload: Callable[[], Any]):
+    if _worker:
+        return _worker.submit_event(buffer_name, generate_payload)
+    logger.warning("[Observability] Worker not initialized, event dropped")
+
+
+class BackgroundWorker:
+    def __init__(self, batch_size: int, timeout: float):
+        self._batch_size = batch_size
+        self._queue: "Queue[Any]" = Queue(maxsize=batch_size)
+        self._lock = Lock()
+        self._thread: Optional[Thread] = None
+        self._thread_for_pid: Optional[int] = None
+        self._timeout = timeout
+
+    def _target(self):
+        logger.info("[Observability] Background worker started")
+        working = True
+        while working:
+            events, events_count, deadline = {}, 0, monotonic() + self._timeout
+            while (
+                events_count < self._batch_size
+                and (timeout := deadline - monotonic()) > 0.0
+            ):
+                try:
+                    event_data = self._queue.get(timeout=timeout)
+                except Empty:
+                    break
+                try:
+                    if event_data is _TERMINATOR:
+                        working = False
+                        break
+                    buffer_name, generate_payload = event_data
+                    events.setdefault(buffer_name, []).append(generate_payload())
+                    events_count += 1
+                except Exception:
+                    logger.error(
+                        "[Observability] Failed generating payload", exc_info=True
+                    )
+                finally:
+                    self._queue.task_done()
+            if events_count:
+                try:
+                    get_buffer("").put_multi_key_events(events)
+                except Exception:
+                    logger.error(
+                        "[Observability] Buffer error, dropped %s events",
+                        events_count,
+                        exc_info=True,
+                    )
+
+    def start(self):
+        with self._lock:
+            if not self.is_alive:
+                self._thread = Thread(
+                    target=self._target,
+                    name="observability_worker",
+                    daemon=True,
+                )
+                self._thread.start()
+                self._thread_for_pid = os.getpid()
+
+    @property
+    def is_alive(self) -> bool:
+        if self._thread_for_pid != os.getpid():
+            return False
+        if not self._thread:
+            return False
+        return self._thread.is_alive()
+
+    def _ensure_thread(self):
+        if not self.is_alive:
+            self.start()
+
+    def submit_event(self, buffer_name: str, generate_payload: Callable[[], Any]):
+        self._ensure_thread()
+        try:
+            self._queue.put_nowait((buffer_name, generate_payload))
+            return True
+        except Full:
+            logger.warning("[Observability] Queue full, event dropped")
+            return False
+
+    def _timed_queue_join(self, timeout: float) -> bool:
+        deadline = monotonic() + timeout
+        queue = self._queue
+        self._timeout = timeout
+        with queue.all_tasks_done:
+            while queue.unfinished_tasks:
+                delay = deadline - monotonic()
+                if delay <= 0:
+                    return False
+                queue.all_tasks_done.wait(timeout=delay)
+            return True
+
+    def _wait_flush(self, timeout: float):
+        initial_timeout = min(0.1, timeout)
+        if not self._timed_queue_join(initial_timeout):
+            pending = self._queue.qsize() + 1
+            logger.debug("[Observability] %d events pending on flush", pending)
+            if not self._timed_queue_join(timeout - initial_timeout):
+                pending = self._queue.qsize() + 1
+                logger.error(
+                    "[Observability] Flush timed out, dropped %s events", pending
+                )
+
+    def flush(self, timeout: float):
+        with self._lock:
+            if self.is_alive and timeout > 0.0:
+                self._wait_flush(timeout)
+
+    def kill(self):
+        logger.debug("[Observability] Worker got kill request")
+        with self._lock:
+            if self._thread:
+                try:
+                    self._queue.put_nowait(_TERMINATOR)
+                except Full:
+                    logger.debug("[Observability] Worker queue full, kill failed")
+                self._thread = None
+                self._thread_for_pid = None
+
+    def close(self):
+        self.flush(FLUSH_TIMEOUT)
+        self.kill()


### PR DESCRIPTION
I want to merge this change because it optimizes the observability reporter. It adds per process background worker, which moves payload generation and Redis buffer uploads to a separate thread. Observability events are gathered and uploaded in batches to reduce the number of requests to the Redis buffer. As a result, the overhead introduced by turning on observability decreases significantly.

Observability overhead measured per Saleor request

|   |  Median |  90% percentile |
| --- | --- | --- |
| No background worker | 9,14 ms  | 21,023 ms |
| Background worker | 0,235 ms  | 0,833 ms |

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
