### PR TITLE
Drop `AnonymouUser` from the context, and assign None instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### GraphQL API
 
 - Add `taxExemptionManage` mutation - #10344 by @SzymJ
+- Fix error when app deleted product added to draft order - (#10574)
 
 # 3.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ All notable, unreleased changes to this project will be documented in this file.
 ### GraphQL API
 
 - Add `taxExemptionManage` mutation - #10344 by @SzymJ
-- Fix error when app deleted product added to draft order - (#10574)
 
 # 3.7.0
 

--- a/saleor/account/events.py
+++ b/saleor/account/events.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from ..app.models import App
-from ..core.utils.validators import user_is_valid
 from ..order.models import Order, OrderLine
 from . import CustomerEvents
 from .models import CustomerEvent, User
@@ -17,8 +16,6 @@ def customer_account_created_event(*, user: User) -> Optional[CustomerEvent]:
 def customer_account_activated_event(
     *, staff_user: UserType, app: AppType, account_id: int
 ) -> Optional[CustomerEvent]:
-    if not user_is_valid(staff_user):
-        staff_user = None
     return CustomerEvent.objects.create(
         user=staff_user,
         app=app,
@@ -30,8 +27,6 @@ def customer_account_activated_event(
 def customer_account_deactivated_event(
     *, staff_user: UserType, app: AppType, account_id: int
 ) -> Optional[CustomerEvent]:
-    if not user_is_valid(staff_user):
-        staff_user = None
     return CustomerEvent.objects.create(
         user=staff_user,
         app=app,
@@ -82,8 +77,6 @@ def customer_placed_order_event(*, user: User, order: Order) -> Optional[Custome
 def customer_added_to_note_order_event(
     *, user: UserType, order: Order, message: str
 ) -> CustomerEvent:
-    if not user_is_valid(user):
-        user = None
     return CustomerEvent.objects.create(
         user=user,
         order=order,
@@ -106,8 +99,6 @@ def customer_downloaded_a_digital_link_event(
 def customer_deleted_event(
     *, staff_user: UserType, app: AppType, deleted_count: int = 1
 ) -> CustomerEvent:
-    if not user_is_valid(staff_user):
-        staff_user = None
     return CustomerEvent.objects.create(
         user=staff_user,
         app=app,
@@ -120,8 +111,6 @@ def customer_deleted_event(
 def assigned_email_to_a_customer_event(
     *, staff_user: UserType, app: AppType, new_email: str
 ) -> CustomerEvent:
-    if not user_is_valid(staff_user):
-        staff_user = None
     return CustomerEvent.objects.create(
         user=staff_user,
         app=app,
@@ -134,8 +123,6 @@ def assigned_email_to_a_customer_event(
 def assigned_name_to_a_customer_event(
     *, staff_user: UserType, app: AppType, new_name: str
 ) -> CustomerEvent:
-    if not user_is_valid(staff_user):
-        staff_user = None
     return CustomerEvent.objects.create(
         user=staff_user,
         app=app,

--- a/saleor/account/events.py
+++ b/saleor/account/events.py
@@ -71,7 +71,7 @@ def customer_email_changed_event(
 
 
 def customer_placed_order_event(*, user: User, order: Order) -> Optional[CustomerEvent]:
-    if user.is_anonymous:
+    if not user:
         return None
 
     return CustomerEvent.objects.create(

--- a/saleor/account/events.py
+++ b/saleor/account/events.py
@@ -66,9 +66,6 @@ def customer_email_changed_event(
 
 
 def customer_placed_order_event(*, user: User, order: Order) -> Optional[CustomerEvent]:
-    if not user:
-        return None
-
     return CustomerEvent.objects.create(
         user=user, order=order, type=CustomerEvents.PLACED_ORDER
     )

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -791,7 +791,7 @@ def complete_checkout(
         raise exc
 
     customer_id = None
-    if payment and user.is_authenticated:
+    if payment and user:
         customer_id = fetch_customer_id(user=user, gateway=payment.gateway)
 
     action_required = False
@@ -807,7 +807,7 @@ def complete_checkout(
             channel_slug=channel_slug,
         )
 
-        if txn.customer_id and user.is_authenticated:
+        if txn.customer_id and user:
             store_customer_id(user, payment.gateway, txn.customer_id)  # type: ignore
 
         action_required = txn.action_required

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -222,7 +222,7 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=(),
+        user=None,
         app=None,
         manager=manager,
     )
@@ -480,7 +480,7 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
             discounts=[],
             taxes_included_in_prices=True,
         ),
-        user=(),
+        user=None,
         app=None,
         manager=manager,
     )
@@ -660,7 +660,7 @@ def test_create_order_with_gift_card(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=customer_user if not is_anonymous_user else (),
+        user=customer_user if not is_anonymous_user else None,
         app=None,
         manager=manager,
     )
@@ -866,7 +866,7 @@ def test_create_order_gift_card_bought(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=customer_user if not is_anonymous_user else (),
+        user=customer_user if not is_anonymous_user else None,
         app=None,
         manager=manager,
     )
@@ -947,7 +947,7 @@ def test_create_order_gift_card_bought_order_not_captured_gift_cards_not_sent(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=customer_user if not is_anonymous_user else (),
+        user=customer_user if not is_anonymous_user else None,
         app=None,
         manager=manager,
     )
@@ -1011,7 +1011,7 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=customer_user if not is_anonymous_user else (),
+        user=customer_user if not is_anonymous_user else None,
         app=None,
         manager=manager,
     )
@@ -1071,7 +1071,7 @@ def test_create_order_gift_card_bought_do_not_fulfill_gift_cards_automatically(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=customer_user if not is_anonymous_user else (),
+        user=customer_user if not is_anonymous_user else None,
         app=None,
         manager=manager,
     )

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 from unittest import mock
 
 import pytest
-from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
 from prices import TaxedMoney
 
@@ -223,7 +222,7 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=AnonymousUser(),
+        user=(),
         app=None,
         manager=manager,
     )
@@ -481,7 +480,7 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
             discounts=[],
             taxes_included_in_prices=True,
         ),
-        user=AnonymousUser(),
+        user=(),
         app=None,
         manager=manager,
     )
@@ -661,7 +660,7 @@ def test_create_order_with_gift_card(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=customer_user if not is_anonymous_user else AnonymousUser(),
+        user=customer_user if not is_anonymous_user else (),
         app=None,
         manager=manager,
     )
@@ -867,7 +866,7 @@ def test_create_order_gift_card_bought(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=customer_user if not is_anonymous_user else AnonymousUser(),
+        user=customer_user if not is_anonymous_user else (),
         app=None,
         manager=manager,
     )
@@ -948,7 +947,7 @@ def test_create_order_gift_card_bought_order_not_captured_gift_cards_not_sent(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=customer_user if not is_anonymous_user else AnonymousUser(),
+        user=customer_user if not is_anonymous_user else (),
         app=None,
         manager=manager,
     )
@@ -1012,7 +1011,7 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=customer_user if not is_anonymous_user else AnonymousUser(),
+        user=customer_user if not is_anonymous_user else (),
         app=None,
         manager=manager,
     )
@@ -1072,7 +1071,7 @@ def test_create_order_gift_card_bought_do_not_fulfill_gift_cards_automatically(
             discounts=None,
             taxes_included_in_prices=True,
         ),
-        user=customer_user if not is_anonymous_user else AnonymousUser(),
+        user=customer_user if not is_anonymous_user else (),
         app=None,
         manager=manager,
     )

--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -598,7 +598,7 @@ def test_create_order_from_checkout_store_shipping_prices(
         checkout_lines=lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser(),
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )
@@ -646,7 +646,7 @@ def test_create_order_from_store_shipping_prices_with_free_shipping_voucher(
         checkout_lines=lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser(),
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )

--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 from unittest import mock
 
 import pytest
-from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
 from prices import TaxedMoney
 
@@ -42,7 +41,7 @@ def test_create_order_insufficient_stock(
             checkout_lines=checkout_lines,
             discounts=[],
             manager=manager,
-            user=AnonymousUser(),
+            user=None,
             app=app,
             tracking_code="tracking_code",
         )
@@ -88,7 +87,7 @@ def test_create_order_with_gift_card(
         checkout_lines=lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser(),
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )
@@ -137,7 +136,7 @@ def test_create_order_with_gift_card_partial_use(
         checkout_lines=checkout_lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser(),
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )
@@ -200,7 +199,7 @@ def test_create_order_with_many_gift_cards(
         checkout_lines=checkout_lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser,
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )
@@ -275,7 +274,7 @@ def test_create_order_gift_card_bought(
         checkout_lines=lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser(),
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )
@@ -352,7 +351,7 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
         checkout_lines=lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser(),
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )
@@ -408,7 +407,7 @@ def test_create_order_gift_card_bought_do_not_fulfill_gift_cards_automatically(
         checkout_lines=lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser(),
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )
@@ -437,7 +436,7 @@ def test_note_in_created_order(
         checkout_lines=checkout_lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser(),
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )
@@ -483,7 +482,7 @@ def test_create_order_use_translations(
         checkout_lines=lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser(),
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )
@@ -519,7 +518,7 @@ def test_create_order_from_checkout_updates_total_authorized_amount(
         checkout_lines=checkout_lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser(),
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )
@@ -558,7 +557,7 @@ def test_create_order_from_checkout_updates_total_charged_amount(
         checkout_lines=checkout_lines,
         discounts=[],
         manager=manager,
-        user=AnonymousUser(),
+        user=None,
         app=app,
         tracking_code="tracking_code",
     )

--- a/saleor/core/permissions/__init__.py
+++ b/saleor/core/permissions/__init__.py
@@ -92,7 +92,7 @@ def one_of_permissions_or_auth_filter_required(context, permissions):
 
     requestor = get_user_or_app_from_context(context)
 
-    if permissions:
+    if requestor and permissions:
         perm_checks_results = []
         for permission in permissions:
             perm_checks_results.append(requestor.has_perm(permission))
@@ -117,11 +117,12 @@ def permission_required(
 
     if isinstance(requestor, User):
         return requestor.has_perms(perms)
-    else:
+    elif requestor:
         # for now MANAGE_STAFF permission for app is not supported
         if AccountPermissions.MANAGE_STAFF in perms:
             return False
         return requestor.has_perms(perms)
+    return False
 
 
 def has_one_of_permissions(

--- a/saleor/core/permissions/auth_filters.py
+++ b/saleor/core/permissions/auth_filters.py
@@ -6,7 +6,8 @@ def is_app(context):
 
 
 def is_user(context):
-    return context.user.is_active and context.user.is_authenticated
+    user = context.user
+    return user and user.is_active
 
 
 def is_staff_user(context):

--- a/saleor/core/utils/validators.py
+++ b/saleor/core/utils/validators.py
@@ -1,10 +1,9 @@
 from datetime import date
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 import micawber
 from django.core.exceptions import ValidationError
 
-from ...account.models import User
 from ...product import ProductMediaTypes
 from ...product.error_codes import ProductErrorCode
 
@@ -34,11 +33,6 @@ def get_oembed_data(url: str, field_name: str) -> Tuple[Dict[str, Any], str]:
                 )
             }
         )
-
-
-def user_is_valid(user: Optional[User]) -> bool:
-    """Return True when user is provided and is not anonymous."""
-    return bool(user and not user.is_anonymous)
 
 
 def is_date_in_future(given_date):

--- a/saleor/giftcard/events.py
+++ b/saleor/giftcard/events.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
 
 from ..account.models import User
 from ..app.models import App
-from ..core.utils.validators import user_is_valid
 from . import GiftCardEvents
 from .models import GiftCard, GiftCardEvent
 
@@ -18,8 +17,6 @@ def gift_card_issued_event(
     user: UserType,
     app: AppType,
 ):
-    if not user_is_valid(user):
-        user = None
     balance_data = {
         "currency": gift_card.currency,
         "initial_balance": gift_card.initial_balance_amount,
@@ -37,8 +34,6 @@ def gift_card_issued_event(
 def gift_cards_issued_event(
     gift_cards: Iterable[GiftCard], user: UserType, app: AppType, balance: dict
 ):
-    if not user_is_valid(user):
-        user = None
     balance_data = {
         "currency": balance["currency"],
         "initial_balance": balance["amount"],
@@ -87,8 +82,6 @@ def gift_card_balance_reset_event(
     user: UserType,
     app: AppType,
 ):
-    if not user_is_valid(user):
-        user = None
     balance_data = {
         "currency": gift_card.currency,
         "initial_balance": gift_card.initial_balance_amount,
@@ -112,8 +105,6 @@ def gift_card_expiry_date_updated_event(
     user: UserType,
     app: AppType,
 ):
-    if not user_is_valid(user):
-        user = None
     return GiftCardEvent.objects.create(
         gift_card=gift_card,
         user=user,
@@ -132,8 +123,6 @@ def gift_card_tags_updated_event(
     user: UserType,
     app: AppType,
 ):
-    if not user_is_valid(user):
-        user = None
     return GiftCardEvent.objects.create(
         gift_card=gift_card,
         user=user,
@@ -153,8 +142,6 @@ def gift_card_activated_event(
     user: UserType,
     app: AppType,
 ):
-    if not user_is_valid(user):
-        user = None
     return GiftCardEvent.objects.create(
         gift_card=gift_card,
         user=user,
@@ -168,8 +155,6 @@ def gift_card_deactivated_event(
     user: UserType,
     app: AppType,
 ):
-    if not user_is_valid(user):
-        user = None
     return GiftCardEvent.objects.create(
         gift_card=gift_card,
         user=user,
@@ -183,8 +168,6 @@ def gift_cards_activated_event(
     user: UserType,
     app: AppType,
 ):
-    if not user_is_valid(user):
-        user = None
     events = [
         GiftCardEvent(
             gift_card_id=gift_card_id,
@@ -202,8 +185,6 @@ def gift_cards_deactivated_event(
     user: UserType,
     app: AppType,
 ):
-    if not user_is_valid(user):
-        user = None
     events = [
         GiftCardEvent(
             gift_card_id=gift_card_id,
@@ -219,8 +200,6 @@ def gift_cards_deactivated_event(
 def gift_card_note_added_event(
     gift_card: GiftCard, user: UserType, app: AppType, message: str
 ) -> GiftCardEvent:
-    if not user_is_valid(user):
-        user = None
     return GiftCardEvent.objects.create(
         gift_card=gift_card,
         user=user,
@@ -236,8 +215,6 @@ def gift_cards_used_in_order_event(
     user: UserType,
     app: AppType,
 ):
-    if not user_is_valid(user):
-        user = None
     events = [
         GiftCardEvent(
             gift_card=gift_card,
@@ -261,8 +238,6 @@ def gift_cards_used_in_order_event(
 def gift_cards_bought_event(
     gift_cards: Iterable[GiftCard], order: "Order", user: UserType, app: AppType
 ):
-    if not user_is_valid(user):
-        user = None
     events = [
         GiftCardEvent(
             gift_card=gift_card,

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -11,7 +11,6 @@ from ..checkout.models import Checkout
 from ..core.exceptions import GiftCardNotApplicable
 from ..core.tracing import traced_atomic_transaction
 from ..core.utils.promo_code import InvalidPromoCode, generate_promo_code
-from ..core.utils.validators import user_is_valid
 from ..order.actions import create_fulfillments
 from ..order.models import OrderLine
 from ..site import GiftCardSettingsExpiryType
@@ -90,7 +89,7 @@ def fulfill_non_shippable_gift_cards(
     app: Optional["App"],
     manager: "PluginsManager",
 ):
-    if not user_is_valid(requestor_user):
+    if not requestor_user:
         requestor_user = None
     gift_card_lines = get_non_shippable_gift_card_lines(order_lines)
     if not gift_card_lines:

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -89,8 +89,6 @@ def fulfill_non_shippable_gift_cards(
     app: Optional["App"],
     manager: "PluginsManager",
 ):
-    if not requestor_user:
-        requestor_user = None
     gift_card_lines = get_non_shippable_gift_card_lines(order_lines)
     if not gift_card_lines:
         return

--- a/saleor/graphql/account/mutations/authentication.py
+++ b/saleor/graphql/account/mutations/authentication.py
@@ -143,6 +143,7 @@ class CreateToken(BaseMutation):
         csrf_token = _get_new_csrf_token()
         refresh_token = create_refresh_token(user, {"csrfToken": csrf_token})
         info.context.refresh_token = refresh_token
+        info.context.user = user
         info.context._cached_user = user
         user.last_login = timezone.now()
         user.save(update_fields=["last_login", "updated_at"])

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -49,10 +49,10 @@ def check_can_edit_address(context, address):
     - customers associated to the given address.
     """
     requester = get_user_or_app_from_context(context)
-    if requester.has_perm(AccountPermissions.MANAGE_USERS):
+    if requester and requester.has_perm(AccountPermissions.MANAGE_USERS):
         return True
     app = load_app(context)
-    if not app and not context.user.is_anonymous:
+    if not app and context.user:
         is_owner = requester.addresses.filter(pk=address.pk).exists()
         if is_owner:
             return True

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -207,7 +207,7 @@ def resolve_address(info, id):
     _, address_pk = from_global_id_or_error(id, Address)
     if app and app.has_perm(AccountPermissions.MANAGE_USERS):
         return models.Address.objects.filter(pk=address_pk).first()
-    if user and not user.is_anonymous:
+    if user:
         return user.addresses.filter(id=address_pk).first()
     raise PermissionDenied(
         permissions=[AccountPermissions.MANAGE_USERS, AuthorizationFilters.OWNER]
@@ -223,7 +223,7 @@ def resolve_addresses(info, ids):
     ]
     if app and app.has_perm(AccountPermissions.MANAGE_USERS):
         return models.Address.objects.filter(id__in=ids)
-    if user and not user.is_anonymous:
+    if user:
         return user.addresses.filter(id__in=ids)
     return models.Address.objects.none()
 

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -194,7 +194,7 @@ class AccountQueries(graphene.ObjectType):
     @staticmethod
     def resolve_me(_root, info):
         user = info.context.user
-        return user if bool(user) else None
+        return user if user else None
 
     @staticmethod
     def resolve_staff_users(_root, info, **kwargs):

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -194,7 +194,7 @@ class AccountQueries(graphene.ObjectType):
     @staticmethod
     def resolve_me(_root, info):
         user = info.context.user
-        return user if user.is_authenticated else None
+        return user if bool(user) else None
 
     @staticmethod
     def resolve_staff_users(_root, info, **kwargs):

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -2591,7 +2591,7 @@ def test_customer_delete_by_app(
     assert mocked_deletion_event.call_count == 1
     args, kwargs = mocked_deletion_event.call_args
     assert kwargs["deleted_count"] == 1
-    assert kwargs["staff_user"].is_anonymous
+    assert kwargs["staff_user"] is None
     assert kwargs["app"] == app
     delete_from_storage_task_mock.assert_called_once_with(customer_user.avatar.name)
 

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from datetime import timedelta
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 from urllib.parse import urlencode
+from uuid import uuid4
 
 import graphene
 import pytest
@@ -4969,7 +4970,10 @@ def test_account_reset_password_user_is_inactive(
     mocked_notify, user_api_client, customer_user, channel_USD
 ):
     user = customer_user
+    user.id = None
+    user.email = "test_customer@example.com"
     user.is_active = False
+    user.uuid = uuid4()
     user.save()
 
     variables = {

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from datetime import timedelta
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 from urllib.parse import urlencode
-from uuid import uuid4
 
 import graphene
 import pytest
@@ -4970,10 +4969,7 @@ def test_account_reset_password_user_is_inactive(
     mocked_notify, user_api_client, customer_user, channel_USD
 ):
     user = customer_user
-    user.id = None
-    user.email = "test_customer@example.com"
     user.is_active = False
-    user.uuid = uuid4()
     user.save()
 
     variables = {

--- a/saleor/graphql/account/tests/test_bulk_delete.py
+++ b/saleor/graphql/account/tests/test_bulk_delete.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import graphene
-from django.contrib.auth.models import AnonymousUser, Group
+from django.contrib.auth.models import Group
 
 from ....account.error_codes import AccountErrorCode
 from ....account.models import User
@@ -126,7 +126,7 @@ def test_delete_customers_by_app(
     ).count() == len(saved_customers)
 
     mocked_deletion_event.assert_called_once_with(
-        staff_user=AnonymousUser(),
+        staff_user=None,
         app=app_api_client.app,
         deleted_count=len(deleted_customers),
     )

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -621,7 +621,7 @@ class Group(ModelObjectType):
         from .resolvers import resolve_permission_groups
 
         requestor = get_user_or_app_from_context(info.context)
-        if not requestor.has_perm(AccountPermissions.MANAGE_STAFF):
+        if not requestor or not requestor.has_perm(AccountPermissions.MANAGE_STAFF):
             qs = auth_models.Group.objects.none()
         else:
             qs = resolve_permission_groups(info)

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -200,12 +200,12 @@ def get_user_permissions(user: "User") -> "QuerySet":
 
 
 def get_out_of_scope_permissions(
-    requestor: Union["User", "App"], permissions: List[str]
+    requestor: Union["User", "App", None], permissions: List[str]
 ) -> List[str]:
     """Return permissions that the requestor hasn't got."""
     missing_permissions = []
     for perm in permissions:
-        if not requestor.has_perm(perm):
+        if not requestor or not requestor.has_perm(perm):
             missing_permissions.append(perm)
     return missing_permissions
 
@@ -229,7 +229,7 @@ def can_user_manage_group(user: "User", group: Group) -> bool:
 def can_manage_app(requestor: Union["User", "App"], app: "App") -> bool:
     """Requestor can't manage app with wider scope of permissions."""
     permissions = app.get_permissions()
-    return requestor.has_perms(permissions)
+    return bool(requestor) and requestor.has_perms(permissions)
 
 
 def get_group_permission_codes(group: Group) -> "QuerySet":

--- a/saleor/graphql/app/resolvers.py
+++ b/saleor/graphql/app/resolvers.py
@@ -6,7 +6,6 @@ from ...core.jwt import (
     create_access_token_for_app,
     create_access_token_for_app_extension,
 )
-from ...core.utils.validators import user_is_valid
 from ..core.utils import from_global_id_or_error
 from .enums import AppTypeEnum
 
@@ -31,7 +30,7 @@ def resolve_access_token_for_app(info, root):
 
 def resolve_access_token_for_app_extension(info, root):
     user = info.context.user
-    if not user_is_valid(user):
+    if not user:
         return None
     extension_permissions = root.permissions.all()
     user_permissions = user.effective_permissions

--- a/saleor/graphql/app/resolvers.py
+++ b/saleor/graphql/app/resolvers.py
@@ -23,7 +23,7 @@ def resolve_access_token_for_app(info, root):
         return None
 
     user = info.context.user
-    if user.is_anonymous or not user.is_staff:
+    if not user or not user.is_staff:
         return None
     return create_access_token_for_app(root, user)
 

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -131,7 +131,7 @@ class AppExtension(AppManifestExtension, ModelObjectType):
             app_id = root.app_id
         else:
             requestor = get_user_or_app_from_context(info.context)
-            if requestor.has_perm(AppPermission.MANAGE_APPS):
+            if requestor and requestor.has_perm(AppPermission.MANAGE_APPS):
                 app_id = root.app_id
 
         if not app_id:
@@ -344,7 +344,7 @@ class App(ModelObjectType):
         from .resolvers import resolve_apps
 
         requestor = get_user_or_app_from_context(info.context)
-        if not requestor.has_perm(AppPermission.MANAGE_APPS):
+        if not requestor or not requestor.has_perm(AppPermission.MANAGE_APPS):
             qs = models.App.objects.none()
         else:
             qs = resolve_apps(info)

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -1,7 +1,6 @@
 from typing import Iterable
 
 import graphene
-from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 
 from ....checkout import AddressType
@@ -250,10 +249,10 @@ class CheckoutComplete(BaseMutationWithMetadata, I18nMixin):
             cls.validate_checkout_addresses(checkout_info, lines)
 
             requestor = get_user_or_app_from_context(info.context)
-            if requestor.has_perm(AccountPermissions.IMPERSONATE_USER):
+            if requestor and requestor.has_perm(AccountPermissions.IMPERSONATE_USER):
                 # Allow impersonating user and process a checkout by using user details
                 # assigned to checkout.
-                customer = checkout.user or AnonymousUser()
+                customer = checkout.user
             else:
                 customer = info.context.user
 

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -284,7 +284,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             )
 
         # Use authenticated user's email as default email
-        if user.is_authenticated:
+        if user:
             email = data.pop("email", None)
             cleaned_input["email"] = email or user.email
 
@@ -339,7 +339,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
     def get_instance(cls, info, **data):
         instance = super().get_instance(info, **data)
         user = info.context.user
-        if user.is_authenticated:
+        if user:
             instance.user = user
         return instance
 

--- a/saleor/graphql/checkout/mutations/checkout_customer_attach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_attach.py
@@ -81,12 +81,14 @@ class CheckoutCustomerAttach(BaseMutation):
 
         if customer_id and customer_id != user_id_from_request:
             requestor = get_user_or_app_from_context(info.context)
-            if not requestor.has_perm(AccountPermissions.IMPERSONATE_USER):
+            if not requestor or not requestor.has_perm(
+                AccountPermissions.IMPERSONATE_USER
+            ):
                 raise PermissionDenied(
                     permissions=[AccountPermissions.IMPERSONATE_USER]
                 )
             customer = cls.get_node_or_error(info, customer_id, only_type="User")
-        elif info.context.user.is_anonymous:
+        elif not info.context.user:
             raise ValidationError(
                 {
                     "customer_id": ValidationError(

--- a/saleor/graphql/checkout/mutations/checkout_customer_attach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_attach.py
@@ -74,10 +74,8 @@ class CheckoutCustomerAttach(BaseMutation):
             )
 
         user_id_from_request = None
-        if not info.context.user.is_anonymous:
-            user_id_from_request = graphene.Node.to_global_id(
-                "User", info.context.user.id
-            )
+        if user := info.context.user:
+            user_id_from_request = graphene.Node.to_global_id("User", user.id)
 
         if customer_id and customer_id != user_id_from_request:
             requestor = get_user_or_app_from_context(info.context)

--- a/saleor/graphql/checkout/mutations/checkout_customer_detach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_detach.py
@@ -52,7 +52,7 @@ class CheckoutCustomerDetach(BaseMutation):
             error_class=CheckoutErrorCode,
         )
         requestor = get_user_or_app_from_context(info.context)
-        if not requestor.has_perm(AccountPermissions.IMPERSONATE_USER):
+        if not requestor or not requestor.has_perm(AccountPermissions.IMPERSONATE_USER):
             # Raise error if the current user doesn't own the checkout of the given ID.
             if checkout.user and checkout.user != info.context.user:
                 raise PermissionDenied(

--- a/saleor/graphql/checkout/resolvers.py
+++ b/saleor/graphql/checkout/resolvers.py
@@ -36,11 +36,15 @@ def resolve_checkout(info, token, id):
             return checkout
 
         # resolve checkout for logged-in customer
-        if checkout.user == info.context.user:
+        user = info.context.user
+        if user and checkout.user == user:
             return checkout
 
     # resolve checkout for staff user
     requester = get_user_or_app_from_context(info.context)
+
+    if not requester:
+        return None
 
     has_manage_checkout = requester.has_perm(CheckoutPermissions.MANAGE_CHECKOUTS)
     has_impersonate_user = requester.has_perm(AccountPermissions.IMPERSONATE_USER)

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -389,7 +389,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(57):
+    with django_assert_num_queries(55):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -407,7 +407,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(57):
+    with django_assert_num_queries(55):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -5,7 +5,6 @@ from unittest.mock import ANY, patch
 import graphene
 import pytest
 import pytz
-from django.contrib.auth.models import AnonymousUser
 from django.db.models.aggregates import Sum
 from django.utils import timezone
 from prices import Money
@@ -564,7 +563,7 @@ def test_checkout_complete_by_app_with_missing_permission(
         payment_data=ANY,
         store_source=ANY,
         discounts=ANY,
-        user=AnonymousUser(),
+        user=None,
         app=ANY,
         site_settings=ANY,
         tracking_code=ANY,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -563,7 +563,7 @@ def test_checkout_complete_by_app_with_missing_permission(
         payment_data=ANY,
         store_source=ANY,
         discounts=ANY,
-        user=ANY,
+        user=None,
         app=ANY,
         site_settings=ANY,
         tracking_code=ANY,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -563,7 +563,7 @@ def test_checkout_complete_by_app_with_missing_permission(
         payment_data=ANY,
         store_source=ANY,
         discounts=ANY,
-        user=None,
+        user=ANY,
         app=ANY,
         site_settings=ANY,
         tracking_code=ANY,

--- a/saleor/graphql/context.py
+++ b/saleor/graphql/context.py
@@ -1,7 +1,6 @@
-from typing import Optional, Union, cast
+from typing import Optional, cast
 
 from django.contrib.auth import authenticate
-from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from django.utils.functional import SimpleLazyObject
 
@@ -24,7 +23,7 @@ def get_context_value(request: HttpRequest) -> SaleorContext:
     return request
 
 
-UserType = Union[User, AnonymousUser]
+UserType = Optional[User]
 
 
 class RequestWithUser(HttpRequest):
@@ -45,7 +44,7 @@ def set_app_on_context(request: SaleorContext):
         request.app = load_app(request)
 
 
-def get_user(request: SaleorContext) -> Optional[UserType]:
+def get_user(request: SaleorContext) -> UserType:
     if not hasattr(request, "_cached_user"):
         request._cached_user = cast(UserType, authenticate(request=request))
     return request._cached_user
@@ -53,10 +52,10 @@ def get_user(request: SaleorContext) -> Optional[UserType]:
 
 def set_auth_on_context(request: SaleorContext):
     if hasattr(request, "app") and request.app:
-        request.user = AnonymousUser()
+        request.user = None
         return request
 
     def user():
-        return get_user(request) or AnonymousUser()
+        return get_user(request) or None
 
     request.user = SimpleLazyObject(user)  # type: ignore

--- a/saleor/graphql/context.py
+++ b/saleor/graphql/context.py
@@ -52,7 +52,7 @@ def get_user(request: SaleorContext) -> UserType:
 
 def set_auth_on_context(request: SaleorContext):
     if hasattr(request, "app") and request.app:
-        request.user = None
+        request.user = SimpleLazyObject(lambda: None)  # type: ignore
         return request
 
     def user():

--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from django.conf import settings
 from django.http import HttpRequest
+from django.utils.functional import empty
 
 from ...account.models import User
 from ...app.models import App
@@ -51,3 +52,9 @@ def get_database_connection_name(context: SaleorContext) -> str:
     if not is_mutation:
         return settings.DATABASE_CONNECTION_REPLICA_NAME
     return settings.DATABASE_CONNECTION_DEFAULT_NAME
+
+
+def setup_context_user(context: SaleorContext) -> None:
+    if getattr(context.user, "_wrapped", None) is empty:
+        context.user._setup()  # type: ignore
+        context.user = context.user._wrapped  # type: ignore

--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -1,7 +1,6 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 
 from ...account.models import User
@@ -11,7 +10,7 @@ if TYPE_CHECKING:
     from .dataloaders import DataLoader
 
 
-UserType = Union[User, AnonymousUser]
+UserType = Optional[User]
 
 
 class SaleorContext(HttpRequest):
@@ -20,6 +19,7 @@ class SaleorContext(HttpRequest):
     is_mutation: bool
     dataloaders: Dict[str, "DataLoader"]
     app: Optional["App"]
+    user: UserType  # type: ignore
 
 
 def set_mutation_flag_in_context(context: SaleorContext) -> None:

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -27,7 +27,7 @@ from ...core.permissions import (
 from ...core.utils.events import call_event
 from ..plugins.dataloaders import load_plugin_manager
 from ..utils import get_nodes, resolve_global_ids_to_primary_keys
-from .context import set_mutation_flag_in_context
+from .context import set_mutation_flag_in_context, setup_context_user
 from .descriptions import DEPRECATED_IN_3X_FIELD
 from .types import (
     TYPES_WITH_DOUBLE_ID_AVAILABLE,
@@ -370,6 +370,7 @@ class BaseMutation(graphene.Mutation):
     @classmethod
     def mutate(cls, root, info, **data):
         set_mutation_flag_in_context(info.context)
+        setup_context_user(info.context)
 
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)
@@ -717,6 +718,8 @@ class BaseBulkMutation(BaseMutation):
     @classmethod
     def mutate(cls, root, info, **data):
         set_mutation_flag_in_context(info.context)
+        setup_context_user(info.context)
+
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)
         manager = load_plugin_manager(info.context)

--- a/saleor/graphql/core/tests/test_base_mutation.py
+++ b/saleor/graphql/core/tests/test_base_mutation.py
@@ -3,6 +3,7 @@ from unittest import mock
 import graphene
 import pytest
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.functional import SimpleLazyObject
 from graphql import GraphQLError
 from graphql.execution import ExecutionResult
 
@@ -348,7 +349,7 @@ def test_mutation_calls_plugin_perform_mutation_after_permission_checks(
     ]
 
     schema_context = request.getfixturevalue("schema_context")
-    schema_context.user = staff_user
+    schema_context.user = SimpleLazyObject(lambda: staff_user)
 
     product_id = graphene.Node.to_global_id("Product", product.pk)
     variables = {"productId": product_id, "channel": channel_USD.slug}

--- a/saleor/graphql/core/tests/test_core.py
+++ b/saleor/graphql/core/tests/test_core.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock, patch
 import django_filters
 import graphene
 import pytest
-from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
@@ -467,12 +466,6 @@ def test_requestor_is_superuser_for_superuser(superuser):
 
 def test_requestor_is_superuser_for_app(app):
     result = requestor_is_superuser(app)
-    assert result is False
-
-
-def test_requestor_is_superuser_for_anonymous_user():
-    user = AnonymousUser()
-    result = requestor_is_superuser(user)
     assert result is False
 
 

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 
 import graphene
 import pytest
-from django.contrib.auth.models import AnonymousUser
 from django.shortcuts import reverse
 from graphql.error import GraphQLError
 from graphql_relay import to_global_id
@@ -52,7 +51,7 @@ def test_jwt_middleware(client, admin_user):
     response = api_client_post(data={"query": user_details_query})
     repl_data = response.json()
     assert response.status_code == 200
-    assert isinstance(response.wsgi_request.user, AnonymousUser)
+    assert response.wsgi_request.user == None  # noqa: E711
     assert repl_data["data"]["me"] is None
 
     # test creating a token for admin user

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -51,14 +51,14 @@ def test_jwt_middleware(client, admin_user):
     response = api_client_post(data={"query": user_details_query})
     repl_data = response.json()
     assert response.status_code == 200
-    assert response.wsgi_request.user == None  # noqa: E711
+    assert not response.wsgi_request.user
     assert repl_data["data"]["me"] is None
 
     # test creating a token for admin user
     response = api_client_post(data={"query": create_token_query})
     repl_data = response.json()
     assert response.status_code == 200
-    assert isinstance(response.wsgi_request.user, AnonymousUser)
+    assert response.wsgi_request.user == admin_user
     token = repl_data["data"]["tokenCreate"]["token"]
     assert token is not None
 

--- a/saleor/graphql/core/utils/__init__.py
+++ b/saleor/graphql/core/utils/__init__.py
@@ -236,7 +236,7 @@ def from_global_id_or_none(
 
 def to_global_id_or_none(instance):
     class_name = instance.__class__.__name__
-    if instance.pk is None:
+    if instance is None or instance.pk is None:
         return None
     return graphene.Node.to_global_id(class_name, instance.pk)
 

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -9,7 +9,7 @@ from ...account.models import User
 from ...core.permissions import GiftcardPermissions
 from ...core.tracing import traced_atomic_transaction
 from ...core.utils.promo_code import generate_promo_code
-from ...core.utils.validators import is_date_in_future, user_is_valid
+from ...core.utils.validators import is_date_in_future
 from ...giftcard import events, models
 from ...giftcard.error_codes import GiftCardErrorCode
 from ...giftcard.notifications import send_gift_card_notification
@@ -166,7 +166,7 @@ class GiftCardCreate(ModelMutation):
     @staticmethod
     def set_created_by_user(cleaned_input, info):
         user = info.context.user
-        if user_is_valid(user):
+        if user:
             cleaned_input["created_by"] = user
             cleaned_input["created_by_email"] = user.email
         cleaned_input["app"] = load_app(info.context)
@@ -514,7 +514,7 @@ class GiftCardResend(BaseMutation):
         target_email = cls.get_target_email(data, gift_card)
         customer_user = cls.get_customer_user(target_email)
         user = info.context.user
-        if not user_is_valid(user):
+        if not user:
             user = None
         app = load_app(info.context)
         manager = load_plugin_manager(info.context)

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -363,11 +363,14 @@ class GiftCard(ModelObjectType):
             requestor = get_user_or_app_from_context(info.context)
             # Gift card code can be fetched by the staff user and app
             # with manage gift card permission and by the card owner.
-            if (
-                not root.used_by_email
-                and requestor.has_perm(GiftcardPermissions.MANAGE_GIFT_CARD)
-            ) or (user and requestor == user):
-                return root.code
+            if requestor:
+                requestor_is_an_owner = user and requestor == user
+                card_already_used = bool(root.used_by_email)
+                if requestor_is_an_owner or (
+                    not card_already_used
+                    and requestor.has_perm(GiftcardPermissions.MANAGE_GIFT_CARD)
+                ):
+                    return root.code
 
             return PermissionDenied(
                 permissions=[

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -200,8 +200,10 @@ class MenuItem(ChannelContextTypeWithMetadata, ModelObjectType):
     def resolve_page(root: ChannelContext[models.MenuItem], info):
         if root.node.page_id:
             requestor = get_user_or_app_from_context(info.context)
-            requestor_has_access_to_all = requestor.is_active and requestor.has_perm(
-                PagePermissions.MANAGE_PAGES
+            requestor_has_access_to_all = (
+                requestor
+                and requestor.is_active
+                and requestor.has_perm(PagePermissions.MANAGE_PAGES)
             )
             return (
                 PageByIdLoader(info.context)

--- a/saleor/graphql/meta/permissions.py
+++ b/saleor/graphql/meta/permissions.py
@@ -49,7 +49,7 @@ def public_user_permissions(info, user_pk: int) -> List[BasePermissionEnum]:
                 )
             }
         )
-    if info.context.user.pk == user.pk:
+    if info.context.user and info.context.user.pk == user.pk:
         return []
     if user.is_staff:
         return [AccountPermissions.MANAGE_STAFF]
@@ -135,7 +135,7 @@ def discount_permissions(_info, _object_pk: Any) -> List[BasePermissionEnum]:
 def public_payment_permissions(info, payment_pk: int) -> List[BasePermissionEnum]:
     context_user = info.context.user
     app = load_app(info.context)
-    if app is not None or context_user.is_staff:
+    if app or (context_user and context_user.is_staff):
         return [PaymentPermissions.HANDLE_PAYMENTS]
     if payment_owned_by_user(payment_pk, context_user):
         return []

--- a/saleor/graphql/meta/resolvers.py
+++ b/saleor/graphql/meta/resolvers.py
@@ -101,7 +101,7 @@ def check_private_metadata_privilege(root: ModelWithMetadata, info):
         raise PermissionDenied()
 
     requester = get_user_or_app_from_context(info.context)
-    if not requester.has_perms(required_permissions):
+    if not requester or not requester.has_perms(required_permissions):
         raise PermissionDenied()
 
 

--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -244,7 +244,7 @@ class OrderFulfill(BaseMutation):
         cleaned_input = cls.clean_input(info, order, data, site=site)
 
         context = info.context
-        user = context.user if not context.user.is_anonymous else None
+        user = context.user
         app = load_app(info.context)
         manager = load_plugin_manager(info.context)
         lines_for_warehouses = cleaned_input["lines_for_warehouses"]

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -8,7 +8,6 @@ from unittest.mock import ANY, MagicMock, Mock, call, patch
 import graphene
 import pytest
 import pytz
-from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.db.models import Sum
@@ -6530,7 +6529,7 @@ def test_order_cancel_as_app(
 
     mock_clean_order_cancel.assert_called_once_with(order)
     mock_cancel_order.assert_called_once_with(
-        order=order, user=AnonymousUser(), app=app_api_client.app, manager=ANY
+        order=order, user=None, app=app_api_client.app, manager=ANY
     )
 
 
@@ -8451,7 +8450,7 @@ def test_order_bulk_cancel_as_app(
     assert not data["errors"]
 
     calls = [
-        call(order=order, user=AnonymousUser(), app=app_api_client.app, manager=ANY)
+        call(order=order, user=None, app=app_api_client.app, manager=ANY)
         for order in orders
     ]
 

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -1102,7 +1102,6 @@ def test_order_available_shipping_methods_with_weight_based_shipping_method(
     permission_manage_orders,
     minimum_order_weight_value,
 ):
-
     shipping_method = shipping_method_weight_based
     order = order_line.order
     if minimum_order_weight_value is not None:
@@ -3941,6 +3940,30 @@ def test_draft_order_delete(staff_api_client, permission_manage_orders, draft_or
     )
     with pytest.raises(order._meta.model.DoesNotExist):
         order.refresh_from_db()
+
+
+def test_draft_order_delete_product(
+    app_api_client, permission_manage_products, draft_order
+):
+    query = """
+        mutation DeleteProduct($id: ID!) {
+          productDelete(id: $id) {
+            product {
+              id
+            }
+          }
+        }
+    """
+    order = draft_order
+    line = order.lines.first()
+    product = line.variant.product
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    variables = {"id": product_id}
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["productDelete"]["product"]["id"] == product_id
 
 
 @pytest.mark.parametrize(
@@ -7189,7 +7212,6 @@ def test_order_refund_with_transaction_action_request_missing_event(
 def test_clean_payment_without_payment_associated_to_order(
     staff_api_client, permission_manage_orders, order, requires_amount, mutation_name
 ):
-
     assert not OrderEvent.objects.exists()
 
     additional_arguments = ", amount: 2" if requires_amount else ""
@@ -9509,7 +9531,6 @@ def test_orders_query_with_filter_by_orders_id(
     permission_manage_orders,
     channel_USD,
 ):
-
     # given
     orders = Order.objects.bulk_create(
         [
@@ -9548,7 +9569,6 @@ def test_orders_query_with_filter_by_old_orders_id(
     permission_manage_orders,
     channel_USD,
 ):
-
     # given
     orders = Order.objects.bulk_create(
         [
@@ -9589,7 +9609,6 @@ def test_orders_query_with_filter_by_old_and_new_orders_id(
     permission_manage_orders,
     channel_USD,
 ):
-
     # given
     orders = Order.objects.bulk_create(
         [
@@ -10526,12 +10545,12 @@ def test_order_resolver_tax_recalculation(
 
     query = (
         """
-    query OrderPrices($id: ID!) {
-        order(id: $id) {
-            %s { net { amount } gross { amount } }
+        query OrderPrices($id: ID!) {
+            order(id: $id) {
+                %s { net { amount } gross { amount } }
+            }
         }
-    }
-    """
+        """
         % price_name
     )
     variables = {"id": order_id}
@@ -10598,14 +10617,14 @@ def test_order_line_resolver_tax_recalculation(
 
     query = (
         """
-    query OrderLinePrices($id: ID!) {
-        order(id: $id) {
-            lines {
-                %s { net { amount } gross { amount } }
+        query OrderLinePrices($id: ID!) {
+            order(id: $id) {
+                lines {
+                    %s { net { amount } gross { amount } }
+                }
             }
         }
-    }
-    """
+        """
         % price_name
     )
     variables = {"id": order_id}
@@ -10636,7 +10655,6 @@ query OrderShippingTaxRate($id: ID!) {
     }
 }
 """
-
 
 ORDER_LINE_TAX_RATE_QUERY = """
 query OrderLineTaxRate($id: ID!) {

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1301,7 +1301,7 @@ class Order(ModelObjectType):
     def resolve_fulfillments(root: models.Order, info):
         def _resolve_fulfillments(fulfillments):
             user = info.context.user
-            if user.is_staff:
+            if user and user.is_staff:
                 return fulfillments
             return filter(
                 lambda fulfillment: fulfillment.status != FulfillmentStatus.CANCELED,

--- a/saleor/graphql/page/dataloaders.py
+++ b/saleor/graphql/page/dataloaders.py
@@ -54,7 +54,11 @@ class PageAttributesByPageTypeIdLoader(DataLoader):
 
     def batch_load(self, keys):
         requestor = get_user_or_app_from_context(self.context)
-        if requestor.is_active and requestor.has_perm(PagePermissions.MANAGE_PAGES):
+        if (
+            requestor
+            and requestor.is_active
+            and requestor.has_perm(PagePermissions.MANAGE_PAGES)
+        ):
             qs = AttributePage.objects.using(self.database_connection_name).all()
         else:
             qs = AttributePage.objects.using(self.database_connection_name).filter(
@@ -93,7 +97,11 @@ class AttributePagesByPageTypeIdLoader(DataLoader):
 
     def batch_load(self, keys):
         requestor = get_user_or_app_from_context(self.context)
-        if requestor.is_active and requestor.has_perm(PagePermissions.MANAGE_PAGES):
+        if (
+            requestor
+            and requestor.is_active
+            and requestor.has_perm(PagePermissions.MANAGE_PAGES)
+        ):
             qs = AttributePage.objects.using(self.database_connection_name).all()
         else:
             qs = AttributePage.objects.using(self.database_connection_name).filter(
@@ -113,7 +121,11 @@ class AssignedPageAttributesByPageIdLoader(DataLoader):
 
     def batch_load(self, keys):
         requestor = get_user_or_app_from_context(self.context)
-        if requestor.is_active and requestor.has_perm(PagePermissions.MANAGE_PAGES):
+        if (
+            requestor
+            and requestor.is_active
+            and requestor.has_perm(PagePermissions.MANAGE_PAGES)
+        ):
             qs = AssignedPageAttribute.objects.using(
                 self.database_connection_name
             ).all()

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -976,7 +976,7 @@ class TransactionRequestAction(BaseMutation):
         for required_permission in required_permissions:
             # We want to allow to call this mutation for requestor with one of following
             # permission: manage_orders, handle_payments
-            if requestor.has_perm(required_permission):
+            if requestor and requestor.has_perm(required_permission):
                 return True
         return False
 

--- a/saleor/graphql/product/dataloaders/attributes.py
+++ b/saleor/graphql/product/dataloaders/attributes.py
@@ -30,8 +30,10 @@ class BaseProductAttributesByProductTypeIdLoader(DataLoader):
             self.extra_fields = []
 
         requestor = get_user_or_app_from_context(self.context)
-        if requestor.is_active and requestor.has_perm(
-            ProductPermissions.MANAGE_PRODUCTS
+        if (
+            requestor
+            and requestor.is_active
+            and requestor.has_perm(ProductPermissions.MANAGE_PRODUCTS)
         ):
             qs = self.model_name.objects.using(self.database_connection_name).all()
         else:
@@ -94,8 +96,10 @@ class AttributeProductsByProductTypeIdLoader(DataLoader):
 
     def batch_load(self, keys):
         requestor = get_user_or_app_from_context(self.context)
-        if requestor.is_active and requestor.has_perm(
-            ProductPermissions.MANAGE_PRODUCTS
+        if (
+            requestor
+            and requestor.is_active
+            and requestor.has_perm(ProductPermissions.MANAGE_PRODUCTS)
         ):
             qs = AttributeProduct.objects.using(self.database_connection_name).all()
         else:
@@ -116,8 +120,10 @@ class AttributeVariantsByProductTypeIdLoader(DataLoader):
 
     def batch_load(self, keys):
         requestor = get_user_or_app_from_context(self.context)
-        if requestor.is_active and requestor.has_perm(
-            ProductPermissions.MANAGE_PRODUCTS
+        if (
+            requestor
+            and requestor.is_active
+            and requestor.has_perm(ProductPermissions.MANAGE_PRODUCTS)
         ):
             qs = AttributeVariant.objects.using(self.database_connection_name).all()
         else:
@@ -138,8 +144,10 @@ class AssignedProductAttributesByProductIdLoader(DataLoader):
 
     def batch_load(self, keys):
         requestor = get_user_or_app_from_context(self.context)
-        if requestor.is_active and requestor.has_perm(
-            ProductPermissions.MANAGE_PRODUCTS
+        if (
+            requestor
+            and requestor.is_active
+            and requestor.has_perm(ProductPermissions.MANAGE_PRODUCTS)
         ):
             qs = AssignedProductAttribute.objects.using(
                 self.database_connection_name
@@ -162,8 +170,10 @@ class AssignedVariantAttributesByProductVariantId(DataLoader):
 
     def batch_load(self, keys):
         requestor = get_user_or_app_from_context(self.context)
-        if requestor.is_active and requestor.has_perm(
-            ProductPermissions.MANAGE_PRODUCTS
+        if (
+            requestor
+            and requestor.is_active
+            and requestor.has_perm(ProductPermissions.MANAGE_PRODUCTS)
         ):
             qs = AssignedVariantAttribute.objects.using(
                 self.database_connection_name

--- a/saleor/graphql/tests/fixtures.py
+++ b/saleor/graphql/tests/fixtures.py
@@ -8,6 +8,7 @@ import pytest
 from django.core.serializers.json import DjangoJSONEncoder
 from django.shortcuts import reverse
 from django.test.client import MULTIPART_CONTENT, Client
+from django.utils.functional import SimpleLazyObject
 
 from ...account.models import User
 from ...core.jwt import create_access_token
@@ -154,8 +155,8 @@ def api_client():
 @pytest.fixture
 def schema_context():
     params = {
-        "user": None,
-        "app": None,
+        "user": SimpleLazyObject(lambda: None),
+        "app": SimpleLazyObject(lambda: None),
         "plugins": get_plugins_manager(),
         "auth_token": "",
     }

--- a/saleor/graphql/tests/fixtures.py
+++ b/saleor/graphql/tests/fixtures.py
@@ -155,7 +155,7 @@ def api_client():
 @pytest.fixture
 def schema_context():
     params = {
-        "user": AnonymousUser(),
+        "user": None,
         "app": None,
         "plugins": get_plugins_manager(),
         "auth_token": "",

--- a/saleor/graphql/tests/fixtures.py
+++ b/saleor/graphql/tests/fixtures.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock
 
 import graphene
 import pytest
-from django.contrib.auth.models import AnonymousUser
 from django.core.serializers.json import DjangoJSONEncoder
 from django.shortcuts import reverse
 from django.test.client import MULTIPART_CONTENT, Client
@@ -166,11 +165,6 @@ def schema_context():
 @pytest.fixture
 def info(schema_context):
     return Mock(context=schema_context)
-
-
-@pytest.fixture
-def anonymous_user():
-    return AnonymousUser()
 
 
 @pytest.fixture

--- a/saleor/graphql/tests/fixtures.py
+++ b/saleor/graphql/tests/fixtures.py
@@ -28,14 +28,14 @@ class ApiClient(Client):
     """GraphQL API client."""
 
     def __init__(self, *args, **kwargs):
-        user = kwargs.pop("user", AnonymousUser())
+        user = kwargs.pop("user", None)
         app = kwargs.pop("app", None)
         self._user = None
         self.token = None
         self.user = user
         self.app_token = None
         self.app = app
-        if not user.is_anonymous:
+        if user:
             self.token = create_access_token(user)
         elif app:
             _, auth_token = app.tokens.create(name="Default")
@@ -44,7 +44,7 @@ class ApiClient(Client):
 
     def _base_environ(self, **request):
         environ = super()._base_environ(**request)
-        if not self.user.is_anonymous:
+        if self.user:
             environ["HTTP_AUTHORIZATION"] = f"JWT {self.token}"
         elif self.app_token:
             environ["HTTP_AUTHORIZATION"] = f"Bearer {self.app_token}"
@@ -57,7 +57,7 @@ class ApiClient(Client):
     @user.setter
     def user(self, user):
         self._user = user
-        if not user.is_anonymous:
+        if user:
             self.token = create_access_token(user)
 
     def post(self, data=None, **kwargs):
@@ -149,7 +149,7 @@ def user2_api_client(customer_user2):
 
 @pytest.fixture
 def api_client():
-    return ApiClient(user=AnonymousUser())
+    return ApiClient(user=None)
 
 
 @pytest.fixture

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -37,13 +37,14 @@ def resolve_webhook_events():
 @traced_resolver
 def resolve_sample_payload(info, event_name):
     app = load_app(info.context)
+    user = info.context.user
     required_permission = WebhookEventAsyncType.PERMISSIONS.get(
         event_name, WebhookEventSyncType.PERMISSIONS.get(event_name)
     )
     if required_permission:
         if app and app.has_perm(required_permission):
             return payloads.generate_sample_payload(event_name)
-        if info.context.user.has_perm(required_permission):
+        if user and user.has_perm(required_permission):
             return payloads.generate_sample_payload(event_name)
     raise PermissionDenied(permissions=[required_permission])
 

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1,5 +1,4 @@
 import graphene
-from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
 from graphene import AbstractType, ObjectType, Union
 from rx import Observable
@@ -103,7 +102,7 @@ class Event(graphene.Interface):
 
     @staticmethod
     def resolve_issuing_principal(_root, info):
-        if isinstance(info.context.requestor, AnonymousUser):
+        if not info.context.requestor:
             return None
         return info.context.requestor
 

--- a/saleor/invoice/events.py
+++ b/saleor/invoice/events.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from ..account.models import User
 from ..app.models import App
-from ..core.utils.validators import user_is_valid
 from ..order.models import Order
 from .models import Invoice, InvoiceEvent, InvoiceEvents
 
@@ -13,8 +12,6 @@ AppType = Optional[App]
 def invoice_requested_event(
     *, user: UserType, app: AppType, order: Order, number: str
 ) -> InvoiceEvent:
-    if not user_is_valid(user):
-        user = None
     return InvoiceEvent.objects.create(
         type=InvoiceEvents.REQUESTED,
         user=user,
@@ -27,8 +24,6 @@ def invoice_requested_event(
 def invoice_requested_deletion_event(
     *, user: UserType, app: AppType, invoice: Invoice
 ) -> InvoiceEvent:
-    if not user_is_valid(user):
-        user = None
     return InvoiceEvent.objects.create(
         type=InvoiceEvents.REQUESTED_DELETION,
         user=user,
@@ -41,8 +36,6 @@ def invoice_requested_deletion_event(
 def invoice_created_event(
     *, user: UserType, app: AppType, invoice: Invoice, number: str, url: str
 ) -> InvoiceEvent:
-    if not user_is_valid(user):
-        user = None
     return InvoiceEvent.objects.create(
         type=InvoiceEvents.CREATED,
         user=user,
@@ -56,8 +49,6 @@ def invoice_created_event(
 def invoice_deleted_event(
     *, user: UserType, app: AppType, invoice_id: int
 ) -> InvoiceEvent:
-    if not user_is_valid(user):
-        user = None
     return InvoiceEvent.objects.create(
         type=InvoiceEvents.DELETED,
         user=user,

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -904,6 +904,8 @@ def order_line_product_removed_event(
     app: AppType,
     order_lines: List[Tuple[int, OrderLine]],
 ):
+    if not user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         type=OrderEvents.ORDER_LINE_PRODUCT_DELETED,
         order=order,
@@ -919,6 +921,8 @@ def order_line_variant_removed_event(
     app: AppType,
     order_lines: List[Tuple[int, OrderLine]],
 ):
+    if not user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         type=OrderEvents.ORDER_LINE_VARIANT_DELETED,
         order=order,

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 from ..account import events as account_events
 from ..account.models import User
 from ..app.models import App
-from ..core.utils.validators import user_is_valid
 from ..discount.models import OrderDiscount
 from ..order.models import Fulfillment, FulfillmentLine, Order, OrderLine
 from ..payment.models import Payment
@@ -42,8 +41,6 @@ def _get_payment_data(amount: Optional[Decimal], payment: Payment) -> Dict:
 def event_transaction_capture_requested(
     order_id: "UUID", reference: str, amount: Decimal, user: UserType, app: AppType
 ):
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order_id=order_id,
         type=OrderEvents.TRANSACTION_CAPTURE_REQUESTED,
@@ -59,8 +56,6 @@ def event_transaction_capture_requested(
 def event_transaction_refund_requested(
     order_id: "UUID", reference: str, amount: Decimal, user: UserType, app: AppType
 ):
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order_id=order_id,
         type=OrderEvents.TRANSACTION_REFUND_REQUESTED,
@@ -76,8 +71,6 @@ def event_transaction_refund_requested(
 def event_transaction_void_requested(
     order_id: "UUID", reference: str, user: UserType, app: AppType
 ):
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order_id=order_id,
         type=OrderEvents.TRANSACTION_VOID_REQUESTED,
@@ -195,8 +188,6 @@ def invoice_requested_event(
     user: UserType,
     app: AppType,
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order, app=app, type=OrderEvents.INVOICE_REQUESTED, user=user
     )
@@ -209,8 +200,6 @@ def invoice_generated_event(
     app: AppType,
     invoice_number: str,
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.INVOICE_GENERATED,
@@ -229,8 +218,6 @@ def invoice_updated_event(
     url: str,
     status: str
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.INVOICE_UPDATED,
@@ -261,8 +248,6 @@ def email_resent_event(
 def draft_order_created_event(
     *, order: Order, user: UserType, app: AppType
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order, type=OrderEvents.DRAFT_CREATED, user=user, app=app
     )
@@ -276,8 +261,6 @@ def order_added_products_event(
     order_lines: List[OrderLine],
     quantity_diff: int = None
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
 
     if quantity_diff:
         lines = [_line_per_quantity_to_line_object(quantity_diff, order_lines[0])]
@@ -301,8 +284,6 @@ def order_removed_products_event(
     order_lines: List[OrderLine],
     quantity_diff: int = None
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
 
     if quantity_diff:
         lines = [_line_per_quantity_to_line_object(quantity_diff, order_lines[0])]
@@ -326,8 +307,6 @@ def draft_order_created_from_replace_event(
     app: AppType,
     lines: List[OrderLine]
 ):
-    if not user_is_valid(user):
-        user = None
     parameters = {
         "related_order_pk": original_order.pk,
         "lines": _lines_per_quantity_to_line_object_list(lines),
@@ -353,23 +332,16 @@ def order_created_event(
             order=order,
         )
 
-    if not user_is_valid(user):
-        user = None
-
     return OrderEvent.objects.create(order=order, type=event_type, user=user, app=app)
 
 
 def order_confirmed_event(*, order: Order, user: UserType, app: AppType) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order, type=OrderEvents.CONFIRMED, user=user, app=app
     )
 
 
 def order_canceled_event(*, order: Order, user: UserType, app: AppType) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order, type=OrderEvents.CANCELED, user=user, app=app
     )
@@ -382,8 +354,6 @@ def order_manually_marked_as_paid_event(
     app: AppType,
     transaction_reference: Optional[str] = None
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     parameters = {}  # type: ignore
     if transaction_reference:
         parameters = {"transaction_reference": transaction_reference}
@@ -397,8 +367,6 @@ def order_manually_marked_as_paid_event(
 
 
 def order_fully_paid_event(*, order: Order, user: UserType, app: AppType) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order, type=OrderEvents.ORDER_FULLY_PAID, user=user, app=app
     )
@@ -407,8 +375,6 @@ def order_fully_paid_event(*, order: Order, user: UserType, app: AppType) -> Ord
 def order_replacement_created(
     *, original_order: Order, replace_order: Order, user: UserType, app: AppType
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     parameters = {"related_order_pk": replace_order.pk}
     return OrderEvent.objects.create(
         order=original_order,
@@ -422,8 +388,6 @@ def order_replacement_created(
 def payment_authorized_event(
     *, order: Order, user: UserType, app: AppType, amount: Decimal, payment: Payment
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.PAYMENT_AUTHORIZED,
@@ -436,8 +400,6 @@ def payment_authorized_event(
 def payment_captured_event(
     *, order: Order, user: UserType, app: AppType, amount: Decimal, payment: Payment
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.PAYMENT_CAPTURED,
@@ -450,8 +412,6 @@ def payment_captured_event(
 def payment_refunded_event(
     *, order: Order, user: UserType, app: AppType, amount: Decimal, payment: Payment
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.PAYMENT_REFUNDED,
@@ -464,8 +424,6 @@ def payment_refunded_event(
 def payment_voided_event(
     *, order: Order, user: UserType, app: AppType, payment: Payment
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.PAYMENT_VOIDED,
@@ -479,8 +437,6 @@ def payment_failed_event(
     *, order: Order, user: UserType, app: AppType, message: str, payment: Payment
 ) -> OrderEvent:
 
-    if not user_is_valid(user):
-        user = None
     parameters = {"message": message}
 
     if payment:
@@ -505,9 +461,6 @@ def transaction_event(
     name: str
 ) -> OrderEvent:
 
-    if not user_is_valid(user):
-        user = None
-
     parameters = {"message": name, "reference": reference, "status": status}
     return OrderEvent.objects.create(
         order=order,
@@ -526,8 +479,6 @@ def external_notification_event(
     message: Optional[str],
     parameters: Optional[dict]
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     parameters = parameters or {}
     parameters["message"] = message
 
@@ -543,8 +494,6 @@ def external_notification_event(
 def fulfillment_canceled_event(
     *, order: Order, user: UserType, app: AppType, fulfillment: Optional[Fulfillment]
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.FULFILLMENT_CANCELED,
@@ -562,8 +511,6 @@ def fulfillment_restocked_items_event(
     fulfillment: Union[Order, Fulfillment],
     warehouse_pk: Optional["UUID"] = None,
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.FULFILLMENT_RESTOCKED_ITEMS,
@@ -583,8 +530,6 @@ def fulfillment_fulfilled_items_event(
     app: AppType,
     fulfillment_lines: List[FulfillmentLine]
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.FULFILLMENT_FULFILLED_ITEMS,
@@ -601,8 +546,6 @@ def fulfillment_awaits_approval_event(
     app: AppType,
     fulfillment_lines: List[FulfillmentLine]
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.FULFILLMENT_AWAITS_APPROVAL,
@@ -619,8 +562,6 @@ def order_returned_event(
     app: AppType,
     returned_lines: List[Tuple[int, OrderLine]],
 ):
-    if not user_is_valid(user):
-        user = None
 
     return OrderEvent.objects.create(
         order=order,
@@ -643,8 +584,6 @@ def fulfillment_replaced_event(
     app: AppType,
     replaced_lines: List[OrderLine],
 ):
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.FULFILLMENT_REPLACED,
@@ -663,8 +602,6 @@ def fulfillment_refunded_event(
     amount: Decimal,
     shipping_costs_included: bool
 ):
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.FULFILLMENT_REFUNDED,
@@ -689,8 +626,6 @@ def fulfillment_tracking_updated_event(
     tracking_number: str,
     fulfillment: Fulfillment
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.TRACKING_UPDATED,
@@ -707,7 +642,7 @@ def order_note_added_event(
     *, order: Order, user: UserType, app: AppType, message: str
 ) -> OrderEvent:
     kwargs: Dict[str, Union[AppType, UserType]] = {"app": app}
-    if user is not None and not user.is_anonymous:
+    if user is not None:
         if order.user is not None and order.user.pk == user.pk:
             account_events.customer_added_to_note_order_event(
                 user=user, order=order, message=message
@@ -749,8 +684,6 @@ def order_discount_event(
     order_discount: "OrderDiscount",
     old_order_discount: Optional["OrderDiscount"] = None
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     discount_parameters = _prepare_discount_object(order_discount, old_order_discount)
 
     return OrderEvent.objects.create(
@@ -839,8 +772,6 @@ def order_line_discount_event(
     line: OrderLine,
     line_before_update: Optional["OrderLine"] = None
 ) -> OrderEvent:
-    if not user_is_valid(user):
-        user = None
     discount_parameters = {
         "value": line.unit_discount_value,
         "amount_value": line.unit_discount_amount,
@@ -904,8 +835,6 @@ def order_line_product_removed_event(
     app: AppType,
     order_lines: List[Tuple[int, OrderLine]],
 ):
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         type=OrderEvents.ORDER_LINE_PRODUCT_DELETED,
         order=order,
@@ -921,8 +850,6 @@ def order_line_variant_removed_event(
     app: AppType,
     order_lines: List[Tuple[int, OrderLine]],
 ):
-    if not user_is_valid(user):
-        user = None
     return OrderEvent.objects.create(
         type=OrderEvents.ORDER_LINE_VARIANT_DELETED,
         order=order,

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -327,10 +327,11 @@ def order_created_event(
         event_type = OrderEvents.PLACED_FROM_DRAFT
     else:
         event_type = OrderEvents.PLACED
-        account_events.customer_placed_order_event(
-            user=user,  # type: ignore
-            order=order,
-        )
+        if user:
+            account_events.customer_placed_order_event(
+                user=user,  # type: ignore
+                order=order,
+            )
 
     return OrderEvent.objects.create(order=order, type=event_type, user=user, app=app)
 

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -385,7 +385,6 @@ def test_send_email_order_confirmation_for_cc(
 def test_send_confirmation_emails_without_addresses_for_payment(
     mocked_notify,
     site_settings,
-    anonymous_user,
     anonymous_plugins,
     digital_content,
     payment_dummy,
@@ -400,7 +399,7 @@ def test_send_confirmation_emails_without_addresses_for_payment(
     line = add_variant_to_order(
         order=order,
         line_data=line_data,
-        user=anonymous_user,
+        user=None,
         app=None,
         manager=anonymous_plugins,
         site_settings=site_settings,
@@ -442,7 +441,6 @@ def test_send_confirmation_emails_without_addresses_for_order(
     order,
     site_settings,
     digital_content,
-    anonymous_user,
     anonymous_plugins,
 ):
 
@@ -456,7 +454,7 @@ def test_send_confirmation_emails_without_addresses_for_order(
     line = add_variant_to_order(
         order=order,
         line_data=line_data,
-        user=anonymous_user,
+        user=None,
         app=None,
         manager=anonymous_plugins,
         site_settings=site_settings,

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -94,7 +94,6 @@ def test_add_variant_to_order_adds_line_for_new_variant(
     product,
     product_translation_fr,
     settings,
-    anonymous_user,
     anonymous_plugins,
     site_settings,
 ):
@@ -107,7 +106,7 @@ def test_add_variant_to_order_adds_line_for_new_variant(
     add_variant_to_order(
         order=order,
         line_data=line_data,
-        user=anonymous_user,
+        user=None,
         app=None,
         manager=anonymous_plugins,
         site_settings=site_settings,
@@ -134,7 +133,6 @@ def test_add_variant_to_order_adds_line_for_new_variant_on_sale(
     sale,
     discount_info,
     settings,
-    anonymous_user,
     anonymous_plugins,
     site_settings,
 ):
@@ -149,7 +147,7 @@ def test_add_variant_to_order_adds_line_for_new_variant_on_sale(
     add_variant_to_order(
         order=order,
         line_data=line_data,
-        user=anonymous_user,
+        user=None,
         app=None,
         manager=anonymous_plugins,
         site_settings=site_settings,
@@ -182,7 +180,6 @@ def test_add_variant_to_draft_order_adds_line_for_variant_with_price_0(
     product,
     product_translation_fr,
     settings,
-    anonymous_user,
     anonymous_plugins,
     site_settings,
 ):
@@ -199,7 +196,7 @@ def test_add_variant_to_draft_order_adds_line_for_variant_with_price_0(
     add_variant_to_order(
         order=order,
         line_data=line_data,
-        user=anonymous_user,
+        user=None,
         app=None,
         manager=anonymous_plugins,
         site_settings=site_settings,
@@ -218,7 +215,6 @@ def test_add_variant_to_draft_order_adds_line_for_variant_with_price_0(
 def test_add_variant_to_order_not_allocates_stock_for_new_variant(
     order_with_lines,
     product,
-    anonymous_user,
     anonymous_plugins,
     site_settings,
 ):
@@ -231,7 +227,7 @@ def test_add_variant_to_order_not_allocates_stock_for_new_variant(
     add_variant_to_order(
         order=order_with_lines,
         line_data=line_data,
-        user=anonymous_user,
+        user=None,
         app=None,
         manager=anonymous_plugins,
         site_settings=site_settings,
@@ -242,7 +238,7 @@ def test_add_variant_to_order_not_allocates_stock_for_new_variant(
 
 
 def test_add_variant_to_order_edits_line_for_existing_variant(
-    order_with_lines, anonymous_user, anonymous_plugins, site_settings
+    order_with_lines, anonymous_plugins, site_settings
 ):
     existing_line = order_with_lines.lines.first()
     variant = existing_line.variant
@@ -255,7 +251,7 @@ def test_add_variant_to_order_edits_line_for_existing_variant(
     add_variant_to_order(
         order=order_with_lines,
         line_data=line_data,
-        user=anonymous_user,
+        user=None,
         app=None,
         manager=anonymous_plugins,
         site_settings=site_settings,
@@ -269,7 +265,7 @@ def test_add_variant_to_order_edits_line_for_existing_variant(
 
 
 def test_add_variant_to_order_not_allocates_stock_for_existing_variant(
-    order_with_lines, anonymous_user, anonymous_plugins, site_settings
+    order_with_lines, anonymous_plugins, site_settings
 ):
     existing_line = order_with_lines.lines.first()
     variant = existing_line.variant
@@ -284,7 +280,7 @@ def test_add_variant_to_order_not_allocates_stock_for_existing_variant(
     add_variant_to_order(
         order=order_with_lines,
         line_data=line_data,
-        user=anonymous_user,
+        user=None,
         app=None,
         manager=anonymous_plugins,
         site_settings=site_settings,
@@ -560,7 +556,7 @@ def test_calculate_order_weight(order_with_lines):
 
 
 def test_order_weight_add_more_variant(
-    order_with_lines, anonymous_user, anonymous_plugins, site_settings
+    order_with_lines, anonymous_plugins, site_settings
 ):
     variant = order_with_lines.lines.first().variant
     line_data = OrderLineData(variant_id=str(variant.id), variant=variant, quantity=2)
@@ -568,7 +564,7 @@ def test_order_weight_add_more_variant(
     add_variant_to_order(
         order=order_with_lines,
         line_data=line_data,
-        user=anonymous_user,
+        user=None,
         app=None,
         manager=anonymous_plugins,
         site_settings=site_settings,
@@ -583,7 +579,6 @@ def test_order_weight_add_more_variant(
 def test_order_weight_add_new_variant(
     order_with_lines,
     product,
-    anonymous_user,
     anonymous_plugins,
     site_settings,
 ):
@@ -593,7 +588,7 @@ def test_order_weight_add_new_variant(
     add_variant_to_order(
         order=order_with_lines,
         line_data=line_data,
-        user=anonymous_user,
+        user=None,
         app=None,
         manager=anonymous_plugins,
         site_settings=site_settings,
@@ -632,7 +627,6 @@ def test_order_weight_delete_line(lines_info):
 def test_get_order_weight_non_existing_product(
     order_with_lines,
     product,
-    anonymous_user,
     anonymous_plugins,
     site_settings,
 ):
@@ -644,7 +638,7 @@ def test_get_order_weight_non_existing_product(
     add_variant_to_order(
         order=order,
         line_data=line_data,
-        user=anonymous_user,
+        user=None,
         app=None,
         manager=anonymous_plugins,
         site_settings=site_settings,

--- a/saleor/page/models.py
+++ b/saleor/page/models.py
@@ -11,7 +11,7 @@ from ..seo.models import SeoModel, SeoModelTranslation
 
 class PageQueryset(PublishedQuerySet):
     def visible_to_user(self, requestor):
-        if requestor.has_perm(PagePermissions.MANAGE_PAGES):
+        if requestor and requestor.has_perm(PagePermissions.MANAGE_PAGES):
             return self.all()
         return self.published()
 

--- a/saleor/payment/gateway.py
+++ b/saleor/payment/gateway.py
@@ -2,8 +2,6 @@ import logging
 from decimal import Decimal
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
-from django.contrib.auth.models import AnonymousUser
-
 from ..account.models import User
 from ..app.models import App
 from ..core.prices import quantize_price

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -12,7 +12,6 @@ from urllib.parse import urlencode, urlparse
 import Adyen
 import graphene
 from django.contrib.auth.hashers import check_password
-from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 from django.core.handlers.wsgi import WSGIRequest
 from django.forms.models import model_to_dict
@@ -221,7 +220,7 @@ def create_order(payment, checkout, manager):
             payment_data={},
             store_source=False,
             discounts=discounts,
-            user=checkout.user or AnonymousUser(),
+            user=checkout.user or None,
             app=None,
         )
     except ValidationError as e:

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -1,7 +1,6 @@
 import logging
 from typing import List, Optional
 
-from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 from django.core.handlers.wsgi import WSGIRequest
 from django.db.models import Prefetch
@@ -202,7 +201,7 @@ def _finalize_checkout(
             payment_data={},
             store_source=False,
             discounts=discounts,
-            user=checkout.user or AnonymousUser(),  # type: ignore
+            user=checkout.user or None,  # type: ignore
             app=None,
         )
     except ValidationError as e:

--- a/saleor/payment/tests/test_gateway.py
+++ b/saleor/payment/tests/test_gateway.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 from unittest.mock import Mock, patch
 
 import pytest
-from django.contrib.auth.models import AnonymousUser
 
 from ...order import OrderEvents
 from ...plugins.manager import get_plugins_manager
@@ -427,7 +426,7 @@ def test_request_capture_action_by_app(
         manager=get_plugins_manager(),
         charge_value=action_value,
         channel_slug=order.channel.slug,
-        user=AnonymousUser(),  # type: ignore
+        user=None,
         app=app,
     )
 
@@ -588,7 +587,7 @@ def test_request_refund_action_by_app(
         manager=get_plugins_manager(),
         refund_value=action_value,
         channel_slug=order.channel.slug,
-        user=AnonymousUser(),  # type: ignore
+        user=None,
         app=app,
     )
 
@@ -741,7 +740,7 @@ def test_request_void_action_by_app(
         transaction=transaction,
         manager=get_plugins_manager(),
         channel_slug=order.channel.slug,
-        user=AnonymousUser(),  # type:ignore
+        user=None,
         app=app,
     )
 

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 from unittest.mock import Mock, patch
 
 import pytest
-from django.contrib.auth.models import AnonymousUser
 
 from ...checkout.calculations import checkout_total
 from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
@@ -772,7 +771,7 @@ def test_payment_is_not_owned_by_user_for_checkout(payment, checkout, customer_u
 
 def test_payment_owned_by_user_anonymous_user(payment):
     # given
-    user = AnonymousUser()
+    user = None
 
     # when
     is_owned = payment_owned_by_user(payment.pk, user)

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -634,7 +634,7 @@ def try_void_or_refund_inactive_payment(
 
 
 def payment_owned_by_user(payment_pk: int, user) -> bool:
-    if user.is_anonymous:
+    if not user:
         return False
     return (
         Payment.objects.filter(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 import graphene
 import pytest
-from django.contrib.auth.models import AnonymousUser
 from freezegun import freeze_time
 
 from .....channel.models import Channel
@@ -41,7 +40,7 @@ from .payloads import (
 
 
 @freeze_time("2022-05-12 12:00:00")
-@pytest.mark.parametrize("requestor_type", ["user", "app", None, "anonymous"])
+@pytest.mark.parametrize("requestor_type", ["user", "app", "anonymous"])
 def test_subscription_query_with_meta(
     requestor_type,
     voucher,
@@ -53,8 +52,7 @@ def test_subscription_query_with_meta(
     requestor_map = {
         "user": staff_user,
         "app": app_with_token,
-        None: None,
-        "anonymous": AnonymousUser(),
+        "anonymous": None,
     }
     webhooks = [subscription_voucher_webhook_with_meta]
     event_type = WebhookEventAsyncType.VOUCHER_CREATED

--- a/saleor/warehouse/reservations.py
+++ b/saleor/warehouse/reservations.py
@@ -392,7 +392,7 @@ def is_reservation_enabled(settings) -> bool:
 
 
 def get_reservation_length(site, user) -> Optional[int]:
-    if user.is_authenticated:
+    if user:
         return site.settings.reserve_stock_duration_authenticated_user
     return site.settings.reserve_stock_duration_anonymous_user
 

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, DefaultDict, Dict, Iterable, List, Optional, Set
 
 import graphene
-from django.contrib.auth.models import AnonymousUser
 from django.db.models import F, QuerySet, Sum
 from django.utils import timezone
 from graphene.utils.str_converters import to_camel_case
@@ -108,7 +107,7 @@ ORDER_PRICE_FIELDS = (
 def generate_requestor(requestor: Optional["RequestorOrLazyObject"] = None):
     if not requestor:
         return {"id": None, "type": None}
-    if isinstance(requestor, (User, AnonymousUser)):
+    if isinstance(requestor, User):
         return {"id": graphene.Node.to_global_id("User", requestor.id), "type": "user"}
     return {"id": requestor.name, "type": "app"}  # type: ignore
 


### PR DESCRIPTION
Fixes #10574

Drop `AnonymouUser` from the context, and assign `None` instead.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
