### PR TITLE
Distinct celery queue for observability

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -513,6 +513,14 @@ CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", None)
+CELERY_TASK_ROUTES = {
+    "saleor.plugins.webhook.tasks.observability_reporter_task": {
+        "queue": "observability"
+    },
+    "saleor.plugins.webhook.tasks.observability_send_events": {
+        "queue": "observability"
+    },
+}
 
 CELERY_BEAT_SCHEDULE = {
     "delete-empty-allocations": {


### PR DESCRIPTION
I want to merge this change because it creates a separate Celery queue for observability tasks.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
