### PR TITLE
Fix stock by ID dataloader

### DIFF
--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -347,7 +347,8 @@ class StockByIdLoader(DataLoader):
     context_key = "stock_by_id"
 
     def batch_load(self, keys):
-        return Stock.objects.using(self.database_connection_name).in_bulk(keys).values()
+        stocks = Stock.objects.using(self.database_connection_name).in_bulk(keys)
+        return [stocks.get(key) for key in keys]
 
 
 class WarehousesByChannelIdLoader(DataLoader):

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -348,7 +348,7 @@ class StockByIdLoader(DataLoader):
 
     def batch_load(self, keys):
         stocks = Stock.objects.using(self.database_connection_name).in_bulk(keys)
-        return [stocks.get(key) for key in keys]
+        return [stocks.get(key, []) for key in keys]
 
 
 class WarehousesByChannelIdLoader(DataLoader):

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -348,7 +348,7 @@ class StockByIdLoader(DataLoader):
 
     def batch_load(self, keys):
         stocks = Stock.objects.using(self.database_connection_name).in_bulk(keys)
-        return [stocks.get(key, []) for key in keys]
+        return [stocks.get(key) for key in keys]
 
 
 class WarehousesByChannelIdLoader(DataLoader):


### PR DESCRIPTION
I want to merge this change because it fixes problem with dataloader that causes it to return stocks in wrong order. That in some situations (like in linked ticket) caused API to return data inconsistent with data from DB.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
