### PR TITLE
Fix the variant quantityAvailable for negative stocks

### DIFF
--- a/saleor/graphql/product/tests/test_variant_availability.py
+++ b/saleor/graphql/product/tests/test_variant_availability.py
@@ -149,6 +149,8 @@ def test_variant_quantity_available_when_one_stock_is_exceeded(
     stock.quantity = -99
     stock.save()
 
+    stock_2 = variant_with_many_stocks.stocks.last()
+
     variables = {
         "id": graphene.Node.to_global_id("ProductVariant", variant_with_many_stocks.pk),
         "channel": channel_USD.slug,
@@ -156,7 +158,9 @@ def test_variant_quantity_available_when_one_stock_is_exceeded(
     response = api_client.post_graphql(QUERY_QUANTITY_AVAILABLE, variables)
     content = get_graphql_content(response)
     variant_data = content["data"]["productVariant"]
-    assert variant_data["quantityAvailable"] == 3
+    assert variant_data["quantityAvailable"] == max(
+        0, stock.quantity + stock_2.quantity
+    )
 
 
 def test_variant_quantity_available_without_country_code_and_no_channel_shipping_zones(
@@ -250,6 +254,45 @@ def test_variant_quantity_available_with_null_as_country_code(
     assert variant_data["byAddress"] == 7
 
 
+def test_variant_quantity_available_with_country_code_only_negative_quantity(
+    api_client,
+    variant,
+    channel_USD,
+    warehouse_for_cc,
+    warehouse,
+):
+    """Ensure the quantity from the collection point without shipping zone is not
+    returned when the country code is given."""
+    # given
+    quantity_cc = 7
+    # stock for local collection point warehouse
+    Stock.objects.create(
+        warehouse=warehouse_for_cc, product_variant=variant, quantity=quantity_cc
+    )
+
+    quantity = -5
+    # stock for standard warehouse
+    Stock.objects.create(
+        warehouse=warehouse, product_variant=variant, quantity=quantity
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("ProductVariant", variant.pk),
+        "channel": channel_USD.slug,
+        "address": {"country": COUNTRY_CODE},
+        "country": COUNTRY_CODE,
+    }
+
+    # when
+    response = api_client.post_graphql(QUERY_VARIANT_AVAILABILITY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    variant_data = content["data"]["productVariant"]
+    assert variant_data["byAddress"] == 0
+    assert variant_data["deprecatedByCountry"] == 0
+
+
 def test_variant_quantity_available_with_country_code_and_cc_warehouse_without_zone(
     api_client,
     variant,
@@ -303,6 +346,42 @@ def test_variant_quantity_available_with_country_code_and_local_cc_warehouse_wit
     warehouse_for_cc.shipping_zones.add(shipping_zone)
 
     quantity = 5
+    # stock for standard warehouse
+    Stock.objects.create(
+        warehouse=warehouse, product_variant=variant, quantity=quantity
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("ProductVariant", variant.pk),
+        "channel": channel_USD.slug,
+        "address": {"country": COUNTRY_CODE},
+        "country": COUNTRY_CODE,
+    }
+
+    # when
+    response = api_client.post_graphql(QUERY_VARIANT_AVAILABILITY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    variant_data = content["data"]["productVariant"]
+    assert variant_data["byAddress"] == quantity_cc + quantity
+    assert variant_data["deprecatedByCountry"] == quantity + quantity_cc
+
+
+def test_variant_qty_available_with_country_code_and_local_cc_warehouse_negative_qty(
+    api_client, variant, channel_USD, warehouse_for_cc, warehouse, shipping_zone
+):
+    """Ensure the quantity from the local collection point without shipping zone
+    is returned."""
+    # given
+    quantity_cc = 7
+    # stock for local collection point warehouse
+    Stock.objects.create(
+        warehouse=warehouse_for_cc, product_variant=variant, quantity=quantity_cc
+    )
+    warehouse_for_cc.shipping_zones.add(shipping_zone)
+
+    quantity = -1
     # stock for standard warehouse
     Stock.objects.create(
         warehouse=warehouse, product_variant=variant, quantity=quantity

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -243,7 +243,11 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
         variants_with_global_cc_warehouses = []
         for stock in stocks:
             reserved_quantity = stocks_reservations[stock.id]
-            quantity = max(0, stock.available_quantity - reserved_quantity)
+            quantity = stock.available_quantity - reserved_quantity
+            # when the available_quantity was under 0 we do not want clipping to zero,
+            # as it means that the stock might be exceeded
+            if stock.available_quantity > 0:
+                quantity = max(0, quantity)
             variant_id = stock.product_variant_id
             warehouse_id = stock.warehouse_id
             if shipping_zone_ids := warehouse_shipping_zones_map[warehouse_id]:


### PR DESCRIPTION
Fix the wrong quantity available calculations in a case when there is stock with a negative quantity.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
