### PR TITLE
Fix conflicting version requirements of django-stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ documentation = "https://docs.saleor.io/"
   types-pytz = "^2022.1.1"
   types-pkg-resources = "^0.1.3"
   types-python-dateutil = "^2.8.0"
-  django-stubs = "^1.9.0"
+  django-stubs = "1.8.0"
   pytest-socket = "^0.5.1"
   before_after = "^1.0.1"
   types-certifi = "^2021.10.8"
@@ -126,9 +126,6 @@ documentation = "https://docs.saleor.io/"
   types-six = "^1.16.17"
   fakeredis = "^1.8"
   types-redis = "^4.2.6"
-
-[tool.poetry.group.dev.dependencies]
-django-stubs = "1.8.0"
 
 [tool.black]
 target_version = [ "py35", "py36", "py37", "py38" ]


### PR DESCRIPTION
This is an artifact of my work on upgrading Django

Fixes:

```
Because saleor depends on both django-stubs (1.8.0) and django-stubs (^1.9.0), version solving failed.
```

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
