### PR TITLE
Clean address fields when input is empty string

### DIFF
--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -84,9 +84,10 @@ class I18nMixin:
                     else:
                         address_form.cleaned_data[field] = address_form.data[field]
                 if error.code == "required":
+                    field_value = address_form.data.get(field)
                     if required_check:
                         errors_dict[field] = errors
-                    elif field_value := address_form.data.get(field):
+                    elif field_value is not None:
                         address_form.cleaned_data[field] = field_value
 
         return errors_dict

--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -83,8 +83,12 @@ class I18nMixin:
                         errors_dict[field] = errors
                     else:
                         address_form.cleaned_data[field] = address_form.data[field]
-                if required_check and error.code == "required":
-                    errors_dict[field] = errors
+                if error.code == "required":
+                    if required_check:
+                        errors_dict[field] = errors
+                    elif field_value := address_form.data.get(field):
+                        address_form.cleaned_data[field] = field_value
+
         return errors_dict
 
     @classmethod

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -204,7 +204,6 @@ def test_checkout_billing_address_update(
     "address_data",
     [
         {"country": "PL"},  # missing postalCode, streetAddress
-        {"country": "PL", "postalCode": ""},
         {"country": "PL", "postalCode": "53-601"},  # missing streetAddress
         {"country": "US"},
         {
@@ -235,6 +234,39 @@ def test_checkout_billing_address_update_with_skip_required_doesnt_raise_error(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     assert checkout_with_items.billing_address
+
+
+def test_checkout_billing_address_update_with_skip_required_overwrite_address(
+    checkout_with_items, user_api_client, address
+):
+    # given
+    checkout_with_items.billing_address = address
+    checkout_with_items.save()
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "billingAddress": {
+            "postalCode": "",
+            "city": "",
+            "country": "US",
+        },
+        "validationRules": {"checkRequiredFields": False},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutBillingAddressUpdate"]
+    assert not data["errors"]
+
+    assert checkout_with_items.billing_address.city == ""
+    assert checkout_with_items.billing_address.postal_code == ""
 
 
 def test_checkout_billing_address_update_with_skip_required_raises_validation_error(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -204,6 +204,7 @@ def test_checkout_billing_address_update(
     "address_data",
     [
         {"country": "PL"},  # missing postalCode, streetAddress
+        {"country": "PL", "postalCode": ""},
         {"country": "PL", "postalCode": "53-601"},  # missing streetAddress
         {"country": "US"},
         {

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -1715,7 +1715,7 @@ def test_create_checkout_with_unpublished_product(
         ),
         (
             {
-                "" "postalCode": "",
+                "postalCode": "",
                 "country": "US",
                 "city": "",
             },  # missing streetAddress, countryArea
@@ -1724,7 +1724,7 @@ def test_create_checkout_with_unpublished_product(
         ),
         (
             {
-                "" "postalCode": "",
+                "postalCode": "",
                 "country": "US",
                 "city": "",
             },  # missing streetAddress, countryArea

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -1713,6 +1713,24 @@ def test_create_checkout_with_unpublished_product(
             "billingAddress",
             "billing_address",
         ),
+        (
+            {
+                "" "postalCode": "",
+                "country": "US",
+                "city": "",
+            },  # missing streetAddress, countryArea
+            "billingAddress",
+            "billing_address",
+        ),
+        (
+            {
+                "" "postalCode": "",
+                "country": "US",
+                "city": "",
+            },  # missing streetAddress, countryArea
+            "shippingAddress",
+            "shipping_address",
+        ),
     ],
 )
 def test_checkout_create_with_skip_required_doesnt_raise_error(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -1713,24 +1713,6 @@ def test_create_checkout_with_unpublished_product(
             "billingAddress",
             "billing_address",
         ),
-        (
-            {
-                "postalCode": "",
-                "country": "US",
-                "city": "",
-            },  # missing streetAddress, countryArea
-            "billingAddress",
-            "billing_address",
-        ),
-        (
-            {
-                "postalCode": "",
-                "country": "US",
-                "city": "",
-            },  # missing streetAddress, countryArea
-            "shippingAddress",
-            "shipping_address",
-        ),
     ],
 )
 def test_checkout_create_with_skip_required_doesnt_raise_error(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -479,6 +479,39 @@ def test_checkout_shipping_address_update_with_skip_required_doesnt_raise_error(
     assert checkout_with_items.shipping_address
 
 
+def test_checkout_shipping_address_update_with_skip_required_overwrite_address(
+    checkout_with_items, user_api_client, address
+):
+    # given
+    checkout_with_items.shipping_address = address
+    checkout_with_items.save()
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_items),
+        "shippingAddress": {
+            "postalCode": "",
+            "city": "",
+            "country": "US",
+        },
+        "validationRules": {"checkRequiredFields": False},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE, variables
+    )
+
+    # then
+    checkout_with_items.refresh_from_db()
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutShippingAddressUpdate"]
+    assert not data["errors"]
+
+    assert checkout_with_items.shipping_address.city == ""
+    assert checkout_with_items.shipping_address.postal_code == ""
+
+
 def test_checkout_shipping_address_update_with_skip_required_raises_validation_error(
     checkout_with_items, user_api_client
 ):

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -446,6 +446,7 @@ def test_checkout_shipping_address_update_exclude_shipping_method(
     "address_data",
     [
         {"country": "PL"},  # missing postalCode, streetAddress
+        {"country": "PL", "postalCode": ""},
         {"country": "PL", "postalCode": "53-601"},  # missing streetAddress
         {"country": "US"},
         {


### PR DESCRIPTION
I want to merge this change because it fixes a case, when providing an empty string didn't change anything on Saleor side

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
