### PR TITLE
Use dataloader for discounts instead of lazy object

### DIFF
--- a/saleor/core/middleware.py
+++ b/saleor/core/middleware.py
@@ -10,7 +10,6 @@ from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 from django.utils.translation import get_language
 
-from ..discount.utils import fetch_discounts
 from ..graphql.utils import get_user_or_app_from_context
 from ..plugins.manager import PluginsManager, get_plugins_manager
 from . import analytics
@@ -53,18 +52,6 @@ def request_time(get_response):
         return get_response(request)
 
     return _stamp_request
-
-
-def discounts(get_response):
-    """Assign active discounts to `request.discounts`."""
-
-    def _discounts_middleware(request):
-        request.discounts = SimpleLazyObject(
-            lambda: fetch_discounts(request.request_time)
-        )
-        return get_response(request)
-
-    return _discounts_middleware
 
 
 def site(get_response):

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -18,7 +18,7 @@ from ..core.dataloaders import DataLoader
 from ..discount.dataloaders import (
     VoucherByCodeLoader,
     VoucherInfoByVoucherCodeLoader,
-    load_request_discounts,
+    load_discounts,
 )
 from ..product.dataloaders import (
     CollectionsByVariantIdLoader,
@@ -107,7 +107,7 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader):
                         voucher.type == VoucherType.SPECIFIC_PRODUCT
                         or voucher.apply_once_per_order
                     ):
-                        discounts = load_request_discounts(self.context)
+                        discounts = load_discounts(self.context)
                         apply_voucher_to_checkout_line(
                             voucher_info=voucher_info,
                             checkout=checkout,
@@ -303,7 +303,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                         )
 
                         manager = self.context.plugins
-                        discounts = load_request_discounts(self.context)
+                        discounts = load_discounts(self.context)
                         shipping_method_listings = [
                             listing
                             for channel_listings in listings_for_channels

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -15,7 +15,11 @@ from ...discount import VoucherType
 from ...payment.models import TransactionItem
 from ..account.dataloaders import AddressByIdLoader, UserByUserIdLoader
 from ..core.dataloaders import DataLoader
-from ..discount.dataloaders import VoucherByCodeLoader, VoucherInfoByVoucherCodeLoader
+from ..discount.dataloaders import (
+    VoucherByCodeLoader,
+    VoucherInfoByVoucherCodeLoader,
+    load_request_discounts,
+)
 from ..product.dataloaders import (
     CollectionsByVariantIdLoader,
     ProductByVariantIdLoader,
@@ -103,11 +107,12 @@ class CheckoutLinesInfoByCheckoutTokenLoader(DataLoader):
                         voucher.type == VoucherType.SPECIFIC_PRODUCT
                         or voucher.apply_once_per_order
                     ):
+                        discounts = load_request_discounts(self.context)
                         apply_voucher_to_checkout_line(
                             voucher_info=voucher_info,
                             checkout=checkout,
                             lines_info=lines_info_map[checkout.pk],
-                            discounts=self.context.discounts,
+                            discounts=discounts,
                         )
                 return [lines_info_map[key] for key in keys]
 
@@ -298,7 +303,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                         )
 
                         manager = self.context.plugins
-                        discounts = self.context.discounts
+                        discounts = load_request_discounts(self.context)
                         shipping_method_listings = [
                             listing
                             for channel_listings in listings_for_channels

--- a/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
@@ -13,6 +13,7 @@ from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
+from ...discount.dataloaders import load_request_discounts
 from ..types import Checkout
 from .utils import get_checkout, update_checkout_shipping_method_if_invalid
 
@@ -62,7 +63,7 @@ class CheckoutAddPromoCode(BaseMutation):
         validate_checkout_email(checkout)
 
         manager = info.context.plugins
-        discounts = info.context.discounts
+        discounts = load_request_discounts(info.context)
 
         lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
         if unavailable_variant_pks:

--- a/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
@@ -13,7 +13,7 @@ from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ..types import Checkout
 from .utils import get_checkout, update_checkout_shipping_method_if_invalid
 
@@ -63,7 +63,7 @@ class CheckoutAddPromoCode(BaseMutation):
         validate_checkout_email(checkout)
 
         manager = info.context.plugins
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
 
         lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
         if unavailable_variant_pks:

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -17,7 +17,7 @@ from ...core.descriptions import (
 )
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ..types import Checkout
 from .checkout_create import CheckoutAddressValidationRules
 from .checkout_shipping_address_update import CheckoutShippingAddressUpdate
@@ -97,7 +97,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
                 checkout, billing_address
             )
             lines, _ = fetch_checkout_lines(checkout)
