### PR TITLE
Fix automatic fulfillment of digital lines

### DIFF
--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -617,7 +617,15 @@ def automatically_fulfill_digital_lines(
             FulfillmentLine(fulfillment=fulfillment, order_line=line, quantity=quantity)
         )
         allocation = line.allocations.first()
-        line_data.warehouse_pk = allocation.stock.warehouse.pk  # type: ignore
+        if allocation:
+            line_data.warehouse_pk = allocation.stock.warehouse.pk
+        else:
+            # allocation is not created when track inventory for given product
+            # is turned off so it doesn't matter which warehouse we'll use
+            line_data.warehouse_pk = (
+                line_data.variant.stocks.first().warehouse  # type: ignore
+            )
+
         lines_info.append(line_data)
 
     FulfillmentLine.objects.bulk_create(fulfillments)

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -576,3 +576,49 @@ def test_fulfill_digital_lines(
     assert fulfillment_lines.count() == 1
     assert line.digital_content_url
     assert mock_email_fulfillment.called
+
+
+@patch("saleor.order.actions.send_fulfillment_confirmation_to_customer")
+@patch("saleor.order.utils.get_default_digital_content_settings")
+def test_fulfill_digital_lines_no_allocation(
+    mock_digital_settings, mock_email_fulfillment, order_with_lines, media_root
+):
+    # given
+    mock_digital_settings.return_value = {"automatic_fulfillment": True}
+    line = order_with_lines.lines.all()[0]
+
+    image_file, image_name = create_image()
+    variant = line.variant
+
+    product_type = variant.product.product_type
+    product_type.is_digital = True
+    product_type.is_shipping_required = False
+    product_type.save(update_fields=["is_digital", "is_shipping_required"])
+
+    digital_content = DigitalContent.objects.create(
+        content_file=image_file, product_variant=variant, use_default_settings=True
+    )
+
+    variant.digital_content = digital_content
+    variant.track_inventory = False
+    variant.save()
+
+    line.is_shipping_required = False
+    line.allocations.all().delete()
+    line.save()
+
+    order_with_lines.refresh_from_db()
+    order_info = fetch_order_info(order_with_lines)
+    manager = get_plugins_manager()
+
+    # when
+    automatically_fulfill_digital_lines(order_info, manager)
+
+    # then
+    line.refresh_from_db()
+    fulfillment = Fulfillment.objects.get(order=order_with_lines)
+    fulfillment_lines = fulfillment.lines.all()
+
+    assert fulfillment_lines.count() == 1
+    assert line.digital_content_url
+    assert mock_email_fulfillment.called


### PR DESCRIPTION
The allocation is not created for lines without track inventory so we cannot require it in the automatic fulfillment of digital lines.

Fixes #9978

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
