### PR TITLE
Add descriptions to async webhooks event types

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -21336,6 +21336,13 @@ enum VolumeUnitsEnum {
   ACRE_FT
 }
 
+"""
+Event sent when new address is created.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AddressCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21349,16 +21356,17 @@ type AddressCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The address the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The address the event relates to."""
   address: Address
 }
 
+"""
+Event sent when address is updated.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AddressUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21372,16 +21380,17 @@ type AddressUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The address the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The address the event relates to."""
   address: Address
 }
 
+"""
+Event sent when address is deleted.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AddressDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21395,16 +21404,17 @@ type AddressDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The address the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The address the event relates to."""
   address: Address
 }
 
+"""
+Event sent when new app is installed.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AppInstalled implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21418,16 +21428,17 @@ type AppInstalled implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The application the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The application the event relates to."""
   app: App
 }
 
+"""
+Event sent when app is updated.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AppUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21441,16 +21452,17 @@ type AppUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The application the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The application the event relates to."""
   app: App
 }
 
+"""
+Event sent when app is deleted.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AppDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21464,16 +21476,17 @@ type AppDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The application the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The application the event relates to."""
   app: App
 }
 
+"""
+Event sent when app status has changed.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AppStatusChanged implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21487,16 +21500,17 @@ type AppStatusChanged implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The application the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The application the event relates to."""
   app: App
 }
 
+"""
+Event sent when new attribute is created.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AttributeCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21510,16 +21524,17 @@ type AttributeCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The attribute the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The attribute the event relates to."""
   attribute: Attribute
 }
 
+"""
+Event sent when attribute is updated.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AttributeUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21533,16 +21548,17 @@ type AttributeUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The attribute the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The attribute the event relates to."""
   attribute: Attribute
 }
 
+"""
+Event sent when attribute is deleted.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AttributeDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21556,16 +21572,17 @@ type AttributeDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The attribute the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The attribute the event relates to."""
   attribute: Attribute
 }
 
+"""
+Event sent when new attribute value is created.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AttributeValueCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21579,16 +21596,17 @@ type AttributeValueCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The attribute value the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The attribute value the event relates to."""
   attributeValue: AttributeValue
 }
 
+"""
+Event sent when attribute value is updated.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AttributeValueUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21602,16 +21620,17 @@ type AttributeValueUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The attribute value the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The attribute value the event relates to."""
   attributeValue: AttributeValue
 }
 
+"""
+Event sent when attribute value is deleted.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type AttributeValueDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21625,16 +21644,17 @@ type AttributeValueDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The attribute value the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The attribute value the event relates to."""
   attributeValue: AttributeValue
 }
 
+"""
+Event sent when new category is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type CategoryCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21648,16 +21668,17 @@ type CategoryCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The category the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The category the event relates to."""
   category: Category
 }
 
+"""
+Event sent when category is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type CategoryUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21671,16 +21692,17 @@ type CategoryUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The category the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The category the event relates to."""
   category: Category
 }
 
+"""
+Event sent when category is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type CategoryDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21694,16 +21716,17 @@ type CategoryDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The category the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The category the event relates to."""
   category: Category
 }
 
+"""
+Event sent when new channel is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ChannelCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21717,16 +21740,17 @@ type ChannelCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The channel the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The channel the event relates to."""
   channel: Channel
 }
 
+"""
+Event sent when channel is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ChannelUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21740,16 +21764,17 @@ type ChannelUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The channel the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The channel the event relates to."""
   channel: Channel
 }
 
+"""
+Event sent when channel is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ChannelDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21763,16 +21788,17 @@ type ChannelDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The channel the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The channel the event relates to."""
   channel: Channel
 }
 
+"""
+Event sent when channel status has changed.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ChannelStatusChanged implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21786,16 +21812,17 @@ type ChannelStatusChanged implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The channel the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The channel the event relates to."""
   channel: Channel
 }
 
+"""
+Event sent when new gift card is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type GiftCardCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21809,16 +21836,17 @@ type GiftCardCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The gift card the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The gift card the event relates to."""
   giftCard: GiftCard
 }
 
+"""
+Event sent when gift card is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type GiftCardUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21832,16 +21860,17 @@ type GiftCardUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The gift card the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The gift card the event relates to."""
   giftCard: GiftCard
 }
 
+"""
+Event sent when gift card is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type GiftCardDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21855,16 +21884,17 @@ type GiftCardDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The gift card the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The gift card the event relates to."""
   giftCard: GiftCard
 }
 
+"""
+Event sent when gift card status has changed.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type GiftCardStatusChanged implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21878,16 +21908,17 @@ type GiftCardStatusChanged implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The gift card the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The gift card the event relates to."""
   giftCard: GiftCard
 }
 
+"""
+Event sent when new menu is created.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type MenuCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21901,19 +21932,20 @@ type MenuCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The menu the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The menu the event relates to."""
   menu(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Menu
 }
 
+"""
+Event sent when menu is updated.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type MenuUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21927,19 +21959,20 @@ type MenuUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The menu the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The menu the event relates to."""
   menu(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Menu
 }
 