-            discounts = load_request_discounts(info.context)
+            discounts = load_discounts(info.context)
             checkout_info = fetch_checkout_info(
                 checkout, lines, discounts, info.context.plugins
             )

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -17,6 +17,7 @@ from ...core.descriptions import (
 )
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
+from ...discount.dataloaders import load_request_discounts
 from ..types import Checkout
 from .checkout_create import CheckoutAddressValidationRules
 from .checkout_shipping_address_update import CheckoutShippingAddressUpdate
@@ -96,14 +97,15 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
                 checkout, billing_address
             )
             lines, _ = fetch_checkout_lines(checkout)
+            discounts = load_request_discounts(info.context)
             checkout_info = fetch_checkout_info(
-                checkout, lines, info.context.discounts, info.context.plugins
+                checkout, lines, discounts, info.context.plugins
             )
             invalidate_prices_updated_fields = invalidate_checkout_prices(
                 checkout_info,
                 lines,
                 info.context.plugins,
-                info.context.discounts,
+                discounts,
                 recalculate_discount=False,
                 save=False,
             )

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -26,6 +26,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...core.validators import validate_one_of_args_is_in_mutation
+from ...discount.dataloaders import load_request_discounts
 from ...order.types import Order
 from ...utils import get_user_or_app_from_context
 from ..types import Checkout
@@ -232,9 +233,8 @@ class CheckoutComplete(BaseMutation, I18nMixin):
                         )
                     }
                 )
-            checkout_info = fetch_checkout_info(
-                checkout, lines, info.context.discounts, manager
-            )
+            discounts = load_request_discounts(info.context)
+            checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
 
             cls.validate_checkout_addresses(
                 lines, checkout_info.shipping_address, checkout_info.billing_address
@@ -254,7 +254,7 @@ class CheckoutComplete(BaseMutation, I18nMixin):
                 lines=lines,
                 payment_data=data.get("payment_data", {}),
                 store_source=store_source,
-                discounts=info.context.discounts,
+                discounts=discounts,
                 user=customer,
                 app=load_app(info.context),
                 site_settings=info.context.site.settings,

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -26,7 +26,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...core.validators import validate_one_of_args_is_in_mutation
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ...order.types import Order
 from ...utils import get_user_or_app_from_context
 from ..types import Checkout
@@ -233,7 +233,7 @@ class CheckoutComplete(BaseMutation, I18nMixin):
                         )
                     }
                 )
-            discounts = load_request_discounts(info.context)
+            discounts = load_discounts(info.context)
             checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
 
             cls.validate_checkout_addresses(

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -32,7 +32,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...core.utils import from_global_id_or_error
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ...shipping.types import ShippingMethod
 from ...warehouse.types import Warehouse
 from ..types import Checkout
@@ -89,7 +89,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             checkout_info, lines, shipping_method=delivery_method, collection_point=None
         )
 
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         cls._update_delivery_method(
             manager,
             checkout_info,
@@ -125,7 +125,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             checkout_info, lines, shipping_method=delivery_method, collection_point=None
         )
 
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         cls._update_delivery_method(
             manager,
             checkout_info,
@@ -154,7 +154,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             shipping_method=None,
             collection_point=collection_point,
         )
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         cls._update_delivery_method(
             manager,
             checkout_info,
@@ -294,7 +294,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             )
         type_name = cls._resolve_delivery_method_type(delivery_method_id)
 
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
         if type_name == "Warehouse":
             return cls.perform_on_collection_point(

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -32,6 +32,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...core.utils import from_global_id_or_error
+from ...discount.dataloaders import load_request_discounts
 from ...shipping.types import ShippingMethod
 from ...warehouse.types import Warehouse
 from ..types import Checkout
@@ -88,11 +89,12 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             checkout_info, lines, shipping_method=delivery_method, collection_point=None
         )
 
