### PR TITLE
Add workflow to test migrations backwards compatibility

### DIFF
--- a/.github/workflows/test-migrations-compatibility.yml
+++ b/.github/workflows/test-migrations-compatibility.yml
@@ -1,0 +1,62 @@
+name: Test migrations compatibility
+
+on:
+  pull_request_target:
+    branches:
+      - "3.*"
+      - "main"
+#    paths:
+#      - "**/migrations/**"
+
+env:
+  DATABASE_URL: "postgres://saleor:saleor@postgres:5432/saleor"
+  SECRET_KEY: ci-test
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: saleor
+          POSTGRES_USER: saleor
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+
+      - name: Install system dependencies
+        run: apt-get install -y libpq-dev
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements_dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install wheel
+          python -m pip install -r requirements_dev.txt
+
+      - name: Migrate
+        run: |
+          ./manage.py migrate
+
+      - name: Checkout base
+        uses: actions/checkout@v3
+        with:
+          ref: {{ env.GITHUB_REF }}
+
+      - name: Run tests
+        run: |
+          export PYTEST_DB_URL=$DATABASE_URL
+          pytest -n 0 --reuse-db

--- a/.github/workflows/test-migrations-compatibility.yml
+++ b/.github/workflows/test-migrations-compatibility.yml
@@ -1,7 +1,7 @@
 name: Test migrations compatibility
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - "3.*"
       - "main"
@@ -54,7 +54,7 @@ jobs:
       - name: Checkout base
         uses: actions/checkout@v3
         with:
-          ref: {{ env.GITHUB_REF }}
+          ref: ${{ github['base_ref'] }}
 
       - name: Run tests
         run: |

--- a/.github/workflows/test-migrations-compatibility.yml
+++ b/.github/workflows/test-migrations-compatibility.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - "3.*"
       - "main"
-#    paths:
-#      - "**/migrations/**"
+    paths:
+      - "**/migrations/**"
 
 env:
   DATABASE_URL: "postgres://saleor:saleor@postgres:5432/saleor"

--- a/.github/workflows/test-migrations-compatibility.yml
+++ b/.github/workflows/test-migrations-compatibility.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: python:3.8
+
     services:
       postgres:
         image: postgres

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,9 @@
+import os
+
+import dj_database_url
+import pytest
+from django.conf import settings
+
 pytest_plugins = [
     "saleor.tests.fixtures",
     "saleor.plugins.tests.fixtures",
@@ -9,3 +15,12 @@ pytest_plugins = [
     "saleor.graphql.webhook.tests.benchmark.fixtures",
     "saleor.plugins.webhook.tests.subscription_webhooks.fixtures",
 ]
+
+if os.environ.get("PYTEST_DB_URL"):
+    @pytest.fixture(scope="session")
+    def django_db_setup():
+        settings.DATABASES = {
+            settings.DATABASE_CONNECTION_DEFAULT_NAME: dj_database_url.config(
+                default=os.environ.get("PYTEST_DB_URL"), conn_max_age=600
+            ),
+        }

--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,7 @@ pytest_plugins = [
 ]
 
 if os.environ.get("PYTEST_DB_URL"):
+
     @pytest.fixture(scope="session")
     def django_db_setup():
         settings.DATABASES = {

--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,6 @@ if os.environ.get("PYTEST_DB_URL"):
     def django_db_setup():
         settings.DATABASES = {
             settings.DATABASE_CONNECTION_DEFAULT_NAME: dj_database_url.config(
-                default=os.environ.get("PYTEST_DB_URL"), conn_max_age=600
+                env="PYTEST_DB_URL", conn_max_age=600
             ),
         }


### PR DESCRIPTION
I want to merge this change because it creates a workflow which tests running PR base branch tests on PR migrated datebase to test migrations backwards compatibility 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