+"""
+Event sent when menu is deleted.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type MenuDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21953,19 +21986,20 @@ type MenuDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The menu the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The menu the event relates to."""
   menu(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Menu
 }
 
+"""
+Event sent when new menu item is created.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type MenuItemCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -21979,19 +22013,20 @@ type MenuItemCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The menu item the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The menu item the event relates to."""
   menuItem(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): MenuItem
 }
 
+"""
+Event sent when menu item is updated.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type MenuItemUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22005,19 +22040,20 @@ type MenuItemUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The menu item the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The menu item the event relates to."""
   menuItem(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): MenuItem
 }
 
+"""
+Event sent when menu item is deleted.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type MenuItemDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22031,19 +22067,20 @@ type MenuItemDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The menu item the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The menu item the event relates to."""
   menuItem(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): MenuItem
 }
 
+"""
+Event sent when new order is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type OrderCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22057,16 +22094,17 @@ type OrderCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The order the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order the event relates to."""
   order: Order
 }
 
+"""
+Event sent when order is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type OrderUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22080,16 +22118,17 @@ type OrderUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The order the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order the event relates to."""
   order: Order
 }
 
+"""
+Event sent when order is confirmed.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type OrderConfirmed implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22103,16 +22142,17 @@ type OrderConfirmed implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The order the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order the event relates to."""
   order: Order
 }
 
+"""
+Event sent when order is fully paid.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type OrderFullyPaid implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22126,16 +22166,17 @@ type OrderFullyPaid implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The order the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order the event relates to."""
   order: Order
 }
 
+"""
+Event sent when order is canceled.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type OrderCancelled implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22149,16 +22190,17 @@ type OrderCancelled implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The order the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order the event relates to."""
   order: Order
 }
 
+"""
+Event sent when order is fulfilled.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type OrderFulfilled implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22172,16 +22214,17 @@ type OrderFulfilled implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The order the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order the event relates to."""
   order: Order
 }
 
+"""
+Event sent when new draft order is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type DraftOrderCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22195,16 +22238,17 @@ type DraftOrderCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The order the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order the event relates to."""
   order: Order
 }
 
+"""
+Event sent when draft order is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type DraftOrderUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22218,16 +22262,17 @@ type DraftOrderUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The order the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order the event relates to."""
   order: Order
 }
 
+"""
+Event sent when draft order is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type DraftOrderDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22241,16 +22286,17 @@ type DraftOrderDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The order the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order the event relates to."""
   order: Order
 }
 
+"""
+Event sent when new product is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ProductCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22264,28 +22310,23 @@ type ProductCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The product the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The product the event relates to."""
   product(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Product
 
-  """
-  The category of the product.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The category of the product."""
   category: Category
 }
 
+"""
+Event sent when product is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ProductUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22299,28 +22340,23 @@ type ProductUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The product the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The product the event relates to."""
   product(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Product
 
-  """
-  The category of the product.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The category of the product."""
   category: Category
 }
 
+"""
+Event sent when product is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ProductDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22334,28 +22370,23 @@ type ProductDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The product the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The product the event relates to."""
   product(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Product
 
-  """
-  The category of the product.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The category of the product."""
   category: Category
 }
 
+"""
+Event sent when new product variant is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ProductVariantCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22369,19 +22400,20 @@ type ProductVariantCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The product variant the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The product variant the event relates to."""
   productVariant(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ProductVariant
 }
 
+"""
+Event sent when product variant is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ProductVariantUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22395,19 +22427,20 @@ type ProductVariantUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The product variant the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The product variant the event relates to."""
   productVariant(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ProductVariant
 }
 
+"""
+Event sent when product variant is out of stock.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ProductVariantOutOfStock implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22421,28 +22454,23 @@ type ProductVariantOutOfStock implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The product variant the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The product variant the event relates to."""
   productVariant(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ProductVariant
 
-  """
-  Look up a warehouse.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Look up a warehouse."""
   warehouse: Warehouse
 }
 
+"""
+Event sent when product variant is back in stock.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ProductVariantBackInStock implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22456,28 +22484,23 @@ type ProductVariantBackInStock implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The product variant the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The product variant the event relates to."""
   productVariant(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ProductVariant
 
-  """
-  Look up a warehouse.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Look up a warehouse."""
   warehouse: Warehouse
 }
 
+"""
+Event sent when product variant is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ProductVariantDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22491,19 +22514,20 @@ type ProductVariantDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The product variant the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The product variant the event relates to."""
   productVariant(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ProductVariant
 }
 
+"""
+Event sent when new sale is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type SaleCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22517,19 +22541,20 @@ type SaleCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The sale the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The sale the event relates to."""
   sale(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Sale
 }
 
+"""
+Event sent when sale is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type SaleUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22543,19 +22568,20 @@ type SaleUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The sale the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The sale the event relates to."""
   sale(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Sale
 }
 