+        discounts = load_request_discounts(info.context)
         cls._update_delivery_method(
             manager,
             checkout_info,
             lines,
-            info.context.discounts,
+            discounts,
             shipping_method=shipping_method,
             external_shipping_method=None,
             collection_point=None,
@@ -123,11 +125,12 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             checkout_info, lines, shipping_method=delivery_method, collection_point=None
         )
 
+        discounts = load_request_discounts(info.context)
         cls._update_delivery_method(
             manager,
             checkout_info,
             lines,
-            info.context.discounts,
+            discounts,
             shipping_method=None,
             external_shipping_method=delivery_method,
             collection_point=None,
@@ -151,11 +154,12 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             shipping_method=None,
             collection_point=collection_point,
         )
+        discounts = load_request_discounts(info.context)
         cls._update_delivery_method(
             manager,
             checkout_info,
             lines,
-            info.context.discounts,
+            discounts,
             shipping_method=None,
             external_shipping_method=None,
             collection_point=collection_point,
@@ -290,9 +294,8 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             )
         type_name = cls._resolve_delivery_method_type(delivery_method_id)
 
-        checkout_info = fetch_checkout_info(
-            checkout, lines, info.context.discounts, manager
-        )
+        discounts = load_request_discounts(info.context)
+        checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
         if type_name == "Warehouse":
             return cls.perform_on_collection_point(
                 info, delivery_method_id, checkout_info, lines, checkout, manager

--- a/saleor/graphql/checkout/mutations/checkout_line_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_line_delete.py
@@ -7,6 +7,7 @@ from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
+from ...discount.dataloaders import load_request_discounts
 from ..types import Checkout, CheckoutLine
 from .utils import get_checkout, update_checkout_shipping_method_if_invalid
 
@@ -58,13 +59,10 @@ class CheckoutLineDelete(BaseMutation):
 
         manager = info.context.plugins
         lines, _ = fetch_checkout_lines(checkout)
-        checkout_info = fetch_checkout_info(
-            checkout, lines, info.context.discounts, manager
-        )
+        discounts = load_request_discounts(info.context)
+        checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
-        invalidate_checkout_prices(
-            checkout_info, lines, manager, info.context.discounts, save=True
-        )
+        invalidate_checkout_prices(checkout_info, lines, manager, discounts, save=True)
         manager.checkout_updated(checkout)
 
         return CheckoutLineDelete(checkout=checkout)

--- a/saleor/graphql/checkout/mutations/checkout_line_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_line_delete.py
@@ -7,7 +7,7 @@ from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ..types import Checkout, CheckoutLine
 from .utils import get_checkout, update_checkout_shipping_method_if_invalid
 
@@ -59,7 +59,7 @@ class CheckoutLineDelete(BaseMutation):
 
         manager = info.context.plugins
         lines, _ = fetch_checkout_lines(checkout)
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
         invalidate_checkout_prices(checkout_info, lines, manager, discounts, save=True)

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -16,6 +16,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError, NonNullList
 from ...core.validators import validate_variants_available_in_channel
+from ...discount.dataloaders import load_request_discounts
 from ...product.types import ProductVariant
 from ..types import Checkout
 from .checkout_create import CheckoutLineInput
@@ -177,7 +178,7 @@ class CheckoutLinesAdd(BaseMutation):
             error_class=CheckoutErrorCode,
         )
 
-        discounts = info.context.discounts
+        discounts = load_request_discounts(info.context)
         manager = info.context.plugins
 
         variants = cls._get_variants_from_lines_input(lines)

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -16,7 +16,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError, NonNullList
 from ...core.validators import validate_variants_available_in_channel
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ...product.types import ProductVariant
 from ..types import Checkout
 from .checkout_create import CheckoutLineInput
