### PR TITLE
Subscription for sync tax webooks

### DIFF
--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -1,0 +1,383 @@
+from decimal import Decimal
+from typing import Union
+import graphene
+
+from saleor.checkout import base_calculations
+from ...order.dataloaders import OrderLinesByOrderIdLoader
+from ....shipping.models import ShippingMethodChannelListing
+from ...shipping.dataloaders import (
+    ShippingMethodChannelListingByShippingMethodIdLoader,
+)
+from ....discount import VoucherType
+from ....core.prices import quantize_price
+from ....core.taxes import include_taxes_in_prices, zero_money
+from ...account.dataloaders import AddressByIdLoader, UserByUserIdLoader
+from ...checkout.dataloaders import (
+    CheckoutByTokenLoader,
+    CheckoutInfoByCheckoutTokenLoader,
+    CheckoutLinesByCheckoutTokenLoader,
+    CheckoutLinesInfoByCheckoutTokenLoader,
+)
+from ...channel import ChannelContext
+
+from ...discount.dataloaders import (
+    DiscountsByDateTimeLoader,
+    OrderDiscountsByOrderIDLoader,
+)
+from promise import Promise
+
+from ...product.dataloaders.products import (
+    ProductByVariantIdLoader,
+    ProductVariantByIdLoader,
+)
+
+from .money import Money
+
+from .common import NonNullList
+from typing import List
+
+from ...checkout import types as checkout_types
+from ...order import types as order_types
+from ....checkout.models import Checkout, CheckoutLine
+from ....order.models import Order, OrderLine
+
+
+class TaxSourceObject(graphene.Union):
+    class Meta:
+        types = (checkout_types.Checkout, order_types.Order)
+
+    @classmethod
+    def resolve_type(cls, instance, info):
+        if isinstance(instance, Checkout):
+            return checkout_types.Checkout
+        if isinstance(instance, Order):
+            return order_types.Order
+        return super(TaxSourceObject, cls).resolve_type(instance, info)
+
+
+class TaxSourceLine(graphene.Union):
+    class Meta:
+        types = (checkout_types.CheckoutLine, order_types.OrderLine)
+
+    @classmethod
+    def resolve_type(cls, instance, info):
+        if isinstance(instance, CheckoutLine):
+            return checkout_types.CheckoutLine
+        if isinstance(instance, OrderLine):
+            return order_types.OrderLine
+        return super(TaxSourceObject, cls).resolve_type(instance, info)
+
+
+class TaxableObjectLine(graphene.ObjectType):
+    source_line = graphene.Field(TaxSourceLine, required=True)
+    quantity = graphene.Int(required=True, description="Number of items.")
+    charge_taxes = graphene.Boolean(
+        required=True,
+        description="Determine if taxes are being charged for the product.",
+    )
+    product_name = graphene.String(description="The product name.", required=True)
+    variant_name = graphene.String(description="The variant name", required=True)
+    product_sku = graphene.String(description="The product sku.")
+
+    unit_price = graphene.Field(
+        Money, description="Price of the single item in the order line.", required=True
+    )
+    total_price = graphene.Field(
+        Money, description="Price of the order line.", required=True
+    )
+
+    @staticmethod
+    def resolve_variant_name(root: Union[CheckoutLine, OrderLine], info):
+        if isinstance(root, CheckoutLine):
+            def get_name(variant):
+                return variant.name
+            if not root.variant_id:
+                return ""
+            return (
+                ProductVariantByIdLoader(info.context)
+                .load(root.variant_id)
+                .then(get_name)
+            )
+        return root.variant_name
+    @staticmethod
+    def resolve_product_name(root: Union[CheckoutLine, OrderLine], info):
+        if isinstance(root, CheckoutLine):
+            def get_name(product):
+                return product.name
+            if not root.variant_id:
+                return ""
+            return (
+                ProductByVariantIdLoader(info.context)
+                .load(root.variant_id)
+                .then(get_name)
+            )
+        return root.product_name
+
+    @staticmethod
+    def resolve_product_sku(root: Union[CheckoutLine, OrderLine], info):
+        if isinstance(root, CheckoutLine):
+            if not root.variant_id:
+                return None
+            def get_sku(variant):
+                return variant.sku
+            return  (ProductVariantByIdLoader(info.context)
+                 .load(root.variant_id)
+                 .then(get_sku)
+             )
+        return root.product_sku
+
+    @staticmethod
+    def resolve_source_line(root: Union[CheckoutLine, OrderLine], info):
+        return root
+
+    @staticmethod
+    def resolve_charge_taxes(root: Union[CheckoutLine, OrderLine], info):
+
+        if not root.variant_id:
+            # By default charge taxes are set to True
+            return True
+
+        def get_charge_taxes(product):
+            return product.charge_taxes
+
+        return (
+            ProductByVariantIdLoader(info.context)
+            .load(root.variant_id)
+            .then(get_charge_taxes)
+        )
+
+    @staticmethod
+    def resolve_unit_price(root: Union[CheckoutLine, OrderLine], info):
+        if isinstance(root, CheckoutLine):
+
+            def with_checkout(checkout):
+                discounts = DiscountsByDateTimeLoader(info.context).load(
+                    info.context.request_time
+                )
+                checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(
+                    checkout.token
+                )
+                lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(
+                    checkout.token
+                )
+
+                def calculate_line_unit_price(data):
+                    (
+                        discounts,
+                        checkout_info,
+                        lines,
+                    ) = data
+                    for line_info in lines:
+                        if line_info.line.pk == root.pk:
+                            return base_calculations.calculate_base_line_unit_price(
+                                line_info=line_info,
+                                channel=checkout_info.channel,
+                                discounts=discounts,
+                            )
+                    return None
+
+                return Promise.all(
+                    [
+                        discounts,
+                        checkout_info,
+                        lines,
+                    ]
+                ).then(calculate_line_unit_price)
+
+            return (
+                CheckoutByTokenLoader(info.context)
+                .load(root.checkout_id)
+                .then(with_checkout)
+            )
+        return root.base_unit_price
+
+    @staticmethod
+    def resolve_total_price(root: Union[CheckoutLine, OrderLine], info):
+        if isinstance(root, CheckoutLine):
+
+            def with_checkout(checkout):
+                discounts = DiscountsByDateTimeLoader(info.context).load(
+                    info.context.request_time
+                )
+                checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(
+                    checkout.token
+                )
+                lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(
+                    checkout.token
+                )
+
+                def calculate_line_total_price(data):
+                    (
+                        discounts,
+                        checkout_info,
+                        lines,
+                    ) = data
+                    for line_info in lines:
+                        if line_info.line.pk == root.pk:
+                            return base_calculations.calculate_base_line_total_price(
+                                line_info=line_info,
+                                channel=checkout_info.channel,
+                                discounts=discounts,
+                            )
+                    return None
+
+                return Promise.all(
+                    [
+                        discounts,
+                        checkout_info,
+                        lines,
+                    ]
+                ).then(calculate_line_total_price)
+
+            return (
+                CheckoutByTokenLoader(info.context)
+                .load(root.checkout_id)
+                .then(with_checkout)
+            )
+        return root.base_unit_price * root.quantity
+
+
+class TaxableObjectDiscount(graphene.ObjectType):
+    name = graphene.String(description="The name of the discount.")
+    amount = graphene.Field(
+        Money, description="The amount of the discount.", required=True
+    )
+
+
+class TaxableObject(graphene.ObjectType):
+    source_object = graphene.Field(TaxSourceObject, required=True)
+    prices_entered_with_tax = graphene.Boolean(
+        required=True, description="Determine if prices contain entered tax."
+    )
+    currency = graphene.String(required=True, description="The currency of the object.")
+    shipping_price = graphene.Field(
+        Money, required=True, description="The price of shipping method."
+    )
+    address = graphene.Field(
+        "saleor.graphql.account.types.Address",
+        description="The address data.",
+    )
+    discounts = NonNullList(
+        TaxableObjectDiscount, description="List of discounts.", required=True
+    )
+    lines = NonNullList(
+        TaxableObjectLine,
+        description="List of lines assigned to the object.",
+        required=True,
+    )
+
+    class Meta:
+        description = "Taxable object."
+
+    def resolve_address(root: Union[Checkout, Order], info):
+        address_id = root.shipping_address_id or root.billing_address_id
+        if not address_id:
+            return None
+        return AddressByIdLoader(info.context).load(address_id)
+
+    @staticmethod
+    def resolve_source_object(root: Union[Checkout, Order], info):
+        return root
+
+    @staticmethod
+    def resolve_prices_entered_with_tax(root: Union[Checkout, Order], info):
+        return include_taxes_in_prices()
+
+    @staticmethod
+    def resolve_currency(root: Union[Checkout, Order], info):
+        return root.currency
+
+    @staticmethod
+    def resolve_shipping_price(root: Union[Checkout, Order], info):
+        if isinstance(root, Checkout):
+
+            def calculate_shipping_price(data):
+                checkout_info, lines = data
+                is_shipping_voucher = (
+                    checkout_info.voucher.type == VoucherType.SHIPPING
+                    if checkout_info.voucher
+                    else False
+                )
+                price = base_calculations.base_checkout_delivery_price(
+                    checkout_info, lines
+                )
+                if is_shipping_voucher:
+                    price.amount = max(
+                        price.amount - checkout_info.checkout.discount_amount,
+                        Decimal("0.0"),
+                    )
+
+                return quantize_price(
+                    price,
+                    checkout_info.checkout.currency,
+                )
+
+            checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(
+                root.token
+            )
+            lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(
+                root.token
+            )
+            return Promise.all(
+                [
+                    checkout_info,
+                    lines,
+                ]
+            ).then(calculate_shipping_price)
+
+        def calculate_base_shipping_method(
+            channel_listins: List[ShippingMethodChannelListing],
+        ):
+            for listing in channel_listins:
+                if listing.channel_id == root.channel_id:
+                    return listing.price
+            return zero_money(root.currency)
+
+        if not root.shipping_method:
+            return zero_money(root.currency)
+
+        return ShippingMethodChannelListingByShippingMethodIdLoader(info.context).load(
+            root.shipping_method_id
+        ).then(calculate_base_shipping_method)
+
+    @staticmethod
+    def resolve_discounts(root: Union[Checkout, Order], info):
+        if isinstance(root, Checkout):
+
+            def calculate_checkout_discounts(checkout_info):
+                is_shipping_voucher = (
+                    checkout_info.voucher.type == VoucherType.SHIPPING
+                    if checkout_info.voucher
+                    else False
+                )
+                checkout = checkout_info.checkout
+                discount_name = checkout.discount_name
+                return (
+                    [{"name": discount_name, "amount": checkout.discount}]
+                    if checkout.discount and not is_shipping_voucher
+                    else []
+                )
+
+            return (
+                CheckoutInfoByCheckoutTokenLoader(info.context)
+                .load(root.token)
+                .then(calculate_checkout_discounts)
+            )
+
+        def map_discounts(discounts):
+            return [
+                {"name": discount.name, "amount": discount.amount}
+                for discount in discounts
+            ]
+
+        return (
+            OrderDiscountsByOrderIDLoader(info.context)
+            .load(root.id)
+            .then(map_discounts)
+        )
+
+    @staticmethod
+    def resolve_lines(root: Union[Checkout, Order], info):
+        if isinstance(root, Checkout):
+            return CheckoutLinesByCheckoutTokenLoader(info.context).load(root.token)
+        return OrderLinesByOrderIdLoader(info.context).load(root.id)

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -71,10 +71,10 @@ class TaxableObjectLine(graphene.ObjectType):
     quantity = graphene.Int(required=True, description="Number of items.")
     charge_taxes = graphene.Boolean(
         required=True,
-        description="Determine if taxes are being charged for the product.",
+        description="Determines if taxes are being charged for the product.",
     )
     product_name = graphene.String(description="The product name.", required=True)
