### PR TITLE
Handle same variant in multiple lines in CheckoutLineAdd/Update

### DIFF
--- a/saleor/checkout/error_codes.py
+++ b/saleor/checkout/error_codes.py
@@ -29,6 +29,7 @@ class CheckoutErrorCode(Enum):
     UNAVAILABLE_VARIANT_IN_CHANNEL = "unavailable_variant_in_channel"
     EMAIL_NOT_SET = "email_not_set"
     NO_LINES = "no_lines"
+    WRONG_PARAMETER = "wrong_parameter"
 
 
 class OrderCreateFromCheckoutErrorCode(Enum):

--- a/saleor/checkout/error_codes.py
+++ b/saleor/checkout/error_codes.py
@@ -29,7 +29,6 @@ class CheckoutErrorCode(Enum):
     UNAVAILABLE_VARIANT_IN_CHANNEL = "unavailable_variant_in_channel"
     EMAIL_NOT_SET = "email_not_set"
     NO_LINES = "no_lines"
-    WRONG_PARAMETER = "wrong_parameter"
 
 
 class OrderCreateFromCheckoutErrorCode(Enum):

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -278,6 +278,7 @@ def fetch_checkout_lines(
             apply_voucher_to_checkout_line(
                 voucher_info, checkout, lines_info, discounts
             )
+
     return lines_info, unavailable_variant_pks
 
 

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -211,7 +211,9 @@ def get_delivery_method_info(
 
 
 def fetch_checkout_lines(
-    checkout: "Checkout", prefetch_variant_attributes=False
+    checkout: "Checkout",
+    prefetch_variant_attributes=False,
+    skip_lines_with_unavailable_variants=True,
 ) -> Tuple[Iterable[CheckoutLineInfo], Iterable[int]]:
     """Fetch checkout lines as CheckoutLineInfo objects."""
     from .utils import get_voucher_for_checkout
@@ -250,6 +252,17 @@ def fetch_checkout_lines(
             checkout, product, variant_channel_listing, product_channel_listing_mapping
         ):
             unavailable_variant_pks.append(variant.pk)
+            if not skip_lines_with_unavailable_variants:
+                lines_info.append(
+                    CheckoutLineInfo(
+                        line=line,
+                        variant=variant,
+                        channel_listing=variant_channel_listing,
+                        product=product,
+                        product_type=product_type,
+                        collections=collections,
+                    )
+                )
             continue
 
         lines_info.append(
@@ -278,7 +291,6 @@ def fetch_checkout_lines(
             apply_voucher_to_checkout_line(
                 voucher_info, checkout, lines_info, discounts
             )
-
     return lines_info, unavailable_variant_pks
 
 

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -251,7 +251,6 @@ def add_variants_to_checkout(
 def _get_line_if_exist(line_data, lines_by_ids):
     if line_data.line_id and line_data.line_id in lines_by_ids:
         return lines_by_ids[line_data.line_id]
-    return
 
 
 def _append_line_to_update(to_update, to_delete, line_data, replace, line):

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -207,7 +207,6 @@ def add_variants_to_checkout(
 
     checkout_lines = checkout.lines.select_related("variant")
 
-    lines_by_variant_id = {str(line.variant_id): line for line in checkout_lines}
     lines_by_id = {str(line.pk): line for line in checkout_lines}
     variants_map = {str(variant.pk): variant for variant in variants}
 
@@ -216,7 +215,7 @@ def add_variants_to_checkout(
     to_delete: List[CheckoutLine] = []
 
     for line_data in checkout_lines_data:
-        line = _get_line_if_exist(line_data, lines_by_variant_id, lines_by_id)
+        line = _get_line_if_exist(line_data, lines_by_id)
         _append_line_to_update(to_update, to_delete, line_data, replace, line)
         _append_line_to_delete(to_delete, line_data, line)
         _append_line_to_create(to_create, checkout, variants_map, line_data, line)
@@ -249,22 +248,10 @@ def add_variants_to_checkout(
     return checkout
 
 
-def _get_line_if_exist(line_data, lines_by_variant_id, lines_by_ids):
-    line_id = line_data.line_id
-    variant_id = line_data.variant_id
-
-    if (variant_id and variant_id not in lines_by_variant_id) or (
-        line_id and line_id not in lines_by_ids
-    ):
-        return
-
-    if line_id:
-        line = lines_by_ids[line_id]
-
-    if variant_id:
-        line = lines_by_variant_id[variant_id]
-
-    return line
+def _get_line_if_exist(line_data, lines_by_ids):
+    if line_data.line_id and line_data.line_id in lines_by_ids:
+        return lines_by_ids[line_data.line_id]
+    return
 
 
 def _append_line_to_update(to_update, to_delete, line_data, replace, line):

--- a/saleor/core/management/commands/populatedb.py
+++ b/saleor/core/management/commands/populatedb.py
@@ -12,6 +12,7 @@ from ...utils.random_data import (
     create_channels,
     create_checkout_with_custom_prices,
     create_checkout_with_preorders,
+    create_checkout_with_same_variant_in_multiple_lines,
     create_gift_cards,
     create_menus,
     create_orders,
@@ -113,6 +114,8 @@ class Command(BaseCommand):
         for msg in create_checkout_with_preorders():
             self.stdout.write(msg)
         for msg in create_checkout_with_custom_prices():
+            self.stdout.write(msg)
+        for msg in create_checkout_with_same_variant_in_multiple_lines():
             self.stdout.write(msg)
 
         if options["createsuperuser"]:

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -1558,11 +1558,16 @@ def get_image(image_dir, image_name):
     return File(open(img_path, "rb"), name=image_name)
 
 
-def create_checkout_with_preorders():
+def prep_checkout():
     channel = Channel.objects.get(slug=settings.DEFAULT_CHANNEL_SLUG)
     checkout = Checkout.objects.create(currency=channel.currency_code, channel=channel)
     checkout.set_country(channel.default_country, commit=True)
     checkout_info = fetch_checkout_info(checkout, [], [], get_plugins_manager())
+    return checkout_info
+
+
+def create_checkout_with_preorders():
+    checkout_info = prep_checkout()
     for product_variant in ProductVariant.objects.all()[:2]:
         product_variant.is_preorder = True
         product_variant.preorder_global_threshold = 10
@@ -1576,19 +1581,31 @@ def create_checkout_with_preorders():
             ]
         )
         add_variant_to_checkout(checkout_info, product_variant, 2)
-    yield f"Created checkout with two preorders. Checkout token: {checkout.token}"
+    yield (
+        "Created checkout with two preorders. Checkout token: "
+        f"{checkout_info.checkout.token}"
+    )
 
 
 def create_checkout_with_custom_prices():
-    channel = Channel.objects.get(slug=settings.DEFAULT_CHANNEL_SLUG)
-    checkout = Checkout.objects.create(currency=channel.currency_code, channel=channel)
-    checkout.set_country(channel.default_country, commit=True)
-    checkout_info = fetch_checkout_info(checkout, [], [], get_plugins_manager())
+    checkout_info = prep_checkout()
     for product_variant in ProductVariant.objects.all()[:2]:
         add_variant_to_checkout(
             checkout_info, product_variant, 2, price_override=Decimal("20.0")
         )
     yield (
         "Created checkout with two lines and custom prices. "
-        f"Checkout token: {checkout.token}."
+        f"Checkout token: {checkout_info.checkout.token}."
+    )
+
+
+def create_checkout_with_same_variant_in_multiple_lines():
+    checkout_info = prep_checkout()
+    for product_variant in ProductVariant.objects.all()[:2]:
+        add_variant_to_checkout(checkout_info, product_variant, 2)
+        add_variant_to_checkout(checkout_info, product_variant, 2, force_new_line=True)
+
+    yield (
+        "Created checkout with four lines and same variant in multiple lines "
+        f"Checkout token: {checkout_info.checkout.token}."
     )

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -15,6 +15,7 @@ from ...channel.utils import clean_channel
 from ...core.descriptions import (
     ADDED_IN_31,
     ADDED_IN_35,
+    ADDED_IN_36,
     DEPRECATED_IN_3X_FIELD,
     PREVIEW_FEATURE,
 )
@@ -28,7 +29,7 @@ from ..types import Checkout
 from .utils import (
     check_lines_quantity,
     check_permissions_for_custom_prices,
-    group_quantity_and_custom_prices_by_variants,
+    group_lines,
     validate_variants_are_published,
     validate_variants_available_for_purchase,
 )
@@ -81,7 +82,7 @@ class CheckoutValidationRules(graphene.InputObjectType):
     )
 
 
-class CheckoutLineInput(graphene.InputObjectType):
+class CheckoutLineBaseInput(graphene.InputObjectType):
     quantity = graphene.Int(required=True, description="The number of items purchased.")
     variant_id = graphene.ID(required=True, description="ID of the product variant.")
     price = PositiveDecimal(
@@ -92,6 +93,17 @@ class CheckoutLineInput(graphene.InputObjectType):
             "will be provided multiple times, the last price will be used."
             + ADDED_IN_31
             + PREVIEW_FEATURE
+        ),
+    )
+
+
+class CheckoutLineInput(CheckoutLineBaseInput):
+    force_new_line = graphene.Boolean(
+        required=False,
+        default_value=False,
+        description=(
+            "Flag that allow force splitting the same variant into multiple lines "
+            "by skipping the matching logic. " + ADDED_IN_36 + PREVIEW_FEATURE
         ),
     )
 
@@ -169,7 +181,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             ),
         )
 
-        checkout_lines_data = group_quantity_and_custom_prices_by_variants(lines)
+        checkout_lines_data = group_lines(lines)
 
         variant_db_ids = {variant.id for variant in variants}
         validate_variants_available_for_purchase(variant_db_ids, channel.id)

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -29,7 +29,7 @@ from ..types import Checkout
 from .utils import (
     check_lines_quantity,
     check_permissions_for_custom_prices,
-    group_lines,
+    group_lines_input_on_add,
     validate_variants_are_published,
     validate_variants_available_for_purchase,
 )
@@ -82,7 +82,7 @@ class CheckoutValidationRules(graphene.InputObjectType):
     )
 
 
-class CheckoutLineBaseInput(graphene.InputObjectType):
+class CheckoutLineInput(graphene.InputObjectType):
     quantity = graphene.Int(required=True, description="The number of items purchased.")
     variant_id = graphene.ID(required=True, description="ID of the product variant.")
     price = PositiveDecimal(
@@ -95,9 +95,6 @@ class CheckoutLineBaseInput(graphene.InputObjectType):
             + PREVIEW_FEATURE
         ),
     )
-
-
-class CheckoutLineInput(CheckoutLineBaseInput):
     force_new_line = graphene.Boolean(
         required=False,
         default_value=False,
@@ -181,7 +178,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             ),
         )
 
