### PR TITLE
Add ability to set tax config in Avalara plugin 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable, unreleased changes to this project will be documented in this file.
 
 # 3.7.0 [Unreleased]
 
+### Other changes
+
+- Fix situation when Payment Gateway try to save to long error message - #10402 by @fowczarek
+- Replaced `context.app` lazy object with a dataloader.
+- Add support for bcrypt password hashes - #10346 by @pkucmus
+- Add ability to set taxes configuration per channel in the Avatax plugin - #10445 by @mociepka
+
 # 3.6.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable, unreleased changes to this project will be documented in this file.
 
 # 3.7.0 [Unreleased]
 
-### Other changes
-
-- Fix situation when Payment Gateway try to save to long error message - #10402 by @fowczarek
-- Replaced `context.app` lazy object with a dataloader.
-- Add support for bcrypt password hashes - #10346 by @pkucmus
-- Add ability to set taxes configuration per channel in the Avatax plugin - #10445 by @mociepka
-
 # 3.6.0
 
 ### Breaking changes
@@ -71,11 +64,13 @@ All notable, unreleased changes to this project will be documented in this file.
   - Add option to calculate taxes via webhooks more info in docs
 
 ### GraphQL API
+
 - Add synchronous tax calculation via webhooks - #9526 by @fowczarek, @mateuszgrzyb, @stnatic
   - Add `CHECKOUT_CALCULATE_TAXES` and `ORDER_CALCULATE_TAXES` to `WebhookEventTypeSyncEnum`
 - Add descriptions for some filters - #10240 by @dekoza
 
 ### Plugins
+
 - Add synchronous tax calculation via webhooks - #9526 by @fowczarek, @mateuszgrzyb, @stnatic
   - Add new method to plugin manager:
     - `get_taxes_for_checkout`

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -60,6 +60,16 @@ class AvataxConfiguration:
     company_name: str = "DEFAULT"
     autocommit: bool = False
     shipping_tax_code: str = ""
+    override_global_tax: bool = False
+    include_taxes_in_prices: bool = True
+
+    @property
+    def tax_included(self) -> bool:
+        return (
+            self.include_taxes_in_prices
+            if self.override_global_tax
+            else Site.objects.get_current().settings.include_taxes_in_prices
+        )
 
 
 class TransactionType:
@@ -208,15 +218,13 @@ def append_line_to_data(
     amount: Decimal,
     tax_code: str,
     item_code: str,
+    tax_included: bool,
     name: str = None,
-    tax_included: Optional[bool] = None,
     discounted: Optional[bool] = False,
     tax_override_data: Optional[dict] = None,
     ref1: Optional[str] = None,
     ref2: Optional[str] = None,
 ):
