### PR TITLE
Fix invoice download URL in send-invoice email

### DIFF
--- a/saleor/plugins/user_email/default_email_templates/send_invoice.html
+++ b/saleor/plugins/user_email/default_email_templates/send_invoice.html
@@ -111,7 +111,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a href="{{download_url}}">
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a href="{{invoice.download_url}}">
             {{invoice.download_url}}
           </a></div>
 


### PR DESCRIPTION
I want to merge this change because default send invoice email currently contains a link to invoice which looks clickable, but isn't.

Not sure how the pipeline of getting the email templates to saleor core works, so I've made another PR in `saleor-email-templates`: https://github.com/saleor/saleor-email-templates/pull/8 just in case.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
