### PR TITLE
Fix default debug logging formatter missing the log date

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -306,7 +306,8 @@ LOGGING = {
         },
         "verbose": {
             "format": (
-                "%(levelname)s %(name)s %(message)s [PID:%(process)d:%(threadName)s]"
+                "%(asctime)s %(levelname)s %(name)s %(message)s "
+                "[PID:%(process)d:%(threadName)s]"
             )
         },
     },


### PR DESCRIPTION
The default logging configuration when `DEBUG=True` was not logging the value of `asctime` like the other formatters, this causes to be unable to see the date and time of logs from other modules such as Celery beat.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
