### PR TITLE
Quickfix for created resolver in productvariant

### DIFF
--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -95,6 +95,7 @@ def test_fetch_variant(
                 unit
                 value
             }
+            created
         }
     }
     """
@@ -117,6 +118,7 @@ def test_fetch_variant(
     content = get_graphql_content(response)
     data = content["data"]["productVariant"]
     assert data["name"] == variant.name
+    assert data["created"] == variant.created_at.isoformat()
 
     stocks_count = variant.stocks.count()
     assert len(data["deprecatedStocksByCountry"]) == stocks_count

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -353,8 +353,8 @@ class ProductVariant(ChannelContextTypeWithMetadata, ModelObjectType):
         model = models.ProductVariant
 
     @staticmethod
-    def resolve_created(root: models.ProductVariant, _info):
-        return root.created_at
+    def resolve_created(root: ChannelContext[models.ProductVariant], _info):
+        return root.node.created_at
 
     @staticmethod
     def resolve_channel(root: ChannelContext[models.Product], _info):


### PR DESCRIPTION
I want to merge this change because it fixes product variant 'created' field resolver and adds this field to test case.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
