### PR TITLE
Fix failing product media migration and task

### DIFF
--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -553,7 +553,7 @@ def test_delete_products_with_images(
     assert delete_from_storage_task_mock.call_count == 2
     assert {
         call_args.args[0] for call_args in delete_from_storage_task_mock.call_args_list
-    } == {media1.image.path, media2.image.path}
+    } == {media1.image.name, media2.image.name}
     mocked_recalculate_orders_task.assert_not_called()
 
 

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -8881,8 +8881,8 @@ def test_delete_product_with_image(
 
     product_img_paths = [media.image for media in product.media.all()]
     variant_img_paths = [media.image for media in variant.media.all()]
-    product_media_paths = [media.image.path for media in product.media.all()]
-    variant_media_paths = [media.image.path for media in variant.media.all()]
+    product_media_paths = [media.image.name for media in product.media.all()]
+    variant_media_paths = [media.image.name for media in variant.media.all()]
     images = product_img_paths + variant_img_paths
 
     variables = {"id": node_id}
@@ -9843,7 +9843,7 @@ def test_product_media_delete(
             }
         """
     media_obj = product.media.first()
-    media_img_path = media_obj.image.path
+    media_img_path = media_obj.image.name
     node_id = graphene.Node.to_global_id("ProductMedia", media_obj.id)
     variables = {"id": node_id}
     response = staff_api_client.post_graphql(

--- a/saleor/graphql/product/tests/test_product_type_delete.py
+++ b/saleor/graphql/product/tests/test_product_type_delete.py
@@ -46,7 +46,7 @@ def test_product_type_delete_mutation_deletes_also_images(
     query = PRODUCT_TYPE_DELETE_MUTATION
     product_type.products.add(product_with_image)
     media_obj = product_with_image.media.first()
-    media_path = media_obj.image.path
+    media_path = media_obj.image.name
     variables = {"id": graphene.Node.to_global_id("ProductType", product_type.id)}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_product_types_and_attributes]

--- a/saleor/product/migrations/0174_drop_media_to_remove.py
+++ b/saleor/product/migrations/0174_drop_media_to_remove.py
@@ -10,9 +10,9 @@ def drop_media_to_remove(apps, _schema_editor):
     # delete all related images
     image_paths_to_delete = []
     for media in ProductMedia.objects.filter(to_remove=True).iterator():
-        image_paths_to_delete.append(media.image.path)
+        image_paths_to_delete.append(media.image.name)
         for thumbnail in media.thumbnails.all():
-            image_paths_to_delete.append(thumbnail.image.path)
+            image_paths_to_delete.append(thumbnail.image.name)
 
     if image_paths_to_delete:
         delete_files_from_storage_task.delay(image_paths_to_delete)

--- a/saleor/product/signals.py
+++ b/saleor/product/signals.py
@@ -13,4 +13,4 @@ def delete_digital_content_file(sender, instance, **kwargs):
 
 def delete_product_media_image(sender, instance, **kwargs):
     if file := instance.image:
-        delete_from_storage_task.delay(file.path)
+        delete_from_storage_task.delay(file.name)

--- a/saleor/product/tests/test_product.py
+++ b/saleor/product/tests/test_product.py
@@ -380,4 +380,4 @@ def test_product_media_delete(delete_from_storage_task_mock, product_with_image)
     media.delete()
 
     # then
-    delete_from_storage_task_mock.assert_called_once_with(media.image.path)
+    delete_from_storage_task_mock.assert_called_once_with(media.image.name)


### PR DESCRIPTION
Fix failing product media migration `0174_drop_media_to_remove` and task `delete_product_media_image`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
