### PR TITLE
Hide Subscription type from Apollo Federation

### DIFF
--- a/saleor/graphql/core/federation/schema.py
+++ b/saleor/graphql/core/federation/schema.py
@@ -135,8 +135,14 @@ def resolve_entities(_, info, *, representations):
 
 
 def create_service_sdl_resolver(schema):
+    # subscriptions are not handled by the federation protocol
+    schema_sans_subscriptions = graphene.Schema(
+        query=schema._query, mutation=schema._mutation, types=schema.types
+    )
     # Render schema to string
-    federated_schema_sdl = print_schema(schema)
+    federated_schema_sdl = print_schema(schema_sans_subscriptions)
+
+    del schema_sans_subscriptions
 
     # Remove "schema { ... }"
     schema_start = federated_schema_sdl.find("schema {")


### PR DESCRIPTION
Reconstruct the schema sans subscriptions before building the SDL for Apollo Federation as it does not support subscriptions.

Fixes #10170

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
