### PR TITLE
http.user_id tag in opentracing spans

### DIFF
--- a/saleor/graphql/context.py
+++ b/saleor/graphql/context.py
@@ -27,6 +27,7 @@ class RequestWithUser(Protocol):
     _cached_user: UserType
     app: Optional[App]
     user: Union[UserType, SimpleLazyObject]
+    user_id: Optional[int]
 
 
 def get_app(raw_auth_token) -> Optional[App]:
@@ -58,6 +59,8 @@ def set_app_on_context(request):
 def get_user(request: RequestWithUser) -> Optional[UserType]:
     if not hasattr(request, "_cached_user"):
         request._cached_user = cast(UserType, authenticate(request=request))
+        if request._cached_user and not request._cached_user.is_anonymous:
+            request.user_id = cast(int, request._cached_user.id)
     return request._cached_user
 
 

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -339,8 +339,8 @@ class GraphQLView(View):
 
                     if app := getattr(request, "app", None):
                         span.set_tag("app.name", app.name)
-                    if user := getattr(request, "user", None):
-                        span.set_tag("http.user_id", user.id)
+                    if user_id := getattr(request, "user_id", None):
+                        span.set_tag("http.user_id", user_id)
 
                     return set_query_cost_on_result(response, query_cost)
             except Exception as e:

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -339,6 +339,8 @@ class GraphQLView(View):
 
                     if app := getattr(request, "app", None):
                         span.set_tag("app.name", app.name)
+                    if user := getattr(request, "user", None):
+                        span.set_tag("http.user_id", user.id)
 
                     return set_query_cost_on_result(response, query_cost)
             except Exception as e:


### PR DESCRIPTION
I want to merge this change because it adds `http.user_id` tag to opentracing spans.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
