### PR TITLE
Possibility to skip validation for checkout addresses billing part

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -5,10 +5,16 @@ from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.utils import change_billing_address_in_checkout
 from ....core.tracing import traced_atomic_transaction
 from ...account.types import AddressInput
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import (
+    ADDED_IN_34,
+    ADDED_IN_35,
+    DEPRECATED_IN_3X_INPUT,
+    PREVIEW_FEATURE,
+)
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ..types import Checkout
+from .checkout_create import CheckoutAddressValidationRules
 from .checkout_shipping_address_update import CheckoutShippingAddressUpdate
 from .utils import get_checkout
 
@@ -34,6 +40,14 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
         billing_address = AddressInput(
             required=True, description="The billing address of the checkout."
         )
+        validation_rules = CheckoutAddressValidationRules(
+            required=False,
+            description=(
+                "The rules for changing validation for received billing address data."
+                + ADDED_IN_35
+                + PREVIEW_FEATURE
+            ),
+        )
 
     class Meta:
         description = "Update billing address in the existing checkout."
@@ -42,7 +56,14 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
 
     @classmethod
     def perform_mutation(
-        cls, _root, info, billing_address, checkout_id=None, token=None, id=None
+        cls,
+        _root,
+        info,
+        billing_address,
+        validation_rules=None,
+        checkout_id=None,
+        token=None,
+        id=None,
     ):
         checkout = get_checkout(
             cls,
@@ -53,11 +74,14 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
             error_class=CheckoutErrorCode,
         )
 
+        address_validation_rules = validation_rules or {}
         billing_address = cls.validate_address(
             billing_address,
             address_type=AddressType.BILLING,
             instance=checkout.billing_address,
             info=info,
+            format_check=address_validation_rules.get("check_fields_format", True),
+            required_check=address_validation_rules.get("check_required_fields", True),
         )
         with traced_atomic_transaction():
             billing_address.save()

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -82,6 +82,9 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
             info=info,
             format_check=address_validation_rules.get("check_fields_format", True),
             required_check=address_validation_rules.get("check_required_fields", True),
+            enable_normalization=address_validation_rules.get(
+                "enable_fields_normalization", True
+            ),
         )
         with traced_atomic_transaction():
             billing_address.save()

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 import graphene
 from django.contrib.auth.models import AnonymousUser
@@ -8,7 +8,11 @@ from ....checkout import AddressType
 from ....checkout.checkout_cleaner import validate_checkout_email
 from ....checkout.complete_checkout import complete_checkout
 from ....checkout.error_codes import CheckoutErrorCode
-from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from ....checkout.fetch import (
+    CheckoutLineInfo,
+    fetch_checkout_info,
+    fetch_checkout_lines,
+)
 from ....checkout.utils import is_shipping_required
 from ....core import analytics
 from ....core.permissions import AccountPermissions
@@ -96,7 +100,12 @@ class CheckoutComplete(BaseMutation, I18nMixin):
         error_type_field = "checkout_errors"
 
     @classmethod
-    def validate_checkout_addresses(cls, shipping_address: "Address"):
+    def validate_checkout_addresses(
+        cls,
+        lines: Iterable[CheckoutLineInfo],
+        shipping_address: "Address",
+        billing_address: "Address",
+    ):
         """Validate checkout addresses.
 
         Mutations for updating addresses have option to turn off a validation. To keep
@@ -104,9 +113,35 @@ class CheckoutComplete(BaseMutation, I18nMixin):
         address and we can finalize a checkout. Raises ValidationError when any address
         is not correct.
         """
+        if is_shipping_required(lines):
+            if not shipping_address:
+                raise ValidationError(
+                    {
+                        "shipping_address": ValidationError(
+                            "Shipping address is not set",
+                            code=CheckoutErrorCode.SHIPPING_ADDRESS_NOT_SET.value,
+                        )
+                    }
+                )
+            cls.validate_address(
+                shipping_address.as_data(),
+                address_type=AddressType.SHIPPING,
+                format_check=True,
+                required_check=True,
+            )
+
+        if not billing_address:
+            raise ValidationError(
+                {
+                    "billing_address": ValidationError(
+                        "Billing address is not set",
+                        code=CheckoutErrorCode.BILLING_ADDRESS_NOT_SET.value,
+                    )
+                }
+            )
         cls.validate_address(
-            shipping_address.as_data(),
-            address_type=AddressType.SHIPPING,
+            billing_address.as_data(),
+            address_type=AddressType.BILLING,
             format_check=True,
             required_check=True,
         )
