### PR TITLE
Allow orders to be filtered by number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix incorrect default value used in `PaymentInput.storePaymentMethod` - #9943 by @korycins
 - Introduce plain text attribute - #9907 by @IKarbowiak
 - Stop auto-assigning default addresses to checkout - #9933 by @SzymJ
-- `numbers` filter added to `OrderFilter` - #9967 by @SzymJ
+- Added `OrderFilter.numbers` filter  - #9967 by @SzymJ
 
 #### Saleor Apps
 - Add webhooks `PAGE_TYPE_CREATED`, `PAGE_TYPE_UPDATED` and `PAGE_TYPE_DELETED` - #9859 by @SzymJ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix incorrect default value used in `PaymentInput.storePaymentMethod` - #9943 by @korycins
 - Introduce plain text attribute - #9907 by @IKarbowiak
 - Stop auto-assigning default addresses to checkout - #9933 by @SzymJ
+- `numbers` filter added to `OrderFilter` - #9967 by @SzymJ
 
 #### Saleor Apps
 - Add webhooks `PAGE_TYPE_CREATED`, `PAGE_TYPE_UPDATED` and `PAGE_TYPE_DELETED` - #9859 by @SzymJ

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -156,7 +156,7 @@ def filter_order_by_id(qs, _, value):
     return qs.filter(Q(id__in=pks) | (Q(use_old_id=True) & Q(number__in=old_pks)))
 
 
-def filter_by_name(qs, _, values):
+def filter_by_order_number(qs, _, values):
     if not values:
         return qs
     return qs.filter(number__in=values)
@@ -198,7 +198,9 @@ class OrderFilter(DraftOrderFilter):
     ids = GlobalIDMultipleChoiceFilter(method=filter_order_by_id)
     gift_card_used = django_filters.BooleanFilter(method=filter_gift_card_used)
     gift_card_bought = django_filters.BooleanFilter(method=filter_gift_card_bought)
-    numbers = ListObjectTypeFilter(input_class=graphene.Int, method=filter_by_name)
+    numbers = ListObjectTypeFilter(
+        input_class=graphene.String, method=filter_by_order_number
+    )
 
     class Meta:
         model = Order

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -1,8 +1,10 @@
 from uuid import UUID
 
 import django_filters
+import graphene
 from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
+from graphql.error import GraphQLError
 
 from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCardEvent
@@ -154,6 +156,12 @@ def filter_order_by_id(qs, _, value):
     return qs.filter(Q(id__in=pks) | (Q(use_old_id=True) & Q(number__in=old_pks)))
 
 
+def filter_by_name(qs, _, values):
+    if not values:
+        return qs
+    return qs.filter(number__in=values)
+
+
 class DraftOrderFilter(MetadataFilterBase):
     customer = django_filters.CharFilter(method=filter_customer)
     created = ObjectTypeFilter(input_class=DateRangeInput, method=filter_created_range)
@@ -190,7 +198,15 @@ class OrderFilter(DraftOrderFilter):
     ids = GlobalIDMultipleChoiceFilter(method=filter_order_by_id)
     gift_card_used = django_filters.BooleanFilter(method=filter_gift_card_used)
     gift_card_bought = django_filters.BooleanFilter(method=filter_gift_card_bought)
+    numbers = ListObjectTypeFilter(input_class=graphene.Int, method=filter_by_name)
 
     class Meta:
         model = Order
         fields = ["payment_status", "status", "customer", "created", "search"]
+
+    def is_valid(self):
+        if "ids" in self.data and "numbers" in self.data:
+            raise GraphQLError(
+                message="'ids' and 'numbers` are not allowed to use together in filter."
+            )
+        return super().is_valid()

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -9180,8 +9180,13 @@ def test_order_query_with_filter_numbers(
 
     # then
     content = get_graphql_content(response)
-    orders = content["data"]["orders"]["edges"]
-    assert len(orders) == 2
+    order_data = content["data"]["orders"]["edges"]
+    assert len(order_data) == 2
+    for order in [
+        {"node": {"id": graphene.Node.to_global_id("Order", orders[0].id)}},
+        {"node": {"id": graphene.Node.to_global_id("Order", orders[2].id)}},
+    ]:
+        assert order in order_data
 
 
 def test_order_query_with_filter_not_allow_numbers_and_ids_together(

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -9159,6 +9159,58 @@ def test_orders_query_with_filter_charge_status(
     assert content["data"]["orders"]["totalCount"] == expected_count
 
 
+def test_order_query_with_filter_numbers(
+    orders_query_with_filter,
+    staff_api_client,
+    permission_manage_orders,
+    orders,
+    channel_USD,
+):
+    # given
+    variables = {
+        "filter": {
+            "numbers": [orders[0].number, orders[2].number],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+    assert len(orders) == 2
+
+
+def test_order_query_with_filter_not_allow_numbers_and_ids_together(
+    orders_query_with_filter,
+    staff_api_client,
+    permission_manage_orders,
+    orders,
+    channel_USD,
+):
+    # given
+    variables = {
+        "filter": {
+            "numbers": [orders[0].number, orders[2].number],
+            "ids": [graphene.Node.to_global_id("Order", orders[1].id)],
+        },
+    }
+    error_message = "'ids' and 'numbers` are not allowed to use together in filter."
+
+    # when
+    response = staff_api_client.post_graphql(
+        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
+    )
+    content = get_graphql_content_from_response(response)
+
+    # then
+    assert content["errors"][0]["message"] == error_message
+    assert not content["data"]["orders"]
+
+
 QUERY_GET_VARIANTS_FROM_ORDER = """
 {
   me{

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -9169,7 +9169,7 @@ def test_order_query_with_filter_numbers(
     # given
     variables = {
         "filter": {
-            "numbers": [orders[0].number, orders[2].number],
+            "numbers": [str(orders[0].number), str(orders[2].number)],
         },
     }
 
@@ -9199,7 +9199,7 @@ def test_order_query_with_filter_not_allow_numbers_and_ids_together(
     # given
     variables = {
         "filter": {
-            "numbers": [orders[0].number, orders[2].number],
+            "numbers": [str(orders[0].number), str(orders[2].number)],
             "ids": [graphene.Node.to_global_id("Order", orders[1].id)],
         },
     }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9493,6 +9493,7 @@ input OrderFilterInput {
   ids: [ID!]
   giftCardUsed: Boolean
   giftCardBought: Boolean
+  numbers: [Int!]
 }
 
 enum OrderStatusFilter {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9493,7 +9493,7 @@ input OrderFilterInput {
   ids: [ID!]
   giftCardUsed: Boolean
   giftCardBought: Boolean
-  numbers: [Int!]
+  numbers: [String!]
 }
 
 enum OrderStatusFilter {


### PR DESCRIPTION
I want to merge this change because it adds new filter `numbers` for orders query.

- is not allowed to use `ids` and `numbers` in the same filter
- `number` field has index in the database

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
