### PR TITLE
Handle same variant in multiple lines in Order mutations

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -22,6 +22,7 @@ from ....order.utils import (
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
 from ...channel.types import Channel
+from ...core.descriptions import ADDED_IN_36, PREVIEW_FEATURE
 from ...core.mutations import ModelMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import NonNullList, OrderError
@@ -50,7 +51,7 @@ class OrderLineCreateInput(OrderLineInput):
         default_value=False,
         description=(
             "Flag that allow force splitting the same variant into multiple lines "
-            "by skipping the matching logic. "
+            "by skipping the matching logic. " + ADDED_IN_36 + PREVIEW_FEATURE
         ),
     )
 

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -1,4 +1,5 @@
-from typing import List, Tuple
+from collections import defaultdict
+from typing import Dict, List
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -14,7 +15,7 @@ from ....order import OrderOrigin, OrderStatus, events, models
 from ....order.error_codes import OrderErrorCode
 from ....order.search import update_order_search_vector
 from ....order.utils import (
-    add_variant_to_order,
+    create_order_line,
     invalidate_order_prices,
     recalculate_order_weight,
 )
@@ -26,8 +27,9 @@ from ...core.scalars import PositiveDecimal
 from ...core.types import NonNullList, OrderError
 from ...product.types import ProductVariant
 from ...shipping.utils import get_shipping_model_by_object_id
-from ..types import Order, OrderLine
+from ..types import Order
 from ..utils import (
+    OrderLineData,
     validate_product_is_published_in_channel,
     validate_variant_channel_listings,
 )
@@ -42,6 +44,14 @@ class OrderLineInput(graphene.InputObjectType):
 class OrderLineCreateInput(OrderLineInput):
     variant_id = graphene.ID(
         description="Product variant ID.", name="variantId", required=True
+    )
+    force_new_line = graphene.Boolean(
+        required=False,
+        default_value=False,
+        description=(
+            "Flag that allow force splitting the same variant into multiple lines "
+            "by skipping the matching logic. "
+        ),
     )
 
 
@@ -171,6 +181,9 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
     @classmethod
     def clean_lines(cls, cleaned_input, lines, channel):
         if lines:
+            grouped_lines_data: List[OrderLineData] = []
+            lines_data_map: Dict[str, OrderLineData] = defaultdict(OrderLineData)
+
             variant_ids = [line.get("variant_id") for line in lines]
             variants = cls.get_nodes_or_error(variant_ids, "variants", ProductVariant)
             validate_product_is_published_in_channel(variants, channel)
@@ -185,8 +198,27 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
                         )
                     }
                 )
