### PR TITLE
Fix incorrect number of decimal places for gift cards

### DIFF
--- a/saleor/giftcard/notifications.py
+++ b/saleor/giftcard/notifications.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from ..account.notifications import get_default_user_payload
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
+from ..core.prices import quantize_price
 
 if TYPE_CHECKING:
     from .models import GiftCard
@@ -38,6 +39,6 @@ def get_default_gift_card_payload(gift_card: "GiftCard"):
     return {
         "id": gift_card.id,
         "code": gift_card.code,
-        "balance": gift_card.current_balance_amount,
+        "balance": quantize_price(gift_card.current_balance_amount, gift_card.currency),
         "currency": gift_card.currency,
     }

--- a/saleor/giftcard/tests/test_notifications.py
+++ b/saleor/giftcard/tests/test_notifications.py
@@ -34,7 +34,12 @@ def test_send_gift_card_notification(
     )
 
     expected_payload = {
-        "gift_card": get_default_gift_card_payload(gift_card),
+        "gift_card": {
+            "id": gift_card.id,
+            "code": gift_card.code,
+            "balance": round(gift_card.current_balance_amount, 2),
+            "currency": gift_card.currency,
+        },
         "user": get_default_user_payload(customer_user) if customer_user else None,
         "requester_user_id": staff_user.id,
         "requester_app_id": None,


### PR DESCRIPTION
The gift card balance was incorrectly rounded in the email.

Port of #10700

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
