### PR TITLE
Add condition to cache requirements if it is not main branch

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -98,11 +98,17 @@ jobs:
 
       - name: Cache Docker layers
         uses: actions/cache@v2
+        # This condition is a temporary fix until
+        # https://github.com/docker/buildx/issues/1044 is resolved, as it
+        # prevents usage of image registry.
+        # Due to limitation of local cache size we are skipping main branch and
+        # prioritize local cache for other branches e.g 3.x.
+        if: github.ref != 'refs/heads/main'
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ hashFiles('requirements_dev.txt') }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ hashFiles('requirements_dev.txt') }}
+            ${{ runner.os }}-buildx-
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1


### PR DESCRIPTION
I want to merge this change because due to issue https://github.com/docker/buildx/issues/1044 we are unable currently to use registry image as cache. By skipping main branch we prioritize local cache for other branches e.g 3.x.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
