### PR TITLE
Allow promote customer user to staff user

### DIFF
--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -281,6 +281,23 @@ class StaffCreate(ModelMutation):
     def post_save_action(cls, info, instance, cleaned_input):
         info.context.plugins.staff_created(instance)
 
+    @classmethod
+    def get_instance(cls, info, **data):
+        object_id = data.get("id")
+        email = data.get("input", {}).get("email")
+        qs = data.get("qs")
+
+        if object_id:
+            model_type = cls.get_type_for_model()
+            instance = cls.get_node_or_error(
+                info, object_id, only_type=model_type, qs=qs
+            )
+        elif email and models.User.objects.filter(email=email, is_staff=False).exists():
+            return models.User.objects.get(email=email)
+        else:
+            instance = cls._meta.model()
+        return instance
+
 
 class StaffUpdate(StaffCreate):
     class Arguments:

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -254,15 +254,13 @@ class StaffCreate(ModelMutation):
         pass
 
     @classmethod
-    def save(cls, info, user, cleaned_input):
+    def save(cls, info, user, cleaned_input, send_notification=True):
         if any([field in cleaned_input for field in USER_SEARCH_FIELDS]):
             user.search_document = prepare_user_search_document_value(
                 user, attach_addresses_data=False
             )
         user.save()
-        if cleaned_input.get("redirect_url") and getattr(
-            info.context, "send_notification", True
-        ):
+        if cleaned_input.get("redirect_url") and send_notification:
             send_set_password_notification(
                 redirect_url=cleaned_input.get("redirect_url"),
                 user=user,
@@ -287,6 +285,7 @@ class StaffCreate(ModelMutation):
     def get_instance(cls, info, **data):
         object_id = data.get("id")
         email = data.get("input", {}).get("email")
+        send_notification = True
 
         if (
             not object_id
@@ -295,9 +294,21 @@ class StaffCreate(ModelMutation):
                 user := models.User.objects.filter(email=email, is_staff=False).first()
             )
         ):
-            info.context.send_notification = False  # type: ignore
-            return user
-        return super().get_instance(info, **data)
+            send_notification = False
+            return user, send_notification
+        return super().get_instance(info, **data), send_notification
+
+    @classmethod
+    def perform_mutation(cls, _root, info, **data):
+        instance, send_notification = cls.get_instance(info, **data)
+        data = data.get("input")
+        cleaned_input = cls.clean_input(info, instance, data)
+        instance = cls.construct_instance(instance, cleaned_input)
+        cls.clean_instance(info, instance)
+        cls.save(info, instance, cleaned_input, send_notification)
+        cls._save_m2m(info, instance, cleaned_input)
+        cls.post_save_action(info, instance, cleaned_input)
+        return cls.success_response(instance)
 
 
 class StaffUpdate(StaffCreate):
@@ -428,7 +439,7 @@ class StaffUpdate(StaffCreate):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        instance = cls.get_instance(info, **data)
+        instance, _ = cls.get_instance(info, **data)
         old_email = instance.email
         response = super().perform_mutation(_root, info, **data)
         user = response.user

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -2430,6 +2430,76 @@ def test_staff_create(
 
 
 @freeze_time("2018-05-31 12:00:01")
+@patch("saleor.plugins.manager.PluginsManager.notify")
+def test_promote_customer_to_staff_user(
+    mocked_notify,
+    staff_api_client,
+    staff_user,
+    customer_user,
+    media_root,
+    permission_group_manage_users,
+    permission_manage_products,
+    permission_manage_staff,
+    permission_manage_users,
+    channel_PLN,
+):
+    group = permission_group_manage_users
+    group.permissions.add(permission_manage_products)
+    staff_user.user_permissions.add(permission_manage_products, permission_manage_users)
+    redirect_url = "https://www.example.com"
+    email = customer_user.email
+    variables = {
+        "email": email,
+        "redirect_url": redirect_url,
+        "add_groups": [graphene.Node.to_global_id("Group", group.pk)],
+    }
+
+    response = staff_api_client.post_graphql(
+        STAFF_CREATE_MUTATION, variables, permissions=[permission_manage_staff]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["staffCreate"]
+    assert data["errors"] == []
+    assert data["user"]["email"] == email
+    assert data["user"]["isStaff"]
+    assert data["user"]["isActive"]
+
+    expected_perms = {
+        permission_manage_products.codename,
+        permission_manage_users.codename,
+    }
+    permissions = data["user"]["userPermissions"]
+    assert {perm["code"].lower() for perm in permissions} == expected_perms
+
+    staff_user = User.objects.get(email=email)
+
+    assert staff_user.is_staff
+
+    groups = data["user"]["permissionGroups"]
+    assert len(groups) == 1
+    assert {perm["code"].lower() for perm in groups[0]["permissions"]} == expected_perms
+
+    token = default_token_generator.make_token(staff_user)
+    params = urlencode({"email": email, "token": token})
+    password_set_url = prepare_url(params, redirect_url)
+    expected_payload = {
+        "user": get_default_user_payload(staff_user),
+        "password_set_url": password_set_url,
+        "token": token,
+        "recipient_email": staff_user.email,
+        "site_name": "mirumee.com",
+        "domain": "mirumee.com",
+        "channel_slug": None,
+    }
+
+    mocked_notify.assert_called_once_with(
+        NotifyEventType.ACCOUNT_SET_STAFF_PASSWORD,
+        payload=expected_payload,
+        channel_slug=None,
+    )
+
+
+@freeze_time("2018-05-31 12:00:01")
 @patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_staff_create_trigger_webhook(

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -2479,24 +2479,7 @@ def test_promote_customer_to_staff_user(
     assert len(groups) == 1
     assert {perm["code"].lower() for perm in groups[0]["permissions"]} == expected_perms
 
-    token = default_token_generator.make_token(staff_user)
-    params = urlencode({"email": email, "token": token})
-    password_set_url = prepare_url(params, redirect_url)
-    expected_payload = {
-        "user": get_default_user_payload(staff_user),
-        "password_set_url": password_set_url,
-        "token": token,
-        "recipient_email": staff_user.email,
-        "site_name": "mirumee.com",
-        "domain": "mirumee.com",
-        "channel_slug": None,
-    }
-
-    mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_SET_STAFF_PASSWORD,
-        payload=expected_payload,
-        channel_slug=None,
-    )
+    mocked_notify.assert_not_called()
 
 
 @freeze_time("2018-05-31 12:00:01")


### PR DESCRIPTION
I want to merge this change because it fixes a bug that does not allow promote customer users to staff users.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
