### PR TITLE
fix tests for shipping methods in subscription payloads

### DIFF
--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1637,17 +1637,18 @@ def test_shipping_list_methods_for_checkout(
     # when
     deliveries = create_deliveries_for_subscriptions(event_type, checkout, webhooks)
     # then
-    expected_payload = {
-        "checkout": {"id": checkout_id},
-        "shippingMethods": [
-            {
-                "id": graphene.Node.to_global_id("ShippingMethod", sm.pk),
-                "name": sm.name,
-            }
-            for sm in all_shipping_methods
-        ],
-    }
-    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    shipping_methods = [
+        {
+            "id": graphene.Node.to_global_id("ShippingMethod", sm.pk),
+            "name": sm.name,
+        }
+        for sm in all_shipping_methods
+    ]
+    payload = json.loads(deliveries[0].payload.payload)
+
+    assert payload["checkout"] == {"id": checkout_id}
+    for method in shipping_methods:
+        assert method in payload["shippingMethods"]
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
 
@@ -1669,17 +1670,18 @@ def test_checkout_filter_shipping_methods(
     # when
     deliveries = create_deliveries_for_subscriptions(event_type, checkout, webhooks)
     # then
-    expected_payload = {
-        "checkout": {"id": checkout_id},
-        "shippingMethods": [
-            {
-                "id": graphene.Node.to_global_id("ShippingMethod", sm.pk),
-                "name": sm.name,
-            }
-            for sm in all_shipping_methods
-        ],
-    }
-    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    shipping_methods = [
+        {
+            "id": graphene.Node.to_global_id("ShippingMethod", sm.pk),
+            "name": sm.name,
+        }
+        for sm in all_shipping_methods
+    ]
+    payload = json.loads(deliveries[0].payload.payload)
+
+    assert payload["checkout"] == {"id": checkout_id}
+    for method in shipping_methods:
+        assert method in payload["shippingMethods"]
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
 
@@ -1808,17 +1810,18 @@ def test_order_filter_shipping_methods(
     # when
     deliveries = create_deliveries_for_subscriptions(event_type, order, webhooks)
     # then
-    expected_payload = {
-        "order": {"id": order_id},
-        "shippingMethods": [
-            {
-                "id": graphene.Node.to_global_id("ShippingMethod", sm.pk),
-                "name": sm.name,
-            }
-            for sm in all_shipping_methods
-        ],
-    }
-    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    shipping_methods = [
+        {
+            "id": graphene.Node.to_global_id("ShippingMethod", sm.pk),
+            "name": sm.name,
+        }
+        for sm in all_shipping_methods
+    ]
+    payload = json.loads(deliveries[0].payload.payload)
+
+    assert payload["order"] == {"id": order_id}
+    for method in shipping_methods:
+        assert method in payload["shippingMethods"]
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
 


### PR DESCRIPTION
I want to merge this change because it fixes tests that could fail when shipping methods were returned in differently ordered lists in db and gql query. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
