### PR TITLE
Prevent sending request without lines data to Avatax

### DIFF
--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -3372,7 +3372,9 @@ def test_show_taxes_on_storefront(plugin_configuration):
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-def test_order_created(api_post_request_task_mock, order, plugin_configuration):
+def test_order_created(
+    api_post_request_task_mock, order, order_line, plugin_configuration
+):
     # given
     plugin_conf = plugin_configuration(
         from_street_address="Tęczowa 7",
@@ -3394,7 +3396,17 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         "createTransactionModel": {
             "companyCode": conf["Company name"],
             "type": TransactionType.INVOICE,
-            "lines": [],
+            "lines": [
+                {
+                    "amount": str(round(order_line.total_price.gross.amount, 3)),
+                    "description": order_line.variant.product.name,
+                    "discounted": False,
+                    "itemCode": order_line.variant.sku,
+                    "quantity": order_line.quantity,
+                    "taxCode": DEFAULT_TAX_CODE,
+                    "taxIncluded": True,
+                }
+            ],
             "code": str(order.id),
             "date": datetime.date.today().strftime("%Y-%m-%d"),
             "customerCode": 0,
@@ -3445,6 +3457,22 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         conf_data,
         order.pk,
     )
+
+
+@patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_order_created_no_lines(
+    api_post_request_task_mock, order, plugin_configuration
+):
+    """Ensure that when order has no lines, the request to avatax api is not sent."""
+    # given
+    manager = get_plugins_manager()
+
+    # when
+    manager.order_created(order)
+
+    # then
+    api_post_request_task_mock.assert_not_called()
 
 
 @pytest.mark.vcr
@@ -3876,13 +3904,10 @@ def test_get_order_request_data_draft_order_with_shipping_voucher(
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
 
-    # lines + shipping
-    assert len(lines_data) == order_with_lines.lines.count() + 1
-    for line_data in lines_data[:-1]:
+    # only lines, shipping is not added as after discount shipping price is 0
+    assert len(lines_data) == order_with_lines.lines.count()
+    for line_data in lines_data:
         assert line_data["discounted"] is False
-    # shipping line shouldn't be discounted
-    assert lines_data[-1]["discounted"] is False
-    assert Decimal(lines_data[-1]["amount"]) == Decimal("0")
 
 
 def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
@@ -3941,13 +3966,10 @@ def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
 
-    # lines + shipping
-    assert len(lines_data) == order_with_lines.lines.count() + 1
+    # only lines, shipping is not added as after discount shipping price is 0
+    assert len(lines_data) == order_with_lines.lines.count()
     for line_data in lines_data[:-1]:
         assert line_data["discounted"] is False
-    # shipping line shouldn't be discounted
-    assert lines_data[-1]["discounted"] is False
-    assert Decimal(lines_data[-1]["amount"]) == Decimal("0")
 
 
 def test_get_order_request_data_draft_order_with_sale(
@@ -4019,6 +4041,20 @@ def test_get_order_tax_data(
     # then
     get_order_request_data_mock.assert_called_once_with(order, conf, True)
     assert response == return_value
+
+
+def test_get_order_tax_data_empty_data(
+    order,
+    plugin_configuration,
+):
+    # given
+    conf = plugin_configuration()
+
+    # when
+    response = get_order_tax_data(order, conf, tax_included=True)
+
+    # then
+    assert response is None
 
 
 @patch("saleor.plugins.avatax.get_order_request_data")


### PR DESCRIPTION
- Do not append the shipping data when the price is zero
- Do not send the avatax request when there are no lines

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
