### PR TITLE
Prevent sending request without lines data to Avatax

### DIFF
--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -202,17 +202,11 @@ class AvataxPlugin(BasePlugin):
         discounts: Iterable[DiscountInfo],
         previous_value: TaxedMoney,
     ) -> TaxedMoney:
-        if self._skip_plugin(previous_value):
-            return previous_value
-        checkout_total = previous_value
-
-        if not _validate_checkout(checkout_info, lines):
-            return checkout_total
-        response = get_checkout_tax_data(
-            checkout_info, lines, self.config.tax_included, discounts, self.config
+        response = self._get_checkout_tax_data(
+            checkout_info, lines, discounts, previous_value
         )
-        if not response or "error" in response:
-            return checkout_total
+        if response is None:
+            return previous_value
 
         currency = checkout_info.checkout.currency
         taxed_total = zero_taxed_money(currency)
@@ -288,17 +282,11 @@ class AvataxPlugin(BasePlugin):
         if not charge_taxes_on_shipping():
             return base_shipping_price
 
-        if self._skip_plugin(previous_value):
-            return base_shipping_price
-
-        if not _validate_checkout(checkout_info, lines):
-            return base_shipping_price
-
-        response = get_checkout_tax_data(
-            checkout_info, lines, self.config.tax_included, discounts, self.config
+        response = self._get_checkout_tax_data(
+            checkout_info, lines, discounts, base_shipping_price
         )
-        if not response or "error" in response:
-            return base_shipping_price
+        if response is None:
+            return previous_value
 
         currency = str(response.get("currencyCode"))
         return self._calculate_checkout_shipping(
@@ -368,6 +356,8 @@ class AvataxPlugin(BasePlugin):
         request_data = get_order_request_data(
             order, self.config, self.config.tax_included
         )
+        if not request_data:
+            return previous_value
 
         transaction_url = urljoin(
             get_api_url(self.config.use_sandbox), "transactions/createoradjust"
@@ -389,18 +379,12 @@ class AvataxPlugin(BasePlugin):
         discounts: Iterable["DiscountInfo"],
         previous_value: TaxedMoney,
     ) -> TaxedMoney:
-        if self._skip_plugin(previous_value):
-            return previous_value
-
         base_total = previous_value
         if not checkout_line_info.product.charge_taxes:
             return base_total
 
-        if not _validate_checkout(checkout_info, lines):
-            return base_total
-
-        taxes_data = get_checkout_tax_data(
-            checkout_info, lines, self.config.tax_included, discounts, self.config
+        taxes_data = self._get_checkout_tax_data(
+            checkout_info, lines, discounts, base_total
         )
         variant = checkout_line_info.variant
 
@@ -452,15 +436,8 @@ class AvataxPlugin(BasePlugin):
         product: "Product",
         previous_value: OrderTaxedPricesData,
     ) -> OrderTaxedPricesData:
-        if self._skip_plugin(previous_value):
-            return previous_value
-
         if not product.charge_taxes:
             return previous_value
-
-        if not _validate_order(order):
-            return previous_value
-
         taxes_data = self._get_order_tax_data(order, previous_value)
         return self._calculate_order_line_total_price(
             taxes_data,
@@ -522,22 +499,16 @@ class AvataxPlugin(BasePlugin):
         discounts: Iterable["DiscountInfo"],
         previous_value: TaxedMoney,
     ) -> TaxedMoney:
-        if self._skip_plugin(previous_value):
-            return previous_value
-
         base_total = previous_value
         if not checkout_line_info.product.charge_taxes:
             return base_total
 
-        if not _validate_checkout(checkout_info, lines):
-            return base_total
-
+        taxes_data = self._get_checkout_tax_data(
+            checkout_info, lines, discounts, base_total
+        )
         variant = checkout_line_info.variant
 
         quantity = checkout_line_info.line.quantity
-        taxes_data = get_checkout_tax_data(
-            checkout_info, lines, self.config.tax_included, discounts, self.config
-        )
         default_total = previous_value * quantity
         taxed_total_price = self._calculate_checkout_line_total_price(
             taxes_data,
@@ -579,6 +550,9 @@ class AvataxPlugin(BasePlugin):
     def _calculate_order_shipping(
         self, order, taxes_data, previous_value
     ) -> TaxedMoney:
+        if taxes_data is None:
+            return previous_value
+
         currency = taxes_data.get("currencyCode")
         for line in taxes_data.get("lines", []):
             if line["itemCode"] == "Shipping":
@@ -609,19 +583,9 @@ class AvataxPlugin(BasePlugin):
     def calculate_order_shipping(
         self, order: "Order", previous_value: TaxedMoney
     ) -> TaxedMoney:
-        if self._skip_plugin(previous_value):
-            return previous_value
-
         if not charge_taxes_on_shipping():
             return previous_value
-
-        if not _validate_order(order):
-            return previous_value
-
-        taxes_data = get_order_tax_data(
-            order, self.config, self.config.tax_included, False
-        )
-
+        taxes_data = self._get_order_tax_data(order, previous_value)
         return self._calculate_order_shipping(order, taxes_data, previous_value)
 
     def calculate_order_total(
@@ -630,16 +594,7 @@ class AvataxPlugin(BasePlugin):
         lines: Iterable["OrderLine"],
         previous_value: TaxedMoney,
     ) -> TaxedMoney:
-        if self._skip_plugin(previous_value):
-            return previous_value
-        order_total = previous_value
-
-        if not _validate_order(order):
-            return order_total
-
-        taxes_data = get_order_tax_data(
-            order, self.config, self.config.tax_included, False
-        )
+        taxes_data = self._get_order_tax_data(order, previous_value)
 
         currency = order.currency
         taxed_subtotal = zero_taxed_money(currency)

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -3372,7 +3372,9 @@ def test_show_taxes_on_storefront(plugin_configuration):
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-def test_order_created(api_post_request_task_mock, order, plugin_configuration):
+def test_order_created(
+    api_post_request_task_mock, order, order_line, plugin_configuration
+):
     # given
     plugin_conf = plugin_configuration(
         from_street_address="Tęczowa 7",
@@ -3394,7 +3396,17 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         "createTransactionModel": {
             "companyCode": conf["Company name"],
             "type": TransactionType.INVOICE,
-            "lines": [],
+            "lines": [
+                {
+                    "amount": str(round(order_line.total_price.gross.amount, 3)),
+                    "description": order_line.variant.product.name,
+                    "discounted": False,
+                    "itemCode": order_line.variant.sku,
+                    "quantity": order_line.quantity,
+                    "taxCode": DEFAULT_TAX_CODE,
+                    "taxIncluded": True,
+                }
+            ],
             "code": str(order.id),
             "date": datetime.date.today().strftime("%Y-%m-%d"),
             "customerCode": 0,
@@ -3445,6 +3457,22 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         conf_data,
         order.pk,
     )
+
+
+@patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_order_created_no_lines(
+    api_post_request_task_mock, order, plugin_configuration
+):
+    """Ensure that when order has no lines, the request to avatax api is not sent."""
+    # given
+    manager = get_plugins_manager()
+
+    # when
+    manager.order_created(order)
+
+    # then
+    api_post_request_task_mock.assert_not_called()
 
 
 @pytest.mark.vcr
@@ -3876,13 +3904,10 @@ def test_get_order_request_data_draft_order_with_shipping_voucher(
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
 
-    # lines + shipping
-    assert len(lines_data) == order_with_lines.lines.count() + 1
-    for line_data in lines_data[:-1]:
+    # only lines, shipping is not added as after discount shipping price is 0
+    assert len(lines_data) == order_with_lines.lines.count()
+    for line_data in lines_data:
         assert line_data["discounted"] is False
-    # shipping line shouldn't be discounted
-    assert lines_data[-1]["discounted"] is False
-    assert Decimal(lines_data[-1]["amount"]) == Decimal("0")
 
 
 def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
@@ -3941,13 +3966,10 @@ def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
 
-    # lines + shipping
-    assert len(lines_data) == order_with_lines.lines.count() + 1
+    # only lines, shipping is not added as after discount shipping price is 0
+    assert len(lines_data) == order_with_lines.lines.count()
     for line_data in lines_data[:-1]:
         assert line_data["discounted"] is False
-    # shipping line shouldn't be discounted
-    assert lines_data[-1]["discounted"] is False
-    assert Decimal(lines_data[-1]["amount"]) == Decimal("0")
 
 
 def test_get_order_request_data_draft_order_with_sale(
@@ -4019,6 +4041,20 @@ def test_get_order_tax_data(
     # then
     get_order_request_data_mock.assert_called_once_with(order, conf, True)
     assert response == return_value
+
+
+def test_get_order_tax_data_empty_data(
+    order,
+    plugin_configuration,
+):
+    # given
+    conf = plugin_configuration()
+
+    # when
+    response = get_order_tax_data(order, conf, tax_included=True)
+
+    # then
+    assert response is None
 
 
 @patch("saleor.plugins.avatax.get_order_request_data")


### PR DESCRIPTION
- Do not append the shipping data when the price is zero
- Do not send the avatax request when there are no lines


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
