### PR TITLE
Add flag for pulling all reference images during build

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - ci/**
+      - CLOUD-1567-build-image-using-github-registry
 
 jobs:
   docker:
@@ -23,6 +24,12 @@ jobs:
           # The name of the owner and of the repository: owner/repository
           IMAGE_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
           echo ::set-output name=image_name::${IMAGE_NAME}
+
+          # setting defaults
+          echo "
+          CACHE_FROM_VERSION="unstable-main"
+          CACHE_TO_VERSION="unstable-main"
+          " >> "${GITHUB_ENV}"
 
       # Outputs container tags for tagged pushes starting by 'v'
       # Pushes only to GitHub Container Repository (ghcr.io)
@@ -43,9 +50,21 @@ jobs:
           if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             # Matches 1.0.0, 1.0.1, etc.
             NAMED_VERSION="latest"
+
+            # setting version for cache-from
+            IFS="." read -r -a VERSION_ARRAY <<< "$VERSION"
+            if [ "${VERSION_ARRAY[-1]}" -gt 0 ]; then
+              PREVIOUS_VERSION[-1]="$((${VERSION_ARRAY[-1]} - 1))"
+              printf -v CACHE_FROM_VERSION "%s." "${PREVIOUS_VERSION[@]}"
+              CACHE_FROM_VERSION="${CACHE_FROM_VERSION%.}"
+            else
+              # setting to unstable-main if patch is lower than 1
+              CACHE_FROM_VERSION="unstable-main"
+            fi
           else
             # Matches 1.0.0a1, 1.0.0rc1, etc.
             NAMED_VERSION="snapshot"
+            CACHE_FROM_VERSION="unstable-main"
           fi
 
           TAGS=$"\
@@ -58,6 +77,8 @@ jobs:
           CONTAINER_TAGS=${TAGS}
           NAMED_VERSION=${NAMED_VERSION}
           VERSION=${VERSION}
+          CACHE_FROM_VERSION=${CACHE_FROM_VERSION}
+          CACHE_TO_VERSION=${VERSION}
           " >> "${GITHUB_ENV}"
 
       # Outputs the containers tags for staging branches
@@ -117,11 +138,12 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: ./
+          pull: true
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ env.CONTAINER_TAGS }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=registry,ref=ghcr.io/saleor/saleor:${{ env.CACHE_FROM_VERSION }}-buildcache
+          cache-to: type=registry,ref=ghcr.io/saleor/saleor:${{ env.CACHE_TO_VERSION }}-buildcache,mode=max
           build-args: |
             PROJECT_VERSION=${{ env.NAMED_VERSION }}
             COMMIT_ID=${{ github.sha }}


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
