### PR TITLE
Fix some async webhooks payloads 3.5

### DIFF
--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import Mock, patch
 
 import graphene
@@ -6,6 +7,7 @@ import requests
 from django.core.exceptions import ValidationError
 from freezegun import freeze_time
 
+from ...core.utils.json_serializer import CustomJsonEncoder
 from ...webhook.event_types import WebhookEventAsyncType
 from ...webhook.payloads import generate_meta, generate_requestor
 from ..installation_utils import install_app
@@ -65,12 +67,15 @@ def test_install_app_created_app_trigger_webhook(
 
     # then
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("App", app.id),
-            "is_active": app.is_active,
-            "name": app.name,
-            "meta": generate_meta(requestor_data=generate_requestor()),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("App", app.id),
+                "is_active": app.is_active,
+                "name": app.name,
+                "meta": generate_meta(requestor_data=generate_requestor()),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.APP_INSTALLED,
         [any_webhook],
         app,

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import re
 from collections import defaultdict
@@ -31,6 +32,7 @@ from ....core.jwt import create_token
 from ....core.notify_events import NotifyEventType
 from ....core.permissions import AccountPermissions, OrderPermissions
 from ....core.tokens import account_delete_token_generator
+from ....core.utils.json_serializer import CustomJsonEncoder
 from ....core.utils.url import prepare_url
 from ....order import OrderStatus
 from ....order.models import FulfillmentStatus, Order
@@ -56,15 +58,20 @@ from ..tests.utils import convert_dict_keys_to_camel_case
 
 def generate_address_webhook_call_args(address, event, requestor, webhook):
     return [
-        {
-            "id": graphene.Node.to_global_id("Address", address.id),
-            "city": address.city,
-            "country": address.country,
-            "company_name": address.company_name,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(SimpleLazyObject(lambda: requestor))
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("Address", address.id),
+                "city": address.city,
+                "country": {"code": address.country.code, "name": address.country.name},
+                "company_name": address.company_name,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: requestor)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         event,
         [webhook],
         address,
@@ -2471,15 +2478,18 @@ def test_staff_create_trigger_webhook(
     assert not data["errors"]
     assert data["user"]
     expected_call = call(
-        {
-            "id": graphene.Node.to_global_id("User", new_staff_user.id),
-            "email": email,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("User", new_staff_user.id),
+                "email": email,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.STAFF_CREATED,
         [any_webhook],
         new_staff_user,
@@ -2794,15 +2804,18 @@ def test_staff_update_trigger_webhook(
     assert not data["errors"]
     assert data["user"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("User", staff_user.id),
-            "email": staff_user.email,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("User", staff_user.id),
+                "email": staff_user.email,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.STAFF_UPDATED,
         [any_webhook],
         staff_user,
@@ -3323,15 +3336,18 @@ def test_staff_delete_trigger_webhook(
     assert not data["errors"]
     assert not User.objects.filter(pk=staff_user.id).exists()
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("User", staff_user.id),
-            "email": staff_user.email,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("User", staff_user.id),
+                "email": staff_user.email,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.STAFF_DELETED,
         [any_webhook],
         staff_user,

--- a/saleor/graphql/app/tests/mutations/test_app_activate.py
+++ b/saleor/graphql/app/tests/mutations/test_app_activate.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -5,6 +6,7 @@ from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
 from .....app.models import App
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -82,16 +84,19 @@ def test_activate_app_trigger_webhook(
     # then
     assert app.is_active
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "is_active": app.is_active,
-            "name": app.name,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "is_active": app.is_active,
+                "name": app.name,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.APP_STATUS_CHANGED,
         [any_webhook],
         app,

--- a/saleor/graphql/app/tests/mutations/test_app_create.py
+++ b/saleor/graphql/app/tests/mutations/test_app_create.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -6,6 +7,7 @@ from freezegun import freeze_time
 
 from .....app.error_codes import AppErrorCode
 from .....app.models import App
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....core.enums import PermissionEnum
@@ -103,16 +105,19 @@ def test_app_create_trigger_webhook(
     # then
     assert content["data"]["appCreate"]["app"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("App", app.id),
-            "is_active": app.is_active,
-            "name": app.name,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("App", app.id),
+                "is_active": app.is_active,
+                "name": app.name,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.APP_INSTALLED,
         [any_webhook],
         app,

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -8,6 +9,7 @@ from freezegun import freeze_time
 
 from .....attribute.error_codes import AttributeErrorCode
 from .....attribute.models import Attribute
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....core.enums import MeasurementUnitsEnum
@@ -154,16 +156,19 @@ def test_create_attribute_trigger_webhook(
     assert data["attribute"]
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("Attribute", attribute.id),
-            "name": attribute.name,
-            "slug": attribute.slug,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("Attribute", attribute.id),
+                "name": attribute.name,
+                "slug": attribute.slug,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.ATTRIBUTE_CREATED,
         [any_webhook],
         attribute,

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_reorder_values.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_reorder_values.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -5,6 +6,7 @@ from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
 from .....attribute.models import AttributeValue
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....tests.utils import get_graphql_content
@@ -205,12 +207,15 @@ def test_sort_values_trigger_webhook(
     )
 
     attribute_updated_call = mock.call(
-        {
-            "id": graphene.Node.to_global_id("Attribute", color_attribute.id),
-            "name": color_attribute.name,
-            "slug": color_attribute.slug,
-            "meta": meta,
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("Attribute", color_attribute.id),
+                "name": color_attribute.name,
+                "slug": color_attribute.slug,
+                "meta": meta,
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.ATTRIBUTE_UPDATED,
         [any_webhook],
         color_attribute,
@@ -219,13 +224,16 @@ def test_sort_values_trigger_webhook(
 
     def generate_attribute_value_update_call(value):
         return mock.call(
-            {
-                "id": graphene.Node.to_global_id("AttributeValue", value.id),
-                "name": value.name,
-                "slug": value.slug,
-                "value": value.value,
-                "meta": meta,
-            },
+            json.dumps(
+                {
+                    "id": graphene.Node.to_global_id("AttributeValue", value.id),
+                    "name": value.name,
+                    "slug": value.slug,
+                    "value": value.value,
+                    "meta": meta,
+                },
+                cls=CustomJsonEncoder,
+            ),
             WebhookEventAsyncType.ATTRIBUTE_VALUE_UPDATED,
             [any_webhook],
             value,

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -9,6 +10,7 @@ from freezegun import freeze_time
 
 from .....attribute.error_codes import AttributeErrorCode
 from .....attribute.models import AttributeValue
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....tests.utils import get_graphql_content
@@ -132,12 +134,15 @@ def test_create_attribute_value_trigger_webhooks(
     )
 
     attribute_updated_call = mock.call(
-        {
-            "id": graphene.Node.to_global_id("Attribute", color_attribute.id),
-            "name": color_attribute.name,
-            "slug": color_attribute.slug,
-            "meta": meta,
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("Attribute", color_attribute.id),
+                "name": color_attribute.name,
+                "slug": color_attribute.slug,
+                "meta": meta,
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.ATTRIBUTE_UPDATED,
         [any_webhook],
         color_attribute,
@@ -145,13 +150,16 @@ def test_create_attribute_value_trigger_webhooks(
     )
 
     attribute_value_created_call = mock.call(
-        {
-            "id": graphene.Node.to_global_id("AttributeValue", attribute_value.id),
-            "name": attribute_value.name,
-            "slug": attribute_value.slug,
-            "value": attribute_value.value,
-            "meta": meta,
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("AttributeValue", attribute_value.id),
+                "name": attribute_value.name,
+                "slug": attribute_value.slug,
+                "value": attribute_value.value,
+                "meta": meta,
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.ATTRIBUTE_VALUE_CREATED,
         [any_webhook],
         attribute_value,

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -6,6 +7,7 @@ from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
 from .....attribute.utils import associate_attribute_values_to_instance
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 
@@ -101,12 +103,15 @@ def test_delete_attribute_value_trigger_webhooks(
     )
 
     attribute_updated_call = mock.call(
-        {
-            "id": graphene.Node.to_global_id("Attribute", color_attribute.id),
-            "name": color_attribute.name,
-            "slug": color_attribute.slug,
-            "meta": meta,
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("Attribute", color_attribute.id),
+                "name": color_attribute.name,
+                "slug": color_attribute.slug,
+                "meta": meta,
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.ATTRIBUTE_UPDATED,
         [any_webhook],
         color_attribute,
@@ -114,13 +119,16 @@ def test_delete_attribute_value_trigger_webhooks(
     )
 
     attribute_value_created_call = mock.call(
-        {
-            "id": graphene.Node.to_global_id("AttributeValue", value.id),
-            "name": value.name,
-            "slug": value.slug,
-            "value": value.value,
-            "meta": meta,
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("AttributeValue", value.id),
+                "name": value.name,
+                "slug": value.slug,
+                "value": value.value,
+                "meta": meta,
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.ATTRIBUTE_VALUE_DELETED,
         [any_webhook],
         value,

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -8,6 +9,7 @@ from freezegun import freeze_time
 
 from .....attribute.error_codes import AttributeErrorCode
 from .....attribute.utils import associate_attribute_values_to_instance
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....tests.utils import get_graphql_content
@@ -133,12 +135,15 @@ def test_update_attribute_value_trigger_webhooks(
     )
 
     attribute_updated_call = mock.call(
-        {
-            "id": graphene.Node.to_global_id("Attribute", attribute.id),
-            "name": attribute.name,
-            "slug": attribute.slug,
-            "meta": meta,
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("Attribute", attribute.id),
+                "name": attribute.name,
+                "slug": attribute.slug,
+                "meta": meta,
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.ATTRIBUTE_UPDATED,
         [any_webhook],
         attribute,
@@ -146,13 +151,16 @@ def test_update_attribute_value_trigger_webhooks(
     )
 
     attribute_value_created_call = mock.call(
-        {
-            "id": graphene.Node.to_global_id("AttributeValue", value.id),
-            "name": value.name,
-            "slug": value.slug,
-            "value": value.value,
-            "meta": meta,
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("AttributeValue", value.id),
+                "name": value.name,
+                "slug": value.slug,
+                "value": value.value,
+                "meta": meta,
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.ATTRIBUTE_VALUE_UPDATED,
         [any_webhook],
         value,

--- a/saleor/graphql/channel/tests/test_channel_availability.py
+++ b/saleor/graphql/channel/tests/test_channel_availability.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -5,6 +6,7 @@ from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
 from ....channel.error_codes import ChannelErrorCode
+from ....core.utils.json_serializer import CustomJsonEncoder
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.payloads import generate_meta, generate_requestor
 from ...tests.utils import get_graphql_content
@@ -83,15 +85,18 @@ def test_channel_activate_mutation_trigger_webhook(
     # then
     assert not content["data"]["channelActivate"]["errors"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "is_active": True,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "is_active": True,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.CHANNEL_STATUS_CHANGED,
         [any_webhook],
         channel_USD,
@@ -190,15 +195,18 @@ def test_channel_deactivate_mutation_trigger_webhook(
     # then
     assert not content["data"]["channelDeactivate"]["errors"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "is_active": False,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "is_active": False,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.CHANNEL_STATUS_CHANGED,
         [any_webhook],
         channel_USD,

--- a/saleor/graphql/channel/tests/test_channel_delete_mutations.py
+++ b/saleor/graphql/channel/tests/test_channel_delete_mutations.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -7,6 +8,7 @@ from freezegun import freeze_time
 from ....channel.error_codes import ChannelErrorCode
 from ....channel.models import Channel
 from ....checkout.models import Checkout
+from ....core.utils.json_serializer import CustomJsonEncoder
 from ....order.models import Order
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.payloads import generate_meta, generate_requestor
@@ -268,15 +270,18 @@ def test_channel_delete_mutation_trigger_webhook(
     assert not Channel.objects.filter(slug=channel_USD.slug).exists()
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("Channel", channel_USD.id),
-            "is_active": channel_USD.is_active,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("Channel", channel_USD.id),
+                "is_active": channel_USD.is_active,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.CHANNEL_DELETED,
         [any_webhook],
         channel_USD,

--- a/saleor/graphql/discount/tests/test_discount.py
+++ b/saleor/graphql/discount/tests/test_discount.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta
 from unittest.mock import ANY, patch
 
@@ -8,6 +9,7 @@ from django.utils.functional import SimpleLazyObject
 from django_countries import countries
 from freezegun import freeze_time
 
+from ....core.utils.json_serializer import CustomJsonEncoder
 from ....discount import DiscountValueType, VoucherType
 from ....discount.error_codes import DiscountErrorCode
 from ....discount.models import Sale, SaleChannelListing, Voucher
@@ -536,16 +538,19 @@ def test_create_voucher_trigger_webhook(
     # then
     assert content["data"]["voucherCreate"]["voucher"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("Voucher", voucher.id),
-            "name": voucher.name,
-            "code": voucher.code,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("Voucher", voucher.id),
+                "name": voucher.name,
+                "code": voucher.code,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.VOUCHER_CREATED,
         [any_webhook],
         voucher,
@@ -740,16 +745,19 @@ def test_update_voucher_trigger_webhook(
     # then
     assert content["data"]["voucherUpdate"]["voucher"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "name": voucher.name,
-            "code": variables["code"],
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "name": voucher.name,
+                "code": variables["code"],
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.VOUCHER_UPDATED,
         [any_webhook],
         voucher,
@@ -816,16 +824,19 @@ def test_voucher_delete_mutation_trigger_webhook(
     # then
     assert content["data"]["voucherDelete"]["voucher"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "name": voucher.name,
-            "code": voucher.code,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "name": voucher.name,
+                "code": voucher.code,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.VOUCHER_DELETED,
         [any_webhook],
         voucher,
@@ -940,16 +951,19 @@ def test_voucher_add_catalogues_trigger_webhook(
     assert content["data"]["voucherCataloguesAdd"]["voucher"]
     assert not data["errors"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "name": voucher.name,
-            "code": voucher.code,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "name": voucher.name,
+                "code": voucher.code,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.VOUCHER_UPDATED,
         [any_webhook],
         voucher,

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_activate.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_activate.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date, timedelta
 from unittest import mock
 
@@ -5,6 +6,7 @@ import graphene
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....giftcard import GiftCardEvents
 from .....giftcard.error_codes import GiftCardErrorCode
 from .....webhook.event_types import WebhookEventAsyncType
@@ -226,15 +228,18 @@ def test_activate_gift_card_trigger_webhook(
     assert data["isActive"]
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "is_active": True,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "is_active": True,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.GIFT_CARD_STATUS_CHANGED,
         [any_webhook],
         gift_card,

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_add_note.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_add_note.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date, timedelta
 from unittest import mock
 
@@ -6,6 +7,7 @@ import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....giftcard import GiftCardEvents
 from .....giftcard.error_codes import GiftCardErrorCode
 from .....webhook.event_types import WebhookEventAsyncType
@@ -238,15 +240,18 @@ def test_gift_card_add_note_trigger_webhook(
     assert data["giftCard"]
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("GiftCard", gift_card.id),
-            "is_active": gift_card.is_active,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("GiftCard", gift_card.id),
+                "is_active": gift_card.is_active,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.GIFT_CARD_UPDATED,
         [any_webhook],
         gift_card,

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_deactivate.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_deactivate.py
@@ -1,9 +1,11 @@
+import json
 from unittest import mock
 
 import graphene
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....giftcard import GiftCardEvents
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
@@ -201,15 +203,18 @@ def test_deactivate_gift_card_trigger_webhook(
     assert not data["isActive"]
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "is_active": False,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "is_active": False,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.GIFT_CARD_STATUS_CHANGED,
         [any_webhook],
         gift_card,

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_delete.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_delete.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -5,6 +6,7 @@ import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -117,15 +119,18 @@ def test_delete_gift_card_trigger_webhook(
 
     assert data["id"] == id
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": id,
-            "is_active": gift_card.is_active,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": id,
+                "is_active": gift_card.is_active,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.GIFT_CARD_DELETED,
         [any_webhook],
         gift_card,

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date, timedelta
 from unittest import mock
 
@@ -6,6 +7,7 @@ import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....giftcard import GiftCardEvents
 from .....giftcard.error_codes import GiftCardErrorCode
 from .....giftcard.models import GiftCardTag
@@ -782,15 +784,18 @@ def test_update_gift_card_trigger_webhook(
     assert data
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("GiftCard", gift_card.id),
-            "is_active": gift_card.is_active,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("GiftCard", gift_card.id),
+                "is_active": gift_card.is_active,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.GIFT_CARD_UPDATED,
         [any_webhook],
         gift_card,

--- a/saleor/graphql/menu/tests/test_menu.py
+++ b/saleor/graphql/menu/tests/test_menu.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from ....core.utils.json_serializer import CustomJsonEncoder
 from ....menu.error_codes import MenuErrorCode
 from ....menu.models import Menu, MenuItem
 from ....product.models import Category
@@ -675,15 +676,18 @@ def test_create_menu_trigger_webhook(
     # then
     assert content["data"]["menuCreate"]["menu"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("Menu", menu.id),
-            "slug": menu.slug,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("Menu", menu.id),
+                "slug": menu.slug,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.MENU_CREATED,
         [any_webhook],
         menu,
@@ -833,15 +837,18 @@ def test_update_menu_trigger_webhook(
     # then
     assert content["data"]["menuUpdate"]["menu"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "slug": variables["slug"],
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "slug": variables["slug"],
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.MENU_UPDATED,
         [any_webhook],
         menu,
@@ -923,15 +930,18 @@ def test_delete_menu_trigger_webhook(
     # then
     assert content["data"]["menuDelete"]["menu"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "slug": menu.slug,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "slug": menu.slug,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.MENU_DELETED,
         [any_webhook],
         menu,
@@ -1000,16 +1010,19 @@ def test_create_menu_item_trigger_webhook(
     # then
     assert content["data"]["menuItemCreate"]["menuItem"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("MenuItem", menu_item.id),
-            "name": menu_item.name,
-            "menu": {"id": menu_id},
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("MenuItem", menu_item.id),
+                "name": menu_item.name,
+                "menu": {"id": menu_id},
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.MENU_ITEM_CREATED,
         [any_webhook],
         menu_item,
@@ -1081,16 +1094,19 @@ def test_update_menu_item_trigger_webhook(
     # then
     assert content["data"]["menuItemUpdate"]["menuItem"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": menu_item_id,
-            "name": menu_item.name,
-            "menu": {"id": graphene.Node.to_global_id("Menu", menu_item.menu_id)},
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": menu_item_id,
+                "name": menu_item.name,
+                "menu": {"id": graphene.Node.to_global_id("Menu", menu_item.menu_id)},
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.MENU_ITEM_UPDATED,
         [any_webhook],
         menu_item,
@@ -1150,16 +1166,19 @@ def test_delete_menu_item_trigger_webhook(
     # then
     assert content["data"]["menuItemDelete"]["menuItem"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": menu_item_id,
-            "name": menu_item.name,
-            "menu": {"id": graphene.Node.to_global_id("Menu", menu_item.menu_id)},
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": menu_item_id,
+                "name": menu_item.name,
+                "menu": {"id": graphene.Node.to_global_id("Menu", menu_item.menu_id)},
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.MENU_ITEM_DELETED,
         [any_webhook],
         menu_item,

--- a/saleor/graphql/page/tests/mutations/test_page_type_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_type_create.py
@@ -1,9 +1,11 @@
+import json
 from unittest import mock
 
 import graphene
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....page.error_codes import PageErrorCode
 from .....page.models import PageType
 from .....webhook.event_types import WebhookEventAsyncType
@@ -119,16 +121,19 @@ def test_page_type_create_trigger_webhook(
     assert not data["errors"]
     assert data["pageType"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("PageType", page_type.id),
-            "name": page_type.name,
-            "slug": page_type.slug,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("PageType", page_type.id),
+                "name": page_type.name,
+                "slug": page_type.slug,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.PAGE_TYPE_CREATED,
         [any_webhook],
         page_type,

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -1,3 +1,4 @@
+import json
 import os
 from unittest.mock import Mock, patch
 
@@ -8,6 +9,7 @@ from django.utils.text import slugify
 from freezegun import freeze_time
 from graphql_relay import to_global_id
 
+from ....core.utils.json_serializer import CustomJsonEncoder
 from ....product.error_codes import ProductErrorCode
 from ....product.models import Category, Product, ProductChannelListing
 from ....product.tests.utils import create_image, create_pdf_file_with_image_ext
@@ -501,14 +503,17 @@ def test_category_create_trigger_webhook(
     assert data["errors"] == []
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("Category", category.id),
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("Category", category.id),
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.CATEGORY_CREATED,
         [any_webhook],
         category,
@@ -729,14 +734,17 @@ def test_category_update_trigger_webhook(
     assert data["errors"] == []
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.CATEGORY_UPDATED,
         [any_webhook],
         category,
@@ -1035,14 +1043,17 @@ def test_category_delete_trigger_webhook(
 
     delete_versatile_image_mock.assert_not_called()
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.CATEGORY_DELETED,
         [any_webhook],
         category,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_method_channel_listing_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_method_channel_listing_update.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 import graphene
@@ -5,6 +6,7 @@ import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....shipping.error_codes import ShippingErrorCode
 from .....shipping.models import ShippingMethodChannelListing
 from .....webhook.event_types import WebhookEventAsyncType
@@ -159,14 +161,17 @@ def test_shipping_method_channel_listing_create_trigger_webhook(
     assert data["shippingMethod"]
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": shipping_method_id,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": shipping_method_id,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.SHIPPING_PRICE_UPDATED,
         [any_webhook],
         shipping_method,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_delete.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_delete.py
@@ -1,9 +1,11 @@
+import json
 from unittest import mock
 
 import graphene
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....tests.utils import get_graphql_content
@@ -84,14 +86,17 @@ def test_delete_shipping_method_trigger_webhook(
     assert not data["errors"]
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": shipping_method_id,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": shipping_method_id,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.SHIPPING_PRICE_DELETED,
         [any_webhook],
         shipping_method,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_exclude_products.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_exclude_products.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -5,6 +6,7 @@ import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....tests.utils import get_graphql_content
@@ -131,10 +133,13 @@ def test_exclude_products_for_shipping_method_trigger_webhook(
     # then
     assert content["data"]["shippingPriceExcludeProducts"]["shippingMethod"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": shipping_method_id,
-            "meta": generate_meta(requestor_data=generate_requestor(issuer)),
-        },
+        json.dumps(
+            {
+                "id": shipping_method_id,
+                "meta": generate_meta(requestor_data=generate_requestor(issuer)),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.SHIPPING_PRICE_UPDATED,
         [any_webhook],
         shipping_method,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_remove_product_from_exclude.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_remove_product_from_exclude.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -5,6 +6,7 @@ import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....tests.utils import get_graphql_content
@@ -156,10 +158,13 @@ def test_remove_products_from_excluded_products_for_shipping_method_trigger_webh
     # then
     assert content["data"]["shippingPriceRemoveProductFromExclude"]["shippingMethod"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": shipping_method_id,
-            "meta": generate_meta(requestor_data=generate_requestor(issuer)),
-        },
+        json.dumps(
+            {
+                "id": shipping_method_id,
+                "meta": generate_meta(requestor_data=generate_requestor(issuer)),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.SHIPPING_PRICE_UPDATED,
         [any_webhook],
         shipping_method,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_update.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -5,6 +6,7 @@ import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....shipping.error_codes import ShippingErrorCode
 from .....tests.utils import dummy_editorjs
 from .....webhook.event_types import WebhookEventAsyncType
@@ -139,14 +141,17 @@ def test_update_shipping_method_trigger_webhook(
     assert not data["errors"]
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": shipping_method_id,
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": shipping_method_id,
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.SHIPPING_PRICE_UPDATED,
         [any_webhook],
         shipping_method,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_create.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_create.py
@@ -1,9 +1,11 @@
+import json
 from unittest import mock
 
 import graphene
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....shipping.error_codes import ShippingErrorCode
 from .....shipping.models import ShippingZone
 from .....webhook.event_types import WebhookEventAsyncType
@@ -136,14 +138,17 @@ def test_create_shipping_zone_trigger_webhook(
     assert data["errors"] == []
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": data["shippingZone"]["id"],
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": data["shippingZone"]["id"],
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.SHIPPING_ZONE_CREATED,
         [any_webhook],
         shipping_zone,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_delete.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_delete.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import graphene
@@ -5,6 +6,7 @@ import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....tests.utils import get_graphql_content
@@ -81,14 +83,17 @@ def test_delete_shipping_zone_trigger_webhook(
     assert data["errors"] == []
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": data["shippingZone"]["id"],
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": data["shippingZone"]["id"],
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.SHIPPING_ZONE_DELETED,
         [any_webhook],
         shipping_zone,

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
@@ -1,9 +1,11 @@
+import json
 from unittest import mock
 
 import graphene
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
+from .....core.utils.json_serializer import CustomJsonEncoder
 from .....shipping.error_codes import ShippingErrorCode
 from .....shipping.models import ShippingMethodChannelListing
 from .....webhook.event_types import WebhookEventAsyncType
@@ -119,14 +121,17 @@ def test_update_shipping_zone_trigger_webhook(
     assert data["shippingZone"]
 
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "meta": generate_meta(
-                requestor_data=generate_requestor(
-                    SimpleLazyObject(lambda: staff_api_client.user)
-                )
-            ),
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "meta": generate_meta(
+                    requestor_data=generate_requestor(
+                        SimpleLazyObject(lambda: staff_api_client.user)
+                    )
+                ),
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.SHIPPING_ZONE_UPDATED,
         [any_webhook],
         shipping_zone,

--- a/saleor/graphql/warehouse/tests/test_warehouse.py
+++ b/saleor/graphql/warehouse/tests/test_warehouse.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 import graphene
@@ -5,6 +6,7 @@ import pytest
 from django.utils.functional import SimpleLazyObject
 
 from ....account.models import Address
+from ....core.utils.json_serializer import CustomJsonEncoder
 from ....warehouse import WarehouseClickAndCollectOption
 from ....warehouse.error_codes import WarehouseErrorCode
 from ....warehouse.models import Stock, Warehouse
@@ -697,10 +699,13 @@ def test_mutation_create_warehouse_trigger_webhook(
     # then
     assert content["data"]["createWarehouse"]["warehouse"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": graphene.Node.to_global_id("Warehouse", warehouse.id),
-            "name": warehouse.name,
-        },
+        json.dumps(
+            {
+                "id": graphene.Node.to_global_id("Warehouse", warehouse.id),
+                "name": warehouse.name,
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.WAREHOUSE_CREATED,
         [any_webhook],
         warehouse,
@@ -870,10 +875,13 @@ def test_mutation_update_warehouse_trigger_webhook(
     # then
     assert content["data"]["updateWarehouse"]["warehouse"]
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": variables["id"],
-            "name": warehouse.name,
-        },
+        json.dumps(
+            {
+                "id": variables["id"],
+                "name": warehouse.name,
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.WAREHOUSE_UPDATED,
         [any_webhook],
         warehouse,
@@ -1165,10 +1173,13 @@ def test_delete_warehouse_mutation_trigger_webhook(
     # then
     assert len(content["data"]["deleteWarehouse"]["errors"]) == 0
     mocked_webhook_trigger.assert_called_once_with(
-        {
-            "id": warehouse_id,
-            "name": warehouse.name,
-        },
+        json.dumps(
+            {
+                "id": warehouse_id,
+                "name": warehouse.name,
+            },
+            cls=CustomJsonEncoder,
+        ),
         WebhookEventAsyncType.WAREHOUSE_DELETED,
         [any_webhook],
         warehouse,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -94,18 +94,27 @@ class WebhookPlugin(BasePlugin):
         super().__init__(*args, **kwargs)
         self.active = True
 
+    @staticmethod
+    def _serialize_payload(data):
+        return json.dumps(data, cls=CustomJsonEncoder)
+
     def _generate_meta(self):
         return generate_meta(requestor_data=generate_requestor(self.requestor))
 
     def _trigger_address_event(self, event_type, address):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("Address", address.id),
-                "city": address.city,
-                "country": address.country,
-                "company_name": address.company_name,
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("Address", address.id),
+                    "city": address.city,
+                    "country": {
+                        "code": address.country.code,
+                        "name": address.country.name,
+                    },
+                    "company_name": address.company_name,
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, address, self.requestor
             )
@@ -127,12 +136,14 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_app_event(self, event_type, app):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("App", app.id),
-                "is_active": app.is_active,
-                "name": app.name,
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("App", app.id),
+                    "is_active": app.is_active,
+                    "name": app.name,
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(payload, event_type, webhooks, app, self.requestor)
 
     def app_installed(self, app: "App", previous_value: None) -> None:
@@ -157,12 +168,14 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_attribute_event(self, event_type, attribute):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("Attribute", attribute.id),
-                "name": attribute.name,
-                "slug": attribute.slug,
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("Attribute", attribute.id),
+                    "name": attribute.name,
+                    "slug": attribute.slug,
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, attribute, self.requestor
             )
@@ -190,13 +203,17 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_attribute_value_event(self, event_type, attribute_value):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("AttributeValue", attribute_value.id),
-                "name": attribute_value.name,
-                "slug": attribute_value.slug,
-                "value": attribute_value.value,
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id(
+                        "AttributeValue", attribute_value.id
+                    ),
+                    "name": attribute_value.name,
+                    "slug": attribute_value.slug,
+                    "value": attribute_value.value,
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, attribute_value, self.requestor
             )
@@ -230,10 +247,12 @@ class WebhookPlugin(BasePlugin):
 
     def __trigger_category_event(self, event_type, category):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("Category", category.id),
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("Category", category.id),
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, category, self.requestor
             )
@@ -255,11 +274,13 @@ class WebhookPlugin(BasePlugin):
 
     def __trigger_channel_event(self, event_type, channel):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("Channel", channel.id),
-                "is_active": channel.is_active,
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("Channel", channel.id),
+                    "is_active": channel.is_active,
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, channel, self.requestor
             )
@@ -288,11 +309,13 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_gift_card_event(self, event_type, gift_card):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("GiftCard", gift_card.id),
-                "is_active": gift_card.is_active,
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("GiftCard", gift_card.id),
+                    "is_active": gift_card.is_active,
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, gift_card, self.requestor
             )
@@ -339,11 +362,13 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_menu_event(self, event_type, menu):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("Menu", menu.id),
-                "slug": menu.slug,
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("Menu", menu.id),
+                    "slug": menu.slug,
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(payload, event_type, webhooks, menu, self.requestor)
 
     def menu_created(self, menu: "Menu", previous_value: None) -> None:
@@ -363,12 +388,16 @@ class WebhookPlugin(BasePlugin):
 
     def __trigger_menu_item_event(self, event_type, menu_item):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("MenuItem", menu_item.id),
-                "name": menu_item.name,
-                "menu": {"id": graphene.Node.to_global_id("Menu", menu_item.menu_id)},
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("MenuItem", menu_item.id),
+                    "name": menu_item.name,
+                    "menu": {
+                        "id": graphene.Node.to_global_id("Menu", menu_item.menu_id)
+                    },
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, menu_item, self.requestor
             )
@@ -803,18 +832,18 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.NOTIFY_USER
         if webhooks := get_webhooks_for_event(event_type):
-            data = {
-                "notify_event": event,
-                "payload": payload,
-                "meta": generate_meta(
-                    requestor_data=generate_requestor(self.requestor)
-                ),
-            }
+            data = self._serialize_payload(
+                {
+                    "notify_event": event,
+                    "payload": payload,
+                    "meta": generate_meta(
+                        requestor_data=generate_requestor(self.requestor)
+                    ),
+                }
+            )
             if event not in NotifyEventType.CHOICES:
                 logger.info(f"Webhook {event_type} triggered for {event} notify event.")
-            trigger_webhooks_async(
-                json.dumps(data, cls=CustomJsonEncoder), event_type, webhooks
-            )
+            trigger_webhooks_async(data, event_type, webhooks)
 
     def page_created(self, page: "Page", previous_value: Any) -> Any:
         if not self.active:
@@ -848,12 +877,14 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_page_type_event(self, event_type, page_type):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("PageType", page_type.id),
-                "name": page_type.name,
-                "slug": page_type.slug,
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("PageType", page_type.id),
+                    "name": page_type.name,
+                    "slug": page_type.slug,
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, page_type, self.requestor
             )
@@ -881,12 +912,14 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_shipping_price_event(self, event_type, shipping_method):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id(
-                    "ShippingMethodType", shipping_method.id
-                ),
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id(
+                        "ShippingMethodType", shipping_method.id
+                    ),
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, shipping_method, self.requestor
             )
@@ -921,10 +954,12 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_shipping_zone_event(self, event_type, shipping_zone):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("ShippingZone", shipping_zone.id),
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("ShippingZone", shipping_zone.id),
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, shipping_zone, self.requestor
             )
@@ -958,11 +993,13 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_staff_event(self, event_type, staff_user):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("User", staff_user.id),
-                "email": staff_user.email,
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("User", staff_user.id),
+                    "email": staff_user.email,
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, staff_user, self.requestor
             )
@@ -1004,10 +1041,12 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_warehouse_event(self, event_type, warehouse):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("Warehouse", warehouse.id),
-                "name": warehouse.name,
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("Warehouse", warehouse.id),
+                    "name": warehouse.name,
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, warehouse, self.requestor
             )
@@ -1035,12 +1074,14 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_voucher_event(self, event_type, voucher):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = {
-                "id": graphene.Node.to_global_id("Voucher", voucher.id),
-                "name": voucher.name,
-                "code": voucher.code,
-                "meta": self._generate_meta(),
-            }
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("Voucher", voucher.id),
+                    "name": voucher.name,
+                    "code": voucher.code,
+                    "meta": self._generate_meta(),
+                }
+            )
             trigger_webhooks_async(
                 payload, event_type, webhooks, voucher, self.requestor
             )


### PR DESCRIPTION
I want to merge this change because it fixes sending as payload python dictionaries instead of json in new async webhooks when the subscription query is not used.

https://app.clickup.com/t/2549495/SALEOR-7837

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