+"""
+Event sent when sale is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type SaleDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22569,13 +22595,7 @@ type SaleDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The sale the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The sale the event relates to."""
   sale(
     """Slug of a channel for which the data should be returned."""
     channel: String
@@ -22615,6 +22635,13 @@ type SaleToggle implements Event {
   ): Sale
 }
 
+"""
+Event sent when invoice is requested.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type InvoiceRequested implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22628,16 +22655,17 @@ type InvoiceRequested implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The invoice the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The invoice the event relates to."""
   invoice: Invoice
 }
 
+"""
+Event sent when invoice is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type InvoiceDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22651,16 +22679,17 @@ type InvoiceDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The invoice the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The invoice the event relates to."""
   invoice: Invoice
 }
 
+"""
+Event sent when invoice is sent.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type InvoiceSent implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22674,16 +22703,17 @@ type InvoiceSent implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The invoice the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The invoice the event relates to."""
   invoice: Invoice
 }
 
+"""
+Event sent when new fulfillment is created.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type FulfillmentCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22697,25 +22727,20 @@ type FulfillmentCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The fulfillment the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The fulfillment the event relates to."""
   fulfillment: Fulfillment
 
-  """
-  The order the fulfillment belongs to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order the fulfillment belongs to."""
   order: Order
 }
 
+"""
+Event sent when fulfillment is canceled.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type FulfillmentCanceled implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22729,25 +22754,20 @@ type FulfillmentCanceled implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The fulfillment the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The fulfillment the event relates to."""
   fulfillment: Fulfillment
 
-  """
-  The order the fulfillment belongs to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The order the fulfillment belongs to."""
   order: Order
 }
 
+"""
+Event sent when new customer user is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type CustomerCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22761,16 +22781,17 @@ type CustomerCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The user the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The user the event relates to."""
   user: User
 }
 
+"""
+Event sent when customer user is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type CustomerUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22784,16 +22805,17 @@ type CustomerUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The user the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The user the event relates to."""
   user: User
 }
 
+"""
+Event sent when new collection is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type CollectionCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22807,19 +22829,20 @@ type CollectionCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The collection the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The collection the event relates to."""
   collection(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Collection
 }
 
+"""
+Event sent when collection is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type CollectionUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22833,19 +22856,20 @@ type CollectionUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The collection the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The collection the event relates to."""
   collection(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Collection
 }
 
+"""
+Event sent when collection is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type CollectionDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22859,19 +22883,20 @@ type CollectionDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The collection the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The collection the event relates to."""
   collection(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Collection
 }
 
+"""
+Event sent when new checkout is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type CheckoutCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22885,16 +22910,17 @@ type CheckoutCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The checkout the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The checkout the event relates to."""
   checkout: Checkout
 }
 
+"""
+Event sent when checkout is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type CheckoutUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22908,16 +22934,17 @@ type CheckoutUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The checkout the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The checkout the event relates to."""
   checkout: Checkout
 }
 
+"""
+Event sent when new page is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type PageCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22931,16 +22958,17 @@ type PageCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The page the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The page the event relates to."""
   page: Page
 }
 
+"""
+Event sent when page is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type PageUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22954,16 +22982,17 @@ type PageUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The page the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The page the event relates to."""
   page: Page
 }
 
+"""
+Event sent when page is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type PageDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -22977,16 +23006,17 @@ type PageDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The page the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The page the event relates to."""
   page: Page
 }
 
+"""
+Event sent when new page type is created.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type PageTypeCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23000,16 +23030,17 @@ type PageTypeCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The page type the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The page type the event relates to."""
   pageType: PageType
 }
 
+"""
+Event sent when page type is updated.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type PageTypeUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23023,16 +23054,17 @@ type PageTypeUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The page type the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The page type the event relates to."""
   pageType: PageType
 }
 
+"""
+Event sent when page type is deleted.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type PageTypeDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23046,16 +23078,17 @@ type PageTypeDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The page type the event relates to.
-  
-  Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The page type the event relates to."""
   pageType: PageType
 }
 
+"""
+Event sent when new permission group is created.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type PermissionGroupCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23069,16 +23102,17 @@ type PermissionGroupCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The permission group the event relates to.
-  
-  Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The permission group the event relates to."""
   permissionGroup: Group
 }
 
+"""
+Event sent when permission group is updated.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type PermissionGroupUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23092,16 +23126,17 @@ type PermissionGroupUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The permission group the event relates to.
-  
-  Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The permission group the event relates to."""
   permissionGroup: Group
 }
 
+"""
+Event sent when permission group is deleted.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type PermissionGroupDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23115,16 +23150,17 @@ type PermissionGroupDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The permission group the event relates to.
-  
-  Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The permission group the event relates to."""
   permissionGroup: Group
 }
 
