### PR TITLE
[SALEOR-6404] Use JWS to sign webhooks with secretKey instead of obscure signature

### DIFF
--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -10,9 +10,8 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style
 from django.utils.module_loading import import_string
-from jwt.algorithms import RSAAlgorithm
 from jwt import api_jws
-
+from jwt.algorithms import RSAAlgorithm
 
 logger = logging.getLogger(__name__)
 

--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -34,6 +34,10 @@ class JWTManagerBase:
         return NotImplemented
 
     @classmethod
+    def jws_encode(cls, payload: bytes, is_payload_detached: bool = True) -> str:
+        return NotImplemented
+
+    @classmethod
     def decode(cls, token: str, verify_expiration: bool = True) -> dict:
         return NotImplemented
 
@@ -121,10 +125,10 @@ class JWTManager(JWTManagerBase):
         )
 
     @classmethod
-    def jws_encode(cls, payload: bytes, is_payload_detached: bool = True) -> bytes:
+    def jws_encode(cls, payload: bytes, is_payload_detached: bool = True) -> str:
         return api_jws.encode(
             payload,
-            key=cls.get_private_key(),
+            key=cls.get_private_key(),  # type: ignore
             algorithm="RS256",
             headers={"kid": KID},
             is_payload_detached=is_payload_detached,

--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -11,6 +11,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style
 from django.utils.module_loading import import_string
 from jwt.algorithms import RSAAlgorithm
+from jwt import api_jws
+
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +118,16 @@ class JWTManager(JWTManagerBase):
     def encode(cls, payload):
         return jwt.encode(
             payload, cls.get_private_key(), algorithm="RS256", headers={"kid": KID}
+        )
+
+    @classmethod
+    def jws_encode(cls, payload: bytes, is_payload_detached: bool = True) -> bytes:
+        return api_jws.encode(
+            payload,
+            key=cls.get_private_key(),
+            algorithm="RS256",
+            headers={"kid": KID},
+            is_payload_detached=is_payload_detached,
         )
 
     @classmethod

--- a/saleor/plugins/webhook/__init__.py
+++ b/saleor/plugins/webhook/__init__.py
@@ -1,15 +1,11 @@
 import hashlib
 import hmac
 
-from jwt.algorithms import get_default_algorithms
-
 from ...core.jwt_manager import get_jwt_manager
 
 
 def signature_for_payload(body: bytes, secret_key):
     if secret_key is None:
-        algorithm = get_default_algorithms()["RS256"]
-        private_key = get_jwt_manager().get_private_key()
-        return algorithm.sign(body, private_key).hex()
+        return get_jwt_manager().jws_encode(body)
     hash = hmac.new(bytes(secret_key, "utf-8"), body, hashlib.sha256)
     return hash.hexdigest()


### PR DESCRIPTION
I want to merge this change because we want to use well recognized JWS standard to ensure authenticity of a payload instead of obscure, ad-hoc created signature.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [X] Documentation needs to be updated => https://github.com/saleor/saleor-docs/pull/452

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
