### PR TITLE
Use dataloader to fetch user/app for granted refunds

### DIFF
--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -1391,6 +1391,7 @@ def test_order_granted_refunds_query_by_app(
     app_api_client,
     permission_manage_orders,
     permission_manage_shipping,
+    permission_manage_users,
     fulfilled_order,
     shipping_zone,
 ):
@@ -1414,7 +1415,7 @@ def test_order_granted_refunds_query_by_app(
     )
 
     app_api_client.app.permissions.set(
-        [permission_manage_orders, permission_manage_shipping]
+        [permission_manage_orders, permission_manage_shipping, permission_manage_users]
     )
 
     # when

--- a/saleor/graphql/order/tests/test_order_grant_refund_update.py
+++ b/saleor/graphql/order/tests/test_order_grant_refund_update.py
@@ -236,7 +236,7 @@ def test_grant_refund_update_by_user_missing_input(
 
 
 def test_grant_refund_update_by_app(
-    app_api_client, staff_user, permission_manage_orders, order
+    app_api_client, staff_user, permission_manage_orders, order, permission_manage_users
 ):
     # given
     current_reason = "Granted refund reason."
@@ -249,7 +249,9 @@ def test_grant_refund_update_by_app(
     )
     updated_at = granted_refund.updated_at
     granted_refund_id = to_global_id_or_none(granted_refund)
-    app_api_client.app.permissions.set([permission_manage_orders])
+    app_api_client.app.permissions.set(
+        [permission_manage_orders, permission_manage_users]
+    )
     amount = Decimal("20.00")
     reason = "New reason"
     variables = {

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -183,6 +183,7 @@ class OrderGrantedRefund(ModelObjectType):
         description = "The details of granted refund." + ADDED_IN_38 + PREVIEW_FEATURE
         model = models.OrderGrantedRefund
 
+    @staticmethod
     def resolve_user(root: models.OrderGrantedRefund, info):
         def _resolve_user(event_user):
             requester = get_user_or_app_from_context(info.context)
@@ -199,6 +200,7 @@ class OrderGrantedRefund(ModelObjectType):
 
         return UserByUserIdLoader(info.context).load(root.user_id).then(_resolve_user)
 
+    @staticmethod
     def resolve_app(root: models.OrderGrantedRefund, info):
         if root.app_id:
             return AppByIdLoader(info.context).load(root.app_id)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -176,7 +176,15 @@ class OrderGrantedRefund(ModelObjectType):
     updated_at = graphene.DateTime(required=True, description="Time of last update.")
     amount = graphene.Field(Money, required=True, description="Refund amount.")
     reason = graphene.String(description="Reason of the refund.")
-    user = graphene.Field(User, description="User who performed the action.")
+    user = graphene.Field(
+        User,
+        description=(
+            "User who performed the action. Requires of of the following "
+            f"permissions: {AccountPermissions.MANAGE_USERS.name}, "
+            f"{AccountPermissions.MANAGE_STAFF.name}, "
+            f"{AuthorizationFilters.OWNER.name}."
+        ),
+    )
     app = graphene.Field(App, description=("App that performed the action."))
 
     class Meta:

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9515,7 +9515,9 @@ type OrderGrantedRefund {
   """Reason of the refund."""
   reason: String
 
-  """User who performed the action."""
+  """
+  User who performed the action. Requires of of the following permissions: MANAGE_USERS, MANAGE_STAFF, OWNER.
+  """
   user: User
 
   """App that performed the action."""


### PR DESCRIPTION
I want to merge this change because it adds missing usage of datalaoder in granted refund type. It also adds the permission flow,  in the same manner as we have for order events. In future PRs, I will try to improve this part.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
