### PR TITLE
Fix sending the old data in `productChannelListingUpdate` mutation

### DIFF
--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -332,12 +332,12 @@ class ProductChannelListingUpdate(BaseChannelListingMutation):
     def save(cls, info, product: "ProductModel", cleaned_input: Dict):
         cls.update_channels(product, cleaned_input.get("update_channels", []))
         cls.remove_channels(product, cleaned_input.get("remove_channels", []))
+        product = ProductModel.objects.prefetched_for_webhook().get(pk=product.pk)
         transaction.on_commit(lambda: info.context.plugins.product_updated(product))
 
     @classmethod
     def perform_mutation(cls, _root, info, id, input):
-        qs = ProductModel.objects.prefetched_for_webhook()
-        product = cls.get_node_or_error(info, id, only_type=Product, field="id", qs=qs)
+        product = cls.get_node_or_error(info, id, only_type=Product, field="id")
         errors = defaultdict(list)
 
         cleaned_input = cls.clean_channels(

--- a/saleor/graphql/product/tests/test_product_channel_listing_update.py
+++ b/saleor/graphql/product/tests/test_product_channel_listing_update.py
@@ -279,12 +279,11 @@ def test_product_channel_listing_update_trigger_webhook_product_updated(
     product,
     permission_manage_products,
     channel_USD,
-    channel_PLN,
 ):
     # given
     publication_date = datetime.datetime.now(pytz.utc)
     product_id = graphene.Node.to_global_id("Product", product.pk)
-    channel_id = graphene.Node.to_global_id("Channel", channel_PLN.id)
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     available_for_purchase_date = datetime.datetime(2007, 1, 1, tzinfo=pytz.utc)
     variables = {
         "id": product_id,
@@ -312,6 +311,10 @@ def test_product_channel_listing_update_trigger_webhook_product_updated(
 
     # then
     mock_product_updated.assert_called_once_with(product)
+    listings = mock_product_updated.call_args.args[0].channel_listings.all()
+    for listing in listings:
+        if listing.channel == channel_USD:
+            assert listing.available_for_purchase_at == available_for_purchase_date
 
 
 def test_product_channel_listing_update_as_app(


### PR DESCRIPTION
Fix the problem with sending the old product data when updating channel listings with the use of `productChannelListingUpdate` mutation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
