### PR TITLE
Fix prepare_thumbnail_file_name function

### DIFF
--- a/saleor/thumbnail/tests/test_utils.py
+++ b/saleor/thumbnail/tests/test_utils.py
@@ -31,6 +31,12 @@ def test_get_thumbnail_size(size, expected_value):
         ("test.txt", 20, None, "test_thumbnail_20.txt"),
         ("test/test.txt", 20, None, "test/test_thumbnail_20.txt"),
         ("test/test.txt", 40, "webp", "test/test_thumbnail_40.webp"),
+        (
+            "test/test_23.03.2022.txt",
+            40,
+            "webp",
+            "test/test_23.03.2022_thumbnail_40.webp",
+        ),
     ],
 )
 def test_prepare_thumbnail_file_name(file_name, size, format, expected_name):

--- a/saleor/thumbnail/utils.py
+++ b/saleor/thumbnail/utils.py
@@ -50,7 +50,7 @@ def get_thumbnail_size(size: Union[str, int]) -> int:
 def prepare_thumbnail_file_name(
     file_name: str, size: int, format: Optional[str]
 ) -> str:
-    file_path, file_ext = file_name.rsplit(".")
+    file_path, file_ext = file_name.rsplit(".", 1)
     file_ext = format or file_ext
     return file_path + f"_thumbnail_{size}." + file_ext
 


### PR DESCRIPTION
I want to merge this change because it fixes `prepare_thumbnail_file_name` function when filename contains `.`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
