### PR TITLE
Fix order total calculation with voucher

### DIFF
--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Iterable
 from prices import Money, TaxedMoney
 
 from ..core.taxes import zero_money
-from ..discount import OrderDiscountType
 from ..discount.utils import apply_discount_to_value
 from .interface import OrderTaxedPricesData
 
@@ -25,8 +24,8 @@ def base_order_shipping(order: "Order") -> Money:
 def base_order_total(order: "Order", lines: Iterable["OrderLine"]) -> Money:
     currency = order.currency
     total = base_order_total_without_order_discount(order, lines)
-    order_discount = order.discounts.filter(type=OrderDiscountType.MANUAL).first()
-    if order_discount:
+    order_discounts = order.discounts.all()
+    for order_discount in order_discounts:
         total = apply_discount_to_value(
             value=order_discount.value,
             value_type=order_discount.value_type,

--- a/saleor/order/tests/test_base_calculations.py
+++ b/saleor/order/tests/test_base_calculations.py
@@ -1,0 +1,39 @@
+from decimal import Decimal
+
+from prices import Money
+
+from ...discount import DiscountValueType, OrderDiscountType
+from .. import base_calculations
+
+
+def test_base_order_total(order_with_lines):
+    # given
+    order = order_with_lines
+    lines = order.lines.all()
+
+    # when
+    order_total = base_calculations.base_order_total(order, lines)
+
+    # then
+    assert order_total == Money(Decimal("80"), order.currency)
+
+
+def test_base_order_total_with_voucher(order_with_lines):
+    # given
+    order = order_with_lines
+    lines = order.lines.all()
+    order.discounts.create(
+        type=OrderDiscountType.VOUCHER,
+        value_type=DiscountValueType.FIXED,
+        value=10,
+        name="Voucher",
+        translated_name="VoucherPL",
+        currency=order.currency,
+        amount_value=10,
+    )
+
+    # when
+    order_total = base_calculations.base_order_total(order, lines)
+
+    # then
+    assert order_total == Money(Decimal("70"), order.currency)


### PR DESCRIPTION
I want to merge this change because fixing order total calculations with a voucher. 
When Saleor is settled to not confirm all orders, then the order total doesn't have a voucher included in the price. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
