### PR TITLE
Fix stock allocation for order with global collection point 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable, unreleased changes to this project will be documented in this file.
   - Database backend: `celery --app saleor.celeryconf:app beat --scheduler saleor.schedulers.schedulers.DatabaseScheduler`
   - Shelve backend: `celery --app saleor.celeryconf:app beat --scheduler saleor.schedulers.schedulers.PersistentScheduler`
 - Fix problem with updating draft order with active avalara - #10183 by @IKarbowiak
+- Fix stock validation and allocation for order with local collection point - #10218 by @IKarbowiak
+- Fix stock allocation for order with global collection point - #10225 by @IKarbowiak
 
 # 3.5.0
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -1824,6 +1824,75 @@ def test_complete_checkout_for_local_click_and_collect(
     assert order.lines.first().allocations.first().stock.warehouse == warehouse_for_cc
 
 
+def test_complete_checkout_for_global_click_and_collect(
+    api_client,
+    checkout_with_item_for_cc,
+    payment_dummy,
+    address,
+    warehouse_for_cc,
+    warehouse,
+):
+    """Ensure that the allocation is made for collection point warehouse even if another
+    warehouse with bigger quantity available exist."""
+    # given
+    order_count = Order.objects.count()
+    checkout = checkout_with_item_for_cc
+
+    warehouse_for_cc.click_and_collect_option = (
+        WarehouseClickAndCollectOption.ALL_WAREHOUSES
+    )
+    warehouse_for_cc.save(update_fields=["click_and_collect_option"])
+
+    checkout.collection_point = warehouse_for_cc
+    checkout.save(update_fields=["collection_point"])
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "redirectUrl": "https://www.example.com",
+    }
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.checkout_total(
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
+    )
+    payment = payment_dummy
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.checkout = checkout
+    payment.save()
+
+    assert not payment.transactions.exists()
+    assert len(lines) == 1
+    variant = lines[0].variant
+
+    # create another stock for the variant with the bigger quantity available
+    Stock.objects.create(product_variant=variant, warehouse=warehouse, quantity=50)
+
+    # when
+    response = api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)["data"]["checkoutComplete"]
+
+    assert not content["errors"]
+    assert Order.objects.count() == order_count + 1
+
+    order = Order.objects.first()
+
+    assert order.collection_point == warehouse_for_cc
+    assert order.shipping_method is None
+    assert order.shipping_address == warehouse_for_cc.address
+    assert order.shipping_price == zero_taxed_money(payment.currency)
+    assert order.lines.count() == 1
+
+    # ensure the allocation is made on the correct warehouse
+    assert order.lines.first().allocations.first().stock.warehouse == warehouse_for_cc
+
+
 def test_complete_checkout_raises_error_for_local_stock(
     api_client, checkout_with_item_for_cc, payment_dummy, address, warehouse_for_cc
 ):


### PR DESCRIPTION
When there is a global collection point assigned, we should allocate the stock from the assigned collection point in the first place.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
