### PR TITLE
Fix observability headers serialization

### DIFF
--- a/saleor/webhook/observability/payloads.py
+++ b/saleor/webhook/observability/payloads.py
@@ -1,7 +1,6 @@
 import json
 import uuid
 from collections.abc import Mapping
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import graphene
@@ -38,6 +37,8 @@ from .payload_schema import (
 from .sensitive_data import SENSITIVE_GQL_FIELDS
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from ...core.models import EventDeliveryAttempt
     from .utils import GraphQLOperationResponse
 
@@ -80,8 +81,10 @@ GQL_OPERATION_PLACEHOLDER = GraphQLOperation(
 GQL_OPERATION_PLACEHOLDER_SIZE = len(dump_payload(GQL_OPERATION_PLACEHOLDER))
 
 
-def serialize_headers(headers: Dict[str, str]) -> HttpHeaders:
-    return [(k, v) for k, v in hide_sensitive_headers(headers).items()]
+def serialize_headers(headers: Optional[Dict[str, str]]) -> HttpHeaders:
+    if headers:
+        return list(hide_sensitive_headers(headers).items())
+    return []
 
 
 def serialize_gql_operation_result(

--- a/saleor/webhook/observability/tests/test_payloads.py
+++ b/saleor/webhook/observability/tests/test_payloads.py
@@ -35,6 +35,7 @@ from ..payloads import (
     pretty_json,
     serialize_gql_operation_result,
     serialize_gql_operation_results,
+    serialize_headers,
     to_camel_case,
 )
 from ..utils import GraphQLOperationResponse
@@ -210,6 +211,21 @@ def test_serialize_gql_operation_results_when_too_low_bytes_limit(
         serialize_gql_operation_results(
             [first_result, second_result], 2 * GQL_OPERATION_PLACEHOLDER_SIZE - 1
         )
+
+
+@pytest.mark.parametrize(
+    "headers,expected",
+    [
+        ({}, []),
+        (None, []),
+        (
+            {"Content-Length": "19", "Content-Type": "application/json"},
+            [("Content-Length", "19"), ("Content-Type", "application/json")],
+        ),
+    ],
+)
+def test_serialize_headers(headers, expected):
+    assert serialize_headers(headers) == expected
 
 
 def test_generate_api_call_payload(app, rf, gql_operation_factory):


### PR DESCRIPTION
I want to merge this change because it fixes observability headers serialization.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
