### PR TITLE
Drop extra Avalara config

### DIFF
--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -64,8 +64,6 @@ class AvataxConfiguration:
     company_name: str = "DEFAULT"
     autocommit: bool = False
     shipping_tax_code: str = ""
-    override_global_tax: bool = False
-    include_taxes_in_prices: bool = True
 
 
 class TransactionType:

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -82,8 +82,6 @@ class AvataxPlugin(BasePlugin):
         {"name": "from_country_area", "value": None},
         {"name": "from_postal_code", "value": None},
         {"name": "shipping_tax_code", "value": "FR000000"},
-        {"name": "override_global_tax", "value": False},
-        {"name": "include_taxes_in_prices", "value": True},
     ]
     CONFIG_STRUCTURE = {
         "Username or account": {
@@ -149,16 +147,6 @@ class AvataxPlugin(BasePlugin):
             ),
             "label": "Shipping tax code",
         },
-        "override_global_tax": {
-            "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Used when setting per channel is needed.",
-            "label": "Override global tax settings.",
-        },
-        "include_taxes_in_prices": {
-            "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": 'Applied only if "Override global tax settings" is on.',
-            "label": "All products prices are entered with tax included.",
-        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -181,8 +169,6 @@ class AvataxPlugin(BasePlugin):
             from_country_area=configuration["from_country_area"],
             from_postal_code=configuration["from_postal_code"],
             shipping_tax_code=configuration["shipping_tax_code"],
-            override_global_tax=configuration["override_global_tax"],
-            include_taxes_in_prices=configuration["include_taxes_in_prices"],
         )
 
     def _skip_plugin(

--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -34,8 +34,6 @@ def plugin_configuration(db, channel_USD):
         from_country_area="",
         from_postal_code="53-601",
         shipping_tax_code="FR000000",
-        override_global_tax=False,
-        include_taxes_in_prices=True,
     ):
         channel = channel or channel_USD
         data = {
@@ -54,8 +52,6 @@ def plugin_configuration(db, channel_USD):
                 {"name": "from_country_area", "value": from_country_area},
                 {"name": "from_postal_code", "value": from_postal_code},
                 {"name": "shipping_tax_code", "value": shipping_tax_code},
-                {"name": "override_global_tax", "value": override_global_tax},
-                {"name": "include_taxes_in_prices", "value": include_taxes_in_prices},
             ],
         }
         configuration = PluginConfiguration.objects.create(


### PR DESCRIPTION
Drop additional fields that were added to Avalara config:  `override_global_tax`, `include_taxes_in_prices`. In the new approach they are migrated to TaxConfiguration object.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
