### PR TITLE
Make API not strip query params from redirect url

### DIFF
--- a/saleor/core/tests/test_url.py
+++ b/saleor/core/tests/test_url.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from urllib.parse import urlencode
 
 from ..utils.url import prepare_url
@@ -8,3 +9,10 @@ def test_prepare_url():
     params = urlencode({"param1": "abc", "param2": "xyz"})
     result = prepare_url(params, redirect_url)
     assert result == f"{redirect_url}?param1=abc&param2=xyz"
+
+
+def test_prepare_url_with_existing_query():
+    redirect_url = "https://www.example.com/?param=1&param=2"
+    params = urlencode(OrderedDict({"param3": "abc", "param4": "xyz"}))
+    result = prepare_url(params, redirect_url)
+    assert result == f"{redirect_url}&param3=abc&param4=xyz"

--- a/saleor/core/utils/url.py
+++ b/saleor/core/utils/url.py
@@ -31,5 +31,8 @@ def validate_storefront_url(url):
 def prepare_url(params: str, redirect_url: str) -> str:
     """Add params to redirect url."""
     split_url = urlsplit(redirect_url)
+    current_params = split_url.query
+    if current_params:
+        params = f"{current_params}&{params}"
     split_url = split_url._replace(query=params)
     return split_url.geturl()


### PR DESCRIPTION
I want to merge this change because it allows providing query params in `redirectUrl` by storefront.
Previously we always replace query params. Now, we add Saleor's params to the existing query params

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
