### PR TITLE
Handle allocation strategies

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -540,7 +540,7 @@ def _create_order(
     allocate_stocks(
         order_lines_info,
         country_code,
-        checkout_info.channel.slug,
+        checkout_info.channel,
         manager,
         checkout_info.delivery_method_info.warehouse_pk,
         additional_warehouse_lookup,
@@ -915,7 +915,7 @@ def _handle_allocations_of_order_lines(
     allocate_stocks(
         order_lines_info,
         country_code,
-        checkout_info.channel.slug,
+        checkout_info.channel,
         manager,
         checkout_info.delivery_method_info.warehouse_pk,
         additional_warehouse_lookup,

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -192,7 +192,7 @@ def add_variants_to_checkout(
     checkout,
     variants,
     checkout_lines_data,
-    channel_slug,
+    channel,
     replace=False,
     replace_reservations=False,
     reservation_length: Optional[int] = None,
@@ -243,7 +243,7 @@ def add_variants_to_checkout(
             to_reserve,
             variants,
             country_code,
-            channel_slug,
+            channel,
             reservation_length,
             replace=replace_reservations,
         )

--- a/saleor/graphql/channel/tests/fixtures.py
+++ b/saleor/graphql/channel/tests/fixtures.py
@@ -1,6 +1,7 @@
 import pytest
 from django.conf import settings
 
+from ....channel import AllocationStrategy
 from ....channel.models import Channel
 
 
@@ -13,6 +14,7 @@ def channel_USD(db):
         currency_code="USD",
         default_country="US",
         is_active=True,
+        allocation_strategy=AllocationStrategy.PRIORITIZE_HIGH_STOCK,
     )
 
 
@@ -24,6 +26,7 @@ def other_channel_USD(db):
         currency_code="USD",
         default_country="US",
         is_active=True,
+        allocation_strategy=AllocationStrategy.PRIORITIZE_HIGH_STOCK,
     )
 
 
@@ -35,6 +38,7 @@ def channel_PLN(db):
         currency_code="PLN",
         default_country="PL",
         is_active=True,
+        allocation_strategy=AllocationStrategy.PRIORITIZE_HIGH_STOCK,
     )
 
 
@@ -46,4 +50,5 @@ def channel_JPY(db):
         currency_code="JPY",
         default_country="JP",
         is_active=True,
+        allocation_strategy=AllocationStrategy.PRIORITIZE_HIGH_STOCK,
     )

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -301,7 +301,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
                 instance,
                 variants,
                 checkout_lines_data,
-                channel.slug,
+                channel,
                 info.context.site.settings.limit_quantity_per_checkout,
                 reservation_length=get_reservation_length(info.context),
             )

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -140,7 +140,7 @@ class CheckoutLinesAdd(BaseMutation):
                 checkout,
                 variants,
                 checkout_lines_data,
-                channel_slug,
+                checkout_info.channel,
                 replace=replace,
                 replace_reservations=True,
                 reservation_length=get_reservation_length(info.context),

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -653,7 +653,7 @@ def test_update_checkout_lines_with_reservations(
             )
             for variant in variants
         ],
-        channel_USD.slug,
+        channel_USD,
         replace_reservations=True,
         reservation_length=5,
     )

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -92,7 +92,6 @@ class DraftOrderComplete(BaseMutation):
         order.save()
 
         channel = order.channel
-        channel_slug = channel.slug
         order_lines_info = []
         for line in order.lines.all():
             if line.variant.track_inventory or line.variant.is_preorder_active():