-    variant_name = graphene.String(description="The variant name", required=True)
+    variant_name = graphene.String(description="The variant name.", required=True)
     product_sku = graphene.String(description="The product sku.")
 
     unit_price = graphene.Field(
@@ -249,6 +249,9 @@ class TaxableObjectDiscount(graphene.ObjectType):
         Money, description="The amount of the discount.", required=True
     )
 
+    class Meta:
+        description = "Taxable object discount."
+
 
 class TaxableObject(graphene.ObjectType):
     source_object = graphene.Field(
@@ -257,7 +260,7 @@ class TaxableObject(graphene.ObjectType):
         description="The source object related to this tax object.",
     )
     prices_entered_with_tax = graphene.Boolean(
-        required=True, description="Determine if prices contain entered tax."
+        required=True, description="Determines if prices contain entered tax.."
     )
     currency = graphene.String(required=True, description="The currency of the object.")
     shipping_price = graphene.Field(

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -62,7 +62,11 @@ class TaxSourceLine(graphene.Union):
 
 
 class TaxableObjectLine(graphene.ObjectType):
-    source_line = graphene.Field(TaxSourceLine, required=True)
+    source_line = graphene.Field(
+        TaxSourceLine,
+        required=True,
+        description="The source line related to this tax line.",
+    )
     quantity = graphene.Int(required=True, description="Number of items.")
     charge_taxes = graphene.Boolean(
         required=True,
@@ -246,7 +250,11 @@ class TaxableObjectDiscount(graphene.ObjectType):
 
 
 class TaxableObject(graphene.ObjectType):
-    source_object = graphene.Field(TaxSourceObject, required=True)
+    source_object = graphene.Field(
+        TaxSourceObject,
+        required=True,
+        description="The source object related to this tax object.",
+    )
     prices_entered_with_tax = graphene.Boolean(
         required=True, description="Determine if prices contain entered tax."
     )

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -969,7 +969,7 @@ class Order(ModelObjectType):
     delivery_method = graphene.Field(
         DeliveryMethod,
         description=(
-            "The delivery method selected for this checkout."
+            "The delivery method selected for this order."
             + ADDED_IN_31
             + PREVIEW_FEATURE
         ),

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -8542,7 +8542,7 @@ type Order implements Node & ObjectWithMetadata {
   isShippingRequired: Boolean!
 
   """
-  The delivery method selected for this checkout.
+  The delivery method selected for this order.
   
   Added in Saleor 3.1.
   
@@ -23957,6 +23957,179 @@ type ShippingListMethodsForCheckout implements Event {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   shippingMethods: [ShippingMethod!]
+}
+
+type CalculateTaxes implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+  sourceObject: TaxSourceObject!
+  taxBase: TaxableObject!
+}
+
+union TaxSourceObject = Checkout | Order
+
+type TaxableObject {
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
+  id: ID!
+  channel: Channel!
+
+  """The shipping address data."""
+  shippingAddress: Address
+
+  """The billing address data."""
+  billingAddress: Address
+  user: User
+  email: String
+
+  """Determine if prices contain entered tax."""
+  pricesEnteredWithTax: Boolean!
+
+  """The currency of the object."""
+  currency: String!
+
+  """The price of shipping method."""
+  shippingPrice: Money!
+
+  """Shipping method name."""
+  shippingName: String
+
+  """List of discounts."""
+  discounts: [TaxableObjectDiscount!]!
+
+  """List of lines assigned to the object."""
+  lines: [TaxableObjectLine!]!
+}
+
+type TaxableObjectDiscount {
+  """The name of the discount."""
+  name: String
+
+  """The amount of the discount."""
+  amount: Money!
+}
+
+type TaxableObjectLine {
+  """List of private metadata items. Requires staff permissions to access."""
+  privateMetadata: [MetadataItem!]!
+
+  """
+  A single key from private metadata. Requires staff permissions to access.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  privateMetafield(key: String!): String
+
+  """
+  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  privateMetafields(keys: [String!]): Metadata
+
+  """List of public metadata items. Can be accessed without permissions."""
+  metadata: [MetadataItem!]!
+
+  """
+  A single key from public metadata.
+  
+  Tip: Use GraphQL aliases to fetch multiple keys.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  metafield(key: String!): String
+
+  """
+  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
+  
+  Added in Saleor 3.3.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  metafields(keys: [String!]): Metadata
+  id: ID!
+  variant: ProductVariant
+
+  """The product name."""
+  productName: String!
+
+  """The variant name"""
+  variantName: String!
+
+  """The product sku."""
+  productSku: String
+
+  """Number of items."""
+  quantity: Int!
+
+  """Determine if taxes are being charged for the product."""
+  chargeTaxes: Boolean!
+
+  """Price of the single item in the order line."""
+  unitPrice: Money!
+
+  """Price of the order line."""
+  totalPrice: Money!
 }
 
 """_Any value scalar as defined by Federation spec."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -24003,6 +24003,7 @@ type TaxableObject {
 
   """List of lines assigned to the object."""
   lines: [TaxableObjectLine!]!
+  channel: Channel!
 }
 
 union TaxSourceObject = Checkout | Order

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23959,6 +23959,13 @@ type ShippingListMethodsForCheckout implements Event {
   shippingMethods: [ShippingMethod!]
 }
 
+"""
+Synchronous webhook for calculating checkout/order taxes.
+
+Added in Saleor 3.7.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
 type CalculateTaxes implements Event {
   """Time of the event."""
   issuedAt: DateTime
@@ -23976,6 +23983,7 @@ type CalculateTaxes implements Event {
 
 """Taxable object."""
 type TaxableObject {
+  """The source object related to this tax object."""
   sourceObject: TaxSourceObject!
 
   """Determine if prices contain entered tax."""
@@ -24008,6 +24016,7 @@ type TaxableObjectDiscount {
 }
 
 type TaxableObjectLine {
+  """The source line related to this tax line."""
   sourceLine: TaxSourceLine!
 
   """Number of items."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23986,7 +23986,7 @@ type TaxableObject {
   """The source object related to this tax object."""
   sourceObject: TaxSourceObject!
 
-  """Determine if prices contain entered tax."""
+  """Determines if prices contain entered tax.."""
   pricesEnteredWithTax: Boolean!
 
   """The currency of the object."""
@@ -24008,6 +24008,7 @@ type TaxableObject {
 
 union TaxSourceObject = Checkout | Order
 
+"""Taxable object discount."""
 type TaxableObjectDiscount {
   """The name of the discount."""
   name: String
@@ -24023,13 +24024,13 @@ type TaxableObjectLine {
   """Number of items."""
   quantity: Int!
 
-  """Determine if taxes are being charged for the product."""
+  """Determines if taxes are being charged for the product."""
   chargeTaxes: Boolean!
 
   """The product name."""
   productName: String!
 
-  """The variant name"""
+  """The variant name."""
   variantName: String!
 
   """The product sku."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23971,68 +23971,12 @@ type CalculateTaxes implements Event {
 
   """The application receiving the webhook."""
   recipient: App
-  sourceObject: TaxSourceObject!
   taxBase: TaxableObject!
 }
 
-union TaxSourceObject = Checkout | Order
-
+"""Taxable object."""
 type TaxableObject {
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
-
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  privateMetafield(key: String!): String
-
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  metafields(keys: [String!]): Metadata
-  id: ID!
-  channel: Channel!
-
-  """The shipping address data."""
-  shippingAddress: Address
-
-  """The billing address data."""
-  billingAddress: Address
-  user: User
-  email: String
+  sourceObject: TaxSourceObject!
 
   """Determine if prices contain entered tax."""
   pricesEnteredWithTax: Boolean!
@@ -24043,8 +23987,8 @@ type TaxableObject {
   """The price of shipping method."""
   shippingPrice: Money!
 
-  """Shipping method name."""
-  shippingName: String
+  """The address data."""
+  address: Address
 
   """List of discounts."""
   discounts: [TaxableObjectDiscount!]!
@@ -24052,6 +23996,8 @@ type TaxableObject {
   """List of lines assigned to the object."""
   lines: [TaxableObjectLine!]!
 }
+
+union TaxSourceObject = Checkout | Order
 
 type TaxableObjectDiscount {
   """The name of the discount."""
@@ -24062,53 +24008,13 @@ type TaxableObjectDiscount {
 }
 
 type TaxableObjectLine {
-  """List of private metadata items. Requires staff permissions to access."""
-  privateMetadata: [MetadataItem!]!
+  sourceLine: TaxSourceLine!
 
-  """
-  A single key from private metadata. Requires staff permissions to access.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  privateMetafield(key: String!): String
+  """Number of items."""
+  quantity: Int!
 
-  """
-  Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  privateMetafields(keys: [String!]): Metadata
-
-  """List of public metadata items. Can be accessed without permissions."""
-  metadata: [MetadataItem!]!
-
-  """
-  A single key from public metadata.
-  
-  Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  metafield(key: String!): String
-
-  """
-  Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  metafields(keys: [String!]): Metadata
-  id: ID!
-  variant: ProductVariant
+  """Determine if taxes are being charged for the product."""
+  chargeTaxes: Boolean!
 
   """The product name."""
   productName: String!
@@ -24119,18 +24025,14 @@ type TaxableObjectLine {
   """The product sku."""
   productSku: String
 
-  """Number of items."""
-  quantity: Int!
-
-  """Determine if taxes are being charged for the product."""
-  chargeTaxes: Boolean!
-
   """Price of the single item in the order line."""
   unitPrice: Money!
 
   """Price of the order line."""
   totalPrice: Money!
 }
+
+union TaxSourceLine = CheckoutLine | OrderLine
 
 """_Any value scalar as defined by Federation spec."""
 scalar _Any

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1,4 +1,3 @@
-from typing import Tuple
 import graphene
 from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
@@ -20,10 +19,6 @@ from ...product.models import (
     ProductTranslation,
     ProductVariantTranslation,
 )
-from ...checkout import models as checkout_models
-from ...order import models as order_models
-from ..checkout.types import Checkout
-from ..order.types import Order
 from ...shipping.models import ShippingMethodTranslation
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..account.types import User as UserType
@@ -37,7 +32,6 @@ from ..core.descriptions import (
     ADDED_IN_36,
     PREVIEW_FEATURE,
 )
-
 from ..core.scalars import PositiveDecimal
 from ..core.types import NonNullList
 from ..payment.enums import TransactionActionEnum
@@ -1363,18 +1357,21 @@ class ShippingListMethodsForCheckout(ObjectType, CheckoutBase):
             "List shipping methods for checkout." + ADDED_IN_36 + PREVIEW_FEATURE
         )
 
+
 # from saleor.graphql.core.types.taxes import TaxableObject
 class CalculateTaxes(ObjectType):
     # source_object = graphene.Field(TaxSourceObject, required=True)
-    tax_base = graphene.Field("saleor.graphql.core.types.taxes.TaxableObject", required=True)
-    
+    tax_base = graphene.Field(
+        "saleor.graphql.core.types.taxes.TaxableObject", required=True
+    )
+
     class Meta:
         interfaces = (Event,)
 
     def resolve_tax_base(root, info):
         _, tax_base = root
         return tax_base
-    
+
 
 class CheckoutFilterShippingMethods(ObjectType, CheckoutBase):
     shipping_methods = NonNullList(
@@ -1568,5 +1565,5 @@ WEBHOOK_TYPES_MAP = {
         ShippingListMethodsForCheckout
     ),
     WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES: CalculateTaxes,
-    WebhookEventSyncType.ORDER_CALCULATE_TAXES: CalculateTaxes
+    WebhookEventSyncType.ORDER_CALCULATE_TAXES: CalculateTaxes,
 }

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -30,6 +30,7 @@ from ..core.descriptions import (
     ADDED_IN_34,
     ADDED_IN_35,
     ADDED_IN_36,
+    ADDED_IN_37,
     PREVIEW_FEATURE,
 )
 from ..core.scalars import PositiveDecimal
@@ -1358,15 +1359,18 @@ class ShippingListMethodsForCheckout(ObjectType, CheckoutBase):
         )
 
 
-# from saleor.graphql.core.types.taxes import TaxableObject
 class CalculateTaxes(ObjectType):
-    # source_object = graphene.Field(TaxSourceObject, required=True)
     tax_base = graphene.Field(
         "saleor.graphql.core.types.taxes.TaxableObject", required=True
     )
 
     class Meta:
         interfaces = (Event,)
+        description = (
+            "Synchronous webhook for calculating checkout/order taxes."
+            + ADDED_IN_37
+            + PREVIEW_FEATURE
+        )
 
     def resolve_tax_base(root, info):
         _, tax_base = root

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 import graphene
 from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
@@ -19,6 +20,10 @@ from ...product.models import (
     ProductTranslation,
     ProductVariantTranslation,
 )
+from ...checkout import models as checkout_models
+from ...order import models as order_models
+from ..checkout.types import Checkout
+from ..order.types import Order
 from ...shipping.models import ShippingMethodTranslation
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..account.types import User as UserType
@@ -32,6 +37,7 @@ from ..core.descriptions import (
     ADDED_IN_36,
     PREVIEW_FEATURE,
 )
+
 from ..core.scalars import PositiveDecimal
 from ..core.types import NonNullList
 from ..payment.enums import TransactionActionEnum
@@ -1357,6 +1363,18 @@ class ShippingListMethodsForCheckout(ObjectType, CheckoutBase):
             "List shipping methods for checkout." + ADDED_IN_36 + PREVIEW_FEATURE
         )
 
+# from saleor.graphql.core.types.taxes import TaxableObject
+class CalculateTaxes(ObjectType):
+    # source_object = graphene.Field(TaxSourceObject, required=True)
+    tax_base = graphene.Field("saleor.graphql.core.types.taxes.TaxableObject", required=True)
+    
+    class Meta:
+        interfaces = (Event,)
+
+    def resolve_tax_base(root, info):
+        _, tax_base = root
+        return tax_base
+    
 
 class CheckoutFilterShippingMethods(ObjectType, CheckoutBase):
     shipping_methods = NonNullList(
@@ -1549,4 +1567,6 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT: (
         ShippingListMethodsForCheckout
     ),
+    WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES: CalculateTaxes,
+    WebhookEventSyncType.ORDER_CALCULATE_TAXES: CalculateTaxes
 }

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1330,6 +1330,8 @@ class WebhookPlugin(BasePlugin):
                 lines,
             ),
             parse_tax_data,
+            checkout_info.checkout,
+            self.requestor,
         )
 
     def get_taxes_for_order(
@@ -1339,6 +1341,8 @@ class WebhookPlugin(BasePlugin):
             WebhookEventSyncType.ORDER_CALCULATE_TAXES,
             lambda: generate_order_payload_for_tax_calculation(order),
             parse_tax_data,
+            order,
+            self.requestor,
         )
 
     def get_shipping_methods_for_checkout(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -28,6 +28,9 @@ subscription {
         address {
           id
         }
+        channel {
+            id
+        }
 
         discounts {
           amount {
@@ -108,6 +111,7 @@ def test_checkout_calculate_taxes(
             },
             "currency": "USD",
             "discounts": [],
+            "channel": {"id": to_global_id_or_none(checkout_ready_to_complete.channel)},
             "lines": [
                 {
                     "chargeTaxes": True,
@@ -166,6 +170,7 @@ def test_checkout_calculate_taxes_with_voucher(
             "address": None,
             "currency": "USD",
             "discounts": [{"amount": {"amount": 20.0}}],
+            "channel": {"id": to_global_id_or_none(checkout_with_voucher.channel)},
             "lines": [
                 {
                     "chargeTaxes": True,
@@ -224,6 +229,7 @@ def test_checkout_calculate_taxes_with_shipping_voucher(
             "address": None,
             "currency": "USD",
             "discounts": [{"amount": {"amount": 20.0}}],
+            "channel": {"id": to_global_id_or_none(checkout_with_voucher.channel)},
             "lines": [
                 {
                     "chargeTaxes": True,
@@ -277,6 +283,7 @@ def test_checkout_calculate_taxes_empty_checkout(
         "__typename": "CalculateTaxes",
         "taxBase": {
             "address": None,
+            "channel": {"id": to_global_id_or_none(checkout.channel)},
             "currency": "USD",
             "discounts": [],
             "lines": [],
@@ -324,6 +331,7 @@ def test_order_calculate_taxes(
             "address": {"id": to_global_id_or_none(order.shipping_address)},
             "currency": "USD",
             "discounts": [],
+            "channel": {"id": to_global_id_or_none(order.channel)},
             "lines": [
                 {
                     "chargeTaxes": True,
@@ -396,6 +404,7 @@ def test_order_calculate_taxes_with_discounts(
             "address": {"id": to_global_id_or_none(order.shipping_address)},
             "currency": "USD",
             "discounts": [{"amount": {"amount": 20.0}}],
+            "channel": {"id": to_global_id_or_none(order.channel)},
             "lines": [
                 {
                     "chargeTaxes": True,
@@ -449,6 +458,7 @@ def test_order_calculate_taxes_empty_order(
             "lines": [],
             "pricesEnteredWithTax": True,
             "shippingPrice": {"amount": 0.0},
+            "channel": {"id": to_global_id_or_none(order.channel)},
             "sourceObject": {
                 "__typename": "Order",
                 "id": to_global_id_or_none(order),

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_taxes.py
@@ -1,0 +1,355 @@
+from decimal import Decimal
+from functools import partial
+
+from .....tests.fixtures import recalculate_order
+from .....graphql.core.utils import to_global_id_or_none
+from ...tasks import create_delivery_for_subscription_sync_event
+from .....webhook.models import Webhook
+from .....webhook.event_types import WebhookEventSyncType
+from freezegun import freeze_time
+import json
+
+TAXES_SUBSCRIPTION_QUERY = """
+subscription {
+  event {
+    __typename
+    ... on CalculateTaxes {
+      taxBase {
+        pricesEnteredWithTax
+        currency
+        shippingPrice {
+          amount
+        }
+        address {
+          id
+        }
+
+        discounts {
+          amount {
+            amount
+          }
+        }
+
+        lines {
+          quantity
+          chargeTaxes
+          productName
+          variantName
+          productSku
+          unitPrice {
+            amount
+          }
+
+          totalPrice {
+            amount
+          }
+          sourceLine {
+            __typename
+            ... on CheckoutLine {
+              id
+            }
+            ... on OrderLine {
+              id
+            }
+          }
+        }
+        sourceObject {
+          __typename
+          ... on Checkout {
+            id
+          }
+          ... on Order {
+            id
+          }
+        }
+      }
+    }
+  }
+}
+
+
+"""
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_checkout_calculate_taxes(
+    checkout_ready_to_complete,
+    webhook_app,
+    permission_handle_taxes,
+):
+    # given
+    webhook_app.permissions.add(permission_handle_taxes)
+    event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TAXES_SUBSCRIPTION_QUERY,
+    )
+    event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+    webhook.events.create(event_type=event_type)
+
+    # when
+    deliveries = create_delivery_for_subscription_sync_event(
+        event_type, checkout_ready_to_complete, webhook
+    )
+
+    # then
+    assert json.loads(deliveries.payload.payload) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": {
+                "id": to_global_id_or_none(checkout_ready_to_complete.shipping_address)
+            },
+            "currency": "USD",
+            "discounts": [],
+            "lines": [
+                {
+                    "chargeTaxes": True,
+                    "productName": "Test product",
+                    "productSku": "123",
+                    "quantity": 3,
+                    "sourceLine": {
+                        "id": to_global_id_or_none(
+                            checkout_ready_to_complete.lines.first()
+                        ),
+                        "__typename": "CheckoutLine",
+                    },
+                    "totalPrice": {"amount": 30.0},
+                    "unitPrice": {"amount": 10.0},
+                    "variantName": "",
+                }
+            ],
+            "pricesEnteredWithTax": True,
+            "shippingPrice": {"amount": 10.0},
+            "sourceObject": {
+                "id": to_global_id_or_none(checkout_ready_to_complete),
+                "__typename": "Checkout",
+            },
+        },
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_checkout_calculate_taxes_with_voucher(
+    checkout_with_voucher,
+    webhook_app,
+    permission_handle_taxes,
+):
+
+    # given
+    webhook_app.permissions.add(permission_handle_taxes)
+    event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TAXES_SUBSCRIPTION_QUERY,
+    )
+    event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+    webhook.events.create(event_type=event_type)
+
+    # when
+    deliveries = create_delivery_for_subscription_sync_event(
+        event_type, checkout_with_voucher, webhook
+    )
+
+    # then
+    assert json.loads(deliveries.payload.payload) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": None,
+            "currency": "USD",
+            "discounts": [{"amount": {"amount": 20.0}}],
+            "lines": [
+                {
+                    "chargeTaxes": True,
+                    "productName": "Test product",
+                    "productSku": "123",
+                    "quantity": 3,
+                    "sourceLine": {
+                        "id": to_global_id_or_none(checkout_with_voucher.lines.first()),
+                        "__typename": "CheckoutLine",
+                    },
+                    "totalPrice": {"amount": 30.0},
+                    "unitPrice": {"amount": 10.0},
+                    "variantName": "",
+                }
+            ],
+            "pricesEnteredWithTax": True,
+            "shippingPrice": {"amount": 0.0},
+            "sourceObject": {
+                "id": to_global_id_or_none(checkout_with_voucher),
+                "__typename": "Checkout",
+            },
+        },
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_checkout_calculate_taxes_empty_checkout(
+    checkout,
+    webhook_app,
+    permission_handle_taxes,
+):
+    # given
+    webhook_app.permissions.add(permission_handle_taxes)
+    event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TAXES_SUBSCRIPTION_QUERY,
+    )
+    event_type = WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
+    webhook.events.create(event_type=event_type)
+
+    # when
+    deliveries = create_delivery_for_subscription_sync_event(
+        event_type, checkout, webhook
+    )
+
+    # then
+    assert json.loads(deliveries.payload.payload) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": None,
+            "currency": "USD",
+            "discounts": [],
+            "lines": [],
+            "pricesEnteredWithTax": True,
+            "shippingPrice": {"amount": 0.0},
+            "sourceObject": {
+                "id": to_global_id_or_none(checkout),
+                "__typename": "Checkout",
+            },
+        },
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_order_calculate_taxes(
+    order_line,
+    webhook_app,
+    permission_handle_taxes,
+):
+
+    # given
+    order = order_line.order
+    webhook_app.permissions.add(permission_handle_taxes)
+    event_type = WebhookEventSyncType.ORDER_CALCULATE_TAXES
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TAXES_SUBSCRIPTION_QUERY,
+    )
+    event_type = WebhookEventSyncType.ORDER_CALCULATE_TAXES
+    webhook.events.create(event_type=event_type)
+
+    # when
+    deliveries = create_delivery_for_subscription_sync_event(event_type, order, webhook)
+
+    # then
+    assert json.loads(deliveries.payload.payload) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": {"id": to_global_id_or_none(order.shipping_address)},
+            "currency": "USD",
+            "discounts": [],
+            "lines": [
+                {
+                    "chargeTaxes": True,
+                    "productName": "Test product",
+                    "productSku": "SKU_A",
+                    "quantity": 3,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(order_line),
+                    },
+                    "totalPrice": {"amount": 36.9},
+                    "unitPrice": {"amount": 12.3},
+                    "variantName": "SKU_A",
+                }
+            ],
+            "pricesEnteredWithTax": True,
+            "shippingPrice": {"amount": 0.0},
+            "sourceObject": {
+                "__typename": "Order",
+                "id": to_global_id_or_none(order),
+            },
+        },
+    }
+
+
+from prices import Money, fixed_discount
+from .....discount import DiscountValueType
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_order_calculate_taxes_with_discounts(
+    order_line,
+    webhook_app,
+    permission_handle_taxes,
+):
+
+    # given
+    order = order_line.order
+    order.total = order_line.total_price + order.shipping_price
+    order.undiscounted_total = order.total
+    order.save()
+
+    value = Decimal("20")
+    discount = partial(fixed_discount, discount=Money(value, order.currency))
+    order.total = discount(order.total)
+    order.save()
+    order.discounts.create(
+        value_type=DiscountValueType.FIXED,
+        value=value,
+        reason="Discount reason",
+        amount=(order.undiscounted_total - order.total).gross,  # type: ignore
+    )
+    recalculate_order(order)
+    order.refresh_from_db()
+
+    webhook_app.permissions.add(permission_handle_taxes)
+    event_type = WebhookEventSyncType.ORDER_CALCULATE_TAXES
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=TAXES_SUBSCRIPTION_QUERY,
+    )
+    event_type = WebhookEventSyncType.ORDER_CALCULATE_TAXES
+    webhook.events.create(event_type=event_type)
+
+    # when
+    deliveries = create_delivery_for_subscription_sync_event(event_type, order, webhook)
+
+    # then
+    assert json.loads(deliveries.payload.payload) == {
+        "__typename": "CalculateTaxes",
+        "taxBase": {
+            "address": {"id": to_global_id_or_none(order.shipping_address)},
+            "currency": "USD",
+            "discounts": [{"amount": {"amount": 20.0}}],
+            "lines": [
+                {
+                    "chargeTaxes": True,
+                    "productName": "Test product",
+                    "productSku": "SKU_A",
+                    "quantity": 3,
+                    "sourceLine": {
+                        "__typename": "OrderLine",
+                        "id": to_global_id_or_none(order_line),
+                    },
+                    "totalPrice": {"amount": 36.9},
+                    "unitPrice": {"amount": 12.3},
+                    "variantName": "SKU_A",
+                }
+            ],
+            "pricesEnteredWithTax": True,
+            "shippingPrice": {"amount": 0.0},
+            "sourceObject": {"__typename": "Order", "id": to_global_id_or_none(order)},
+        },
+    }


### PR DESCRIPTION
I want to merge this change because It adds support for synchronous tax webhook subscriptions. 
It introduces a single event that covers tax calculations for order and checkout.
We introduced a new type for tax, but each tax object has access to source object (`source...` field).

```graphql
type CalculateTaxes implements Event {
   issuedAt: DateTime
   version: String
   issuingPrincipal: IssuingPrincipal
   recipient: App
   taxBase: TaxableObject!
 }

 """Taxable object."""
 type TaxableObject {
   sourceObject: TaxSourceObject!
   pricesEnteredWithTax: Boolean!
   currency: String!
   shippingPrice: Money!
   address: Address
   discounts: [TaxableObjectDiscount!]!
   lines: [TaxableObjectLine!]!
 }

 union TaxSourceObject = Checkout | Order

 type TaxableObjectDiscount {
   name: String
   amount: Money!
 }

 type TaxableObjectLine {
   sourceLine: TaxSourceLine!
   quantity: Int!
   chargeTaxes: Boolean!
   productName: String!
   variantName: String!
   productSku: String
   unitPrice: Money!
   totalPrice: Money!
 }

 union TaxSourceLine = CheckoutLine | OrderLine
```


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
