### PR TITLE
Fix product media reordering

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1413,7 +1413,10 @@ class ProductMediaReorder(BaseMutation):
             only_type=Product,
             qs=models.Product.objects.prefetched_for_webhook(),
         )
-        if len(media_ids) != product.media.count():
+
+        # we do not care about media with the to_remove flag set to True
+        # as they will be deleted soon
+        if len(media_ids) != product.media.exclude(to_remove=True).count():
             raise ValidationError(
                 {
                     "order": ValidationError(


### PR DESCRIPTION
There was a problem that when one of the product media was deleted the `productMediaReorder` was raising an error. It was caused by validation that compares the number of provided media ids in mutation to the actual number of product media. As the `productMediaDelete` does not delete the `ProductMedia` instance, it only changed `to_remove` flag to True and the deletion process Is delegated to the celery task, the number of products media instanced was bigger than the number of provided ids. The solution excludes the media with the `to_remove` flag set to True in the comparison.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
