### PR TITLE
Fix recalculating order prices immediately after creation

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -502,6 +502,7 @@ def _create_order(
         status=status,
         origin=OrderOrigin.CHECKOUT,
         channel=checkout_info.channel,
+        should_refresh_prices=False,
     )
     if checkout.discount:
         # store voucher as a fixed value as it this the simplest solution for now.
@@ -1052,6 +1053,7 @@ def _create_order_from_checkout(
         metadata=checkout_info.checkout.metadata,
         private_metadata=checkout_info.checkout.private_metadata,
         redirect_url=checkout_info.checkout.redirect_url,
+        should_refresh_prices=False,
         **_process_shipping_data_for_order(
             checkout_info, shipping_total, manager, checkout_lines_info
         ),

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -47,6 +47,15 @@ MUTATION_CHECKOUT_COMPLETE = """
                         id
                     }
                 }
+                total {
+                    currency
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
             }
             errors {
                 field,
@@ -197,9 +206,11 @@ def test_checkout_complete_with_inactive_channel(
 
 
 @pytest.mark.integration
+@patch("saleor.order.calculations._recalculate_order_prices")
 @patch("saleor.plugins.manager.PluginsManager.order_confirmed")
 def test_checkout_complete(
     order_confirmed_mock,
+    _recalculate_order_prices_mock,
     site_settings,
     user_api_client,
     checkout_with_gift_card,
@@ -287,6 +298,7 @@ def test_checkout_complete(
         pk=checkout.pk
     ).exists(), "Checkout should have been deleted"
     order_confirmed_mock.assert_called_once_with(order)
+    _recalculate_order_prices_mock.assert_not_called()
 
 
 @pytest.mark.integration
@@ -602,9 +614,11 @@ def test_checkout_complete_with_variant_without_price(
     assert errors[0]["variants"] == [variant_id]
 
 
+@patch("saleor.order.calculations._recalculate_order_prices")
 @patch("saleor.plugins.manager.PluginsManager.order_confirmed")
 def test_checkout_complete_requires_confirmation(
     order_confirmed_mock,
+    _recalculate_order_prices_mock,
     user_api_client,
     site_settings,
     payment_dummy,
@@ -629,6 +643,7 @@ def test_checkout_complete_requires_confirmation(
     order = Order.objects.get(pk=order_id)
     assert order.is_unconfirmed()
     order_confirmed_mock.assert_not_called()
+    _recalculate_order_prices_mock.assert_not_called()
 
 
 @pytest.mark.integration

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -28,10 +28,19 @@ MUTATION_ORDER_CREATE_FROM_CHECKOUT = """
 mutation orderCreateFromCheckout($id: ID!){
     orderCreateFromCheckout(id: $id){
         order{
-            id,
+            id
             token
             original
             origin
+            total {
+                currency
+                net {
+                    amount
+                }
+                gross {
+                    amount
+                }
+            }
         }
         errors{
             field
@@ -82,9 +91,11 @@ def test_order_from_checkout_with_inactive_channel(
 
 
 @pytest.mark.integration
+@patch("saleor.order.calculations._recalculate_order_prices")
 @patch("saleor.plugins.manager.PluginsManager.order_confirmed")
 def test_order_from_checkout(
     order_confirmed_mock,
+    _recalculate_order_prices_mock,
     app_api_client,
     permission_handle_checkouts,
     site_settings,
@@ -167,6 +178,7 @@ def test_order_from_checkout(
     )
 
     order_confirmed_mock.assert_called_once_with(order)
+    _recalculate_order_prices_mock.assert_not_called()
 
 
 def test_order_from_checkout_by_app_with_missing_permission(
@@ -396,9 +408,11 @@ def test_order_from_checkout_with_variant_without_price(
     assert errors[0]["variants"] == [variant_id]
 
 
+@patch("saleor.order.calculations._recalculate_order_prices")
 @patch("saleor.plugins.manager.PluginsManager.order_confirmed")
 def test_order_from_checkout_requires_confirmation(
     order_confirmed_mock,
+    _recalculate_order_prices_mock,
     app_api_client,
     permission_handle_checkouts,
     site_settings,
@@ -423,6 +437,7 @@ def test_order_from_checkout_requires_confirmation(
     order = Order.objects.get(pk=order_id)
     assert order.is_unconfirmed()
     order_confirmed_mock.assert_not_called()
+    _recalculate_order_prices_mock.assert_not_called()
 
 
 @pytest.mark.integration


### PR DESCRIPTION
There is no need to recalculate order prices just after order creation.

Port of #10649

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
