### PR TITLE
Build jwt signature when secret key is an empty string

### DIFF
--- a/saleor/plugins/webhook/__init__.py
+++ b/saleor/plugins/webhook/__init__.py
@@ -1,11 +1,12 @@
 import hashlib
 import hmac
+from typing import Optional
 
 from ...core.jwt_manager import get_jwt_manager
 
 
-def signature_for_payload(body: bytes, secret_key):
-    if secret_key is None:
+def signature_for_payload(body: bytes, secret_key: Optional[str]):
+    if not secret_key:
         return get_jwt_manager().jws_encode(body)
     hash = hmac.new(bytes(secret_key, "utf-8"), body, hashlib.sha256)
     return hash.hexdigest()


### PR DESCRIPTION
I want to merge this change because we just introduce a new way of signing payload, but we missed providing this when secret key is saved as empty string

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
