### PR TITLE
Add ability to set tax config in Avalara plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix situation when Payment Gateway try to save to long error message - #10402 by @fowczarek
 - Replaced `context.app` lazy object with a dataloader.
 - Add support for bcrypt password hashes - #10346 by @pkucmus
-
+- Add ability to set taxes configuration per channel in the Avatax plugin - #10445 by @mociepka
 
 # 3.6.0
 

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -207,15 +207,13 @@ def append_line_to_data(
     amount: Decimal,
     tax_code: str,
     item_code: str,
+    tax_included: bool,
     name: str = None,
-    tax_included: Optional[bool] = None,
     discounted: Optional[bool] = False,
     tax_override_data: Optional[dict] = None,
     ref1: Optional[str] = None,
     ref2: Optional[str] = None,
 ):
-    if tax_included is None:
-        tax_included = Site.objects.get_current().settings.include_taxes_in_prices
     line_data = {
         "quantity": quantity,
         "amount": str(amount),
@@ -239,6 +237,7 @@ def append_shipping_to_data(
     data: List[Dict],
     shipping_price_amount: Optional[Decimal],
     shipping_tax_code: str,
+    tax_included: bool,
     discounted: Optional[bool] = False,
 ):
     charge_taxes_on_shipping = (
@@ -251,6 +250,7 @@ def append_shipping_to_data(
             amount=shipping_price_amount,
             tax_code=shipping_tax_code,
             item_code="Shipping",
+            tax_included=tax_included,
             discounted=discounted,
         )
 
@@ -259,11 +259,11 @@ def get_checkout_lines_data(
     checkout_info: "CheckoutInfo",
     lines_info: Iterable["CheckoutLineInfo"],
     config: AvataxConfiguration,
+    tax_included: bool,
     discounts=None,
 ) -> List[Dict[str, Union[str, int, bool, None]]]:
     data: List[Dict[str, Union[str, int, bool, None]]] = []
     channel = checkout_info.channel
-    tax_included = Site.objects.get_current().settings.include_taxes_in_prices
     voucher = checkout_info.voucher
     is_entire_order_discount = (
         voucher.type == VoucherType.ENTIRE_ORDER
@@ -335,6 +335,7 @@ def get_checkout_lines_data(
             data,
             price.amount if price else None,
             config.shipping_tax_code,
+            tax_included,
             is_shipping_discount,
         )
 
@@ -342,7 +343,7 @@ def get_checkout_lines_data(
 
 
 def get_order_lines_data(
-    order: "Order", config: AvataxConfiguration, discounted: bool
+    order: "Order", config: AvataxConfiguration, tax_included: bool, discounted: bool
 ) -> List[Dict[str, Union[str, int, bool, None]]]:
     data: List[Dict[str, Union[str, int, bool, None]]] = []
     lines = order.lines.prefetch_related(
@@ -350,7 +351,6 @@ def get_order_lines_data(
         "variant__product__collections",
         "variant__product__product_type",
     ).filter(variant__product__charge_taxes=True)
-    tax_included = Site.objects.get_current().settings.include_taxes_in_prices
     for line in lines:
         if not line.variant:
             continue
@@ -403,9 +403,7 @@ def get_order_lines_data(
             Decimal("0"),
         )
         append_shipping_to_data(
-            data,
-            shipping_price,
-            config.shipping_tax_code,
+            data, shipping_price, config.shipping_tax_code, tax_included
         )
     return data
 
@@ -459,12 +457,15 @@ def generate_request_data_from_checkout(
     checkout_info: "CheckoutInfo",
     lines_info: Iterable["CheckoutLineInfo"],
     config: AvataxConfiguration,
+    tax_included: bool,
     transaction_token=None,
     transaction_type=TransactionType.ORDER,
     discounts=None,
 ):
     address = checkout_info.shipping_address or checkout_info.billing_address
-    lines = get_checkout_lines_data(checkout_info, lines_info, config, discounts)
+    lines = get_checkout_lines_data(
+        checkout_info, lines_info, config, tax_included, discounts
+    )
     voucher = checkout_info.voucher
     # for apply_once_per_order vouchers the discount is already applied on lines
     discount_amount = (
@@ -533,16 +534,19 @@ def get_cached_response_or_fetch(
 def get_checkout_tax_data(
     checkout_info: "CheckoutInfo",
     lines_info: Iterable["CheckoutLineInfo"],
+    tax_included: bool,
     discounts,
     config: AvataxConfiguration,
 ) -> Dict[str, Any]:
     data = generate_request_data_from_checkout(
-        checkout_info, lines_info, config, discounts=discounts
+        checkout_info, lines_info, config, tax_included, discounts=discounts
     )
     return get_cached_response_or_fetch(data, str(checkout_info.checkout.token), config)
 
 
-def get_order_request_data(order: "Order", config: AvataxConfiguration):
+def get_order_request_data(
+    order: "Order", config: AvataxConfiguration, tax_included: bool
+):
     address = order.shipping_address or order.billing_address
     transaction = (
         TransactionType.INVOICE
@@ -551,7 +555,9 @@ def get_order_request_data(order: "Order", config: AvataxConfiguration):
     )
     discount_amount = get_total_order_discount_excluding_shipping(order).amount
     discounted_lines = discount_amount != Decimal("0")
-    lines = get_order_lines_data(order, config, discounted=discounted_lines)
+    lines = get_order_lines_data(
+        order, config, tax_included, discounted=discounted_lines
+    )
     data = generate_request_data(
         transaction_type=transaction,
         lines=lines,
@@ -566,9 +572,9 @@ def get_order_request_data(order: "Order", config: AvataxConfiguration):
 
 
 def get_order_tax_data(
-    order: "Order", config: AvataxConfiguration, force_refresh=False
+    order: "Order", config: AvataxConfiguration, tax_included: bool, force_refresh=False
 ) -> Dict[str, Any]:
-    data = get_order_request_data(order, config)
+    data = get_order_request_data(order, config, tax_included)
     response = get_cached_response_or_fetch(
         data, "order_%s" % order.id, config, force_refresh
     )

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -59,6 +59,16 @@ class AvataxConfiguration:
     company_name: str = "DEFAULT"
     autocommit: bool = False
     shipping_tax_code: str = ""
+    override_global_tax: bool = False
+    include_taxes_in_prices: bool = True
+
+    @property
+    def tax_included(self) -> bool:
+        return (
+            self.include_taxes_in_prices
+            if self.override_global_tax
+            else Site.objects.get_current().settings.include_taxes_in_prices
+        )
 
 
 class TransactionType:

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -71,6 +71,8 @@ class AvataxPlugin(BasePlugin):
         {"name": "from_country_area", "value": None},
         {"name": "from_postal_code", "value": None},
         {"name": "shipping_tax_code", "value": "FR000000"},
+        {"name": "override_global_tax", "value": False},
+        {"name": "include_taxes_in_prices", "value": True},
     ]
     CONFIG_STRUCTURE = {
         "Username or account": {
@@ -136,6 +138,16 @@ class AvataxPlugin(BasePlugin):
             ),
             "label": "Shipping tax code",
         },
+        "override_global_tax": {
+            "type": ConfigurationTypeField.BOOLEAN,
+            "help_text": "Used when setting per channel is needed.",
+            "label": "Override global tax settings.",
+        },
+        "include_taxes_in_prices": {
+            "type": ConfigurationTypeField.BOOLEAN,
+            "help_text": 'Applied only if "Override global tax settings" is on.',
+            "label": "All products prices are entered with tax included.",
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -198,10 +210,6 @@ class AvataxPlugin(BasePlugin):
         if not response or "error" in response:
             return checkout_total
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
-
         currency = checkout_info.checkout.currency
         taxed_total = zero_taxed_money(currency)
 
@@ -209,7 +217,7 @@ class AvataxPlugin(BasePlugin):
             taxed_line_total_data = self._calculate_checkout_line_total_price(
                 taxes_data=response,
                 item_code=line.variant.sku or line.variant.get_global_id(),
-                tax_included=tax_included,
+                tax_included=self._tax_included,
                 # for some cases we will need a base_value but no need to call it for
                 # each line
                 base_value=SimpleLazyObject(  # type:ignore
@@ -250,10 +258,7 @@ class AvataxPlugin(BasePlugin):
                 shipping_tax = Decimal(line["tax"])
                 break
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
-        if currency == "JPY" and tax_included():
+        if currency == "JPY" and self._tax_included():
             shipping_gross = Money(amount=shipping_price.amount, currency=currency)
             shipping_net = Money(
                 amount=shipping_gross.amount - shipping_tax, currency=currency
@@ -385,17 +390,13 @@ class AvataxPlugin(BasePlugin):
         if not _validate_checkout(checkout_info, lines):
             return base_total
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
-
         taxes_data = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
         variant = checkout_line_info.variant
 
         return self._calculate_checkout_line_total_price(
             taxes_data,
             variant.sku or variant.get_global_id(),
-            tax_included,
+            self._tax_included,
             previous_value,
         )
 
@@ -449,15 +450,11 @@ class AvataxPlugin(BasePlugin):
         if not _validate_order(order):
             return previous_value
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
-
         taxes_data = self._get_order_tax_data(order, previous_value)
         return self._calculate_order_line_total_price(
             taxes_data,
             variant.sku or variant.get_global_id(),
-            tax_included,
+            self._tax_included,
             previous_value,
         )
 
@@ -524,9 +521,6 @@ class AvataxPlugin(BasePlugin):
         if not _validate_checkout(checkout_info, lines):
             return base_total
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
         variant = checkout_line_info.variant
 
         quantity = checkout_line_info.line.quantity
@@ -535,7 +529,7 @@ class AvataxPlugin(BasePlugin):
         taxed_total_price = self._calculate_checkout_line_total_price(
             taxes_data,
             variant.sku or variant.get_global_id(),
-            tax_included,
+            self._tax_included,
             default_total,
         )
         return taxed_total_price / quantity
@@ -551,10 +545,6 @@ class AvataxPlugin(BasePlugin):
         if not variant or (variant and not product.charge_taxes):
             return previous_value
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
-
         quantity = order_line.quantity
         taxes_data = self._get_order_tax_data(order, previous_value)
         default_total = OrderTaxedPricesData(
@@ -564,13 +554,24 @@ class AvataxPlugin(BasePlugin):
         taxed_total_prices_data = self._calculate_order_line_total_price(
             taxes_data,
             variant.sku or variant.get_global_id(),
-            tax_included,
+            self._tax_included,
             default_total,
         )
         return OrderTaxedPricesData(
             undiscounted_price=taxed_total_prices_data.undiscounted_price / quantity,
             price_with_discounts=taxed_total_prices_data.price_with_discounts
             / quantity,
+        )
+
+    @property
+    def _tax_included(self) -> Callable[[], bool]:
+        configuration = {item["name"]: item["value"] for item in self.configuration}
+        override_global_tax = configuration["override_global_tax"]
+        include_taxes_in_prices = configuration["include_taxes_in_prices"]
+        return lambda: (
+            include_taxes_in_prices
+            if override_global_tax
+            else Site.objects.get_current().settings.include_taxes_in_prices
         )
 
     def calculate_order_shipping(
@@ -586,15 +587,12 @@ class AvataxPlugin(BasePlugin):
             return previous_value
         taxes_data = get_order_tax_data(order, self.config, False)
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
         currency = taxes_data.get("currencyCode")
         for line in taxes_data.get("lines", []):
             if line["itemCode"] == "Shipping":
                 tax = Decimal(line.get("tax", 0.0))
                 net = Decimal(line.get("lineAmount", 0.0))
-                if currency == "JPY" and tax_included():
+                if currency == "JPY" and self._tax_included():
                     gross = previous_value.gross
                     net = Money(amount=gross.amount - tax, currency=currency)
                 else:

--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -34,6 +34,8 @@ def plugin_configuration(db, channel_USD):
         from_country_area="",
         from_postal_code="53-601",
         shipping_tax_code="FR000000",
+        override_global_tax=False,
+        include_taxes_in_prices=True,
     ):
         channel = channel or channel_USD
         data = {
@@ -52,6 +54,8 @@ def plugin_configuration(db, channel_USD):
                 {"name": "from_country_area", "value": from_country_area},
                 {"name": "from_postal_code", "value": from_postal_code},
                 {"name": "shipping_tax_code", "value": shipping_tax_code},
+                {"name": "override_global_tax", "value": override_global_tax},
+                {"name": "include_taxes_in_prices", "value": include_taxes_in_prices},
             ],
         }
         configuration = PluginConfiguration.objects.create(

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -3386,6 +3386,8 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         "from_country": conf["from_country"],
         "from_country_area": conf["from_country_area"],
         "shipping_tax_code": conf["shipping_tax_code"],
+        "override_global_tax": conf["override_global_tax"],
+        "include_taxes_in_prices": conf["include_taxes_in_prices"],
     }
 
     api_post_request_task_mock.assert_called_once_with(

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -4428,3 +4428,40 @@ def test_assign_tax_code_to_object_meta_no_obj_id(
         META_CODE_KEY: tax_code,
         META_DESCRIPTION_KEY: description,
     }
+
+
+@pytest.mark.parametrize(
+    "global_include_taxes_in_prices, override_global_tax, "
+    "include_taxes_in_prices, expected_tax_included",
+    [(True, False, False, True), (True, True, True, True), (True, True, False, False)],
+)
+@patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_plugin_tax_override_setting(
+    api_post_request_task_mock,
+    global_include_taxes_in_prices,
+    override_global_tax,
+    include_taxes_in_prices,
+    expected_tax_included,
+    site_settings,
+    order_line,
+    plugin_configuration,
+):
+    # given
+    site_settings.include_taxes_in_prices = global_include_taxes_in_prices
+    site_settings.save()
+
+    plugin_configuration(
+        override_global_tax=override_global_tax,
+        include_taxes_in_prices=include_taxes_in_prices,
+    )
+
+    manager = get_plugins_manager()
+
+    # when
+    manager.order_created(order_line.order)
+
+    # then
+    transaction = api_post_request_task_mock.call_args[0][1]["createTransactionModel"]
+    transaction_line = transaction["lines"][0]
+    assert transaction_line["taxIncluded"] == expected_tax_included

--- a/saleor/plugins/avatax/tests/test_avatax_caching.py
+++ b/saleor/plugins/avatax/tests/test_avatax_caching.py
@@ -33,7 +33,7 @@ def test_calculate_checkout_total_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -94,7 +94,7 @@ def test_calculate_checkout_total_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("72.2", "USD"), gross=Money("75", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -122,7 +122,7 @@ def test_calculate_checkout_subtotal_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -183,7 +183,7 @@ def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("64.07", "USD"), gross=Money("65", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -211,7 +211,7 @@ def test_calculate_checkout_shipping_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -272,7 +272,7 @@ def test_calculate_checkout_shipping_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("8.13", "USD"), gross=Money("10", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -301,7 +301,7 @@ def test_calculate_checkout_line_total_use_cache(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -363,7 +363,7 @@ def test_calculate_checkout_line_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("4.07", "USD"), gross=Money("5", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -392,7 +392,7 @@ def test_calculate_checkout_line_unit_price_use_cache(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -466,7 +466,7 @@ def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("4.07", "USD"), gross=Money("5", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -495,7 +495,7 @@ def test_get_checkout_line_tax_rate_use_cache(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -574,7 +574,7 @@ def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
     assert result == Decimal("0.36")
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -602,7 +602,7 @@ def test_get_checkout_shipping_tax_rate_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -665,6 +665,6 @@ def test_get_checkout_shipping_tax_rate_save_avatax_response_in_cache(
     assert result == Decimal("0.46")
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)

--- a/saleor/plugins/avatax/tests/test_tasks.py
+++ b/saleor/plugins/avatax/tests/test_tasks.py
@@ -30,7 +30,7 @@ def test_api_post_request_task_sends_request(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     transaction_url = urljoin(
         get_api_url(config.use_sandbox), "transactions/createoradjust"
@@ -62,7 +62,7 @@ def test_api_post_request_task_creates_order_event(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     transaction_url = urljoin(
         get_api_url(config.use_sandbox), "transactions/createoradjust"
@@ -95,7 +95,7 @@ def test_api_post_request_task_missing_response(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     transaction_url = urljoin(
         get_api_url(config.use_sandbox), "transactions/createoradjust"


### PR DESCRIPTION
I want to merge this change because I cannot set the "All products prices are entered with tax included." tax setting per channel.

This change extends Avalara plugin configuration with the ability to override the "All products prices are entered with tax included." per channel.

<img width="832" alt="image" src="https://user-images.githubusercontent.com/1870738/185788031-a711a9f9-05c1-44e5-ba63-18f9491495a0.png">


# Impact

* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
