### PR TITLE
Fix assigning an email address that does not belong to an existing user to draft order

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -117,6 +117,9 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
             object_id=data.pop("shipping_method", None), raise_error=False
         )
 
+        if data.get("user_email", None):
+            data["user"] = None
+
         cleaned_input = super().clean_input(info, instance, data)
 
         channel = cls.clean_channel_id(info, instance, cleaned_input, channel_id)

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -120,7 +120,7 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
 
         if email := data.get("user_email", None):
             try:
-                user = User.objects.get(email=email, is_staff=False)
+                user = User.objects.get(email=email, is_active=True)
                 data["user"] = graphene.Node.to_global_id("User", user.id)
             except User.DoesNotExist:
                 data["user"] = None

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -3865,6 +3865,30 @@ def test_draft_order_update_free_shipping_voucher(
     assert order.voucher
 
 
+DRAFT_ORDER_UPDATE_USER_EMAIL_MUTATION = """
+    mutation draftUpdate(
+        $id: ID!
+        $userEmail: String!
+    ) {
+        draftOrderUpdate(
+            id: $id
+            input: {
+                userEmail: $userEmail
+            }
+        ) {
+            errors {
+                field
+                message
+                code
+            }
+            order {
+                id
+            }
+        }
+    }
+    """
+
+
 def test_draft_order_update_when_not_existing_customer_email_provided(
     staff_api_client, permission_manage_orders, draft_order
 ):
@@ -3872,33 +3896,9 @@ def test_draft_order_update_when_not_existing_customer_email_provided(
     order = draft_order
     assert order.user
 
-    query = """
-        mutation draftUpdate(
-            $id: ID!
-            $userEmail: String!
-        ) {
-            draftOrderUpdate(
-                id: $id
-                input: {
-                    userEmail: $userEmail
-                }
-            ) {
-                errors {
-                    field
-                    message
-                    code
-                }
-                order {
-                    id
-                }
-            }
-        }
-        """
-
+    query = DRAFT_ORDER_UPDATE_USER_EMAIL_MUTATION
     order_id = graphene.Node.to_global_id("Order", order.id)
-
     email = "notexisting@example.com"
-
     variables = {"id": order_id, "userEmail": email}
 
     # when
@@ -3913,6 +3913,35 @@ def test_draft_order_update_when_not_existing_customer_email_provided(
     assert not data["errors"]
     assert not order.user
     assert order.user_email == email
+
+
+def test_draft_order_update_assign_user_when_existing_customer_email_provided(
+    staff_api_client, permission_manage_orders, draft_order
+):
+    # given
+    order = draft_order
+    user = order.user
+    user_email = user.email
+    order.user = None
+    order.save(update_fields=["user"])
+    assert not order.user
+
+    query = DRAFT_ORDER_UPDATE_USER_EMAIL_MUTATION
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id, "userEmail": user_email}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderUpdate"]
+    order.refresh_from_db()
+
+    # then
+    assert not data["errors"]
+    assert order.user == user
+    assert order.user_email == user_email
 
 
 def test_draft_order_delete(staff_api_client, permission_manage_orders, draft_order):


### PR DESCRIPTION
I want to merge this change because it fixes bug that does not allow assigning not existing email addresses to draft orders.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