@@ -178,7 +178,7 @@ class CheckoutLinesAdd(BaseMutation):
             error_class=CheckoutErrorCode,
         )
 
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         manager = info.context.plugins
 
         variants = cls._get_variants_from_lines_input(lines)

--- a/saleor/graphql/checkout/mutations/checkout_lines_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_delete.py
@@ -8,6 +8,7 @@ from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError, NonNullList
+from ...discount.dataloaders import load_request_discounts
 from ...utils import resolve_global_ids_to_primary_keys
 from ..types import Checkout
 from .utils import get_checkout, update_checkout_shipping_method_if_invalid
@@ -77,13 +78,10 @@ class CheckoutLinesDelete(BaseMutation):
         lines, _ = fetch_checkout_lines(checkout)
 
         manager = info.context.plugins
-        checkout_info = fetch_checkout_info(
-            checkout, lines, info.context.discounts, manager
-        )
+        discounts = load_request_discounts(info.context)
+        checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
-        invalidate_checkout_prices(
-            checkout_info, lines, manager, info.context.discounts, save=True
-        )
+        invalidate_checkout_prices(checkout_info, lines, manager, discounts, save=True)
         manager.checkout_updated(checkout)
 
         return CheckoutLinesDelete(checkout=checkout)

--- a/saleor/graphql/checkout/mutations/checkout_lines_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_delete.py
@@ -8,7 +8,7 @@ from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError, NonNullList
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ...utils import resolve_global_ids_to_primary_keys
 from ..types import Checkout
 from .utils import get_checkout, update_checkout_shipping_method_if_invalid
@@ -78,7 +78,7 @@ class CheckoutLinesDelete(BaseMutation):
         lines, _ = fetch_checkout_lines(checkout)
 
         manager = info.context.plugins
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
         invalidate_checkout_prices(checkout_info, lines, manager, discounts, save=True)

--- a/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
@@ -18,6 +18,7 @@ from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...core.utils import from_global_id_or_error
 from ...core.validators import validate_one_of_args_is_in_mutation
+from ...discount.dataloaders import load_request_discounts
 from ...discount.types import Voucher
 from ...giftcard.types import GiftCard
 from ..types import Checkout
@@ -84,9 +85,8 @@ class CheckoutRemovePromoCode(BaseMutation):
         )
 
         manager = info.context.plugins
-        checkout_info = fetch_checkout_info(
-            checkout, [], info.context.discounts, manager
-        )
+        discounts = load_request_discounts(info.context)
+        checkout_info = fetch_checkout_info(checkout, [], discounts, manager)
 
         removed = False
         if promo_code:
@@ -102,7 +102,7 @@ class CheckoutRemovePromoCode(BaseMutation):
                 checkout_info,
                 lines,
                 manager,
-                info.context.discounts,
+                discounts,
                 recalculate_discount=False,
                 save=True,
             )

--- a/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
@@ -18,7 +18,7 @@ from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...core.utils import from_global_id_or_error
 from ...core.validators import validate_one_of_args_is_in_mutation
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ...discount.types import Voucher
 from ...giftcard.types import GiftCard
 from ..types import Checkout
