### PR TITLE
New playground

### DIFF
--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -4,56 +4,32 @@
   <meta charset=utf-8/>
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <title>GraphQL Playground</title>
-  <link rel="stylesheet" crossorigin="anonymous" integrity="sha256-dKnNLEFwKSVFpkpjRWe+o/jQDM6n/JsvQ0J3l5Dk3fc" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/css/index.css" />
   <link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
-  <script crossorigin="anonymous" integrity="sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI=" src="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/js/middleware.js"></script>
-  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src 'sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI=' 'sha256-jpQ7CLb9c8nrwEY+pDfFNOgGpKzrNTRsWVv4yB8QVnQ='; style-src https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/css/index.css 'sha256-jkwxzyKPdPQHgIYu9x7it0jbIOtzMGr9iFmRtSaiwX4='; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/media/logo.8c98d067.png https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png">
+
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-2/dist/umd/index.css"
+    integrity="sha512-lv8Iui8FzUeT+neScoyQToW+F7Lt4hQxjCOQf+Vz3BepIfzB1ULseZ4TMDY/dNcKvHNTlk6eW+ptXl33qbzJ/g=="
+    crossorigin="anonymous"
+  />
+
+  <meta http-equiv="content-security-policy" content=" default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-2/dist/umd/index.js 'sha256-BqK5R+xYeI6N82LyL/VNQyZrqy/uwVWkXVUCQaN+KEo='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-2/dist/umd/index.css; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png">
 </head>
 <body>
-  <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}>
-    {# sha256-jkwxzyKPdPQHgIYu9x7it0jbIOtzMGr9iFmRtSaiwX4= #}
-    <style>
-      body {
-        background-color: rgb(23, 42, 58);
-        font-family: Open Sans, sans-serif;
-        height: 90vh;
-      }
-      #root {
-        height: 100%;
-        width: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-      }
-      .loading {
-        font-size: 32px;
-        font-weight: 200;
-        color: rgba(255, 255, 255, .6);
-        margin-left: 20px;
-      }
-      img {
-        width: 78px;
-        height: 78px;
-      }
-      .title {
-        font-weight: 400;
-      }
-    </style>
-    <img src='https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/media/logo.8c98d067.png' alt=''>
-    <div class="loading"> Loading
-      <span class="title">GraphQL Playground</span>
-    </div>
-  </div>
-  {# sha256-jpQ7CLb9c8nrwEY+pDfFNOgGpKzrNTRsWVv4yB8QVnQ= #}
-  <script>window.addEventListener('load', function (event) {
-      const settings = {
-        "schema.polling.enable": false
-      };
-      const root = document.getElementById("root");
-      const endpoint = root.dataset.endpoint;
-      const query = root.dataset.query;
-      const tabs = query && endpoint ? [{ endpoint, query }] : null;
-      GraphQLPlayground.init(root, { settings, tabs });
-    })</script>
+  <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}></div>
+  <script
+    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-2/dist/umd/index.js"
+    integrity="sha512-vb0Tp7rKdq9n7wGsFDsNxsBO7vzzBHK47z0I4ZBenr4RrPhDf10B6hXP+qvd5eiQ6DK8ZeJlfwO3Jr84DA7C2g=="
+    crossorigin="anonymous"
+  ></script>
+
+  {# sha256-BqK5R+xYeI6N82LyL/VNQyZrqy/uwVWkXVUCQaN+KEo= #}
+  <script type="module">
+    const root = document.querySelector("#root");
+    const endpoint = root.dataset.endpoint;
+    const query = root.dataset.query;
+
+    createPlayground(root, { query, endpoint });
+  </script>
 </body>
 </html>

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -8,18 +8,18 @@
 
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.css"
-    integrity="sha512-lv8Iui8FzUeT+neScoyQToW+F7Lt4hQxjCOQf+Vz3BepIfzB1ULseZ4TMDY/dNcKvHNTlk6eW+ptXl33qbzJ/g=="
+    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-0/dist/umd/index.css"
+    integrity="sha512-ivOjBFuy6pAspvPNtIz/vpI8ZHAU4X2EDuRnqOWK64GwlRCwypdgbPuaGqMWt20Bg2KjcNk2Vq9kkl8+XgSb9g=="
     crossorigin="anonymous"
   />
 
-  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.css; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png">
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-0/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-0/dist/umd/index.css; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
 </head>
 <body>
   <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}></div>
   <script
