### PR TITLE
Fix failing `TaxExemptionManage` tests

### DIFF
--- a/saleor/graphql/tax/mutations/tax_exemption_manage.py
+++ b/saleor/graphql/tax/mutations/tax_exemption_manage.py
@@ -13,6 +13,7 @@ from ...core.descriptions import ADDED_IN_38, PREVIEW_FEATURE
 from ...core.types import Error
 from ...core.types.taxes import TaxSourceObject
 from ...discount.dataloaders import load_discounts
+from ...plugins.dataloaders import load_plugin_manager
 
 TaxExemptionManageErrorCode = graphene.Enum.from_enum(
     error_codes.TaxExemptionManageErrorCode
@@ -71,16 +72,15 @@ class TaxExemptionManage(BaseMutation):
 
     @classmethod
     def _invalidate_checkout_prices(cls, info, checkout):
+        manager = load_plugin_manager(info.context)
         discounts = load_discounts(info.context)
 
-        checkout_info = fetch_checkout_info(
-            checkout, [], discounts, info.context.plugins
-        )
+        checkout_info = fetch_checkout_info(checkout, [], discounts, manager)
         lines_info, _ = fetch_checkout_lines(checkout)
         invalidate_checkout_prices(
             checkout_info,
             lines_info,
-            info.context.plugins,
+            manager,
             discounts,
             save=False,
         )


### PR DESCRIPTION
Some `TaxExemptionManage` failed after merging #10581

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
