### PR TITLE
Move order discount recalculation to base order total calculation.

### DIFF
--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -7,9 +7,8 @@ from prices import Money, TaxedMoney
 
 from ..core.prices import quantize_price
 from ..core.taxes import TaxData, TaxError, zero_taxed_money
-from ..discount import OrderDiscountType
 from ..plugins.manager import PluginsManager
-from . import ORDER_EDITABLE_STATUS, utils
+from . import ORDER_EDITABLE_STATUS
 from .interface import OrderTaxedPricesData
 from .models import Order, OrderLine
 
@@ -117,14 +116,6 @@ def fetch_order_prices_if_expired(
         prefetch_related_objects(lines, "variant__product__product_type")
 
     order.should_refresh_prices = False
-
-    order_discount = order.discounts.filter(type=OrderDiscountType.MANUAL).first()
-    if order_discount:
-        utils.update_order_discount_for_order(
-            order,
-            lines,
-            order_discount,
-        )
 
     _recalculate_order_prices(manager, order, lines)
 

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -43,7 +43,6 @@ from . import (
     OrderAuthorizeStatus,
     OrderChargeStatus,
     OrderStatus,
-    base_calculations,
     events,
 )
 from .fetch import OrderLineInfo
@@ -751,40 +750,6 @@ def create_order_discount_for_order(
         amount=new_amount,  # type: ignore
     )
     return order_discount
-
-
-def update_order_discount_for_order(
-    order: Order,
-    lines: Iterable[OrderLine],
-    order_discount_to_update: OrderDiscount,
-    reason: Optional[str] = None,
-    value_type: Optional[str] = None,
-    value: Optional[Decimal] = None,
-):
-    """Update the order_discount for an order."""
-    current_value = order_discount_to_update.value
-    value = value if value is not None else current_value
-    value_type = value_type or order_discount_to_update.value_type
-    fields_to_update = []
-    if reason is not None:
-        order_discount_to_update.reason = reason
-        fields_to_update.append("reason")
-
-    current_total = base_calculations.base_order_total_without_order_discount(
-        order, lines
-    )
-
-    discounted_total = apply_discount_to_value(
-        value, value_type, order.currency, current_total
-    )
-    new_amount = quantize_price(current_total - discounted_total, order.currency)
-
-    order_discount_to_update.amount = new_amount
-    order_discount_to_update.value = value
-    order_discount_to_update.value_type = value_type
-    fields_to_update.extend(["value_type", "value", "amount_value"])
-
-    order_discount_to_update.save(update_fields=fields_to_update)
 
 
 def remove_order_discount_from_order(order: Order, order_discount: OrderDiscount):


### PR DESCRIPTION
I want to merge this change because moving order discount recalculation to base order total calculation.

Previously, We had a separate function to recalculate order discounts. But we need to calculate the discount value 2 times. 
In the new approach, we update the order discount immediately when calculating the discount amount. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
