### PR TITLE
Add missing ID field to webhook checkout payload

### DIFF
--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -526,7 +526,6 @@ def generate_checkout_payload(
     checkout_data = serializer.serialize(
         [checkout],
         fields=checkout_fields,
-        obj_id_name="token",
         pk_field_name="token",
         additional_fields={
             "channel": (lambda o: o.channel, CHANNEL_FIELDS),
@@ -551,6 +550,9 @@ def generate_checkout_payload(
             else None,
             "meta": generate_meta(requestor_data=generate_requestor(requestor)),
             "created": checkout.created_at,
+            # We add token as a graphql ID as it worked in that way since we introduce
+            # a checkout payload
+            "token": graphene.Node.to_global_id("Checkout", checkout.token),
         },
     )
     return checkout_data

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -1547,6 +1547,7 @@ def test_generate_checkout_payload(
     # then
     assert payload == {
         "type": "Checkout",
+        "id": graphene.Node.to_global_id("Checkout", checkout.pk),
         "token": graphene.Node.to_global_id("Checkout", checkout.pk),
         "created": parse_django_datetime(checkout.created_at),
         "last_change": parse_django_datetime(checkout.last_change),


### PR DESCRIPTION
I want to merge this change because it adds missing `ID` field to checkout payload.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
