### PR TITLE
Fix wrong expression count in flat concatenation warnings

### DIFF
--- a/saleor/core/postgres.py
+++ b/saleor/core/postgres.py
@@ -78,12 +78,12 @@ class FlatConcat(Expression):
             and len(expressions) > self.max_expression_count
         ):
             if self.silent_drop_expression:
-                expressions = expressions[: self.max_expression_count]
                 logger.warning(
                     "Maximum expression count exceed (%d out of %d)",
                     len(expressions),
                     self.max_expression_count,
                 )
+                expressions = expressions[: self.max_expression_count]
             else:
                 raise ValueError("Maximum expression count exceeded")
         self.source_expressions: List[SearchVector] = self._parse_expressions(


### PR DESCRIPTION
When `FlatConcat` truncates expressions, the logged warning contains the wrong expression count.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