@@ -105,7 +104,7 @@ class DraftOrderComplete(BaseMutation):
                         allocate_stocks(
                             [line_data],
                             country,
-                            channel_slug,
+                            channel,
                             manager,
                             check_reservations=is_reservation_enabled(
                                 info.context.site.settings
@@ -113,7 +112,7 @@ class DraftOrderComplete(BaseMutation):
                         )
                         allocate_preorders(
                             [line_data],
-                            channel_slug,
+                            channel.slug,
                             check_reservations=is_reservation_enabled(
                                 info.context.site.settings
                             ),

--- a/saleor/graphql/order/mutations/order_line_update.py
+++ b/saleor/graphql/order/mutations/order_line_update.py
@@ -77,7 +77,7 @@ class OrderLineUpdate(EditableOrderValidationMixin, ModelMutation):
                 line_info,
                 instance.old_quantity,
                 instance.quantity,
-                instance.order.channel.slug,
+                instance.order.channel,
                 manager,
             )
         except InsufficientStock:

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -591,7 +591,7 @@ def test_order_weight_change_line_quantity(staff_user, lines_info):
         line_info,
         new_quantity,
         line_info.quantity,
-        order.channel.slug,
+        order.channel,
         get_plugins_manager(),
     )
     assert order.weight == _calculate_order_weight_from_lines(order)
@@ -876,7 +876,7 @@ def test_ordered_item_change_quantity(staff_user, transactional_db, lines_info):
         lines_info[1],
         lines_info[1].quantity,
         0,
-        order.channel.slug,
+        order.channel,
         get_plugins_manager(),
     )
     change_order_line_quantity(
@@ -885,7 +885,7 @@ def test_ordered_item_change_quantity(staff_user, transactional_db, lines_info):
         lines_info[0],
         lines_info[0].quantity,
         0,
-        order.channel.slug,
+        order.channel,
         get_plugins_manager(),
     )
     assert order.get_total_quantity() == 0
@@ -905,7 +905,7 @@ def test_change_order_line_quantity_changes_total_prices(
         line_info,
         line_info.quantity,
         new_quantity,
-        order.channel.slug,
+        order.channel,
         get_plugins_manager(),
     )
     assert line_info.line.total_price == line_info.line.unit_price * new_quantity

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -65,7 +65,7 @@ def test_change_quantity_generates_proper_event(
         line_info,
         previous_quantity,
         new_quantity,
-        order_with_lines.channel.slug,
+        order_with_lines.channel,
         get_plugins_manager(),
     )
 
@@ -117,7 +117,7 @@ def test_change_quantity_update_line_fields(
         line_info,
         line.quantity,
         new_quantity,
-        order_with_lines.channel.slug,
+        order_with_lines.channel,
         get_plugins_manager(),
     )
 

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -49,6 +49,7 @@ from .models import Order, OrderLine
 
 if TYPE_CHECKING:
     from ..app.models import App
+    from ..channel.models import Channel
     from ..checkout.fetch import CheckoutInfo
     from ..plugins.manager import PluginsManager
 
@@ -300,7 +301,7 @@ def create_order_line(
                     warehouse_pk=None,
                 )
             ],
-            channel.slug,
+            channel,
             manager=manager,
         )
 
@@ -335,7 +336,7 @@ def add_variant_to_order(
             line_info,
             old_quantity,
             new_quantity,
-            channel.slug,
+            channel,
             manager=manager,
             send_event=False,
         )
@@ -350,7 +351,7 @@ def add_variant_to_order(
                         warehouse_pk=None,
                     )
                 ],
-                channel.slug,
+                channel,
                 manager=manager,
             )
 
@@ -435,7 +436,7 @@ def _update_allocations_for_line(
     line_info: OrderLineInfo,
     old_quantity: int,
     new_quantity: int,
-    channel_slug: str,
+    channel: "Channel",
     manager: "PluginsManager",
 ):
     if old_quantity == new_quantity:
@@ -446,7 +447,7 @@ def _update_allocations_for_line(
 
     if old_quantity < new_quantity:
         line_info.quantity = new_quantity - old_quantity
-        increase_allocations([line_info], channel_slug, manager)
+        increase_allocations([line_info], channel, manager)
     else:
         line_info.quantity = old_quantity - new_quantity
         decrease_allocations([line_info], manager)
@@ -458,7 +459,7 @@ def change_order_line_quantity(
     line_info,
     old_quantity: int,
     new_quantity: int,
-    channel_slug: str,
+    channel: "Channel",
     manager: "PluginsManager",
     send_event=True,
 ):
@@ -467,7 +468,7 @@ def change_order_line_quantity(
     if new_quantity:
         if line.order.is_unconfirmed():
             _update_allocations_for_line(
-                line_info, old_quantity, new_quantity, channel_slug, manager
+                line_info, old_quantity, new_quantity, channel, manager
             )
         line.quantity = new_quantity
         total_price_net_amount = line.quantity * line.unit_price_net_amount

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -110,8 +110,8 @@ def allocate_stocks(
         channel.allocation_strategy,
         stocks,
         channel,
-        collection_point_pk,
         quantity_allocation_for_stocks,
+        collection_point_pk,
     )
 
     variant_to_stocks: Dict[str, List[StockData]] = defaultdict(list)
@@ -188,8 +188,8 @@ def sort_stocks(
     allocation_strategy: str,
     stocks: List[dict],
     channel: "Channel",
-    collection_point_pk: Optional[str],
     quantity_allocation_for_stocks: Dict[int, int],
+    collection_point_pk: Optional[str] = None,
 ):
     warehouse_ids = [stock_data["warehouse_id"] for stock_data in stocks]
     channel_warehouse_ids = ChannelWarehouse.objects.filter(
@@ -207,7 +207,7 @@ def sort_stocks(
         )
 
     def sort_stocks_by_warehouse_sorting_order(stock_data):
-        """Sort the stocks based on the warehouse with channel order."""
+        """Sort the stocks based on the warehouse within channel order."""
         # get the sort order for stocks warehouses within the channel
         sorted_warehouse_list = list(channel_warehouse_ids)
 

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -106,7 +106,7 @@ def allocate_stocks(
             "quantity_allocated_sum"
         ]
 
-    stocks = _sort_stocks(
+    stocks = sort_stocks(
         channel.allocation_strategy,
         stocks,
         channel,
@@ -184,12 +184,12 @@ def _prepare_stock_to_reserved_quantity_map(
     return quantity_reservation_for_stocks
 
 
-def _sort_stocks(
-    allocation_strategy,
-    stocks,
-    channel,
-    collection_point_pk,
-    quantity_allocation_for_stocks,
+def sort_stocks(
+    allocation_strategy: str,
+    stocks: List[dict],
+    channel: "Channel",
+    collection_point_pk: Optional[str],
+    quantity_allocation_for_stocks: Dict[int, int],
 ):
     warehouse_ids = [stock_data["warehouse_id"] for stock_data in stocks]
     channel_warehouse_ids = ChannelWarehouse.objects.filter(

--- a/saleor/warehouse/reservations.py
+++ b/saleor/warehouse/reservations.py
@@ -12,6 +12,7 @@ from ..product.models import ProductVariant, ProductVariantChannelListing
 from .models import Allocation, PreorderReservation, Reservation, Stock
 
 if TYPE_CHECKING:
+    from ..channel.models import Channel
     from ..checkout.fetch import CheckoutLine
 
 StockData = namedtuple("StockData", ["pk", "quantity"])
@@ -22,7 +23,7 @@ def reserve_stocks_and_preorders(
     checkout_lines: Iterable["CheckoutLine"],
     variants: Iterable["ProductVariant"],
     country_code: str,
-    channel_slug: str,
+    channel: "Channel",
     length_in_minutes: int,
     *,
     replace: bool = True,
@@ -47,7 +48,7 @@ def reserve_stocks_and_preorders(
             stock_lines,
             stock_variants,
             country_code,
-            channel_slug,
+            channel,
             length_in_minutes,
             replace=replace,
         )
@@ -57,7 +58,7 @@ def reserve_stocks_and_preorders(
             preorder_lines,
             preorder_variants,
             country_code,
-            channel_slug,
+            channel.slug,
             length_in_minutes,
             replace=replace,
         )
@@ -67,7 +68,7 @@ def reserve_stocks(
     checkout_lines: Iterable["CheckoutLine"],
     variants: Iterable["ProductVariant"],
     country_code: str,
-    channel_slug: str,
+    channel: "Channel",
     length_in_minutes: int,
     *,
     replace: bool = True,
@@ -87,7 +88,7 @@ def reserve_stocks(
 
     stocks = list(
         Stock.objects.select_for_update(of=("self",))
-        .get_variants_stocks_for_country(country_code, channel_slug, variants)
+        .get_variants_stocks_for_country(country_code, channel.slug, variants)
         .order_by("pk")
         .values("id", "product_variant", "pk", "quantity")
     )

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -31,7 +31,7 @@ def test_allocate_stocks(order_line, stock, channel_USD):
     line_data = OrderLineInfo(line=order_line, variant=order_line.variant, quantity=50)
 
     allocate_stocks(
-        [line_data], COUNTRY_CODE, channel_USD.slug, manager=get_plugins_manager()
+        [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
     )
 
     stock.refresh_from_db()
@@ -68,7 +68,7 @@ def test_allocate_stocks_multiple_lines(order_line, order, product, stock, chann
     allocate_stocks(
         [line_data_1, line_data_2],
         COUNTRY_CODE,
-        channel_USD.slug,
+        channel_USD,
         manager=get_plugins_manager(),
     )
 
@@ -88,7 +88,7 @@ def test_allocate_stock_many_stocks(order_line, variant_with_many_stocks, channe
 
     line_data = OrderLineInfo(line=order_line, variant=order_line.variant, quantity=5)
     allocate_stocks(
-        [line_data], COUNTRY_CODE, channel_USD.slug, manager=get_plugins_manager()
+        [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
     )
 
     allocations = Allocation.objects.filter(order_line=order_line, stock__in=stocks)
@@ -109,7 +109,7 @@ def test_allocate_stock_with_reservations(
     allocate_stocks(
         [line_data],
         COUNTRY_CODE,
-        channel_USD.slug,
+        channel_USD,
         manager=get_plugins_manager(),
         check_reservations=True,
     )
@@ -134,7 +134,7 @@ def test_allocate_stock_insufficient_stock_due_to_reservations(
         allocate_stocks(
             [line_data],
             COUNTRY_CODE,
-            channel_USD.slug,
+            channel_USD,
             manager=get_plugins_manager(),
             check_reservations=True,
         )
@@ -161,7 +161,7 @@ def test_allocate_stock_many_stocks_partially_allocated(
 
     # when
     allocate_stocks(
-        [line_data], COUNTRY_CODE, channel_USD.slug, manager=get_plugins_manager()
+        [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
     )
 
     # then
@@ -187,7 +187,7 @@ def test_allocate_stock_partially_allocated_insufficient_stocks(
     line_data = OrderLineInfo(line=order_line, variant=order_line.variant, quantity=6)
     with pytest.raises(InsufficientStock):
         allocate_stocks(
-            [line_data], COUNTRY_CODE, channel_USD.slug, manager=get_plugins_manager()
+            [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
         )
 
     assert not Allocation.objects.filter(
@@ -204,7 +204,7 @@ def test_allocate_stocks_no_channel_shipping_zones(order_line, stock, channel_US
     line_data = OrderLineInfo(line=order_line, variant=order_line.variant, quantity=50)
     with pytest.raises(InsufficientStock):
         allocate_stocks(
-            [line_data], COUNTRY_CODE, channel_USD.slug, manager=get_plugins_manager()
+            [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
         )
 
 
@@ -217,7 +217,7 @@ def test_allocate_stock_insufficient_stocks(
     line_data = OrderLineInfo(line=order_line, variant=order_line.variant, quantity=10)
     with pytest.raises(InsufficientStock):
         allocate_stocks(
-            [line_data], COUNTRY_CODE, channel_USD.slug, manager=get_plugins_manager()
+            [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
         )
 
     assert not Allocation.objects.filter(
@@ -254,7 +254,7 @@ def test_allocate_stock_insufficient_stocks_for_multiple_lines(
         allocate_stocks(
             [line_data_1, line_data_2],
             COUNTRY_CODE,
-            channel_USD.slug,
+            channel_USD,
             manager=get_plugins_manager(),
         )
 
@@ -431,7 +431,7 @@ def test_increase_allocations(quantity, allocation):
     allocation.save(update_fields=["quantity_allocated"])
 
     increase_allocations(
-        [order_line_info], order_line.order.channel.slug, manager=get_plugins_manager()
+        [order_line_info], order_line.order.channel, manager=get_plugins_manager()
     )
 
     stock.refresh_from_db()
@@ -464,7 +464,7 @@ def test_increase_allocation_insufficient_stock(allocation):
     with pytest.raises(InsufficientStock):
         increase_allocations(
             [order_line_info],
-            order_line.order.channel.slug,
+            order_line.order.channel,
             manager=get_plugins_manager(),
         )
 

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -189,7 +189,7 @@ def test_allocate_stock_with_reservations_prioritize_sorting_order_strategy(
     channel_warehouse_1 = stock_1.warehouse.channelwarehouse.first()
     channel_warehouse_2 = stock_2.warehouse.channelwarehouse.first()
 
-    # se the warehouse order
+    # set the warehouse order
     channel_warehouse_2.sort_order = 0
     channel_warehouse_1.sort_order = 1
     ChannelWarehouse.objects.bulk_update(

--- a/saleor/warehouse/tests/test_stock_reservations_management.py
+++ b/saleor/warehouse/tests/test_stock_reservations_management.py
@@ -3,9 +3,10 @@ from datetime import timedelta
 import pytest
 from django.utils import timezone
 
+from ...channel import AllocationStrategy
 from ...checkout.models import Checkout
 from ...core.exceptions import InsufficientStock
-from ..models import Reservation, Stock, Warehouse
+from ..models import ChannelWarehouse, Reservation, Stock, Warehouse
 from ..reservations import reserve_stocks
 
 COUNTRY_CODE = "US"
@@ -58,7 +59,7 @@ def test_stocks_reservation_skips_prev_reservation_delete_if_replace_is_disabled
         )
 
 
-def test_multiple_stocks_are_reserved_if_single_stock_is_not_enough(
+def test_multiple_stocks_reserved_if_single_stock_is_not_enough_highest_stock_strategy(
     checkout_line, warehouse, shipping_zone, channel_USD
 ):
     checkout_line.quantity = 5
@@ -79,7 +80,7 @@ def test_multiple_stocks_are_reserved_if_single_stock_is_not_enough(
     secondary_warehouse.save()
 
     secondary_stock = Stock.objects.create(
-        warehouse=secondary_warehouse, product_variant=stock.product_variant, quantity=3
+        warehouse=secondary_warehouse, product_variant=stock.product_variant, quantity=2
     )
 
     reserve_stocks(
@@ -102,6 +103,74 @@ def test_multiple_stocks_are_reserved_if_single_stock_is_not_enough(
     )
     assert second_reservation.quantity_reserved == 2
     assert second_reservation.reserved_until > timezone.now() + timedelta(minutes=1)
+
+
+def test_multiple_stocks_reserved_if_single_stock_is_not_enough_sorting_order_strategy(
+    checkout_line, warehouse, shipping_zone, channel_USD
+):
+    # given
+    # set the prioritize sorting order stratefy
+    channel_USD.allocation_strategy = AllocationStrategy.PRIORITIZE_SORTING_ORDER
+    channel_USD.save(update_fields=["allocation_strategy"])
+
+    quantity = 5
+    checkout_line.quantity = quantity
+    checkout_line.save()
+
+    stock = Stock.objects.get(product_variant=checkout_line.variant)
+    stock_quantity = 4
+    stock.quantity = stock_quantity
+    stock.save(update_fields=["quantity"])
+
+    secondary_warehouse = Warehouse.objects.create(
+        address=warehouse.address,
+        name="Warehouse 2",
+        slug="warehouse-2",
+        email=warehouse.email,
+    )
+    secondary_warehouse.shipping_zones.add(shipping_zone)
+    secondary_warehouse.channels.add(channel_USD)
+    secondary_warehouse.save()
+
+    secondary_stock_quantity = 3
+    secondary_stock = Stock.objects.create(
+        warehouse=secondary_warehouse,
+        product_variant=stock.product_variant,
+        quantity=secondary_stock_quantity,
+    )
+
+    channel_warehouse_1 = stock.warehouse.channelwarehouse.first()
+    channel_warehouse_2 = secondary_stock.warehouse.channelwarehouse.first()
+
+    # set the warehouse order
+    channel_warehouse_2.sort_order = 0
+    channel_warehouse_1.sort_order = 1
+    ChannelWarehouse.objects.bulk_update(
+        [channel_warehouse_1, channel_warehouse_2], ["sort_order"]
+    )
+
+    # when
+    reserve_stocks(
+        [checkout_line],
+        [checkout_line.variant],
+        COUNTRY_CODE,
+        channel_USD,
+        RESERVATION_LENGTH,
+    )
+
+    # then
+    stock.refresh_from_db()
+    assert stock.quantity == stock_quantity
+
+    second_reservation = Reservation.objects.get(
+        checkout_line=checkout_line, stock=secondary_stock
+    )
+    assert second_reservation.quantity_reserved == secondary_stock_quantity
+    assert second_reservation.reserved_until > timezone.now() + timedelta(minutes=1)
+
+    reservation = Reservation.objects.get(checkout_line=checkout_line, stock=stock)
+    assert reservation.quantity_reserved == quantity - secondary_stock_quantity
+    assert reservation.reserved_until > timezone.now() + timedelta(minutes=1)
 
 
 def test_stocks_reservation_removes_previous_reservations_for_checkout(

--- a/saleor/warehouse/tests/test_stock_reservations_management.py
+++ b/saleor/warehouse/tests/test_stock_reservations_management.py
@@ -24,7 +24,7 @@ def test_reserve_stocks(checkout_line, channel_USD):
         [checkout_line],
         [checkout_line.variant],
         COUNTRY_CODE,
-        channel_USD.slug,
+        channel_USD,
         RESERVATION_LENGTH,
     )
 
@@ -43,7 +43,7 @@ def test_stocks_reservation_skips_prev_reservation_delete_if_replace_is_disabled
             [checkout_line],
             [checkout_line.variant],
             COUNTRY_CODE,
-            channel_USD.slug,
+            channel_USD,
             RESERVATION_LENGTH,
             replace=False,
         )
@@ -53,7 +53,7 @@ def test_stocks_reservation_skips_prev_reservation_delete_if_replace_is_disabled
             [checkout_line],
             [checkout_line.variant],
             COUNTRY_CODE,
-            channel_USD.slug,
+            channel_USD,
             RESERVATION_LENGTH,
         )
 
@@ -86,7 +86,7 @@ def test_multiple_stocks_are_reserved_if_single_stock_is_not_enough(
         [checkout_line],
         [checkout_line.variant],
         COUNTRY_CODE,
-        channel_USD.slug,
+        channel_USD,
         RESERVATION_LENGTH,
     )
 
@@ -125,7 +125,7 @@ def test_stocks_reservation_removes_previous_reservations_for_checkout(
         [checkout_line],
         [checkout_line.variant],
         COUNTRY_CODE,
-        channel_USD.slug,
+        channel_USD,
         RESERVATION_LENGTH,
     )
 
@@ -148,7 +148,7 @@ def test_stock_reservation_fails_if_there_is_not_enough_stock_available(
             [checkout_line],
             [checkout_line.variant],
             COUNTRY_CODE,
-            channel_USD.slug,
+            channel_USD,
             RESERVATION_LENGTH,
         )
 
@@ -164,7 +164,7 @@ def test_stock_reservation_fails_if_there_is_no_stock(checkout_line, channel_USD
             [checkout_line],
             [checkout_line.variant],
             COUNTRY_CODE,
-            channel_USD.slug,
+            channel_USD,
             RESERVATION_LENGTH,
         )
 
@@ -185,7 +185,7 @@ def test_stock_reservation_accounts_for_order_allocations(
             [checkout_line],
             [variant],
             COUNTRY_CODE,
-            channel_USD.slug,
+            channel_USD,
             RESERVATION_LENGTH,
         )
 
@@ -222,6 +222,6 @@ def test_stock_reservation_accounts_for_order_allocations_and_reservations(
             [checkout_line],
             [variant],
             COUNTRY_CODE,
-            channel_USD.slug,
+            channel_USD,
             RESERVATION_LENGTH,
         )


### PR DESCRIPTION
Handle the allocation strategies in allocation and reservation.
- For the `PRIORITIZE_HIGH_STOCK` strategy - create allocation or reservations firstly in the stock with the highest quantities.
- For the `PRIORITIZE_SORTING_ORDER ` strategy - follow the warehouse within channel order during allocation or reservation creation.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