-            cleaned_input["variants"] = variants
-            cleaned_input["quantities"] = quantities
+
+            for line in lines:
+                variant_id = line.get("variant_id")
+                _, variant_db_id = graphene.Node.from_global_id(variant_id)
+                variant = list(
+                    filter(lambda x: (x.pk == int(variant_db_id)), variants)
+                )[0]
+
+                if line.get("force_new_line"):
+                    line_data = OrderLineData(variant_id=variant_db_id, variant=variant)
+                    grouped_lines_data.append(line_data)
+                else:
+                    line_data = lines_data_map[variant_db_id]
+                    line_data.variant_id = variant_db_id
+                    line_data.variant = variant
+
+                if (quantity := line.get("quantity")) is not None:
+                    line_data.quantity += quantity
+
+            grouped_lines_data += list(lines_data_map.values())
+            cleaned_input["lines_data"] = grouped_lines_data
 
     @classmethod
     def clean_addresses(
@@ -235,20 +267,17 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
             instance.billing_address = billing_address.get_copy()
 
     @staticmethod
-    def _save_lines(info, instance, quantities, variants):
-        if variants and quantities:
-            lines: List[Tuple[int, OrderLine]] = []
-            for variant, quantity in zip(variants, quantities):
-                line = add_variant_to_order(
+    def _save_lines(info, instance, lines_data):
+        if lines_data:
+            lines = []
+            for line_data in lines_data:
+                new_line = create_order_line(
                     instance,
-                    variant,
-                    quantity,
-                    info.context.user,
-                    info.context.app,
+                    line_data,
                     info.context.plugins,
                     info.context.site.settings,
                 )
-                lines.append((quantity, line))
+                lines.append(new_line)
 
             # New event
             events.order_added_products_event(
@@ -294,12 +323,7 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
 
         try:
             # Process any lines to add
-            cls._save_lines(
-                info,
-                instance,
-                cleaned_input.get("quantities"),
-                cleaned_input.get("variants"),
-            )
+            cls._save_lines(info, instance, cleaned_input.get("lines_data"))
         except TaxError as tax_error:
             raise ValidationError(
                 "Unable to calculate taxes - %s" % str(tax_error),

--- a/saleor/graphql/order/mutations/order_line_delete.py
+++ b/saleor/graphql/order/mutations/order_line_delete.py
@@ -78,7 +78,7 @@ class OrderLineDelete(EditableOrderValidationMixin, BaseMutation):
             order=order,
             user=info.context.user,
             app=info.context.app,
-            order_lines=[(line.quantity, line)],
+            order_lines=[line],
         )
 
         invalidate_order_prices(order)

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -1,4 +1,5 @@
-from typing import List, Tuple
+from collections import defaultdict
+from typing import Dict, List
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -9,6 +10,7 @@ from ....core.taxes import TaxError
 from ....core.tracing import traced_atomic_transaction
 from ....order import events
 from ....order.error_codes import OrderErrorCode
+from ....order.fetch import fetch_order_lines
 from ....order.search import update_order_search_vector
 from ....order.utils import (
     add_variant_to_order,
@@ -20,6 +22,7 @@ from ...core.types import NonNullList, OrderError
 from ...product.types import ProductVariant
 from ..types import Order, OrderLine
 from ..utils import (
+    OrderLineData,
     validate_product_is_published_in_channel,
     validate_variant_channel_listings,
 )
@@ -49,17 +52,46 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         errors_mapping = {"lines": "input", "channel": "input"}
 
     @classmethod
-    def validate_lines(cls, info, data):
-        lines_to_add = []
+    def validate_lines(cls, info, data, existing_lines_info):
+        grouped_lines_data: List[OrderLineData] = []
+        lines_data_map: Dict[str, OrderLineData] = defaultdict(OrderLineData)
+
+        variants_from_existing_lines = [
+            line_info.line.variant_id for line_info in existing_lines_info
+        ]
+
         invalid_ids = []
         for input_line in data.get("input"):
             variant_id = input_line["variant_id"]
+            force_new_line = input_line["force_new_line"]
             variant = cls.get_node_or_error(
                 info, variant_id, "variant_id", only_type=ProductVariant
             )
             quantity = input_line["quantity"]
+
             if quantity > 0:
-                lines_to_add.append((quantity, variant))
+                if force_new_line or variants_from_existing_lines.count(variant.pk) > 1:
+                    grouped_lines_data.append(
+                        OrderLineData(
+                            variant_id=str(variant.id),
+                            variant=variant,
+                            quantity=quantity,
+                        )
+                    )
+                else:
+                    line_id = cls._find_line_id_for_variant_if_exist(
+                        variant.pk, existing_lines_info
+                    )
+
+                    if line_id:
+                        line_data = lines_data_map[line_id]
+                        line_data.line_id = line_id
+                    else:
+                        line_data = lines_data_map[str(variant.id)]
+                        line_data.variant_id = str(variant.id)
+
+                    line_data.variant = variant
+                    line_data.quantity += quantity
             else:
                 invalid_ids.append(variant_id)
         if invalid_ids:
@@ -72,7 +104,9 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
                     ),
                 }
             )
-        return lines_to_add
+
+        grouped_lines_data += list(lines_data_map.values())
+        return grouped_lines_data
 
     @classmethod
     def validate_variants(cls, order, variants):
@@ -85,16 +119,13 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             raise ValidationError(error)
 
     @staticmethod
-    def add_lines_to_order(
-        order, lines_to_add, user, app, manager, settings, discounts
-    ):
-        added_lines: List[Tuple[int, OrderLine]] = []
+    def add_lines_to_order(order, lines_data, user, app, manager, settings, discounts):
+        added_lines: List[OrderLine] = []
         try:
-            for quantity, variant in lines_to_add:
+            for line_data in lines_data:
                 line = add_variant_to_order(
                     order,
-                    variant,
-                    quantity,
+                    line_data,
                     user,
                     app,
                     manager,
@@ -102,7 +133,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
                     discounts=discounts,
                     allocate_stock=order.is_unconfirmed(),
                 )
-                added_lines.append((quantity, line))
+                added_lines.append(line)
         except TaxError as tax_error:
             raise ValidationError(
                 "Unable to calculate taxes - %s" % str(tax_error),
@@ -115,8 +146,10 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
     def perform_mutation(cls, _root, info, **data):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
         cls.validate_order(order)
-        lines_to_add = cls.validate_lines(info, data)
-        variants = [line[1] for line in lines_to_add]
+        existing_lines_info = fetch_order_lines(order)
+
+        lines_to_add = cls.validate_lines(info, data, existing_lines_info)
+        variants = [line.variant for line in lines_to_add]
         cls.validate_variants(order, variants)
 
         added_lines = cls.add_lines_to_order(
@@ -137,8 +170,6 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             order_lines=added_lines,
         )
 
-        lines = [line for _, line in added_lines]
-
         invalidate_order_prices(order)
         recalculate_order_weight(order)
         update_order_search_vector(order, save=False)
@@ -153,4 +184,19 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         func = get_webhook_handler_by_order_status(order.status, info)
         transaction.on_commit(lambda: func(order))
 
-        return OrderLinesCreate(order=order, order_lines=lines)
+        return OrderLinesCreate(order=order, order_lines=added_lines)
+
+    @classmethod
+    def _find_line_id_for_variant_if_exist(cls, variant_id, lines_info):
+        """Return line id by using provided variantId parameter."""
+        if not lines_info:
+            return
+
+        line_info = list(
+            filter(lambda x: (x.variant.pk == int(variant_id)), lines_info)
+        )
+
+        if not line_info or len(line_info) > 1:
+            return
+
+        return str(line_info[0].line.id)

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -2616,6 +2616,101 @@ def test_draft_order_create(
     assert event_parameters["lines"][1]["quantity"] == 1
 
 
+def test_draft_order_create_with_same_variant_and_force_new_line(
+    staff_api_client,
+    permission_manage_orders,
+    staff_user,
+    customer_user,
+    shipping_method,
+    variant,
+    voucher,
+    channel_USD,
+    graphql_address_data,
+):
+    variant_0 = variant
+    query = DRAFT_ORDER_CREATE_MUTATION
+
+    # Ensure no events were created yet
+    assert not OrderEvent.objects.exists()
+
+    user_id = graphene.Node.to_global_id("User", customer_user.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant_0.id)
+
+    discount = "10"
+    customer_note = "Test note"
+    variant_list = [
+        {"variantId": variant_id, "quantity": 2},
+        {"variantId": variant_id, "quantity": 1, "forceNewLine": True},
+    ]
+    shipping_address = graphql_address_data
+    shipping_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
+    voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+    redirect_url = "https://www.example.com"
+
+    variables = {
+        "user": user_id,
+        "discount": discount,
+        "lines": variant_list,
+        "billingAddress": shipping_address,
+        "shippingAddress": shipping_address,
+        "shippingMethod": shipping_id,
+        "voucher": voucher_id,
+        "customerNote": customer_note,
+        "channel": channel_id,
+        "redirectUrl": redirect_url,
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    assert not content["data"]["draftOrderCreate"]["errors"]
+    data = content["data"]["draftOrderCreate"]["order"]
+    assert data["status"] == OrderStatus.DRAFT.upper()
+    assert data["voucher"]["code"] == voucher.code
+    assert data["customerNote"] == customer_note
+    assert data["redirectUrl"] == redirect_url
+    assert (
+        data["billingAddress"]["streetAddress1"]
+        == graphql_address_data["streetAddress1"]
+    )
+    assert (
+        data["shippingAddress"]["streetAddress1"]
+        == graphql_address_data["streetAddress1"]
+    )
+
+    order = Order.objects.first()
+    assert order.user == customer_user
+    assert order.shipping_method == shipping_method
+    assert order.billing_address
+    assert order.shipping_address
+    assert order.search_vector
+
+    # Ensure the correct event was created
+    created_draft_event = OrderEvent.objects.get(
+        type=order_events.OrderEvents.DRAFT_CREATED
+    )
+    assert created_draft_event.user == staff_user
+    assert created_draft_event.parameters == {}
+
+    # Ensure the order_added_products_event was created properly
+    added_products_event = OrderEvent.objects.get(
+        type=order_events.OrderEvents.ADDED_PRODUCTS
+    )
+    event_parameters = added_products_event.parameters
+    assert event_parameters
+    assert len(event_parameters["lines"]) == 2
+
+    order_lines = list(order.lines.all())
+    assert event_parameters["lines"][0]["item"] == str(order_lines[0])
+    assert event_parameters["lines"][0]["line_pk"] == str(order_lines[0].pk)
+    assert event_parameters["lines"][0]["quantity"] == 1
+
+    assert event_parameters["lines"][1]["item"] == str(order_lines[1])
+    assert event_parameters["lines"][1]["line_pk"] == str(order_lines[1].pk)
+    assert event_parameters["lines"][1]["quantity"] == 2
+
+
 def test_draft_order_create_with_inactive_channel(
     staff_api_client,
     permission_manage_orders,
@@ -2835,9 +2930,9 @@ def test_draft_order_create_variant_with_0_price(
     assert created_draft_event.parameters == {}
 
 
-@patch("saleor.graphql.order.mutations.draft_order_create.add_variant_to_order")
+@patch("saleor.graphql.order.mutations.draft_order_create.create_order_line")
 def test_draft_order_create_tax_error(
-    add_variant_to_order_mock,
+    create_order_line_mock,
     staff_api_client,
     permission_manage_orders,
     staff_user,
@@ -2851,7 +2946,7 @@ def test_draft_order_create_tax_error(
 ):
     variant_0 = variant
     err_msg = "Test error"
-    add_variant_to_order_mock.side_effect = TaxError(err_msg)
+    create_order_line_mock.side_effect = TaxError(err_msg)
     query = DRAFT_ORDER_CREATE_MUTATION
     # Ensure no events were created yet
     assert not OrderEvent.objects.exists()
@@ -4861,9 +4956,17 @@ def test_draft_order_complete_not_draft_order(
 
 
 ORDER_LINES_CREATE_MUTATION = """
-    mutation OrderLinesCreate($orderId: ID!, $variantId: ID!, $quantity: Int!) {
+    mutation OrderLinesCreate(
+            $orderId: ID!, $variantId: ID!, $quantity: Int!, $forceNewLine: Boolean
+        ) {
         orderLinesCreate(id: $orderId,
-                input: [{variantId: $variantId, quantity: $quantity}]) {
+                input: [
+                    {
+                        variantId: $variantId,
+                        quantity: $quantity,
+                        forceNewLine: $forceNewLine
+                    }
+                ]) {
 
             errors {
                 field
@@ -5138,6 +5241,112 @@ def test_order_lines_create_with_existing_variant(
     assert data["orderLines"][0]["productSku"] == variant.sku
     assert data["orderLines"][0]["productVariantId"] == variant.get_global_id()
     assert data["orderLines"][0]["quantity"] == old_quantity + quantity
+    assert_proper_webhook_called_once(
+        order, status, draft_order_updated_webhook_mock, order_updated_webhook_mock
+    )
+
+
+@pytest.mark.parametrize("status", (OrderStatus.DRAFT, OrderStatus.UNCONFIRMED))
+@patch("saleor.plugins.manager.PluginsManager.draft_order_updated")
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+def test_order_lines_create_with_same_variant_and_force_new_line(
+    order_updated_webhook_mock,
+    draft_order_updated_webhook_mock,
+    status,
+    order_with_lines,
+    permission_manage_orders,
+    staff_api_client,
+):
+    query = ORDER_LINES_CREATE_MUTATION
+    order = order_with_lines
+    order.status = status
+    order.save(update_fields=["status"])
+    lines = order.lines.all()
+    assert len(lines) == 2
+    line = lines[0]
+    variant = line.variant
+
+    quantity = 1
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    variables = {
+        "orderId": order_id,
+        "variantId": variant_id,
+        "quantity": quantity,
+        "forceNewLine": True,
+    }
+
+    # mutation should fail without proper permissions
+    response = staff_api_client.post_graphql(query, variables)
+    assert_no_permission(response)
+    assert not OrderEvent.objects.exists()
+    order_updated_webhook_mock.assert_not_called()
+    draft_order_updated_webhook_mock.assert_not_called()
+
+    # assign permissions
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    response = staff_api_client.post_graphql(query, variables)
+    assert order.lines.count() == 3
+    assert OrderEvent.objects.count() == 1
+    assert OrderEvent.objects.last().type == order_events.OrderEvents.ADDED_PRODUCTS
+    content = get_graphql_content(response)
+    data = content["data"]["orderLinesCreate"]
+    assert data["orderLines"][0]["productSku"] == variant.sku
+    assert data["orderLines"][0]["productVariantId"] == variant.get_global_id()
+    assert data["orderLines"][0]["quantity"] == quantity
+    assert_proper_webhook_called_once(
+        order, status, draft_order_updated_webhook_mock, order_updated_webhook_mock
+    )
+
+
+@pytest.mark.parametrize("status", (OrderStatus.DRAFT, OrderStatus.UNCONFIRMED))
+@patch("saleor.plugins.manager.PluginsManager.draft_order_updated")
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+def test_order_lines_create_when_variant_already_in_multiple_lines(
+    order_updated_webhook_mock,
+    draft_order_updated_webhook_mock,
+    status,
+    order_with_lines,
+    permission_manage_orders,
+    staff_api_client,
+):
+    order = order_with_lines
+    order.status = status
+    order.save(update_fields=["status"])
+
+    line = order.lines.first()
+    variant = line.variant
+
+    # copy line and add to order
+    line.id = None
+    line.save()
+
+    assert order.lines.count() == 3
+
+    quantity = 1
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    variables = {
+        "orderId": order_id,
+        "variantId": variant_id,
+        "quantity": quantity,
+        "forceNewLine": True,
+    }
+
+    # assign permissions
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    response = staff_api_client.post_graphql(ORDER_LINES_CREATE_MUTATION, variables)
+
+    assert order.lines.count() == 4
+    assert OrderEvent.objects.count() == 1
+    assert OrderEvent.objects.last().type == order_events.OrderEvents.ADDED_PRODUCTS
+    content = get_graphql_content(response)
+    data = content["data"]["orderLinesCreate"]
+    assert data["orderLines"][0]["productSku"] == variant.sku
+    assert data["orderLines"][0]["productVariantId"] == variant.get_global_id()
+    assert data["orderLines"][0]["quantity"] == quantity
     assert_proper_webhook_called_once(
         order, status, draft_order_updated_webhook_mock, order_updated_webhook_mock
     )
@@ -5689,11 +5898,10 @@ def test_retrieving_event_lines_with_deleted_line(
 ):
     order = order_with_lines
     lines = order_with_lines.lines.all()
-    quantities_per_lines = [(line.quantity, line) for line in lines]
 
     # Create the test event
     order_events.order_added_products_event(
-        order=order, user=staff_user, app=None, order_lines=quantities_per_lines
+        order=order, user=staff_user, app=None, order_lines=lines
     )
 
     # Delete a line
@@ -5708,9 +5916,10 @@ def test_retrieving_event_lines_with_deleted_line(
     data = content["data"]["orders"]["edges"][0]["node"]["events"][0]
 
     # Check every line is returned and the one deleted is None
-    assert len(data["lines"]) == len(quantities_per_lines)
-    for expected_data, received_line in zip(quantities_per_lines, data["lines"]):
-        quantity, line = expected_data
+    assert len(data["lines"]) == len(lines)
+    for expected_data, received_line in zip(lines, data["lines"]):
+        quantity = expected_data.quantity
+        line = expected_data
 
         if line is deleted_line:
             assert received_line["orderLine"] is None
@@ -5728,11 +5937,10 @@ def test_retrieving_event_lines_with_missing_line_pk_in_data(
 ):
     order = order_with_lines
     line = order_with_lines.lines.first()
-    quantities_per_lines = [(line.quantity, line)]
 
     # Create the test event
     event = order_events.order_added_products_event(
-        order=order, user=staff_user, app=None, order_lines=quantities_per_lines
+        order=order, user=staff_user, app=None, order_lines=[line]
     )
     del event.parameters["lines"][0]["line_pk"]
     event.save(update_fields=["parameters"])

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -17,8 +17,17 @@ from ..core.validators import validate_variants_available_in_channel
 if TYPE_CHECKING:
     from ...channel.models import Channel
     from ...order.models import Order
+from dataclasses import dataclass
 
 T_ERRORS = Dict[str, List[ValidationError]]
+
+
+@dataclass
+class OrderLineData:
+    variant_id: Optional[str] = None
+    variant: Optional[ProductVariant] = None
+    line_id: Optional[str] = None
+    quantity: int = 0
 
 
 def validate_total_quantity(order: "Order", errors: T_ERRORS):

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -164,9 +164,8 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
 
         # run order event for deleted lines
         for order, order_lines in draft_order_lines_data.order_to_lines_mapping.items():
-            lines_data = [(line.quantity, line) for line in order_lines]
             order_events.order_line_product_removed_event(
-                order, info.context.user, info.context.app, lines_data
+                order, info.context.user, info.context.app, order_lines
             )
 
         order_pks = draft_order_lines_data.order_pks
@@ -629,9 +628,8 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
 
         # run order event for deleted lines
         for order, order_lines in draft_order_lines_data.order_to_lines_mapping.items():
-            lines_data = [(line.quantity, line) for line in order_lines]
             order_events.order_line_variant_removed_event(
-                order, info.context.user, info.context.app, lines_data
+                order, info.context.user, info.context.app, order_lines
             )
 
         order_pks = draft_order_lines_data.order_pks

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -767,9 +767,8 @@ class ProductDelete(ModelDeleteMutation):
 
         # run order event for deleted lines
         for order, order_lines in draft_order_lines_data.order_to_lines_mapping.items():
-            lines_data = [(line.quantity, line) for line in order_lines]
             order_events.order_line_product_removed_event(
-                order, info.context.user, info.context.app, lines_data
+                order, info.context.user, info.context.app, order_lines
             )
 
         order_pks = draft_order_lines_data.order_pks
@@ -1183,9 +1182,8 @@ class ProductVariantDelete(ModelDeleteMutation):
 
         # run order event for deleted lines
         for order, order_lines in draft_order_lines_data.order_to_lines_mapping.items():
-            lines_data = [(line.quantity, line) for line in order_lines]
             order_events.order_line_variant_removed_event(
-                order, info.context.user, info.context.app, lines_data
+                order, info.context.user, info.context.app, order_lines
             )
 
         order_pks = draft_order_lines_data.order_pks

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17421,6 +17421,11 @@ input OrderLineCreateInput {
 
   """Product variant ID."""
   variantId: ID!
+
+  """
+  Flag that allow force splitting the same variant into multiple lines by skipping the matching logic.
+  """
+  forceNewLine: Boolean = false
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17423,7 +17423,11 @@ input OrderLineCreateInput {
   variantId: ID!
 
   """
-  Flag that allow force splitting the same variant into multiple lines by skipping the matching logic.
+  Flag that allow force splitting the same variant into multiple lines by skipping the matching logic. 
+  
+  Added in Saleor 3.6.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   forceNewLine: Boolean = false
 }

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -1122,7 +1122,7 @@ def create_replace_order(
         order_line.quantity_fulfilled = 0
         order_line_to_create[order_line_id] = order_line
 
-    lines_to_create = order_line_to_create.values()
+    lines_to_create = list(order_line_to_create.values())
     OrderLine.objects.bulk_create(lines_to_create)
 
     draft_order_created_from_replace_event(
@@ -1130,7 +1130,7 @@ def create_replace_order(
         original_order=original_order,
         user=user,
         app=app,
-        lines=[(line.quantity, line) for line in lines_to_create],
+        lines=lines_to_create,
     )
     return replace_order
 
@@ -1299,12 +1299,11 @@ def process_replace(
         order_lines_to_replace=order_lines,
         fulfillment_lines_to_replace=fulfillment_lines,
     )
-    replaced_lines = [(line.quantity, line) for line in new_order.lines.all()]
     fulfillment_replaced_event(
         order=order,
         user=user,
         app=app,
-        replaced_lines=replaced_lines,
+        replaced_lines=list(new_order.lines.all()),
     )
     order_replacement_created(
         original_order=order,

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -11,6 +11,7 @@ from ...core.notify_events import NotifyEventType
 from ...core.prices import quantize_price
 from ...discount import DiscountValueType
 from ...graphql.core.utils import to_global_id_or_none
+from ...graphql.order.utils import OrderLineData
 from ...order import notifications
 from ...order.fetch import fetch_order_info
 from ...plugins.manager import get_plugins_manager
@@ -389,11 +390,15 @@ def test_send_confirmation_emails_without_addresses_for_payment(
     payment_dummy,
 ):
     order = payment_dummy.order
+    line_data = OrderLineData(
+        variant_id=str(digital_content.product_variant.id),
+        variant=digital_content.product_variant,
+        quantity=1,
+    )
 
     line = add_variant_to_order(
         order,
-        digital_content.product_variant,
-        quantity=1,
+        line_data,
         user=info.context.user,
         app=info.context.app,
         manager=info.context.plugins,
@@ -436,11 +441,15 @@ def test_send_confirmation_emails_without_addresses_for_order(
 ):
 
     assert not order.lines.count()
+    line_data = OrderLineData(
+        variant_id=str(digital_content.product_variant.id),
+        variant=digital_content.product_variant,
+        quantity=1,
+    )
 
     line = add_variant_to_order(
         order,
-        digital_content.product_variant,
-        quantity=1,
+        line_data,
         user=info.context.user,
         app=info.context.app,
         manager=info.context.plugins,

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -170,46 +170,6 @@ def test_add_variant_to_order_adds_line_for_new_variant_on_sale(
     assert line.unit_discount_reason
 
 
-def test_add_variant_to_draft_order_adds_line_for_new_variant_with_tax(
-    order_with_lines, product, product_translation_fr, settings, info, site_settings
-):
-    order = order_with_lines
-    variant = product.variants.get()
-    lines_before = order.lines.count()
-    settings.LANGUAGE_CODE = "fr"
-    unit_price = TaxedMoney(net=Money(8, "USD"), gross=Money(10, "USD"))
-    total_price = TaxedMoney(net=Money("30.34", "USD"), gross=Money("36.49", "USD"))
-    unit_price_data = OrderTaxedPricesData(
-        undiscounted_price=unit_price,
-        price_with_discounts=unit_price,
-    )
-    total_price_data = OrderTaxedPricesData(
-        undiscounted_price=total_price,
-        price_with_discounts=total_price,
-    )
-    manager = Mock(
-        calculate_order_line_unit=Mock(return_value=unit_price_data),
-        calculate_order_line_total=Mock(return_value=total_price_data),
-        get_order_line_tax_rate=Mock(return_value=0.25),
-    )
-
-    line_data = OrderLineData(variant_id=str(variant.id), variant=variant, quantity=1)
-    add_variant_to_order(
-        order, line_data, info.context.user, info.context.app, manager, site_settings
-    )
-
-    line = order.lines.last()
-    assert order.lines.count() == lines_before + 1
-    assert line.product_sku == variant.sku
-    assert line.product_variant_id == variant.get_global_id()
-    assert line.quantity == 1
-    assert line.unit_price == unit_price
-    assert line.total_price == total_price
-    assert line.translated_product_name == str(variant.product.translated)
-    assert line.variant_name == str(variant)
-    assert line.product_name == str(variant.product)
-
-
 def test_add_variant_to_draft_order_adds_line_for_variant_with_price_0(
     order_with_lines, product, product_translation_fr, settings, info, site_settings
 ):

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -7,6 +7,8 @@ from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ...discount import DiscountValueType, OrderDiscountType
 from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCardEvent
+from ...graphql.order.utils import OrderLineData
+from ...order.interface import OrderTaxedPricesData
 from ...plugins.manager import get_plugins_manager
 from .. import OrderStatus
 from ..events import OrderEvents
@@ -269,10 +271,12 @@ def test_add_variant_to_order(
     undiscounted_total_price = undiscounted_unit_price * quantity
 
     # when
+    line_data = OrderLineData(
+        variant_id=str(variant.id), variant=variant, quantity=quantity
+    )
     line = add_variant_to_order(
         order,
-        variant,
-        quantity,
+        line_data,
         customer_user,
         None,
         manager,

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -8,7 +8,6 @@ from ...discount import DiscountValueType, OrderDiscountType
 from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCardEvent
 from ...graphql.order.utils import OrderLineData
-from ...order.interface import OrderTaxedPricesData
 from ...plugins.manager import get_plugins_manager
 from .. import OrderStatus
 from ..events import OrderEvents

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3988,7 +3988,8 @@ def order_with_lines_and_events(order_with_lines, staff_user):
         order=order_with_lines,
         user=staff_user,
         app=None,
-        order_lines=[(1, order_with_lines.lines.first())],
+        order_lines=[order_with_lines.lines.first()],
+        quantity_diff=1,
     )
     return order_with_lines
 


### PR DESCRIPTION
I want to merge this change because it adds the possibility to force a new line in `OrderCreate`, `DraftOrderCreate` and `OrderLinesCreate` mutations.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
