### PR TITLE
Add taxClass field to ProductType type

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -539,6 +539,12 @@ class ProductInput(graphene.InputObjectType):
     description = JSONString(description="Product description." + RICH_CONTENT)
     name = graphene.String(description="Product name.")
     slug = graphene.String(description="Product slug.")
+    tax_class = graphene.ID(
+        description=(
+            "ID of a tax class to assign to this product. If not provided, product "
+            "will use the tax class which is assigned to the product type."
+        )
+    )
     tax_code = graphene.String(description="Tax rate for enabled tax gateway.")
     seo = SeoInput(description="Search engine optimization fields.")
     weight = WeightScalar(description="Weight of the Product.", required=False)

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -48,6 +48,7 @@ from ....product.tasks import update_variants_names
 from ....product.tests.utils import create_image, create_pdf_file_with_image_ext
 from ....product.utils.availability import get_variant_availability
 from ....product.utils.costs import get_product_costs_data
+from ....tax.models import TaxClass
 from ....tests.utils import dummy_editorjs, flush_post_commit_hooks
 from ....warehouse.models import Allocation, Stock, Warehouse
 from ....webhook.event_types import WebhookEventAsyncType
@@ -4290,6 +4291,9 @@ CREATE_PRODUCT_MUTATION = """
                             }
                             description
                             chargeTaxes
+                            taxClass {
+                                id
+                            }
                             taxType {
                                 taxCode
                                 description
@@ -4343,6 +4347,7 @@ def test_create_product(
     description_json,
     permission_manage_products,
     monkeypatch,
+    tax_classes,
 ):
     query = CREATE_PRODUCT_MUTATION
 
@@ -4354,6 +4359,7 @@ def test_create_product(
     product_slug = "product-test-slug"
     product_charge_taxes = True
     product_tax_rate = "STANDARD"
+    tax_class_id = graphene.Node.to_global_id("TaxClass", tax_classes[0].pk)
 
     # Mock tax interface with fake response from tax gateway
     monkeypatch.setattr(
@@ -4381,6 +4387,7 @@ def test_create_product(
             "slug": product_slug,
             "description": description_json,
             "chargeTaxes": product_charge_taxes,
+            "taxClass": tax_class_id,
             "taxCode": product_tax_rate,
             "attributes": [
                 {"id": color_attr_id, "values": [color_value_slug]},
@@ -4402,6 +4409,7 @@ def test_create_product(
     assert data["product"]["taxType"]["taxCode"] == product_tax_rate
     assert data["product"]["productType"]["name"] == product_type.name
     assert data["product"]["category"]["name"] == category.name
+    assert data["product"]["taxClass"]["id"] == tax_class_id
     values = (
         data["product"]["attributes"][0]["values"][0]["slug"],
         data["product"]["attributes"][1]["values"][0]["slug"],
@@ -4412,6 +4420,36 @@ def test_create_product(
     product = Product.objects.first()
     created_webhook_mock.assert_called_once_with(product)
     updated_webhook_mock.assert_not_called()
+
+
+def test_create_product_use_tax_class_from_product_type(
+    staff_api_client,
+    product_type,
+    permission_manage_products,
+    tax_classes,
+):
+    # given
+    default_tax_class = TaxClass.objects.get(is_default=True)
+    default_tax_class_id = graphene.Node.to_global_id("TaxClass", default_tax_class.pk)
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    variables = {
+        "input": {
+            "productType": product_type_id,
+            "name": "Test Empty Tax Class",
+            "slug": "test-empty-tax-class",
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_PRODUCT_MUTATION, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["productCreate"]
+    assert data["errors"] == []
+    assert data["product"]["taxClass"]["id"] == default_tax_class_id
 
 
 def test_create_product_description_plaintext(

--- a/saleor/graphql/product/tests/test_product_type_update.py
+++ b/saleor/graphql/product/tests/test_product_type_update.py
@@ -15,6 +15,7 @@ mutation updateProductType(
     $hasVariants: Boolean!,
     $isShippingRequired: Boolean!,
     $productAttributes: [ID!],
+    $taxClass: ID
     ) {
         productTypeUpdate(
         id: $id,
@@ -23,6 +24,7 @@ mutation updateProductType(
             hasVariants: $hasVariants,
             isShippingRequired: $isShippingRequired,
             productAttributes: $productAttributes
+            taxClass: $taxClass
         }) {
             productType {
                 name
@@ -33,6 +35,9 @@ mutation updateProductType(
                     id
                 }
                 productAttributes {
+                    id
+                }
+                taxClass {
                     id
                 }
             }
@@ -51,6 +56,7 @@ def test_product_type_update_mutation(
     product_type,
     product,
     permission_manage_product_types_and_attributes,
+    tax_classes,
 ):
     query = PRODUCT_TYPE_UPDATE_MUTATION
     product_type_name = "test type updated"
@@ -58,6 +64,7 @@ def test_product_type_update_mutation(
     has_variants = True
     require_shipping = False
     product_type_id = graphene.Node.to_global_id("ProductType", product_type.id)
+    tax_class_id = graphene.Node.to_global_id("TaxClass", tax_classes[0].pk)
 
     # Test scenario: remove all product attributes using [] as input
     # but do not change variant attributes
@@ -73,6 +80,7 @@ def test_product_type_update_mutation(
         "hasVariants": has_variants,
         "isShippingRequired": require_shipping,
         "productAttributes": product_attributes_ids,
+        "taxClass": tax_class_id,
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_product_types_and_attributes]
@@ -85,6 +93,7 @@ def test_product_type_update_mutation(
     assert data["isShippingRequired"] == require_shipping
     assert not data["productAttributes"]
     assert len(data["variantAttributes"]) == (variant_attributes.count())
+    assert data["taxClass"]["id"] == tax_class_id
 
 
 def test_product_type_update_mutation_not_valid_attributes(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2846,6 +2846,13 @@ type ShippingMethodType implements Node & ObjectWithMetadata {
 
   """Minimal number of days for delivery."""
   minimumDeliveryDays: Int
+
+  """
+  Tax class assigned to this shipping method.
+  
+  Requires one of the following permissions: MANAGE_TAXES, MANAGE_SHIPPING.
+  """
+  taxClass: TaxClass!
 }
 
 """An enumeration."""
@@ -15301,6 +15308,11 @@ input ShippingPriceInput {
 
   """Inclusion type for currently assigned postal code rules."""
   inclusionType: PostalCodeRuleInclusionTypeEnum
+
+  """
+  ID of a tax class to assign to this shipping method. If not provided, the default tax class will be used.
+  """
+  taxClass: ID
 }
 
 scalar WeightScalar

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3890,6 +3890,13 @@ type Product implements Node & ObjectWithMetadata {
 
   """Whether the product is available for purchase."""
   isAvailableForPurchase: Boolean
+
+  """
+  Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
+  
+  Requires one of the following permissions: MANAGE_TAXES, MANAGE_PRODUCTS.
+  """
+  taxClass: TaxClass!
 }
 
 """