@@ -85,7 +85,7 @@ class CheckoutRemovePromoCode(BaseMutation):
         )
 
         manager = info.context.plugins
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         checkout_info = fetch_checkout_info(checkout, [], discounts, manager)
 
         removed = False

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -29,7 +29,7 @@ from ...core.descriptions import (
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ..types import Checkout
 from .checkout_create import CheckoutAddressValidationRules
 from .utils import (
@@ -155,7 +155,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
             ),
         )
 
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         manager = info.context.plugins
         shipping_channel_listings = checkout.channel.shipping_method_listings.all()
         checkout_info = fetch_checkout_info(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -29,6 +29,7 @@ from ...core.descriptions import (
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
+from ...discount.dataloaders import load_request_discounts
 from ..types import Checkout
 from .checkout_create import CheckoutAddressValidationRules
 from .utils import (
@@ -154,7 +155,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
             ),
         )
 
-        discounts = info.context.discounts
+        discounts = load_request_discounts(info.context)
         manager = info.context.plugins
         shipping_channel_listings = checkout.channel.shipping_method_listings.all()
         checkout_info = fetch_checkout_info(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -20,7 +20,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...core.utils import from_global_id_or_error
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ...shipping.types import ShippingMethod
 from ..types import Checkout
 from .utils import ERROR_DOES_NOT_SHIP, clean_delivery_method, get_checkout
@@ -102,7 +102,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
                     )
                 }
             )
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
         if not is_shipping_required(lines):
             raise ValidationError(
@@ -173,7 +173,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
 
         delete_external_shipping_id(checkout=checkout)
         checkout.shipping_method = shipping_method
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         invalidate_prices_updated_fields = invalidate_checkout_prices(
             checkout_info, lines, manager, discounts, save=False
         )
@@ -204,7 +204,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
 
         set_external_shipping_id(checkout=checkout, app_shipping_id=delivery_method.id)
         checkout.shipping_method = None
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         invalidate_prices_updated_fields = invalidate_checkout_prices(
             checkout_info, lines, manager, discounts, save=False
         )

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -20,6 +20,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...core.utils import from_global_id_or_error
+from ...discount.dataloaders import load_request_discounts
 from ...shipping.types import ShippingMethod
 from ..types import Checkout
 from .utils import ERROR_DOES_NOT_SHIP, clean_delivery_method, get_checkout
@@ -101,10 +102,8 @@ class CheckoutShippingMethodUpdate(BaseMutation):
                     )
                 }
             )
