### PR TITLE
Fix failing quantityAvailable calculations for warehouse withous shipping zones

### DIFF
--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -77,7 +77,6 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
         stocks = Stock.objects.using(self.database_connection_name).filter(
             product_variant_id__in=variant_ids
         )
-        additional_warehouse_filter = True if country_code or channel_slug else False
 
         warehouse_shipping_zones = self.get_warehouse_shipping_zones(
             country_code, channel_slug
@@ -91,11 +90,11 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
             warehouse_shipping_zones_map[warehouse_shipping_zone.warehouse_id].append(
                 warehouse_shipping_zone.shippingzone_id
             )
-        if additional_warehouse_filter:
-            stocks = stocks.filter(
-                Q(warehouse_id__in=warehouse_shipping_zones_map.keys())
-                | Q(warehouse_id__in=cc_warehouses.values("id"))
-            )
+
+        stocks = stocks.filter(
+            Q(warehouse_id__in=warehouse_shipping_zones_map.keys())
+            | Q(warehouse_id__in=cc_warehouses.values("id"))
+        )
 
         stocks = stocks.annotate_available_quantity()
 


### PR DESCRIPTION
The standard warehouses (with disabled c&c option) shouldn't be taken into consideration during `quanatityAvailable` calculation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
