### PR TITLE
Add custom SearchVector class

### DIFF
--- a/saleor/product/postgres.py
+++ b/saleor/product/postgres.py
@@ -1,0 +1,37 @@
+from django.contrib.postgres.search import (
+    CombinedSearchVector,
+    SearchVector,
+    SearchVectorCombinable,
+)
+
+
+class NoValidationSearchVectorCombinable(SearchVectorCombinable):
+    def _combine(self, other, connector, reversed):
+        if not isinstance(other, NoValidationSearchVectorCombinable):
+            raise TypeError(
+                "SearchVector can only be combined with other SearchVector "
+                "instances, got %s." % type(other).__name__
+            )
+        if reversed:
+            return NoValidationCombinedSearchVector(other, connector, self, self.config)
+        return NoValidationCombinedSearchVector(self, connector, other, self.config)
+
+
+class NoValidationCombinedSearchVector(
+    NoValidationSearchVectorCombinable, CombinedSearchVector
+):
+    contains_aggregate = False
+    contains_over_clause = False
+
+
+class NoValidationSearchVector(SearchVector, NoValidationSearchVectorCombinable):
+    """The purpose of this class is to omit Django's SQL compiler's validation.
+
+    This validation can lead to RecursionError while processing a large number of
+    expressions.
+    If expressions contained aggregate or over clause, then exception still be raised
+    during SQL execution instead of before preparing SQL.
+
+    This class is only safe to use with expressions that do not contain aggregation
+    and/or over clause.
+    """


### PR DESCRIPTION
I want to merge this change because this adds custom SearchVector class, that when used skips Django's SQL Compiler validation that leads into RecursionError while processing large number of expressions (for example, 250 product variants).

The validation that is being skipped by this class: https://github.com/django/django/blob/08e6073f878264a0c091da0d3db456820252ef6c/django/db/models/sql/compiler.py#L1502

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
