### PR TITLE
Add expiration time to observability buffer

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -570,7 +570,7 @@ OBSERVABILITY_REPORT_ALL_API_CALLS = get_bool_from_env(
     "OBSERVABILITY_REPORT_ALL_API_CALLS", False
 )
 OBSERVABILITY_MAX_PAYLOAD_SIZE = int(
-    os.environ.get("OBSERVABILITY_MAX_PAYLOAD_SIZE", 128 * 1024)
+    os.environ.get("OBSERVABILITY_MAX_PAYLOAD_SIZE", 25 * 1000)
 )
 OBSERVABILITY_BUFFER_SIZE_LIMIT = int(
     os.environ.get("OBSERVABILITY_BUFFER_SIZE_LIMIT", 1000)
@@ -581,12 +581,20 @@ OBSERVABILITY_BUFFER_BATCH_SIZE = int(
 OBSERVABILITY_REPORT_PERIOD = timedelta(
     seconds=parse(os.environ.get("OBSERVABILITY_REPORT_PERIOD", "20 seconds"))
 )
+OBSERVABILITY_BUFFER_TIMEOUT = timedelta(
+    seconds=parse(os.environ.get("OBSERVABILITY_BUFFER_TIMEOUT", "5 minutes"))
+)
 if OBSERVABILITY_ACTIVE:
     CELERY_BEAT_SCHEDULE["observability-reporter"] = {
         "task": "saleor.plugins.webhook.tasks.observability_reporter_task",
         "schedule": OBSERVABILITY_REPORT_PERIOD,
         "options": {"expires": OBSERVABILITY_REPORT_PERIOD.total_seconds()},
     }
+    if OBSERVABILITY_BUFFER_TIMEOUT < OBSERVABILITY_REPORT_PERIOD * 2:
+        warnings.warn(
+            "OBSERVABILITY_REPORT_PERIOD is too big compared to "
+            "OBSERVABILITY_BUFFER_TIMEOUT. That can lead to a loss of events."
+        )
 
 # Change this value if your application is running behind a proxy,
 # e.g. HTTP_CF_Connecting_IP for Cloudflare or X_FORWARDED_FOR


### PR DESCRIPTION
I want to merge this change because it:
- Adds expiration time (timeout) to the observability buffer. Redis will automatically clear the buffer if not used after the time set in `OBSERVABILITY_BUFFER_TIMEOUT`
- Changes the default value of the buffer's `connection_timeout`
- Changes the default value of `OBSERVABILITY_MAX_PAYLOAD_SIZE` to 25KB 

CLOUD-1832

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
