### PR TITLE
Fix returning GraphQL IDs in the SALE_TOGGLE webhook

### DIFF
--- a/saleor/discount/tasks.py
+++ b/saleor/discount/tasks.py
@@ -1,11 +1,13 @@
 from collections import defaultdict
 from datetime import datetime
 
+import graphene
 import pytz
 from celery.utils.log import get_task_logger
 from django.db.models import F, Q
 
 from ..celeryconf import app
+from ..graphql.discount.mutations.utils import CATALOGUE_FIELD_TO_TYPE_NAME
 from ..plugins.manager import get_plugins_manager
 from .models import Sale
 from .utils import CATALOGUE_FIELDS, CatalogueInfo
@@ -44,7 +46,9 @@ def fetch_catalogue_infos(sales):
 
         for field in CATALOGUE_FIELDS:
             if id := sale_data.get(field):
-                catalogue_info[sale_data["id"]][field].add(id)
+                type_name = CATALOGUE_FIELD_TO_TYPE_NAME[field]
+                global_id = graphene.Node.to_global_id(type_name, id)
+                catalogue_info[sale_data["id"]][field].add(global_id)
 
     return catalogue_info
 

--- a/saleor/discount/tests/test_tasks.py
+++ b/saleor/discount/tests/test_tasks.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest.mock import ANY, patch
 
+import graphene
 from django.utils import timezone
 from freezegun import freeze_time
 
@@ -19,16 +20,20 @@ def test_fetch_catalogue_infos(sale, new_sale):
     for sale_instance in sales:
         catalogue_info = catalogue_infos[sale_instance.id]
         assert catalogue_info["categories"] == set(
-            sale_instance.categories.all().values_list("id", flat=True)
+            graphene.Node.to_global_id("Category", id)
+            for id in sale_instance.categories.all().values_list("id", flat=True)
         )
         assert catalogue_info["collections"] == set(
-            sale_instance.collections.all().values_list("id", flat=True)
+            graphene.Node.to_global_id("Collection", id)
+            for id in sale_instance.collections.all().values_list("id", flat=True)
         )
         assert catalogue_info["products"] == set(
-            sale_instance.products.all().values_list("id", flat=True)
+            graphene.Node.to_global_id("Product", id)
+            for id in sale_instance.products.all().values_list("id", flat=True)
         )
         assert catalogue_info["variants"] == set(
-            sale_instance.variants.all().values_list("id", flat=True)
+            graphene.Node.to_global_id("ProductVariant", id)
+            for id in sale_instance.variants.all().values_list("id", flat=True)
         )
 
 

--- a/saleor/graphql/discount/mutations/utils.py
+++ b/saleor/graphql/discount/mutations/utils.py
@@ -5,15 +5,20 @@ import graphene
 
 from ....discount.utils import CatalogueInfo
 
+CATALOGUE_FIELD_TO_TYPE_NAME = {
+    "categories": "Category",
+    "collections": "Collection",
+    "products": "Product",
+    "variants": "ProductVariant",
+}
+
 
 def convert_catalogue_info_to_global_ids(
     catalogue_info: CatalogueInfo,
 ) -> DefaultDict[str, Set[str]]:
-    catalogue_fields = ["categories", "collections", "products", "variants"]
-    type_names = ["Category", "Collection", "Product", "ProductVariant"]
     converted_catalogue_info: DefaultDict[str, Set[str]] = defaultdict(set)
 
-    for type_name, catalogue_field in zip(type_names, catalogue_fields):
+    for catalogue_field, type_name in CATALOGUE_FIELD_TO_TYPE_NAME.items():
         converted_catalogue_info[catalogue_field].update(
             graphene.Node.to_global_id(type_name, id_)
             for id_ in catalogue_info[catalogue_field]


### PR DESCRIPTION
The task that is responsible for sending the toggle notification was preparing the catalogues with the database ids. Update the methods to return catalogues with the graphql ids.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
