### PR TITLE
Log Python warning using JSON logging configuration

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1,4 +1,5 @@
 import ast
+import logging
 import os.path
 import warnings
 from datetime import timedelta
@@ -283,6 +284,10 @@ if ENABLE_DEBUG_TOOLBAR:
             "debug_toolbar.panels.profiling.ProfilingPanel",
         ]
         DEBUG_TOOLBAR_CONFIG = {"RESULTS_CACHE_SIZE": 100}
+
+# Log Python 'warnings' events using the 'logging' module
+# This is needed in order to log them as JSON when DEBUG=False
+logging.captureWarnings(True)
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
This change allow to log all `warnings.warn()` events after Django configures the logging module allowing to get more information thanks to JSON logs.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
