### PR TITLE
Fix version of GraphQL Inspector action

### DIFF
--- a/.github/workflows/graphql-inspector.yml
+++ b/.github/workflows/graphql-inspector.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: kamilkisiela/graphql-inspector@v3
+      - uses: kamilkisiela/graphql-inspector@v3.3.0
         with:
           schema: "main:saleor/graphql/schema.graphql"


### PR DESCRIPTION
I somehow managed to break the version string in my previous PR

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