-        checkout_lines_data = group_lines(lines)
+        checkout_lines_data = group_lines_input_on_add(lines)
 
         variant_db_ids = {variant.id for variant in variants}
         validate_variants_available_for_purchase(variant_db_ids, channel.id)

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -179,7 +179,9 @@ class CheckoutLinesAdd(BaseMutation):
             checkout, [], discounts, manager, shipping_channel_listings
         )
 
-        existing_lines_info, _ = fetch_checkout_lines(checkout)
+        existing_lines_info, _ = fetch_checkout_lines(
+            checkout, skip_lines_with_unavailable_variants=False
+        )
         input_lines_data = cls._get_grouped_lines_data(lines, existing_lines_info)
 
         lines = cls.clean_input(
@@ -210,4 +212,4 @@ class CheckoutLinesAdd(BaseMutation):
 
     @classmethod
     def _get_grouped_lines_data(cls, lines, existing_lines_info):
-        return group_lines_input_on_add(lines)
+        return group_lines_input_on_add(lines, existing_lines_info)

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -297,16 +297,23 @@ def group_lines_input_on_add(
             grouped_checkout_lines_data.append(line_data)
         else:
             _, variant_db_id = graphene.Node.from_global_id(variant_id)
-            line_db_id = find_line_id_when_variant_parameter_used(
-                variant_db_id, existing_lines_info
-            )
 
-            if not line_db_id:
-                line_data = checkout_lines_data_map[variant_db_id]
-                line_data.variant_id = variant_db_id
-            else:
-                line_data = checkout_lines_data_map[line_db_id]
-                line_data.line_id = line_db_id
+            try:
+                line_db_id = find_line_id_when_variant_parameter_used(
+                    variant_db_id, existing_lines_info
+                )
+
+                if not line_db_id:
+                    line_data = checkout_lines_data_map[variant_db_id]
+                    line_data.variant_id = variant_db_id
+                else:
+                    line_data = checkout_lines_data_map[line_db_id]
+                    line_data.line_id = line_db_id
+
+            # when variant already exist in multiple lines then create a new line
+            except ValidationError:
+                line_data = CheckoutLineData(variant_id=variant_db_id)
+                grouped_checkout_lines_data.append(line_data)
 
         if (quantity := line.get("quantity")) is not None:
             line_data.quantity += quantity

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -596,6 +596,7 @@ def test_update_checkout_lines(
             },
         ],
     }
