### PR TITLE
Patch migration to set search_index_dirty default value on db

### DIFF
--- a/saleor/attribute/tasks.py
+++ b/saleor/attribute/tasks.py
@@ -4,7 +4,6 @@ from django.db.models import Exists, OuterRef, Q
 from ..attribute.models import AttributeValue
 from ..celeryconf import app
 from ..product.models import Product, ProductVariant
-from ..product.search import update_products_search_vector
 
 task_logger = get_task_logger(__name__)
 
@@ -19,8 +18,7 @@ def update_associated_products_search_vector(attribute_value_pk: int):
     variants = ProductVariant.objects.filter(
         Exists(instance.variantassignments.filter(variant_id=OuterRef("id")))
     )
-    products = Product.objects.filter(
+    Product.objects.filter(
         Q(Exists(instance.productassignments.filter(product_id=OuterRef("id"))))
         | Q(Exists(variants.filter(product_id=OuterRef("id"))))
-    )
-    update_products_search_vector(products)
+    ).update(search_index_dirty=True)

--- a/saleor/product/migrations/0171_product_search_index_dirty.py
+++ b/saleor/product/migrations/0171_product_search_index_dirty.py
@@ -15,4 +15,11 @@ class Migration(migrations.Migration):
             name="search_index_dirty",
             field=models.BooleanField(default=False),
         ),
+        migrations.RunSQL(
+            """
+            ALTER TABLE product_product ALTER COLUMN search_index_dirty SET DEFAULT
+            false;
+            """,
+            migrations.RunSQL.noop,
+        ),
     ]


### PR DESCRIPTION
I want to merge this change because it patches migration to set `search_index_dirty` default value on db.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
