### PR TITLE
Add displayGrossPrices to ProductPricingInfo

### DIFF
--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -139,6 +139,7 @@ def test_product_details(product_with_image, api_client, count_queries, channel_
                           }
                         }
                       }
+                      displayGrossPrices
                     }
                   }
                 }
@@ -299,6 +300,7 @@ def test_retrieve_channel_listings(
                         }
                       }
                     }
+                    displayGrossPrices
                   }
                 }
               }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5511,6 +5511,11 @@ type ProductPricingInfo {
   The discounted price range of the product variants in the local currency.
   """
   priceRangeLocalCurrency: TaxedMoneyRange
+
+  """
+  Determines whether this product's price displayed in a storefront should include taxes.
+  """
+  displayGrossPrices: Boolean!
 }
 
 """Represents a range of monetary values."""

--- a/saleor/graphql/tax/dataloaders.py
+++ b/saleor/graphql/tax/dataloaders.py
@@ -1,6 +1,11 @@
 from collections import defaultdict
 
-from ...tax.models import TaxClass, TaxClassCountryRate, TaxConfigurationPerCountry
+from ...tax.models import (
+    TaxClass,
+    TaxClassCountryRate,
+    TaxConfiguration,
+    TaxConfigurationPerCountry,
+)
 from ..core.dataloaders import DataLoader
 
 
@@ -17,6 +22,16 @@ class TaxConfigurationPerCountryByTaxConfigurationIDLoader(DataLoader):
             one_to_many[obj.tax_configuration_id].append(obj)
 
         return [one_to_many[key] for key in keys]
+
+
+class TaxConfigurationByChannelId(DataLoader):
+    context_key = "tax_configuration_by_channel_id"
+
+    def batch_load(self, keys):
+        tax_configs = TaxConfiguration.objects.using(
+            self.database_connection_name
+        ).in_bulk(keys, field_name="channel_id")
+        return [tax_configs[key] for key in keys]
 
 
 class TaxClassCountryRateByTaxClassIDLoader(DataLoader):

--- a/saleor/tax/tests/test_models.py
+++ b/saleor/tax/tests/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 from django.db import IntegrityError
 
-from saleor.tax.models import TaxClass
+from ..models import TaxClass
 
 
 def test_deleting_default_tax_class_raises_error():

--- a/saleor/tax/tests/test_utils.py
+++ b/saleor/tax/tests/test_utils.py
@@ -1,0 +1,19 @@
+from ..utils import get_display_gross_prices
+
+
+def test_get_display_gross_prices(channel_USD):
+    # given
+    tax_configuration = channel_USD.tax_configuration
+    tax_configuration.display_gross_prices = True
+    country_exception = tax_configuration.country_exceptions.first()
+    country_exception.display_gross_prices = False
+
+    # then
+    assert (
+        get_display_gross_prices(tax_configuration, None)
+        == tax_configuration.display_gross_prices
+    )
+    assert (
+        get_display_gross_prices(tax_configuration, country_exception)
+        == country_exception.display_gross_prices
+    )

--- a/saleor/tax/utils.py
+++ b/saleor/tax/utils.py
@@ -1,0 +1,15 @@
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .models import TaxConfiguration, TaxConfigurationPerCountry
+
+
+def get_display_gross_prices(
+    tax_configuration: "TaxConfiguration",
+    country_tax_configuration: Optional["TaxConfigurationPerCountry"],
+):
+    return (
+        country_tax_configuration.display_gross_prices
+        if country_tax_configuration
+        else tax_configuration.display_gross_prices
+    )


### PR DESCRIPTION
Add `displayGrossPrices` field to `Product`, `Order` and `Checkout` types. Also, refactored a bit some resolvers which were using multiple nested functions to call data loaders, but instead the could be resolved as a promise list with `Promise.all` which is more readable.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
