### PR TITLE
Fix validation for multiple events defined in subscription query

### DIFF
--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -58,13 +58,14 @@ def check_document_is_single_subscription(document: GraphQLDocument) -> bool:
     """
     subscriptions = []
     for definition in document.document_ast.definitions:
-        if len(definition.selection_set.selections) != 1:
-            return False
         if isinstance(definition, FragmentDefinition):
             pass
         elif isinstance(definition, OperationDefinition):
             if definition.operation == "subscription":
+                if len(definition.selection_set.selections) != 1:
+                    return False
                 subscriptions.append(definition)
+
             else:
                 return False
         else:

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1785,3 +1785,72 @@ subscription{
   }
 }
 """
+
+
+INVALID_MULTIPLE_EVENTS = """
+    subscription{
+      event{
+        ...on ProductUpdated{
+          product{
+            id
+          }
+        }
+      }
+      event{
+        ...on ProductCreated{
+          product{
+            id
+          }
+        }
+      }
+    }
+"""
+
+INVALID_MULTIPLE_EVENTS_WITH_FRAGMENTS = (
+    fragments.PRODUCT_VARIANT
+    + fragments.CATEGORY_DETAILS
+    + """
+    subscription{
+      event{
+        ...on ProductUpdated{
+          product{
+          variants{
+            ...ProductVariant
+            }
+            ...CategoryDetails
+          }
+        }
+      }
+      event{
+        ...on ProductCreated{
+          product{
+          variants{
+                ...ProductVariant
+            }
+            ...CategoryDetails
+          }
+        }
+      }
+    }
+    """
+)
+
+
+QUERY_WITH_MULTIPLE_FRAGMENTS = (
+    fragments.PRODUCT_VARIANT
+    + fragments.CATEGORY_DETAILS
+    + """
+    subscription{
+      event{
+        ...on ProductUpdated{
+          product{
+          variants{
+            ...ProductVariant
+            }
+            ...CategoryDetails
+          }
+        }
+      }
+    }
+    """
+)

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1976,6 +1976,25 @@ def test_validate_invalid_multiple_subscriptions():
     assert result is False
 
 
+def test_vaidate_invalid_multiple_events_in_subscription():
+    result = validate_subscription_query(subscription_queries.INVALID_MULTIPLE_EVENTS)
+    assert result is False
+
+
+def test_vaidate_invalid_multiple_events_and_fragments_in_subscription():
+    result = validate_subscription_query(
+        subscription_queries.INVALID_MULTIPLE_EVENTS_WITH_FRAGMENTS
+    )
+    assert result is False
+
+
+def test_validate_query_with_multiple_fragments():
+    result = validate_subscription_query(
+        subscription_queries.QUERY_WITH_MULTIPLE_FRAGMENTS
+    )
+    assert result is True
+
+
 def test_generate_payload_from_subscription_return_permission_errors_in_payload(
     gift_card, subscription_gift_card_created_webhook, permission_manage_gift_card
 ):


### PR DESCRIPTION
I want to merge this change because it fixes validation for subscription queries so it properly validates if subscriptions does not have more than one event defined. It fixes this issue #10349 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
