### PR TITLE
Allow apps to query data protected by MANAGE_STAFF permission

### DIFF
--- a/saleor/core/permissions/__init__.py
+++ b/saleor/core/permissions/__init__.py
@@ -90,18 +90,12 @@ def one_of_permissions_or_auth_filter_required(context, permissions):
     # TODO: move this function from graphql to core
     from saleor.graphql.utils import get_user_or_app_from_context
 
-    is_app = bool(getattr(context, "app", None))
     requestor = get_user_or_app_from_context(context)
 
     if permissions:
         perm_checks_results = []
         for permission in permissions:
-            if is_app and permission == AccountPermissions.MANAGE_STAFF:
-                # `MANAGE_STAFF` permission for apps is not supported, as apps using it
-                # could create a staff user with full access.
-                perm_checks_results.append(False)
-            else:
-                perm_checks_results.append(requestor.has_perm(permission))
+            perm_checks_results.append(requestor.has_perm(permission))
         granted_by_permissions = any(perm_checks_results)
 
     if authorization_filters:

--- a/saleor/graphql/account/bulk_mutations.py
+++ b/saleor/graphql/account/bulk_mutations.py
@@ -48,7 +48,9 @@ class CustomerBulkDelete(CustomerDeleteMixin, UserBulkDelete):
 
 class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
     class Meta:
-        description = "Deletes staff users."
+        description = (
+            "Deletes staff users. " "Apps are not allowed to perform this mutation."
+        )
         model = models.User
         object_type = User
         permissions = (AccountPermissions.MANAGE_STAFF,)

--- a/saleor/graphql/account/bulk_mutations.py
+++ b/saleor/graphql/account/bulk_mutations.py
@@ -5,7 +5,6 @@ from django.core.exceptions import ValidationError
 
 from ...account import models
 from ...account.error_codes import AccountErrorCode
-from ...core.exceptions import PermissionDenied
 from ...core.permissions import AccountPermissions
 from ..core.mutations import BaseBulkMutation, ModelBulkDeleteMutation
 from ..core.types import AccountError, NonNullList, StaffError
@@ -49,7 +48,7 @@ class CustomerBulkDelete(CustomerDeleteMixin, UserBulkDelete):
 class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
     class Meta:
         description = (
-            "Deletes staff users. " "Apps are not allowed to perform this mutation."
+            "Deletes staff users. Apps are not allowed to perform this mutation."
         )
         model = models.User
         object_type = User
@@ -73,11 +72,6 @@ class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
     @classmethod
     def clean_instances(cls, info, users):
         errors = defaultdict(list)
-
-        if bool(getattr(info.context, "app", None)):
-            raise PermissionDenied(
-                message="Apps are not allowed to perform this mutation."
-            )
 
         requestor = info.context.user
         cls.check_if_users_can_be_deleted(info, users, "ids", errors)

--- a/saleor/graphql/account/mutations/permission_group.py
+++ b/saleor/graphql/account/mutations/permission_group.py
@@ -105,7 +105,7 @@ class PermissionGroupCreate(ModelMutation):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        if bool(getattr(context, "app", None)):
+        if context.app:
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."
             )
@@ -198,7 +198,7 @@ class PermissionGroupUpdate(PermissionGroupCreate):
 
     class Meta:
         description = (
-            "Update permission group. " "Apps are not allowed to perform this mutation."
+            "Update permission group. Apps are not allowed to perform this mutation."
         )
         model = auth_models.Group
         object_type = Group
@@ -422,7 +422,7 @@ class PermissionGroupDelete(ModelDeleteMutation):
 
     class Meta:
         description = (
-            "Delete permission group. " "Apps are not allowed to perform this mutation."
+            "Delete permission group. Apps are not allowed to perform this mutation."
         )
         model = auth_models.Group
         object_type = Group
@@ -444,7 +444,7 @@ class PermissionGroupDelete(ModelDeleteMutation):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        if bool(getattr(context, "app", None)):
+        if context.app:
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."
             )

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -200,7 +200,7 @@ class StaffCreate(ModelMutation):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        if bool(getattr(context, "app", None)):
+        if context.app:
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."
             )
@@ -209,11 +209,6 @@ class StaffCreate(ModelMutation):
     @classmethod
     def clean_input(cls, info, instance, data):
         cleaned_input = super().clean_input(info, instance, data)
-
-        if bool(getattr(info.context, "app", None)):
-            raise PermissionDenied(
-                message="Apps are not allowed to perform this mutation."
-            )
 
         errors = defaultdict(list)
         if cleaned_input.get("redirect_url"):
