### PR TITLE
Fix the migration for removing media marked as to remove

### DIFF
--- a/saleor/core/tasks.py
+++ b/saleor/core/tasks.py
@@ -38,3 +38,9 @@ def delete_event_payloads_task():
 def delete_product_media_task(media_id):
     # TODO: to delete
     pass
+
+
+@app.task
+def delete_files_from_storage_task(paths):
+    for path in paths:
+        default_storage.delete(path)

--- a/saleor/core/tests/test_tasks.py
+++ b/saleor/core/tests/test_tasks.py
@@ -6,7 +6,11 @@ from freezegun import freeze_time
 
 from ...webhook.event_types import WebhookEventAsyncType
 from ..models import EventDelivery, EventDeliveryAttempt, EventPayload
-from ..tasks import delete_event_payloads_task, delete_from_storage_task
+from ..tasks import (
+    delete_event_payloads_task,
+    delete_files_from_storage_task,
+    delete_from_storage_task,
+)
 
 
 def test_delete_from_storage_task(product_with_image, media_root):
@@ -53,3 +57,32 @@ def test_delete_event_payloads_task(webhook, settings):
     assert EventPayload.objects.count() == 1
     assert EventDelivery.objects.count() == 1
     assert EventDeliveryAttempt.objects.count() == 1
+
+
+def test_delete_files_from_storage_task(
+    product_with_image, variant_with_image, media_root
+):
+    # given
+    path_1 = product_with_image.media.first().image.path
+    path_2 = variant_with_image.media.first().image.path
+    assert default_storage.exists(path_1)
+    assert default_storage.exists(path_2)
+
+    # when
+    delete_files_from_storage_task([path_1, path_2])
+
+    # then
+    assert not default_storage.exists(path_1)
+    assert not default_storage.exists(path_2)
+
+
+def test_delete_files_from_storage_task_files_not_existing_files(media_root):
+    """Ensure method not fail when trying to remove not existing file."""
+    # given
+    path = "random/test-path"
+    path_2 = "random/test-path-2"
+    assert not default_storage.exists(path)
+    assert not default_storage.exists(path_2)
+
+    # when
+    delete_files_from_storage_task([path, path_2])


### PR DESCRIPTION
- Add a dependency in the product migration.
- Add a celery task that deletes the provided files.
- Run this task in the migration.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
