### PR TITLE
Handle same variant in multiple lines in checkout limits calculation

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -29,6 +29,7 @@ from ..types import Checkout
 from .utils import (
     check_lines_quantity,
     check_permissions_for_custom_prices,
+    get_variants_and_total_quantities,
     group_lines_input_on_add,
     validate_variants_are_published,
     validate_variants_available_for_purchase,
@@ -186,7 +187,11 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             variant_db_ids, channel.id, CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL
         )
         validate_variants_are_published(variant_db_ids, channel.id)
-        quantities = [line_data.quantity for line_data in checkout_lines_data]
+
+        variants, quantities = get_variants_and_total_quantities(
+            variants, checkout_lines_data
+        )
+
         check_lines_quantity(
             variants,
             quantities,

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -22,6 +22,7 @@ from .utils import (
     check_lines_quantity,
     check_permissions_for_custom_prices,
     get_checkout,
+    get_variants_and_total_quantities,
     group_lines_input_on_add,
     update_checkout_shipping_method_if_invalid,
     validate_variants_are_published,
@@ -74,7 +75,9 @@ class CheckoutLinesAdd(BaseMutation):
         channel_slug,
         lines=None,
     ):
-        quantities = [line_data.quantity for line_data in checkout_lines_data]
+        variants, quantities = get_variants_and_total_quantities(
+            variants, checkout_lines_data
+        )
         check_lines_quantity(
             variants,
             quantities,

--- a/saleor/graphql/checkout/mutations/checkout_lines_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_update.py
@@ -19,7 +19,11 @@ from ...core.validators import validate_one_of_args_is_in_mutation
 from ...product.types import ProductVariant
 from ..types import Checkout
 from .checkout_lines_add import CheckoutLinesAdd
-from .utils import check_lines_quantity, group_lines_input_data_on_update
+from .utils import (
+    check_lines_quantity,
+    get_variants_and_total_quantities,
+    group_lines_input_data_on_update,
+)
 
 
 class CheckoutLineUpdateInput(graphene.InputObjectType):
@@ -94,16 +98,12 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
         channel_slug,
         lines=None,
     ):
-        variants_to_validate = []
-        quantities = []
-
-        for variant, line_data in zip(variants, checkout_lines_data):
-            if line_data.quantity_to_update:
-                variants_to_validate.append(variant)
-                quantities.append(line_data.quantity)
+        variants, quantities = get_variants_and_total_quantities(
+            variants, checkout_lines_data, quantity_to_update_check=True
+        )
 
         check_lines_quantity(
-            variants_to_validate,
+            variants,
             quantities,
             country,
             channel_slug,

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -101,16 +101,19 @@ def update_checkout_shipping_method_if_invalid(
 def get_variants_and_total_quantities(
     variants, lines_data, quantity_to_update_check=False
 ):
-    variants_total_quantity_map = defaultdict(lambda: 0)
+    variants_total_quantity_map = defaultdict(int)
+    mapped_data = defaultdict(int)
+
+    if quantity_to_update_check:
+        lines_data = filter(lambda d: d.quantity_to_update, lines_data)
+
+    for data in lines_data:
+        mapped_data[data.variant_id] += data.quantity
 
     for variant in variants:
-        for data in lines_data:
-            if quantity_to_update_check:
-                if data.quantity_to_update and str(variant.id) == data.variant_id:
-                    variants_total_quantity_map[variant] += data.quantity
-            else:
-                if str(variant.id) == data.variant_id:
-                    variants_total_quantity_map[variant] += data.quantity
+        quantity = mapped_data.get(str(variant.id), None)
+        if quantity is not None:
+            variants_total_quantity_map[variant] += quantity
 
     return variants_total_quantity_map.keys(), variants_total_quantity_map.values()
 

--- a/saleor/graphql/checkout/tests/mutations/test_utils.py
+++ b/saleor/graphql/checkout/tests/mutations/test_utils.py
@@ -168,7 +168,7 @@ def test_group_on_update_when_one_line_and_mixed_parameters_provided(
 
     expected = [
         CheckoutLineData(
-            variant_id=None,
+            variant_id=str(line.variant_id),
             line_id=str(line.id),
             quantity=7,
             quantity_to_update=True,


### PR DESCRIPTION
I want to merge this change because it updates checkout limits calculation to handle same variants in multiple lines.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
