### PR TITLE
Move send order updated task outside migration in 3.4

### DIFF
--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from ..celeryconf import app
+from ..plugins.manager import get_plugins_manager
 from .models import Order
 from .utils import recalculate_order
 
@@ -10,3 +11,10 @@ def recalculate_orders_task(order_ids: List[int]):
     orders = Order.objects.filter(id__in=order_ids)
     for order in orders:
         recalculate_order(order)
+
+
+@app.task
+def send_order_updated(order_ids):
+    manager = get_plugins_manager()
+    for order in Order.objects.filter(id__in=order_ids):
+        manager.order_updated(order)


### PR DESCRIPTION
I want to merge this change because moving send_order_updated outside migration.
In some cases migration, saleor/order/migrations/0139_fix_undiscounted_total_on_lines.py could fail due to an unregistered task.

PR to 3.3: #10039 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