+
     response = get_graphql_content(
         api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
     )
@@ -644,7 +645,7 @@ def test_update_checkout_lines_with_reservations(
         variants,
         [
             CheckoutLineData(
-                variant_id=variant.pk,
+                variant_id=str(variant.pk),
                 quantity=2,
                 quantity_to_update=True,
                 custom_price=None,

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -644,13 +644,14 @@ def test_update_checkout_lines_with_reservations(
         variants,
         [
             CheckoutLineData(
+                variant_id=variant.pk,
                 quantity=2,
                 quantity_to_update=True,
                 custom_price=None,
                 custom_price_to_update=False,
             )
-        ]
-        * 10,
+            for variant in variants
+        ],
         channel_USD.slug,
         replace_reservations=True,
         reservation_length=5,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -110,6 +110,107 @@ def test_checkout_lines_update(
     assert mocked_invalidate_checkout_prices.call_count == 1
 
 
+@mock.patch(
+    "saleor.graphql.checkout.mutations.checkout_lines_add."
+    "update_checkout_shipping_method_if_invalid",
+    wraps=update_checkout_shipping_method_if_invalid,
+)
+def test_checkout_lines_update_using_line_id(
+    mocked_update_shipping_method, user_api_client, checkout_with_item
+):
+    checkout = checkout_with_item
+    lines, _ = fetch_checkout_lines(checkout)
+    assert checkout.lines.count() == 1
+    assert calculate_checkout_quantity(lines) == 3
+    line = checkout.lines.first()
+    variant = line.variant
+    assert line.quantity == 3
+    previous_last_change = checkout.last_change
+
+    line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_item),
+        "lines": [{"lineId": line_id, "quantity": 1}],
+    }
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
+    content = get_graphql_content(response)
+
+    data = content["data"]["checkoutLinesUpdate"]
+    assert not data["errors"]
+    checkout.refresh_from_db()
+    lines, _ = fetch_checkout_lines(checkout)
+    assert checkout.lines.count() == 1
+    line = checkout.lines.first()
+    assert line.variant == variant
+    assert line.quantity == 1
+    assert calculate_checkout_quantity(lines) == 1
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+    assert checkout.last_change != previous_last_change
+
+
+def test_checkout_lines_update_block_when_variant_id_and_same_variant_in_multiple_lines(
+    user_api_client, checkout_with_same_items_in_multiple_lines
+):
+    # given
+    checkout = checkout_with_same_items_in_multiple_lines
+    lines, _ = fetch_checkout_lines(checkout)
+    assert checkout.lines.count() == 2
+    assert calculate_checkout_quantity(lines) == 2
+    line = checkout.lines.first()
+    variant = line.variant
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "lines": [{"variantId": variant_id, "quantity": 2}],
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutLinesUpdate"]
+
+    # then
+    assert data["errors"][0]["code"] == CheckoutErrorCode.WRONG_PARAMETER.name
+    assert data["errors"][0]["field"] == "variantId"
+
+
+def test_checkout_lines_update_block_when_variant_id_and_line_id_provided(
+    user_api_client, checkout_with_item
+):
+    # given
+    checkout = checkout_with_item
+    lines, _ = fetch_checkout_lines(checkout)
+    assert checkout.lines.count() == 1
+    assert calculate_checkout_quantity(lines) == 3
+    line = checkout.lines.first()
+    variant = line.variant
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "lines": [{"variantId": variant_id, "lineId": line_id, "quantity": 2}],
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
+    content = get_graphql_content(response)
+
+    data = content["data"]["checkoutLinesUpdate"]
+    expected_message = "Argument 'line_id' cannot be combined with 'variant_id'"
+
+    # then
+    assert data["errors"][0]["code"] == CheckoutErrorCode.GRAPHQL_ERROR.name
+    assert data["errors"][0]["message"] == expected_message
+
+
 def test_checkout_lines_update_checkout_with_voucher(
     user_api_client, checkout_with_item, voucher_percentage
 ):

--- a/saleor/graphql/checkout/tests/mutations/test_utils.py
+++ b/saleor/graphql/checkout/tests/mutations/test_utils.py
@@ -1,80 +1,178 @@
-import pytest
+import graphene
 
-from ...mutations.utils import (
-    CheckoutLineData,
-    group_quantity_and_custom_prices_by_variants,
-)
+from ...mutations.utils import CheckoutLineData, group_lines
 
 
-@pytest.mark.parametrize(
-    "lines, expected",
-    [
-        (
-            [
-                {"quantity": 6, "variant_id": "abc", "price": 1.22},
-                {"quantity": 6, "variant_id": "abc"},
-                {"quantity": 1, "variant_id": "def", "price": 33.2},
-                {"quantity": 1, "variant_id": "def", "price": 10},
-            ],
-            [
-                CheckoutLineData(
-                    quantity=12,
-                    quantity_to_update=True,
-                    custom_price=1.22,
-                    custom_price_to_update=True,
-                ),
-                CheckoutLineData(
-                    quantity=2,
-                    quantity_to_update=True,
-                    custom_price=10,
-                    custom_price_to_update=True,
-                ),
-            ],
+def test_group_when_same_variants_in_multiple_lines():
+    variant_1_id = graphene.Node.to_global_id("ProductVariant", 1)
+    variant_2_id = graphene.Node.to_global_id("ProductVariant", 2)
+    variant_3_id = graphene.Node.to_global_id("ProductVariant", 3)
+    variant_4_id = graphene.Node.to_global_id("ProductVariant", 4)
+    variant_5_id = graphene.Node.to_global_id("ProductVariant", 5)
+
+    lines_data = [
+        {"quantity": 8, "variant_id": variant_1_id},
+        {"quantity": 2, "variant_id": variant_1_id},
+        {"quantity": 6, "variant_id": variant_2_id},
+        {"quantity": 1, "variant_id": variant_3_id},
+        {"quantity": 6, "variant_id": variant_2_id},
+        {"quantity": 1, "variant_id": variant_3_id},
+        {"quantity": 8, "variant_id": variant_1_id},
+        {"quantity": 2, "variant_id": variant_1_id},
+        {"quantity": 922, "variant_id": variant_4_id},
+        {"quantity": 6, "variant_id": variant_2_id},
+        {"quantity": 1, "variant_id": variant_3_id},
+        {"quantity": 6, "variant_id": variant_2_id},
+        {"quantity": 1, "variant_id": variant_3_id},
+        {"quantity": 1000, "variant_id": variant_5_id},
+    ]
+
+    expected = [
+        CheckoutLineData(
+            variant_id=id + 1,
+            line_id=None,
+            quantity=quantity,
+            quantity_to_update=True,
+            custom_price=None,
+            custom_price_to_update=False,
+        )
+        for id, quantity in enumerate([20, 24, 4, 922, 1000])
+    ]
+
+    assert expected == group_lines(lines_data)
+
+
+def test_group_when_same_variants_in_multiple_lines_and_price_provided():
+    variant_1_id = graphene.Node.to_global_id("ProductVariant", 1)
+    variant_2_id = graphene.Node.to_global_id("ProductVariant", 2)
+
+    lines_data = [
+        {"quantity": 6, "variant_id": variant_1_id, "price": 1.22},
+        {"quantity": 6, "variant_id": variant_1_id},
+        {"quantity": 1, "variant_id": variant_2_id, "price": 33.2},
+        {"quantity": 1, "variant_id": variant_2_id, "price": 10},
+    ]
+
+    expected = [
+        CheckoutLineData(
+            variant_id=1,
+            line_id=None,
+            quantity=12,
+            quantity_to_update=True,
+            custom_price=1.22,
+            custom_price_to_update=True,
         ),
-        (
-            [
-                {"quantity": 8, "variant_id": "ghi"},
-                {"quantity": 2, "variant_id": "ghi"},
-                {"quantity": 6, "variant_id": "abc"},
-                {"quantity": 1, "variant_id": "def"},
-                {"quantity": 6, "variant_id": "abc"},
-                {"quantity": 1, "variant_id": "def"},
-                {"quantity": 8, "variant_id": "ghi"},
-                {"quantity": 2, "variant_id": "ghi"},
-                {"quantity": 922, "variant_id": "xyz"},
-                {"quantity": 6, "variant_id": "abc"},
-                {"quantity": 1, "variant_id": "def"},
-                {"quantity": 6, "variant_id": "abc"},
-                {"quantity": 1, "variant_id": "def"},
-                {"quantity": 1000, "variant_id": "jkl"},
-                {"quantity": 999, "variant_id": "zzz"},
-            ],
-            [
-                CheckoutLineData(
-                    quantity=quantity,
-                    quantity_to_update=True,
-                    custom_price=None,
-                    custom_price_to_update=False,
-                )
-                for quantity in [20, 24, 4, 922, 1000, 999]
-            ],
+        CheckoutLineData(
+            variant_id=2,
+            line_id=None,
+            quantity=2,
+            quantity_to_update=True,
+            custom_price=10,
+            custom_price_to_update=True,
         ),
-        (
-            [
-                {"quantity": 100, "variant_id": name}
-                for name in (l1 + l2 for l1 in "abcdef" for l2 in "ghijkl")
-            ],
-            [
-                CheckoutLineData(
-                    quantity=100,
-                    quantity_to_update=True,
-                    custom_price=None,
-                    custom_price_to_update=False,
-                )
-            ]
-            * 36,
+    ]
+
+    assert expected == group_lines(lines_data)
+
+
+def test_group_when_same_variants_in_multiple_lines_and_force_new_line():
+    variant_1_id = graphene.Node.to_global_id("ProductVariant", 1)
+    variant_2_id = graphene.Node.to_global_id("ProductVariant", 2)
+
+    lines_data = [
+        {"quantity": 6, "variant_id": variant_1_id, "price": 1.22},
+        {"quantity": 6, "variant_id": variant_1_id, "force_new_line": True},
+        {"quantity": 1, "variant_id": variant_2_id, "price": 33.2},
+        {"quantity": 1, "variant_id": variant_2_id, "price": 10},
+    ]
+
+    expected = [
+        CheckoutLineData(
+            variant_id=1,
+            line_id=None,
+            quantity=6,
+            quantity_to_update=True,
+            custom_price=1.22,
+            custom_price_to_update=True,
         ),
-    ],
-)
-def test_group_by_variants(lines, expected):
-    assert expected == group_quantity_and_custom_prices_by_variants(lines)
+        CheckoutLineData(
+            variant_id=2,
+            line_id=None,
+            quantity=2,
+            quantity_to_update=True,
+            custom_price=10,
+            custom_price_to_update=True,
+        ),
+        CheckoutLineData(
+            variant_id=1,
+            line_id=None,
+            quantity=6,
+            quantity_to_update=True,
+            custom_price=None,
+            custom_price_to_update=False,
+        ),
+    ]
+
+    assert expected == group_lines(lines_data)
+
+
+def test_group_when_line_id_as_parameter_provided():
+    line_1_id = graphene.Node.to_global_id("CheckoutLine", "abc")
+    line_2_id = graphene.Node.to_global_id("CheckoutLine", "qwe")
+
+    lines_data = [
+        {"quantity": 6, "line_id": line_1_id, "price": 1.22},
+        {"quantity": 1, "line_id": line_2_id, "price": 10},
+    ]
+
+    expected = [
+        CheckoutLineData(
+            variant_id=None,
+            line_id="abc",
+            quantity=6,
+            quantity_to_update=True,
+            custom_price=1.22,
+            custom_price_to_update=True,
+        ),
+        CheckoutLineData(
+            variant_id=None,
+            line_id="qwe",
+            quantity=1,
+            quantity_to_update=True,
+            custom_price=10,
+            custom_price_to_update=True,
+        ),
+    ]
+
+    assert expected == group_lines(lines_data)
+
+
+def test_group_when_mixed_parameters_provided():
+    variant_id = graphene.Node.to_global_id("ProductVariant", 1)
+    line_id = graphene.Node.to_global_id("CheckoutLine", "qwe")
+
+    lines_data = [
+        {"quantity": 6, "variant_id": variant_id, "price": 1.22},
+        {"quantity": 1, "line_id": line_id, "price": 10},
+    ]
+
+    expected = [
+        CheckoutLineData(
+            variant_id=1,
+            line_id=None,
+            quantity=6,
+            quantity_to_update=True,
+            custom_price=1.22,
+            custom_price_to_update=True,
+        ),
+        CheckoutLineData(
+            variant_id=None,
+            line_id="qwe",
+            quantity=1,
+            quantity_to_update=True,
+            custom_price=10,
+            custom_price_to_update=True,
+        ),
+    ]
+
+    assert expected == group_lines(lines_data)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -19370,7 +19370,6 @@ enum CheckoutErrorCode {
   UNAVAILABLE_VARIANT_IN_CHANNEL
   EMAIL_NOT_SET
   NO_LINES
-  WRONG_PARAMETER
 }
 
 """Update billing address in the existing checkout."""
@@ -19565,16 +19564,16 @@ type CheckoutLinesUpdate {
 
 input CheckoutLineUpdateInput {
   """
-  The number of items purchased. Optional for apps, required for any other users.
-  """
-  quantity: Int
-
-  """
   ID of the product variant. 
   
   DEPRECATED: this field will be removed in Saleor 4.0. Use `lineId` instead.
   """
   variantId: ID
+
+  """
+  The number of items purchased. Optional for apps, required for any other users.
+  """
+  quantity: Int
 
   """
   Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.
@@ -19585,7 +19584,11 @@ input CheckoutLineUpdateInput {
   """
   price: PositiveDecimal
 
-  """ID of the line."""
+  """
+  ID of the line.
+  
+  Added in Saleor 3.6.
+  """
   lineId: ID
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -19370,6 +19370,7 @@ enum CheckoutErrorCode {
   UNAVAILABLE_VARIANT_IN_CHANNEL
   EMAIL_NOT_SET
   NO_LINES
+  WRONG_PARAMETER
 }
 
 """Update billing address in the existing checkout."""
@@ -19474,6 +19475,15 @@ input CheckoutLineInput {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   price: PositiveDecimal
+
+  """
+  Flag that allow force splitting the same variant into multiple lines by skipping the matching logic. 
+  
+  Added in Saleor 3.6.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  forceNewLine: Boolean = false
 }
 
 input CheckoutValidationRules {
@@ -19559,8 +19569,12 @@ input CheckoutLineUpdateInput {
   """
   quantity: Int
 
-  """ID of the product variant."""
-  variantId: ID!
+  """
+  ID of the product variant. 
+  
+  DEPRECATED: this field will be removed in Saleor 4.0. Use `lineId` instead.
+  """
+  variantId: ID
 
   """
   Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.
@@ -19570,6 +19584,9 @@ input CheckoutLineUpdateInput {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   price: PositiveDecimal
+
+  """ID of the line."""
+  lineId: ID
 }
 
 """Remove a gift card or a voucher from a checkout."""

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -322,6 +322,16 @@ def checkout_with_item(checkout, product):
 
 
 @pytest.fixture
+def checkout_with_same_items_in_multiple_lines(checkout, product):
+    variant = product.variants.first()
+    checkout_info = fetch_checkout_info(checkout, [], [], get_plugins_manager())
+    add_variant_to_checkout(checkout_info, variant, 1)
+    add_variant_to_checkout(checkout_info, variant, 1, force_new_line=True)
+    checkout.save()
+    return checkout
+
+
+@pytest.fixture
 def checkout_with_item_and_voucher_specific_products(
     checkout_with_item, voucher_specific_product_type
 ):


### PR DESCRIPTION
I want to merge this change because it adds the possibility to force a new line in checkout and use `lineId` to update lines.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
