### PR TITLE
Refactor warehouse mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,18 @@ All notable, unreleased changes to this project will be documented in this file.
 # 3.7.0 [Unreleased]
 
 ### GraphQL API
+
 - Sorting warehouses within channel - #10416 by @IKarbowiak
   - Add `channelReorderWarehouses` mutation
   - Extend the `Channel` type with `stockSettings` field
   - Extend `ChannelCreateInput` and `ChannelUpdateInput` with `stockSettings`
+  - Add `name` parameter to `ProductVariantInput` - #10456 by @SzymJ
+
+### Breaking changes
+
+- Refactor warehouse mutations - #10239 by @IKarbowiak
+  - Providing the value in `shippingZone` filed in `WarehouseCreate` mutation will raise a ValidationError.
+  Use `WarehouseShippingZoneAssign` to assign shipping zones to warehouse .
 
 ### Other changes
 
@@ -17,8 +25,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add support for bcrypt password hashes - #10346 by @pkucmus
 - Add ability to set taxes configuration per channel in the Avatax plugin - #10445 by @mociepka
 
-### GraphQL API
- - Add `name` parameter to `ProductVariantInput` - #10456 by @SzymJ
 
 # 3.6.0
 

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -339,7 +339,7 @@ class PaymentError(Error):
     code = PaymentErrorCode(description="The error code.", required=True)
     variants = NonNullList(
         graphene.ID,
-        description="List of varint IDs which causes the error.",
+        description="List of variants IDs which causes the error.",
         required=False,
     )
 
@@ -387,6 +387,11 @@ class UploadError(Error):
 
 class WarehouseError(Error):
     code = WarehouseErrorCode(description="The error code.", required=True)
