### PR TITLE
Allow values of different attributes to share the same slug

### DIFF
--- a/saleor/core/tests/test_core.py
+++ b/saleor/core/tests/test_core.py
@@ -13,6 +13,7 @@ from django_countries.fields import Country
 
 from ...account.models import Address, User
 from ...account.utils import create_superuser
+from ...attribute.models import AttributeValue
 from ...channel.models import Channel
 from ...discount.models import Sale, SaleChannelListing, Voucher, VoucherChannelListing
 from ...giftcard.models import GiftCard, GiftCardEvent
@@ -315,6 +316,42 @@ def test_generate_unique_slug_for_slug_with_max_characters_number(category):
 def test_generate_unique_slug_non_slugable_value_and_slugable_field(category):
     with pytest.raises(Exception):
         generate_unique_slug(category)
+
+
+def test_generate_unique_slug_with_additional_lookup_slug_not_changed(
+    color_attribute, attribute_without_values
+):
+    # given
+    value_1 = color_attribute.values.first()
+
+    # when
+    value_2 = AttributeValue(name=value_1.name, attribute=attribute_without_values)
+
+    # then
+    result = generate_unique_slug(
+        value_2,
+        value_2.name,
+        additional_search_lookup={"attribute": value_2.attribute_id},
+    )
+
+    assert result == value_1.slug
+
+
+def test_generate_unique_slug_with_additional_lookup_slug_changed(color_attribute):
+    # given
+    value_1 = color_attribute.values.first()
+
+    # when
+    value_2 = AttributeValue(name=value_1.name, attribute=color_attribute)
+
+    # then
+    result = generate_unique_slug(
+        value_2,
+        value_2.name,
+        additional_search_lookup={"attribute": value_2.attribute_id},
+    )
+
+    assert result == f"{value_1.slug}-2"
 
 
 @override_settings(DEBUG=False)

--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -656,7 +656,9 @@ class AttributeValueCreate(AttributeMixin, ModelMutation):
         cleaned_input = super().clean_input(info, instance, data)
         if "name" in cleaned_input:
             cleaned_input["slug"] = generate_unique_slug(
-                instance, cleaned_input["name"]
+                instance,
+                cleaned_input["name"],
+                additional_search_lookup={"attribute_id": instance.attribute_id},
             )
         input_type = instance.attribute.input_type
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -170,6 +170,40 @@ def test_update_attribute_value_name_not_unique(
     assert data["attributeValue"]["slug"] == "pink-2"
 
 
+def test_update_attribute_value_the_same_name_as_different_attribute_value(
+    staff_api_client,
+    size_attribute,
+    color_attribute,
+    permission_manage_product_types_and_attributes,
+):
+    """Ensure the attribute value with the same slug as value of different attribute
+    can be set."""
+    # given
+    query = UPDATE_ATTRIBUTE_VALUE_MUTATION
+
+    value = size_attribute.values.first()
+    based_value = color_attribute.values.first()
+
+    node_id = graphene.Node.to_global_id("AttributeValue", value.id)
+    name = based_value.name
+    variables = {"input": {"name": name}, "id": node_id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["attributeValueUpdate"]
+    value.refresh_from_db()
+    assert data["attributeValue"]["name"] == name == value.name
+    assert data["attributeValue"]["slug"] == based_value.slug
+    assert name in [
+        value["node"]["name"] for value in data["attribute"]["choices"]["edges"]
+    ]
+
+
 def test_update_attribute_value_product_search_document_updated(
     staff_api_client,
     pink_attribute_value,


### PR DESCRIPTION
Allow creating attribute value with the same slug as the value of another attribute.
Still creating values with the same slug in one attribute is not possible.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
