### PR TITLE
Fix thumbnail url crash for id of not existsing instance

### DIFF
--- a/saleor/thumbnail/tests/test_views.py
+++ b/saleor/thumbnail/tests/test_views.py
@@ -230,3 +230,15 @@ def test_handle_thumbnail_view_invalid_instance_id(client, category):
 
     # then
     assert response.status_code == 404
+
+
+def test_handle_thumbnail_view_object_does_not_exists(client):
+    # given
+    size = 60
+    category_id = graphene.Node.to_global_id("Category", 1)
+
+    # when
+    response = client.get(f"/thumbnail/{category_id}/{size}/")
+
+    # then
+    assert response.status_code == 404

--- a/saleor/thumbnail/views.py
+++ b/saleor/thumbnail/views.py
@@ -56,7 +56,7 @@ def handle_thumbnail(request, instance_id: str, size: str, format: str = None):
     try:
         instance = model_data.model.objects.get(id=pk)
     except ObjectDoesNotExist:
-        return HttpResponseNotFound("Cannot found instance with the given id.")
+        return HttpResponseNotFound("Instance with the given id cannot be found.")
 
     image = getattr(instance, model_data.image_field)
     if not bool(image):

--- a/saleor/thumbnail/views.py
+++ b/saleor/thumbnail/views.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseNotFound, HttpResponseRedirect
 from graphql.error import GraphQLError
 
@@ -52,7 +53,11 @@ def handle_thumbnail(request, instance_id: str, size: str, format: str = None):
     ).first():
         return HttpResponseRedirect(thumbnail.image.url)
 
-    instance = model_data.model.objects.get(id=pk)
+    try:
+        instance = model_data.model.objects.get(id=pk)
+    except ObjectDoesNotExist:
+        return HttpResponseNotFound("Cannot found instance with the given id.")
+
     image = getattr(instance, model_data.image_field)
     if not bool(image):
         return HttpResponseNotFound("There is no image for provided instance.")


### PR DESCRIPTION
Raise `HttpResponseNotFound` when `id` of not existing instance is given.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
