### PR TITLE
Call order_confirmed events on_commit in transaction in 3.5

### DIFF
--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -84,13 +84,15 @@ class OrderConfirm(ModelMutation):
             gateway.capture(
                 payment, info.context.plugins, channel_slug=order.channel.slug
             )
-            order_captured(
-                order_info,
-                info.context.user,
-                info.context.app,
-                payment.total,
-                payment,
-                manager,
+            transaction.on_commit(
+                lambda: order_captured(
+                    order_info,
+                    info.context.user,
+                    info.context.app,
+                    payment.total,
+                    payment,
+                    manager,
+                )
             )
         transaction.on_commit(
             lambda: order_confirmed(


### PR DESCRIPTION
I want to merge this change because it is a port of changes from #10248
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