+"""
+Event sent when new shipping price is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ShippingPriceCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23138,31 +23174,26 @@ type ShippingPriceCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The shipping method the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The shipping method the event relates to."""
   shippingMethod(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ShippingMethodType
 
-  """
-  The shipping zone the shipping method belongs to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The shipping zone the shipping method belongs to."""
   shippingZone(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ShippingZone
 }
 
+"""
+Event sent when shipping price is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ShippingPriceUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23176,31 +23207,26 @@ type ShippingPriceUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The shipping method the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The shipping method the event relates to."""
   shippingMethod(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ShippingMethodType
 
-  """
-  The shipping zone the shipping method belongs to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The shipping zone the shipping method belongs to."""
   shippingZone(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ShippingZone
 }
 
+"""
+Event sent when shipping price is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ShippingPriceDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23214,31 +23240,26 @@ type ShippingPriceDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The shipping method the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The shipping method the event relates to."""
   shippingMethod(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ShippingMethodType
 
-  """
-  The shipping zone the shipping method belongs to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The shipping zone the shipping method belongs to."""
   shippingZone(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ShippingZone
 }
 
+"""
+Event sent when new shipping zone is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ShippingZoneCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23252,19 +23273,20 @@ type ShippingZoneCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The shipping zone the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The shipping zone the event relates to."""
   shippingZone(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ShippingZone
 }
 
+"""
+Event sent when shipping zone is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ShippingZoneUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23278,19 +23300,20 @@ type ShippingZoneUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The shipping zone the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The shipping zone the event relates to."""
   shippingZone(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ShippingZone
 }
 
+"""
+Event sent when shipping zone is deleted.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type ShippingZoneDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23304,19 +23327,20 @@ type ShippingZoneDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The shipping zone the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The shipping zone the event relates to."""
   shippingZone(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): ShippingZone
 }
 
+"""
+Event sent when new staff user is created.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type StaffCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23330,16 +23354,17 @@ type StaffCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The user the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The user the event relates to."""
   user: User
 }
 
+"""
+Event sent when staff user is updated.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type StaffUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23353,16 +23378,17 @@ type StaffUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The user the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The user the event relates to."""
   user: User
 }
 
+"""
+Event sent when staff user is deleted.
+
+Added in Saleor 3.5.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type StaffDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23376,16 +23402,17 @@ type StaffDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The user the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The user the event relates to."""
   user: User
 }
 
+"""
+Event sent when transaction action is requested.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type TransactionActionRequest implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23426,6 +23453,13 @@ type TransactionAction {
   amount: PositiveDecimal
 }
 
+"""
+Event sent when new translation is created.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type TranslationCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23439,18 +23473,19 @@ type TranslationCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The translation the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The translation the event relates to."""
   translation: TranslationTypes
 }
 
 union TranslationTypes = ProductTranslation | CollectionTranslation | CategoryTranslation | AttributeTranslation | AttributeValueTranslation | ProductVariantTranslation | PageTranslation | ShippingMethodTranslation | SaleTranslation | VoucherTranslation | MenuItemTranslation
 
+"""
+Event sent when translation is updated.
+
+Added in Saleor 3.2.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type TranslationUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23464,16 +23499,17 @@ type TranslationUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The translation the event relates to.
-  
-  Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The translation the event relates to."""
   translation: TranslationTypes
 }
 
+"""
+Event sent when new voucher is created.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type VoucherCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23487,19 +23523,20 @@ type VoucherCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The voucher the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The voucher the event relates to."""
   voucher(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Voucher
 }
 
+"""
+Event sent when voucher is updated.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type VoucherUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23513,19 +23550,20 @@ type VoucherUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The voucher the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The voucher the event relates to."""
   voucher(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Voucher
 }
 
+"""
+Event sent when voucher is deleted.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type VoucherDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23539,19 +23577,20 @@ type VoucherDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The voucher the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The voucher the event relates to."""
   voucher(
     """Slug of a channel for which the data should be returned."""
     channel: String
   ): Voucher
 }
 
+"""
+Event sent when new warehouse is created.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type WarehouseCreated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23565,16 +23604,17 @@ type WarehouseCreated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The warehouse the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The warehouse the event relates to."""
   warehouse: Warehouse
 }
 
+"""
+Event sent when warehouse is updated.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type WarehouseUpdated implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23588,16 +23628,17 @@ type WarehouseUpdated implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The warehouse the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The warehouse the event relates to."""
   warehouse: Warehouse
 }
 
+"""
+Event sent when warehouse is deleted.
+
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type WarehouseDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23611,13 +23652,7 @@ type WarehouseDeleted implements Event {
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  The warehouse the event relates to.
-  
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """The warehouse the event relates to."""
   warehouse: Warehouse
 }
 

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -200,7 +200,7 @@ class Event(graphene.Interface):
 class AddressBase(AbstractType):
     address = graphene.Field(
         "saleor.graphql.account.types.Address",
-        description="The address the event relates to." + ADDED_IN_35 + PREVIEW_FEATURE,
+        description="The address the event relates to.",
     )
 
     @staticmethod