@@ -16011,6 +16018,11 @@ input ProductCreateInput {
   """Product slug."""
   slug: String
 
+  """
+  ID of a tax class to assign to this product. If not provided, product will use the tax class which is assigned to the product type.
+  """
+  taxClass: ID
+
   """Tax rate for enabled tax gateway."""
   taxCode: String
 
@@ -16120,6 +16132,11 @@ input ProductInput {
 
   """Product slug."""
   slug: String
+
+  """
+  ID of a tax class to assign to this product. If not provided, product will use the tax class which is assigned to the product type.
+  """
+  taxClass: ID
 
   """Tax rate for enabled tax gateway."""
   taxCode: String

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3974,6 +3974,13 @@ type ProductType implements Node & ObjectWithMetadata {
   """A type of tax. Assigned by enabled tax gateway"""
   taxType: TaxType
 
+  """
+  Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
+  
+  Requires one of the following permissions: MANAGE_TAXES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  """
+  taxClass: TaxClass!
+
   """Variant attributes of that product type."""
   variantAttributes(
     """Define scope of returned attributes."""
@@ -4046,6 +4053,93 @@ type TaxType {
 
   """External tax code used to identify given tax group."""
   taxCode: String
+}
+
+"""
+Tax class is a named object used to define tax rates per country. Tax class can be assigned to product types, products and shipping methods to define their tax rates.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type TaxClass implements Node & ObjectWithMetadata {
+  """The ID of the object."""
+  id: ID!
+
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
+
+  """Name of the tax class."""
+  name: String!
+
+  """
+  Determines whether a tax class is a default one. Default tax class is created by the system and cannot be removed.
+  """
+  isDefault: Boolean!
+
+  """Country-specific tax rates for this tax class."""
+  countries: [TaxClassCountryRate!]!
+}
+
+"""
+Country-specific tax rate value for a tax class.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type TaxClassCountryRate {
+  """Country in which this tax rate applies."""
+  country: CountryDisplay!
+
+  """Tax rate value."""
+  rate: Float!
+
+  """Related tax class."""
+  taxClass: TaxClass!
 }
 
 """
@@ -7017,93 +7111,6 @@ type TaxConfigurationCountableEdge {
 input TaxConfigurationFilterInput {
   metadata: [MetadataFilter!]
   ids: [ID!]
-}
-
-"""
-Tax class is a named object used to define tax rates per country. Tax class can be assigned to product types, products and shipping methods to define their tax rates.
-
-Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
-type TaxClass implements Node & ObjectWithMetadata {
-  """The ID of the object."""
-  id: ID!
-
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  privateMetafield(key: String!): String
-
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  metafields(keys: [String!]): Metadata
-
-  """Name of the tax class."""
-  name: String!
-
-  """
-  Determines whether a tax class is a default one. Default tax class is created by the system and cannot be removed.
-  """
-  isDefault: Boolean!
-
-  """Country-specific tax rates for this tax class."""
-  countries: [TaxClassCountryRate!]!
-}
-
-"""
-Country-specific tax rate value for a tax class.
-
-Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-"""
-type TaxClassCountryRate {
-  """Country in which this tax rate applies."""
-  country: CountryDisplay!
-
-  """Tax rate value."""
-  rate: Float!
-
-  """Related tax class."""
-  taxClass: TaxClass!
 }
 
 type TaxClassCountableConnection {
@@ -16378,6 +16385,11 @@ input ProductTypeInput {
 
   """Tax rate for enabled tax gateway."""
   taxCode: String
+
+  """
+  ID of a tax class to assign to this product type. All products of this product type would use this tax class, unless it's overridden in the `Product` type.
+  """
+  taxClass: ID
 }
 
 """

--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -16,6 +16,7 @@ from ....shipping.utils import (
     default_shipping_zone_exists,
     get_countries_without_shipping_zone,
 )
+from ....tax.models import TaxClass
 from ...channel.types import ChannelContext
 from ...core.fields import JSONString
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
@@ -65,6 +66,12 @@ class ShippingPriceInput(graphene.InputObjectType):
     )
     inclusion_type = PostalCodeRuleInclusionTypeEnum(
         description="Inclusion type for currently assigned postal code rules.",
+    )
+    tax_class = graphene.ID(
+        description=(
+            "ID of a tax class to assign to this shipping method. If not provided, "
+            "the default tax class will be used."
+        )
     )
 
 
@@ -324,6 +331,11 @@ class ShippingPriceMixin:
                     )
                 }
             )
+
+        if "tax_class" in cleaned_input and cleaned_input["tax_class"] is None:
+            cleaned_input["tax_class"] = TaxClass.objects.filter(
+                is_default=True
+            ).first()
 
         return cleaned_input
 

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_create.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_create.py
@@ -25,45 +25,51 @@ PRICE_BASED_SHIPPING_MUTATION = """
         $addPostalCodeRules: [ShippingPostalCodeRulesCreateInputRange!]
         $deletePostalCodeRules: [ID!]
         $inclusionType: PostalCodeRuleInclusionTypeEnum
+        $taxClass: ID
     ) {
-    shippingPriceCreate(
-        input: {
-            name: $name, shippingZone: $shippingZone, type: $type,
-            maximumDeliveryDays: $maximumDeliveryDays,
-            minimumDeliveryDays: $minimumDeliveryDays,
-            addPostalCodeRules: $addPostalCodeRules,
-            deletePostalCodeRules: $deletePostalCodeRules,
-            inclusionType: $inclusionType, description: $description
-        }) {
-        errors {
-            field
-            code
-        }
-        shippingZone {
-            id
-        }
-        shippingMethod {
-            id
-            name
-            description
-            channelListings {
-            price {
-                amount
+        shippingPriceCreate(
+            input: {
+                name: $name, shippingZone: $shippingZone, type: $type,
+                maximumDeliveryDays: $maximumDeliveryDays,
+                minimumDeliveryDays: $minimumDeliveryDays,
+                addPostalCodeRules: $addPostalCodeRules,
+                deletePostalCodeRules: $deletePostalCodeRules,
+                inclusionType: $inclusionType,
+                description: $description,
+                taxClass: $taxClass
+            }) {
+            errors {
+                field
+                code
             }
-            minimumOrderPrice {
-                amount
+            shippingZone {
+                id
             }
-            maximumOrderPrice {
-                amount
-            }
-            }
-            type
-            minimumDeliveryDays
-            maximumDeliveryDays
-            postalCodeRules {
-                start
-                end
-            }
+            shippingMethod {
+                id
+                name
+                description
+                channelListings {
+                    price {
+                        amount
+                    }
+                    minimumOrderPrice {
+                        amount
+                    }
+                    maximumOrderPrice {
+                        amount
+                    }
+                }
+                taxClass {
+                    id
+                }
+                type
+                minimumDeliveryDays
+                maximumDeliveryDays
+                postalCodeRules {
+                    start
+                    end
+                }
             }
         }
     }
@@ -82,12 +88,14 @@ def test_create_shipping_method(
     shipping_zone,
     postal_code_rules,
     permission_manage_shipping,
+    tax_classes,
 ):
     name = "DHL"
     shipping_zone_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
     max_del_days = 10
     min_del_days = 3
     description = dummy_editorjs("description", True)
+    tax_class_id = graphene.Node.to_global_id("TaxClass", tax_classes[0].pk)
     variables = {
         "shippingZone": shipping_zone_id,
         "name": name,
@@ -98,6 +106,7 @@ def test_create_shipping_method(
         "addPostalCodeRules": postal_code_rules,
         "deletePostalCodeRules": [],
         "inclusionType": PostalCodeRuleInclusionTypeEnum.EXCLUDE.name,
+        "taxClass": tax_class_id,
     }
     response = staff_api_client.post_graphql(
         PRICE_BASED_SHIPPING_MUTATION,
@@ -115,6 +124,7 @@ def test_create_shipping_method(
     assert data["shippingMethod"]["minimumDeliveryDays"] == min_del_days
     assert data["shippingMethod"]["maximumDeliveryDays"] == max_del_days
     assert data["shippingMethod"]["postalCodeRules"] == postal_code_rules
+    assert data["shippingMethod"]["taxClass"]["id"] == tax_class_id
 
 
 @freeze_time("2022-05-12 12:00:00")

--- a/saleor/tax/tests/fixtures.py
+++ b/saleor/tax/tests/fixtures.py
@@ -20,3 +20,24 @@ def default_tax_class(db):
         ]
     )
     return tax_class
+
+
+@pytest.fixture
+def tax_classes(db):
+    objects = []
+    for name in ["Books", "Groceries"]:
+        tax_class, _ = TaxClass.objects.get_or_create(
+            name=name,
+            defaults={
+                "metadata": {"key": "value"},
+                "private_metadata": {"key": "value"},
+            },
+        )
+        TaxClassCountryRate.objects.bulk_create(
+            [
+                TaxClassCountryRate(country="PL", rate=23, tax_class=tax_class),
+                TaxClassCountryRate(country="DE", rate=19, tax_class=tax_class),
+            ]
+        )
+        objects.append(tax_class)
+    return objects


### PR DESCRIPTION
Integrate tax classes with products, product types and shipping methods API.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
