### PR TITLE
Replace local build cache with Github Registry

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -88,7 +88,7 @@ jobs:
             printf -v CACHE_FROM_VERSION "%s." "${PREVIOUS_VERSION[@]}"
             CACHE_FROM_VERSION="${CACHE_FROM_VERSION%.}"
           else
-            # setting to unstable-main if patch is lower than 0 or is not
+            # setting to unstable-main if patch is lower than 1 or is not
             # a digit
             CACHE_FROM_VERSION="unstable-main"
           fi

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -69,7 +69,7 @@ jobs:
           set -x
 
           # Version name is the branch name
-          # Slashes are substitued by dashes
+          # Slashes are substituted by dashes
           CLEAN_BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)
 
           # Target GHCR with the branch name as the tag, e.g. unstable-main
@@ -81,10 +81,23 @@ jobs:
           # <branch>-<drift>-g<6-digit-hash>
           NAMED_VERSION=$(git describe --all --long | tr -d $'\n')
 
+          # setting version for cache-from
+          IFS="." read -r -a VERSION_ARRAY <<< "$VERSION"
+          if [ "${VERSION_ARRAY[-1]}" -gt 0 ]; then
+            PREVIOUS_VERSION[-1]="$((${VERSION_ARRAY[-1]} - 1))"
+            printf -v CACHE_FROM_VERSION "%s." "${PREVIOUS_VERSION[@]}"
+            CACHE_FROM_VERSION="${CACHE_FROM_VERSION%.}"
+          else
+            # setting to unstable-main if patch is lower than 0 or is not
+            # a digit
+            CACHE_FROM_VERSION="unstable-main"
+          fi
+
           # Output the target tags
           echo "
           CONTAINER_TAGS=${TAGS}
           NAMED_VERSION=${NAMED_VERSION}
+          CACHE_FROM_VERSION=${CACHE_FROM_VERSION}
           " >> "${GITHUB_ENV}"
 
       - name: Set up QEMU
@@ -95,14 +108,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ hashFiles('requirements_dev.txt') }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -120,8 +125,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ env.CONTAINER_TAGS }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=registry,ref=saleor/saleor:${CACHE_FROM_VERSION}
+          cache-to: type=registry,ref=saleor/saleor:${VERSION},mode=max
           build-args: |
             PROJECT_VERSION=${{ env.NAMED_VERSION }}
             COMMIT_ID=${{ github.sha }}


### PR DESCRIPTION
I want to merge this change because will speed up build time by utilizing Github Registry

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
