### PR TITLE
Fix performance of update_variant_names

### DIFF
--- a/saleor/product/utils/variants.py
+++ b/saleor/product/utils/variants.py
@@ -7,7 +7,9 @@ if TYPE_CHECKING:
     from ..models import ProductVariant
 
 
-def generate_and_set_variant_name(variant: "ProductVariant", sku: Optional[str]):
+def generate_and_set_variant_name(
+    variant: "ProductVariant", sku: Optional[str], save: Optional[bool] = True
+):
     """Generate ProductVariant's name based on its attributes."""
     attributes_display = []
 
@@ -27,7 +29,9 @@ def generate_and_set_variant_name(variant: "ProductVariant", sku: Optional[str])
         name = sku or variant.get_global_id()
 
     variant.name = name
-    variant.save(update_fields=["name", "updated_at"])
+    if save:
+        variant.save(update_fields=["name", "updated_at"])
+    return variant
 
 
 def get_variant_selection_attributes(


### PR DESCRIPTION
I want to merge this change because it fixes the performance of `update_variants_names` task.
Local database (over 2500 affected variants)
Before: 26.7s ❌ 
After: 1.9s ✅ 

⚠️  This is a port of https://github.com/saleor/saleor/pull/10657

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