@@ -212,24 +212,31 @@ class AddressBase(AbstractType):
 class AddressCreated(ObjectType, AddressBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new address is created." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class AddressUpdated(ObjectType, AddressBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when address is updated." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class AddressDeleted(ObjectType, AddressBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when address is deleted." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class AppBase(AbstractType):
     app = graphene.Field(
         "saleor.graphql.app.types.App",
-        description="The application the event relates to."
-        + ADDED_IN_34
-        + PREVIEW_FEATURE,
+        description="The application the event relates to.",
     )
 
     @staticmethod
@@ -241,29 +248,35 @@ class AppBase(AbstractType):
 class AppInstalled(ObjectType, AppBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new app is installed." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class AppUpdated(ObjectType, AppBase):
     class Meta:
         interfaces = (Event,)
+        description = "Event sent when app is updated." + ADDED_IN_34 + PREVIEW_FEATURE
 
 
 class AppDeleted(ObjectType, AppBase):
     class Meta:
         interfaces = (Event,)
+        description = "Event sent when app is deleted." + ADDED_IN_34 + PREVIEW_FEATURE
 
 
 class AppStatusChanged(ObjectType, AppBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when app status has changed." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class AttributeBase(AbstractType):
     attribute = graphene.Field(
         "saleor.graphql.attribute.types.Attribute",
-        description="The attribute the event relates to."
-        + ADDED_IN_35
-        + PREVIEW_FEATURE,
+        description="The attribute the event relates to.",
     )
 
     @staticmethod
@@ -275,24 +288,31 @@ class AttributeBase(AbstractType):
 class AttributeCreated(ObjectType, AttributeBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new attribute is created." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class AttributeUpdated(ObjectType, AttributeBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when attribute is updated." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class AttributeDeleted(ObjectType, AttributeBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when attribute is deleted." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class AttributeValueBase(AbstractType):
     attribute_value = graphene.Field(
         "saleor.graphql.attribute.types.AttributeValue",
-        description="The attribute value the event relates to."
-        + ADDED_IN_35
-        + PREVIEW_FEATURE,
+        description="The attribute value the event relates to.",
     )
 
     @staticmethod
@@ -304,24 +324,37 @@ class AttributeValueBase(AbstractType):
 class AttributeValueCreated(ObjectType, AttributeValueBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new attribute value is created."
+            + ADDED_IN_35
+            + PREVIEW_FEATURE
+        )
 
 
 class AttributeValueUpdated(ObjectType, AttributeValueBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when attribute value is updated."
+            + ADDED_IN_35
+            + PREVIEW_FEATURE
+        )
 
 
 class AttributeValueDeleted(ObjectType, AttributeValueBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when attribute value is deleted."
+            + ADDED_IN_35
+            + PREVIEW_FEATURE
+        )
 
 
 class CategoryBase(AbstractType):
     category = graphene.Field(
         "saleor.graphql.product.types.Category",
-        description="The category the event relates to."
-        + ADDED_IN_32
-        + PREVIEW_FEATURE,
+        description="The category the event relates to.",
     )
 
     @staticmethod
@@ -333,22 +366,31 @@ class CategoryBase(AbstractType):
 class CategoryCreated(ObjectType, CategoryBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new category is created." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class CategoryUpdated(ObjectType, CategoryBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when category is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class CategoryDeleted(ObjectType, CategoryBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when category is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class ChannelBase(AbstractType):
     channel = graphene.Field(
         "saleor.graphql.channel.types.Channel",
-        description="The channel the event relates to." + ADDED_IN_32 + PREVIEW_FEATURE,
+        description="The channel the event relates to.",
     )
 
     @staticmethod
@@ -360,27 +402,41 @@ class ChannelBase(AbstractType):
 class ChannelCreated(ObjectType, ChannelBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new channel is created." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class ChannelUpdated(ObjectType, ChannelBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when channel is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class ChannelDeleted(ObjectType, ChannelBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when channel is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class ChannelStatusChanged(ObjectType, ChannelBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when channel status has changed."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
 
 class OrderBase(AbstractType):
     order = graphene.Field(
         "saleor.graphql.order.types.Order",
-        description="The order the event relates to." + ADDED_IN_32 + PREVIEW_FEATURE,
+        description="The order the event relates to.",
     )
 
     @staticmethod
@@ -392,54 +448,81 @@ class OrderBase(AbstractType):
 class OrderCreated(ObjectType, OrderBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new order is created." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class OrderUpdated(ObjectType, OrderBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when order is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class OrderConfirmed(ObjectType, OrderBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when order is confirmed." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class OrderFullyPaid(ObjectType, OrderBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when order is fully paid." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class OrderFulfilled(ObjectType, OrderBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when order is fulfilled." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class OrderCancelled(ObjectType, OrderBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when order is canceled." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class DraftOrderCreated(ObjectType, OrderBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new draft order is created."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
 
 class DraftOrderUpdated(ObjectType, OrderBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when draft order is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class DraftOrderDeleted(ObjectType, OrderBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when draft order is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class GiftCardBase(AbstractType):
     gift_card = graphene.Field(
         "saleor.graphql.giftcard.types.GiftCard",
-        description="The gift card the event relates to."
-        + ADDED_IN_32
-        + PREVIEW_FEATURE,
+        description="The gift card the event relates to.",
     )
 
     @staticmethod
@@ -451,21 +534,35 @@ class GiftCardBase(AbstractType):
 class GiftCardCreated(ObjectType, GiftCardBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new gift card is created." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class GiftCardUpdated(ObjectType, GiftCardBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when gift card is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class GiftCardDeleted(ObjectType, GiftCardBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when gift card is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class GiftCardStatusChanged(ObjectType, GiftCardBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when gift card status has changed."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
 
 class MenuBase(AbstractType):
@@ -474,7 +571,7 @@ class MenuBase(AbstractType):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="The menu the event relates to." + ADDED_IN_34 + PREVIEW_FEATURE,
+        description="The menu the event relates to.",
     )
 
     @staticmethod
@@ -486,16 +583,21 @@ class MenuBase(AbstractType):
 class MenuCreated(ObjectType, MenuBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new menu is created." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class MenuUpdated(ObjectType, MenuBase):
     class Meta:
         interfaces = (Event,)
+        description = "Event sent when menu is updated." + ADDED_IN_34 + PREVIEW_FEATURE
 
 
 class MenuDeleted(ObjectType, MenuBase):
     class Meta:
         interfaces = (Event,)
+        description = "Event sent when menu is deleted." + ADDED_IN_34 + PREVIEW_FEATURE
 
 
 class MenuItemBase(AbstractType):
@@ -504,9 +606,7 @@ class MenuItemBase(AbstractType):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="The menu item the event relates to."
-        + ADDED_IN_34
-        + PREVIEW_FEATURE,
+        description="The menu item the event relates to.",
     )
 
     @staticmethod
@@ -518,16 +618,25 @@ class MenuItemBase(AbstractType):
 class MenuItemCreated(ObjectType, MenuItemBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new menu item is created." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class MenuItemUpdated(ObjectType, MenuItemBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when menu item is updated." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class MenuItemDeleted(ObjectType, MenuItemBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when menu item is deleted." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class ProductBase(AbstractType):
@@ -536,11 +645,11 @@ class ProductBase(AbstractType):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="The product the event relates to." + ADDED_IN_32 + PREVIEW_FEATURE,
+        description="The product the event relates to.",
     )
     category = graphene.Field(
         "saleor.graphql.product.types.products.Category",
-        description="The category of the product." + ADDED_IN_32 + PREVIEW_FEATURE,
+        description="The category of the product.",
     )
 
     @staticmethod
@@ -557,16 +666,25 @@ class ProductBase(AbstractType):
 class ProductCreated(ObjectType, ProductBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new product is created." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class ProductUpdated(ObjectType, ProductBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when product is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class ProductDeleted(ObjectType, ProductBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when product is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class ProductVariantBase(AbstractType):
@@ -575,9 +693,7 @@ class ProductVariantBase(AbstractType):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="The product variant the event relates to."
-        + ADDED_IN_32
-        + PREVIEW_FEATURE,
+        description="The product variant the event relates to.",
     )
 
     @staticmethod
@@ -589,26 +705,45 @@ class ProductVariantBase(AbstractType):
 class ProductVariantCreated(ObjectType, ProductVariantBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new product variant is created."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
 
 class ProductVariantUpdated(ObjectType, ProductVariantBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when product variant is updated."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
 
 class ProductVariantDeleted(ObjectType, ProductVariantBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when product variant is deleted."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
 
 class ProductVariantOutOfStock(ObjectType, ProductVariantBase):
     warehouse = graphene.Field(
-        "saleor.graphql.warehouse.types.Warehouse",
-        description="Look up a warehouse." + ADDED_IN_32 + PREVIEW_FEATURE,
+        "saleor.graphql.warehouse.types.Warehouse", description="Look up a warehouse."
     )
 
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when product variant is out of stock."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
     @staticmethod
     def resolve_product_variant(root, info, channel=None):
@@ -624,12 +759,16 @@ class ProductVariantOutOfStock(ObjectType, ProductVariantBase):
 
 class ProductVariantBackInStock(ObjectType, ProductVariantBase):
     warehouse = graphene.Field(
-        "saleor.graphql.warehouse.types.Warehouse",
-        description="Look up a warehouse." + ADDED_IN_32 + PREVIEW_FEATURE,
+        "saleor.graphql.warehouse.types.Warehouse", description="Look up a warehouse."
     )
 
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when product variant is back in stock."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
     @staticmethod
     def resolve_product_variant(root, _info, channel=None):
@@ -649,7 +788,7 @@ class SaleBase(AbstractType):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="The sale the event relates to." + ADDED_IN_32 + PREVIEW_FEATURE,
+        description="The sale the event relates to.",
     )
 
     @staticmethod
@@ -661,16 +800,21 @@ class SaleBase(AbstractType):
 class SaleCreated(ObjectType, SaleBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new sale is created." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class SaleUpdated(ObjectType, SaleBase):
     class Meta:
         interfaces = (Event,)
+        description = "Event sent when sale is updated." + ADDED_IN_32 + PREVIEW_FEATURE
 
 
 class SaleDeleted(ObjectType, SaleBase):
     class Meta:
         interfaces = (Event,)
+        description = "Event sent when sale is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
 
 
 class SaleToggle(ObjectType, SaleBase):
@@ -694,7 +838,7 @@ class SaleToggle(ObjectType, SaleBase):
 class InvoiceBase(AbstractType):
     invoice = graphene.Field(
         "saleor.graphql.invoice.types.Invoice",
-        description="The invoice the event relates to." + ADDED_IN_32 + PREVIEW_FEATURE,
+        description="The invoice the event relates to.",
     )
 
     @staticmethod
@@ -706,30 +850,33 @@ class InvoiceBase(AbstractType):
 class InvoiceRequested(ObjectType, InvoiceBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when invoice is requested." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class InvoiceDeleted(ObjectType, InvoiceBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when invoice is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class InvoiceSent(ObjectType, InvoiceBase):
     class Meta:
         interfaces = (Event,)
+        description = "Event sent when invoice is sent." + ADDED_IN_32 + PREVIEW_FEATURE
 
 
 class FulfillmentBase(AbstractType):
     fulfillment = graphene.Field(
         "saleor.graphql.order.types.Fulfillment",
-        description="The fulfillment the event relates to."
-        + ADDED_IN_32
-        + PREVIEW_FEATURE,
+        description="The fulfillment the event relates to.",
     )
     order = graphene.Field(
         "saleor.graphql.order.types.Order",
-        description="The order the fulfillment belongs to."
-        + ADDED_IN_34
-        + PREVIEW_FEATURE,
+        description="The order the fulfillment belongs to.",
     )
 
     @staticmethod
@@ -746,17 +893,25 @@ class FulfillmentBase(AbstractType):
 class FulfillmentCreated(ObjectType, FulfillmentBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new fulfillment is created."
+            + ADDED_IN_34
+            + PREVIEW_FEATURE
+        )
 
 
 class FulfillmentCanceled(ObjectType, FulfillmentBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when fulfillment is canceled." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class UserBase(AbstractType):
     user = graphene.Field(
         "saleor.graphql.account.types.User",
-        description="The user the event relates to." + ADDED_IN_32 + PREVIEW_FEATURE,
+        description="The user the event relates to.",
     )
 
     @staticmethod
@@ -768,11 +923,19 @@ class UserBase(AbstractType):
 class CustomerCreated(ObjectType, UserBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new customer user is created."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
 
 class CustomerUpdated(ObjectType, UserBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when customer user is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class CollectionBase(AbstractType):
@@ -781,9 +944,7 @@ class CollectionBase(AbstractType):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="The collection the event relates to."
-        + ADDED_IN_32
-        + PREVIEW_FEATURE,
+        description="The collection the event relates to.",
     )
 
     @staticmethod
@@ -795,24 +956,31 @@ class CollectionBase(AbstractType):
 class CollectionCreated(ObjectType, CollectionBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new collection is created." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class CollectionUpdated(ObjectType, CollectionBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when collection is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class CollectionDeleted(ObjectType, CollectionBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when collection is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class CheckoutBase(AbstractType):
     checkout = graphene.Field(
         "saleor.graphql.checkout.types.Checkout",
-        description="The checkout the event relates to."
-        + ADDED_IN_32
-        + PREVIEW_FEATURE,
+        description="The checkout the event relates to.",
     )
 
     @staticmethod
@@ -824,17 +992,22 @@ class CheckoutBase(AbstractType):
 class CheckoutCreated(ObjectType, CheckoutBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new checkout is created." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class CheckoutUpdated(ObjectType, CheckoutBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when checkout is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class PageBase(AbstractType):
     page = graphene.Field(
-        "saleor.graphql.page.types.Page",
-        description="The page the event relates to." + ADDED_IN_32 + PREVIEW_FEATURE,
+        "saleor.graphql.page.types.Page", description="The page the event relates to."
     )
 
     @staticmethod
@@ -846,24 +1019,27 @@ class PageBase(AbstractType):
 class PageCreated(ObjectType, PageBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new page is created." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class PageUpdated(ObjectType, PageBase):
     class Meta:
         interfaces = (Event,)
+        description = "Event sent when page is updated." + ADDED_IN_32 + PREVIEW_FEATURE
 
 
 class PageDeleted(ObjectType, PageBase):
     class Meta:
         interfaces = (Event,)
+        description = "Event sent when page is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
 
 
 class PageTypeBase(AbstractType):
     page_type = graphene.Field(
         "saleor.graphql.page.types.PageType",
-        description="The page type the event relates to."
-        + ADDED_IN_35
-        + PREVIEW_FEATURE,
+        description="The page type the event relates to.",
     )
 
     @staticmethod
@@ -875,24 +1051,31 @@ class PageTypeBase(AbstractType):
 class PageTypeCreated(ObjectType, PageTypeBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new page type is created." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class PageTypeUpdated(ObjectType, PageTypeBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when page type is updated." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class PageTypeDeleted(ObjectType, PageTypeBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when page type is deleted." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class PermissionGroupBase(AbstractType):
     permission_group = graphene.Field(
         "saleor.graphql.account.types.Group",
-        description="The permission group the event relates to."
-        + ADDED_IN_36
-        + PREVIEW_FEATURE,
+        description="The permission group the event relates to.",
     )
 
     @staticmethod
@@ -904,16 +1087,31 @@ class PermissionGroupBase(AbstractType):
 class PermissionGroupCreated(ObjectType, PermissionGroupBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new permission group is created."
+            + ADDED_IN_36
+            + PREVIEW_FEATURE
+        )
 
 
 class PermissionGroupUpdated(ObjectType, PermissionGroupBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when permission group is updated."
+            + ADDED_IN_36
+            + PREVIEW_FEATURE
+        )
 
 
 class PermissionGroupDeleted(ObjectType, PermissionGroupBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when permission group is deleted."
+            + ADDED_IN_36
+            + PREVIEW_FEATURE
+        )
 
 
 class ShippingPriceBase(AbstractType):
@@ -922,18 +1120,14 @@ class ShippingPriceBase(AbstractType):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="The shipping method the event relates to."
-        + ADDED_IN_32
-        + PREVIEW_FEATURE,
+        description="The shipping method the event relates to.",
     )
     shipping_zone = graphene.Field(
         "saleor.graphql.shipping.types.ShippingZone",
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="The shipping zone the shipping method belongs to."
-        + ADDED_IN_32
-        + PREVIEW_FEATURE,
+        description="The shipping zone the shipping method belongs to.",
     )
 
     @staticmethod
@@ -950,16 +1144,27 @@ class ShippingPriceBase(AbstractType):
 class ShippingPriceCreated(ObjectType, ShippingPriceBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new shipping price is created."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
 
 class ShippingPriceUpdated(ObjectType, ShippingPriceBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when shipping price is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class ShippingPriceDeleted(ObjectType, ShippingPriceBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when shipping price is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class ShippingZoneBase(AbstractType):
@@ -968,9 +1173,7 @@ class ShippingZoneBase(AbstractType):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="The shipping zone the event relates to."
-        + ADDED_IN_32
-        + PREVIEW_FEATURE,
+        description="The shipping zone the event relates to.",
     )
 
     @staticmethod
@@ -982,31 +1185,51 @@ class ShippingZoneBase(AbstractType):
 class ShippingZoneCreated(ObjectType, ShippingZoneBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new shipping zone is created."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
 
 class ShippingZoneUpdated(ObjectType, ShippingZoneBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when shipping zone is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class ShippingZoneDeleted(ObjectType, ShippingZoneBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when shipping zone is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class StaffCreated(ObjectType, UserBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new staff user is created." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class StaffUpdated(ObjectType, UserBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when staff user is updated." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class StaffDeleted(ObjectType, UserBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when staff user is deleted." + ADDED_IN_35 + PREVIEW_FEATURE
+        )
 
 
 class TransactionAction(ObjectType, AbstractType):
@@ -1039,6 +1262,11 @@ class TransactionActionRequest(ObjectType):
 
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when transaction action is requested."
+            + ADDED_IN_34
+            + PREVIEW_FEATURE
+        )
 
     @staticmethod
     def resolve_transaction(root, _info):
@@ -1068,10 +1296,7 @@ class TranslationTypes(Union):
 
 class TranslationBase(AbstractType):
     translation = graphene.Field(
-        TranslationTypes,
-        description="The translation the event relates to."
-        + ADDED_IN_32
-        + PREVIEW_FEATURE,
+        TranslationTypes, description="The translation the event relates to."
     )
 
     @staticmethod
@@ -1083,11 +1308,19 @@ class TranslationBase(AbstractType):
 class TranslationCreated(ObjectType, TranslationBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new translation is created."
+            + ADDED_IN_32
+            + PREVIEW_FEATURE
+        )
 
 
 class TranslationUpdated(ObjectType, TranslationBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when translation is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        )
 
 
 class VoucherBase(AbstractType):
@@ -1096,7 +1329,7 @@ class VoucherBase(AbstractType):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="The voucher the event relates to." + ADDED_IN_34 + PREVIEW_FEATURE,
+        description="The voucher the event relates to.",
     )
 
     @staticmethod
@@ -1108,24 +1341,31 @@ class VoucherBase(AbstractType):
 class VoucherCreated(ObjectType, VoucherBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new voucher is created." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class VoucherUpdated(ObjectType, VoucherBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when voucher is updated." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class VoucherDeleted(ObjectType, VoucherBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when voucher is deleted." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class WarehouseBase(AbstractType):
     warehouse = graphene.Field(
         "saleor.graphql.warehouse.types.Warehouse",
-        description="The warehouse the event relates to."
-        + ADDED_IN_34
-        + PREVIEW_FEATURE,
+        description="The warehouse the event relates to.",
     )
 
     @staticmethod
@@ -1137,16 +1377,25 @@ class WarehouseBase(AbstractType):
 class WarehouseCreated(ObjectType, WarehouseBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when new warehouse is created." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class WarehouseUpdated(ObjectType, WarehouseBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when warehouse is updated." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class WarehouseDeleted(ObjectType, WarehouseBase):
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Event sent when warehouse is deleted." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
 
 
 class Subscription(ObjectType):


### PR DESCRIPTION
I want to merge this change because it adds descriptions to async subscription events types.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
