### PR TITLE
Add missing Saleor versions to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,12 +22,16 @@ assignees: ''
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **System information**
-<!-- Provide the version of Saleor or whether you're using it from the `main` branch. If using Saleor Dashboard or Storefront, provide their versions too. -->
-Saleor version:
+<!--
+Provide the version of Saleor or whether you're using it from the `main` branch. If using Saleor Dashboard or Storefront, provide their versions too. -->
+Saleor core version:
 - [ ] dev (current main)
-- [ ] 3.0
-- [ ] 2.11
-- [ ] 2.10
+- [ ] 3.6
+- [ ] 3.5
+- [ ] 3.4
+- [ ] 3.3
+- [ ] 3.2
+- [ ] 3.1
 
 Operating system:
 - [ ] Windows

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,8 +22,7 @@ assignees: ''
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **System information**
-<!--
-Provide the version of Saleor or whether you're using it from the `main` branch. If using Saleor Dashboard or Storefront, provide their versions too. -->
+<!-- Provide the version of Saleor or whether you're using it from the `main` branch. If using Saleor Dashboard or Storefront, provide their versions too. -->
 Saleor core version:
 - [ ] dev (current main)
 - [ ] 3.6


### PR DESCRIPTION
<3.1 is no longer supported >3.0 were missing

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
