### PR TITLE
Prevent sending request without lines data to Avatax

### DIFF
--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -397,9 +397,10 @@ def get_order_lines_data(
         shipping_method=order.shipping_method_id, channel=order.channel_id
     ).first()
     if shipping_method_channel_listing:
+        shipping_price = shipping_method_channel_listing.price.amount
         append_shipping_to_data(
             data,
-            shipping_method_channel_listing.price.amount,
+            shipping_price if shipping_price else None,
             config.shipping_tax_code,
         )
     return data
@@ -459,6 +460,9 @@ def generate_request_data_from_checkout(
     address = checkout_info.shipping_address or checkout_info.billing_address
     lines = get_checkout_lines_data(checkout_info, lines_info, config, discounts)
 
+    if not lines:
+        return {}
+
     currency = checkout_info.checkout.currency
     customer_email = cast(str, checkout_info.get_customer_email())
     data = generate_request_data(
@@ -504,6 +508,9 @@ def get_cached_response_or_fetch(
 
     Return cached response if requests data are the same. Fetch new data in other cases.
     """
+    # if the data is empty it means there is nothing to send to avalara
+    if not data:
+        return None
     data_cache_key = CACHE_KEY + token_in_cache
     cached_data = cache.get(data_cache_key)
     if taxes_need_new_fetch(data, cached_data) or force_refresh:
@@ -534,6 +541,10 @@ def get_order_request_data(order: "Order", config: AvataxConfiguration):
     )
     is_invoice_transaction = transaction == TransactionType.INVOICE
     lines = get_order_lines_data(order, config, is_invoice_transaction)
+
+    if not lines:
+        return {}
+
     data = generate_request_data(
         transaction_type=transaction,
         lines=lines,
@@ -553,9 +564,8 @@ def get_order_tax_data(
     response = get_cached_response_or_fetch(
         data, "order_%s" % order.id, config, force_refresh
     )
-    error = response.get("error")
-    if error:
-        raise TaxError(error)
+    if response and "error" in response:
+        raise TaxError(response.get("error"))
     return response
 
 

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -2656,7 +2656,9 @@ def test_show_taxes_on_storefront(plugin_configuration):
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-def test_order_created(api_post_request_task_mock, order, plugin_configuration):
+def test_order_created(
+    api_post_request_task_mock, order, order_line, plugin_configuration
+):
     # given
     plugin_conf = plugin_configuration(
         from_street_address="Tęczowa 7",
@@ -2678,7 +2680,16 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         "createTransactionModel": {
             "companyCode": conf["Company name"],
             "type": TransactionType.INVOICE,
-            "lines": [],
+            "lines": [
+                {
+                    "amount": str(round(order_line.total_price.gross.amount, 3)),
+                    "description": order_line.variant.product.name,
+                    "itemCode": order_line.variant.sku,
+                    "quantity": order_line.quantity,
+                    "taxCode": DEFAULT_TAX_CODE,
+                    "taxIncluded": True,
+                }
+            ],
             "code": str(order.id),
             "date": datetime.date.today().strftime("%Y-%m-%d"),
             "customerCode": 0,
@@ -2726,6 +2737,22 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         conf_data,
         order.pk,
     )
+
+
+@patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_order_created_no_lines(
+    api_post_request_task_mock, order, plugin_configuration
+):
+    """Ensure that when order has no lines, the request to avatax api is not sent."""
+    # given
+    manager = get_plugins_manager()
+
+    # when
+    manager.order_created(order)
+
+    # then
+    api_post_request_task_mock.assert_not_called()
 
 
 @pytest.mark.vcr
@@ -3068,7 +3095,8 @@ def test_get_order_request_data_draft_order_with_voucher(
     request_data = get_order_request_data(order_with_lines, config)
     lines_data = request_data["createTransactionModel"]["lines"]
 
-    # every line has additional discount data and extra one from shipping data
+    # every line has additional discount data
+    # shipping line is not added as after discount shipping price is 0
     assert len(lines_data) == order_with_lines.lines.count() * 2 + 1
 
 
@@ -3135,6 +3163,20 @@ def test_get_order_tax_data(
     # then
     get_order_request_data_mock.assert_called_once_with(order, conf)
     assert response == return_value
+
+
+def test_get_order_tax_data_empty_data(
+    order,
+    plugin_configuration,
+):
+    # given
+    conf = plugin_configuration()
+
+    # when
+    response = get_order_tax_data(order, conf)
+
+    # then
+    assert response is None
 
 
 @patch("saleor.plugins.avatax.get_order_request_data")


### PR DESCRIPTION
- Do not append the shipping data when the price is zero
- Do not send the Avatax request when there are no lines

Port of #10601

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
