### PR TITLE
Add missing descriptions to wehbook enums.

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1456,12 +1456,26 @@ enum WebhookEventTypeEnum {
 
   """An order is fulfilled."""
   ORDER_FULFILLED
+
+  """A draft order is created."""
   DRAFT_ORDER_CREATED
+
+  """A draft order is updated."""
   DRAFT_ORDER_UPDATED
+
+  """A draft order is deleted."""
   DRAFT_ORDER_DELETED
+
+  """A sale is created."""
   SALE_CREATED
+
+  """A sale is updated."""
   SALE_UPDATED
+
+  """A sale is deleted."""
   SALE_DELETED
+
+  """A sale is activated or deactivated."""
   SALE_TOGGLE
 
   """An invoice for order requested."""
@@ -1508,7 +1522,11 @@ enum WebhookEventTypeEnum {
 
   """A product variant is deleted."""
   PRODUCT_VARIANT_DELETED
+
+  """A product variant is out of stock."""
   PRODUCT_VARIANT_OUT_OF_STOCK
+
+  """A product variant is back in stock."""
   PRODUCT_VARIANT_BACK_IN_STOCK
 
   """A new checkout is created."""
@@ -1564,12 +1582,22 @@ enum WebhookEventTypeEnum {
   """A shipping zone is deleted."""
   SHIPPING_ZONE_DELETED
 
-  """A staff user is deleted"""
+  """A new staff user is created."""
   STAFF_CREATED
+
+  """A staff user is updated."""
   STAFF_UPDATED
+
+  """A staff user is deleted."""
   STAFF_DELETED
+
+  """An action requested for transaction."""
   TRANSACTION_ACTION_REQUEST
+
+  """A new translation is created."""
   TRANSLATION_CREATED
+
+  """A translation is updated."""
   TRANSLATION_UPDATED
 
   """A new warehouse created."""
@@ -1592,15 +1620,35 @@ enum WebhookEventTypeEnum {
 
   """An observability event is created."""
   OBSERVABILITY
+
+  """Authorize payment."""
   PAYMENT_AUTHORIZE
+
+  """Capture payment."""
   PAYMENT_CAPTURE
+
+  """Confirm payment."""
   PAYMENT_CONFIRM
+
+  """Listing available payment gateways."""
   PAYMENT_LIST_GATEWAYS
+
+  """Process payment."""
   PAYMENT_PROCESS
+
+  """Refund payment."""
   PAYMENT_REFUND
+
+  """Void payment."""
   PAYMENT_VOID
+
+  """Fetch external shipping methods for checkout."""
   SHIPPING_LIST_METHODS_FOR_CHECKOUT
+
+  """Filter shipping methods for order."""
   ORDER_FILTER_SHIPPING_METHODS
+
+  """Filter shipping methods for checkout."""
   CHECKOUT_FILTER_SHIPPING_METHODS
 }
 
@@ -1615,15 +1663,34 @@ type WebhookEventSync {
 
 """Enum determining type of webhook."""
 enum WebhookEventTypeSyncEnum {
+  """Authorize payment."""
   PAYMENT_AUTHORIZE
+
+  """Capture payment."""
   PAYMENT_CAPTURE
+
+  """Confirm payment."""
   PAYMENT_CONFIRM
+
+  """Listing available payment gateways."""
   PAYMENT_LIST_GATEWAYS
+
+  """Process payment."""
   PAYMENT_PROCESS
+
+  """Refund payment."""
   PAYMENT_REFUND
+
+  """Void payment."""
   PAYMENT_VOID
+
+  """Fetch external shipping methods for checkout."""
   SHIPPING_LIST_METHODS_FOR_CHECKOUT
+
+  """Filter shipping methods for order."""
   ORDER_FILTER_SHIPPING_METHODS
+
+  """Filter shipping methods for checkout."""
   CHECKOUT_FILTER_SHIPPING_METHODS
 }
 
@@ -1752,12 +1819,26 @@ enum WebhookEventTypeAsyncEnum {
 
   """An order is fulfilled."""
   ORDER_FULFILLED
+
+  """A draft order is created."""
   DRAFT_ORDER_CREATED
+
+  """A draft order is updated."""
   DRAFT_ORDER_UPDATED
+
+  """A draft order is deleted."""
   DRAFT_ORDER_DELETED
+
+  """A sale is created."""
   SALE_CREATED
+
+  """A sale is updated."""
   SALE_UPDATED
+
+  """A sale is deleted."""
   SALE_DELETED
+
+  """A sale is activated or deactivated."""
   SALE_TOGGLE
 
   """An invoice for order requested."""
@@ -1804,7 +1885,11 @@ enum WebhookEventTypeAsyncEnum {
 
   """A product variant is deleted."""
   PRODUCT_VARIANT_DELETED
+
+  """A product variant is out of stock."""
   PRODUCT_VARIANT_OUT_OF_STOCK
+
+  """A product variant is back in stock."""
   PRODUCT_VARIANT_BACK_IN_STOCK
 
   """A new checkout is created."""
@@ -1860,12 +1945,22 @@ enum WebhookEventTypeAsyncEnum {
   """A shipping zone is deleted."""
   SHIPPING_ZONE_DELETED
 
-  """A staff user is deleted"""
+  """A new staff user is created."""
   STAFF_CREATED
+
+  """A staff user is updated."""
   STAFF_UPDATED
+
+  """A staff user is deleted."""
   STAFF_DELETED
+
+  """An action requested for transaction."""
   TRANSACTION_ACTION_REQUEST
+
+  """A new translation is created."""
   TRANSLATION_CREATED
+
+  """A translation is updated."""
   TRANSLATION_UPDATED
 
   """A new warehouse created."""

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -71,6 +71,13 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.ORDER_UPDATED: order_updated_event_enum_description,
     WebhookEventAsyncType.ORDER_CANCELLED: "An order is cancelled.",
     WebhookEventAsyncType.ORDER_FULFILLED: "An order is fulfilled.",
+    WebhookEventAsyncType.DRAFT_ORDER_CREATED: "A draft order is created.",
+    WebhookEventAsyncType.DRAFT_ORDER_UPDATED: "A draft order is updated.",
+    WebhookEventAsyncType.DRAFT_ORDER_DELETED: "A draft order is deleted.",
+    WebhookEventAsyncType.SALE_CREATED: "A sale is created.",
+    WebhookEventAsyncType.SALE_UPDATED: "A sale is updated.",
+    WebhookEventAsyncType.SALE_DELETED: "A sale is deleted.",
+    WebhookEventAsyncType.SALE_TOGGLE: "A sale is activated or deactivated.",
     WebhookEventAsyncType.FULFILLMENT_CREATED: "A new fulfillment is created.",
     WebhookEventAsyncType.FULFILLMENT_CANCELED: "A fulfillment is cancelled.",
     WebhookEventAsyncType.PAGE_CREATED: "A new page is created.",
@@ -85,15 +92,26 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.PRODUCT_VARIANT_CREATED: "A new product variant is created.",
     WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED: "A product variant is updated.",
     WebhookEventAsyncType.PRODUCT_VARIANT_DELETED: "A product variant is deleted.",
+    WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK: (
+        "A product variant is out of stock."
+    ),
+    WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK: (
+        "A product variant is back in stock."
+    ),
     WebhookEventAsyncType.SHIPPING_PRICE_CREATED: "A new shipping price is created.",
     WebhookEventAsyncType.SHIPPING_PRICE_UPDATED: "A shipping price is updated.",
     WebhookEventAsyncType.SHIPPING_PRICE_DELETED: "A shipping price is deleted.",
     WebhookEventAsyncType.SHIPPING_ZONE_CREATED: "A new shipping zone is created.",
     WebhookEventAsyncType.SHIPPING_ZONE_UPDATED: "A shipping zone is updated.",
     WebhookEventAsyncType.SHIPPING_ZONE_DELETED: "A shipping zone is deleted.",
-    WebhookEventAsyncType.STAFF_CREATED: "A new staff user is created",
-    WebhookEventAsyncType.STAFF_CREATED: "A staff user is updated",
-    WebhookEventAsyncType.STAFF_CREATED: "A staff user is deleted",
+    WebhookEventAsyncType.STAFF_CREATED: "A new staff user is created.",
+    WebhookEventAsyncType.STAFF_UPDATED: "A staff user is updated.",
+    WebhookEventAsyncType.STAFF_DELETED: "A staff user is deleted.",
+    WebhookEventAsyncType.TRANSACTION_ACTION_REQUEST: (
+        "An action requested for transaction."
+    ),
+    WebhookEventAsyncType.TRANSLATION_CREATED: "A new translation is created.",
+    WebhookEventAsyncType.TRANSLATION_UPDATED: "A translation is updated.",
     WebhookEventAsyncType.WAREHOUSE_CREATED: "A new warehouse created.",
     WebhookEventAsyncType.WAREHOUSE_UPDATED: "A warehouse is updated.",
     WebhookEventAsyncType.WAREHOUSE_DELETED: "A warehouse is deleted.",
@@ -102,6 +120,22 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.VOUCHER_DELETED: "A voucher is deleted.",
     WebhookEventAsyncType.ANY: "All the events.",
     WebhookEventAsyncType.OBSERVABILITY: "An observability event is created.",
+    WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT: (
+        "Fetch external shipping methods for checkout."
+    ),
+    WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS: (
+        "Filter shipping methods for checkout."
+    ),
+    WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS: (
+        "Filter shipping methods for order."
+    ),
+    WebhookEventSyncType.PAYMENT_LIST_GATEWAYS: "Listing available payment gateways.",
+    WebhookEventSyncType.PAYMENT_AUTHORIZE: "Authorize payment.",
+    WebhookEventSyncType.PAYMENT_CAPTURE: "Capture payment.",
+    WebhookEventSyncType.PAYMENT_REFUND: "Refund payment.",
+    WebhookEventSyncType.PAYMENT_VOID: "Void payment.",
+    WebhookEventSyncType.PAYMENT_CONFIRM: "Confirm payment.",
+    WebhookEventSyncType.PAYMENT_PROCESS: "Process payment.",
 }
 
 


### PR DESCRIPTION
I want to merge this change because adding missing descriptions to webhook enums. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
