### PR TITLE
Fix create_fake_user ID generation

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.core.files import File
+from django.db import connection
 from django.db.models import F
 from django.utils import timezone
 from django.utils.text import slugify
@@ -537,8 +538,11 @@ def create_fake_user(user_password, save=True):
     except User.DoesNotExist:
         pass
 
+    _, max_user_id = connection.ops.integer_field_range(
+        User.id.field.get_internal_type()
+    )
     user = User(
-        id=fake.numerify(),
+        id=fake.random_int(min=1, max=max_user_id),
         first_name=address.first_name,
         last_name=address.last_name,
         email=email,


### PR DESCRIPTION
I want to merge this change because User ID collisions in `create_fake_user` are causing `test_create_fake_users` to fail intermittently in our project. This change reduces the likelihood of collisions occurring.

[Faker's `numerify`](https://faker.readthedocs.io/en/master/providers/baseprovider.html#faker.providers.BaseProvider.numerify) is currently used to set the User's `id` value, returning an integer between 0 and 999 (inclusive) when no `text` argument is provided. If this generates an *existing* user ID then Django updates the existing database record instead of inserting a new one, causing the test assertion to fail.

This isn't a problem when running Saleor's tests directly due to Faker being seeded with constant `0` but in our project we have opted to seed Faker with a different value for each test run, resulting in around 1% of test runs failing.

```
=================================== FAILURES ===================================
____________________________ test_create_fake_users ____________________________
[gw0] linux -- Python 3.9.9 /usr/local/bin/python

db = None

    def test_create_fake_users(db):
        how_many = 5
        for _ in random_data.create_users("password", how_many):
            pass
>       assert User.objects.all().count() == 5
E       assert 4 == 5
E        +  where 4 = <bound method QuerySet.count of <QuerySet [<User: elizabeth.richardson@example.com>, <User: mark.chavez@example.com>, <User: samuel.woods@example.com>, <User: stephanie.keith@example.com>]>>()
E        +    where <bound method QuerySet.count of <QuerySet [<User: elizabeth.richardson@example.com>, <User: mark.chavez@example.com>, <User: samuel.woods@example.com>, <User: stephanie.keith@example.com>]>> = <QuerySet [<User: elizabeth.richardson@example.com>, <User: mark.chavez@example.com>, <User: samuel.woods@example.com>, <User: stephanie.keith@example.com>]>.count
E        +      where <QuerySet [<User: elizabeth.richardson@example.com>, <User: mark.chavez@example.com>, <User: samuel.woods@example.com>, <User: stephanie.keith@example.com>]> = <bound method BaseManager.all of <jr_api.models.UserManager object at 0x7fcada398f40>>()
E        +        where <bound method BaseManager.all of <jr_api.models.UserManager object at 0x7fcada398f40>> = <jr_api.models.UserManager object at 0x7fcada398f40>.all
E        +          where <jr_api.models.UserManager object at 0x7fcada398f40> = User.objects

saleor/core/tests/test_core.py:124: AssertionError
```

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
