### PR TITLE
Allow to pass metadata directly to line data in checkoutCreate and checkoutLinesAdd mutations

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -226,7 +226,9 @@ def add_variants_to_checkout(
     if to_delete:
         CheckoutLine.objects.filter(pk__in=[line.pk for line in to_delete]).delete()
     if to_update:
-        CheckoutLine.objects.bulk_update(to_update, ["quantity", "price_override"])
+        CheckoutLine.objects.bulk_update(
+            to_update, ["quantity", "price_override", "metadata"]
+        )
     if to_create:
         CheckoutLine.objects.bulk_create(to_create)
 
@@ -257,6 +259,10 @@ def _get_line_if_exist(line_data, lines_by_ids):
 
 
 def _append_line_to_update(to_update, to_delete, line_data, replace, line):
+    if line_data.metadata_list:
+        line.store_value_in_metadata(
+            {data.key: data.value for data in line_data.metadata_list}
+        )
     if line_data.quantity_to_update:
         quantity = line_data.quantity
         if quantity > 0:
@@ -281,15 +287,18 @@ def _append_line_to_delete(to_delete, line_data, line):
 def _append_line_to_create(to_create, checkout, variant, line_data, line):
     if line is None:
         if line_data.quantity > 0:
-            to_create.append(
-                CheckoutLine(
-                    checkout=checkout,
-                    variant=variant,
-                    quantity=line_data.quantity,
-                    currency=checkout.currency,
-                    price_override=line_data.custom_price,
-                )
+            checkout_line = CheckoutLine(
+                checkout=checkout,
+                variant=variant,
+                quantity=line_data.quantity,
+                currency=checkout.currency,
+                price_override=line_data.custom_price,
             )
+            if line_data.metadata_list:
+                checkout_line.store_value_in_metadata(
+                    {data.key: data.value for data in line_data.metadata_list}
+                )
+            to_create.append(checkout_line)
 
 
 def _check_new_checkout_address(checkout, address, address_type):

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -17,6 +17,7 @@ from ...core.descriptions import (
     ADDED_IN_31,
     ADDED_IN_35,
     ADDED_IN_36,
+    ADDED_IN_38,
     DEPRECATED_IN_3X_FIELD,
     PREVIEW_FEATURE,
 )
@@ -39,6 +40,8 @@ from .utils import (
 if TYPE_CHECKING:
     from ....account.models import Address
     from .utils import CheckoutLineData
+
+from ...meta.mutations import MetadataInput
 
 
 class CheckoutAddressValidationRules(graphene.InputObjectType):
@@ -104,6 +107,11 @@ class CheckoutLineInput(graphene.InputObjectType):
             "Flag that allow force splitting the same variant into multiple lines "
             "by skipping the matching logic. " + ADDED_IN_36 + PREVIEW_FEATURE
         ),
+    )
+    metadata = NonNullList(
+        MetadataInput,
+        description=("Fields required to update the object's metadata." + ADDED_IN_38),
+        required=False,
     )
 
 

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -18,6 +18,7 @@ ADDED_IN_34 = "\n\nAdded in Saleor 3.4."
 ADDED_IN_35 = "\n\nAdded in Saleor 3.5."
 ADDED_IN_36 = "\n\nAdded in Saleor 3.6."
 ADDED_IN_37 = "\n\nAdded in Saleor 3.7."
+ADDED_IN_38 = "\n\nAdded in Saleor 3.8."
 
 
 PREVIEW_FEATURE = (

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -19602,6 +19602,13 @@ input CheckoutLineInput {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   forceNewLine: Boolean = false
+
+  """
+  Fields required to update the object's metadata.
+  
+  Added in Saleor 3.8.
+  """
+  metadata: [MetadataInput!]
 }
 
 input CheckoutValidationRules {


### PR DESCRIPTION
I want to merge this change because it adds the possibility to pass metadata for lines directly in `checkoutCreate` and `checkoutLinesAdd` mutations.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