@@ -188,8 +223,10 @@ class CheckoutComplete(BaseMutation, I18nMixin):
             checkout_info = fetch_checkout_info(
                 checkout, lines, info.context.discounts, manager
             )
-            if is_shipping_required(lines) and checkout_info.shipping_address:
-                cls.validate_checkout_addresses(checkout_info.shipping_address)
+
+            cls.validate_checkout_addresses(
+                lines, checkout_info.shipping_address, checkout_info.billing_address
+            )
 
             requestor = get_user_or_app_from_context(info.context)
             if requestor.has_perm(AccountPermissions.IMPERSONATE_USER):

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -62,6 +62,12 @@ class CheckoutValidationRules(graphene.InputObjectType):
             " data."
         )
     )
+    billing_address = CheckoutAddressValidationRules(
+        description=(
+            "The validation rules that can be applied to provided billing address"
+            " data."
+        )
+    )
 
 
 class CheckoutLineInput(graphene.InputObjectType):
@@ -189,9 +195,17 @@ class CheckoutCreate(ModelMutation, I18nMixin):
 
     @classmethod
     def retrieve_billing_address(cls, user, data: dict) -> Optional["Address"]:
+        address_validation_rules = data.get("validation_rules", {}).get(
+            "billing_address", {}
+        )
         if data.get("billing_address") is not None:
             return cls.validate_address(
-                data["billing_address"], address_type=AddressType.BILLING
+                data["billing_address"],
+                address_type=AddressType.BILLING,
+                format_check=address_validation_rules.get("check_fields_format", True),
+                required_check=address_validation_rules.get(
+                    "check_required_fields", True
+                ),
             )
         return None
 

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -220,6 +220,9 @@ class CheckoutCreate(ModelMutation, I18nMixin):
                 required_check=address_validation_rules.get(
                     "check_required_fields", True
                 ),
