### PR TITLE
Disable query counter steps on forked repositories

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -88,7 +88,7 @@ jobs:
           query_raw_dump_path: ${{ env.BENCH_PATH }}
           diff_endpoint: "https://dtab784j47g1o.cloudfront.net/default/saleor-db-queries-bot-diff"
           diff_results_base_url: "https://dtab784j47g1o.cloudfront.net"
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request' && github.repository == 'saleor/saleor'
 
       # Save results for future comparison against pull requests
       - uses: NyanKiyoshi/pytest-django-queries-ci-tools@v1
@@ -96,7 +96,7 @@ jobs:
           query_raw_dump_path: ${{ env.BENCH_PATH }}
           upload_endpoint: ${{ secrets.QUERIES_UPLOAD_ENDPOINT_URL }}
           upload_secret_key: ${{ secrets.QUERIES_UPLOAD_SECRET }}
-        if: ${{ github.event_name == 'push' }}
+        if: github.event_name == 'push' && github.repository == 'saleor/saleor'
 
       # Run linters and Django related checks
       - name: Run Linters and Checks


### PR DESCRIPTION
This disables running pytest-django-queries result publishing on forks that have GitHub Actions enabled.

Currently forks get errors due to lack of credentials.



# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
