### PR TITLE
Add `FULFILLMENT_APPROVED` webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Saleor Apps
 
 - Trigger the `SALE_DELETED` webhook when deleting sales in bulk (#10461) (2052841e9)
+- Add `FULFILLMENT_APPROVED` webhook - #10621 by @IKarbowiak
 
 ### Other changes
 

--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -1800,9 +1800,11 @@ APPROVE_FULFILLMENT_MUTATION = """
 """
 
 
+@patch("saleor.plugins.manager.PluginsManager.fulfillment_approved")
 @patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
 def test_fulfillment_approve(
     mock_email_fulfillment,
+    mock_fulfillment_approved,
     staff_api_client,
     fulfillment,
     permission_manage_orders,
@@ -1829,6 +1831,7 @@ def test_fulfillment_approve(
     event = events[0]
     assert event.type == OrderEvents.FULFILLMENT_FULFILLED_ITEMS
     assert event.user == staff_api_client.user
+    mock_fulfillment_approved.assert_called_once_with(fulfillment)
 
 
 @patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
@@ -1869,9 +1872,11 @@ def test_fulfillment_approve_delete_products_before_approval_allow_stock_exceede
     assert event.user == staff_api_client.user
 
 
+@patch("saleor.plugins.manager.PluginsManager.fulfillment_approved")
 @patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
 def test_fulfillment_approve_delete_products_before_approval_allow_stock_exceeded_false(
     mock_email_fulfillment,
+    mock_fulfillment_approved,
     staff_api_client,
     fulfillment,
     permission_manage_orders,
@@ -1918,6 +1923,7 @@ def test_fulfillment_approve_delete_products_before_approval_allow_stock_exceede
     assert mock_email_fulfillment.call_count == 1
     events = fulfillment.order.events.all()
     assert len(events) == 0
+    mock_fulfillment_approved.assert_not_called()
 
 
 @patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1544,6 +1544,9 @@ enum WebhookEventTypeEnum {
   """A fulfillment is cancelled."""
   FULFILLMENT_CANCELED
 
+  """A fulfillment is approved."""
+  FULFILLMENT_APPROVED
+
   """User notification triggered."""
   NOTIFY_USER
 
@@ -1951,6 +1954,9 @@ enum WebhookEventTypeAsyncEnum {
 
   """A fulfillment is cancelled."""
   FULFILLMENT_CANCELED
+
+  """A fulfillment is approved."""
+  FULFILLMENT_APPROVED
 
   """User notification triggered."""
   NOTIFY_USER
@@ -2578,6 +2584,7 @@ enum WebhookSampleEventTypeEnum {
   CHECKOUT_UPDATED
   FULFILLMENT_CREATED
   FULFILLMENT_CANCELED
+  FULFILLMENT_APPROVED
   NOTIFY_USER
   PAGE_CREATED
   PAGE_UPDATED
@@ -22893,6 +22900,33 @@ Added in Saleor 3.4.
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type FulfillmentCanceled implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The fulfillment the event relates to."""
+  fulfillment: Fulfillment
+
+  """The order the fulfillment belongs to."""
+  order: Order
+}
+
+"""
+Event sent when fulfillment is approved.
+
+Added in Saleor 3.7.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type FulfillmentApproved implements Event {
   """Time of the event."""
   issuedAt: DateTime
 

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -81,6 +81,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.SALE_TOGGLE: "A sale is activated or deactivated.",
     WebhookEventAsyncType.FULFILLMENT_CREATED: "A new fulfillment is created.",
     WebhookEventAsyncType.FULFILLMENT_CANCELED: "A fulfillment is cancelled.",
+    WebhookEventAsyncType.FULFILLMENT_APPROVED: "A fulfillment is approved.",
     WebhookEventAsyncType.PAGE_CREATED: "A new page is created.",
     WebhookEventAsyncType.PAGE_UPDATED: "A page is updated.",
     WebhookEventAsyncType.PAGE_DELETED: "A page is deleted.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -30,6 +30,7 @@ from ..core.descriptions import (
     ADDED_IN_34,
     ADDED_IN_35,
     ADDED_IN_36,
+    ADDED_IN_37,
     PREVIEW_FEATURE,
 )
 from ..core.scalars import PositiveDecimal
@@ -818,6 +819,14 @@ class FulfillmentCanceled(ObjectType, FulfillmentBase):
         )
 
 
+class FulfillmentApproved(ObjectType, FulfillmentBase):
+    class Meta:
+        interfaces = (Event,)
+        description = (
+            "Event sent when fulfillment is approved." + ADDED_IN_37 + PREVIEW_FEATURE
+        )
+
+
 class UserBase(AbstractType):
     user = graphene.Field(
         "saleor.graphql.account.types.User",
@@ -1501,6 +1510,7 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.INVOICE_SENT: InvoiceSent,
     WebhookEventAsyncType.FULFILLMENT_CREATED: FulfillmentCreated,
     WebhookEventAsyncType.FULFILLMENT_CANCELED: FulfillmentCanceled,
+    WebhookEventAsyncType.FULFILLMENT_APPROVED: FulfillmentApproved,
     WebhookEventAsyncType.CUSTOMER_CREATED: CustomerCreated,
     WebhookEventAsyncType.CUSTOMER_UPDATED: CustomerUpdated,
     WebhookEventAsyncType.COLLECTION_CREATED: CollectionCreated,

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -264,7 +264,7 @@ def order_fulfilled(
     if order.status == OrderStatus.FULFILLED:
         transaction.on_commit(lambda: manager.order_fulfilled(order))
         for fulfillment in fulfillments:
-            transaction.on_commit(lambda: manager.fulfillment_approved(fulfillment))
+            transaction.on_commit(lambda f=fulfillment: manager.fulfillment_approved(f))
 
     if notify_customer:
         for fulfillment in fulfillments:
@@ -478,7 +478,7 @@ def approve_fulfillment(
     transaction.on_commit(lambda: manager.order_updated(order))
     if order.status == OrderStatus.FULFILLED:
         transaction.on_commit(lambda: manager.order_fulfilled(order))
-        transaction.on_commit(lambda: manager.fulfillment_approved(fulfillment))
+        transaction.on_commit(lambda f=fulfillment: manager.fulfillment_approved(f))
 
     if gift_card_lines_info:
         gift_cards_create(

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -263,6 +263,8 @@ def order_fulfilled(
 
     if order.status == OrderStatus.FULFILLED:
         transaction.on_commit(lambda: manager.order_fulfilled(order))
+        for fulfillment in fulfillments:
+            transaction.on_commit(lambda: manager.fulfillment_approved(fulfillment))
 
     if notify_customer:
         for fulfillment in fulfillments:
@@ -476,6 +478,7 @@ def approve_fulfillment(
     transaction.on_commit(lambda: manager.order_updated(order))
     if order.status == OrderStatus.FULFILLED:
         transaction.on_commit(lambda: manager.order_fulfilled(order))
+        transaction.on_commit(lambda: manager.fulfillment_approved(fulfillment))
 
     if gift_card_lines_info:
         gift_cards_create(

--- a/saleor/order/tests/test_fulfillments_actions.py
+++ b/saleor/order/tests/test_fulfillments_actions.py
@@ -11,9 +11,11 @@ from ..actions import create_fulfillments
 from ..models import FulfillmentLine, OrderStatus
 
 
+@patch("saleor.plugins.manager.PluginsManager.fulfillment_approved")
 @patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
 def test_create_fulfillments(
     mock_email_fulfillment,
+    mock_fulfillment_approved,
     staff_user,
     order_with_lines,
     warehouse,
@@ -71,14 +73,18 @@ def test_create_fulfillments(
         [fulfillment_lines[0].pk, fulfillment_lines[1].pk]
     )
 
+    flush_post_commit_hooks()
     mock_email_fulfillment.assert_called_once_with(
         order, order.fulfillments.get(), staff_user, None, manager
     )
+    mock_fulfillment_approved.assert_called_once_with(fulfillment)
 
 
+@patch("saleor.plugins.manager.PluginsManager.fulfillment_approved")
 @patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
 def test_create_fulfillments_require_approval(
     mock_email_fulfillment,
+    mock_fulfillment_approved,
     staff_user,
     order_with_lines,
     warehouse,
@@ -140,7 +146,9 @@ def test_create_fulfillments_require_approval(
         [fulfillment_lines[0].pk, fulfillment_lines[1].pk]
     )
 
+    flush_post_commit_hooks()
     mock_email_fulfillment.assert_not_called()
+    mock_fulfillment_approved.assert_not_called()
 
 
 @patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -490,6 +490,11 @@ class BasePlugin:
     #  cancelled.
     fulfillment_canceled: Callable[["Fulfillment", Any], Any]
 
+    #  Trigger when fulfillemnt is approved.
+    #  Overwrite this method if you need to trigger specific logic when a fulfillment is
+    #  approved.
+    fulfillment_approved: Callable[["Fulfillment", Any], Any]
+
     get_checkout_line_tax_rate: Callable[
         [
             "CheckoutInfo",

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -791,6 +791,15 @@ class PluginsManager(PaymentInterface):
             channel_slug=fulfillment.order.channel.slug,
         )
 
+    def fulfillment_approved(self, fulfillment: "Fulfillment"):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "fulfillment_approved",
+            default_value,
+            fulfillment,
+            channel_slug=fulfillment.order.channel.slug,
+        )
+
     def tracking_number_updated(self, fulfillment: "Fulfillment"):
         default_value = None
         return self.__run_method_on_plugins(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -648,6 +648,16 @@ class WebhookPlugin(BasePlugin):
                 fulfillment_data, event_type, webhooks, fulfillment, self.requestor
             )
 
+    def fulfillment_approved(self, fulfillment: "Fulfillment", previous_value):
+        if not self.active:
+            return previous_value
+        event_type = WebhookEventAsyncType.FULFILLMENT_APPROVED
+        if webhooks := get_webhooks_for_event(event_type):
+            fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
+            trigger_webhooks_async(
+                fulfillment_data, event_type, webhooks, fulfillment, self.requestor
+            )
+
     def customer_created(self, customer: "User", previous_value: Any) -> Any:
         if not self.active:
             return previous_value

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -471,6 +471,14 @@ def subscription_fulfillment_canceled_webhook(subscription_webhook):
 
 
 @pytest.fixture
+def subscription_fulfillment_approved_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.FULFILLMENT_APPROVED,
+        WebhookEventAsyncType.FULFILLMENT_APPROVED,
+    )
+
+
+@pytest.fixture
 def subscription_customer_created_webhook(subscription_webhook):
     return subscription_webhook(
         queries.CUSTOMER_CREATED, WebhookEventAsyncType.CUSTOMER_CREATED

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -940,6 +940,24 @@ FULFILLMENT_CANCELED = (
 """
 )
 
+FULFILLMENT_APPROVED = (
+    fragments.FULFILLMENT_DETAILS
+    + """
+    subscription{
+      event{
+        ...on FulfillmentApproved{
+          fulfillment{
+            ...FulfillmentDetails
+          }
+          order{
+            id
+          }
+        }
+      }
+    }
+"""
+)
+
 CUSTOMER_CREATED = (
     fragments.CUSTOMER_DETAILS
     + """

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1211,6 +1211,21 @@ def test_fulfillment_canceled(fulfillment, subscription_fulfillment_canceled_web
     assert deliveries[0].webhook == webhooks[0]
 
 
+def test_fulfillment_approved(fulfillment, subscription_fulfillment_approved_webhook):
+    # given
+    webhooks = [subscription_fulfillment_approved_webhook]
+    event_type = WebhookEventAsyncType.FULFILLMENT_APPROVED
+    expected_payload = generate_fulfillment_payload(fulfillment)
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, fulfillment, webhooks)
+
+    # then
+    assert deliveries[0].payload.payload == json.dumps(expected_payload)
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
 def test_customer_created(customer_user, subscription_customer_created_webhook):
     # given
     webhooks = [subscription_customer_created_webhook]

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -62,8 +62,11 @@ class WebhookEventAsyncType:
     ORDER_FULLY_PAID = "order_fully_paid"
     ORDER_UPDATED = "order_updated"
     ORDER_CANCELLED = "order_cancelled"
-    FULFILLMENT_CANCELED = "fulfillment_canceled"
     ORDER_FULFILLED = "order_fulfilled"
+
+    FULFILLMENT_CREATED = "fulfillment_created"
+    FULFILLMENT_CANCELED = "fulfillment_canceled"
+    FULFILLMENT_APPROVED = "fulfillment_approved"
 
     DRAFT_ORDER_CREATED = "draft_order_created"
     DRAFT_ORDER_UPDATED = "draft_order_updated"
@@ -77,8 +80,6 @@ class WebhookEventAsyncType:
     INVOICE_REQUESTED = "invoice_requested"
     INVOICE_DELETED = "invoice_deleted"
     INVOICE_SENT = "invoice_sent"
-
-    FULFILLMENT_CREATED = "fulfillment_created"
 
     CUSTOMER_CREATED = "customer_created"
     CUSTOMER_UPDATED = "customer_updated"
@@ -209,6 +210,7 @@ class WebhookEventAsyncType:
         CHECKOUT_UPDATED: "Checkout updated",
         FULFILLMENT_CREATED: "Fulfillment created",
         FULFILLMENT_CANCELED: "Fulfillment cancelled",
+        FULFILLMENT_APPROVED: "Fulfillment approved",
         NOTIFY_USER: "Notify user",
         PAGE_CREATED: "Page Created",
         PAGE_UPDATED: "Page Updated",
@@ -306,6 +308,7 @@ class WebhookEventAsyncType:
         (CHECKOUT_UPDATED, DISPLAY_LABELS[CHECKOUT_UPDATED]),
         (FULFILLMENT_CREATED, DISPLAY_LABELS[FULFILLMENT_CREATED]),
         (FULFILLMENT_CANCELED, DISPLAY_LABELS[FULFILLMENT_CANCELED]),
+        (FULFILLMENT_APPROVED, DISPLAY_LABELS[FULFILLMENT_APPROVED]),
         (NOTIFY_USER, DISPLAY_LABELS[NOTIFY_USER]),
         (PAGE_CREATED, DISPLAY_LABELS[PAGE_CREATED]),
         (PAGE_UPDATED, DISPLAY_LABELS[PAGE_UPDATED]),
@@ -404,6 +407,7 @@ class WebhookEventAsyncType:
         CHECKOUT_UPDATED: CheckoutPermissions.MANAGE_CHECKOUTS,
         FULFILLMENT_CREATED: OrderPermissions.MANAGE_ORDERS,
         FULFILLMENT_CANCELED: OrderPermissions.MANAGE_ORDERS,
+        FULFILLMENT_APPROVED: OrderPermissions.MANAGE_ORDERS,
         NOTIFY_USER: AccountPermissions.MANAGE_USERS,
         PAGE_CREATED: PagePermissions.MANAGE_PAGES,
         PAGE_UPDATED: PagePermissions.MANAGE_PAGES,


### PR DESCRIPTION
- Add `FULFILLMENT_APPROVED` webhook
- Call the new webhook when fulfillment is automatically approved
- Call the new webhook when fulfillment is approved with the use of `FulfillmentApprove` mutation

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