+                enable_normalization=address_validation_rules.get(
+                    "enable_fields_normalization", True
+                ),
             )
         return None
 

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -64,7 +64,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         validation_rules = CheckoutAddressValidationRules(
             required=False,
             description=(
-                "The rules for changing validation for recieved shipping address data."
+                "The rules for changing validation for received shipping address data."
                 + ADDED_IN_35
                 + PREVIEW_FEATURE
             ),

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -1,13 +1,20 @@
+import pytest
+
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import get_graphql_content
 
 MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE = """
     mutation checkoutBillingAddressUpdate(
-            $checkoutId: ID, $id: ID, $billingAddress: AddressInput!) {
+            $checkoutId: ID,
+            $id: ID,
+            $billingAddress: AddressInput!
+            $validationRules: CheckoutAddressValidationRules
+        ) {
         checkoutBillingAddressUpdate(
                 id: $id,
                 checkoutId: $checkoutId,
                 billingAddress: $billingAddress
+                validationRules: $validationRules
         ){
             checkout {
                 token,
@@ -179,3 +186,291 @@ def test_checkout_billing_address_update(
     assert checkout.billing_address.country == billing_address["country"]
     assert checkout.billing_address.city == billing_address["city"].upper()
     assert checkout.last_change != previous_last_change
+
+
+@pytest.mark.parametrize(
+    "address_data",
+    [
+        {"country": "PL"},  # missing postalCode, streetAddress
+        {"country": "PL", "postalCode": "53-601"},  # missing streetAddress
+        {"country": "US"},
+        {
+            "country": "US",
+            "city": "New York",
+        },  # missing postalCode, streetAddress, countryArea
+    ],
+)
+def test_checkout_billing_address_update_with_skip_required_doesnt_raise_error(
+    address_data, checkout_with_items, user_api_client
+):
+    # given
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": address_data,
+        "validationRules": {"checkRequiredFields": False},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert not data["errors"]
+    assert checkout_with_items.billing_address
+
+
+def test_checkout_billing_address_update_with_skip_required_raises_validation_error(
+    checkout_with_items, user_api_client
+):
+    # given
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": {"country": "US", "postalCode": "XX-123"},
+        "validationRules": {"checkRequiredFields": False},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["code"] == "INVALID"
+    assert data["errors"][0]["field"] == "postalCode"
+    assert not checkout_with_items.billing_address
+
+
+def test_checkout_billing_address_update_with_skip_required_saves_address(
+    checkout_with_items, user_api_client
+):
+    # given
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": {"country": "PL", "postalCode": "53-601"},
+        "validationRules": {"checkRequiredFields": False},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert not data["errors"]
+
+    assert checkout_with_items.billing_address
+    assert checkout_with_items.billing_address.country.code == "PL"
+    assert checkout_with_items.billing_address.postal_code == "53-601"
+
+
+@pytest.mark.parametrize(
+    "address_data",
+    [
+        {
+            "country": "PL",
+            "city": "Wroclaw",
+            "postalCode": "XYZ",
+            "streetAddress1": "Teczowa 7",
+        },  # incorrect postalCode
+        {
+            "country": "US",
+            "city": "New York",
+            "countryArea": "ABC",
+            "streetAddress1": "New street",
+            "postalCode": "53-601",
+        },  # incorrect postalCode
+    ],
+)
+def test_checkout_billing_address_update_with_skip_value_check_doesnt_raise_error(
+    address_data, checkout_with_items, user_api_client
+):
+    # given
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": address_data,
+        "validationRules": {"checkFieldsFormat": False},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert not data["errors"]
+    assert checkout_with_items.billing_address
+
+
+@pytest.mark.parametrize(
+    "address_data",
+    [
+        {
+            "country": "PL",
+            "city": "Wroclaw",
+            "postalCode": "XYZ",
+        },  # incorrect postalCode
+        {
+            "country": "US",
+            "city": "New York",
+            "countryArea": "XYZ",
+            "postalCode": "XYZ",
+        },  # incorrect postalCode
+    ],
+)
+def test_checkout_billing_address_update_with_skip_value_raises_required_fields_error(
+    address_data, checkout_with_items, user_api_client
+):
+    # given
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": address_data,
+        "validationRules": {"checkFieldsFormat": False},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["code"] == "REQUIRED"
+    assert data["errors"][0]["field"] == "streetAddress1"
+    assert not checkout_with_items.billing_address
+
+
+def test_checkout_billing_address_update_with_skip_value_check_saves_address(
+    checkout_with_items, user_api_client
+):
+    # given
+    city = "Wroclaw"
+    street_address = "Teczowa 7"
+    postal_code = "XX-601"  # incorrect format for PL
+    country_code = "PL"
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": {
+            "country": country_code,
+            "city": city,
+            "streetAddress1": street_address,
+            "postalCode": postal_code,
+        },
+        "validationRules": {"checkFieldsFormat": False},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert not data["errors"]
+
+    address = checkout_with_items.billing_address
+    assert address
+
+    assert address.street_address_1 == street_address
+    assert address.city == city
+    assert address.country.code == country_code
+    assert address.postal_code == postal_code
+
+
+@pytest.mark.parametrize(
+    "address_data",
+    [
+        {
+            "country": "PL",
+            "postalCode": "XYZ",
+        },  # incorrect postalCode, missing city, streetAddress
+        {
+            "country": "US",
+            "countryArea": "DC",
+            "postalCode": "XYZ",
+        },  # incorrect postalCode, missing city
+    ],
+)
+def test_checkout_billing_address_update_with_skip_value_and_skip_required_fields(
+    address_data, checkout_with_items, user_api_client
+):
+    # given
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": address_data,
+        "validationRules": {"checkFieldsFormat": False, "checkRequiredFields": False},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert not data["errors"]
+    assert checkout_with_items.billing_address
+
+
+def test_checkout_address_update_with_skip_value_and_skip_required_saves_address(
+    checkout_with_items, user_api_client
+):
+    # given
+    city = "Wroclaw"
+    postal_code = "XX-601"  # incorrect format for PL
+    country_code = "PL"
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": {
+            "country": country_code,
+            "city": city,
+            "postalCode": postal_code,
+        },
+        "validationRules": {"checkFieldsFormat": False, "checkRequiredFields": False},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    address = checkout_with_items.billing_address
+    assert not data["errors"]
+
+    assert address
+    assert address.country.code == country_code
+    assert address.postal_code == postal_code
+    assert address.city == city
+    assert address.street_address_1 == ""

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -2893,3 +2893,65 @@ def test_checkout_complete_with_not_normalized_shipping_address(
     assert shipping_address
     assert shipping_address.city == "WASHINGTON"
     assert shipping_address.country_area == "DC"
+
+
+def test_checkout_complete_with_not_normalized_billing_address(
+    site_settings,
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    payment_dummy,
+    address,
+    shipping_method,
+):
+    # given
+    assert not gift_card.last_used_on
+
+    checkout = checkout_with_gift_card
+    billing_address = Address.objects.create(
+        **{
+            "country": "US",
+            "city": "Washington",
+            "country_area": "District of Columbia",
+            "street_address_1": "1600 Pennsylvania Avenue NW",
+            "postal_code": "20500",
+        }
+    )
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = billing_address
+    checkout.store_value_in_metadata(items={"accepted": "true"})
+    checkout.store_value_in_private_metadata(items={"accepted": "false"})
+    checkout.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+    payment = payment_dummy
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.checkout = checkout
+    payment.save()
+    assert not payment.transactions.exists()
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+
+    order = Order.objects.first()
+    billing_address = order.billing_address
+    assert billing_address
+    assert billing_address.city == "WASHINGTON"
+    assert billing_address.country_area == "DC"

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -1587,19 +1587,55 @@ def test_create_checkout_with_unpublished_product(
 
 
 @pytest.mark.parametrize(
-    "address_data",
+    "address_data, address_input_name, address_db_field_name",
     [
-        {"country": "PL"},  # missing postalCode, streetAddress
-        {"country": "PL", "postalCode": "53-601"},  # missing streetAddress
-        {"country": "US"},
-        {
-            "country": "US",
-            "city": "New York",
-        },  # missing postalCode, streetAddress, countryArea
+        (
+            {"country": "PL"},  # missing postalCode, streetAddress
+            "shippingAddress",
+            "shipping_address",
+        ),
+        (
+            {"country": "PL", "postalCode": "53-601"},  # missing streetAddress
+            "shippingAddress",
+            "shipping_address",
+        ),
+        ({"country": "US"}, "shippingAddress", "shipping_address"),
+        (
+            {
+                "country": "US",
+                "city": "New York",
+            },  # missing postalCode, streetAddress, countryArea
+            "shippingAddress",
+            "shipping_address",
+        ),
+        (
+            {"country": "PL"},  # missing postalCode, streetAddress
+            "billingAddress",
+            "billing_address",
+        ),
+        (
+            {"country": "PL", "postalCode": "53-601"},  # missing streetAddress
+            "billingAddress",
+            "billing_address",
+        ),
+        ({"country": "US"}, "shippingAddress", "shipping_address"),
+        (
+            {
+                "country": "US",
+                "city": "New York",
+            },  # missing postalCode, streetAddress, countryArea
+            "billingAddress",
+            "billing_address",
+        ),
     ],
 )
 def test_checkout_create_with_skip_required_doesnt_raise_error(
-    address_data, api_client, stock, channel_USD
+    address_data,
+    address_input_name,
+    address_db_field_name,
+    api_client,
+    stock,
+    channel_USD,
 ):
     # given
     variant = stock.product_variant
@@ -1609,8 +1645,8 @@ def test_checkout_create_with_skip_required_doesnt_raise_error(
         "checkoutInput": {
             "lines": [{"quantity": 1, "variantId": variant_id}],
             "email": "test@example.com",
-            "shippingAddress": address_data,
-            "validationRules": {"shippingAddress": {"checkRequiredFields": False}},
+            address_input_name: address_data,
+            "validationRules": {address_input_name: {"checkRequiredFields": False}},
             "channel": channel_USD.slug,
         }
     }
@@ -1624,11 +1660,15 @@ def test_checkout_create_with_skip_required_doesnt_raise_error(
 
     assert not data["errors"]
     assert created_checkout
-    assert created_checkout.shipping_address
+    assert getattr(created_checkout, address_db_field_name)
 
 
+@pytest.mark.parametrize(
+    "address_input_name",
+    ["shippingAddress", "billingAddress"],
+)
 def test_checkout_create_with_skip_required_raises_validation_error(
-    api_client, stock, channel_USD
+    address_input_name, api_client, stock, channel_USD
 ):
     # given
     variant = stock.product_variant
@@ -1638,8 +1678,8 @@ def test_checkout_create_with_skip_required_raises_validation_error(
         "checkoutInput": {
             "lines": [{"quantity": 1, "variantId": variant_id}],
             "email": "test@example.com",
-            "shippingAddress": {"country": "US", "postalCode": "XX-123"},
-            "validationRules": {"shippingAddress": {"checkRequiredFields": False}},
+            address_input_name: {"country": "US", "postalCode": "XX-123"},
+            "validationRules": {address_input_name: {"checkRequiredFields": False}},
             "channel": channel_USD.slug,
         }
     }
@@ -1656,8 +1696,12 @@ def test_checkout_create_with_skip_required_raises_validation_error(
     assert created_checkout is None
 
 
+@pytest.mark.parametrize(
+    "address_input_name, address_db_field_name",
+    [("shippingAddress", "shipping_address"), ("billingAddress", "billing_address")],
+)
 def test_checkout_create_with_skip_required_saves_address(
-    api_client, stock, channel_USD
+    address_input_name, address_db_field_name, api_client, stock, channel_USD
 ):
     # given
     variant = stock.product_variant
@@ -1667,8 +1711,8 @@ def test_checkout_create_with_skip_required_saves_address(
         "checkoutInput": {
             "lines": [{"quantity": 1, "variantId": variant_id}],
             "email": "test@example.com",
-            "shippingAddress": {"country": "PL", "postalCode": "53-601"},
-            "validationRules": {"shippingAddress": {"checkRequiredFields": False}},
+            address_input_name: {"country": "PL", "postalCode": "53-601"},
+            "validationRules": {address_input_name: {"checkRequiredFields": False}},
             "channel": channel_USD.slug,
         }
     }
@@ -1682,31 +1726,65 @@ def test_checkout_create_with_skip_required_saves_address(
 
     assert not data["errors"]
     assert created_checkout is not None
-    assert created_checkout.shipping_address
-    assert created_checkout.shipping_address.country.code == "PL"
-    assert created_checkout.shipping_address.postal_code == "53-601"
+    assert getattr(created_checkout, address_db_field_name)
+    assert getattr(created_checkout, address_db_field_name).country.code == "PL"
+    assert getattr(created_checkout, address_db_field_name).postal_code == "53-601"
 
 
 @pytest.mark.parametrize(
-    "address_data",
+    "address_data, address_input_name, address_db_field_name",
     [
-        {
-            "country": "PL",
-            "city": "Wroclaw",
-            "postalCode": "XYZ",
-            "streetAddress1": "Teczowa 7",
-        },  # incorrect postalCode
-        {
-            "country": "US",
-            "city": "New York",
-            "countryArea": "ABC",
-            "streetAddress1": "New street",
-            "postalCode": "53-601",
-        },  # incorrect postalCode
+        (
+            {
+                "country": "PL",
+                "city": "Wroclaw",
+                "postalCode": "XYZ",
+                "streetAddress1": "Teczowa 7",
+            },  # incorrect postalCode
+            "shippingAddress",
+            "shipping_address",
+        ),
+        (
+            {
+                "country": "US",
+                "city": "New York",
+                "countryArea": "ABC",
+                "streetAddress1": "New street",
+                "postalCode": "53-601",
+            },  # incorrect postalCode
+            "shippingAddress",
+            "shipping_address",
+        ),
+        (
+            {
+                "country": "PL",
+                "city": "Wroclaw",
+                "postalCode": "XYZ",
+                "streetAddress1": "Teczowa 7",
+            },  # incorrect postalCode
+            "billingAddress",
+            "billing_address",
+        ),
+        (
+            {
+                "country": "US",
+                "city": "New York",
+                "countryArea": "ABC",
+                "streetAddress1": "New street",
+                "postalCode": "53-601",
+            },  # incorrect postalCode
+            "billingAddress",
+            "billing_address",
+        ),
     ],
 )
 def test_checkout_create_with_skip_value_check_doesnt_raise_error(
-    address_data, api_client, stock, channel_USD
+    address_data,
+    address_input_name,
+    address_db_field_name,
+    api_client,
+    stock,
+    channel_USD,
 ):
     # given
     variant = stock.product_variant
@@ -1716,8 +1794,8 @@ def test_checkout_create_with_skip_value_check_doesnt_raise_error(
         "checkoutInput": {
             "lines": [{"quantity": 1, "variantId": variant_id}],
             "email": "test@example.com",
-            "shippingAddress": address_data,
-            "validationRules": {"shippingAddress": {"checkFieldsFormat": False}},
+            address_input_name: address_data,
+            "validationRules": {address_input_name: {"checkFieldsFormat": False}},
             "channel": channel_USD.slug,
         }
     }
@@ -1731,27 +1809,50 @@ def test_checkout_create_with_skip_value_check_doesnt_raise_error(
 
     assert not data["errors"]
     assert created_checkout
-    assert created_checkout.shipping_address
+    assert getattr(created_checkout, address_db_field_name)
 
 
 @pytest.mark.parametrize(
-    "address_data",
+    "address_data, address_input_name",
     [
-        {
-            "country": "PL",
-            "city": "Wroclaw",
-            "postalCode": "XYZ",
-        },  # incorrect postalCode
-        {
-            "country": "US",
-            "city": "New York",
-            "countryArea": "XYZ",
-            "postalCode": "XYZ",
-        },  # incorrect postalCode
+        (
+            {
+                "country": "PL",
+                "city": "Wroclaw",
+                "postalCode": "XYZ",
+            },  # incorrect postalCode
+            "shippingAddress",
+        ),
+        (
+            {
+                "country": "US",
+                "city": "New York",
+                "countryArea": "XYZ",
+                "postalCode": "XYZ",
+            },  # incorrect postalCode
+            "shippingAddress",
+        ),
+        (
+            {
+                "country": "PL",
+                "city": "Wroclaw",
+                "postalCode": "XYZ",
+            },  # incorrect postalCode
+            "billingAddress",
+        ),
+        (
+            {
+                "country": "US",
+                "city": "New York",
+                "countryArea": "XYZ",
+                "postalCode": "XYZ",
+            },  # incorrect postalCode
+            "billingAddress",
+        ),
     ],
 )
 def test_checkout_create_with_skip_value_raises_required_fields_error(
-    address_data, api_client, stock, channel_USD
+    address_data, address_input_name, api_client, stock, channel_USD
 ):
     # given
     variant = stock.product_variant
@@ -1761,8 +1862,8 @@ def test_checkout_create_with_skip_value_raises_required_fields_error(
         "checkoutInput": {
             "lines": [{"quantity": 1, "variantId": variant_id}],
             "email": "test@example.com",
-            "shippingAddress": address_data,
-            "validationRules": {"shippingAddress": {"checkFieldsFormat": False}},
+            address_input_name: address_data,
+            "validationRules": {address_input_name: {"checkFieldsFormat": False}},
             "channel": channel_USD.slug,
         }
     }
@@ -1779,8 +1880,12 @@ def test_checkout_create_with_skip_value_raises_required_fields_error(
     assert created_checkout is None
 
 
+@pytest.mark.parametrize(
+    "address_input_name, address_db_field_name",
+    [("shippingAddress", "shipping_address"), ("billingAddress", "billing_address")],
+)
 def test_checkout_create_with_skip_value_check_saves_address(
-    api_client, stock, channel_USD
+    address_input_name, address_db_field_name, api_client, stock, channel_USD
 ):
     # given
     city = "Wroclaw"
@@ -1795,13 +1900,13 @@ def test_checkout_create_with_skip_value_check_saves_address(
         "checkoutInput": {
             "lines": [{"quantity": 1, "variantId": variant_id}],
             "email": "test@example.com",
-            "shippingAddress": {
+            address_input_name: {
                 "country": country_code,
                 "city": city,
                 "streetAddress1": street_address,
                 "postalCode": postal_code,
             },
-            "validationRules": {"shippingAddress": {"checkFieldsFormat": False}},
+            "validationRules": {address_input_name: {"checkFieldsFormat": False}},
             "channel": channel_USD.slug,
         }
     }
@@ -1815,29 +1920,65 @@ def test_checkout_create_with_skip_value_check_saves_address(
     assert not data["errors"]
 
     assert created_checkout
-    assert created_checkout.shipping_address
-    assert created_checkout.shipping_address.street_address_1 == street_address
-    assert created_checkout.shipping_address.city == city
-    assert created_checkout.shipping_address.postal_code == postal_code
-    assert created_checkout.shipping_address.country.code == country_code
+    assert getattr(created_checkout, address_db_field_name)
+    assert (
+        getattr(created_checkout, address_db_field_name).street_address_1
+        == street_address
+    )
+    assert getattr(created_checkout, address_db_field_name).city == city
+    assert getattr(created_checkout, address_db_field_name).postal_code == postal_code
+    assert getattr(created_checkout, address_db_field_name).country.code == country_code
+
+
+[("shippingAddress", "shipping_address"), ("billingAddress", "billing_address")],
 
 
 @pytest.mark.parametrize(
-    "address_data",
+    "address_data, address_input_name, address_db_field_name",
     [
-        {
-            "country": "PL",
-            "postalCode": "XYZ",
-        },  # incorrect postalCode, missing city, streetAddress
-        {
-            "country": "US",
-            "countryArea": "DC",
-            "postalCode": "XYZ",
-        },  # incorrect postalCode, missing city
+        (
+            {
+                "country": "PL",
+                "postalCode": "XYZ",
+            },  # incorrect postalCode, missing city, streetAddress
+            "shippingAddress",
+            "shipping_address",
+        ),
+        (
+            {
+                "country": "US",
+                "countryArea": "DC",
+                "postalCode": "XYZ",
+            },  # incorrect postalCode, missing city
+            "shippingAddress",
+            "shipping_address",
+        ),
+        (
+            {
+                "country": "PL",
+                "postalCode": "XYZ",
+            },  # incorrect postalCode, missing city, streetAddress
+            "billingAddress",
+            "billing_address",
+        ),
+        (
+            {
+                "country": "US",
+                "countryArea": "DC",
+                "postalCode": "XYZ",
+            },  # incorrect postalCode, missing city
+            "billingAddress",
+            "billing_address",
+        ),
     ],
 )
 def test_checkout_create_with_skip_value_and_skip_required_fields(
-    address_data, api_client, stock, channel_USD
+    address_data,
+    address_input_name,
+    address_db_field_name,
+    api_client,
+    stock,
+    channel_USD,
 ):
     # given
     variant = stock.product_variant
@@ -1847,9 +1988,9 @@ def test_checkout_create_with_skip_value_and_skip_required_fields(
         "checkoutInput": {
             "lines": [{"quantity": 1, "variantId": variant_id}],
             "email": "test@example.com",
-            "shippingAddress": address_data,
+            address_input_name: address_data,
             "validationRules": {
-                "shippingAddress": {
+                address_input_name: {
                     "checkFieldsFormat": False,
                     "checkRequiredFields": False,
                 }
@@ -1865,11 +2006,15 @@ def test_checkout_create_with_skip_value_and_skip_required_fields(
     created_checkout = Checkout.objects.first()
     data = get_graphql_content(response)["data"]["checkoutCreate"]
     assert not data["errors"]
-    assert created_checkout.shipping_address
+    assert getattr(created_checkout, address_db_field_name)
 
 
+@pytest.mark.parametrize(
+    "address_input_name, address_db_field_name",
+    [("shippingAddress", "shipping_address"), ("billingAddress", "billing_address")],
+)
 def test_checkout_create_with_skip_value_and_skip_required_saves_address(
-    api_client, stock, channel_USD
+    address_input_name, address_db_field_name, api_client, stock, channel_USD
 ):
     # given
     city = "Wroclaw"
@@ -1883,13 +2028,13 @@ def test_checkout_create_with_skip_value_and_skip_required_saves_address(
         "checkoutInput": {
             "lines": [{"quantity": 1, "variantId": variant_id}],
             "email": "test@example.com",
-            "shippingAddress": {
+            address_input_name: {
                 "country": country_code,
                 "city": city,
                 "postalCode": postal_code,
             },
             "validationRules": {
-                "shippingAddress": {
+                address_input_name: {
                     "checkFieldsFormat": False,
                     "checkRequiredFields": False,
                 }
@@ -1907,11 +2052,11 @@ def test_checkout_create_with_skip_value_and_skip_required_saves_address(
     assert not data["errors"]
 
     assert created_checkout
-    assert created_checkout.shipping_address
-    assert created_checkout.shipping_address.country.code == country_code
-    assert created_checkout.shipping_address.postal_code == postal_code
-    assert created_checkout.shipping_address.city == city
-    assert created_checkout.shipping_address.street_address_1 == ""
+    assert getattr(created_checkout, address_db_field_name)
+    assert getattr(created_checkout, address_db_field_name).country.code == country_code
+    assert getattr(created_checkout, address_db_field_name).postal_code == postal_code
+    assert getattr(created_checkout, address_db_field_name).city == city
+    assert getattr(created_checkout, address_db_field_name).street_address_1 == ""
 
 
 @pytest.mark.parametrize("with_shipping_address", (True, False))

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12809,6 +12809,15 @@ type Mutation {
     DEPRECATED: this field will be removed in Saleor 4.0. Use `id` instead.
     """
     token: UUID
+
+    """
+    The rules for changing validation for received billing address data.
+    
+    Added in Saleor 3.5.
+    
+    Note: this API is currently in Feature Preview and can be subject to changes at later point.
+    """
+    validationRules: CheckoutAddressValidationRules
   ): CheckoutBillingAddressUpdate
 
   """
@@ -19063,6 +19072,18 @@ type CheckoutBillingAddressUpdate {
   errors: [CheckoutError!]!
 }
 
+input CheckoutAddressValidationRules {
+  """
+  Determines if an error should be raised when the provided address doesn't have all required fields. Providing `country` code is always required.
+  """
+  checkRequiredFields: Boolean = true
+
+  """
+  Determines if an error should be raised when the provided address doesn'tmatch to expected format.
+  """
+  checkFieldsFormat: Boolean = true
+}
+
 """
 Completes the checkout. As a result a new order is created and a payment charge is made. This action requires a successful payment before it can be performed. In case additional confirmation step as 3D secure is required confirmationNeeded flag will be set to True and no order created until payment is confirmed with second call of this mutation.
 """
@@ -19147,18 +19168,11 @@ input CheckoutValidationRules {
   The validation rules that can be applied to provided shipping address data.
   """
   shippingAddress: CheckoutAddressValidationRules
