### PR TITLE
Add data migration for fixing invalid undiscounted total on order line in 3.3

### DIFF
--- a/saleor/order/__init__.py
+++ b/saleor/order/__init__.py
@@ -5,6 +5,9 @@ if TYPE_CHECKING:
     from .models import FulfillmentLine
 
 
+default_app_config = "saleor.order.app.OrderAppConfig"
+
+
 class OrderStatus:
     DRAFT = "draft"  # fully editable, not finalized order created by staff users
     UNCONFIRMED = (

--- a/saleor/order/app.py
+++ b/saleor/order/app.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class OrderAppConfig(AppConfig):
+    name = "saleor.order"

--- a/saleor/order/migrations/0139_fix_undiscounted_total_on_lines.py
+++ b/saleor/order/migrations/0139_fix_undiscounted_total_on_lines.py
@@ -1,0 +1,120 @@
+from functools import partial
+
+from django.db import migrations
+from django.db.models import F, Q
+from django.db.models.signals import post_migrate
+from saleor.plugins.manager import get_plugins_manager
+from saleor.order.app import OrderAppConfig
+from saleor.celeryconf import app
+
+# We need to send `order_updated` for each updated order. When we drop plugin manager
+# we should rewrite `send_order_updated`
+
+BATCH_SIZE = 500
+
+
+def queryset_in_batches(queryset):
+    """Slice a queryset into batches.
+
+    Input queryset should be sorted be pk.
+    """
+    start_pk = 0
+
+    while True:
+        qs = queryset.filter(pk__gt=start_pk)[:BATCH_SIZE]
+        pks = list(qs.values_list("pk", flat=True))
+
+        if not pks:
+            break
+
+        yield pks
+
+        start_pk = pks[-1]
+
+
+@app.task
+def send_order_updated(order_ids):
+    from saleor.order.models import Order
+
+    # We need to import Order in this way because when we import it by
+    # `Order = apps.get_model("order", "Order")` models doesn't contains
+    # model methods which are required by `order_updated`
+
+    manager = get_plugins_manager()
+    for order in Order.objects.filter(id__in=order_ids):
+        manager.order_updated(order)
+
+
+def set_order_line_base_prices(apps, schema_editor):
+    def on_migrations_complete(sender=None, **kwargs):
+        # The `post_migrate`` signal is sent once for every app migrated
+        # we should execute it only once after update `order` module.
+        if isinstance(sender, OrderAppConfig):
+            order_ids = list(kwargs.get("updated_orders_pks"))
+            send_order_updated.delay(order_ids)
+
+    OrderLine = apps.get_model("order", "OrderLine")
+    order_lines_to_update = OrderLine.objects.filter(
+        ~Q(
+            undiscounted_total_price_gross_amount=F(
+                "undiscounted_unit_price_gross_amount"
+            )
+            * F("quantity")
+        )
+        | ~Q(
+            undiscounted_total_price_net_amount=F("undiscounted_unit_price_net_amount")
+            * F("quantity")
+        )
+    ).order_by("pk")
+    updated_orders_pks = []
+    for batch_pks in queryset_in_batches(order_lines_to_update):
+        order_lines = OrderLine.objects.filter(pk__in=batch_pks)
+        for order_line in order_lines:
+            old_undiscounted_total_price_gross_amount = (
+                order_line.undiscounted_total_price_gross_amount
+            )
+            old_undiscounted_total_price_net_amount = (
+                order_line.undiscounted_total_price_net_amount
+            )
+            order_line.undiscounted_total_price_gross_amount = (
+                order_line.undiscounted_unit_price_gross_amount * order_line.quantity
+            )
+            order_line.undiscounted_total_price_net_amount = (
+                order_line.undiscounted_unit_price_net_amount * order_line.quantity
+            )
+            if (
+                order_line.undiscounted_total_price_gross_amount
+                != old_undiscounted_total_price_gross_amount
+                or order_line.undiscounted_total_price_net_amount
+                != old_undiscounted_total_price_net_amount
+            ):
+                updated_orders_pks.append(order_line.order_id)
+        OrderLine.objects.bulk_update(
+            order_lines,
+            [
+                "undiscounted_total_price_gross_amount",
+                "undiscounted_total_price_net_amount",
+            ],
+        )
+
+    # If we updated any order we should trigger `order_updated` after migrations
+    if updated_orders_pks:
+        updated_orders_pks = set(updated_orders_pks)
+        post_migrate.connect(
+            partial(on_migrations_complete, updated_orders_pks=updated_orders_pks),
+            weak=False,
+            dispatch_uid="send_order_updated",
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("order", "0138_orderline_base_price"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            set_order_line_base_prices, reverse_code=migrations.RunPython.noop
+        ),
+    ]


### PR DESCRIPTION
This PR adds data migration to fix invalid undiscounted total values in order lines in Saleor 3.3.
Related to #9965

Previously, `OrderLine` undiscounted total was calculated from `unit_price` instead of `undiscounted_unict_price`.

Previously we have OrderLine with:
unit_price: 5 USD
undiscounted_unit_price: 10 USD
quantity: 2
total_price: 10 USD
**undiscoutend_total_price: 10 USD**

After migration we have:
unit_price: 5 USD
undiscounted_unit_price: 10 USD
quantity: 2
total_price: 10 USD
**undiscoutend_total_price: 20 USD**

**Warning** :warning: 
- This migration changes the value of `undiscoutend_total_price` field in the database for any order where the value is currently invalid.
- We trigger `ORDER_UPDATED` for each updated order.
- Only order lines that were created from draft orders are affected, or order lines that were manually added by admins/apps after the order was created. Regular orders created from checkouts are not affected by this bug.



<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
