### PR TITLE
[SALEOR-7006] Deprecate configurationUrl and dataPrivacy fields in apps

### DIFF
--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -13,7 +13,7 @@ from ...core.permissions import (
 )
 from ..account.utils import is_owner_or_has_one_of_perms
 from ..core.connection import CountableConnection
-from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE, DEPRECATED_IN_3X_FIELD
+from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_FIELD, PREVIEW_FEATURE
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.types import Job, ModelObjectType, NonNullList, Permission
 from ..core.utils import from_global_id_or_error

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -13,7 +13,7 @@ from ...core.permissions import (
 )
 from ..account.utils import is_owner_or_has_one_of_perms
 from ..core.connection import CountableConnection
-from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE, DEPRECATED_IN_3X_FIELD
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.types import Job, ModelObjectType, NonNullList, Permission
 from ..core.utils import from_global_id_or_error
@@ -157,9 +157,15 @@ class Manifest(graphene.ObjectType):
     about = graphene.String()
     permissions = NonNullList(Permission)
     app_url = graphene.String()
-    configuration_url = graphene.String()
+    configuration_url = graphene.String(
+        description="Url to iframe with the configuration for the app.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `appUrl` instead.",
+    )
     token_target_url = graphene.String()
-    data_privacy = graphene.String()
+    data_privacy = graphene.String(
+        description="Description of the data privacy defined for this app.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `dataPrivacyUrl` instead.",
+    )
     data_privacy_url = graphene.String()
     homepage_url = graphene.String()
     support_url = graphene.String()
@@ -231,7 +237,8 @@ class App(ModelObjectType):
     about_app = graphene.String(description="Description of this app.")
 
     data_privacy = graphene.String(
-        description="Description of the data privacy defined for this app."
+        description="Description of the data privacy defined for this app.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `dataPrivacyUrl` instead.",
     )
     data_privacy_url = graphene.String(
         description="Url to details about the privacy policy on the app owner page."
@@ -239,7 +246,8 @@ class App(ModelObjectType):
     homepage_url = graphene.String(description="Homepage of the app.")
     support_url = graphene.String(description="Support page for the app.")
     configuration_url = graphene.String(
-        description="Url to iframe with the configuration for the app."
+        description="Url to iframe with the configuration for the app.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `appUrl` instead.",
     )
     app_url = graphene.String(description="Url to iframe with the app.")
     version = graphene.String(description="Version number of the app.")

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -104,10 +104,7 @@ class CheckoutMutations(graphene.ObjectType):
     checkout_customer_detach = CheckoutCustomerDetach.Field()
     checkout_email_update = CheckoutEmailUpdate.Field()
     checkout_line_delete = CheckoutLineDelete.Field(
-        deprecation_reason=(
-            "DEPRECATED: Will be removed in Saleor 4.0. "
-            "Use `checkoutLinesDelete` instead."
-        )
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `checkoutLinesDelete` instead."
     )
     checkout_lines_delete = CheckoutLinesDelete.Field()
     checkout_lines_add = CheckoutLinesAdd.Field()

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -104,7 +104,9 @@ class CheckoutMutations(graphene.ObjectType):
     checkout_customer_detach = CheckoutCustomerDetach.Field()
     checkout_email_update = CheckoutEmailUpdate.Field()
     checkout_line_delete = CheckoutLineDelete.Field(
-        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `checkoutLinesDelete` instead."
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use `checkoutLinesDelete` instead."
+        )
     )
     checkout_lines_delete = CheckoutLinesDelete.Field()
     checkout_lines_add = CheckoutLinesAdd.Field()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1929,7 +1929,7 @@ type App implements Node & ObjectWithMetadata {
   aboutApp: String
 
   """Description of the data privacy defined for this app."""
-  dataPrivacy: String
+  dataPrivacy: String @deprecated(reason: "This field will be removed in Saleor 4.0. Use `dataPrivacyUrl` instead.")
 
   """Url to details about the privacy policy on the app owner page."""
   dataPrivacyUrl: String
@@ -1941,7 +1941,7 @@ type App implements Node & ObjectWithMetadata {
   supportUrl: String
 
   """Url to iframe with the configuration for the app."""
-  configurationUrl: String
+  configurationUrl: String @deprecated(reason: "This field will be removed in Saleor 4.0. Use `appUrl` instead.")
 
   """Url to iframe with the app."""
   appUrl: String
@@ -12840,7 +12840,7 @@ type Mutation {
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
-  ): CheckoutLineDelete @deprecated(reason: "DEPRECATED: Will be removed in Saleor 4.0. Use `checkoutLinesDelete` instead.")
+  ): CheckoutLineDelete @deprecated(reason: "This field will be removed in Saleor 4.0. Use `checkoutLinesDelete` instead.")
 
   """Deletes checkout lines."""
   checkoutLinesDelete(
@@ -19855,9 +19855,13 @@ type Manifest {
   about: String
   permissions: [Permission!]
   appUrl: String
-  configurationUrl: String
+
+  """Url to iframe with the configuration for the app."""
+  configurationUrl: String @deprecated(reason: "This field will be removed in Saleor 4.0. Use `appUrl` instead.")
   tokenTargetUrl: String
-  dataPrivacy: String
+
+  """Description of the data privacy defined for this app."""
+  dataPrivacy: String @deprecated(reason: "This field will be removed in Saleor 4.0. Use `dataPrivacyUrl` instead.")
   dataPrivacyUrl: String
   homepageUrl: String
   supportUrl: String

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -315,12 +315,12 @@ class ShippingMethod(graphene.ObjectType):
     maximum_order_weight = graphene.Field(
         Weight,
         description="Maximum order weight for this shipping method.",
-        deprecation_reason="This field will be removed in Saleor 4.0.",
+        deprecation_reason=DEPRECATED_IN_3X_FIELD,
     )
     minimum_order_weight = graphene.Field(
         Weight,
         description="Minimum order weight for this shipping method.",
-        deprecation_reason="This field will be removed in Saleor 4.0.",
+        deprecation_reason=DEPRECATED_IN_3X_FIELD,
     )
     translation = TranslationField(
         ShippingMethodTranslation,


### PR DESCRIPTION
I want to merge this change because we want to deprecate `configurationUrl` and `dataPrivacy` fields in apps (and their manifests).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [X] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [X] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
