### PR TITLE
Remove hardcoded test server domain from tests

### DIFF
--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -35,6 +35,7 @@ from ....core.utils.url import prepare_url
 from ....order import OrderStatus
 from ....order.models import FulfillmentStatus, Order
 from ....product.tests.utils import create_image
+from ....tests.consts import TEST_SERVER_DOMAIN
 from ....thumbnail.models import Thumbnail
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.payloads import (
@@ -796,7 +797,7 @@ def test_query_user_avatar_with_size_and_format_proxy_url_returned(
     data = content["data"]["user"]
     assert (
         data["avatar"]["url"]
-        == f"http://testserver/thumbnail/{id}/128/{format.lower()}/"
+        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{id}/128/{format.lower()}/"
     )
 
 
@@ -821,7 +822,7 @@ def test_query_user_avatar_with_size_proxy_url_returned(
     # then
     content = get_graphql_content(response)
     data = content["data"]["user"]
-    assert data["avatar"]["url"] == f"http://testserver/thumbnail/{id}/128/"
+    assert data["avatar"]["url"] == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{id}/128/"
 
 
 def test_query_user_avatar_with_size_thumbnail_url_returned(
@@ -851,7 +852,7 @@ def test_query_user_avatar_with_size_thumbnail_url_returned(
     data = content["data"]["user"]
     assert (
         data["avatar"]["url"]
-        == f"http://testserver/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
@@ -880,7 +881,7 @@ def test_query_user_avatar_only_format_provided_original_image_returned(
     data = content["data"]["user"]
     assert (
         data["avatar"]["url"]
-        == f"http://testserver/media/user-avatars/{avatar_mock.name}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/user-avatars/{avatar_mock.name}"
     )
 
 
@@ -907,7 +908,7 @@ def test_query_user_avatar_no_size_value(
     data = content["data"]["user"]
     assert (
         data["avatar"]["url"]
-        == f"http://testserver/media/user-avatars/{avatar_mock.name}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/user-avatars/{avatar_mock.name}"
     )
 
 
@@ -5377,7 +5378,7 @@ def test_user_avatar_update_mutation(monkeypatch, staff_api_client, media_root):
 
     assert user.avatar
     assert data["user"]["avatar"]["url"].startswith(
-        "http://testserver/media/user-avatars/avatar"
+        f"http://{TEST_SERVER_DOMAIN}/media/user-avatars/avatar"
     )
     img_name, format = os.path.splitext(image_file._name)
     file_name = user.avatar.name
@@ -5415,7 +5416,7 @@ def test_user_avatar_update_mutation_image_exists(staff_api_client, media_root):
 
     assert user.avatar != avatar_mock
     assert data["user"]["avatar"]["url"].startswith(
-        "http://testserver/media/user-avatars/new_image"
+        f"http://{TEST_SERVER_DOMAIN}/media/user-avatars/new_image"
     )
     assert not user.thumbnails.exists()
 

--- a/saleor/graphql/core/tests/test_file_upload.py
+++ b/saleor/graphql/core/tests/test_file_upload.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 from django.core.files.storage import default_storage
 
 from ....product.tests.utils import create_image
+from ....tests.consts import TEST_SERVER_DOMAIN
 from ...tests.utils import (
     assert_no_permission,
     get_graphql_content,
@@ -149,6 +150,8 @@ def test_file_upload_file_with_the_same_name_already_exists(
     assert not errors
     assert data["uploadedFile"]["contentType"] == "image/png"
     file_url = data["uploadedFile"]["url"]
-    assert file_url != "http://testserver/media/" + image_file._name
-    assert file_url != "http://testserver/media/" + path
-    assert default_storage.exists(file_url.replace("http://testserver/media/", ""))
+    assert file_url != f"http://{TEST_SERVER_DOMAIN}/media/{image_file._name}"
+    assert file_url != f"http://{TEST_SERVER_DOMAIN}/media/{path}"
+    assert default_storage.exists(
+        file_url.replace(f"http://{TEST_SERVER_DOMAIN}/media/", "")
+    )

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -44,6 +44,7 @@ from ....plugins.base_plugin import ExcludedShippingMethod
 from ....plugins.manager import PluginsManager, get_plugins_manager
 from ....product.models import ProductVariant, ProductVariantChannelListing
 from ....shipping.models import ShippingMethod, ShippingMethodChannelListing
+from ....tests.consts import TEST_SERVER_DOMAIN
 from ....thumbnail.models import Thumbnail
 from ....warehouse.models import Allocation, PreorderAllocation, Stock, Warehouse
 from ....warehouse.tests.utils import get_available_quantity_for_stock
@@ -1360,7 +1361,7 @@ def test_order_query_product_image_size_and_format_given_proxy_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://testserver/thumbnail/{media_id}/128/{format.lower()}/"
+        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{media_id}/128/{format.lower()}/"
     )
 
 
@@ -1389,7 +1390,7 @@ def test_order_query_product_image_size_given_proxy_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://testserver/thumbnail/{media_id}/128/"
+        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{media_id}/128/"
     )
 
 
@@ -1422,7 +1423,7 @@ def test_order_query_product_image_size_given_thumbnail_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://testserver/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
@@ -1453,7 +1454,7 @@ def test_order_query_variant_image_size_and_format_given_proxy_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://testserver/thumbnail/{media_id}/128/{format.lower()}/"
+        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{media_id}/128/{format.lower()}/"
     )
 
 
@@ -1482,7 +1483,7 @@ def test_order_query_variant_image_size_given_proxy_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://testserver/thumbnail/{media_id}/128/"
+        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{media_id}/128/"
     )
 
 
@@ -1515,7 +1516,7 @@ def test_order_query_variant_image_size_given_thumbnail_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://testserver/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 

--- a/saleor/graphql/page/tests/mutations/test_page_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_create.py
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 
 from .....page.error_codes import PageErrorCode
 from .....page.models import Page, PageType
+from .....tests.consts import TEST_SERVER_DOMAIN
 from .....tests.utils import dummy_editorjs
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_page_payload
@@ -409,7 +410,7 @@ def test_create_page_with_file_attribute(
                 "slug": f"{attr_value.slug}-2",
                 "name": attr_value.name,
                 "file": {
-                    "url": f"http://testserver/media/{attr_value.file_url}",
+                    "url": f"http://{TEST_SERVER_DOMAIN}/media/{attr_value.file_url}",
                     "contentType": None,
                 },
                 "reference": None,
@@ -488,7 +489,7 @@ def test_create_page_with_file_attribute_new_attribute_value(
                 "reference": None,
                 "name": new_value,
                 "file": {
-                    "url": "http://testserver/media/" + new_value,
+                    "url": f"http://{TEST_SERVER_DOMAIN}/media/" + new_value,
                     "contentType": new_value_content_type,
                 },
                 "plainText": None,

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -13,6 +13,7 @@ from .....attribute.models import AttributeValue
 from .....attribute.utils import associate_attribute_values_to_instance
 from .....page.error_codes import PageErrorCode
 from .....page.models import Page
+from .....tests.consts import TEST_SERVER_DOMAIN
 from .....tests.utils import dummy_editorjs
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_page_payload
@@ -286,7 +287,7 @@ def test_update_page_with_file_attribute_value(
                 "plainText": None,
                 "reference": None,
                 "file": {
-                    "url": "http://testserver/media/" + new_value,
+                    "url": f"http://{TEST_SERVER_DOMAIN}/media/" + new_value,
                     "contentType": None,
                 },
             }
@@ -340,7 +341,9 @@ def test_update_page_with_file_attribute_new_value_is_not_created(
                 "plainText": None,
                 "reference": None,
                 "file": {
-                    "url": f"http://testserver/media/{existing_value.file_url}",
+                    "url": (
+                        f"http://{TEST_SERVER_DOMAIN}/media/{existing_value.file_url}"
+                    ),
                     "contentType": existing_value.content_type,
                 },
             }

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -12,6 +12,7 @@ from graphql_relay import to_global_id
 from ....product.error_codes import ProductErrorCode
 from ....product.models import Category, Product, ProductChannelListing
 from ....product.tests.utils import create_image, create_pdf_file_with_image_ext
+from ....tests.consts import TEST_SERVER_DOMAIN
 from ....tests.utils import dummy_editorjs
 from ....thumbnail.models import Thumbnail
 from ....webhook.event_types import WebhookEventAsyncType
@@ -759,7 +760,7 @@ def test_category_update_background_image_mutation(
     assert category.background_image.file
     assert data["category"]["backgroundImage"]["alt"] == image_alt
     assert data["category"]["backgroundImage"]["url"].startswith(
-        f"http://testserver/media/category-backgrounds/{image_name}"
+        f"http://{TEST_SERVER_DOMAIN}/media/category-backgrounds/{image_name}"
     )
 
     # ensure that thumbnails for old background image has been deleted
@@ -1298,7 +1299,7 @@ def test_category_image_query_with_size_and_format_proxy_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://testserver/thumbnail/{category_id}/128/{format.lower()}/"
+        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{category_id}/128/{format.lower()}/"
     )
 
 
@@ -1331,7 +1332,7 @@ def test_category_image_query_with_size_proxy_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://testserver/thumbnail/{category_id}/{size}/"
+        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{category_id}/{size}/"
     )
 
 
@@ -1368,7 +1369,7 @@ def test_category_image_query_with_size_thumbnail_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://testserver/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
@@ -1400,10 +1401,10 @@ def test_category_image_query_only_format_provided_original_image_returned(
 
     data = content["data"]["category"]
     assert data["backgroundImage"]["alt"] == alt_text
-    assert (
-        data["backgroundImage"]["url"]
-        == f"http://testserver/media/category-backgrounds/{background_mock.name}"
+    expected_url = (
+        f"http://{TEST_SERVER_DOMAIN}/media/category-backgrounds/{background_mock.name}"
     )
+    assert data["backgroundImage"]["url"] == expected_url
 
 
 def test_category_image_query_no_size_value_original_image_returned(
@@ -1431,10 +1432,10 @@ def test_category_image_query_no_size_value_original_image_returned(
 
     data = content["data"]["category"]
     assert data["backgroundImage"]["alt"] == alt_text
-    assert (
-        data["backgroundImage"]["url"]
-        == f"http://testserver/media/category-backgrounds/{background_mock.name}"
+    expected_url = (
+        f"http://{TEST_SERVER_DOMAIN}/media/category-backgrounds/{background_mock.name}"
     )
+    assert data["backgroundImage"]["url"] == expected_url
 
 
 def test_category_image_query_without_associated_file(

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -9,6 +9,7 @@ from graphql_relay import to_global_id
 from ....product.error_codes import CollectionErrorCode, ProductErrorCode
 from ....product.models import Collection, Product
 from ....product.tests.utils import create_image, create_pdf_file_with_image_ext
+from ....tests.consts import TEST_SERVER_DOMAIN
 from ....tests.utils import dummy_editorjs
 from ....thumbnail.models import Thumbnail
 from ...core.enums import ThumbnailFormatEnum
@@ -725,7 +726,7 @@ def test_update_collection_with_background_image(
     collection = Collection.objects.get(slug=slug)
     assert data["collection"]["backgroundImage"]["alt"] == image_alt
     assert data["collection"]["backgroundImage"]["url"].startswith(
-        f"http://testserver/media/collection-backgrounds/{image_name}"
+        f"http://{TEST_SERVER_DOMAIN}/media/collection-backgrounds/{image_name}"
     )
 
     # ensure that thumbnails for old background image has been deleted
@@ -1272,10 +1273,10 @@ def test_collection_image_query_with_size_and_format_proxy_url_returned(
 
     data = content["data"]["collection"]
     assert data["backgroundImage"]["alt"] == alt_text
-    assert (
-        data["backgroundImage"]["url"]
-        == f"http://testserver/thumbnail/{collection_id}/128/{format.lower()}/"
+    expected_url = (
+        f"http://{TEST_SERVER_DOMAIN}/thumbnail/{collection_id}/128/{format.lower()}/"
     )
+    assert data["backgroundImage"]["url"] == expected_url
 
 
 def test_collection_image_query_with_size_proxy_url_returned(
@@ -1308,7 +1309,7 @@ def test_collection_image_query_with_size_proxy_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://testserver/thumbnail/{collection_id}/{size}/"
+        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{collection_id}/{size}/"
     )
 
 
@@ -1346,7 +1347,7 @@ def test_collection_image_query_with_size_thumbnail_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://testserver/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
@@ -1379,10 +1380,11 @@ def test_collection_image_query_only_format_provided_original_image_returned(
 
     data = content["data"]["collection"]
     assert data["backgroundImage"]["alt"] == alt_text
-    assert (
-        data["backgroundImage"]["url"]
-        == f"http://testserver/media/collection-backgrounds/{background_mock.name}"
+    expected_url = (
+        f"http://{TEST_SERVER_DOMAIN}"
+        f"/media/collection-backgrounds/{background_mock.name}"
     )
+    assert data["backgroundImage"]["url"] == expected_url
 
 
 def test_collection_image_query_no_size_value_original_image_returned(
@@ -1411,10 +1413,11 @@ def test_collection_image_query_no_size_value_original_image_returned(
 
     data = content["data"]["collection"]
     assert data["backgroundImage"]["alt"] == alt_text
-    assert (
-        data["backgroundImage"]["url"]
-        == f"http://testserver/media/collection-backgrounds/{background_mock.name}"
+    expected_url = (
+        f"http://{TEST_SERVER_DOMAIN}"
+        f"/media/collection-backgrounds/{background_mock.name}"
     )
+    assert data["backgroundImage"]["url"] == expected_url
 
 
 def test_collection_image_query_without_associated_file(

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -48,6 +48,7 @@ from ....product.tasks import update_variants_names
 from ....product.tests.utils import create_image, create_pdf_file_with_image_ext
 from ....product.utils.availability import get_variant_availability
 from ....product.utils.costs import get_product_costs_data
+from ....tests.consts import TEST_SERVER_DOMAIN
 from ....tests.utils import dummy_editorjs, flush_post_commit_hooks
 from ....thumbnail.models import Thumbnail
 from ....warehouse.models import Allocation, Stock, Warehouse
@@ -690,10 +691,11 @@ def test_query_product_thumbnail_with_size_and_format_proxy_url_returned(
     product_media_id = graphene.Node.to_global_id(
         "ProductMedia", product_with_image.media.first().pk
     )
-    assert (
-        data["thumbnail"]["url"]
-        == f"http://testserver/thumbnail/{product_media_id}/128/{format.lower()}/"
+    expected_url = (
+        f"http://{TEST_SERVER_DOMAIN}"
+        f"/thumbnail/{product_media_id}/128/{format.lower()}/"
     )
+    assert data["thumbnail"]["url"] == expected_url
 
 
 def test_query_product_thumbnail_with_size_and_proxy_url_returned(
@@ -718,7 +720,7 @@ def test_query_product_thumbnail_with_size_and_proxy_url_returned(
     )
     assert (
         data["thumbnail"]["url"]
-        == f"http://testserver/thumbnail/{product_media_id}/128/"
+        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{product_media_id}/128/"
     )
 
 
@@ -749,7 +751,7 @@ def test_query_product_thumbnail_with_size_and_thumbnail_url_returned(
     data = content["data"]["product"]
     assert (
         data["thumbnail"]["url"]
-        == f"http://testserver/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
@@ -775,10 +777,11 @@ def test_query_product_thumbnail_only_format_provided_default_size_is_used(
     product_media_id = graphene.Node.to_global_id(
         "ProductMedia", product_with_image.media.first().pk
     )
-    assert (
-        data["thumbnail"]["url"]
-        == f"http://testserver/thumbnail/{product_media_id}/256/{format.lower()}/"
+    expected_url = (
+        f"http://{TEST_SERVER_DOMAIN}"
+        f"/thumbnail/{product_media_id}/256/{format.lower()}/"
     )
+    assert data["thumbnail"]["url"] == expected_url
 
 
 def test_query_product_thumbnail_no_product_media(
@@ -3881,7 +3884,7 @@ def test_query_product_media_by_id_with_size_and_format_proxy_url_returned(
     assert content["data"]["product"]["mediaById"]["id"]
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://testserver/thumbnail/{media_id}/128/{format.lower()}/"
+        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{media_id}/128/{format.lower()}/"
     )
 
 
@@ -3906,7 +3909,7 @@ def test_query_product_media_by_id_with_size_proxy_url_returned(
     assert content["data"]["product"]["mediaById"]["id"]
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://testserver/thumbnail/{media_id}/128/"
+        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{media_id}/128/"
     )
 
 
@@ -3936,7 +3939,7 @@ def test_query_product_media_by_id_with_size_thumbnail_url_returned(
     assert content["data"]["product"]["mediaById"]["id"]
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://testserver/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
@@ -3962,7 +3965,7 @@ def test_query_product_media_by_id_only_format_provided_original_image_returned(
     assert content["data"]["product"]["mediaById"]["id"]
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://testserver/media/{media.image.name}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/{media.image.name}"
     )
 
 
@@ -3986,7 +3989,7 @@ def test_query_product_media_by_id_no_size_value_original_image_returned(
     assert content["data"]["product"]["mediaById"]["id"]
     assert (
         content["data"]["product"]["mediaById"]["url"]
-        == f"http://testserver/media/{media.image.name}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/{media.image.name}"
     )
 
 
@@ -5524,6 +5527,7 @@ def test_create_product_with_file_attribute(
     assert data["product"]["productType"]["name"] == product_type.name
     assert data["product"]["category"]["name"] == category.name
     assert len(data["product"]["attributes"]) == 2
+    expected_url = f"http://{TEST_SERVER_DOMAIN}/media/{existing_value.file_url}"
     expected_attributes_data = [
         {"attribute": {"slug": color_attribute.slug}, "values": []},
         {
@@ -5533,7 +5537,7 @@ def test_create_product_with_file_attribute(
                     "name": existing_value.name,
                     "slug": f"{existing_value.slug}-2",
                     "file": {
-                        "url": f"http://testserver/media/{existing_value.file_url}",
+                        "url": expected_url,
                         "contentType": None,
                     },
                     "reference": None,
@@ -5888,7 +5892,8 @@ def test_create_product_with_file_attribute_new_attribute_value(
                     "date": None,
                     "dateTime": None,
                     "file": {
-                        "url": "http://testserver/media/" + non_existing_value,
+                        "url": f"http://{TEST_SERVER_DOMAIN}/media/"
+                        + non_existing_value,
                         "contentType": None,
                     },
                 }
@@ -7339,7 +7344,7 @@ def test_update_product_with_file_attribute_value(
                 "slug": slugify(new_value),
                 "reference": None,
                 "file": {
-                    "url": "http://testserver/media/" + new_value,
+                    "url": f"http://{TEST_SERVER_DOMAIN}/media/{new_value}",
                     "contentType": None,
                 },
                 "boolean": None,
@@ -7402,7 +7407,9 @@ def test_update_product_with_file_attribute_value_new_value_is_not_created(
                 "slug": existing_value.slug,
                 "reference": None,
                 "file": {
-                    "url": f"http://testserver/media/{existing_value.file_url}",
+                    "url": (
+                        f"http://{TEST_SERVER_DOMAIN}/media/{existing_value.file_url}"
+                    ),
                     "contentType": existing_value.content_type,
                 },
                 "boolean": None,
@@ -12369,7 +12376,7 @@ def test_query_product_media_for_federation(
         {
             "__typename": "ProductMedia",
             "id": media_id,
-            "url": "http://testserver/media/products/product.jpg",
+            "url": f"http://{TEST_SERVER_DOMAIN}/media/products/product.jpg",
         }
     ]
 

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -20,6 +20,7 @@ from ....order import OrderEvents, OrderStatus
 from ....order.models import OrderEvent, OrderLine
 from ....product.error_codes import ProductErrorCode
 from ....product.models import Product, ProductChannelListing, ProductVariant
+from ....tests.consts import TEST_SERVER_DOMAIN
 from ....tests.utils import dummy_editorjs, flush_post_commit_hooks
 from ....warehouse.error_codes import StockErrorCode
 from ....warehouse.models import Allocation, Stock, Warehouse
@@ -3135,7 +3136,7 @@ def test_update_product_variant_with_file_attribute_new_value_is_not_created(
     assert value_data["name"] == existing_value.name
     assert (
         value_data["file"]["url"]
-        == f"http://testserver/media/{existing_value.file_url}"
+        == f"http://{TEST_SERVER_DOMAIN}/media/{existing_value.file_url}"
     )
     assert value_data["file"]["contentType"] == existing_value.content_type
 

--- a/saleor/tests/consts.py
+++ b/saleor/tests/consts.py
@@ -1,0 +1,1 @@
+TEST_SERVER_DOMAIN = "testserver"

--- a/saleor/webhook/observability/tests/test_payloads.py
+++ b/saleor/webhook/observability/tests/test_payloads.py
@@ -9,6 +9,7 @@ from django.http import JsonResponse
 from django.utils import timezone
 
 from ....core import EventDeliveryStatus
+from ....tests.consts import TEST_SERVER_DOMAIN
 from ....webhook.event_types import WebhookEventAsyncType
 from ..exceptions import TruncationError
 from ..obfuscation import MASK
@@ -253,7 +254,7 @@ def test_generate_api_call_payload(app, rf, gql_operation_factory):
         request=ApiCallRequest(
             id=request_id,
             method="POST",
-            url="http://testserver/graphql",
+            url=f"http://{TEST_SERVER_DOMAIN}/graphql",
             time=request.request_time.timestamp(),
             content_length=19,
             headers=[


### PR DESCRIPTION
Those hard-coded domains in tests are making it difficult to work on test clients that do not use the `testserver` domain. Having it as a constant makes it easy to override.



<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
