### PR TITLE
Allow to pass metadata directly in checkoutComplete and OrderCreateFromCheckout mutations

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -469,9 +469,9 @@ def _create_order(
     user: User,
     app: Optional["App"],
     manager: "PluginsManager",
-    site_settings=None,
-    metadata_list=None,
-    private_metadata_list=None
+    site_settings: Optional["SiteSettings"] = None,
+    metadata_list: Optional[List] = None,
+    private_metadata_list: Optional[List] = None
 ) -> Order:
     """Create an order from the checkout.
 
@@ -746,8 +746,8 @@ def complete_checkout(
     site_settings=None,
     tracking_code=None,
     redirect_url=None,
-    metadata_list=None,
-    private_metadata_list=None,
+    metadata_list: Optional[List] = None,
+    private_metadata_list: Optional[List] = None,
 ) -> Tuple[Optional[Order], bool, dict]:
     """Logic required to finalize the checkout and convert it to order.
 

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -469,7 +469,9 @@ def _create_order(
     user: User,
     app: Optional["App"],
     manager: "PluginsManager",
-    site_settings=None
+    site_settings=None,
+    metadata_list=None,
+    private_metadata_list=None
 ) -> Order:
     """Create an order from the checkout.
 
@@ -565,8 +567,17 @@ def _create_order(
 
     # copy metadata from the checkout into the new order
     order.metadata = checkout.metadata
+    if metadata_list:
+        order.store_value_in_metadata({data.key: data.value for data in metadata_list})
+
     order.redirect_url = checkout.redirect_url
+
     order.private_metadata = checkout.private_metadata
+    if private_metadata_list:
+        order.store_value_in_private_metadata(
+            {data.key: data.value for data in private_metadata_list}
+        )
+
     update_order_charge_data(order, with_save=False)
     update_order_authorize_data(order, with_save=False)
     order.search_vector = FlatConcatSearchVector(
@@ -735,6 +746,8 @@ def complete_checkout(
     site_settings=None,
     tracking_code=None,
     redirect_url=None,
+    metadata_list=None,
+    private_metadata_list=None,
 ) -> Tuple[Optional[Order], bool, dict]:
     """Logic required to finalize the checkout and convert it to order.
 
@@ -807,6 +820,8 @@ def complete_checkout(
                 app=app,
                 manager=manager,
                 site_settings=site_settings,
+                metadata_list=metadata_list,
+                private_metadata_list=private_metadata_list,
             )
             # remove checkout after order is successfully created
             checkout.delete()
@@ -1003,6 +1018,8 @@ def _create_order_from_checkout(
     user: User,
     app: Optional["App"],
     tracking_code: Optional[str] = None,
+    metadata_list: Optional[List] = None,
+    private_metadata_list: Optional[List] = None,
 ):
     from ..order.utils import add_gift_cards_to_order
 
@@ -1040,6 +1057,16 @@ def _create_order_from_checkout(
         if site_settings.automatically_confirm_all_new_orders
         else OrderStatus.UNCONFIRMED
     )
