### PR TITLE
Fix assigning tax code to object meta

### DIFF
--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -4310,3 +4310,105 @@ def test_get_order_lines_data_sets_different_tax_code_only_for_zero_amount(
     # then
     assert lines_data[0]["amount"] == "10.000"
     assert lines_data[0]["taxCode"] == "taxcode"
+
+
+def test_assign_tax_code_to_object_meta(
+    settings, channel_USD, plugin_configuration, product, monkeypatch
+):
+    # given
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    plugin_configuration(channel=channel_USD)
+
+    tax_code = "standard"
+    description = "desc"
+
+    monkeypatch.setattr(
+        "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
+        lambda _: {tax_code: description},
+    )
+
+    manager = get_plugins_manager()
+
+    # when
+    manager.assign_tax_code_to_object_meta(product, tax_code)
+
+    # then
+    assert product.metadata == {
+        META_CODE_KEY: tax_code,
+        META_DESCRIPTION_KEY: description,
+    }
+
+
+def test_assign_tax_code_to_object_meta_none_as_tax_code(
+    settings, channel_USD, plugin_configuration, product, monkeypatch
+):
+    # given
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    plugin_configuration(channel=channel_USD)
+
+    tax_code = None
+    description = "desc"
+
+    monkeypatch.setattr(
+        "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
+        lambda _: {"standard": description},
+    )
+    manager = get_plugins_manager()
+
+    # when
+    manager.assign_tax_code_to_object_meta(product, tax_code)
+
+    # then
+    assert product.metadata == {}
+
+
+def test_assign_tax_code_to_object_meta_no_obj_id_and_none_as_tax_code(
+    settings, channel_USD, plugin_configuration, monkeypatch
+):
+    # given
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    plugin_configuration(channel=channel_USD)
+
+    tax_code = None
+    description = "desc"
+
+    monkeypatch.setattr(
+        "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
+        lambda _: {"standard": description},
+    )
+
+    product = Product(name="A new product.")
+    manager = get_plugins_manager()
+
+    # when
+    manager.assign_tax_code_to_object_meta(product, tax_code)
+
+    # then
+    assert product.metadata == {}
+
+
+def test_assign_tax_code_to_object_meta_no_obj_id(
+    settings, channel_USD, plugin_configuration, monkeypatch
+):
+    # given
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    plugin_configuration(channel=channel_USD)
+
+    tax_code = "standard"
+    description = "desc"
+
+    monkeypatch.setattr(
+        "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
+        lambda _: {tax_code: description},
+    )
+    product = Product(name="A new product.")
+    manager = get_plugins_manager()
+
+    # when
+    manager.assign_tax_code_to_object_meta(product, tax_code)
+
+    # then
+    assert product.metadata == {
+        META_CODE_KEY: tax_code,
+        META_DESCRIPTION_KEY: description,
+    }

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -546,10 +546,12 @@ class VatlayerPlugin(BasePlugin):
         if tax_code is None and obj.pk:
             obj.delete_value_from_metadata(self.META_CODE_KEY)
             obj.delete_value_from_metadata(self.META_DESCRIPTION_KEY)
-            return previous_value
-
-        tax_item = {self.META_CODE_KEY: tax_code, self.META_DESCRIPTION_KEY: tax_code}
-        obj.store_value_in_metadata(items=tax_item)
+        elif tax_code is not None:
+            tax_item = {
+                self.META_CODE_KEY: tax_code,
+                self.META_DESCRIPTION_KEY: tax_code,
+            }
+            obj.store_value_in_metadata(items=tax_item)
         return previous_value
 
     def get_tax_code_from_object_meta(

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -184,6 +184,66 @@ def test_apply_tax_to_price_no_taxes_raise_typeerror_for_invalid_type():
         assert apply_tax_to_price(None, "standard", 100)
 
 
+@override_settings(PLUGINS=["saleor.plugins.vatlayer.plugin.VatlayerPlugin"])
+def test_assign_tax_code_to_object_meta(vatlayer, product):
+    # given
+    manager = get_plugins_manager()
+    tax_code = "standard"
+
+    # when
+    manager.assign_tax_code_to_object_meta(product, tax_code)
+
+    # then
+    assert product.metadata == {
+        VatlayerPlugin.META_CODE_KEY: tax_code,
+        VatlayerPlugin.META_DESCRIPTION_KEY: tax_code,
+    }
+
+
+@override_settings(PLUGINS=["saleor.plugins.vatlayer.plugin.VatlayerPlugin"])
+def test_assign_tax_code_to_object_meta_none_as_tax_code(vatlayer, product):
+    # given
+    manager = get_plugins_manager()
+    tax_code = None
+
+    # when
+    manager.assign_tax_code_to_object_meta(product, tax_code)
+
+    # then
+    assert product.metadata == {}
+
+
+@override_settings(PLUGINS=["saleor.plugins.vatlayer.plugin.VatlayerPlugin"])
+def test_assign_tax_code_to_object_meta_no_obj_id_and_none_as_tax_code(vatlayer):
+    # given
+    manager = get_plugins_manager()
+    product = Product(name="A new product.")
+    tax_code = None
+
+    # when
+    manager.assign_tax_code_to_object_meta(product, tax_code)
+
+    # then
+    assert product.metadata == {}
+
+
+@override_settings(PLUGINS=["saleor.plugins.vatlayer.plugin.VatlayerPlugin"])
+def test_assign_tax_code_to_object_meta_no_obj_id(vatlayer):
+    # given
+    manager = get_plugins_manager()
+    product = Product(name="A new product.")
+    tax_code = "standard"
+
+    # when
+    manager.assign_tax_code_to_object_meta(product, tax_code)
+
+    # then
+    assert product.metadata == {
+        VatlayerPlugin.META_CODE_KEY: tax_code,
+        VatlayerPlugin.META_DESCRIPTION_KEY: tax_code,
+    }
+
+
 @pytest.mark.parametrize(
     "with_discount, expected_net, expected_gross, voucher_amount, taxes_in_prices",
     [


### PR DESCRIPTION
When running `assign_tax_code_to_object_meta` method on `vatlayer` with empty `tax_code` parameter and for object without `id`, the metadata was updated with `None` as value what crashes the API. The metadata value and key are not nullable.

Port of https://github.com/saleor/saleor/pull/10389

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
