### PR TITLE
Stop auto-assigning default addresses to checkout.

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -138,8 +138,6 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             return cls.validate_address(
                 data["shipping_address"], address_type=AddressType.SHIPPING
             )
-        if user.is_authenticated:
-            return user.default_shipping_address
         return None
 
     @classmethod
@@ -148,8 +146,6 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             return cls.validate_address(
                 data["billing_address"], address_type=AddressType.BILLING
             )
-        if user.is_authenticated:
-            return user.default_billing_address
         return None
 
     @classmethod

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1165,16 +1165,8 @@ def test_checkout_create_logged_in_customer(user_api_client, stock, channel_USD)
     checkout_user = new_checkout.user
     customer = user_api_client.user
     assert customer.id == checkout_user.id
-    assert customer.default_shipping_address_id != new_checkout.shipping_address_id
-    assert (
-        customer.default_shipping_address.as_data()
-        == new_checkout.shipping_address.as_data()
-    )
-    assert customer.default_billing_address_id != new_checkout.billing_address_id
-    assert (
-        customer.default_billing_address.as_data()
-        == new_checkout.billing_address.as_data()
-    )
+    assert new_checkout.shipping_address is None
+    assert new_checkout.billing_address is None
     assert customer.email == new_checkout.email
 
 


### PR DESCRIPTION
I want to merge this change because the default address should be a hint for the API client. Saleor should not be the one deciding on whether to use the default address or not.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
