### PR TITLE
Rename allocationSettings to stockSettings

### DIFF
--- a/saleor/graphql/channel/mutations.py
+++ b/saleor/graphql/channel/mutations.py
@@ -28,20 +28,21 @@ from .types import Channel
 from .utils import delete_invalid_warehouse_to_shipping_zone_relations
 
 
-class AllocationSettingsInput(graphene.InputObjectType):
+class StockSettingsInput(graphene.InputObjectType):
     allocation_strategy = AllocationStrategyEnum(
-        description=("Allocation strategy options."),
+        description=(
+            "Allocation strategy options. Strategy defines the preference "
+            "of warehouses for allocations and reservations."
+        ),
         required=True,
     )
 
 
 class ChannelInput(graphene.InputObjectType):
     is_active = graphene.Boolean(description="isActive flag.")
-    allocation_settings = graphene.Field(
-        AllocationSettingsInput,
-        description=(
-            "The channel allocation settings." + ADDED_IN_37 + PREVIEW_FEATURE
-        ),
+    stock_settings = graphene.Field(
+        StockSettingsInput,
+        description=("The channel stock settings." + ADDED_IN_37 + PREVIEW_FEATURE),
         required=False,
     )
     add_shipping_zones = NonNullList(
@@ -100,10 +101,8 @@ class ChannelCreate(ModelMutation):
         slug = cleaned_input.get("slug")
         if slug:
             cleaned_input["slug"] = slugify(slug)
-        if allocation_settings := cleaned_input.get("allocation_settings"):
-            cleaned_input["allocation_strategy"] = allocation_settings[
-                "allocation_strategy"
-            ]
+        if stock_settings := cleaned_input.get("stock_settings"):
+            cleaned_input["allocation_strategy"] = stock_settings["allocation_strategy"]
 
         return cleaned_input
 
@@ -184,10 +183,8 @@ class ChannelUpdate(ModelMutation):
         slug = cleaned_input.get("slug")
         if slug:
             cleaned_input["slug"] = slugify(slug)
-        if allocation_settings := cleaned_input.get("allocation_settings"):
-            cleaned_input["allocation_strategy"] = allocation_settings[
-                "allocation_strategy"
-            ]
+        if stock_settings := cleaned_input.get("stock_settings"):
+            cleaned_input["allocation_strategy"] = stock_settings["allocation_strategy"]
 
         return cleaned_input
 

--- a/saleor/graphql/channel/tests/test_channel_create_mutations.py
+++ b/saleor/graphql/channel/tests/test_channel_create_mutations.py
@@ -29,7 +29,7 @@ CHANNEL_CREATE_MUTATION = """
                 warehouses {
                     slug
                 }
-                allocationSettings {
+                stockSettings {
                     allocationStrategy
                 }
             }
@@ -59,7 +59,7 @@ def test_channel_create_mutation_as_staff_user(
             "slug": slug,
             "currencyCode": currency_code,
             "defaultCountry": default_country,
-            "allocationSettings": {"allocationStrategy": allocation_strategy},
+            "stockSettings": {"allocationStrategy": allocation_strategy},
         }
     }
 
@@ -84,9 +84,7 @@ def test_channel_create_mutation_as_staff_user(
         == channel.default_country.code
         == default_country
     )
-    assert (
-        channel_data["allocationSettings"]["allocationStrategy"] == allocation_strategy
-    )
+    assert channel_data["stockSettings"]["allocationStrategy"] == allocation_strategy
 
 
 def test_channel_create_mutation_as_app(
@@ -129,7 +127,7 @@ def test_channel_create_mutation_as_app(
         == default_country
     )
     assert (
-        channel_data["allocationSettings"]["allocationStrategy"]
+        channel_data["stockSettings"]["allocationStrategy"]
         == AllocationStrategyEnum.PRIORITIZE_SORTING_ORDER.name
     )
 
@@ -147,7 +145,7 @@ def test_channel_create_mutation_as_customer(user_api_client):
             "slug": slug,
             "currencyCode": currency_code,
             "defaultCountry": default_country,
-            "allocationSettings": {"allocationStrategy": allocation_strategy},
+            "stockSettings": {"allocationStrategy": allocation_strategy},
         }
     }
 
@@ -234,7 +232,7 @@ def test_channel_create_mutation_with_duplicated_slug(
             "slug": slug,
             "currencyCode": currency_code,
             "defaultCountry": default_country,
-            "allocationSettings": {"allocationStrategy": allocation_strategy},
+            "stockSettings": {"allocationStrategy": allocation_strategy},
         }
     }
 
@@ -273,7 +271,7 @@ def test_channel_create_mutation_with_shipping_zones(
             "currencyCode": currency_code,
             "addShippingZones": shipping_zones_ids,
             "defaultCountry": default_country,
-            "allocationSettings": {"allocationStrategy": allocation_strategy},
+            "stockSettings": {"allocationStrategy": allocation_strategy},
         }
     }
 
@@ -297,9 +295,7 @@ def test_channel_create_mutation_with_shipping_zones(
     assert channel_data["currencyCode"] == channel.currency_code == currency_code
     for shipping_zone in shipping_zones:
         shipping_zone.channels.get(slug=slug)
-    assert (
-        channel_data["allocationSettings"]["allocationStrategy"] == allocation_strategy
-    )
+    assert channel_data["stockSettings"]["allocationStrategy"] == allocation_strategy
 
 
 def test_channel_create_mutation_with_warehouses(
@@ -324,7 +320,7 @@ def test_channel_create_mutation_with_warehouses(
             "currencyCode": currency_code,
             "addWarehouses": warehouses_ids,
             "defaultCountry": default_country,
-            "allocationSettings": {"allocationStrategy": allocation_strategy},
+            "stockSettings": {"allocationStrategy": allocation_strategy},
         }
     }
 
@@ -349,9 +345,7 @@ def test_channel_create_mutation_with_warehouses(
     assert {
         warehouse_data["slug"] for warehouse_data in channel_data["warehouses"]
     } == {warehouse.slug for warehouse in warehouses}
-    assert (
-        channel_data["allocationSettings"]["allocationStrategy"] == allocation_strategy
-    )
+    assert channel_data["stockSettings"]["allocationStrategy"] == allocation_strategy
 
 
 @freeze_time("2022-05-12 12:00:00")
@@ -380,7 +374,7 @@ def test_channel_create_mutation_trigger_webhook(
             "slug": slug,
             "currencyCode": currency_code,
             "defaultCountry": default_country,
-            "allocationSettings": {"allocationStrategy": allocation_strategy},
+            "stockSettings": {"allocationStrategy": allocation_strategy},
         }
     }
 

--- a/saleor/graphql/channel/tests/test_channel_queries.py
+++ b/saleor/graphql/channel/tests/test_channel_queries.py
@@ -165,7 +165,7 @@ QUERY_CHANNEL = """
             name
             slug
             currencyCode
-            allocationSettings{
+            stockSettings{
                 allocationStrategy
             }
         }
@@ -188,7 +188,7 @@ def test_query_channel_as_staff_user(staff_api_client, channel_USD):
     assert channel_data["name"] == channel_USD.name
     assert channel_data["slug"] == channel_USD.slug
     assert channel_data["currencyCode"] == channel_USD.currency_code
-    allocation_strategy = channel_data["allocationSettings"]["allocationStrategy"]
+    allocation_strategy = channel_data["stockSettings"]["allocationStrategy"]
     assert (
         AllocationStrategyEnum[allocation_strategy].value
         == channel_USD.allocation_strategy
@@ -210,7 +210,7 @@ def test_query_channel_as_app(app_api_client, channel_USD):
     assert channel_data["name"] == channel_USD.name
     assert channel_data["slug"] == channel_USD.slug
     assert channel_data["currencyCode"] == channel_USD.currency_code
-    allocation_strategy = channel_data["allocationSettings"]["allocationStrategy"]
+    allocation_strategy = channel_data["stockSettings"]["allocationStrategy"]
     assert (
         AllocationStrategyEnum[allocation_strategy].value
         == channel_USD.allocation_strategy

--- a/saleor/graphql/channel/tests/test_channel_update_mutations.py
+++ b/saleor/graphql/channel/tests/test_channel_update_mutations.py
@@ -29,7 +29,7 @@ CHANNEL_UPDATE_MUTATION = """
                 warehouses {
                     slug
                 }
-                allocationSettings {
+                stockSettings {
                     allocationStrategy
                 }
             }
@@ -60,7 +60,7 @@ def test_channel_update_mutation_as_staff_user(
             "name": name,
             "slug": slug,
             "defaultCountry": default_country,
-            "allocationSettings": {"allocationStrategy": allocation_strategy},
+            "stockSettings": {"allocationStrategy": allocation_strategy},
         },
     }
 
@@ -85,9 +85,7 @@ def test_channel_update_mutation_as_staff_user(
         == channel_USD.default_country.code
         == default_country
     )
-    assert (
-        channel_data["allocationSettings"]["allocationStrategy"] == allocation_strategy
-    )
+    assert channel_data["stockSettings"]["allocationStrategy"] == allocation_strategy
 
 
 def test_channel_update_mutation_as_app(

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -129,17 +129,18 @@ class ChannelContextTypeWithMetadata(
         abstract = True
 
 
-class AllocationSettings(ObjectType):
+class StockSettings(ObjectType):
     allocation_strategy = AllocationStrategyEnum(
-        description="Allocation strategy options.",
+        description=(
+            "Allocation strategy options. Strategy defines the preference "
+            "of warehouses for allocations and reservations."
+        ),
         required=True,
     )
 
     class Meta:
         description = (
-            "Represents the channel allocation settings."
-            + ADDED_IN_37
-            + PREVIEW_FEATURE
+            "Represents the channel stock settings." + ADDED_IN_37 + PREVIEW_FEATURE
         )
 
 
@@ -223,12 +224,10 @@ class Channel(ModelObjectType):
         + ADDED_IN_36
         + PREVIEW_FEATURE,
     )
-    allocation_settings = PermissionsField(
-        AllocationSettings,
+    stock_settings = PermissionsField(
+        StockSettings,
         description=(
-            "Define the allocation setting for this channel."
-            + ADDED_IN_37
-            + PREVIEW_FEATURE
+            "Define the stock setting for this channel." + ADDED_IN_37 + PREVIEW_FEATURE
         ),
         required=True,
         permissions=[
@@ -364,5 +363,5 @@ class Channel(ModelObjectType):
         return shipping_zones_loader.then(get_shipping_methods)
 
     @staticmethod
-    def resolve_allocation_settings(root: models.Channel, _info):
-        return AllocationSettings(allocation_strategy=root.allocation_strategy)
+    def resolve_stock_settings(root: models.Channel, _info):
+        return StockSettings(allocation_strategy=root.allocation_strategy)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3884,7 +3884,7 @@ type Channel implements Node {
   availableShippingMethodsPerCountry(countries: [CountryCode!]): [ShippingMethodsPerCountry!]
 
   """
-  Define the allocation setting for this channel.
+  Define the stock setting for this channel.
   
   Added in Saleor 3.7.
   
@@ -3892,7 +3892,7 @@ type Channel implements Node {
   
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
-  allocationSettings: AllocationSettings!
+  stockSettings: StockSettings!
 }
 
 """
@@ -4283,14 +4283,16 @@ enum WeightUnitsEnum {
 }
 
 """
-Represents the channel allocation settings.
+Represents the channel stock settings.
 
 Added in Saleor 3.7.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
-type AllocationSettings {
-  """Allocation strategy options."""
+type StockSettings {
+  """
+  Allocation strategy options. Strategy defines the preference of warehouses for allocations and reservations.
+  """
   allocationStrategy: AllocationStrategyEnum!
 }
 
@@ -19894,13 +19896,13 @@ input ChannelCreateInput {
   isActive: Boolean
 
   """
-  The channel allocation settings.
+  The channel stock settings.
   
   Added in Saleor 3.7.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
-  allocationSettings: AllocationSettingsInput
+  stockSettings: StockSettingsInput
 
   """List of shipping zones to assign to the channel."""
   addShippingZones: [ID!]
@@ -19933,8 +19935,10 @@ input ChannelCreateInput {
   defaultCountry: CountryCode!
 }
 
-input AllocationSettingsInput {
-  """Allocation strategy options."""
+input StockSettingsInput {
+  """
+  Allocation strategy options. Strategy defines the preference of warehouses for allocations and reservations.
+  """
   allocationStrategy: AllocationStrategyEnum!
 }
 
@@ -19954,13 +19958,13 @@ input ChannelUpdateInput {
   isActive: Boolean
 
   """
-  The channel allocation settings.
+  The channel stock settings.
   
   Added in Saleor 3.7.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
-  allocationSettings: AllocationSettingsInput
+  stockSettings: StockSettingsInput
 
   """List of shipping zones to assign to the channel."""
   addShippingZones: [ID!]


### PR DESCRIPTION
Rename `allocationSettings` to `stockSettings`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