-    if tax_included is None:
-        tax_included = Site.objects.get_current().settings.include_taxes_in_prices
     line_data = {
         "quantity": quantity,
         "amount": str(amount),
@@ -240,6 +248,7 @@ def append_shipping_to_data(
     data: List[Dict],
     shipping_price_amount: Optional[Decimal],
     shipping_tax_code: str,
+    tax_included: bool,
     discounted: Optional[bool] = False,
 ):
     charge_taxes_on_shipping = (
@@ -252,6 +261,7 @@ def append_shipping_to_data(
             amount=shipping_price_amount,
             tax_code=shipping_tax_code,
             item_code="Shipping",
+            tax_included=tax_included,
             discounted=discounted,
         )
 
@@ -260,11 +270,11 @@ def get_checkout_lines_data(
     checkout_info: "CheckoutInfo",
     lines_info: Iterable["CheckoutLineInfo"],
     config: AvataxConfiguration,
+    tax_included: bool,
     discounts=None,
 ) -> List[Dict[str, Union[str, int, bool, None]]]:
     data: List[Dict[str, Union[str, int, bool, None]]] = []
     channel = checkout_info.channel
-    tax_included = Site.objects.get_current().settings.include_taxes_in_prices
     voucher = checkout_info.voucher
     is_entire_order_discount = (
         voucher.type == VoucherType.ENTIRE_ORDER
@@ -336,6 +346,7 @@ def get_checkout_lines_data(
             data,
             price.amount if price else None,
             config.shipping_tax_code,
+            tax_included,
             is_shipping_discount,
         )
 
@@ -343,7 +354,7 @@ def get_checkout_lines_data(
 
 
 def get_order_lines_data(
-    order: "Order", config: AvataxConfiguration, discounted: bool
+    order: "Order", config: AvataxConfiguration, tax_included: bool, discounted: bool
 ) -> List[Dict[str, Union[str, int, bool, None]]]:
     data: List[Dict[str, Union[str, int, bool, None]]] = []
     lines = order.lines.prefetch_related(
@@ -351,7 +362,6 @@ def get_order_lines_data(
         "variant__product__collections",
         "variant__product__product_type",
     ).filter(variant__product__charge_taxes=True)
-    tax_included = Site.objects.get_current().settings.include_taxes_in_prices
     for line in lines:
         if not line.variant:
             continue
@@ -407,7 +417,11 @@ def get_order_lines_data(
             type=OrderDiscountType.MANUAL
         ).exists()
         append_shipping_to_data(
-            data, shipping_price, config.shipping_tax_code, shipping_discounted
+            data,
+            shipping_price,
+            config.shipping_tax_code,
+            tax_included,
+            shipping_discounted,
         )
     return data
 
@@ -461,12 +475,15 @@ def generate_request_data_from_checkout(
     checkout_info: "CheckoutInfo",
     lines_info: Iterable["CheckoutLineInfo"],
     config: AvataxConfiguration,
+    tax_included: bool,
     transaction_token=None,
     transaction_type=TransactionType.ORDER,
     discounts=None,
 ):
     address = checkout_info.shipping_address or checkout_info.billing_address
-    lines = get_checkout_lines_data(checkout_info, lines_info, config, discounts)
+    lines = get_checkout_lines_data(
+        checkout_info, lines_info, config, tax_included, discounts
+    )
     voucher = checkout_info.voucher
     # for apply_once_per_order vouchers the discount is already applied on lines
     discount_amount = (
@@ -535,16 +552,19 @@ def get_cached_response_or_fetch(
 def get_checkout_tax_data(
     checkout_info: "CheckoutInfo",
     lines_info: Iterable["CheckoutLineInfo"],
+    tax_included: bool,
     discounts,
     config: AvataxConfiguration,
 ) -> Dict[str, Any]:
     data = generate_request_data_from_checkout(
-        checkout_info, lines_info, config, discounts=discounts
+        checkout_info, lines_info, config, tax_included, discounts=discounts
     )
     return get_cached_response_or_fetch(data, str(checkout_info.checkout.token), config)
 
 
-def get_order_request_data(order: "Order", config: AvataxConfiguration):
+def get_order_request_data(
+    order: "Order", config: AvataxConfiguration, tax_included: bool
+):
     address = order.shipping_address or order.billing_address
     transaction = (
         TransactionType.INVOICE
@@ -553,7 +573,9 @@ def get_order_request_data(order: "Order", config: AvataxConfiguration):
     )
     discount_amount = get_total_order_discount_excluding_shipping(order).amount
     discounted_lines = discount_amount != Decimal("0")
-    lines = get_order_lines_data(order, config, discounted=discounted_lines)
+    lines = get_order_lines_data(
+        order, config, tax_included, discounted=discounted_lines
+    )
     data = generate_request_data(
         transaction_type=transaction,
         lines=lines,
@@ -568,9 +590,9 @@ def get_order_request_data(order: "Order", config: AvataxConfiguration):
 
 
 def get_order_tax_data(
-    order: "Order", config: AvataxConfiguration, force_refresh=False
+    order: "Order", config: AvataxConfiguration, tax_included: bool, force_refresh=False
 ) -> Dict[str, Any]:
-    data = get_order_request_data(order, config)
+    data = get_order_request_data(order, config, tax_included)
     response = get_cached_response_or_fetch(
         data, "order_%s" % order.id, config, force_refresh
     )

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -6,7 +6,6 @@ from urllib.parse import urljoin
 
 import opentracing
 import opentracing.tags
-from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.utils.functional import SimpleLazyObject
 from django_countries import countries
@@ -72,6 +71,8 @@ class AvataxPlugin(BasePlugin):
         {"name": "from_country_area", "value": None},
         {"name": "from_postal_code", "value": None},
         {"name": "shipping_tax_code", "value": "FR000000"},
+        {"name": "override_global_tax", "value": False},
+        {"name": "include_taxes_in_prices", "value": True},
     ]
     CONFIG_STRUCTURE = {
         "Username or account": {
@@ -137,6 +138,16 @@ class AvataxPlugin(BasePlugin):
             ),
             "label": "Shipping tax code",
         },
+        "override_global_tax": {
+            "type": ConfigurationTypeField.BOOLEAN,
+            "help_text": "Used when setting per channel is needed.",
+            "label": "Override global tax settings.",
+        },
+        "include_taxes_in_prices": {
+            "type": ConfigurationTypeField.BOOLEAN,
+            "help_text": 'Applied only if "Override global tax settings" is on.',
+            "label": "All products prices are entered with tax included.",
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -159,6 +170,8 @@ class AvataxPlugin(BasePlugin):
             from_country_area=configuration["from_country_area"],
             from_postal_code=configuration["from_postal_code"],
             shipping_tax_code=configuration["shipping_tax_code"],
+            override_global_tax=configuration["override_global_tax"],
+            include_taxes_in_prices=configuration["include_taxes_in_prices"],
         )
 
     def _skip_plugin(
@@ -195,13 +208,11 @@ class AvataxPlugin(BasePlugin):
 
         if not _validate_checkout(checkout_info, lines):
             return checkout_total
-        response = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
+        response = get_checkout_tax_data(
+            checkout_info, lines, self.config.tax_included, discounts, self.config
+        )
         if not response or "error" in response:
             return checkout_total
-
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
 
         currency = checkout_info.checkout.currency
         taxed_total = zero_taxed_money(currency)
@@ -210,7 +221,7 @@ class AvataxPlugin(BasePlugin):
             taxed_line_total_data = self._calculate_checkout_line_total_price(
                 taxes_data=response,
                 item_code=line.variant.sku or line.variant.get_global_id(),
-                tax_included=tax_included,
+                tax_included=self.config.tax_included,
                 # for some cases we will need a base_value but no need to call it for
                 # each line
                 base_value=SimpleLazyObject(  # type:ignore
@@ -251,10 +262,7 @@ class AvataxPlugin(BasePlugin):
                 shipping_tax = Decimal(line["tax"])
                 break
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
-        if currency == "JPY" and tax_included():
+        if currency == "JPY" and self.config.tax_included:
             shipping_gross = Money(amount=shipping_price.amount, currency=currency)
             shipping_net = Money(
                 amount=shipping_gross.amount - shipping_tax, currency=currency
@@ -286,7 +294,9 @@ class AvataxPlugin(BasePlugin):
         if not _validate_checkout(checkout_info, lines):
             return base_shipping_price
 
-        response = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
+        response = get_checkout_tax_data(
+            checkout_info, lines, self.config.tax_included, discounts, self.config
+        )
         if not response or "error" in response:
             return base_shipping_price
 
@@ -321,6 +331,7 @@ class AvataxPlugin(BasePlugin):
             checkout_info,
             lines,
             self.config,
+            self.config.tax_included,
             transaction_token=str(checkout_info.checkout.token),
             transaction_type=TransactionType.ORDER,
             discounts=discounts,
@@ -354,7 +365,9 @@ class AvataxPlugin(BasePlugin):
     def order_created(self, order: "Order", previous_value: Any) -> Any:
         if not self.active or order.is_unconfirmed():
             return previous_value
-        request_data = get_order_request_data(order, self.config)
+        request_data = get_order_request_data(
+            order, self.config, self.config.tax_included
+        )
 
         transaction_url = urljoin(
             get_api_url(self.config.use_sandbox), "transactions/createoradjust"
@@ -386,17 +399,15 @@ class AvataxPlugin(BasePlugin):
         if not _validate_checkout(checkout_info, lines):
             return base_total
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
+        taxes_data = get_checkout_tax_data(
+            checkout_info, lines, self.config.tax_included, discounts, self.config
         )
-
-        taxes_data = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
         variant = checkout_line_info.variant
 
         return self._calculate_checkout_line_total_price(
             taxes_data,
             variant.sku or variant.get_global_id(),
-            tax_included,
+            self.config.tax_included,
             previous_value,
         )
 
@@ -404,7 +415,7 @@ class AvataxPlugin(BasePlugin):
     def _calculate_checkout_line_total_price(
         taxes_data: Dict[str, Any],
         item_code: str,
-        tax_included: Callable[[], bool],
+        tax_included: bool,
         base_value: TaxedMoney,
     ) -> TaxedMoney:
         if not taxes_data or "error" in taxes_data:
@@ -422,7 +433,7 @@ class AvataxPlugin(BasePlugin):
             discount_amount = Decimal(line.get("discountAmount", 0.0))
             net = Decimal(line["lineAmount"])
 
-            if currency == "JPY" and tax_included():
+            if currency == "JPY" and tax_included:
                 line_gross = base_value.gross
                 line_net = Money(amount=line_gross.amount - tax, currency=currency)
             else:
@@ -450,15 +461,11 @@ class AvataxPlugin(BasePlugin):
         if not _validate_order(order):
             return previous_value
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
-
         taxes_data = self._get_order_tax_data(order, previous_value)
         return self._calculate_order_line_total_price(
             taxes_data,
             variant.sku or variant.get_global_id(),
-            tax_included,
+            self.config.tax_included,
             previous_value,
         )
 
@@ -466,7 +473,7 @@ class AvataxPlugin(BasePlugin):
     def _calculate_order_line_total_price(
         taxes_data: Dict[str, Any],
         item_code: str,
-        tax_included: Callable[[], bool],
+        tax_included: bool,
         base_value: OrderTaxedPricesData,
     ) -> OrderTaxedPricesData:
         if not taxes_data or "error" in taxes_data:
@@ -485,7 +492,7 @@ class AvataxPlugin(BasePlugin):
             discount_amount = Decimal(line.get("discountAmount", 0.0))
             net = Decimal(line["lineAmount"])
 
-            if currency == "JPY" and tax_included():
+            if currency == "JPY" and tax_included:
                 line_gross = Money(
                     base_value.price_with_discounts.gross.amount - discount_amount,
                     currency,
@@ -525,18 +532,17 @@ class AvataxPlugin(BasePlugin):
         if not _validate_checkout(checkout_info, lines):
             return base_total
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
         variant = checkout_line_info.variant
 
         quantity = checkout_line_info.line.quantity
-        taxes_data = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
+        taxes_data = get_checkout_tax_data(
+            checkout_info, lines, self.config.tax_included, discounts, self.config
+        )
         default_total = previous_value * quantity
         taxed_total_price = self._calculate_checkout_line_total_price(
             taxes_data,
             variant.sku or variant.get_global_id(),
-            tax_included,
+            self.config.tax_included,
             default_total,
         )
         return taxed_total_price / quantity
@@ -552,10 +558,6 @@ class AvataxPlugin(BasePlugin):
         if not variant or (variant and not product.charge_taxes):
             return previous_value
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
-        )
-
         quantity = order_line.quantity
         taxes_data = self._get_order_tax_data(order, previous_value)
         default_total = OrderTaxedPricesData(
@@ -565,7 +567,7 @@ class AvataxPlugin(BasePlugin):
         taxed_total_prices_data = self._calculate_order_line_total_price(
             taxes_data,
             variant.sku or variant.get_global_id(),
-            tax_included,
+            self.config.tax_included,
             default_total,
         )
         return OrderTaxedPricesData(
@@ -575,7 +577,7 @@ class AvataxPlugin(BasePlugin):
         )
 
     def _calculate_order_shipping(
-        self, order, taxes_data, tax_included, previous_value
+        self, order, taxes_data, previous_value
     ) -> TaxedMoney:
         currency = taxes_data.get("currencyCode")
         for line in taxes_data.get("lines", []):
@@ -583,7 +585,7 @@ class AvataxPlugin(BasePlugin):
                 tax = Decimal(line.get("tax", 0.0))
                 discount_amount = Decimal(line.get("discountAmount", 0.0))
                 net = Decimal(line.get("lineAmount", 0.0)) - discount_amount
-                if currency == "JPY" and tax_included():
+                if currency == "JPY" and self.config.tax_included:
                     gross = previous_value.gross
                     net = Money(amount=gross.amount - tax, currency=currency)
                 else:
@@ -615,15 +617,11 @@ class AvataxPlugin(BasePlugin):
         if not _validate_order(order):
             return previous_value
 
-        taxes_data = get_order_tax_data(order, self.config, False)
-
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
+        taxes_data = get_order_tax_data(
+            order, self.config, self.config.tax_included, False
         )
 
-        return self._calculate_order_shipping(
-            order, taxes_data, tax_included, previous_value
-        )
+        return self._calculate_order_shipping(order, taxes_data, previous_value)
 
     def calculate_order_total(
         self,
@@ -638,10 +636,9 @@ class AvataxPlugin(BasePlugin):
         if not _validate_order(order):
             return order_total
 
-        tax_included = (
-            lambda: Site.objects.get_current().settings.include_taxes_in_prices
+        taxes_data = get_order_tax_data(
+            order, self.config, self.config.tax_included, False
         )
-        taxes_data = get_order_tax_data(order, self.config, False)
 
         currency = order.currency
         taxed_subtotal = zero_taxed_money(currency)
@@ -657,14 +654,14 @@ class AvataxPlugin(BasePlugin):
             taxed_line_total_data = self._calculate_order_line_total_price(
                 taxes_data,
                 line.product_sku or line.variant_name,
-                tax_included,
+                self.config.tax_included,
                 base_line_price,
             ).price_with_discounts
             taxed_subtotal += taxed_line_total_data
 
         base_shipping_price = base_order_calculations.base_order_shipping(order)
         shipping_price = self._calculate_order_shipping(
-            order, taxes_data, tax_included, base_shipping_price
+            order, taxes_data, base_shipping_price
         )
 
         taxed_total = taxed_subtotal + shipping_price
@@ -752,7 +749,7 @@ class AvataxPlugin(BasePlugin):
             return None
 
         response = get_checkout_tax_data(
-            checkout_info, lines_info, discounts, self.config
+            checkout_info, lines_info, self.config.tax_included, discounts, self.config
         )
         if not response or "error" in response:
             return None
@@ -769,7 +766,9 @@ class AvataxPlugin(BasePlugin):
         if not valid:
             return None
 
-        response = get_order_tax_data(order, self.config, False)
+        response = get_order_tax_data(
+            order, self.config, self.config.tax_included, False
+        )
         if not response or "error" in response:
             return None
 

--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -34,6 +34,8 @@ def plugin_configuration(db, channel_USD):
         from_country_area="",
         from_postal_code="53-601",
         shipping_tax_code="FR000000",
+        override_global_tax=False,
+        include_taxes_in_prices=True,
     ):
         channel = channel or channel_USD
         data = {
@@ -52,6 +54,8 @@ def plugin_configuration(db, channel_USD):
                 {"name": "from_country_area", "value": from_country_area},
                 {"name": "from_postal_code", "value": from_postal_code},
                 {"name": "shipping_tax_code", "value": shipping_tax_code},
+                {"name": "override_global_tax", "value": override_global_tax},
+                {"name": "include_taxes_in_prices", "value": include_taxes_in_prices},
             ],
         }
         configuration = PluginConfiguration.objects.create(

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -2581,7 +2581,9 @@ def test_checkout_needs_new_fetch(checkout_with_item, address, shipping_method):
     manager = get_plugins_manager()
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
-    checkout_data = generate_request_data_from_checkout(checkout_info, lines, config)
+    checkout_data = generate_request_data_from_checkout(
+        checkout_info, lines, config, tax_included=True
+    )
     assert taxes_need_new_fetch(checkout_data, None)
 
 
@@ -2600,7 +2602,9 @@ def test_taxes_need_new_fetch_uses_cached_data(checkout_with_item, address):
     manager = get_plugins_manager()
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
-    checkout_data = generate_request_data_from_checkout(checkout_info, lines, config)
+    checkout_data = generate_request_data_from_checkout(
+        checkout_info, lines, config, tax_included=True
+    )
     assert not taxes_need_new_fetch(checkout_data, (checkout_data, None))
 
 
@@ -3404,6 +3408,8 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         "from_country": conf["from_country"],
         "from_country_area": conf["from_country_area"],
         "shipping_tax_code": conf["shipping_tax_code"],
+        "override_global_tax": conf["override_global_tax"],
+        "include_taxes_in_prices": conf["include_taxes_in_prices"],
     }
 
     api_post_request_task_mock.assert_called_once_with(
@@ -3569,7 +3575,7 @@ def test_get_order_request_data_checks_when_taxes_are_included_to_price(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
     lines_data = request_data["createTransactionModel"]["lines"]
 
     assert all([line for line in lines_data if line["taxIncluded"] is True])
@@ -3610,7 +3616,9 @@ def test_get_order_request_data_for_line_with_already_included_taxes_in_price(
     )
 
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(
+        order_with_lines, config, tax_included=include_taxes_in_prices
+    )
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -3632,7 +3640,6 @@ def test_get_order_request_data_for_line_with_already_included_taxes_in_price(
 def test_get_order_request_data_confirmed_order_with_voucher(
     order_with_lines, shipping_zone, site_settings, address, voucher
 ):
-    site_settings.include_taxes_in_prices = True
     site_settings.company_address = address
     site_settings.save()
     method = shipping_zone.shipping_methods.get()
@@ -3672,7 +3679,7 @@ def test_get_order_request_data_confirmed_order_with_voucher(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
     lines_data = request_data["createTransactionModel"]["lines"]
 
     # extra one from shipping data
@@ -3719,7 +3726,7 @@ def test_get_order_request_data_confirmed_order_with_sale(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
     lines_data = request_data["createTransactionModel"]["lines"]
 
     # extra one from shipping data
@@ -3773,7 +3780,7 @@ def test_get_order_request_data_draft_order_with_voucher(
     )
 
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -3837,7 +3844,7 @@ def test_get_order_request_data_draft_order_with_shipping_voucher(
     )
 
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -3857,7 +3864,6 @@ def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
     """Ensure that when order has shipping voucher with price bigger than shipping
     price, the shipping price will not be negative."""
     # given
-    site_settings.include_taxes_in_prices = True
     site_settings.company_address = address
     site_settings.save()
     method = shipping_zone.shipping_methods.get()
@@ -3903,7 +3909,7 @@ def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
     )
 
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -3957,7 +3963,7 @@ def test_get_order_request_data_draft_order_with_sale(
     )
 
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -3981,10 +3987,10 @@ def test_get_order_tax_data(
     get_cached_response_or_fetch_mock.return_value = return_value
 
     # when
-    response = get_order_tax_data(order, conf)
+    response = get_order_tax_data(order, conf, tax_included=True)
 
     # then
-    get_order_request_data_mock.assert_called_once_with(order, conf)
+    get_order_request_data_mock.assert_called_once_with(order, conf, True)
     assert response == return_value
 
 
@@ -4004,7 +4010,7 @@ def test_get_order_tax_data_raised_error(
 
     # when
     with pytest.raises(TaxError) as e:
-        get_order_tax_data(order, conf)
+        get_order_tax_data(order, conf, tax_included=True)
 
     # then
     assert e._excinfo[1].args[0] == return_value["error"]
@@ -4094,7 +4100,9 @@ def test_get_checkout_lines_data_sets_different_tax_code_for_zero_amount(
     config = avatax_config
 
     # when
-    lines_data = get_checkout_lines_data(checkout_info, lines, config)
+    lines_data = get_checkout_lines_data(
+        checkout_info, lines, config, tax_included=True
+    )
 
     # then
     assert lines_data[0]["amount"] == "0.00"
@@ -4127,7 +4135,9 @@ def test_get_checkout_lines_data_sets_different_tax_code_only_for_zero_amount(
     config = avatax_config
 
     # when
-    lines_data = get_checkout_lines_data(checkout_info, lines, config)
+    lines_data = get_checkout_lines_data(
+        checkout_info, lines, config, tax_included=True
+    )
 
     # then
     assert lines_data[0]["amount"] == "11.00"
@@ -4168,7 +4178,9 @@ def test_get_checkout_lines_data_with_collection_point(
     config = avatax_config
 
     # when
-    lines_data = get_checkout_lines_data(checkout_info, lines, config)
+    lines_data = get_checkout_lines_data(
+        checkout_info, lines, config, tax_included=True
+    )
 
     # then
     assert len(lines_data) == checkout_with_item.lines.count()
@@ -4208,7 +4220,9 @@ def test_get_checkout_lines_data_with_shipping_method(
     config = avatax_config
 
     # when
-    lines_data = get_checkout_lines_data(checkout_info, lines, config)
+    lines_data = get_checkout_lines_data(
+        checkout_info, lines, config, tax_included=True
+    )
 
     # then
     assert len(lines_data) == checkout_with_item.lines.count() + 1
@@ -4249,7 +4263,9 @@ def test_get_order_lines_data_sets_different_tax_code_for_zero_amount(
     )
 
     # when
-    lines_data = get_order_lines_data(order_with_lines, config, discounted=False)
+    lines_data = get_order_lines_data(
+        order_with_lines, config, tax_included=True, discounted=False
+    )
 
     # then
     assert lines_data[0]["amount"] == "0.000"
@@ -4291,7 +4307,7 @@ def test_get_order_lines_data_with_discounted(
     )
 
     # when
-    lines_data = get_order_lines_data(order, config, discounted=True)
+    lines_data = get_order_lines_data(order, config, tax_included=True, discounted=True)
 
     # then
     assert len(lines_data) == 1
@@ -4327,7 +4343,9 @@ def test_get_order_lines_data_sets_different_tax_code_only_for_zero_amount(
     config = avatax_config
 
     # when
-    lines_data = get_order_lines_data(order_with_lines, config, discounted=False)
+    lines_data = get_order_lines_data(
+        order_with_lines, config, tax_included=True, discounted=False
+    )
 
     # then
     assert lines_data[0]["amount"] == "10.000"
@@ -4434,3 +4452,40 @@ def test_assign_tax_code_to_object_meta_no_obj_id(
         META_CODE_KEY: tax_code,
         META_DESCRIPTION_KEY: description,
     }
+
+
+@pytest.mark.parametrize(
+    "global_include_taxes_in_prices, override_global_tax, "
+    "include_taxes_in_prices, expected_tax_included",
+    [(True, False, False, True), (True, True, True, True), (True, True, False, False)],
+)
+@patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_plugin_tax_override_setting(
+    api_post_request_task_mock,
+    global_include_taxes_in_prices,
+    override_global_tax,
+    include_taxes_in_prices,
+    expected_tax_included,
+    site_settings,
+    order_line,
+    plugin_configuration,
+):
+    # given
+    site_settings.include_taxes_in_prices = global_include_taxes_in_prices
+    site_settings.save()
+
+    plugin_configuration(
+        override_global_tax=override_global_tax,
+        include_taxes_in_prices=include_taxes_in_prices,
+    )
+
+    manager = get_plugins_manager()
+
+    # when
+    manager.order_created(order_line.order)
+
+    # then
+    transaction = api_post_request_task_mock.call_args[0][1]["createTransactionModel"]
+    transaction_line = transaction["lines"][0]
+    assert transaction_line["taxIncluded"] == expected_tax_included

--- a/saleor/plugins/avatax/tests/test_avatax_caching.py
+++ b/saleor/plugins/avatax/tests/test_avatax_caching.py
@@ -33,7 +33,7 @@ def test_calculate_checkout_total_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -94,7 +94,7 @@ def test_calculate_checkout_total_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("72.2", "USD"), gross=Money("75", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -122,7 +122,7 @@ def test_calculate_checkout_subtotal_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -183,7 +183,7 @@ def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("64.07", "USD"), gross=Money("65", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -211,7 +211,7 @@ def test_calculate_checkout_shipping_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -272,7 +272,7 @@ def test_calculate_checkout_shipping_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("8.13", "USD"), gross=Money("10", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -301,7 +301,7 @@ def test_calculate_checkout_line_total_use_cache(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -363,7 +363,7 @@ def test_calculate_checkout_line_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("4.07", "USD"), gross=Money("5", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -392,7 +392,7 @@ def test_calculate_checkout_line_unit_price_use_cache(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -466,7 +466,7 @@ def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("4.07", "USD"), gross=Money("5", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -495,7 +495,7 @@ def test_get_checkout_line_tax_rate_use_cache(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -574,7 +574,7 @@ def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
     assert result == Decimal("0.36")
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -602,7 +602,7 @@ def test_get_checkout_shipping_tax_rate_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -665,6 +665,6 @@ def test_get_checkout_shipping_tax_rate_save_avatax_response_in_cache(
     assert result == Decimal("0.46")
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)

--- a/saleor/plugins/avatax/tests/test_tasks.py
+++ b/saleor/plugins/avatax/tests/test_tasks.py
@@ -30,7 +30,7 @@ def test_api_post_request_task_sends_request(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     transaction_url = urljoin(
         get_api_url(config.use_sandbox), "transactions/createoradjust"
@@ -62,7 +62,7 @@ def test_api_post_request_task_creates_order_event(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     transaction_url = urljoin(
         get_api_url(config.use_sandbox), "transactions/createoradjust"
@@ -95,7 +95,7 @@ def test_api_post_request_task_missing_response(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     transaction_url = urljoin(
         get_api_url(config.use_sandbox), "transactions/createoradjust"


### PR DESCRIPTION
Port PR #10445 to 3.6

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
