### PR TITLE
Store information about sensitive fields in the schema definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "build-schema": "python manage.py get_graphql_schema > saleor/graphql/schema.graphql",
+    "build-sensitive-fields-map": "python manage.py get_sensitive_fields_map > saleor/graphql/sensitive_fields_map.json",
     "release": "release-it"
   }
 }

--- a/saleor/graphql/account/mutations/authentication.py
+++ b/saleor/graphql/account/mutations/authentication.py
@@ -21,7 +21,7 @@ from ....core.jwt import (
     jwt_decode,
 )
 from ....core.permissions import AuthorizationFilters, get_permissions_from_names
-from ...core.fields import JSONString
+from ...core.fields import CustomField, JSONString
 from ...core.mutations import BaseMutation
 from ...core.types import AccountError
 from ..types import User
@@ -72,12 +72,20 @@ class CreateToken(BaseMutation):
         error_type_class = AccountError
         error_type_field = "account_errors"
 
-    token = graphene.String(description="JWT token, required to authenticate.")
-    refresh_token = graphene.String(
-        description="JWT refresh token, required to re-generate access token."
+    token = CustomField(
+        graphene.String,
+        description="JWT token, required to authenticate.",
+        sensitive=True,
     )
-    csrf_token = graphene.String(
-        description="CSRF token required to re-generate access token."
+    refresh_token = CustomField(
+        graphene.String,
+        description="JWT refresh token, required to re-generate access token.",
+        sensitive=True,
+    )
+    csrf_token = CustomField(
+        graphene.String,
+        description="CSRF token required to re-generate access token.",
+        sensitive=True,
     )
     user = graphene.Field(User, description="A user instance.")
 
@@ -143,7 +151,11 @@ class CreateToken(BaseMutation):
 class RefreshToken(BaseMutation):
     """Mutation that refresh user token and returns token and user data."""
 
-    token = graphene.String(description="JWT token, required to authenticate.")
+    token = CustomField(
+        graphene.String,
+        description="JWT token, required to authenticate.",
+        sensitive=True,
+    )
     user = graphene.Field(User, description="A user instance.")
 
     class Arguments:

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -26,7 +26,7 @@ from ..core.connection import CountableConnection, create_connection_slice
 from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.enums import LanguageCodeEnum
 from ..core.federation import federated_entity, resolve_federation_references
-from ..core.fields import ConnectionField, PermissionsField
+from ..core.fields import ConnectionField, CustomField, PermissionsField
 from ..core.scalars import UUID
 from ..core.types import CountryDisplay, Image, ModelObjectType, NonNullList, Permission
 from ..core.utils import from_global_id_or_error, str_to_enum, to_global_id_or_none
@@ -56,11 +56,11 @@ class AddressInput(graphene.InputObjectType):
 @federated_entity("id")
 class Address(ModelObjectType):
     id = graphene.GlobalID(required=True)
-    first_name = graphene.String(required=True)
-    last_name = graphene.String(required=True)
-    company_name = graphene.String(required=True)
-    street_address_1 = graphene.String(required=True)
-    street_address_2 = graphene.String(required=True)
+    first_name = CustomField(graphene.String, required=True, sensitive=True)
+    last_name = CustomField(graphene.String, required=True, sensitive=True)
+    company_name = CustomField(graphene.String, required=True, sensitive=True)
+    street_address_1 = CustomField(graphene.String, required=True, sensitive=True)
+    street_address_2 = CustomField(graphene.String, required=True, sensitive=True)
     city = graphene.String(required=True)
     city_area = graphene.String(required=True)
     postal_code = graphene.String(required=True)
@@ -68,7 +68,7 @@ class Address(ModelObjectType):
         CountryDisplay, required=True, description="Shop's default country."
     )
     country_area = graphene.String(required=True)
-    phone = graphene.String()
+    phone = CustomField(graphene.String, sensitive=True)
     is_default_shipping_address = graphene.Boolean(
         required=False, description="Address is user's default shipping address."
     )
@@ -229,9 +229,9 @@ class UserPermission(Permission):
 @federated_entity("email")
 class User(ModelObjectType):
     id = graphene.GlobalID(required=True)
-    email = graphene.String(required=True)
-    first_name = graphene.String(required=True)
-    last_name = graphene.String(required=True)
+    email = CustomField(graphene.String, required=True, sensitive=True)
+    first_name = CustomField(graphene.String, required=True, sensitive=True)
+    last_name = CustomField(graphene.String, required=True, sensitive=True)
     is_staff = graphene.Boolean(required=True)
     is_active = graphene.Boolean(required=True)
     addresses = NonNullList(Address, description="List of all user's addresses.")

--- a/saleor/graphql/app/mutations.py
+++ b/saleor/graphql/app/mutations.py
@@ -16,6 +16,7 @@ from ...core.permissions import AppPermission, get_permissions
 from ..account.utils import can_manage_app
 from ..core import types as grapqhl_types
 from ..core.enums import PermissionEnum
+from ..core.fields import CustomField
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types import AppError, NonNullList
 from ..decorators import staff_member_required
@@ -40,8 +41,10 @@ class AppTokenInput(graphene.InputObjectType):
 
 
 class AppTokenCreate(ModelMutation):
-    auth_token = graphene.types.String(
-        description="The newly created authentication token."
+    auth_token = CustomField(
+        graphene.types.String,
+        description="The newly created authentication token.",
+        sensitive=True,
     )
 
     class Arguments:

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -20,6 +20,7 @@ from ..core.descriptions import (
     PREVIEW_FEATURE,
 )
 from ..core.federation import federated_entity, resolve_federation_references
+from ..core.fields import CustomField
 from ..core.types import Job, ModelObjectType, NonNullList, Permission
 from ..core.utils import from_global_id_or_error
 from ..meta.types import ObjectWithMetadata
@@ -225,7 +226,9 @@ class Manifest(graphene.ObjectType):
 class AppToken(graphene.ObjectType):
     id = graphene.GlobalID(required=True)
     name = graphene.String(description="Name of the authenticated token.")
-    auth_token = graphene.String(description="Last 4 characters of the token.")
+    auth_token = CustomField(
+        graphene.String, description="Last 4 characters of the token.", sensitive=True
+    )
 
     class Meta:
         description = "Represents token data."
@@ -295,8 +298,10 @@ class App(ModelObjectType):
         description="URL to manifest used during app's installation." + ADDED_IN_35
     )
     version = graphene.String(description="Version number of the app.")
-    access_token = graphene.String(
-        description="JWT token used to authenticate by thridparty app."
+    access_token = CustomField(
+        graphene.String,
+        description="JWT token used to authenticate by thridparty app.",
+        sensitive=True,
     )
     extensions = NonNullList(
         AppExtension,

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -26,6 +26,7 @@ from ..core.descriptions import (
     PREVIEW_FEATURE,
 )
 from ..core.enums import LanguageCodeEnum
+from ..core.fields import CustomField
 from ..core.scalars import UUID
 from ..core.types import ModelObjectType, Money, NonNullList, TaxedMoney
 from ..core.utils import str_to_enum
@@ -419,7 +420,12 @@ class Checkout(ModelObjectType):
         description="List of available payment gateways.",
         required=True,
     )
-    email = graphene.String(description="Email of a customer.", required=False)
+    email = CustomField(
+        graphene.String,
+        description="Email of a customer.",
+        required=False,
+        sensitive=True,
+    )
     gift_cards = NonNullList(
         GiftCard,
         description="List of gift cards associated with this checkout.",

--- a/saleor/graphql/core/fields.py
+++ b/saleor/graphql/core/fields.py
@@ -10,7 +10,16 @@ from ..decorators import one_of_permissions_required
 from .connection import FILTERS_NAME, FILTERSET_CLASS
 
 
-class PermissionsField(graphene.Field):
+class CustomField(graphene.Field):
+    def __init__(self, *args, **kwargs):
+        self.sensitive = kwargs.pop("sensitive", False)
+        assert isinstance(
+            self.sensitive, bool
+        ), f"CustomField `sensitive` argument must be a bool: {self.sensitive}"
+        super(CustomField, self).__init__(*args, **kwargs)
+
+
+class PermissionsField(CustomField):
     def __init__(self, *args, **kwargs):
         self.permissions = kwargs.pop("permissions", [])
         auto_permission_message = kwargs.pop("auto_permission_message", True)

--- a/saleor/graphql/management/commands/get_sensitive_fields_map.py
+++ b/saleor/graphql/management/commands/get_sensitive_fields_map.py
@@ -1,0 +1,14 @@
+import json
+
+from django.core.management.base import BaseCommand
+
+from ...api import schema
+from ...schema_maps import build_sensitive_fields_map
+
+
+class Command(BaseCommand):
+    help = "Writes sensitive fields map for GraphQL API schema to stdout"
+
+    def handle(self, *args, **options):
+        sensitive_fields = build_sensitive_fields_map(schema.get_type_map())
+        self.stdout.write(json.dumps(sensitive_fields, indent=4, sort_keys=True))

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -66,7 +66,7 @@ from ..core.descriptions import (
     PREVIEW_FEATURE,
 )
 from ..core.enums import LanguageCodeEnum
-from ..core.fields import PermissionsField
+from ..core.fields import CustomField, PermissionsField
 from ..core.mutations import validation_error_to_error_type
 from ..core.scalars import PositiveDecimal
 from ..core.types import (
@@ -891,7 +891,8 @@ class Order(ModelObjectType):
         description="The difference between the paid and the order total amount.",
         required=True,
     )
-    user_email = graphene.String(
+    user_email = CustomField(
+        graphene.String,
         description=(
             "Email address of the customer. The full data can be access for orders "
             "created in Saleor 3.2 and later, for other orders requires one of "
@@ -899,6 +900,7 @@ class Order(ModelObjectType):
             f"{AuthorizationFilters.OWNER.name}."
         ),
         required=False,
+        sensitive=True,
     )
     is_shipping_required = graphene.Boolean(
         description="Returns True, if order requires shipping.", required=True

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -8,7 +8,7 @@ from ...payment import models
 from ..checkout.dataloaders import CheckoutByTokenLoader
 from ..core.connection import CountableConnection
 from ..core.descriptions import ADDED_IN_31, ADDED_IN_34, PREVIEW_FEATURE
-from ..core.fields import JSONString, PermissionsField
+from ..core.fields import CustomField, JSONString, PermissionsField
 from ..core.types import ModelObjectType, Money, NonNullList
 from ..meta.permissions import public_payment_permissions
 from ..meta.resolvers import resolve_metadata
@@ -142,8 +142,10 @@ class Payment(ModelObjectType):
         description="Maximum amount of money that can be refunded.",
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )
-    credit_card = graphene.Field(
-        CreditCard, description="The details of the card used for this payment."
+    credit_card = CustomField(
+        CreditCard,
+        description="The details of the card used for this payment.",
+        sensitive=True,
     )
 
     class Meta:

--- a/saleor/graphql/schema_maps.py
+++ b/saleor/graphql/schema_maps.py
@@ -1,0 +1,29 @@
+from typing import Dict, List
+
+from graphene.types.definitions import GrapheneObjectType
+from graphene.utils.str_converters import to_camel_case
+from graphql.type.definition import GraphQLType
+
+from .core.fields import CustomField
+
+TypeMap = Dict[str, GraphQLType]
+SensitiveFieldsMap = Dict[str, List[str]]
+
+
+def _get_field_name(name: str, camelcase=True) -> str:
+    if camelcase:
+        return to_camel_case(name)
+    return name
+
+
+def build_sensitive_fields_map(type_map: TypeMap, camelcase=True) -> SensitiveFieldsMap:
+    sensitive_fields: SensitiveFieldsMap = {}
+    for type_name, gql_type in type_map.items():
+        if isinstance(gql_type, GrapheneObjectType):
+            for field_name, field in gql_type.graphene_type._meta.fields.items():
+                if isinstance(field, CustomField) and field.sensitive:
+                    field_name = field.name or _get_field_name(field_name, camelcase)
+                    if field_name not in gql_type.fields:
+                        continue
+                    sensitive_fields.setdefault(type_name, []).append(field_name)
+    return sensitive_fields

--- a/saleor/graphql/sensitive_fields_map.json
+++ b/saleor/graphql/sensitive_fields_map.json
@@ -1,0 +1,46 @@
+{
+    "Address": [
+        "firstName",
+        "lastName",
+        "companyName",
+        "streetAddress1",
+        "streetAddress2",
+        "phone"
+    ],
+    "App": [
+        "accessToken"
+    ],
+    "AppToken": [
+        "authToken"
+    ],
+    "AppTokenCreate": [
+        "authToken"
+    ],
+    "Checkout": [
+        "email"
+    ],
+    "CreateToken": [
+        "token",
+        "refreshToken",
+        "csrfToken"
+    ],
+    "Order": [
+        "userEmail"
+    ],
+    "Payment": [
+        "creditCard"
+    ],
+    "RefreshToken": [
+        "token"
+    ],
+    "SetPassword": [
+        "token",
+        "refreshToken",
+        "csrfToken"
+    ],
+    "User": [
+        "email",
+        "firstName",
+        "lastName"
+    ]
+}

--- a/saleor/webhook/observability/obfuscation.py
+++ b/saleor/webhook/observability/obfuscation.py
@@ -21,7 +21,8 @@ from graphql.validation.rules.base import ValidationRule
 from graphql.validation.validation import ValidationContext
 
 from ...graphql.api import schema
-from .sensitive_data import SENSITIVE_HEADERS, SensitiveFieldsMap
+from ...graphql.schema_maps import SensitiveFieldsMap
+from .sensitive_data import SENSITIVE_HEADERS
 
 if TYPE_CHECKING:
     from graphql import GraphQLDocument

--- a/saleor/webhook/observability/sensitive_data.py
+++ b/saleor/webhook/observability/sensitive_data.py
@@ -6,9 +6,9 @@ SENSITIVE_GQL_FIELDS is a dict of sets representing fields of GraphGL types to a
 - Type
 - Fields
 """
-from typing import Dict, Set
-
 from ...core.auth import DEFAULT_AUTH_HEADER, SALEOR_AUTH_HEADER
+from ...graphql.api import schema
+from ...graphql.schema_maps import build_sensitive_fields_map
 
 SENSITIVE_HEADERS = (
     SALEOR_AUTH_HEADER,
@@ -19,23 +19,5 @@ SENSITIVE_HEADERS = tuple(
     x[5:] if x.startswith("HTTP_") else x for x in SENSITIVE_HEADERS
 )
 
-SensitiveFieldsMap = Dict[str, Set[str]]
-SENSITIVE_GQL_FIELDS: SensitiveFieldsMap = {
-    "RefreshToken": {"token"},
-    "CreateToken": {"token", "refreshToken", "csrfToken"},
-    "User": {"email", "firstName", "lastName"},
-    "Address": {
-        "firstName",
-        "lastName",
-        "companyName",
-        "streetAddress1",
-        "streetAddress2",
-        "phone",
-    },
-    "AppTokenCreate": {"authToken"},
-    "AppToken": {"authToken"},
-    "App": {"accessToken"},
-    "Order": {"userEmail"},
-    "Payment": {"creditCard"},
-    "Checkout": {"email"},
-}
+
+SENSITIVE_GQL_FIELDS = build_sensitive_fields_map(schema.get_type_map())

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,12 @@ whitelist_externals = sh
 commands =
     sh -c './manage.py get_graphql_schema | diff saleor/graphql/schema.graphql -'
 
+[testenv:check_sensitive_fields]
+basepython = python3.9
+whitelist_externals = sh
+commands =
+    sh -c './manage.py get_sensitive_fields_map | diff saleor/graphql/sensitive_fields_map.json -'
+
 [testenv:check_migrations]
 basepython = python3.9
 whitelist_externals = psql


### PR DESCRIPTION
I want to merge this change because it moves storing information about sensitive fields to the schema definition, creating a single point of truth and reducing the possibility of forgetting to mark sensitive data. It is still a draft, and I welcome everyone for discussion. Sensitive fields map is additionally dumped to JSON file to make it part of git/CI workflow. If this approach is accepted, we can use it to store query cost data and replace the static `query_cost_map` from the query cost validator.

CLOUD-1768

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
