### PR TITLE
Hotfix sending invoice notification emails

### DIFF
--- a/saleor/plugins/sendgrid/tasks.py
+++ b/saleor/plugins/sendgrid/tasks.py
@@ -155,11 +155,11 @@ def send_invoice_email_task(payload: dict, configuration: dict):
     invoice_events.notification_invoice_sent_event(
         user_id=payload["requester_user_id"],
         app_id=payload["requester_app_id"],
-        invoice_id=payload["invoice"]["id"],
+        invoice_id=from_global_id_or_none(payload["invoice"]["id"]),
         customer_email=payload["recipient_email"],
     )
     order_events.event_invoice_sent_notification(
-        order_id=payload["invoice"]["order_id"],
+        order_id=from_global_id_or_none(payload["invoice"]["order_id"]),
         user_id=payload["requester_user_id"],
         app_id=payload["requester_app_id"],
         email=payload["recipient_email"],

--- a/saleor/plugins/sendgrid/tasks.py
+++ b/saleor/plugins/sendgrid/tasks.py
@@ -153,15 +153,15 @@ def send_invoice_email_task(payload: dict, configuration: dict):
         payload=payload,
     )
     invoice_events.notification_invoice_sent_event(
-        user_id=payload["requester_user_id"],
-        app_id=payload["requester_app_id"],
+        user_id=from_global_id_or_none(payload["requester_user_id"]),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
         invoice_id=from_global_id_or_none(payload["invoice"]["id"]),
         customer_email=payload["recipient_email"],
     )
     order_events.event_invoice_sent_notification(
         order_id=from_global_id_or_none(payload["invoice"]["order_id"]),
-        user_id=payload["requester_user_id"],
-        app_id=payload["requester_app_id"],
+        user_id=from_global_id_or_none(payload["requester_user_id"]),
+        app_id=from_global_id_or_none(payload["requester_app_id"]),
         email=payload["recipient_email"],
     )
 

--- a/saleor/plugins/sendgrid/tests/test_tasks.py
+++ b/saleor/plugins/sendgrid/tests/test_tasks.py
@@ -1,6 +1,7 @@
 from dataclasses import asdict
 from unittest.mock import Mock, patch
 
+import graphene
 import pytest
 
 from ....account import CustomerEvents
@@ -301,8 +302,8 @@ def test_send_invoice_email_task_by_user(
     recipient_email = "user@example.com"
     payload = {
         "invoice": {
-            "id": invoice.id,
-            "order_id": order.id,
+            "id": graphene.Node.to_global_id("Invoice", invoice.id),
+            "order_id": graphene.Node.to_global_id("Order", order.id),
             "number": 999,
             "download_url": "http://localhost:8000/download",
         },
@@ -348,8 +349,8 @@ def test_send_invoice_email_task_by_app(
     recipient_email = "user@example.com"
     payload = {
         "invoice": {
-            "id": invoice.id,
-            "order_id": order.id,
+            "id": graphene.Node.to_global_id("Invoice", invoice.id),
+            "order_id": graphene.Node.to_global_id("Order", order.id),
             "number": 999,
             "download_url": "http://localhost:8000/download",
         },

--- a/saleor/plugins/sendgrid/tests/test_tasks.py
+++ b/saleor/plugins/sendgrid/tests/test_tasks.py
@@ -1,7 +1,6 @@
 from dataclasses import asdict
 from unittest.mock import Mock, patch
 
-import graphene
 import pytest
 
 from ....account import CustomerEvents
@@ -302,15 +301,15 @@ def test_send_invoice_email_task_by_user(
     recipient_email = "user@example.com"
     payload = {
         "invoice": {
-            "id": graphene.Node.to_global_id("Invoice", invoice.id),
-            "order_id": graphene.Node.to_global_id("Order", order.id),
+            "id": to_global_id_or_none(invoice),
+            "order_id": to_global_id_or_none(order),
             "number": 999,
             "download_url": "http://localhost:8000/download",
         },
         "recipient_email": recipient_email,
         "site_name": "Saleor",
         "domain": "localhost:8000",
-        "requester_user_id": staff_user.id,
+        "requester_user_id": to_global_id_or_none(staff_user),
         "requester_app_id": None,
     }
 
@@ -349,8 +348,8 @@ def test_send_invoice_email_task_by_app(
     recipient_email = "user@example.com"
     payload = {
         "invoice": {
-            "id": graphene.Node.to_global_id("Invoice", invoice.id),
-            "order_id": graphene.Node.to_global_id("Order", order.id),
+            "id": to_global_id_or_none(invoice),
+            "order_id": to_global_id_or_none(order),
             "number": 999,
             "download_url": "http://localhost:8000/download",
         },
@@ -358,7 +357,7 @@ def test_send_invoice_email_task_by_app(
         "site_name": "Saleor",
         "domain": "localhost:8000",
         "requester_user_id": None,
-        "requester_app_id": app.pk,
+        "requester_app_id": to_global_id_or_none(app),
     }
 
     plugin = sendgrid_email_plugin(


### PR DESCRIPTION
It seems that #9388 has introduced an issue where graphql ids are sometimes passed into db manager functions.

```
ValueError saleor.plugins.sendgrid.tasks.send_invoice_email_task
Field 'id' expected a number but got 'SW52b2ljZToxMA=='.
```

This pull requests parses the global id into a database id. A cleaner solution would be probably to refactor the code in order to avoid double id conversions, but I'm providing this hotfix to address unhandled exception on `main`

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
