### PR TITLE
Allow tracking number to be passed to orderFulfill in 3.6

### DIFF
--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -10,6 +10,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....order import models as order_models
 from ....order.actions import create_fulfillments
 from ....order.error_codes import OrderErrorCode
+from ...core.descriptions import ADDED_IN_36
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, OrderError
 from ...core.utils import get_duplicated_values
@@ -55,7 +56,7 @@ class OrderFulfillInput(graphene.InputObjectType):
         default_value=False,
     )
     tracking_number = graphene.String(
-        description="Fulfillment tracking number.",
+        description="Fulfillment tracking number." + ADDED_IN_36,
         required=False,
     )
 

--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -54,6 +54,10 @@ class OrderFulfillInput(graphene.InputObjectType):
         description="If true, then allow proceed fulfillment when stock is exceeded.",
         default_value=False,
     )
+    tracking_number = graphene.String(
+        description="Fulfillment tracking number.",
+        required=False,
+    )
 
 
 class FulfillmentUpdateTrackingInput(graphene.InputObjectType):
@@ -249,7 +253,7 @@ class OrderFulfill(BaseMutation):
         )
 
         approved = info.context.site.settings.fulfillment_auto_approve
-
+        tracking_number = cleaned_input.get("tracking_number", "")
         try:
             fulfillments = create_fulfillments(
                 user,
@@ -261,6 +265,7 @@ class OrderFulfill(BaseMutation):
                 notify_customer,
                 allow_stock_to_be_exceeded=allow_stock_to_be_exceeded,
                 approved=approved,
+                tracking_number=tracking_number,
             )
         except InsufficientStock as exc:
             errors = prepare_insufficient_stock_order_validation_errors(exc)

--- a/saleor/graphql/order/tests/deprecated/test_order.py
+++ b/saleor/graphql/order/tests/deprecated/test_order.py
@@ -287,6 +287,7 @@ def test_order_fulfill_old_line_id(
         True,
         allow_stock_to_be_exceeded=False,
         approved=fulfillment_auto_approve,
+        tracking_number="",
     )
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17591,6 +17591,9 @@ input OrderFulfillInput {
 
   """If true, then allow proceed fulfillment when stock is exceeded."""
   allowStockToBeExceeded: Boolean = false
+
+  """Fulfillment tracking number."""
+  trackingNumber: String
 }
 
 input OrderFulfillLineInput {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17592,7 +17592,11 @@ input OrderFulfillInput {
   """If true, then allow proceed fulfillment when stock is exceeded."""
   allowStockToBeExceeded: Boolean = false
 
-  """Fulfillment tracking number."""
+  """
+  Fulfillment tracking number.
+  
+  Added in Saleor 3.6.
+  """
   trackingNumber: String
 }
 

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -820,7 +820,8 @@ def create_fulfillments(
                 allow_stock_to_be_exceeded=allow_stock_to_be_exceeded,
             )
         )
-        transaction.on_commit(lambda: manager.tracking_number_updated(fulfillment))
+        if tracking_number:
+            transaction.on_commit(lambda: manager.tracking_number_updated(fulfillment))
 
     FulfillmentLine.objects.bulk_create(fulfillment_lines)
     order.refresh_from_db()

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -754,6 +754,7 @@ def create_fulfillments(
     notify_customer: bool = True,
     approved: bool = True,
     allow_stock_to_be_exceeded: bool = False,
+    tracking_number: Optional[str] = "",
 ) -> List[Fulfillment]:
     """Fulfill order.
 
@@ -783,6 +784,7 @@ def create_fulfillments(
             otherwise waiting_for_approval.
         allow_stock_to_be_exceeded (bool): If `True` then stock quantity could exceed.
             Default value is set to `False`.
+        tracking_number (str): Optional fulfillment tracking number.
 
     Return:
         List[Fulfillment]: Fulfillmet with lines created for this order
@@ -802,7 +804,9 @@ def create_fulfillments(
         else FulfillmentStatus.WAITING_FOR_APPROVAL
     )
     for warehouse_pk in fulfillment_lines_for_warehouses:
-        fulfillment = Fulfillment.objects.create(order=order, status=status)
+        fulfillment = Fulfillment.objects.create(
+            order=order, status=status, tracking_number=tracking_number
+        )
         fulfillments.append(fulfillment)
         fulfillment_lines.extend(
             _create_fulfillment_lines(

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -820,6 +820,7 @@ def create_fulfillments(
                 allow_stock_to_be_exceeded=allow_stock_to_be_exceeded,
             )
         )
+        transaction.on_commit(lambda: manager.tracking_number_updated(fulfillment))
 
     FulfillmentLine.objects.bulk_create(fulfillment_lines)
     order.refresh_from_db()


### PR DESCRIPTION
I want to merge this change because it allows to add optional tracking_number to orderFulfill mutation.

It a port of #10332

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
