### PR TITLE
Use Django way of resolution for settings module

### DIFF
--- a/saleor/core/tasks.py
+++ b/saleor/core/tasks.py
@@ -1,11 +1,11 @@
 from botocore.exceptions import ClientError
+from django.conf import settings
 from django.core.files.storage import default_storage
 from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
 
 from ..celeryconf import app
 from ..product.models import ProductMedia
-from ..settings import EVENT_PAYLOAD_DELETE_PERIOD
 from ..thumbnail.models import Thumbnail
 from .models import EventDelivery, EventDeliveryAttempt, EventPayload
 
@@ -17,7 +17,7 @@ def delete_from_storage_task(path):
 
 @app.task
 def delete_event_payloads_task():
-    delete_period = timezone.now() - EVENT_PAYLOAD_DELETE_PERIOD
+    delete_period = timezone.now() - settings.EVENT_PAYLOAD_DELETE_PERIOD
     deliveries = EventDelivery.objects.filter(created_at__lte=delete_period)
     attempts = EventDeliveryAttempt.objects.filter(
         Q(Exists(deliveries.filter(id=OuterRef("delivery_id"))))

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -17,7 +17,6 @@ from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
 from ....giftcard.utils import assign_user_gift_cards
 from ....order.utils import match_orders_with_new_user
-from ....settings import JWT_TTL_REQUEST_EMAIL_CHANGE
 from ...channel.utils import clean_channel
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
@@ -477,7 +476,7 @@ class RequestEmailChange(BaseMutation):
             "new_email": new_email,
             "user_pk": user.pk,
         }
-        token = create_token(token_payload, JWT_TTL_REQUEST_EMAIL_CHANGE)
+        token = create_token(token_payload, settings.JWT_TTL_REQUEST_EMAIL_CHANGE)
         notifications.send_request_user_change_email_notification(
             redirect_url,
             user,

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -25,7 +25,6 @@ from ...graphql.webhook.subscription_payload import (
     initialize_request,
 )
 from ...payment import PaymentError
-from ...settings import WEBHOOK_SYNC_TIMEOUT, WEBHOOK_TIMEOUT
 from ...site.models import Site
 from ...webhook import observability
 from ...webhook.event_types import SUBSCRIBABLE_EVENTS, WebhookEventAsyncType
@@ -181,7 +180,7 @@ def trigger_webhook_sync(
 
 
 def send_webhook_using_http(
-    target_url, message, domain, signature, event_type, timeout=WEBHOOK_TIMEOUT
+    target_url, message, domain, signature, event_type, timeout=settings.WEBHOOK_TIMEOUT
 ):
     """Send a webhook request using http / https protocol.
 
@@ -409,7 +408,7 @@ def send_webhook_request_async(self, event_delivery_id):
 
 
 def send_webhook_request_sync(
-    app_name, delivery, timeout=WEBHOOK_SYNC_TIMEOUT
+    app_name, delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT
 ) -> Optional[Dict[Any, Any]]:
     event_payload = delivery.payload
     data = event_payload.payload


### PR DESCRIPTION
I want to merge this change because I believe we should use Django way of resolution for settings module

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
