### PR TITLE
Add webhook triggering to bulk sales_delete

### DIFF
--- a/saleor/graphql/discount/bulk_mutations.py
+++ b/saleor/graphql/discount/bulk_mutations.py
@@ -1,12 +1,12 @@
 import graphene
 
-from .mutations.utils import convert_catalogue_info_to_global_ids
 from ...core.permissions import DiscountPermissions
 from ...discount import models
+from ...discount.utils import fetch_catalogue_info
 from ..core.mutations import ModelBulkDeleteMutation
 from ..core.types import DiscountError, NonNullList
+from .mutations.utils import convert_catalogue_info_to_global_ids
 from .types import Sale, Voucher
-from ...discount.utils import fetch_catalogue_info
 
 
 class SaleBulkDelete(ModelBulkDeleteMutation):

--- a/saleor/graphql/discount/tests/test_bulk_delete.py
+++ b/saleor/graphql/discount/tests/test_bulk_delete.py
@@ -85,7 +85,7 @@ def test_delete_sales_triggers_webhook(
     sale_list,
     permission_manage_discounts,
     any_webhook,
-    settings
+    settings,
 ):
     query = """
     mutation saleBulkDelete($ids: [ID!]!) {

--- a/saleor/graphql/discount/tests/test_bulk_delete.py
+++ b/saleor/graphql/discount/tests/test_bulk_delete.py
@@ -76,6 +76,38 @@ def test_delete_sales(staff_api_client, sale_list, permission_manage_discounts):
     assert not Sale.objects.filter(id__in=[sale.id for sale in sale_list]).exists()
 
 
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
+def test_delete_sales_triggers_webhook(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    staff_api_client,
+    sale_list,
+    permission_manage_discounts,
+    any_webhook,
+    settings
+):
+    query = """
+    mutation saleBulkDelete($ids: [ID!]!) {
+        saleBulkDelete(ids: $ids) {
+            count
+        }
+    }
+    """
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    variables = {
+        "ids": [graphene.Node.to_global_id("Sale", sale.id) for sale in sale_list]
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["saleBulkDelete"]["count"] == 3
+    assert mocked_webhook_trigger.call_count == 3
+
+
 BULK_DELETE_VOUCHERS_MUTATION = """
     mutation voucherBulkDelete($ids: [ID!]!) {
         voucherBulkDelete(ids: $ids) {


### PR DESCRIPTION
I want to merge this change because it adds webhook triggering in sales delete bulk mutation

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
