### PR TITLE
ORDER_CANCELED notification is fired at the end of transaction

### DIFF
--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -172,7 +172,9 @@ def cancel_order(
     transaction.on_commit(lambda: manager.order_cancelled(order))
     transaction.on_commit(lambda: manager.order_updated(order))
 
-    send_order_canceled_confirmation(order, user, app, manager)
+    transaction.on_commit(
+        lambda: send_order_canceled_confirmation(order, user, app, manager)
+    )
 
 
 def order_refunded(

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -10,6 +10,7 @@ from ...payment.models import Payment
 from ...plugins.manager import get_plugins_manager
 from ...product.models import DigitalContent
 from ...product.tests.utils import create_image
+from ...tests.utils import flush_post_commit_hooks
 from ...warehouse.models import Allocation, Stock
 from .. import FulfillmentStatus, OrderEvents, OrderStatus
 from ..actions import (
@@ -236,6 +237,7 @@ def test_cancel_order(
         order_line__order=order, quantity_allocated__gt=0
     ).exists()
 
+    flush_post_commit_hooks()
     send_order_canceled_confirmation_mock.assert_called_once_with(
         order, None, None, manager
     )


### PR DESCRIPTION
I want to merge this change because it fixes ORDER_CANCELED webhook.
Sample error log from worker when trying to trigger ORDER_CANCELED webhook:
```{"asctime": "2022-07-09T07:10:06Z", "levelname": "ERROR", "celeryTaskId": "1e4e14db-41b6-44ae-891c-fba2177cfbce", "celeryTaskName": "saleor.plugins.webhook.tasks.send_webhook_request_async", "message": "Event delivery id: 903 not found", "hostname": "123"}```
It happens because worker is trying to handle order event that's not persisted in db yet. Moving `send_order_canceled_confirmation` to `transaction.on_commit` block fixes this issue.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
