### PR TITLE
Fix "canceled" spelling issue

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -8523,7 +8523,7 @@ enum PaymentChargeStatusEnum {
   PARTIALLY_REFUNDED
   FULLY_REFUNDED
   REFUSED
-  CANCELLED
+  CANCELED
 }
 
 """

--- a/saleor/payment/__init__.py
+++ b/saleor/payment/__init__.py
@@ -107,7 +107,7 @@ class ChargeStatus:
     PARTIALLY_REFUNDED = "partially-refunded"
     FULLY_REFUNDED = "fully-refunded"
     REFUSED = "refused"
-    CANCELLED = "cancelled"
+    CANCELED = "canceled"
 
     CHOICES = [
         (NOT_CHARGED, "Not charged"),
@@ -117,7 +117,7 @@ class ChargeStatus:
         (PARTIALLY_REFUNDED, "Partially refunded"),
         (FULLY_REFUNDED, "Fully refunded"),
         (REFUSED, "Refused"),
-        (CANCELLED, "Cancelled"),
+        (CANCELED, "Canceled"),
     ]
 
 

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
@@ -1434,7 +1434,7 @@ def test_handle_not_created_order_void_when_create_order_raises(
         ChargeStatus.PARTIALLY_REFUNDED,
         ChargeStatus.REFUSED,
         ChargeStatus.FULLY_REFUNDED,
-        ChargeStatus.CANCELLED,
+        ChargeStatus.CANCELED,
     ],
 )
 def test_handle_not_created_order_return_none(

--- a/saleor/payment/gateways/stripe/tests/test_webhooks.py
+++ b/saleor/payment/gateways/stripe/tests/test_webhooks.py
@@ -938,7 +938,7 @@ def test_handle_failed_payment_intent_for_checkout(
 
     assert not payment.order_id
     assert not payment.is_active
-    assert payment.charge_status == ChargeStatus.CANCELLED
+    assert payment.charge_status == ChargeStatus.CANCELED
     assert payment.transactions.filter(kind=TransactionKind.CANCEL).exists()
 
 
@@ -968,7 +968,7 @@ def test_handle_failed_payment_intent_for_order(
     payment.refresh_from_db()
 
     assert not payment.is_active
-    assert payment.charge_status == ChargeStatus.CANCELLED
+    assert payment.charge_status == ChargeStatus.CANCELED
     assert payment.transactions.filter(kind=TransactionKind.CANCEL).exists()
 
 

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -476,7 +476,7 @@ def update_payment_charge_status(payment, transaction, changed_fields=None):
         payment.charge_status = ChargeStatus.PENDING
         changed_fields += ["charge_status"]
     elif transaction_kind == TransactionKind.CANCEL:
-        payment.charge_status = ChargeStatus.CANCELLED
+        payment.charge_status = ChargeStatus.CANCELED
         payment.is_active = False
         changed_fields += ["charge_status", "is_active"]
     elif transaction_kind == TransactionKind.CAPTURE_FAILED:

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4987,7 +4987,7 @@ def payment(payment_dummy, payment_app):
 
 @pytest.fixture
 def payment_cancelled(payment_dummy):
-    payment_dummy.charge_status = ChargeStatus.CANCELLED
+    payment_dummy.charge_status = ChargeStatus.CANCELED
     payment_dummy.save()
     return payment_dummy
 


### PR DESCRIPTION
I want to merge this change because it fixes "canceled" spelling issue.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
