### PR TITLE
Disable connection reuse

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -79,13 +79,13 @@ DATABASE_CONNECTION_REPLICA_NAME = "default"
 
 DATABASES = {
     DATABASE_CONNECTION_DEFAULT_NAME: dj_database_url.config(
-        default="postgres://saleor:saleor@localhost:5432/saleor", conn_max_age=600
+        default="postgres://saleor:saleor@localhost:5432/saleor", conn_max_age=0
     ),
     # TODO: We need to add read only user to saleor platfrom, and we need to update
     # docs.
     # DATABASE_CONNECTION_REPLICA_NAME: dj_database_url.config(
     #     default="postgres://saleor_read_only:saleor@localhost:5432/saleor",
-    #     conn_max_age=600,
+    #     conn_max_age=0,
     # ),
 }
 


### PR DESCRIPTION
Django does not have any support for connection pooling. Instead, it implements "poor man's pooling," where connections are left lingering between requests and can be reused by the subsequent request if the connection is fresh enough. Django 4 made the request context async-local, which means the subsequent request never sees the previous connection. This removed the benefit of keeping connections alive but also started to leak unterminated connections, which can lead to PostgreSQL rejecting new connections.

Related ticket in Django: https://code.djangoproject.com/ticket/33497

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
