### PR TITLE
New events related to permission groups changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Saleor Apps
 
 - Add support for the CUSTOMER_* app mount points (#10163) by @krzysztofwolski
+- Add permission group webhooks: `PERMISSION_GROUP_CREATED`, `PERMISSION_GROUP_UPDATED`, `PERMISSION_GROUP_DELETED` - #10214 by @SzymJ
 
 ### Breaking changes
 - Drop django-versatileimagefield package; add a proxy view to generate thumbnails on-demand - #9988 by @IKarbowiak

--- a/saleor/graphql/account/mutations/permission_group.py
+++ b/saleor/graphql/account/mutations/permission_group.py
@@ -73,6 +73,10 @@ class PermissionGroupCreate(ModelMutation):
             instance.user_set.add(*users)
 
     @classmethod
+    def post_save_action(cls, info, instance, cleaned_input):
+        info.context.plugins.permission_group_created(instance)
+
+    @classmethod
     def clean_input(cls, info, instance, data):
         cleaned_input = super().clean_input(info, instance, data)
 
@@ -216,6 +220,10 @@ class PermissionGroupUpdate(PermissionGroupCreate):
         remove_permissions = cleaned_data.get("remove_permissions")
         if remove_permissions:
             instance.permissions.remove(*remove_permissions)
+
+    @classmethod
+    def post_save_action(cls, info, instance, cleaned_input):
+        info.context.plugins.permission_group_updated(instance)
 
     @classmethod
     def clean_input(
@@ -429,6 +437,10 @@ class PermissionGroupDelete(ModelDeleteMutation):
         permissions = (AccountPermissions.MANAGE_STAFF,)
         error_type_class = PermissionGroupError
         error_type_field = "permission_group_errors"
+
+    @classmethod
+    def post_save_action(cls, info, instance, cleaned_input):
+        info.context.plugins.permission_group_deleted(instance)
 
     @classmethod
     def clean_instance(cls, info, instance):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1546,6 +1546,15 @@ enum WebhookEventTypeEnum {
   """A page type is deleted."""
   PAGE_TYPE_DELETED
 
+  """A new permission group is created."""
+  PERMISSION_GROUP_CREATED
+
+  """A permission group is updated."""
+  PERMISSION_GROUP_UPDATED
+
+  """A permission group is deleted."""
+  PERMISSION_GROUP_DELETED
+
   """A new shipping price is created."""
   SHIPPING_PRICE_CREATED
 
@@ -1841,6 +1850,15 @@ enum WebhookEventTypeAsyncEnum {
 
   """A page type is deleted."""
   PAGE_TYPE_DELETED
+
+  """A new permission group is created."""
+  PERMISSION_GROUP_CREATED
+
+  """A permission group is updated."""
+  PERMISSION_GROUP_UPDATED
+
+  """A permission group is deleted."""
+  PERMISSION_GROUP_DELETED
 
   """A new shipping price is created."""
   SHIPPING_PRICE_CREATED
@@ -2434,6 +2452,9 @@ enum WebhookSampleEventTypeEnum {
   PAGE_TYPE_CREATED
   PAGE_TYPE_UPDATED
   PAGE_TYPE_DELETED
+  PERMISSION_GROUP_CREATED
+  PERMISSION_GROUP_UPDATED
+  PERMISSION_GROUP_DELETED
   SHIPPING_PRICE_CREATED
   SHIPPING_PRICE_UPDATED
   SHIPPING_PRICE_DELETED
@@ -22832,6 +22853,75 @@ type PageTypeDeleted implements Event {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   pageType: PageType
+}
+
+type PermissionGroupCreated implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """
+  The permission group the event relates to.
+  
+  Added in Saleor 3.5.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  permissionGroup: Group
+}
+
+type PermissionGroupUpdated implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """
+  The permission group the event relates to.
+  
+  Added in Saleor 3.5.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  permissionGroup: Group
+}
+
+type PermissionGroupDeleted implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """
+  The permission group the event relates to.
+  
+  Added in Saleor 3.5.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  permissionGroup: Group
 }
 
 type ShippingPriceCreated implements Event {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22871,7 +22871,7 @@ type PermissionGroupCreated implements Event {
   """
   The permission group the event relates to.
   
-  Added in Saleor 3.5.
+  Added in Saleor 3.6.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -22894,7 +22894,7 @@ type PermissionGroupUpdated implements Event {
   """
   The permission group the event relates to.
   
-  Added in Saleor 3.5.
+  Added in Saleor 3.6.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -22917,7 +22917,7 @@ type PermissionGroupDeleted implements Event {
   """
   The permission group the event relates to.
   
-  Added in Saleor 3.5.
+  Added in Saleor 3.6.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """

--- a/saleor/graphql/tests/queries/fragments.py
+++ b/saleor/graphql/tests/queries/fragments.py
@@ -321,6 +321,19 @@ fragment PageTypeDetails on PageType{
 """
 
 
+PERMISSION_GROUP_DETAILS = """
+fragment PermissionGroupDetails on Group{
+  name
+  permissions {
+    name
+  }
+  users {
+    email
+  }
+}
+"""
+
+
 SALE_DETAILS = """
 fragment SaleDetails on Sale {
   id

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -79,6 +79,11 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.PAGE_TYPE_CREATED: "A new page type is created.",
     WebhookEventAsyncType.PAGE_TYPE_UPDATED: "A page type is updated.",
     WebhookEventAsyncType.PAGE_TYPE_DELETED: "A page type is deleted.",
+    WebhookEventAsyncType.PERMISSION_GROUP_CREATED: (
+        "A new permission group is created."
+    ),
+    WebhookEventAsyncType.PERMISSION_GROUP_UPDATED: "A permission group is updated.",
+    WebhookEventAsyncType.PERMISSION_GROUP_DELETED: "A permission group is deleted.",
     WebhookEventAsyncType.PRODUCT_CREATED: "A new product is created.",
     WebhookEventAsyncType.PRODUCT_UPDATED: "A product is updated.",
     WebhookEventAsyncType.PRODUCT_DELETED: "A product is deleted.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -23,7 +23,13 @@ from ...webhook.event_types import WebhookEventAsyncType
 from ..account.types import User as UserType
 from ..app.types import App as AppType
 from ..channel import ChannelContext
-from ..core.descriptions import ADDED_IN_32, ADDED_IN_34, ADDED_IN_35, PREVIEW_FEATURE
+from ..core.descriptions import (
+    ADDED_IN_32,
+    ADDED_IN_34,
+    ADDED_IN_35,
+    ADDED_IN_36,
+    PREVIEW_FEATURE,
+)
 from ..core.scalars import PositiveDecimal
 from ..payment.enums import TransactionActionEnum
 from ..payment.types import TransactionItem
@@ -885,7 +891,7 @@ class PermissionGroupBase(AbstractType):
     permission_group = graphene.Field(
         "saleor.graphql.account.types.Group",
         description="The permission group the event relates to."
-        + ADDED_IN_35
+        + ADDED_IN_36
         + PREVIEW_FEATURE,
     )
 

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -143,6 +143,9 @@ class Event(graphene.Interface):
             WebhookEventAsyncType.PAGE_TYPE_CREATED: PageTypeCreated,
             WebhookEventAsyncType.PAGE_TYPE_UPDATED: PageTypeUpdated,
             WebhookEventAsyncType.PAGE_TYPE_DELETED: PageTypeDeleted,
+            WebhookEventAsyncType.PERMISSION_GROUP_CREATED: PermissionGroupCreated,
+            WebhookEventAsyncType.PERMISSION_GROUP_UPDATED: PermissionGroupUpdated,
+            WebhookEventAsyncType.PERMISSION_GROUP_DELETED: PermissionGroupDeleted,
             WebhookEventAsyncType.SHIPPING_PRICE_CREATED: ShippingPriceCreated,
             WebhookEventAsyncType.SHIPPING_PRICE_UPDATED: ShippingPriceUpdated,
             WebhookEventAsyncType.SHIPPING_PRICE_DELETED: ShippingPriceDeleted,
@@ -878,6 +881,35 @@ class PageTypeDeleted(ObjectType, PageTypeBase):
         interfaces = (Event,)
 
 
+class PermissionGroupBase(AbstractType):
+    permission_group = graphene.Field(
+        "saleor.graphql.account.types.Group",
+        description="The permission group the event relates to."
+        + ADDED_IN_35
+        + PREVIEW_FEATURE,
+    )
+
+    @staticmethod
+    def resolve_permission_group(root, _info):
+        _, permission_group = root
+        return permission_group
+
+
+class PermissionGroupCreated(ObjectType, PermissionGroupBase):
+    class Meta:
+        interfaces = (Event,)
+
+
+class PermissionGroupUpdated(ObjectType, PermissionGroupBase):
+    class Meta:
+        interfaces = (Event,)
+
+
+class PermissionGroupDeleted(ObjectType, PermissionGroupBase):
+    class Meta:
+        interfaces = (Event,)
+
+
 class ShippingPriceBase(AbstractType):
     shipping_method = graphene.Field(
         "saleor.graphql.shipping.types.ShippingMethodType",
@@ -1195,6 +1227,9 @@ SUBSCRIPTION_EVENTS_TYPES = [
     PageTypeCreated,
     PageTypeUpdated,
     PageTypeDeleted,
+    PermissionGroupCreated,
+    PermissionGroupUpdated,
+    PermissionGroupDeleted,
     ShippingPriceCreated,
     ShippingPriceUpdated,
     ShippingPriceDeleted,

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -38,7 +38,7 @@ from .models import PluginConfiguration
 
 if TYPE_CHECKING:
     # flake8: noqa
-    from ..account.models import Address, User
+    from ..account.models import Address, Group, User
     from ..app.models import App
     from ..attribute.models import Attribute, AttributeValue
     from ..channel.models import Channel
@@ -698,6 +698,24 @@ class BasePlugin:
     #  Overwrite this method if you need to trigger specific logic when a page type is
     #  updated.
     page_type_updated: Callable[["PageType", Any], Any]
+
+    #  Trigger when permission group is created.
+    #
+    #  Overwrite this method if you need to trigger specific logic when a permission
+    #  group is created.
+    permission_group_created: Callable[["Group", Any], Any]
+
+    #  Trigger when permission group type is deleted.
+    #
+    #  Overwrite this method if you need to trigger specific logic when a permission
+    #  group is deleted.
+    permission_group_deleted: Callable[["Group", Any], Any]
+
+    #  Trigger when permission group is updated.
+    #
+    #  Overwrite this method if you need to trigger specific logic when a permission
+    #  group is updated.
+    permission_group_updated: Callable[["Group", Any], Any]
 
     #  Trigger directly before order creation.
     #

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -38,7 +38,7 @@ from .models import PluginConfiguration
 
 if TYPE_CHECKING:
     # flake8: noqa
-    from ..account.models import Address, User
+    from ..account.models import Address, Group, User
     from ..app.models import App
     from ..attribute.models import Attribute, AttributeValue
     from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
@@ -833,6 +833,24 @@ class PluginsManager(PaymentInterface):
         default_value = None
         return self.__run_method_on_plugins(
             "page_type_deleted", default_value, page_type
+        )
+
+    def permission_group_created(self, group: "Group"):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "permission_group_created", default_value, group
+        )
+
+    def permission_group_updated(self, group: "Group"):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "permission_group_updated", default_value, group
+        )
+
+    def permission_group_deleted(self, group: "Group"):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "permission_group_deleted", default_value, group
         )
 
     def transaction_action_request(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -51,7 +51,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from ...account.models import Address, User
+    from ...account.models import Address, Group, User
     from ...attribute.models import Attribute, AttributeValue
     from ...channel.models import Channel
     from ...checkout.models import Checkout
@@ -877,6 +877,35 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         self._trigger_page_type_event(
             WebhookEventAsyncType.PAGE_TYPE_DELETED, page_type
+        )
+
+    def _trigger_permission_group_event(self, event_type, group):
+        if webhooks := get_webhooks_for_event(event_type):
+            payload = {
+                "id": graphene.Node.to_global_id("Group", group.id),
+                "meta": self._generate_meta(),
+            }
+            trigger_webhooks_async(payload, event_type, webhooks, group, self.requestor)
+
+    def permission_group_created(self, group: "Group", previous_value: Any) -> Any:
+        if not self.active:
+            return previous_value
+        self._trigger_permission_group_event(
+            WebhookEventAsyncType.PERMISSION_GROUP_CREATED, group
+        )
+
+    def permission_group_updated(self, group: "Group", previous_value: Any) -> Any:
+        if not self.active:
+            return previous_value
+        self._trigger_permission_group_event(
+            WebhookEventAsyncType.PERMISSION_GROUP_UPDATED, group
+        )
+
+    def permission_group_deleted(self, group: "Group", previous_value: Any) -> Any:
+        if not self.active:
+            return previous_value
+        self._trigger_permission_group_event(
+            WebhookEventAsyncType.PERMISSION_GROUP_DELETED, group
         )
 
     def _trigger_shipping_price_event(self, event_type, shipping_method):

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -580,6 +580,30 @@ def subscription_page_type_deleted_webhook(subscription_webhook):
 
 
 @pytest.fixture
+def subscription_permission_group_created_webhook(subscription_webhook):
+    return subscription_webhook(
+        subscription_queries.PERMISSION_GROUP_CREATED,
+        WebhookEventAsyncType.PERMISSION_GROUP_CREATED,
+    )
+
+
+@pytest.fixture
+def subscription_permission_group_updated_webhook(subscription_webhook):
+    return subscription_webhook(
+        subscription_queries.PERMISSION_GROUP_UPDATED,
+        WebhookEventAsyncType.PERMISSION_GROUP_UPDATED,
+    )
+
+
+@pytest.fixture
+def subscription_permission_group_deleted_webhook(subscription_webhook):
+    return subscription_webhook(
+        subscription_queries.PERMISSION_GROUP_DELETED,
+        WebhookEventAsyncType.PERMISSION_GROUP_DELETED,
+    )
+
+
+@pytest.fixture
 def subscription_product_created_multiple_events_webhook(subscription_webhook):
     return subscription_webhook(
         subscription_queries.MULTIPLE_EVENTS,

--- a/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
@@ -220,6 +220,18 @@ def generate_page_type_payload(page_type):
     }
 
 
+def generate_permission_group_payload(group):
+    return {
+        "permissionGroup": {
+            "name": group.name,
+            "permissions": [
+                {"name": permission.name} for permission in group.permissions.all()
+            ],
+            "users": [{"email": user.email} for user in group.user_set.all()],
+        }
+    }
+
+
 def generate_invoice_payload(invoice):
     return {
         "invoice": {

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1152,6 +1152,51 @@ PAGE_TYPE_DELETED = (
 """
 )
 
+PERMISSION_GROUP_CREATED = (
+    fragments.PERMISSION_GROUP_DETAILS
+    + """
+    subscription{
+      event{
+        ...on PermissionGroupCreated{
+          permissionGroup{
+            ...PermissionGroupDetails
+          }
+        }
+      }
+    }
+"""
+)
+
+PERMISSION_GROUP_UPDATED = (
+    fragments.PERMISSION_GROUP_DETAILS
+    + """
+    subscription{
+      event{
+        ...on PermissionGroupUpdated{
+          permissionGroup{
+            ...PermissionGroupDetails
+          }
+        }
+      }
+    }
+"""
+)
+
+PERMISSION_GROUP_DELETED = (
+    fragments.PERMISSION_GROUP_DETAILS
+    + """
+    subscription{
+      event{
+        ...on PermissionGroupDeleted{
+          permissionGroup{
+            ...PermissionGroupDetails
+          }
+        }
+      }
+    }
+"""
+)
+
 
 MULTIPLE_EVENTS = """
 subscription{

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -30,6 +30,7 @@ from .payloads import (
     generate_menu_payload,
     generate_page_payload,
     generate_page_type_payload,
+    generate_permission_group_payload,
     generate_sale_payload,
     generate_shipping_method_payload,
     generate_staff_payload,
@@ -1431,6 +1432,64 @@ def test_page_type_deleted(page_type, subscription_page_type_deleted_webhook):
 
     # when
     deliveries = create_deliveries_for_subscriptions(event_type, page_type, webhooks)
+
+    # then
+    assert deliveries[0].payload.payload == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_permission_group_created(
+    permission_group_manage_users, subscription_permission_group_created_webhook
+):
+    # given
+    group = permission_group_manage_users
+    webhooks = [subscription_permission_group_created_webhook]
+    event_type = WebhookEventAsyncType.PERMISSION_GROUP_CREATED
+    expected_payload = json.dumps(generate_permission_group_payload(group))
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, group, webhooks)
+
+    # then
+    assert deliveries[0].payload.payload == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_permission_group_updated(
+    permission_group_manage_users, subscription_permission_group_updated_webhook
+):
+    # given
+    group = permission_group_manage_users
+    webhooks = [subscription_permission_group_updated_webhook]
+    event_type = WebhookEventAsyncType.PERMISSION_GROUP_UPDATED
+    expected_payload = json.dumps(generate_permission_group_payload(group))
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, group, webhooks)
+
+    # then
+    assert deliveries[0].payload.payload == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_permission_group_deleted(
+    permission_group_manage_users, subscription_permission_group_deleted_webhook
+):
+    # given
+    group = permission_group_manage_users
+    group_id = group.id
+    group.delete()
+    group.id = group_id
+
+    webhooks = [subscription_permission_group_deleted_webhook]
+    event_type = WebhookEventAsyncType.PERMISSION_GROUP_DELETED
+    expected_payload = json.dumps(generate_permission_group_payload(group))
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, group, webhooks)
 
     # then
     assert deliveries[0].payload.payload == expected_payload

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -112,6 +112,10 @@ class WebhookEventAsyncType:
     PAGE_TYPE_UPDATED = "page_type_updated"
     PAGE_TYPE_DELETED = "page_type_deleted"
 
+    PERMISSION_GROUP_CREATED = "permission_group_created"
+    PERMISSION_GROUP_UPDATED = "permission_group_updated"
+    PERMISSION_GROUP_DELETED = "permission_group_deleted"
+
     SHIPPING_PRICE_CREATED = "shipping_price_created"
     SHIPPING_PRICE_UPDATED = "shipping_price_updated"
     SHIPPING_PRICE_DELETED = "shipping_price_deleted"
@@ -212,6 +216,9 @@ class WebhookEventAsyncType:
         PAGE_TYPE_CREATED: "Page type created",
         PAGE_TYPE_UPDATED: "Page type updated",
         PAGE_TYPE_DELETED: "Page type deleted",
+        PERMISSION_GROUP_CREATED: "Permission group created",
+        PERMISSION_GROUP_UPDATED: "Permission group updated",
+        PERMISSION_GROUP_DELETED: "Permission group deleted",
         SHIPPING_PRICE_CREATED: "Shipping price created",
         SHIPPING_PRICE_UPDATED: "Shipping price updated",
         SHIPPING_PRICE_DELETED: "Shipping price deleted",
@@ -306,6 +313,9 @@ class WebhookEventAsyncType:
         (PAGE_TYPE_CREATED, DISPLAY_LABELS[PAGE_TYPE_CREATED]),
         (PAGE_TYPE_UPDATED, DISPLAY_LABELS[PAGE_TYPE_UPDATED]),
         (PAGE_TYPE_DELETED, DISPLAY_LABELS[PAGE_TYPE_DELETED]),
+        (PERMISSION_GROUP_CREATED, DISPLAY_LABELS[PERMISSION_GROUP_CREATED]),
+        (PERMISSION_GROUP_UPDATED, DISPLAY_LABELS[PERMISSION_GROUP_UPDATED]),
+        (PERMISSION_GROUP_DELETED, DISPLAY_LABELS[PERMISSION_GROUP_DELETED]),
         (SHIPPING_PRICE_CREATED, DISPLAY_LABELS[SHIPPING_PRICE_CREATED]),
         (SHIPPING_PRICE_UPDATED, DISPLAY_LABELS[SHIPPING_PRICE_UPDATED]),
         (SHIPPING_PRICE_DELETED, DISPLAY_LABELS[SHIPPING_PRICE_DELETED]),
@@ -401,6 +411,9 @@ class WebhookEventAsyncType:
         PAGE_TYPE_CREATED: PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
         PAGE_TYPE_UPDATED: PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
         PAGE_TYPE_DELETED: PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+        PERMISSION_GROUP_CREATED: AccountPermissions.MANAGE_STAFF,
+        PERMISSION_GROUP_UPDATED: AccountPermissions.MANAGE_STAFF,
+        PERMISSION_GROUP_DELETED: AccountPermissions.MANAGE_STAFF,
         SHIPPING_PRICE_CREATED: ShippingPermissions.MANAGE_SHIPPING,
         SHIPPING_PRICE_UPDATED: ShippingPermissions.MANAGE_SHIPPING,
         SHIPPING_PRICE_DELETED: ShippingPermissions.MANAGE_SHIPPING,
@@ -565,6 +578,9 @@ SUBSCRIBABLE_EVENTS = [
     WebhookEventAsyncType.PAGE_TYPE_CREATED,
     WebhookEventAsyncType.PAGE_TYPE_UPDATED,
     WebhookEventAsyncType.PAGE_TYPE_DELETED,
+    WebhookEventAsyncType.PERMISSION_GROUP_CREATED,
+    WebhookEventAsyncType.PERMISSION_GROUP_UPDATED,
+    WebhookEventAsyncType.PERMISSION_GROUP_DELETED,
     WebhookEventAsyncType.SHIPPING_PRICE_CREATED,
     WebhookEventAsyncType.SHIPPING_PRICE_UPDATED,
     WebhookEventAsyncType.SHIPPING_PRICE_DELETED,


### PR DESCRIPTION
I want to merge this change because it adds new subscription base webhooks for permission group create, update, delete events.

New webhook events:
- `PERMISSION_GROUP_CREATED`
- `PERMISSION_GROUP_UPDATED`
- `PERMISSION_GROUP_DELETED`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
