### PR TITLE
Call order_confirmed events on_commit in transaction

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -1,5 +1,6 @@
 import graphene
 from django.core.exceptions import ValidationError
+from django.db import transaction
 
 from ....account.models import User
 from ....core.exceptions import InsufficientStock
@@ -60,6 +61,7 @@ class DraftOrderComplete(BaseMutation):
             )
 
     @classmethod
+    @traced_atomic_transaction()
     def perform_mutation(cls, _root, info, id):
         manager = info.context.plugins
         order = cls.get_node_or_error(
@@ -124,13 +126,14 @@ class DraftOrderComplete(BaseMutation):
             payment=order.get_last_payment(),
             lines_data=order_lines_info,
         )
-
-        order_created(
-            order_info=order_info,
-            user=info.context.user,
-            app=info.context.app,
-            manager=info.context.plugins,
-            from_draft=True,
+        transaction.on_commit(
+            lambda: order_created(
+                order_info=order_info,
+                user=info.context.user,
+                app=info.context.app,
+                manager=info.context.plugins,
+                from_draft=True,
+            )
         )
 
         return DraftOrderComplete(order=order)

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -84,13 +84,15 @@ class OrderConfirm(ModelMutation):
             gateway.capture(
                 payment, info.context.plugins, channel_slug=order.channel.slug
             )
-            order_captured(
-                order_info,
-                info.context.user,
-                info.context.app,
-                payment.total,
-                payment,
-                manager,
+            transaction.on_commit(
+                lambda: order_captured(
+                    order_info,
+                    info.context.user,
+                    info.context.app,
+                    payment.total,
+                    payment,
+                    manager,
+                )
             )
         transaction.on_commit(
             lambda: order_confirmed(


### PR DESCRIPTION
I want to merge this change because in mutations order_confirmed events should be called on_commit . It is connected to  #9532. Events from current PR were missing in the previous one mentioned.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
