### PR TITLE
Move attribute value update post save to celery task

### DIFF
--- a/saleor/attribute/tasks.py
+++ b/saleor/attribute/tasks.py
@@ -1,0 +1,23 @@
+from celery.utils.log import get_task_logger
+from django.db.models import Exists, OuterRef, Q
+
+from ..attribute.models import AttributeValue
+from ..celeryconf import app
+from ..product.models import Product, ProductVariant
+from ..product.search import update_products_search_vector
+
+task_logger = get_task_logger(__name__)
+
+
+@app.task
+def update_associated_products_search_vector(attribute_value_pk: int):
+    task_logger.info("Updating associated products search_vector")
+    instance = AttributeValue.objects.get(pk=attribute_value_pk)
+    variants = ProductVariant.objects.filter(
+        Exists(instance.variantassignments.filter(variant_id=OuterRef("id")))
+    )
+    products = Product.objects.filter(
+        Q(Exists(instance.productassignments.filter(product_id=OuterRef("id"))))
+        | Q(Exists(variants.filter(product_id=OuterRef("id"))))
+    )
+    update_products_search_vector(products)


### PR DESCRIPTION
I want to merge this change because speeds up response time for AttributeValueUpdate mutation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