-
-        checkout_info = fetch_checkout_info(
-            checkout, lines, info.context.discounts, manager
-        )
+        discounts = load_request_discounts(info.context)
+        checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
         if not is_shipping_required(lines):
             raise ValidationError(
                 {
@@ -174,8 +173,9 @@ class CheckoutShippingMethodUpdate(BaseMutation):
 
         delete_external_shipping_id(checkout=checkout)
         checkout.shipping_method = shipping_method
+        discounts = load_request_discounts(info.context)
         invalidate_prices_updated_fields = invalidate_checkout_prices(
-            checkout_info, lines, manager, info.context.discounts, save=False
+            checkout_info, lines, manager, discounts, save=False
         )
         checkout.save(
             update_fields=[
@@ -204,8 +204,9 @@ class CheckoutShippingMethodUpdate(BaseMutation):
 
         set_external_shipping_id(checkout=checkout, app_shipping_id=delivery_method.id)
         checkout.shipping_method = None
+        discounts = load_request_discounts(info.context)
         invalidate_prices_updated_fields = invalidate_checkout_prices(
-            checkout_info, lines, manager, info.context.discounts, save=False
+            checkout_info, lines, manager, discounts, save=False
         )
         checkout.save(
             update_fields=[

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -12,7 +12,7 @@ from ...app.dataloaders import load_app
 from ...core.descriptions import ADDED_IN_32, PREVIEW_FEATURE
 from ...core.mutations import BaseMutation
 from ...core.types import Error
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ...order.types import Order
 from ..enums import OrderCreateFromCheckoutErrorCode
 from ..types import Checkout
@@ -84,7 +84,7 @@ class OrderCreateFromCheckout(BaseMutation):
         )
         tracking_code = analytics.get_client_id(info.context)
 
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         manager = info.context.plugins
         checkout_lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
         checkout_info = fetch_checkout_info(

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -12,6 +12,7 @@ from ...app.dataloaders import load_app
 from ...core.descriptions import ADDED_IN_32, PREVIEW_FEATURE
 from ...core.mutations import BaseMutation
 from ...core.types import Error
+from ...discount.dataloaders import load_request_discounts
 from ...order.types import Order
 from ..enums import OrderCreateFromCheckoutErrorCode
 from ..types import Checkout
@@ -83,7 +84,7 @@ class OrderCreateFromCheckout(BaseMutation):
         )
         tracking_code = analytics.get_client_id(info.context)
 
-        discounts = info.context.discounts
+        discounts = load_request_discounts(info.context)
         manager = info.context.plugins
         checkout_lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
         checkout_info = fetch_checkout_info(
@@ -102,7 +103,7 @@ class OrderCreateFromCheckout(BaseMutation):
             order = create_order_from_checkout(
                 checkout_info=checkout_info,
                 checkout_lines=checkout_lines,
-                discounts=info.context.discounts,
+                discounts=discounts,
                 manager=info.context.plugins,
                 user=info.context.user,
                 app=app,

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -658,7 +658,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-    with django_assert_num_queries(54):
+    with django_assert_num_queries(53):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -672,7 +672,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(54):
+    with django_assert_num_queries(53):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],
@@ -915,7 +915,7 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(53):
+    with django_assert_num_queries(52):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -928,7 +928,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(53):
+    with django_assert_num_queries(52):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,

--- a/saleor/graphql/discount/dataloaders.py
+++ b/saleor/graphql/discount/dataloaders.py
@@ -229,5 +229,5 @@ class OrderDiscountsByOrderIDLoader(DataLoader):
         return [discount_map.get(order_id, []) for order_id in keys]
 
 
-def load_request_discounts(request):
+def load_discounts(request):
     return DiscountsByDateTimeLoader(request).load(request.request_time).get()

--- a/saleor/graphql/discount/dataloaders.py
+++ b/saleor/graphql/discount/dataloaders.py
@@ -227,3 +227,7 @@ class OrderDiscountsByOrderIDLoader(DataLoader):
         for discount in discounts:
             discount_map[discount.order_id].append(discount)
         return [discount_map.get(order_id, []) for order_id in keys]
+
+
+def load_request_discounts(request):
+    return DiscountsByDateTimeLoader(request).load(request.request_time).get()

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -20,7 +20,7 @@ from ....order.utils import (
 from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, OrderError
-from ...discount.dataloaders import load_request_discounts
+from ...discount.dataloaders import load_discounts
 from ...product.types import ProductVariant
 from ..types import Order, OrderLine
 from ..utils import (
@@ -154,7 +154,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         variants = [line.variant for line in lines_to_add]
         cls.validate_variants(order, variants)
         app = load_app(info.context)
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         added_lines = cls.add_lines_to_order(
             order,
             lines_to_add,

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -20,6 +20,7 @@ from ....order.utils import (
 from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, OrderError
+from ...discount.dataloaders import load_request_discounts
 from ...product.types import ProductVariant
 from ..types import Order, OrderLine
 from ..utils import (
@@ -153,7 +154,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         variants = [line.variant for line in lines_to_add]
         cls.validate_variants(order, variants)
         app = load_app(info.context)
-
+        discounts = load_request_discounts(info.context)
         added_lines = cls.add_lines_to_order(
             order,
             lines_to_add,
@@ -161,7 +162,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             app,
             info.context.plugins,
             info.context.site.settings,
-            info.context.discounts,
+            discounts,
         )
 
         # Create the products added event

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -48,7 +48,7 @@ from ..core.fields import JSONString
 from ..core.mutations import BaseMutation
 from ..core.scalars import UUID, PositiveDecimal
 from ..core.types import common as common_types
-from ..discount.dataloaders import load_request_discounts
+from ..discount.dataloaders import load_discounts
 from ..meta.mutations import MetadataInput
 from ..utils import get_user_or_app_from_context
 from .enums import StorePaymentMethodEnum, TransactionActionEnum, TransactionStatusEnum
@@ -273,7 +273,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
                     )
                 }
             )
-        discounts = load_request_discounts(info.context)
+        discounts = load_discounts(info.context)
         checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
 
         cls.validate_token(

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -48,6 +48,7 @@ from ..core.fields import JSONString
 from ..core.mutations import BaseMutation
 from ..core.scalars import UUID, PositiveDecimal
 from ..core.types import common as common_types
+from ..discount.dataloaders import load_request_discounts
 from ..meta.mutations import MetadataInput
 from ..utils import get_user_or_app_from_context
 from .enums import StorePaymentMethodEnum, TransactionActionEnum, TransactionStatusEnum
@@ -272,9 +273,8 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
                     )
                 }
             )
-        checkout_info = fetch_checkout_info(
-            checkout, lines, info.context.discounts, manager
-        )
+        discounts = load_request_discounts(info.context)
+        checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
 
         cls.validate_token(
             manager, gateway, data, channel_slug=checkout_info.channel.slug
@@ -288,7 +288,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
             checkout_info=checkout_info,
             lines=lines,
             address=address,
-            discounts=info.context.discounts,
+            discounts=discounts,
         )
         amount = data.get("amount", checkout_total.gross.amount)
         clean_checkout_shipping(checkout_info, lines, PaymentErrorCode)

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -11,6 +11,7 @@ from ...webhook.deprecated_event_types import WebhookEventType
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..app.dataloaders import load_app
 from ..core.utils import from_global_id_or_error
+from ..discount.dataloaders import load_request_discounts
 from .types import Webhook, WebhookEvent
 
 
@@ -48,7 +49,7 @@ def resolve_sample_payload(info, event_name):
 
 def resolve_shipping_methods_for_checkout(info, checkout):
     manager = info.context.plugins
-    discounts = info.context.discounts
+    discounts = load_request_discounts(info.context)
     lines, _ = fetch_checkout_lines(checkout)
     shipping_channel_listings = checkout.channel.shipping_method_listings.all()
     checkout_info = fetch_checkout_info(
@@ -63,7 +64,7 @@ def resolve_shipping_methods_for_checkout(info, checkout):
         checkout_info,
         checkout.shipping_address,
         lines,
-        info.context.discounts,
+        discounts,
         shipping_channel_listings,
         manager,
     )

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -11,7 +11,7 @@ from ...webhook.deprecated_event_types import WebhookEventType
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..app.dataloaders import load_app
 from ..core.utils import from_global_id_or_error
-from ..discount.dataloaders import load_request_discounts
+from ..discount.dataloaders import load_discounts
 from .types import Webhook, WebhookEvent
 
 
@@ -49,7 +49,7 @@ def resolve_sample_payload(info, event_name):
 
 def resolve_shipping_methods_for_checkout(info, checkout):
     manager = info.context.plugins
-    discounts = load_request_discounts(info.context)
+    discounts = load_discounts(info.context)
     lines, _ = fetch_checkout_lines(checkout)
     shipping_channel_listings = checkout.channel.shipping_method_listings.all()
     checkout_info = fetch_checkout_info(

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -14,7 +14,6 @@ from promise import Promise
 
 from ...app.models import App
 from ...core.exceptions import PermissionDenied
-from ...discount.utils import fetch_discounts
 from ...plugins.manager import PluginsManager
 from ...settings import get_host
 from ...webhook.error_codes import WebhookErrorCode
@@ -99,9 +98,6 @@ def initialize_request(requestor=None, sync_event=False) -> HttpRequest:
     request.requestor = requestor  # type: ignore
     request.request_time = request_time  # type: ignore
     request.site = SimpleLazyObject(lambda: Site.objects.get_current())  # type: ignore
-    request.discounts = SimpleLazyObject(  # type: ignore
-        lambda: fetch_discounts(request_time)
-    )
     request.plugins = SimpleLazyObject(lambda: _get_plugins(requestor))  # type: ignore
 
     return request

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -198,7 +198,6 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.middleware.common.CommonMiddleware",
     "saleor.core.middleware.request_time",
-    "saleor.core.middleware.discounts",
     "saleor.core.middleware.google_analytics",
     "saleor.core.middleware.site",
     "saleor.core.middleware.plugins",


### PR DESCRIPTION
Internal change removing use of lazy object in favor of dataloader - this time for discounts.

One extra effect - in two tests the query count dropped by 1 :smile: 