### PR TITLE
Fix default value of checkout discounts amount should be decimal 

### DIFF
--- a/saleor/checkout/models.py
+++ b/saleor/checkout/models.py
@@ -143,7 +143,7 @@ class Checkout(ModelWithMetadata):
     discount_amount = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
-        default=0,
+        default=Decimal("0.0"),
     )
     discount = MoneyField(amount_field="discount_amount", currency_field="currency")
     discount_name = models.CharField(max_length=255, blank=True, null=True)

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -869,7 +869,13 @@ def test_remove_voucher_from_checkout(checkout_with_voucher, voucher_translation
     assert not checkout.voucher_code
     assert not checkout.discount_name
     assert not checkout.translated_discount_name
+    assert isinstance(checkout.discount_amount, Decimal)
     assert checkout.discount == zero_money(checkout.channel.currency_code)
+
+
+def test_checkout_discount_amount_should_be_decimal():
+    checkout = Checkout()
+    assert isinstance(checkout.discount_amount, Decimal)
 
 
 def test_recalculate_checkout_discount(

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -1,4 +1,5 @@
 """Checkout-related utility functions."""
+from decimal import Decimal
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union, cast
 
 import graphene
@@ -747,7 +748,7 @@ def remove_voucher_from_checkout(checkout: Checkout):
     checkout.voucher_code = None
     checkout.discount_name = None
     checkout.translated_discount_name = None
-    checkout.discount_amount = 0
+    checkout.discount_amount = Decimal("0")
     checkout.save(
         update_fields=[
             "voucher_code",


### PR DESCRIPTION
I want to merge this change because fixing the default value of checkout discounts amount should be decimal.

Port #10663 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