-}
-
-input CheckoutAddressValidationRules {
-  """
-  Determines if an error should be raised when the provided address doesn't have all required fields. Providing `country` code is always required.
-  """
-  checkRequiredFields: Boolean = true
 
   """
-  Determines if an error should be raised when the provided address doesn'tmatch to expected format.
+  The validation rules that can be applied to provided billing address data.
   """
-  checkFieldsFormat: Boolean = true
+  billingAddress: CheckoutAddressValidationRules
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13137,7 +13137,7 @@ type Mutation {
     token: UUID
 
     """
-    The rules for changing validation for recieved shipping address data.
+    The rules for changing validation for received shipping address data.
     
     Added in Saleor 3.5.
     


### PR DESCRIPTION
checkoutBillingAddressUpdate - receives an input `validationRules`. The `validationRules` will allow to disable requiring fields OR/AND skip validation
```
type CheckoutAddressValidationRules {
        checkRequiredFields: Boolean = true
        checkFieldsFormat: Boolean = true
        enableFieldsNormalization: Boolean = true
}

checkoutBillingAddressUpdate(
  <...>
  billingAddress: AddressInput!
  validationRules: CheckoutAddressValidationRules
): CheckoutShippingAddres
```

CheckoutCreate receives validationRules
```
input CheckoutCreateInput {
  <...>
  validationRules: {
    <...>
    billingAddress: CheckoutAddressValidationRules
  }
}
```
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