+    shipping_zones = NonNullList(
+        graphene.ID,
+        description="List of shipping zones IDs which causes the error.",
+        required=False,
+    )
 
 
 class WebhookError(Error):

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -339,7 +339,7 @@ class PaymentError(Error):
     code = PaymentErrorCode(description="The error code.", required=True)
     variants = NonNullList(
         graphene.ID,
-        description="List of variants IDs which causes the error.",
+        description="List of variant IDs which causes the error.",
         required=False,
     )
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16823,7 +16823,7 @@ type PaymentError {
   """The error code."""
   code: PaymentErrorCode!
 
-  """List of variants IDs which causes the error."""
+  """List of variant IDs which causes the error."""
   variants: [ID!]
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14605,7 +14605,7 @@ input WarehouseCreateInput {
   """
   Shipping zones supported by the warehouse.
   
-  DEPRECATED: this field will be removed in Saleor 4.0. Providing the zone ids will not assign any zones to the warehouse.
+  DEPRECATED: this field will be removed in Saleor 4.0. Providing the zone ids will raise a ValidationError.
   """
   shippingZones: [ID!]
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14574,6 +14574,9 @@ type WarehouseError {
 
   """The error code."""
   code: WarehouseErrorCode!
+
+  """List of shipping zones IDs which causes the error."""
+  shippingZones: [ID!]
 }
 
 """An enumeration."""
@@ -14599,7 +14602,11 @@ input WarehouseCreateInput {
   """Address of the warehouse."""
   address: AddressInput!
 
-  """Shipping zones supported by the warehouse."""
+  """
+  Shipping zones supported by the warehouse.
+  
+  DEPRECATED: this field will be removed in Saleor 4.0. Providing the zone ids will not assign any zones to the warehouse.
+  """
   shippingZones: [ID!]
 }
 
@@ -16816,7 +16823,7 @@ type PaymentError {
   """The error code."""
   code: PaymentErrorCode!
 
-  """List of varint IDs which causes the error."""
+  """List of variants IDs which causes the error."""
   variants: [ID!]
 }
 

--- a/saleor/graphql/warehouse/mutations.py
+++ b/saleor/graphql/warehouse/mutations.py
@@ -1,7 +1,10 @@
+from collections import defaultdict
+
 import graphene
 from django.core.exceptions import ValidationError
 from django.db import transaction
 
+from ...channel import models as channel_models
 from ...core.permissions import ProductPermissions
 from ...core.tracing import traced_atomic_transaction
 from ...warehouse import WarehouseClickAndCollectOption, models
@@ -48,12 +51,8 @@ class WarehouseMixin:
                 error.code = WarehouseErrorCode.REQUIRED.value
                 raise ValidationError({"name": error})
 
-        shipping_zones = cleaned_input.get("shipping_zones", [])
-        if not validate_warehouse_count(shipping_zones, instance):
-            msg = "Shipping zone can be assigned only to one warehouse."
-            raise ValidationError(
-                {"shipping_zones": msg}, code=WarehouseErrorCode.INVALID
-            )
+        # assigning shipping zones in the WarehouseCreate mutation is deprecated
+        cleaned_input.pop("shipping_zones", None)
 
         click_and_collect_option = cleaned_input.get(
             "click_and_collect_option", instance.click_and_collect_option
@@ -103,7 +102,7 @@ class WarehouseCreate(WarehouseMixin, ModelMutation, I18nMixin):
         info.context.plugins.warehouse_created(instance)
 
 
-class WarehouseShippingZoneAssign(WarehouseMixin, ModelMutation, I18nMixin):
+class WarehouseShippingZoneAssign(ModelMutation, I18nMixin):
     class Meta:
         model = models.Warehouse
         object_type = Warehouse
@@ -126,11 +125,88 @@ class WarehouseShippingZoneAssign(WarehouseMixin, ModelMutation, I18nMixin):
         shipping_zones = cls.get_nodes_or_error(
             data.get("shipping_zone_ids"), "shipping_zone_id", only_type=ShippingZone
         )
+        cls.clean_shipping_zones(warehouse, shipping_zones)
         warehouse.shipping_zones.add(*shipping_zones)
         return WarehouseShippingZoneAssign(warehouse=warehouse)
 
+    @classmethod
+    def clean_shipping_zones(cls, instance, shipping_zones):
+        if not validate_warehouse_count(shipping_zones, instance):
+            msg = "Shipping zone can be assigned only to one warehouse."
+            raise ValidationError(
+                {"shipping_zones": msg}, code=WarehouseErrorCode.INVALID
+            )
 
-class WarehouseShippingZoneUnassign(WarehouseMixin, ModelMutation, I18nMixin):
+        cls.check_if_zones_can_be_assigned(instance, shipping_zones)
+
+    @classmethod
+    def check_if_zones_can_be_assigned(cls, instance, shipping_zones):
+        """Check if all shipping zones to add has common channel with warehouse.
+
+        Raise and error when the condition is not fulfilled.
+        """
+        shipping_zone_ids = [zone.id for zone in shipping_zones]
+        ChannelShippingZone = channel_models.Channel.shipping_zones.through
+        channel_shipping_zones = ChannelShippingZone.objects.filter(
+            shippingzone_id__in=shipping_zone_ids
+        )
+
+        # shipping zone cannot be assigned when aby channel is assigned to the zone
+        if not channel_shipping_zones:
+            invalid_shipping_zone_ids = shipping_zone_ids
+
+        zone_to_channel_mapping = defaultdict(set)
+        for shipping_zone_id, channel_id in channel_shipping_zones.values_list(
+            "shippingzone_id", "channel_id"
+        ):
+            zone_to_channel_mapping[shipping_zone_id].add(channel_id)
+
+        WarehouseChannel = models.Warehouse.channels.through
+        zone_channel_ids = set(
+            WarehouseChannel.objects.filter(warehouse_id=instance.id).values_list(
+                "channel_id", flat=True
+            )
+        )
+
+        invalid_shipping_zone_ids = cls._find_invalid_shipping_zones(
+            zone_to_channel_mapping, shipping_zone_ids, zone_channel_ids
+        )
+
+        if invalid_shipping_zone_ids:
+            invalid_zones = {
+                graphene.Node.to_global_id("ShippingZone", pk)
+                for pk in invalid_shipping_zone_ids
+            }
+            raise ValidationError(
+                {
+                    "shipping_zones": ValidationError(
+                        "Only warehouses that have common channel with shipping zone "
+                        "can be assigned.",
+                        code=WarehouseErrorCode.INVALID,
+                        params={
+                            "shipping_zones": invalid_zones,
+                        },
+                    )
+                }
+            )
+
+    @staticmethod
+    def _find_invalid_shipping_zones(
+        zone_to_channel_mapping, shipping_zone_ids, warehouse_channel_ids
+    ):
+        invalid_warehouse_ids = []
+        for zone_id in shipping_zone_ids:
+            zone_channels = zone_to_channel_mapping.get(zone_id)
+            # shipping zone cannot be added if it hasn't got any channel assigned
+            # or if it does not have common channel with the warehouse
+            if not zone_channels or not zone_channels.intersection(
+                warehouse_channel_ids
+            ):
+                invalid_warehouse_ids.append(zone_id)
+        return invalid_warehouse_ids
+
+
+class WarehouseShippingZoneUnassign(ModelMutation, I18nMixin):
     class Meta:
         model = models.Warehouse
         object_type = Warehouse

--- a/saleor/graphql/warehouse/mutations.py
+++ b/saleor/graphql/warehouse/mutations.py
@@ -52,7 +52,16 @@ class WarehouseMixin:
                 raise ValidationError({"name": error})
 
         # assigning shipping zones in the WarehouseCreate mutation is deprecated
-        cleaned_input.pop("shipping_zones", None)
+        if cleaned_input.get("shipping_zones"):
+            raise ValidationError(
+                {
+                    "shipping_zones": ValidationError(
+                        "The shippingZone input field is deprecated. "
+                        "Use WarehouseShippingZoneAssign mutation",
+                        code=WarehouseErrorCode.INVALID.value,
+                    )
+                }
+            )
 
         click_and_collect_option = cleaned_input.get(
             "click_and_collect_option", instance.click_and_collect_option
@@ -151,7 +160,7 @@ class WarehouseShippingZoneAssign(ModelMutation, I18nMixin):
             shippingzone_id__in=shipping_zone_ids
         )
 
-        # shipping zone cannot be assigned when aby channel is assigned to the zone
+        # shipping zone cannot be assigned when any channel is assigned to the zone
         if not channel_shipping_zones:
             invalid_shipping_zone_ids = shipping_zone_ids
 

--- a/saleor/graphql/warehouse/tests/test_warehouse.py
+++ b/saleor/graphql/warehouse/tests/test_warehouse.py
@@ -123,6 +123,13 @@ mutation createWarehouse($input: WarehouseCreateInput!) {
             address {
                 id
             }
+            shippingZones(first: 5) {
+                edges {
+                    node {
+                        id
+                    }
+                }
+            }
         }
         errors {
             message
@@ -179,6 +186,7 @@ mutation assignWarehouseShippingZone($id: ID!, $shippingZoneIds: [ID!]!) {
       field
       message
       code
+      shippingZones
     }
   }
 }
@@ -631,6 +639,7 @@ def test_mutation_create_warehouse(
                 "postalCode": "53-601",
                 "companyName": "Amazing Company Inc",
             },
+            # DEPRECATED
             "shippingZones": [
                 graphene.Node.to_global_id("ShippingZone", shipping_zone.id)
             ],
@@ -652,6 +661,8 @@ def test_mutation_create_warehouse(
     assert created_warehouse["name"] == warehouse.name
     assert created_warehouse["slug"] == warehouse.slug
     assert created_warehouse["companyName"] == warehouse.address.company_name
+    # no shipping zones are assigned as it's deprecated
+    assert not created_warehouse["shippingZones"]["edges"]
 
 
 @patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
@@ -1254,41 +1265,35 @@ def test_delete_warehouse_deletes_associated_address(
 
 
 def test_shipping_zone_can_be_assigned_only_to_one_warehouse(
-    staff_api_client, warehouse, permission_manage_products
+    staff_api_client, warehouse, warehouse_JPY, permission_manage_products
 ):
+    # given
     used_shipping_zone = warehouse.shipping_zones.first()
     used_shipping_zone_id = graphene.Node.to_global_id(
         "ShippingZone", used_shipping_zone.pk
     )
+    zone_warehouses_count = used_shipping_zone.warehouses.count()
 
     variables = {
-        "input": {
-            "name": "Warehouse #q",
-            "email": "test@example.com",
-            "address": {
-                "streetAddress1": "Teczowa 8",
-                "city": "Wroclaw",
-                "country": "PL",
-                "companyName": "Big Company",
-                "postalCode": "53-601",
-            },
-            "shippingZones": [used_shipping_zone_id],
-        }
+        "id": graphene.Node.to_global_id("Warehouse", warehouse_JPY.pk),
+        "shippingZoneIds": [used_shipping_zone_id],
     }
 
+    # when
     response = staff_api_client.post_graphql(
-        MUTATION_CREATE_WAREHOUSE,
+        MUTATION_ASSIGN_SHIPPING_ZONE_WAREHOUSE,
         variables=variables,
         permissions=[permission_manage_products],
     )
+
+    # then
     content = get_graphql_content(response)
-    errors = content["data"]["createWarehouse"]["errors"]
+    errors = content["data"]["assignWarehouseShippingZone"]["errors"]
     assert len(errors) == 1
-    assert (
-        errors[0]["message"] == "Shipping zone can be assigned only to one warehouse."
-    )
+    assert errors[0]["code"] == WarehouseErrorCode.INVALID.name
+    assert errors[0]["field"] == "shippingZones"
     used_shipping_zone.refresh_from_db()
-    assert used_shipping_zone.warehouses.count() == 1
+    assert used_shipping_zone.warehouses.count() == zone_warehouses_count
 
 
 def test_shipping_zone_assign_to_warehouse(
@@ -1312,6 +1317,82 @@ def test_shipping_zone_assign_to_warehouse(
     warehouse_no_shipping_zone.refresh_from_db()
     shipping_zone.refresh_from_db()
     assert warehouse_no_shipping_zone.shipping_zones.first().pk == shipping_zone.pk
+
+
+def test_shipping_zone_assign_to_warehouse_no_common_channel(
+    staff_api_client,
+    warehouse_no_shipping_zone,
+    shipping_zone,
+    permission_manage_products,
+    channel_PLN,
+):
+    # given
+    assert not warehouse_no_shipping_zone.shipping_zones.all()
+
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+
+    # remove channel_USD from shipping zone channels, assign channel_PLN
+    shipping_zone.channels.set([channel_PLN])
+
+    zone_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
+
+    variables = {
+        "id": graphene.Node.to_global_id("Warehouse", warehouse_no_shipping_zone.pk),
+        "shippingZoneIds": [zone_id],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION_ASSIGN_SHIPPING_ZONE_WAREHOUSE, variables=variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    errors = content["data"]["assignWarehouseShippingZone"]["errors"]
+
+    assert len(errors) == 1
+    assert errors[0]["code"] == WarehouseErrorCode.INVALID.name
+    assert errors[0]["field"] == "shippingZones"
+    assert errors[0]["shippingZones"] == [zone_id]
+
+
+def test_shipping_zone_assign_to_warehouse_no_zone_channels(
+    staff_api_client,
+    warehouse_no_shipping_zone,
+    shipping_zone,
+    permission_manage_products,
+    channel_PLN,
+):
+    # given
+    assert not warehouse_no_shipping_zone.shipping_zones.all()
+
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+
+    # remove all channels from the shipping zone
+    shipping_zone.channels.clear()
+
+    zone_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
+
+    variables = {
+        "id": graphene.Node.to_global_id("Warehouse", warehouse_no_shipping_zone.pk),
+        "shippingZoneIds": [
+            graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION_ASSIGN_SHIPPING_ZONE_WAREHOUSE, variables=variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    errors = content["data"]["assignWarehouseShippingZone"]["errors"]
+
+    assert len(errors) == 1
+    assert errors[0]["code"] == WarehouseErrorCode.INVALID.name
+    assert errors[0]["field"] == "shippingZones"
+    assert errors[0]["shippingZones"] == [zone_id]
 
 
 def test_empty_shipping_zone_assign_to_warehouse(

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -9,7 +9,12 @@ from ...warehouse.reservations import is_reservation_enabled
 from ..account.dataloaders import AddressByIdLoader
 from ..channel import ChannelContext
 from ..core.connection import CountableConnection, create_connection_slice
-from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_FIELD, PREVIEW_FEATURE
+from ..core.descriptions import (
+    ADDED_IN_31,
+    DEPRECATED_IN_3X_FIELD,
+    DEPRECATED_IN_3X_INPUT,
+    PREVIEW_FEATURE,
+)
 from ..core.fields import ConnectionField, PermissionsField
 from ..core.types import ModelObjectType, NonNullList
 from ..meta.types import ObjectWithMetadata
@@ -31,7 +36,10 @@ class WarehouseCreateInput(WarehouseInput):
         required=True,
     )
     shipping_zones = NonNullList(
-        graphene.ID, description="Shipping zones supported by the warehouse."
+        graphene.ID,
+        description="Shipping zones supported by the warehouse."
+        + DEPRECATED_IN_3X_INPUT
+        + " Providing the zone ids will not assign any zones to the warehouse.",
     )
 
 

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -39,7 +39,7 @@ class WarehouseCreateInput(WarehouseInput):
         graphene.ID,
         description="Shipping zones supported by the warehouse."
         + DEPRECATED_IN_3X_INPUT
-        + " Providing the zone ids will not assign any zones to the warehouse.",
+        + " Providing the zone ids will raise a ValidationError.",
     )
 
 


### PR DESCRIPTION
- Deprecate the `shippingZone` from the `WarehouseCreateInput`
- Add shipping zones validation in `WarehouseShippingZoneAssign`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
