### PR TITLE
Fix variant quantity available for no channel and country code in 3.5

### DIFF
--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -383,6 +383,8 @@ class ProductVariant(ChannelContextTypeWithMetadata, ModelObjectType):
         if address is not None:
             country_code = address.country
 
+        channel_slug = str(root.channel_slug) if root.channel_slug else None
+
         global_quantity_limit_per_checkout = (
             info.context.site.settings.limit_quantity_per_checkout
         )
@@ -391,7 +393,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, ModelObjectType):
             variant = root.node
             channel_listing = VariantChannelListingByVariantIdAndChannelSlugLoader(
                 info.context
-            ).load((variant.id, str(root.channel_slug)))
+            ).load((variant.id, channel_slug))
 
             def calculate_available_per_channel(channel_listing):
                 if (
@@ -486,7 +488,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, ModelObjectType):
 
         return AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
             info.context
-        ).load((root.node.id, country_code, str(root.channel_slug)))
+        ).load((root.node.id, country_code, channel_slug))
 
     @staticmethod
     def resolve_digital_content(root: ChannelContext[models.ProductVariant], _info):


### PR DESCRIPTION
I want to merge this change because it is a port of #10297 changes

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
