### PR TITLE
Fix missing Vatlayer recalculation in order price recalculation

### DIFF
--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -46,6 +46,10 @@ def _recalculate_order_prices(
             except TaxError:
                 pass
 
+    # Plugins like Vatlayer don't implement Order line calculation instead of implement
+    # `update_taxes_for_order_lines`
+    manager.update_taxes_for_order_lines(order, list(lines))
+
     try:
         order.shipping_price = manager.calculate_order_shipping(order)
         order.shipping_tax_rate = manager.get_order_shipping_tax_rate(

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -7,6 +7,7 @@ from prices import Money, TaxedMoney
 
 from ...core.prices import quantize_price
 from ...core.taxes import TaxData, TaxError, TaxLineData, zero_taxed_money
+from ...plugins.manager import get_plugins_manager
 from .. import OrderStatus, calculations
 from ..interface import OrderTaxedPricesData
 
@@ -122,6 +123,22 @@ def test_recalculate_order_prices(order_with_lines, order_lines, tax_data):
         assert line.total_price == line_total.price_with_discounts
         assert line.undiscounted_total_price == line_total.undiscounted_price
         assert tax_rate == line.tax_rate
+
+
+@patch("saleor.plugins.manager.PluginsManager.update_taxes_for_order_lines")
+def test_recalculate_order_prices_calls_update_taxes_for_order_lines(
+    mocked_update_taxes_for_order_lines, order_with_lines, order_lines
+):
+    # given
+    order = order_with_lines
+    manager = get_plugins_manager()
+    lines = list(order_lines)
+
+    # when
+    calculations._recalculate_order_prices(manager, order, lines)
+
+    # then
+    mocked_update_taxes_for_order_lines.assert_called_once_with(order, lines)
 
 
 @pytest.mark.parametrize(

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -15,10 +15,10 @@ from django_prices_vatlayer.utils import (
 )
 from prices import Money, TaxedMoney, TaxedMoneyRange
 
-from ...checkout import base_calculations, calculations
+from ...checkout import base_calculations
 from ...core.prices import quantize_price
-from ...core.taxes import TaxType, zero_money
-from ...discount import VoucherType
+from ...core.taxes import TaxType, zero_money, zero_taxed_money
+from ...discount import OrderDiscountType, VoucherType
 from ...order.interface import OrderTaxedPricesData
 from ...order.utils import (
     get_total_order_discount_excluding_shipping,
@@ -42,15 +42,9 @@ if TYPE_CHECKING:
     from ...account.models import Address
     from ...channel.models import Channel
     from ...checkout.fetch import CheckoutInfo, CheckoutLineInfo
-    from ...checkout.models import Checkout
     from ...discount import DiscountInfo
     from ...order.models import Order, OrderLine
-    from ...product.models import (
-        Collection,
-        Product,
-        ProductVariant,
-        ProductVariantChannelListing,
-    )
+    from ...product.models import Product, ProductVariant
     from ..models import PluginConfiguration
 
 
@@ -178,6 +172,32 @@ class VatlayerPlugin(BasePlugin):
         ) + manager.calculate_checkout_shipping(
             checkout_info, lines, address, discounts
         )
+
+    def calculate_order_total(
+        self,
+        order: "Order",
+        lines: Iterable["OrderLine"],
+        previous_value: TaxedMoney,
+    ) -> TaxedMoney:
+        if self._skip_plugin(previous_value):
+            return previous_value
+
+        currency = order.currency
+
+        total = zero_taxed_money(currency)
+        undiscounted_subtotal = zero_taxed_money(currency)
+        for line in lines:
+            total += line.total_price
+            undiscounted_subtotal += line.undiscounted_total_price
+        total += order.shipping_price
+
+        # Vatlayer doesn't propagate order discount to shipping we should include
+        # remaining amount in total calculation.
+        order_discount = order.discounts.filter(type=OrderDiscountType.MANUAL).first()
+        if order_discount and order_discount.amount > undiscounted_subtotal.gross:
+            remaining_amount = order_discount.amount - undiscounted_subtotal.gross
+            total -= remaining_amount
+        return max(total, zero_taxed_money(currency))
 
     def _get_taxes_for_country(self, country: Country):
         """Try to fetch cached taxes on the plugin level.
@@ -347,9 +367,12 @@ class VatlayerPlugin(BasePlugin):
         )
         line.total_price = line.unit_price * line.quantity
         line.undiscounted_total_price = line.undiscounted_unit_price * line.quantity
-        line.tax_rate = (line.unit_price.tax / line.unit_price.net).quantize(
-            Decimal(".0001")
-        )
+        if line.unit_price.net == zero_money(line.currency):
+            line.tax_rate = Decimal("0")
+        else:
+            line.tax_rate = (line.unit_price.tax / line.unit_price.net).quantize(
+                Decimal(".0001")
+            )
 
     def calculate_checkout_line_total(
         self,


### PR DESCRIPTION
I want to merge this change because adding missing Vatlayer recalculation in order price recalculation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
