### PR TITLE
Use Saleor's custom UvicornWorker in Procfile to avoid lifespan warnings

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: python manage.py migrate --no-input
-web: gunicorn --bind :$PORT --workers 4 --worker-class uvicorn.workers.UvicornWorker saleor.asgi:application
+web: gunicorn --bind :$PORT --workers 4 --worker-class saleor.asgi.gunicorn_worker.UvicornWorker saleor.asgi:application
 celeryworker: celery -A saleor --app=saleor.celeryconf:app worker --loglevel=info -E


### PR DESCRIPTION
I want to merge this change because it updates the Procfile gunicorn web process to use Saleor's custom UvicornWorker and prevent lifespan warnings. See https://github.com/saleor/saleor/pull/8517

> Default uvicorn worker uses lifespan protocol, which is not supported by Django and raises warnings:
>
> Django can only handle ASGI/HTTP connections, not lifespan.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
