### PR TITLE
Fix invalid content type of webp thumbnails when running on linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+RUN echo 'image/webp webp' >> /etc/mime.types
+
 RUN mkdir -p /app/media /app/static \
   && chown -R saleor:saleor /app/
 


### PR DESCRIPTION
I want to merge this change because the `mime-support` system package lacks proper content-type definition for webp files - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=978015. This causes issues with S3 storage, where webp thumbnails are stored with `content-type: application/octet-stream` causing unwanted browser behavior. 

Issue can be reproduced when running Saleor on Linux or from within docker container. The solution is to manually provide content type definition for webp to `/etc/mime.types` 

To be ported to 3.6 and 3.7 branches

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