-    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.js"
-    integrity="sha512-pqpfnUCE85xYG/67oyuGbQvbGgj0IyrL6cUdvXZ/EgPsN0ozjRGbEGdaRyFZtnDC/XivJ/l32qziUSJdkcp1Ug=="
+    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-0/dist/umd/index.js"
+    integrity="sha512-qsKAT98vfXNeckMOMa7oXU78EKKVcfX4ukhSoDtAcQPawlyrrkoQDPYUaqjiMrstEwWtBm65PGesrNh5/q64OA=="
     crossorigin="anonymous"
   ></script>
 

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -13,7 +13,7 @@
     crossorigin="anonymous"
   />
 
-  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1n0BhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.css; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png">
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.css; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png">
 </head>
 <body>
   <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}></div>
@@ -23,7 +23,7 @@
     crossorigin="anonymous"
   ></script>
 
-  {# sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1n0BhZrL+c= #}
+  {# sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c= #}
   <script type="module">
     const root = document.querySelector("#root");
     const endpoint = root.dataset.endpoint;

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -13,7 +13,7 @@
     crossorigin="anonymous"
   />
 
-  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.js 'sha256-BqK5R+xYeI6N82LyL/VNQyZrqy/uwVWkXVUCQaN+KEo='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.css; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png">
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1n0BhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.css; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png">
 </head>
 <body>
   <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}></div>
@@ -23,7 +23,7 @@
     crossorigin="anonymous"
   ></script>
 
-  {# sha256-BqK5R+xYeI6N82LyL/VNQyZrqy/uwVWkXVUCQaN+KEo= #}
+  {# sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1n0BhZrL+c= #}
   <script type="module">
     const root = document.querySelector("#root");
     const endpoint = root.dataset.endpoint;

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -8,18 +8,18 @@
 
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-2/dist/umd/index.css"
+    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.css"
     integrity="sha512-lv8Iui8FzUeT+neScoyQToW+F7Lt4hQxjCOQf+Vz3BepIfzB1ULseZ4TMDY/dNcKvHNTlk6eW+ptXl33qbzJ/g=="
     crossorigin="anonymous"
   />
 
-  <meta http-equiv="content-security-policy" content=" default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-2/dist/umd/index.js 'sha256-BqK5R+xYeI6N82LyL/VNQyZrqy/uwVWkXVUCQaN+KEo='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-2/dist/umd/index.css; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png">
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.js 'sha256-BqK5R+xYeI6N82LyL/VNQyZrqy/uwVWkXVUCQaN+KEo='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.css; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png">
 </head>
 <body>
   <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}></div>
   <script
-    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-2/dist/umd/index.js"
-    integrity="sha512-vb0Tp7rKdq9n7wGsFDsNxsBO7vzzBHK47z0I4ZBenr4RrPhDf10B6hXP+qvd5eiQ6DK8ZeJlfwO3Jr84DA7C2g=="
+    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@1.0.0-3/dist/umd/index.js"
+    integrity="sha512-pqpfnUCE85xYG/67oyuGbQvbGgj0IyrL6cUdvXZ/EgPsN0ozjRGbEGdaRyFZtnDC/XivJ/l32qziUSJdkcp1Ug=="
     crossorigin="anonymous"
   ></script>
 


### PR DESCRIPTION
I want to merge this change because the new GraphQL playground is more extensible and powerful.

Demo: https://saleor-graphql-playground.vercel.app/

https://app.clickup.com/t/2549495/SALEOR-7662

Comparison:

| feature             | old    | new    |
| ------------------- | ------ | ------ |
| tabs                | ✅ yes | ✅ yes |
| query variables     | ✅ yes | ✅ yes |
| http headers        | ✅ yes | ✅ yes |
| docs                | ✅ yes | ✅ yes |
| prettify            | ✅ yes | ✅ yes |
| history             | ✅ yes | ✅ yes |
| search in schema    | 😄 kind of  | ✅ yes |
| sharing via URL     | ❌ no  | ✅ yes |
| editor settings     | ✅ yes | ✅ yes  |
| dark mode     | ✅ yes | ✅ yes  |
| easier to customize | ❌ no  | ✅ yes |


# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