@@ -320,11 +315,6 @@ class StaffUpdate(StaffCreate):
 
     @classmethod
     def clean_input(cls, info, instance, data):
-        if bool(getattr(info.context, "app", None)):
-            raise PermissionDenied(
-                message="Apps are not allowed to perform this mutation."
-            )
-
         requestor = info.context.user
         # check if requestor can manage this user
         if not requestor.is_superuser and get_out_of_scope_users(requestor, [instance]):
@@ -452,7 +442,7 @@ class StaffUpdate(StaffCreate):
 class StaffDelete(StaffDeleteMixin, UserDelete):
     class Meta:
         description = (
-            "Deletes a staff user. " "Apps are not allowed to perform this mutation."
+            "Deletes a staff user. Apps are not allowed to perform this mutation."
         )
         model = models.User
         object_type = User

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -187,13 +187,24 @@ class StaffCreate(ModelMutation):
         )
 
     class Meta:
-        description = "Creates a new staff user."
+        description = (
+            "Creates a new staff user. "
+            "Apps are not allowed to perform this mutation."
+        )
         exclude = ["password"]
         model = models.User
         object_type = User
         permissions = (AccountPermissions.MANAGE_STAFF,)
         error_type_class = StaffError
         error_type_field = "staff_errors"
+
+    @classmethod
+    def check_permissions(cls, context, permissions=None):
+        if bool(getattr(context, "app", None)):
+            raise PermissionDenied(
+                message="Apps are not allowed to perform this mutation."
+            )
+        return super().check_permissions(context, permissions)
 
     @classmethod
     def clean_input(cls, info, instance, data):
@@ -296,7 +307,10 @@ class StaffUpdate(StaffCreate):
         )
 
     class Meta:
-        description = "Updates an existing staff user."
+        description = (
+            "Updates an existing staff user. "
+            "Apps are not allowed to perform this mutation."
+        )
         exclude = ["password"]
         model = models.User
         object_type = User
@@ -437,7 +451,9 @@ class StaffUpdate(StaffCreate):
 
 class StaffDelete(StaffDeleteMixin, UserDelete):
     class Meta:
