### PR TITLE
Fix checkout line currency migration

### DIFF
--- a/saleor/checkout/migrations/0051_auto_20220713_1103.py
+++ b/saleor/checkout/migrations/0051_auto_20220713_1103.py
@@ -39,7 +39,9 @@ def set_default_checkout_line_currency(apps, schema_editor):
     Checkout = apps.get_model("checkout", "Checkout")
     CheckoutLine = apps.get_model("checkout", "CheckoutLine")
 
-    for currency in Checkout.objects.values_list("currency", flat=True):
+    for currency in (
+        Checkout.objects.values_list("currency", flat=True).distinct().order_by()
+    ):
         CheckoutLine.objects.filter(currency=None, checkout__currency=currency).update(
             currency=currency
         )


### PR DESCRIPTION
I want to merge this change because of fixing the checkout line currency migration.

Port #10540 

Previously: 
```
In [22]: Checkout.objects.values_list("currency", flat=True)
Out[22]: <QuerySet ['PLN', 'PLN', 'USD', 'PLN', 'PLN', 'USD', 'USD', 'USD', 'USD', 'PLN', 'USD', 'PLN', 'PLN', 'USD', 'USD', 'USD', 'USD', 'PLN', 'USD', 'PLN', '...(remaining elements truncated)...']>

In [23]: len(Checkout.objects.values_list("currency", flat=True))
Out[23]: 20003
```

New query:
```
In [24]: Checkout.objects.values_list("currency", flat=True).distinct().order_by()
Out[24]: <QuerySet ['USD', 'PLN']>

In [25]: len(Checkout.objects.values_list("currency", flat=True).distinct().order_by())
Out[25]: 2
```
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
