### PR TITLE
Fix attribute mutations validation

### DIFF
--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -198,13 +198,13 @@ class AttributeValueInput(graphene.InputObjectType):
         description=AttributeValueDescriptions.RICH_TEXT
         + DEPRECATED_IN_3X_INPUT
         + "The rich text attribute hasn't got predefined value, so can be specified "
-        "only from instance support the given attribute."
+        "only from instance that supports the given attribute."
     )
     plain_text = graphene.String(
         description=AttributeValueDescriptions.PLAIN_TEXT
         + DEPRECATED_IN_3X_INPUT
         + "The plain text attribute hasn't got predefined value, so can be specified "
-        "only from instance support the given attribute."
+        "only from instance that supports the given attribute."
     )
     file_url = graphene.String(
         required=False,

--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -360,7 +360,11 @@ class AttributeMixin:
             for field, err in validation_errors.error_dict.items():
                 if field == "attribute":
                     continue
-                raise ValidationError({cls.ATTRIBUTE_VALUES_FIELD: err})
+                errors = []
+                for error in err:
+                    error.code = AttributeErrorCode.INVALID.value
+                    errors.append(error)
+                raise ValidationError({cls.ATTRIBUTE_VALUES_FIELD: errors})
 
     @classmethod
     def validate_non_swatch_attr_value(cls, value_data: dict):

--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -19,6 +19,7 @@ from ...core.permissions import (
 from ...core.tracing import traced_atomic_transaction
 from ...core.utils import generate_unique_slug
 from ...product import models as product_models
+from ..core.descriptions import DEPRECATED_IN_3X_INPUT
 from ..core.enums import MeasurementUnitsEnum
 from ..core.fields import JSONString
 from ..core.inputs import ReorderInput
@@ -193,8 +194,18 @@ class BaseReorderAttributeValuesMutation(BaseMutation):
 
 class AttributeValueInput(graphene.InputObjectType):
     value = graphene.String(description=AttributeValueDescriptions.VALUE)
-    rich_text = JSONString(description=AttributeValueDescriptions.RICH_TEXT)
-    plain_text = graphene.String(description=AttributeValueDescriptions.PLAIN_TEXT)
+    rich_text = JSONString(
+        description=AttributeValueDescriptions.RICH_TEXT
+        + DEPRECATED_IN_3X_INPUT
+        + "The rich text attribute hasn't got predefined value, so can be specified "
+        "only from instance support the given attribute."
+    )
+    plain_text = graphene.String(
+        description=AttributeValueDescriptions.PLAIN_TEXT
+        + DEPRECATED_IN_3X_INPUT
+        + "The plain text attribute hasn't got predefined value, so can be specified "
+        "only from instance support the given attribute."
+    )
     file_url = graphene.String(
         required=False,
         description="URL of the file attribute. Every time, a new value is created.",

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
@@ -211,27 +211,10 @@ def test_create_numeric_attribute_and_attribute_values(
 
     # then
     content = get_graphql_content(response)
-    assert not content["data"]["attributeCreate"]["errors"]
     data = content["data"]["attributeCreate"]
-
-    # Check if the attribute was correctly created
-    assert data["attribute"]["name"] == attribute_name
-    assert data["attribute"]["slug"] == slugify(
-        attribute_name
-    ), "The default slug should be the slugified name"
-    assert (
-        data["attribute"]["productTypes"]["edges"] == []
-    ), "The attribute should not have been assigned to a product type"
-
-    # Check if the attribute values were correctly created
-    assert data["attribute"]["type"] == AttributeTypeEnum.PRODUCT_TYPE.name
-    assert data["attribute"]["unit"] == MeasurementUnitsEnum.M.name
-    assert data["attribute"]["inputType"] == AttributeInputTypeEnum.NUMERIC.name
-    assert data["attribute"]["filterableInStorefront"] is True
-    assert data["attribute"]["filterableInDashboard"] is True
-    assert data["attribute"]["availableInGrid"] is True
-    assert data["attribute"]["storefrontSearchPosition"] == 0
-    assert data["attribute"]["choices"]["edges"] == []
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["code"] == AttributeErrorCode.INVALID.name
+    assert data["errors"][0]["field"] == "values"
 
 
 def test_create_numeric_attribute_and_attribute_values_not_numeric_value_provided(

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
@@ -203,6 +203,37 @@ def test_update_empty_attribute_and_add_values(
     assert attribute.values.filter(name=attribute_value_name).exists()
 
 
+def test_update_empty_attribute_and_add_values_name_not_given(
+    staff_api_client,
+    color_attribute_without_values,
+    permission_manage_product_types_and_attributes,
+):
+    # given
+    query = UPDATE_ATTRIBUTE_MUTATION
+    attribute = color_attribute_without_values
+    node_id = graphene.Node.to_global_id("Attribute", attribute.id)
+    variables = {
+        "id": node_id,
+        "input": {
+            "addValues": [{"value": "abc"}],
+            "removeValues": [],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    attribute.refresh_from_db()
+    data = content["data"]["attributeUpdate"]
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["code"] == AttributeErrorCode.REQUIRED.name
+    assert data["errors"][0]["field"] == "addValues"
+
+
 def test_update_attribute_with_file_input_type(
     staff_api_client,
     file_attribute_with_file_input_type_without_values,

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
@@ -378,6 +378,31 @@ def test_update_attribute_with_file_input_type_invalid_settings(
     assert {error["code"] for error in errors} == {AttributeErrorCode.INVALID.name}
 
 
+def test_update_attribute_provide_existing_value_name(
+    staff_api_client, color_attribute, permission_manage_product_types_and_attributes
+):
+    # given
+    query = UPDATE_ATTRIBUTE_MUTATION
+    attribute = color_attribute
+    value = color_attribute.values.first()
+    node_id = graphene.Node.to_global_id("Attribute", attribute.id)
+    variables = {
+        "input": {"addValues": [{"name": value.name}], "removeValues": []},
+        "id": node_id,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    attribute.refresh_from_db()
+    data = content["data"]["attributeUpdate"]
+    assert len(data["errors"]) == 1
+
+
 UPDATE_ATTRIBUTE_SLUG_MUTATION = """
     mutation updateAttribute(
     $id: ID!, $slug: String) {

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -435,3 +435,29 @@ def test_update_attribute_value_invalid_input_data(
     assert len(data["errors"]) == 1
     assert data["errors"][0]["code"] == AttributeErrorCode.INVALID.name
     assert data["errors"][0]["field"] == field
+
+
+def test_update_attribute_value_swatch_attr_value(
+    staff_api_client,
+    swatch_attribute,
+    permission_manage_product_types_and_attributes,
+):
+    # given
+    query = UPDATE_ATTRIBUTE_VALUE_MUTATION
+    value = swatch_attribute.values.first()
+    node_id = graphene.Node.to_global_id("AttributeValue", value.id)
+    new_value = "#FFFFF"
+    variables = {"input": {"value": new_value}, "id": node_id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["attributeValueUpdate"]
+    value.refresh_from_db()
+    assert data["attributeValue"]["name"] == value.name
+    assert data["attributeValue"]["slug"] == value.slug
+    assert data["attributeValue"]["value"] == new_value

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20287,14 +20287,14 @@ input AttributeValueCreateInput {
   
   Rich text format. For reference see https://editorjs.io/
   
-  DEPRECATED: this field will be removed in Saleor 4.0.The rich text attribute hasn't got predefined value, so can be specified only from instance support the given attribute.
+  DEPRECATED: this field will be removed in Saleor 4.0.The rich text attribute hasn't got predefined value, so can be specified only from instance that supports the given attribute.
   """
   richText: JSONString
 
   """
   Represents the text of the attribute value, plain text without formating.
   
-  DEPRECATED: this field will be removed in Saleor 4.0.The plain text attribute hasn't got predefined value, so can be specified only from instance support the given attribute.
+  DEPRECATED: this field will be removed in Saleor 4.0.The plain text attribute hasn't got predefined value, so can be specified only from instance that supports the given attribute.
   """
   plainText: String
 
@@ -20381,14 +20381,14 @@ input AttributeValueUpdateInput {
   
   Rich text format. For reference see https://editorjs.io/
   
-  DEPRECATED: this field will be removed in Saleor 4.0.The rich text attribute hasn't got predefined value, so can be specified only from instance support the given attribute.
+  DEPRECATED: this field will be removed in Saleor 4.0.The rich text attribute hasn't got predefined value, so can be specified only from instance that supports the given attribute.
   """
   richText: JSONString
 
   """
   Represents the text of the attribute value, plain text without formating.
   
-  DEPRECATED: this field will be removed in Saleor 4.0.The plain text attribute hasn't got predefined value, so can be specified only from instance support the given attribute.
+  DEPRECATED: this field will be removed in Saleor 4.0.The plain text attribute hasn't got predefined value, so can be specified only from instance that supports the given attribute.
   """
   plainText: String
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -20286,11 +20286,15 @@ input AttributeValueCreateInput {
   Represents the text of the attribute value, includes formatting.
   
   Rich text format. For reference see https://editorjs.io/
+  
+  DEPRECATED: this field will be removed in Saleor 4.0.The rich text attribute hasn't got predefined value, so can be specified only from instance support the given attribute.
   """
   richText: JSONString
 
   """
   Represents the text of the attribute value, plain text without formating.
+  
+  DEPRECATED: this field will be removed in Saleor 4.0.The plain text attribute hasn't got predefined value, so can be specified only from instance support the given attribute.
   """
   plainText: String
 
@@ -20376,11 +20380,15 @@ input AttributeValueUpdateInput {
   Represents the text of the attribute value, includes formatting.
   
   Rich text format. For reference see https://editorjs.io/
+  
+  DEPRECATED: this field will be removed in Saleor 4.0.The rich text attribute hasn't got predefined value, so can be specified only from instance support the given attribute.
   """
   richText: JSONString
 
   """
   Represents the text of the attribute value, plain text without formating.
+  
+  DEPRECATED: this field will be removed in Saleor 4.0.The plain text attribute hasn't got predefined value, so can be specified only from instance support the given attribute.
   """
   plainText: String
 


### PR DESCRIPTION
- Deprecate `richText` and `plainText` in `AttributeValueInput`
- Only attribute with choices values can be defined in Attribute mutations (`AttributeCreate`, `AttributeUpdate` mutation)
- Only attribute with choices values can be created or updated with the use of `AttributeValueCreate`, `AttributeValueUpdate`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