-        description = "Deletes a staff user."
+        description = (
+            "Deletes a staff user. " "Apps are not allowed to perform this mutation."
+        )
         model = models.User
         object_type = User
         permissions = (AccountPermissions.MANAGE_STAFF,)

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -409,36 +409,6 @@ def test_query_customer_user_app(
     assert data["email"] == user.email
 
 
-def test_query_customer_user_app_no_permission(
-    app_api_client,
-    customer_user,
-    address,
-    permission_manage_users,
-    permission_manage_staff,
-    media_root,
-    app,
-):
-    user = customer_user
-    user.default_shipping_address.country = "US"
-    user.default_shipping_address.save()
-    user.addresses.add(address.get_copy())
-
-    avatar_mock = MagicMock(spec=File)
-    avatar_mock.name = "image.jpg"
-    user.avatar = avatar_mock
-    user.save()
-
-    Group.objects.create(name="empty group")
-
-    query = FULL_USER_QUERY
-    ID = graphene.Node.to_global_id("User", customer_user.id)
-    variables = {"id": ID}
-    app.permissions.add(permission_manage_staff)
-    response = app_api_client.post_graphql(query, variables)
-
-    assert_no_permission(response)
-
-
 def test_query_customer_user_with_orders_by_app_no_manage_orders_perm(
     app_api_client,
     customer_user,
@@ -3533,14 +3503,14 @@ def test_user_delete_errors(staff_user, admin_user):
 
 
 def test_staff_delete_errors(staff_user, customer_user, admin_user):
-    info = Mock(context=Mock(user=staff_user))
+    info = Mock(context=Mock(user=staff_user, app=None))
     with pytest.raises(ValidationError) as e:
         StaffDelete.clean_instance(info, customer_user)
     msg = "Cannot delete a non-staff users."
     assert e.value.error_dict["id"][0].message == msg
 
     # should not raise any errors
-    info = Mock(context=Mock(user=admin_user))
+    info = Mock(context=Mock(user=admin_user, app=None))
     StaffDelete.clean_instance(info, staff_user)
 
 
@@ -5498,27 +5468,6 @@ def test_query_staff_members_with_filter_by_ids(
     # then
     users = content["data"]["staffUsers"]["edges"]
     assert len(users) == 1
-
-
-def test_query_staff_members_app_no_permission(
-    query_staff_users_with_filter,
-    app_api_client,
-    permission_manage_staff,
-):
-
-    User.objects.bulk_create(
-        [
-            User(email="second@example.com", is_staff=True, is_active=False),
-            User(email="third@example.com", is_staff=True, is_active=True),
-        ]
-    )
-
-    variables = {"filter": {"status": "DEACTIVATED"}}
-    response = app_api_client.post_graphql(
-        query_staff_users_with_filter, variables, permissions=[permission_manage_staff]
-    )
-
-    assert_no_permission(response)
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/account/tests/test_account_permission_group.py
+++ b/saleor/graphql/account/tests/test_account_permission_group.py
@@ -2200,24 +2200,6 @@ def test_permission_groups_query_with_filter_by_ids(
     assert len(data) == 1
 
 
-def test_permission_groups_app_no_permission(
-    permission_group_manage_users,
-    permission_manage_staff,
-    app_api_client,
-    app,
-):
-    app.permissions.add(permission_manage_staff)
-    query = QUERY_PERMISSION_GROUP_WITH_FILTER
-    Group.objects.bulk_create(
-        [Group(name="Manage product."), Group(name="Remove product.")]
-    )
-    variables = {"filter": {"search": "Manage user groups"}}
-
-    response = app_api_client.post_graphql(query, variables)
-
-    assert_no_permission(response)
-
-
 def test_permission_groups_no_permission_to_perform(
     permission_group_manage_users,
     permission_manage_staff,
@@ -2330,24 +2312,6 @@ def test_permission_group_query(
         == permissions_codes
     )
     assert data["userCanManage"] is True
-
-
-def test_permission_group_query_app_no_permission(
-    permission_group_manage_users,
-    staff_user,
-    permission_manage_staff,
-    permission_manage_users,
-    app_api_client,
-    app,
-):
-    app.permissions.add(permission_manage_staff, permission_manage_users)
-    group = permission_group_manage_users
-    query = QUERY_PERMISSION_GROUP
-    variables = {"id": graphene.Node.to_global_id("Group", group.id)}
-
-    response = app_api_client.post_graphql(query, variables)
-
-    assert_no_permission(response)
 
 
 def test_permission_group_query_user_cannot_manage(

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -83,13 +83,16 @@ class StaffDeleteMixin(UserDeleteMixin):
         abstract = True
 
     @classmethod
-    def clean_instance(cls, info, instance):
-        errors = defaultdict(list)
-
-        if bool(getattr(info.context, "app", None)):
+    def check_permissions(cls, context, permissions=None):
+        if bool(getattr(context, "app", None)):
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."
             )
+        return super().check_permissions(context, permissions)
+
+    @classmethod
+    def clean_instance(cls, info, instance):
+        errors = defaultdict(list)
 
         requestor = info.context.user
 

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -84,7 +84,7 @@ class StaffDeleteMixin(UserDeleteMixin):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        if bool(getattr(context, "app", None)):
+        if context.app:
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."
             )

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -85,7 +85,14 @@ class StaffDeleteMixin(UserDeleteMixin):
     @classmethod
     def clean_instance(cls, info, instance):
         errors = defaultdict(list)
+
+        if bool(getattr(info.context, "app", None)):
+            raise PermissionDenied(
+                message="Apps are not allowed to perform this mutation."
+            )
+
         requestor = info.context.user
+
         cls.check_if_users_can_be_deleted(info, [instance], "id", errors)
         cls.check_if_requestor_can_manage_users(requestor, [instance], "id", errors)
         cls.check_if_removing_left_not_manageable_permissions(

--- a/saleor/graphql/meta/tests/test_meta_queries.py
+++ b/saleor/graphql/meta/tests/test_meta_queries.py
@@ -174,23 +174,6 @@ def test_query_public_meta_for_staff_as_other_staff(
     assert metadata["value"] == PUBLIC_VALUE
 
 
-def test_query_public_meta_for_staff_as_app(
-    app_api_client, permission_manage_staff, admin_user
-):
-    # given
-    admin_user.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
-    admin_user.save(update_fields=["metadata"])
-    variables = {"id": graphene.Node.to_global_id("User", admin_user.pk)}
-
-    # when
-    response = app_api_client.post_graphql(
-        QUERY_USER_PUBLIC_META, variables, [permission_manage_staff]
-    )
-
-    # then
-    assert_no_permission(response)
-
-
 QUERY_CHECKOUT_PUBLIC_META = """
     query checkoutMeta($token: UUID!){
         checkout(token: $token){
@@ -1965,23 +1948,6 @@ def test_query_private_meta_for_staff_as_other_staff(
     metadata = content["data"]["user"]["privateMetadata"][0]
     assert metadata["key"] == PRIVATE_KEY
     assert metadata["value"] == PRIVATE_VALUE
-
-
-def test_query_private_meta_for_staff_as_app(
-    app_api_client, permission_manage_staff, admin_user
-):
-    # given
-    admin_user.store_value_in_private_metadata({PRIVATE_KEY: PRIVATE_VALUE})
-    admin_user.save(update_fields=["private_metadata"])
-    variables = {"id": graphene.Node.to_global_id("User", admin_user.pk)}
-
-    # when
-    response = app_api_client.post_graphql(
-        QUERY_USER_PRIVATE_META, variables, [permission_manage_staff]
-    )
-
-    # then
-    assert_no_permission(response)
 
 
 QUERY_CHECKOUT_PRIVATE_META = """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13889,7 +13889,7 @@ type Mutation {
   ): CustomerBulkDelete
 
   """
-  Creates a new staff user. 
+  Creates a new staff user. Apps are not allowed to perform this mutation. 
   
   Requires one of the following permissions: MANAGE_STAFF.
   """
@@ -13899,7 +13899,7 @@ type Mutation {
   ): StaffCreate
 
   """
-  Updates an existing staff user. 
+  Updates an existing staff user. Apps are not allowed to perform this mutation. 
   
   Requires one of the following permissions: MANAGE_STAFF.
   """
@@ -13912,7 +13912,7 @@ type Mutation {
   ): StaffUpdate
 
   """
-  Deletes a staff user. 
+  Deletes a staff user. Apps are not allowed to perform this mutation. 
   
   Requires one of the following permissions: MANAGE_STAFF.
   """
@@ -13922,7 +13922,7 @@ type Mutation {
   ): StaffDelete
 
   """
-  Deletes staff users. 
+  Deletes staff users. Apps are not allowed to perform this mutation. 
   
   Requires one of the following permissions: MANAGE_STAFF.
   """
@@ -13962,7 +13962,7 @@ type Mutation {
   ): UserBulkSetActive
 
   """
-  Create new permission group. 
+  Create new permission group. Apps are not allowed to perform this mutation. 
   
   Requires one of the following permissions: MANAGE_STAFF.
   """
@@ -13972,7 +13972,7 @@ type Mutation {
   ): PermissionGroupCreate
 
   """
-  Update permission group. 
+  Update permission group. Apps are not allowed to perform this mutation. 
   
   Requires one of the following permissions: MANAGE_STAFF.
   """
@@ -13985,7 +13985,7 @@ type Mutation {
   ): PermissionGroupUpdate
 
   """
-  Delete permission group. 
+  Delete permission group. Apps are not allowed to perform this mutation. 
   
   Requires one of the following permissions: MANAGE_STAFF.
   """
@@ -20577,7 +20577,7 @@ type CustomerBulkDelete {
 }
 
 """
-Creates a new staff user. 
+Creates a new staff user. Apps are not allowed to perform this mutation. 
 
 Requires one of the following permissions: MANAGE_STAFF.
 """
@@ -20638,7 +20638,7 @@ input StaffCreateInput {
 }
 
 """
-Updates an existing staff user. 
+Updates an existing staff user. Apps are not allowed to perform this mutation. 
 
 Requires one of the following permissions: MANAGE_STAFF.
 """
@@ -20672,7 +20672,7 @@ input StaffUpdateInput {
 }
 
 """
-Deletes a staff user. 
+Deletes a staff user. Apps are not allowed to perform this mutation. 
 
 Requires one of the following permissions: MANAGE_STAFF.
 """
@@ -20683,7 +20683,7 @@ type StaffDelete {
 }
 
 """
-Deletes staff users. 
+Deletes staff users. Apps are not allowed to perform this mutation. 
 
 Requires one of the following permissions: MANAGE_STAFF.
 """
@@ -20731,7 +20731,7 @@ type UserBulkSetActive {
 }
 
 """
-Create new permission group. 
+Create new permission group. Apps are not allowed to perform this mutation. 
 
 Requires one of the following permissions: MANAGE_STAFF.
 """
@@ -20784,7 +20784,7 @@ input PermissionGroupCreateInput {
 }
 
 """
-Update permission group. 
+Update permission group. Apps are not allowed to perform this mutation. 
 
 Requires one of the following permissions: MANAGE_STAFF.
 """
@@ -20812,7 +20812,7 @@ input PermissionGroupUpdateInput {
 }
 
 """
-Delete permission group. 
+Delete permission group. Apps are not allowed to perform this mutation. 
 
 Requires one of the following permissions: MANAGE_STAFF.
 """


### PR DESCRIPTION
I want to merge this change because it adds the possibility for apps with `MANAGE_STAFF` permission to fetch data protected by this permission.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
