### PR TITLE
Fix click and collect address shouldn't be stored in customer address book

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -114,7 +114,11 @@ def _process_shipping_data_for_order(
     delivery_method_info = checkout_info.delivery_method_info
     shipping_address = delivery_method_info.shipping_address
 
-    if checkout_info.user and shipping_address:
+    if (
+        delivery_method_info.store_as_customer_address
+        and checkout_info.user
+        and shipping_address
+    ):
         store_user_address(
             checkout_info.user, shipping_address, AddressType.SHIPPING, manager=manager
         )

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -96,6 +96,7 @@ class CheckoutInfo:
 class DeliveryMethodBase:
     delivery_method: Optional[Union["ShippingMethodData", "Warehouse"]] = None
     shipping_address: Optional["Address"] = None
+    store_as_customer_address: bool = False
 
     @property
     def warehouse_pk(self) -> Optional[str]:
@@ -127,6 +128,7 @@ class DeliveryMethodBase:
 class ShippingMethodInfo(DeliveryMethodBase):
     delivery_method: "ShippingMethodData"
     shipping_address: Optional["Address"]
+    store_as_customer_address: bool = True
 
     @property
     def delivery_method_name(self) -> Dict[str, Optional[str]]:


### PR DESCRIPTION
I want to merge this change because fixing the click and collect addresses shouldn't be stored in the customer address book.

Port #10645

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
