### PR TITLE
Fix returning errors in payloads from subscription webhooks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable, unreleased changes to this project will be documented in this file.
 #### Saleor Apps
 - Add webhooks `PAGE_TYPE_CREATED`, `PAGE_TYPE_UPDATED` and `PAGE_TYPE_DELETED` - #9859 by @SzymJ
 - Add webhooks `ADDRESS_CREATED`, `ADDRESS_UPDATED` and `ADDRESS_DELETED` - #9860 by @SzymJ
+- Returning errors in subscription webhooks payloads fix - #9905 by @SzymJ
 
 # 3.4.0
 

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -2,3 +2,17 @@ from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
 __version__ = "3.5.0-a"
+
+
+class PatchedSubscriberExecutionContext(object):
+    __slots__ = "exe_context", "errors"
+
+    def __init__(self, exe_context):
+        self.exe_context = exe_context
+        self.errors = self.exe_context.errors
+
+    def reset(self):
+        self.errors = []
+
+    def __getattr__(self, name):
+        return getattr(self.exe_context, name)

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -369,7 +369,7 @@ class GiftCard(ModelObjectType):
             ) or (user and requestor == user):
                 return root.code
 
-            raise PermissionDenied(
+            return PermissionDenied(
                 permissions=[
                     AuthorizationFilters.OWNER,
                     GiftcardPermissions.MANAGE_GIFT_CARD,

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -369,7 +369,7 @@ class GiftCard(ModelObjectType):
             ) or (user and requestor == user):
                 return root.code
 
-            return PermissionDenied(
+            raise PermissionDenied(
                 permissions=[
                     AuthorizationFilters.OWNER,
                     GiftcardPermissions.MANAGE_GIFT_CARD,

--- a/saleor/graphql/tests/fixtures.py
+++ b/saleor/graphql/tests/fixtures.py
@@ -14,7 +14,7 @@ from ...account.models import User
 from ...core.jwt import create_access_token
 from ...plugins.manager import get_plugins_manager
 from ...tests.utils import flush_post_commit_hooks
-from ..views import handled_errors_logger, unhandled_errors_logger
+from ..utils import handled_errors_logger, unhandled_errors_logger
 from .utils import assert_no_permission
 
 API_PATH = reverse("api")
@@ -94,7 +94,7 @@ class ApiClient(Client):
 
         if permissions:
             if check_no_permissions:
-                with mock.patch("saleor.graphql.views.handled_errors_logger"):
+                with mock.patch("saleor.graphql.utils.handled_errors_logger"):
                     response = super().post(API_PATH, data, **kwargs)
                 assert_no_permission(response)
             if self.app:

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Dict, Optional
 
 from celery.utils.log import get_task_logger
@@ -13,16 +12,13 @@ from graphql.language.ast import FragmentDefinition, OperationDefinition
 from promise import Promise
 
 from ...app.models import App
+from ...core.exceptions import PermissionDenied
 from ...discount.utils import fetch_discounts
 from ...plugins.manager import PluginsManager
-from ...core.exceptions import PermissionDenied
 from ...settings import get_host
 from ..utils import format_error
 
 logger = get_task_logger(__name__)
-
-unhandled_errors_logger = logging.getLogger("saleor.graphql.errors.unhandled")
-handled_errors_logger = logging.getLogger("saleor.graphql.errors.handled")
 
 
 def validate_subscription_query(query: str) -> bool:

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest
 from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 from graphql import GraphQLDocument, get_default_backend, parse
-from graphql.error import GraphQLSyntaxError
+from graphql.error import GraphQLSyntaxError, format_error
 from graphql.language.ast import FragmentDefinition, OperationDefinition
 from promise import Promise
 
@@ -84,6 +84,14 @@ def initialize_request(requestor=None) -> HttpRequest:
     return request
 
 
+def get_event_payload(event):
+    # Queries that use dataloaders return Promise object for the "event" field. In that
+    # case, we need to resolve them first.
+    if isinstance(event, Promise):
+        return event.get()
+    return event
+
+
 def generate_payload_from_subscription(
     event_type: str,
     subscribable_object,
@@ -96,7 +104,7 @@ def generate_payload_from_subscription(
     It uses a graphql's engine to build payload by using the same logic as response.
     As an input it expects given event type and object and the query which will be
     used to resolve a payload.
-    event_type: is a event which will be triggered.
+    event_type: is an event which will be triggered.
     subscribable_object: is an object which have a dedicated own type in Subscription
     definition.
     subscription_query: query used to prepare a payload via graphql engine.
@@ -132,6 +140,7 @@ def generate_payload_from_subscription(
             extra={"query": subscription_query, "app": app_id},
         )
         return None
+
     payload = []  # type: ignore
     results.subscribe(payload.append)
 
@@ -143,11 +152,11 @@ def generate_payload_from_subscription(
         return None
 
     payload_instance = payload[0]
-    event_payload = payload_instance.data.get("event")
+    event_payload = get_event_payload(payload_instance.data.get("event"))
 
-    # Queries that use dataloaders return Promise object for the "event" field. In that
-    # case, we need to resolve them first.
-    if isinstance(event_payload, Promise):
-        return event_payload.get()
+    if payload_instance.errors:
+        event_payload["errors"] = [
+            format_error(error) for error in payload_instance.errors
+        ]
 
     return event_payload

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1446,9 +1446,9 @@ def test_generate_payload_from_subscription_return_permission_errors_in_payload(
 
     # then
     payload = json.loads(deliveries[0].payload.payload)
-    message = "You need one of the following permissions: OWNER, MANAGE_GIFT_CARD"
+    error_code = "PermissionDenied"
 
     assert not payload["giftCard"]
-    assert payload["errors"][0]["message"] == message
+    assert payload["errors"][0]["extensions"]["exception"]["code"] == error_code
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1428,3 +1428,27 @@ def test_validate_invalid_multiple_subscriptions():
         subscription_queries.TEST_INVALID_MULTIPLE_SUBSCRIPTION
     )
     assert result is False
+
+
+def test_generate_payload_from_subscription_return_permission_errors_in_payload(
+    gift_card, subscription_gift_card_created_webhook, permission_manage_gift_card
+):
+    # given
+    subscription_gift_card_created_webhook.app.permissions.remove(
+        permission_manage_gift_card
+    )
+    webhooks = [subscription_gift_card_created_webhook]
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        WebhookEventAsyncType.GIFT_CARD_CREATED, gift_card, webhooks
+    )
+
+    # then
+    payload = json.loads(deliveries[0].payload.payload)
+    message = "You need one of the following permissions: OWNER, MANAGE_GIFT_CARD"
+
+    assert not payload["giftCard"]
+    assert payload["errors"][0]["message"] == message
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -14,12 +14,13 @@ import sentry_sdk.utils
 from celery.schedules import crontab
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.utils import get_random_secret_key
+from graphql.execution import executor
 from pytimeparse import parse
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 
-from . import __version__
+from . import PatchedSubscriberExecutionContext, __version__
 from .core.languages import LANGUAGES as CORE_LANGUAGES
 
 
@@ -729,4 +730,8 @@ JWT_TTL_REQUEST_EMAIL_CHANGE = timedelta(
     seconds=parse(os.environ.get("JWT_TTL_REQUEST_EMAIL_CHANGE", "1 hour")),
 )
 
-# Support multiple interface notation in schema for Apollo tooling.
+
+# Patch SubscriberExecutionContext class from `graphql-core-legacy` package
+# to fix bug causing not returning errors for subscription queries.
+
+executor.SubscriberExecutionContext = PatchedSubscriberExecutionContext  # type: ignore


### PR DESCRIPTION
I want to merge this change because it fixes returning errors in subscription webhooks payloads.

There is a bug in `SubscriberExecutionContext` class from `graphql-core-legacy` package that's why we are patching this class.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
