### PR TITLE
Move AttributeValueUpdate post_save_action to celery task

### DIFF
--- a/saleor/attribute/tasks.py
+++ b/saleor/attribute/tasks.py
@@ -1,0 +1,26 @@
+from celery.utils.log import get_task_logger
+from django.db.models import Exists, OuterRef, Q
+
+from ..attribute.models import AttributeValue
+from ..celeryconf import app
+from ..product.models import Product, ProductVariant
+from ..product.search import update_products_search_vector
+
+task_logger = get_task_logger(__name__)
+
+
+@app.task
+def update_associated_products_search_vector(attribute_value_pk: int):
+    try:
+        instance = AttributeValue.objects.get(pk=attribute_value_pk)
+    except AttributeValue.DoesNotExist:
+        return
+
+    variants = ProductVariant.objects.filter(
+        Exists(instance.variantassignments.filter(variant_id=OuterRef("id")))
+    )
+    products = Product.objects.filter(
+        Q(Exists(instance.productassignments.filter(product_id=OuterRef("id"))))
+        | Q(Exists(variants.filter(product_id=OuterRef("id"))))
+    )
+    update_products_search_vector(products)

--- a/saleor/attribute/tasks.py
+++ b/saleor/attribute/tasks.py
@@ -14,6 +14,13 @@ def update_associated_products_search_vector(attribute_value_pk: int):
     try:
         instance = AttributeValue.objects.get(pk=attribute_value_pk)
     except AttributeValue.DoesNotExist:
+        task_logger.warning(
+            (
+                "Could not perform search_vector update on associated products as "
+                'AttributeValue with pk "%s" does not exists.'
+            ),
+            attribute_value_pk,
+        )
         return
 
     variants = ProductVariant.objects.filter(

--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -8,6 +8,7 @@ from django.utils.text import slugify
 from ...attribute import ATTRIBUTE_PROPERTIES_CONFIGURATION, AttributeInputType
 from ...attribute import models as models
 from ...attribute.error_codes import AttributeErrorCode
+from ...attribute.tasks import update_associated_products_search_vector
 from ...core.exceptions import PermissionDenied
 from ...core.permissions import (
     PageTypePermissions,
@@ -748,16 +749,9 @@ class AttributeValueUpdate(AttributeValueCreate):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        variants = product_models.ProductVariant.objects.filter(
-            Exists(instance.variantassignments.filter(variant_id=OuterRef("id")))
-        )
-        products = product_models.Product.objects.filter(
-            Q(Exists(instance.productassignments.filter(product_id=OuterRef("id"))))
-            | Q(Exists(variants.filter(product_id=OuterRef("id"))))
-        )
-        update_products_search_vector(products)
         info.context.plugins.attribute_value_updated(instance)
         info.context.plugins.attribute_updated(instance.attribute)
+        update_associated_products_search_vector.delay(instance.pk)
 
 
 class AttributeValueDelete(ModelDeleteMutation):


### PR DESCRIPTION
I want to merge this change because speeds up response time for AttributeValueUpdate mutation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