+
+    # update metadata
+    if metadata_list:
+        checkout_info.checkout.store_value_in_metadata(
+            {data.key: data.value for data in metadata_list}
+        )
+    if private_metadata_list:
+        checkout_info.checkout.store_value_in_private_metadata(
+            {data.key: data.value for data in private_metadata_list}
+        )
 
     # order
     order = Order.objects.create(
@@ -1128,6 +1155,8 @@ def create_order_from_checkout(
     app: Optional["App"],
     tracking_code: str,
     delete_checkout: bool = True,
+    metadata_list: Optional[List] = None,
+    private_metadata_list: Optional[List] = None,
 ) -> Order:
     """Crate order from checkout.
 
@@ -1161,6 +1190,8 @@ def create_order_from_checkout(
                 user=user,
                 app=app,
                 tracking_code=tracking_code,
+                metadata_list=metadata_list,
+                private_metadata_list=private_metadata_list,
             )
             if delete_checkout:
                 checkout_info.checkout.delete()

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -29,8 +29,8 @@ from ...core.fields import JSONString
 from ...core.scalars import UUID
 from ...core.types import CheckoutError, NonNullList
 from ...core.validators import validate_one_of_args_is_in_mutation
-from ...meta.mutations import BaseMutationWithMetadata, MetadataInput
 from ...discount.dataloaders import load_discounts
+from ...meta.mutations import BaseMutationWithMetadata, MetadataInput
 from ...order.types import Order
 from ...site.dataloaders import load_site
 from ...utils import get_user_or_app_from_context

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -27,9 +27,9 @@ from ...app.dataloaders import load_app
 from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.fields import JSONString
 from ...core.scalars import UUID
-from ...core.types import CheckoutError
+from ...core.types import CheckoutError, NonNullList
 from ...core.validators import validate_one_of_args_is_in_mutation
-from ...meta.mutations import BaseMutationWithMetadata
+from ...meta.mutations import BaseMutationWithMetadata, MetadataInput
 from ...discount.dataloaders import load_discounts
 from ...order.types import Order
 from ...site.dataloaders import load_site
@@ -55,7 +55,7 @@ class CheckoutComplete(BaseMutationWithMetadata, I18nMixin):
         ),
     )
 
-    class Arguments(BaseMutationWithMetadata.Arguments):
+    class Arguments:
         id = graphene.ID(
             description="The checkout's ID." + ADDED_IN_34,
             required=False,
@@ -89,6 +89,11 @@ class CheckoutComplete(BaseMutationWithMetadata, I18nMixin):
             description=(
                 "Client-side generated data required to finalize the payment."
             ),
+        )
+        metadata = NonNullList(
+            MetadataInput,
+            description="Fields required to update the object's metadata.",
+            required=False,
         )
 
     class Meta:
@@ -258,7 +263,6 @@ class CheckoutComplete(BaseMutationWithMetadata, I18nMixin):
                 tracking_code=tracking_code,
                 redirect_url=data.get("redirect_url"),
                 metadata_list=data.get("metadata"),
-                private_metadata_list=data.get("private_metadata"),
             )
         # If gateway returns information that additional steps are required we need
         # to inform the frontend and pass all required data

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -93,7 +93,7 @@ class CheckoutComplete(BaseMutationWithMetadata, I18nMixin):
         metadata = NonNullList(
             MetadataInput,
             description=(
-                "Fields required to update the object's metadata." + ADDED_IN_38
+                "Fields required to update the checkout metadata." + ADDED_IN_38
             ),
             required=False,
         )

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -24,7 +24,7 @@ from ....core.transactions import transaction_with_commit_on_errors
 from ....order import models as order_models
 from ...account.i18n import I18nMixin
 from ...app.dataloaders import load_app
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
+from ...core.descriptions import ADDED_IN_34, ADDED_IN_38, DEPRECATED_IN_3X_INPUT
 from ...core.fields import JSONString
 from ...core.scalars import UUID
 from ...core.types import CheckoutError, NonNullList
@@ -92,7 +92,9 @@ class CheckoutComplete(BaseMutationWithMetadata, I18nMixin):
         )
         metadata = NonNullList(
             MetadataInput,
-            description="Fields required to update the object's metadata.",
+            description=(
+                "Fields required to update the object's metadata." + ADDED_IN_38
+            ),
             required=False,
         )
 

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -109,7 +109,6 @@ class CheckoutComplete(BaseMutationWithMetadata, I18nMixin):
         )
         error_type_class = CheckoutError
         error_type_field = "checkout_errors"
-        metadata_permissions_map_key = "Checkout"
 
     @classmethod
     def validate_checkout_addresses(
@@ -210,6 +209,12 @@ class CheckoutComplete(BaseMutationWithMetadata, I18nMixin):
                         order=order, confirmation_needed=False, confirmation_data={}
                     )
                 raise e
+
+            cls.validate_metadata(
+                info,
+                id or checkout_id or graphene.Node.to_global_id("Checkout", token),
+                data.get("metadata"),
+            )
 
             validate_checkout_email(checkout)
 

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -26,10 +26,10 @@ from ...account.i18n import I18nMixin
 from ...app.dataloaders import load_app
 from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.fields import JSONString
-from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...core.validators import validate_one_of_args_is_in_mutation
+from ...meta.mutations import BaseMutationWithMetadata
 from ...discount.dataloaders import load_discounts
 from ...order.types import Order
 from ...site.dataloaders import load_site
@@ -38,7 +38,7 @@ from ..types import Checkout
 from .utils import get_checkout
 
 
-class CheckoutComplete(BaseMutation, I18nMixin):
+class CheckoutComplete(BaseMutationWithMetadata, I18nMixin):
     order = graphene.Field(Order, description="Placed order.")
     confirmation_needed = graphene.Boolean(
         required=True,
@@ -55,7 +55,7 @@ class CheckoutComplete(BaseMutation, I18nMixin):
         ),
     )
 
-    class Arguments:
+    class Arguments(BaseMutationWithMetadata.Arguments):
         id = graphene.ID(
             description="The checkout's ID." + ADDED_IN_34,
             required=False,
@@ -102,6 +102,7 @@ class CheckoutComplete(BaseMutation, I18nMixin):
         )
         error_type_class = CheckoutError
         error_type_field = "checkout_errors"
+        metadata_permissions_map_key = "Checkout"
 
     @classmethod
     def validate_checkout_addresses(
@@ -256,6 +257,8 @@ class CheckoutComplete(BaseMutation, I18nMixin):
                 site_settings=site.settings,
                 tracking_code=tracking_code,
                 redirect_url=data.get("redirect_url"),
+                metadata_list=data.get("metadata"),
+                private_metadata_list=data.get("private_metadata"),
             )
         # If gateway returns information that additional steps are required we need
         # to inform the frontend and pass all required data

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -11,8 +11,8 @@ from ....discount.models import NotApplicable
 from ...app.dataloaders import load_app
 from ...core.descriptions import ADDED_IN_32, PREVIEW_FEATURE
 from ...core.types import Error
-from ...meta.mutations import BaseMutationWithMetadata
 from ...discount.dataloaders import load_discounts
+from ...meta.mutations import BaseMutationWithMetadata
 from ...order.types import Order
 from ..enums import OrderCreateFromCheckoutErrorCode
 from ..types import Checkout

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -53,14 +53,14 @@ class OrderCreateFromCheckout(BaseMutationWithMetadata):
         private_metadata = NonNullList(
             MetadataInput,
             description=(
-                "Fields required to update the object's private metadata." + ADDED_IN_38
+                "Fields required to update the checkout private metadata." + ADDED_IN_38
             ),
             required=False,
         )
         metadata = NonNullList(
             MetadataInput,
             description=(
-                "Fields required to update the object's metadata." + ADDED_IN_38
+                "Fields required to update the checkout metadata." + ADDED_IN_38
             ),
             required=False,
         )

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -25,8 +25,12 @@ from .....warehouse.tests.utils import get_available_quantity_for_stock
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 MUTATION_ORDER_CREATE_FROM_CHECKOUT = """
-mutation orderCreateFromCheckout($id: ID!){
-    orderCreateFromCheckout(id: $id){
+mutation orderCreateFromCheckout(
+        $id: ID!, $metadata: [MetadataInput!], $privateMetadata: [MetadataInput!]
+    ){
+    orderCreateFromCheckout(
+            id: $id, metadata: $metadata, privateMetadata: $privateMetadata
+        ){
         order{
             id,
             token
@@ -166,6 +170,74 @@ def test_order_from_checkout(
         gift_card=gift_card, type=GiftCardEvents.USED_IN_ORDER
     )
 
+    order_confirmed_mock.assert_called_once_with(order)
+
+
+@pytest.mark.integration
+@patch("saleor.plugins.manager.PluginsManager.order_confirmed")
+def test_order_from_checkout_with_metadata(
+    order_confirmed_mock,
+    app_api_client,
+    permission_handle_checkouts,
+    permission_manage_checkouts,
+    site_settings,
+    checkout_with_gift_card,
+    gift_card,
+    address,
+    shipping_method,
+):
+    # given
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.store_value_in_metadata(items={"accepted": "true"})
+    checkout.store_value_in_private_metadata(items={"accepted": "false"})
+    checkout.save()
+
+    metadata_key = "md key"
+    metadata_value = "md value"
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+    site_settings.automatically_confirm_all_new_orders = True
+    site_settings.save()
+
+    orders_count = Order.objects.count()
+    variables = {
+        "id": graphene.Node.to_global_id("Checkout", checkout.pk),
+        "metadata": [{"key": metadata_key, "value": metadata_value}],
+        "privateMetadata": [{"key": metadata_key, "value": metadata_value}],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_ORDER_CREATE_FROM_CHECKOUT,
+        variables,
+        permissions=[permission_handle_checkouts, permission_manage_checkouts],
+    )
+
+    content = get_graphql_content(response)
+    data = content["data"]["orderCreateFromCheckout"]
+    assert not data["errors"]
+
+    order_token = data["order"]["token"]
+    assert Order.objects.count() == orders_count + 1
+    order = Order.objects.first()
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.origin == OrderOrigin.CHECKOUT
+    assert not order.original
+    assert str(order.pk) == order_token
+    assert order.total.gross == total.gross
+    assert order.metadata == {**checkout.metadata, **{metadata_key: metadata_value}}
+    assert order.private_metadata == {
+        **checkout.private_metadata,
+        **{metadata_key: metadata_value},
+    }
     order_confirmed_mock.assert_called_once_with(order)
 
 

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -18,6 +18,7 @@ ADDED_IN_34 = "\n\nAdded in Saleor 3.4."
 ADDED_IN_35 = "\n\nAdded in Saleor 3.5."
 ADDED_IN_36 = "\n\nAdded in Saleor 3.6."
 ADDED_IN_37 = "\n\nAdded in Saleor 3.7."
+ADDED_IN_38 = "\n\nAdded in Saleor 3.8."
 
 
 PREVIEW_FEATURE = (

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -481,10 +481,10 @@ class BaseMutationWithMetadata(BaseMutation):
         type_name = cls._meta.metadata_permissions_map_key
 
         if metadata:
-            cls.check_metadata_permissions(type_name, info, data["id"])
+            cls.check_metadata_permissions(type_name, info, data.get("id"))
 
         if private_metadata:
-            cls.check_metadata_permissions(type_name, info, data["id"], True)
+            cls.check_metadata_permissions(type_name, info, data.get("id"), True)
 
         result = info.context.plugins.perform_mutation(
             mutation_cls=cls, root=root, info=info, data=data

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -9,7 +9,6 @@ from graphql.error.base import GraphQLError
 
 from ...checkout import models as checkout_models
 from ...core import models
-from ...core.db.utils import set_mutation_flag_in_context
 from ...core.error_codes import MetadataErrorCode
 from ...core.exceptions import PermissionDenied
 from ...discount import models as discount_models
@@ -18,6 +17,8 @@ from ...order import models as order_models
 from ...product import models as product_models
 from ...shipping import models as shipping_models
 from ..channel import ChannelContext
+from ..core.context import set_mutation_flag_in_context
+from ..core.descriptions import ADDED_IN_38
 from ..core.mutations import BaseMutation
 from ..core.types import MetadataError, NonNullList
 from ..core.utils import from_global_id_or_error
@@ -407,12 +408,16 @@ class BaseMutationWithMetadata(BaseMutation):
     class Arguments:
         private_metadata = NonNullList(
             MetadataInput,
-            description="Fields required to update the object's private metadata.",
+            description=(
+                "Fields required to update the object's private metadata." + ADDED_IN_38
+            ),
             required=False,
         )
         metadata = NonNullList(
             MetadataInput,
-            description="Fields required to update the object's metadata.",
+            description=(
+                "Fields required to update the object's metadata." + ADDED_IN_38
+            ),
             required=False,
         )
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13216,7 +13216,11 @@ type Mutation {
     """
     id: ID
 
-    """Fields required to update the object's metadata."""
+    """
+    Fields required to update the object's metadata.
+    
+    Added in Saleor 3.8.
+    """
     metadata: [MetadataInput!]
 
     """Client-side generated data required to finalize the payment."""
@@ -13627,10 +13631,18 @@ type Mutation {
     """ID of a checkout that will be converted to an order."""
     id: ID!
 
-    """Fields required to update the object's metadata."""
+    """
+    Fields required to update the object's metadata.
+    
+    Added in Saleor 3.8.
+    """
     metadata: [MetadataInput!]
 
-    """Fields required to update the object's private metadata."""
+    """
+    Fields required to update the object's private metadata.
+    
+    Added in Saleor 3.8.
+    """
     privateMetadata: [MetadataInput!]
 
     """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13217,7 +13217,7 @@ type Mutation {
     id: ID
 
     """
-    Fields required to update the object's metadata.
+    Fields required to update the checkout metadata.
     
     Added in Saleor 3.8.
     """
@@ -13632,14 +13632,14 @@ type Mutation {
     id: ID!
 
     """
-    Fields required to update the object's metadata.
+    Fields required to update the checkout metadata.
     
     Added in Saleor 3.8.
     """
     metadata: [MetadataInput!]
 
     """
-    Fields required to update the object's private metadata.
+    Fields required to update the checkout private metadata.
     
     Added in Saleor 3.8.
     """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13222,9 +13222,6 @@ type Mutation {
     """Client-side generated data required to finalize the payment."""
     paymentData: JSONString
 
-    """Fields required to update the object's private metadata."""
-    privateMetadata: [MetadataInput!]
-
     """
     URL of a view where users should be redirected to see the order details. URL in RFC 1808 format.
     """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13216,8 +13216,14 @@ type Mutation {
     """
     id: ID
 
+    """Fields required to update the object's metadata."""
+    metadata: [MetadataInput!]
+
     """Client-side generated data required to finalize the payment."""
     paymentData: JSONString
+
+    """Fields required to update the object's private metadata."""
+    privateMetadata: [MetadataInput!]
 
     """
     URL of a view where users should be redirected to see the order details. URL in RFC 1808 format.
@@ -13623,6 +13629,12 @@ type Mutation {
   orderCreateFromCheckout(
     """ID of a checkout that will be converted to an order."""
     id: ID!
+
+    """Fields required to update the object's metadata."""
+    metadata: [MetadataInput!]
+
+    """Fields required to update the object's private metadata."""
+    privateMetadata: [MetadataInput!]
 
     """
     Determines if checkout should be removed after creating an order. Default true.


### PR DESCRIPTION
I want to merge this change because it adds possibility to update `metadata` directly in `checkoutComplete` and `OrderCreateFromCheckout` mutations.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
