### PR TITLE
Recalculate order prices when marking order as paid

### DIFF
--- a/saleor/graphql/order/mutations/order_mark_as_paid.py
+++ b/saleor/graphql/order/mutations/order_mark_as_paid.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 
 from ....core.permissions import OrderPermissions
 from ....order.actions import clean_mark_order_as_paid, mark_order_as_paid
+from ....order.calculations import fetch_order_prices_if_expired
 from ....order.error_codes import OrderErrorCode
 from ....order.search import update_order_search_vector
 from ...core.mutations import BaseMutation
@@ -37,6 +38,8 @@ class OrderMarkAsPaid(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
+        manager = info.context.plugins
+        order, _ = fetch_order_prices_if_expired(order, manager)
         transaction_reference = data.get("transaction_reference")
         cls.clean_billing_address(order)
         user = info.context.user


### PR DESCRIPTION
I want to merge this change because of recalculating order prices when marking orders as paid.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
