### PR TITLE
Limit the maximum number of search vectors to generate per index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 # 3.5.4 [Unreleased]
 - Fix ORM crash when generating hundreds of search vector in SQL - #10261 by @NyanKiyoshi
+- Fix "stack depth limit exceeded" crash when generating thousands of search vector in SQL - #10279 by @NyanKiyoshi
 
 # 3.5.3 [Released]
 - Use custom search vector in order search - #10247 by @fowczarek

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -23,7 +23,7 @@ from ..account.utils import store_user_address
 from ..checkout import calculations
 from ..checkout.error_codes import CheckoutErrorCode
 from ..core.exceptions import GiftCardNotApplicable, InsufficientStock
-from ..core.postgres import FlatConcat
+from ..core.postgres import FlatConcatSearchVector
 from ..core.taxes import TaxError, zero_taxed_money
 from ..core.tracing import traced_atomic_transaction
 from ..core.utils.url import validate_storefront_url
@@ -566,7 +566,9 @@ def _create_order(
     order.private_metadata = checkout.private_metadata
     update_order_charge_data(order, with_save=False)
     update_order_authorize_data(order, with_save=False)
-    order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+    order.search_vector = FlatConcatSearchVector(
+        *prepare_order_search_vector_value(order)
+    )
     order.save()
 
     order_info = OrderInfo(
@@ -1099,7 +1101,9 @@ def _create_order_from_checkout(
     update_order_authorize_data(order, with_save=False)
 
     # order search
-    order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+    order.search_vector = FlatConcatSearchVector(
+        *prepare_order_search_vector_value(order)
+    )
     order.save()
 
     # post create actions

--- a/saleor/core/postgres.py
+++ b/saleor/core/postgres.py
@@ -1,11 +1,15 @@
+import logging
 from typing import List, Optional, Union
 
+from django.conf import settings
 from django.contrib.postgres.search import (
     CombinedSearchVector,
     SearchVector,
     SearchVectorCombinable,
 )
 from django.db.models import Expression
+
+logger = logging.getLogger(__name__)
 
 
 class NoValidationSearchVectorCombinable(SearchVectorCombinable):
@@ -57,8 +61,31 @@ class FlatConcat(Expression):
     contains_aggregate = False
     contains_over_clause = False
 
+    # Maximum allowed expression to be passed to the function
+    # If ``silent_drop_expression`` is True then it will truncate
+    # and log a warning event. Otherwise, it will raise ValueError
+    #
+    # If the maximum expression count is not limited and there are multiple thousand
+    # values to join, PostgreSQL may reject the SQL statement with:
+    # "django.db.utils.OperationalError: stack depth limit exceeded"
+    max_expression_count: Optional[int] = None
+    silent_drop_expression: bool = False
+
     def __init__(self, *expressions, output_field=None):
         super().__init__(output_field=output_field)
+        if (
+            self.max_expression_count is not None
+            and len(expressions) > self.max_expression_count
+        ):
+            if self.silent_drop_expression:
+                expressions = expressions[: self.max_expression_count]
+                logger.warning(
+                    "Maximum expression count exceed (%d out of %d)",
+                    len(expressions),
+                    self.max_expression_count,
+                )
+            else:
+                raise ValueError("Maximum expression count exceeded")
         self.source_expressions: List[SearchVector] = self._parse_expressions(
             *expressions
         )
@@ -107,3 +134,8 @@ class FlatConcat(Expression):
             params.extend(arg_params)
         data = {"expressions": self.arg_joiner.join(sql_parts)}
         return self.template % data, params
+
+
+class FlatConcatSearchVector(FlatConcat):
+    max_expression_count = settings.INDEX_MAXIMUM_EXPR_COUNT
+    silent_drop_expression = True

--- a/saleor/core/search_tasks.py
+++ b/saleor/core/search_tasks.py
@@ -12,7 +12,7 @@ from ..product.search import (
     PRODUCT_FIELDS_TO_PREFETCH,
     prepare_product_search_vector_value,
 )
-from .postgres import FlatConcat
+from .postgres import FlatConcatSearchVector
 
 task_logger = get_task_logger(__name__)
 
@@ -129,7 +129,7 @@ def set_search_vector_values(
 ):
     Model = instances[0]._meta.model
     for instance in instances:
-        instance.search_vector = FlatConcat(
+        instance.search_vector = FlatConcatSearchVector(
             *prepare_search_vector_func(instance, already_prefetched=True)
         )
     Model.objects.bulk_update(instances, ["search_vector"])

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -93,7 +93,7 @@ from ...shipping.models import (
 from ...warehouse import WarehouseClickAndCollectOption
 from ...warehouse.management import increase_stock
 from ...warehouse.models import PreorderAllocation, Stock, Warehouse
-from ..postgres import FlatConcat
+from ..postgres import FlatConcatSearchVector
 
 fake = Factory.create()
 fake.seed(0)
@@ -835,7 +835,9 @@ def create_fake_order(discounts, max_order_lines=5, create_preorder_lines=False)
     for line in order.lines.all():
         weight += line.variant.get_weight()
     order.weight = weight
-    order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+    order.search_vector = FlatConcatSearchVector(
+        *prepare_order_search_vector_value(order)
+    )
     order.save()
 
     create_fake_payment(order=order)

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -5,7 +5,7 @@ from django.db import transaction
 from ....account.models import User
 from ....core.exceptions import InsufficientStock
 from ....core.permissions import OrderPermissions
-from ....core.postgres import FlatConcat
+from ....core.postgres import FlatConcatSearchVector
 from ....core.taxes import zero_taxed_money
 from ....core.tracing import traced_atomic_transaction
 from ....order import OrderStatus, models
@@ -86,7 +86,9 @@ class DraftOrderComplete(BaseMutation):
                 order.shipping_address.delete()
                 order.shipping_address = None
 
-        order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+        order.search_vector = FlatConcatSearchVector(
+            *prepare_order_search_vector_value(order)
+        )
         order.save()
 
         channel = order.channel

--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -4,7 +4,7 @@ from django.db import transaction
 
 from ....account.models import User
 from ....core.permissions import OrderPermissions
-from ....core.postgres import FlatConcat
+from ....core.postgres import FlatConcatSearchVector
 from ....core.tracing import traced_atomic_transaction
 from ....order import OrderStatus, models
 from ....order.error_codes import OrderErrorCode
@@ -78,7 +78,7 @@ class OrderUpdate(DraftOrderCreate):
         if instance.user_email:
             user = User.objects.filter(email=instance.user_email).first()
             instance.user = user
-        instance.search_vector = FlatConcat(
+        instance.search_vector = FlatConcatSearchVector(
             *prepare_order_search_vector_value(instance)
         )
 

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -23,7 +23,7 @@ from ....checkout import AddressType
 from ....checkout.utils import PRIVATE_META_APP_SHIPPING_ID
 from ....core.anonymize import obfuscate_email
 from ....core.notify_events import NotifyEventType
-from ....core.postgres import FlatConcat
+from ....core.postgres import FlatConcatSearchVector
 from ....core.prices import quantize_price
 from ....core.taxes import TaxError, zero_taxed_money
 from ....discount.models import OrderDiscount, VoucherChannelListing
@@ -9083,7 +9083,9 @@ def test_orders_query_with_filter_search(
         tax_rate=Decimal("0.23"),
     )
     for order in orders:
-        order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+        order.search_vector = FlatConcatSearchVector(
+            *prepare_order_search_vector_value(order)
+        )
     Order.objects.bulk_update(orders, ["search_vector"])
 
     variables = {"filter": orders_filter}
@@ -9125,7 +9127,9 @@ def test_orders_query_with_filter_search_by_global_payment_id(
     payment = Payment.objects.create(order=order_with_payment)
     global_id = graphene.Node.to_global_id("Payment", payment.pk)
     for order in orders:
-        order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+        order.search_vector = FlatConcatSearchVector(
+            *prepare_order_search_vector_value(order)
+        )
     Order.objects.bulk_update(orders, ["search_vector"])
 
     variables = {"filter": {"search": global_id}}
@@ -9481,7 +9485,9 @@ def test_draft_orders_query_with_filter_search(
         ]
     )
     for order in orders:
-        order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+        order.search_vector = FlatConcatSearchVector(
+            *prepare_order_search_vector_value(order)
+        )
     Order.objects.bulk_update(orders, ["search_vector"])
 
     variables = {"filter": draft_orders_filter}

--- a/saleor/graphql/order/tests/test_pagination.py
+++ b/saleor/graphql/order/tests/test_pagination.py
@@ -6,7 +6,7 @@ import pytest
 from freezegun import freeze_time
 from prices import Money, TaxedMoney
 
-from ....core.postgres import FlatConcat
+from ....core.postgres import FlatConcatSearchVector
 from ....discount.models import OrderDiscount
 from ....order.models import Order, OrderStatus
 from ....order.search import (
@@ -37,7 +37,9 @@ def orders_for_pagination(db, channel_USD):
     )
 
     for order in orders:
-        order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+        order.search_vector = FlatConcatSearchVector(
+            *prepare_order_search_vector_value(order)
+        )
     Order.objects.bulk_update(orders, ["search_vector"])
 
     return orders
@@ -456,7 +458,9 @@ def test_orders_query_pagination_with_filter_search(
     )
 
     for order in orders:
-        order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+        order.search_vector = FlatConcatSearchVector(
+            *prepare_order_search_vector_value(order)
+        )
     Order.objects.bulk_update(orders, ["search_vector"])
 
     after = None
@@ -538,7 +542,9 @@ def test_draft_orders_query_pagination_with_filter_search(
     )
 
     for order in orders:
-        order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+        order.search_vector = FlatConcatSearchVector(
+            *prepare_order_search_vector_value(order)
+        )
     Order.objects.bulk_update(orders, ["search_vector"])
 
     page_size = 2

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -12,7 +12,7 @@ from graphene.types import InputObjectType
 from ....attribute import AttributeInputType
 from ....attribute import models as attribute_models
 from ....core.permissions import ProductPermissions, ProductTypePermissions
-from ....core.postgres import FlatConcat
+from ....core.postgres import FlatConcatSearchVector
 from ....core.tracing import traced_atomic_transaction
 from ....order import events as order_events
 from ....order import models as order_models
@@ -644,7 +644,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
             pk__in=product_pks, default_variant__isnull=True
         )
         for product in products:
-            product.search_vector = FlatConcat(
+            product.search_vector = FlatConcatSearchVector(
                 *prepare_product_search_vector_value(product)
             )
             product.default_variant = product.variants.first()

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -25,7 +25,7 @@ from prices import Money, TaxedMoney
 from ....attribute import AttributeInputType, AttributeType
 from ....attribute.models import Attribute, AttributeValue
 from ....attribute.utils import associate_attribute_values_to_instance
-from ....core.postgres import FlatConcat
+from ....core.postgres import FlatConcatSearchVector
 from ....core.taxes import TaxType
 from ....core.units import MeasurementUnits, WeightUnits
 from ....order import OrderEvents, OrderStatus
@@ -2831,7 +2831,9 @@ def test_products_query_with_filter_category_and_search(
     product.save()
 
     for pr in [product, second_product]:
-        pr.search_vector = FlatConcat(*prepare_product_search_vector_value(pr))
+        pr.search_vector = FlatConcatSearchVector(
+            *prepare_product_search_vector_value(pr)
+        )
     Product.objects.bulk_update([product, second_product], ["search_vector"])
 
     category_id = graphene.Node.to_global_id("Category", category.id)
@@ -2963,7 +2965,7 @@ def test_products_query_with_filter(
         channel=channel_USD,
         is_published=False,
     )
-    second_product.search_vector = FlatConcat(
+    second_product.search_vector = FlatConcatSearchVector(
         *prepare_product_search_vector_value(second_product)
     )
     second_product.save(update_fields=["search_vector"])
@@ -3076,7 +3078,7 @@ def test_products_query_with_filter_search_by_dropdown_attribute_value(
 
     product_with_dropdown_attr.refresh_from_db()
 
-    product_with_dropdown_attr.search_vector = FlatConcat(
+    product_with_dropdown_attr.search_vector = FlatConcatSearchVector(
         *prepare_product_search_vector_value(product_with_dropdown_attr)
     )
     product_with_dropdown_attr.save(update_fields=["search_document", "search_vector"])
@@ -3139,7 +3141,7 @@ def test_products_query_with_filter_search_by_multiselect_attribute_value(
 
     product_with_multiselect_attr.refresh_from_db()
 
-    product_with_multiselect_attr.search_vector = FlatConcat(
+    product_with_multiselect_attr.search_vector = FlatConcatSearchVector(
         *prepare_product_search_vector_value(product_with_multiselect_attr)
     )
     product_with_multiselect_attr.save(update_fields=["search_vector"])
@@ -3187,7 +3189,7 @@ def test_products_query_with_filter_search_by_rich_text_attribute(
 
     product_with_rich_text_attr.refresh_from_db()
 
-    product_with_rich_text_attr.search_vector = FlatConcat(
+    product_with_rich_text_attr.search_vector = FlatConcatSearchVector(
         *prepare_product_search_vector_value(product_with_rich_text_attr)
     )
     product_with_rich_text_attr.save(update_fields=["search_vector"])
@@ -3235,7 +3237,7 @@ def test_products_query_with_filter_search_by_plain_text_attribute(
 
     product_with_plain_text_attr.refresh_from_db()
 
-    product_with_plain_text_attr.search_vector = FlatConcat(
+    product_with_plain_text_attr.search_vector = FlatConcatSearchVector(
         *prepare_product_search_vector_value(product_with_plain_text_attr)
     )
     product_with_plain_text_attr.save(update_fields=["search_vector"])
@@ -3286,7 +3288,7 @@ def test_products_query_with_filter_search_by_numeric_attribute_value(
 
     product_with_numeric_attr.refresh_from_db()
 
-    product_with_numeric_attr.search_vector = FlatConcat(
+    product_with_numeric_attr.search_vector = FlatConcatSearchVector(
         *prepare_product_search_vector_value(product_with_numeric_attr)
     )
     product_with_numeric_attr.save(update_fields=["search_vector"])
@@ -3333,7 +3335,7 @@ def test_products_query_with_filter_search_by_numeric_attribute_value_without_un
 
     product_with_numeric_attr.refresh_from_db()
 
-    product_with_numeric_attr.search_vector = FlatConcat(
+    product_with_numeric_attr.search_vector = FlatConcatSearchVector(
         *prepare_product_search_vector_value(product_with_numeric_attr)
     )
     product_with_numeric_attr.save(update_fields=["search_vector"])
@@ -3381,7 +3383,7 @@ def test_products_query_with_filter_search_by_date_attribute_value(
 
     product_with_date_attr.refresh_from_db()
 
-    product_with_date_attr.search_vector = FlatConcat(
+    product_with_date_attr.search_vector = FlatConcatSearchVector(
         *prepare_product_search_vector_value(product_with_date_attr)
     )
     product_with_date_attr.save(update_fields=["search_vector"])
@@ -3429,7 +3431,7 @@ def test_products_query_with_filter_search_by_date_time_attribute_value(
 
     product_with_date_time_attr.refresh_from_db()
 
-    product_with_date_time_attr.search_vector = FlatConcat(
+    product_with_date_time_attr.search_vector = FlatConcatSearchVector(
         *prepare_product_search_vector_value(product_with_date_time_attr)
     )
     product_with_date_time_attr.save(update_fields=["search_vector"])
@@ -5329,7 +5331,9 @@ def test_search_product_by_description_and_name(
 
     product_list.append(product)
     for prod in product_list:
-        prod.search_vector = FlatConcat(*prepare_product_search_vector_value(prod))
+        prod.search_vector = FlatConcatSearchVector(
+            *prepare_product_search_vector_value(prod)
+        )
 
     Product.objects.bulk_update(
         product_list,
@@ -5382,7 +5386,9 @@ def test_search_product_by_description_and_name_without_sort_by(
 
     product_list.append(product)
     for prod in product_list:
-        prod.search_vector = FlatConcat(*prepare_product_search_vector_value(prod))
+        prod.search_vector = FlatConcatSearchVector(
+            *prepare_product_search_vector_value(prod)
+        )
 
     Product.objects.bulk_update(
         product_list,
@@ -5419,7 +5425,9 @@ def test_search_product_by_description_and_name_and_use_cursor(
 
     product_list.append(product)
     for prod in product_list:
-        prod.search_vector = FlatConcat(*prepare_product_search_vector_value(prod))
+        prod.search_vector = FlatConcatSearchVector(
+            *prepare_product_search_vector_value(prod)
+        )
 
     Product.objects.bulk_update(
         product_list,

--- a/saleor/plugins/anonymize/plugin.py
+++ b/saleor/plugins/anonymize/plugin.py
@@ -6,7 +6,7 @@ from faker import Faker
 
 from ...account import search
 from ...core.anonymize import obfuscate_address
-from ...core.postgres import FlatConcat
+from ...core.postgres import FlatConcatSearchVector
 from ...order.search import prepare_order_search_vector_value
 from ..base_plugin import BasePlugin
 from . import obfuscate_order
@@ -49,7 +49,9 @@ class AnonymizePlugin(BasePlugin):
 
     def order_created(self, order: "Order", previous_value: Any):
         order = obfuscate_order(order)
-        order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+        order.search_vector = FlatConcatSearchVector(
+            *prepare_order_search_vector_value(order)
+        )
         order.save()
 
     def customer_created(self, customer: "User", previous_value: Any) -> Any:

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -726,6 +726,20 @@ CHECKOUT_PRICES_TTL = timedelta(
     seconds=parse(os.environ.get("CHECKOUT_PRICES_TTL", "1 hour"))
 )
 
+# The maximum SearchVector expression count allowed per index SQL statement
+# If the count is exceeded, the expression list will be truncated
+INDEX_MAXIMUM_EXPR_COUNT = 4000
+
+# Maximum related objects that can be indexed in an order
+SEARCH_ORDERS_MAX_INDEXED_PAYMENTS = 20
+SEARCH_ORDERS_MAX_INDEXED_DISCOUNTS = 20
+SEARCH_ORDERS_MAX_INDEXED_LINES = 100
+
+# Maximum related objects that can be indexed in a product
+PRODUCT_MAX_INDEXED_ATTRIBUTES = 1000
+PRODUCT_MAX_INDEXED_ATTRIBUTE_VALUES = 100
+PRODUCT_MAX_INDEXED_VARIANTS = 1000
+
 
 # Patch SubscriberExecutionContext class from `graphql-core-legacy` package
 # to fix bug causing not returning errors for subscription queries.

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -44,7 +44,7 @@ from ..checkout.utils import add_variant_to_checkout, add_voucher_to_checkout
 from ..core import EventDeliveryStatus, JobStatus
 from ..core.models import EventDelivery, EventDeliveryAttempt, EventPayload
 from ..core.payments import PaymentInterface
-from ..core.postgres import FlatConcat
+from ..core.postgres import FlatConcatSearchVector
 from ..core.taxes import zero_money
 from ..core.units import MeasurementUnits
 from ..core.utils.editorjs import clean_editor_js
@@ -905,7 +905,9 @@ def order(customer_user, channel_USD):
 
 @pytest.fixture
 def order_with_search_vector_value(order):
-    order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+    order.search_vector = FlatConcatSearchVector(
+        *prepare_order_search_vector_value(order)
+    )
     order.save(update_fields=["search_vector"])
     return order
 
@@ -2303,7 +2305,9 @@ def product_with_two_variants(product_type, category, warehouse, channel_USD):
             for variant in variants
         ]
     )
-    product.search_vector = FlatConcat(*prepare_product_search_vector_value(product))
+    product.search_vector = FlatConcatSearchVector(
+        *prepare_product_search_vector_value(product)
+    )
     product.save(update_fields=["search_vector"])
 
     return product
@@ -2519,7 +2523,9 @@ def product_with_default_variant(
     )
     Stock.objects.create(warehouse=warehouse, product_variant=variant, quantity=100)
 
-    product.search_vector = FlatConcat(*prepare_product_search_vector_value(product))
+    product.search_vector = FlatConcatSearchVector(
+        *prepare_product_search_vector_value(product)
+    )
     product.save(update_fields=["search_vector"])
 
     return product
@@ -2933,7 +2939,7 @@ def product_list(product_type, category, warehouse, channel_USD, channel_PLN):
 
     for product in products:
         associate_attribute_values_to_instance(product, product_attr, attr_value)
-        product.search_vector = FlatConcat(
+        product.search_vector = FlatConcatSearchVector(
             *prepare_product_search_vector_value(product)
         )
 
@@ -5892,7 +5898,9 @@ def allocations(order_list, stock, channel_USD):
     )
 
     for order in order_list:
-        order.search_vector = FlatConcat(*prepare_order_search_vector_value(order))
+        order.search_vector = FlatConcatSearchVector(
+            *prepare_order_search_vector_value(order)
+        )
     Order.objects.bulk_update(order_list, ["search_vector"])
 
     return Allocation.objects.bulk_create(


### PR DESCRIPTION
This ports the crash fix when multiple thousand values are to be indexed due to PostgreSQL rejecting the statement. Such crash would look like this:
```
django.db.utils.OperationalError: stack depth limit exceeded
HINT:  Increase the configuration parameter "max_stack_depth" (currently 2048kB), after ensuring the platform's stack depth limit is adequate.
```

Original #10279, part of #10282 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
