### PR TITLE
Prevent sending request without lines data to Avatax

### DIFF
--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -410,7 +410,7 @@ def get_order_lines_data(
         )
         append_shipping_to_data(
             data,
-            shipping_price,
+            shipping_price if shipping_price else None,
             config.shipping_tax_code,
         )
     return data
@@ -471,6 +471,8 @@ def generate_request_data_from_checkout(
 ):
     address = checkout_info.shipping_address or checkout_info.billing_address
     lines = get_checkout_lines_data(checkout_info, lines_info, config, discounts)
+    if not lines:
+        return {}
     voucher = checkout_info.voucher
     # for apply_once_per_order vouchers the discount is already applied on lines
     discount_amount = (
@@ -527,6 +529,9 @@ def get_cached_response_or_fetch(
 
     Return cached response if requests data are the same. Fetch new data in other cases.
     """
+    # if the data is empty it means there is nothing to send to avalara
+    if not data:
+        return None
     data_cache_key = CACHE_KEY + token_in_cache
     cached_data = cache.get(data_cache_key)
     if taxes_need_new_fetch(data, cached_data) or force_refresh:
@@ -558,6 +563,9 @@ def get_order_request_data(order: "Order", config: AvataxConfiguration):
     discount_amount = get_total_order_discount_excluding_shipping(order).amount
     discounted_lines = discount_amount != Decimal("0")
     lines = get_order_lines_data(order, config, discounted=discounted_lines)
+    # if there is no lines to sent we do not want to send the request to avalara
+    if not lines:
+        return {}
     data = generate_request_data(
         transaction_type=transaction,
         lines=lines,
@@ -578,9 +586,8 @@ def get_order_tax_data(
     response = get_cached_response_or_fetch(
         data, "order_%s" % order.id, config, force_refresh
     )
-    error = response.get("error")
-    if error:
-        raise TaxError(error)
+    if response and "error" in response:
+        raise TaxError(response.get("error"))
     return response
 
 

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -189,15 +189,11 @@ class AvataxPlugin(BasePlugin):
         discounts: Iterable[DiscountInfo],
         previous_value: TaxedMoney,
     ) -> TaxedMoney:
-        if self._skip_plugin(previous_value):
+        response = self._get_checkout_tax_data(
+            checkout_info, lines, discounts, previous_value
+        )
+        if response is None:
             return previous_value
-        checkout_total = previous_value
-
-        if not _validate_checkout(checkout_info, lines):
-            return checkout_total
-        response = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
-        if not response or "error" in response:
-            return checkout_total
 
         tax_included = (
             lambda: Site.objects.get_current().settings.include_taxes_in_prices
@@ -292,15 +288,11 @@ class AvataxPlugin(BasePlugin):
         if not charge_taxes_on_shipping():
             return base_shipping_price
 
-        if self._skip_plugin(previous_value):
-            return base_shipping_price
-
-        if not _validate_checkout(checkout_info, lines):
-            return base_shipping_price
-
-        response = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
-        if not response or "error" in response:
-            return base_shipping_price
+        response = self._get_checkout_tax_data(
+            checkout_info, lines, discounts, base_shipping_price
+        )
+        if response is None:
+            return previous_value
 
         currency = str(response.get("currencyCode"))
         return self._calculate_checkout_shipping(
@@ -367,6 +359,8 @@ class AvataxPlugin(BasePlugin):
         if not self.active or order.is_unconfirmed():
             return previous_value
         request_data = get_order_request_data(order, self.config)
+        if not request_data:
+            return previous_value
 
         transaction_url = urljoin(
             get_api_url(self.config.use_sandbox), "transactions/createoradjust"
@@ -388,21 +382,20 @@ class AvataxPlugin(BasePlugin):
         discounts: Iterable["DiscountInfo"],
         previous_value: CheckoutTaxedPricesData,
     ) -> CheckoutTaxedPricesData:
-        if self._skip_plugin(previous_value):
-            return previous_value
-
         base_total = previous_value
         if not checkout_line_info.product.charge_taxes:
             return base_total
 
-        if not _validate_checkout(checkout_info, lines):
+        taxes_data = self._get_checkout_tax_data(
+            checkout_info, lines, discounts, base_total
+        )
+        if not taxes_data:
             return base_total
 
         tax_included = (
             lambda: Site.objects.get_current().settings.include_taxes_in_prices
         )
 
-        taxes_data = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
         variant = checkout_line_info.variant
 
         return self._calculate_checkout_line_total_price(
@@ -464,20 +457,13 @@ class AvataxPlugin(BasePlugin):
         product: "Product",
         previous_value: OrderTaxedPricesData,
     ) -> OrderTaxedPricesData:
-        if self._skip_plugin(previous_value):
-            return previous_value
-
         if not product.charge_taxes:
             return previous_value
 
-        if not _validate_order(order):
-            return previous_value
-
+        taxes_data = self._get_order_tax_data(order, previous_value)
         tax_included = (
             lambda: Site.objects.get_current().settings.include_taxes_in_prices
         )
-
-        taxes_data = self._get_order_tax_data(order, previous_value)
         return self._calculate_order_line_total_price(
             taxes_data,
             variant.sku or variant.get_global_id(),
@@ -538,14 +524,14 @@ class AvataxPlugin(BasePlugin):
         discounts: Iterable["DiscountInfo"],
         previous_value: CheckoutTaxedPricesData,
     ) -> CheckoutTaxedPricesData:
-        if self._skip_plugin(previous_value):
-            return previous_value
-
         base_total = previous_value
         if not checkout_line_info.product.charge_taxes:
             return base_total
 
-        if not _validate_checkout(checkout_info, lines):
+        taxes_data = self._get_checkout_tax_data(
+            checkout_info, lines, discounts, base_total
+        )
+        if not taxes_data:
             return base_total
 
         tax_included = (
@@ -554,7 +540,6 @@ class AvataxPlugin(BasePlugin):
         variant = checkout_line_info.variant
 
         quantity = checkout_line_info.line.quantity
-        taxes_data = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
         default_total = CheckoutTaxedPricesData(
             price_with_discounts=previous_value.price_with_discounts * quantity,
             price_with_sale=previous_value.price_with_sale * quantity,
@@ -609,15 +594,12 @@ class AvataxPlugin(BasePlugin):
     def calculate_order_shipping(
         self, order: "Order", previous_value: TaxedMoney
     ) -> TaxedMoney:
-        if self._skip_plugin(previous_value):
-            return previous_value
-
         if not charge_taxes_on_shipping():
             return previous_value
 
-        if not _validate_order(order):
+        taxes_data = self._get_order_tax_data(order, previous_value)
+        if taxes_data is None:
             return previous_value
-        taxes_data = get_order_tax_data(order, self.config, False)
 
         tax_included = (
             lambda: Site.objects.get_current().settings.include_taxes_in_prices
@@ -670,6 +652,8 @@ class AvataxPlugin(BasePlugin):
         response = self._get_checkout_tax_data(
             checkout_info, lines, discounts, previous_value
         )
+        if response is None:
+            return previous_value
         variant = checkout_line_info.variant
         return self._get_unit_tax_rate(
             response,
@@ -716,7 +700,7 @@ class AvataxPlugin(BasePlugin):
         checkout_info: "CheckoutInfo",
         lines_info: Iterable["CheckoutLineInfo"],
         discounts: Iterable[DiscountInfo],
-        base_value: Decimal,
+        base_value: Union[Decimal, CheckoutTaxedPricesData],
     ):
         if self._skip_plugin(base_value):
             return None

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -3388,7 +3388,9 @@ def test_show_taxes_on_storefront(plugin_configuration):
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-def test_order_created(api_post_request_task_mock, order, plugin_configuration):
+def test_order_created(
+    api_post_request_task_mock, order, order_line, plugin_configuration
+):
     # given
     plugin_conf = plugin_configuration(
         from_street_address="Tęczowa 7",
@@ -3410,7 +3412,17 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         "createTransactionModel": {
             "companyCode": conf["Company name"],
             "type": TransactionType.INVOICE,
-            "lines": [],
+            "lines": [
+                {
+                    "amount": str(round(order_line.total_price.gross.amount, 3)),
+                    "description": order_line.variant.product.name,
+                    "discounted": False,
+                    "itemCode": order_line.variant.sku,
+                    "quantity": order_line.quantity,
+                    "taxCode": DEFAULT_TAX_CODE,
+                    "taxIncluded": True,
+                }
+            ],
             "code": str(order.id),
             "date": datetime.date.today().strftime("%Y-%m-%d"),
             "customerCode": 0,
@@ -3459,6 +3471,22 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         conf_data,
         order.pk,
     )
+
+
+@patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_order_created_no_lines(
+    api_post_request_task_mock, order, plugin_configuration
+):
+    """Ensure that when order has no lines, the request to avatax api is not sent."""
+    # given
+    manager = get_plugins_manager()
+
+    # when
+    manager.order_created(order)
+
+    # then
+    api_post_request_task_mock.assert_not_called()
 
 
 @pytest.mark.vcr
@@ -3889,13 +3917,10 @@ def test_get_order_request_data_draft_order_with_shipping_voucher(
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
 
-    # lines + shipping
-    assert len(lines_data) == order_with_lines.lines.count() + 1
-    for line_data in lines_data[:-1]:
+    # only lines, shipping is not added as after discount shipping price is 0
+    assert len(lines_data) == order_with_lines.lines.count()
+    for line_data in lines_data:
         assert line_data["discounted"] is False
-    # shipping line shouldn't be discounted
-    assert lines_data[-1]["discounted"] is False
-    assert Decimal(lines_data[-1]["amount"]) == Decimal("0")
 
 
 def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
@@ -3955,13 +3980,10 @@ def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
 
-    # lines + shipping
-    assert len(lines_data) == order_with_lines.lines.count() + 1
+    # only lines, shipping is not added as after discount shipping price is 0
+    assert len(lines_data) == order_with_lines.lines.count()
     for line_data in lines_data[:-1]:
         assert line_data["discounted"] is False
-    # shipping line shouldn't be discounted
-    assert lines_data[-1]["discounted"] is False
-    assert Decimal(lines_data[-1]["amount"]) == Decimal("0")
 
 
 def test_get_order_request_data_draft_order_with_sale(
@@ -4033,6 +4055,20 @@ def test_get_order_tax_data(
     # then
     get_order_request_data_mock.assert_called_once_with(order, conf)
     assert response == return_value
+
+
+def test_get_order_tax_data_empty_data(
+    order,
+    plugin_configuration,
+):
+    # given
+    conf = plugin_configuration()
+
+    # when
+    response = get_order_tax_data(order, conf)
+
+    # then
+    assert response is None
 
 
 @patch("saleor.plugins.avatax.get_order_request_data")


### PR DESCRIPTION
- Do not append the shipping data when the price is zero
- Do not send the Avatax request when there are no lines

Port of #10601

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
