### PR TITLE
Mark webhook secretKey as deprecated

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1319,12 +1319,8 @@ type Webhook implements Node {
   """Informs if webhook is activated."""
   isActive: Boolean!
 
-  """
-  Used to create a hash signature with each payload.
-  
-  If not set, since Saleor 3.5, your payload will be signed using private key used also to sign JWT tokens.
-  """
-  secretKey: String
+  """Used to create a hash signature for each payload."""
+  secretKey: String @deprecated(reason: "This field will be removed in Saleor 4.0. As of Saleor 3.5, webhook payloads default to signing using a verifiable JWS.")
 
   """Used to define payloads for specific events."""
   subscriptionQuery: String
@@ -14408,7 +14404,11 @@ input WebhookCreateInput {
   """Determine if webhook will be set active or not."""
   isActive: Boolean
 
-  """The secret key used to create a hash signature with each payload."""
+  """
+  The secret key used to create a hash signature with each payload.
+  
+  DEPRECATED: this field will be removed in Saleor 4.0. As of Saleor 3.5, webhook payloads default to signing using a verifiable JWS.
+  """
   secretKey: String
 
   """
@@ -14469,7 +14469,11 @@ input WebhookUpdateInput {
   """Determine if webhook will be set active or not."""
   isActive: Boolean
 
-  """Use to create a hash signature with each payload."""
+  """
+  Use to create a hash signature with each payload.
+  
+  DEPRECATED: this field will be removed in Saleor 4.0. As of Saleor 3.5, webhook payloads default to signing using a verifiable JWS.
+  """
   secretKey: String
 
   """

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -38,7 +38,9 @@ class WebhookCreateInput(graphene.InputObjectType):
         description="Determine if webhook will be set active or not.", required=False
     )
     secret_key = graphene.String(
-        description="The secret key used to create a hash signature with each payload.",
+        description="The secret key used to create a hash signature with each payload."
+        f"{DEPRECATED_IN_3X_INPUT} As of Saleor 3.5, webhook payloads default to "
+        "signing using a verifiable JWS.",
         required=False,
     )
     query = graphene.String(
@@ -155,7 +157,10 @@ class WebhookUpdateInput(graphene.InputObjectType):
         description="Determine if webhook will be set active or not.", required=False
     )
     secret_key = graphene.String(
-        description="Use to create a hash signature with each payload.", required=False
+        description="Use to create a hash signature with each payload."
+        f"{DEPRECATED_IN_3X_INPUT} As of Saleor 3.5, webhook payloads default to "
+        "signing using a verifiable JWS.",
+        required=False,
     )
     query = graphene.String(
         description="Subscription query used to define a webhook payload."

--- a/saleor/graphql/webhook/types.py
+++ b/saleor/graphql/webhook/types.py
@@ -177,11 +177,11 @@ class Webhook(ModelObjectType):
         required=True, description="Informs if webhook is activated."
     )
     secret_key = graphene.String(
-        description=(
-            "Used to create a hash signature with each payload."
-            "\n\nIf not set, since Saleor 3.5, your payload will be "
-            "signed using private key used also to sign JWT tokens."
-        )
+        description="Used to create a hash signature for each payload.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} As of Saleor 3.5, webhook payloads default to "
+            "signing using a verifiable JWS."
+        ),
     )
     subscription_query = graphene.String(
         description="Used to define payloads for specific events."


### PR DESCRIPTION
Fixes #10425

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [x] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
