### PR TITLE
Fix webhook payloads for return products

### DIFF
--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4526,7 +4526,7 @@ def dummy_gateway_config():
 
 
 @pytest.fixture
-def dummy_payment_data(payment_dummy):
+def dummy_payment_data(payment_dummy, order_line):
     return PaymentData(
         gateway=payment_dummy.gateway,
         amount=Decimal(10),

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4526,7 +4526,7 @@ def dummy_gateway_config():
 
 
 @pytest.fixture
-def dummy_payment_data(payment_dummy, order_line):
+def dummy_payment_data(payment_dummy):
     return PaymentData(
         gateway=payment_dummy.gateway,
         amount=Decimal(10),

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -656,6 +656,15 @@ def serialize_product_channel_listing_payload(channel_listings):
     return channel_listing_payload
 
 
+def serialize_refund_data(refund_data):
+    order_lines_to_refund = refund_data.get("order_lines_to_refund", [])
+    for line_data in order_lines_to_refund:
+        line = line_data["line"]
+        line_data["line"] = str(line.pk)
+        line_data["variant"] = line.variant.pk
+    return order_lines_to_refund
+
+
 @traced_payload_generator
 def generate_product_payload(
     product: "Product", requestor: Optional["RequestorOrLazyObject"] = None
@@ -961,9 +970,12 @@ def generate_payment_payload(
     payment_data: "PaymentData", requestor: Optional["RequestorOrLazyObject"] = None
 ):
     data = asdict(payment_data)
+    if refund_data := data.get("refund_data"):
+        data["refund_data"]["order_lines_to_refund"] = serialize_refund_data(
+            refund_data
+        )
     data["amount"] = quantize_price(data["amount"], data["currency"])
-    payment_app_data = from_payment_app_id(data["gateway"])
-    if payment_app_data:
+    if payment_app_data := from_payment_app_id(data["gateway"]):
         data["payment_method"] = payment_app_data.name
         data["meta"] = generate_meta(requestor_data=generate_requestor(requestor))
     return json.dumps(data, cls=CustomJsonEncoder)


### PR DESCRIPTION
I want to merge this change because webhook payloads break on serialization in some cases (refund with an order or fulfillment lines), causing TypeError (Object of type X is not JSON serializable).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
