### PR TITLE
Update source of Saleor CLI to be npm pkg under Saleor org

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The fastest way to develop with Saleor is by using developer accounts in [Saleor
 
 Register [here](https://cloud.saleor.io/register) or install our [CLI tool](https://github.com/saleor/saleor-cli):
 
-`npm i -g saleor@latest`
+`npm i -g @saleor/cli`
 
 and run the following command:
 


### PR DESCRIPTION
I want to merge this change because...

Saleor CLI package is being migrated from `saleor` to Saleor's org in NPM. Package name now will be `@saleor/cli`, but executable binary stays: `saleor`

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [x] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
