### PR TITLE
Fix bulk delete mutation for sales

### DIFF
--- a/saleor/graphql/discount/bulk_mutations.py
+++ b/saleor/graphql/discount/bulk_mutations.py
@@ -25,13 +25,13 @@ class SaleBulkDelete(ModelBulkDeleteMutation):
 
     @classmethod
     def bulk_action(cls, info, queryset):
-        sales = list(queryset)
+        sales_and_catalogues = [
+            (sale, convert_catalogue_info_to_global_ids(fetch_catalogue_info(sale)))
+            for sale in list(queryset)
+        ]
         queryset.delete()
-        for sale in sales:
-            previous_catalogue = fetch_catalogue_info(sale)
-            info.context.plugins.sale_deleted(
-                sale, convert_catalogue_info_to_global_ids(previous_catalogue)
-            )
+        for sale, previous_catalogue in sales_and_catalogues:
+            info.context.plugins.sale_deleted(sale, previous_catalogue)
 
 
 class VoucherBulkDelete(ModelBulkDeleteMutation):

--- a/saleor/graphql/discount/tests/test_bulk_delete.py
+++ b/saleor/graphql/discount/tests/test_bulk_delete.py
@@ -1,10 +1,14 @@
+import json
 from unittest import mock
 
 import graphene
 import pytest
 
 from ....discount.models import Sale, SaleChannelListing, Voucher, VoucherChannelListing
+from ....discount.utils import fetch_catalogue_info
+from ....webhook.payloads import generate_sale_payload
 from ...tests.utils import get_graphql_content
+from ..mutations.utils import convert_catalogue_info_to_global_ids
 
 
 @pytest.fixture
@@ -55,8 +59,7 @@ def voucher_list(channel_USD):
     return voucher_1, voucher_2, voucher_3
 
 
-def test_delete_sales(staff_api_client, sale_list, permission_manage_discounts):
-    query = """
+SALE_BULK_DELETE_MUTATION = """
     mutation saleBulkDelete($ids: [ID!]!) {
         saleBulkDelete(ids: $ids) {
             count
@@ -64,11 +67,14 @@ def test_delete_sales(staff_api_client, sale_list, permission_manage_discounts):
     }
     """
 
+
+def test_delete_sales(staff_api_client, sale_list, permission_manage_discounts):
+
     variables = {
         "ids": [graphene.Node.to_global_id("Sale", sale.id) for sale in sale_list]
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_discounts]
+        SALE_BULK_DELETE_MUTATION, variables, permissions=[permission_manage_discounts]
     )
     content = get_graphql_content(response)
 
@@ -87,22 +93,76 @@ def test_delete_sales_triggers_webhook(
     any_webhook,
     settings,
 ):
-    query = """
-    mutation saleBulkDelete($ids: [ID!]!) {
-        saleBulkDelete(ids: $ids) {
-            count
-        }
-    }
-    """
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     variables = {
         "ids": [graphene.Node.to_global_id("Sale", sale.id) for sale in sale_list]
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_discounts]
+        SALE_BULK_DELETE_MUTATION, variables, permissions=[permission_manage_discounts]
     )
     content = get_graphql_content(response)
+
+    assert content["data"]["saleBulkDelete"]["count"] == 3
+    assert mocked_webhook_trigger.call_count == 3
+
+
+@mock.patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
+def test_delete_sales_with_variants_triggers_webhook(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    staff_api_client,
+    sale_list,
+    permission_manage_discounts,
+    any_webhook,
+    settings,
+    product,
+    collection,
+    category,
+    product_variant_list,
+):
+    # given
+    for sale in sale_list:
+        sale.products.add(product)
+        sale.collections.add(collection)
+        sale.categories.add(category)
+        sale.variants.add(*product_variant_list)
+
+    # create list of payloads that should be called in mutation
+    payloads_per_sale = []
+    for sale in sale_list:
+        payloads_per_sale.append(
+            generate_sale_payload(
+                sale,
+                convert_catalogue_info_to_global_ids(fetch_catalogue_info(sale)),
+                requestor=staff_api_client.user,
+            )
+        )
+
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    variables = {
+        "ids": [graphene.Node.to_global_id("Sale", sale.id) for sale in sale_list]
+    }
+    # when
+    response = staff_api_client.post_graphql(
+        SALE_BULK_DELETE_MUTATION, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+    # create a list of payloads with which the webhook was called
+    called_payloads_list = []
+    for arg_list in mocked_webhook_trigger.call_args_list:
+        called_arg = json.loads(arg_list[0][0])
+        # we don't want to compare meta fields, only rest of payloads
+        called_arg[0].pop("meta")
+        called_payloads_list.append(called_arg)
+
+    # then
+    for payload in payloads_per_sale:
+        payload = json.loads(payload)
+        payload[0].pop("meta")
+        assert payload in called_payloads_list
 
     assert content["data"]["saleBulkDelete"]["count"] == 3
     assert mocked_webhook_trigger.call_count == 3


### PR DESCRIPTION
I want to merge this change because catalogue info needs to be fetched before the deletion to be able to properly return this data in payload.
It is port of #10553 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
