### PR TITLE
Unquote secret access when calling sqs

### DIFF
--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import unquote, urlparse, urlunparse
 
 import boto3
 import requests
@@ -228,7 +228,9 @@ def send_webhook_using_aws_sqs(target_url, message, domain, signature, event_typ
         "sqs",
         region_name=region,
         aws_access_key_id=parts.username,
-        aws_secret_access_key=parts.password,
+        aws_secret_access_key=(
+            unquote(parts.password) if parts.password else parts.password
+        ),
     )
     queue_url = urlunparse(
         ("https", parts.hostname, parts.path, parts.params, parts.query, parts.fragment)

--- a/saleor/plugins/webhook/tests/test_webhook_protocols.py
+++ b/saleor/plugins/webhook/tests/test_webhook_protocols.py
@@ -69,6 +69,13 @@ def test_trigger_webhooks_with_aws_sqs(
     mocked_client.send_message.assert_called_once_with(**expected_call_args)
 
 
+@pytest.mark.parametrize(
+    "secret_key, unquoted_secret",
+    [
+        ("secret_access", "secret_access"),
+        ("secret%2B%2Faccess", "secret+/access"),
+    ],
+)
 def test_trigger_webhooks_with_aws_sqs_and_secret_key(
     webhook,
     order_with_lines,
@@ -76,6 +83,8 @@ def test_trigger_webhooks_with_aws_sqs_and_secret_key(
     permission_manage_users,
     permission_manage_products,
     monkeypatch,
+    secret_key,
+    unquoted_secret,
 ):
     mocked_client = MagicMock(spec=AsyncSQSConnection)
     mocked_client.send_message.return_value = {"example": "response"}
@@ -88,14 +97,13 @@ def test_trigger_webhooks_with_aws_sqs_and_secret_key(
 
     webhook.app.permissions.add(permission_manage_orders)
     access_key = "access_key_id"
-    secret_key = "secret_access"
     region = "us-east-1"
 
     webhook.target_url = (
         f"awssqs://{access_key}:{secret_key}@sqs.{region}.amazonaws.com/account_id/"
         f"queue_name"
     )
-    webhook.secret_key = "secret_key"
+    webhook.secret_key = "secret+/access"
     webhook.save()
 
     expected_data = serialize("json", [order_with_lines])
@@ -111,7 +119,7 @@ def test_trigger_webhooks_with_aws_sqs_and_secret_key(
         "sqs",
         region_name=region,
         aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
+        aws_secret_access_key=unquoted_secret,
     )
     mocked_client.send_message.assert_called_once_with(
         QueueUrl="https://sqs.us-east-1.amazonaws.com/account_id/queue_name",


### PR DESCRIPTION
ℹ️ This is a 3.4 port of #10076

I want to merge this change because it unqotes secret access when calling SQS.
So in case when secret access contains special characters it should get decoded (ex. secret%2B%2Faccess -> secret+/access) when being passed to the SQS client.

✔️  tested with SQS connected

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
