### PR TITLE
Fix deadlocks on attributeValueUpdate

### DIFF
--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -2,7 +2,8 @@ from typing import TYPE_CHECKING
 
 import graphene
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db.models import Exists, OuterRef, Q
+from django.db import transaction
+from django.db.models import Exists, OuterRef, Q, Subquery
 from django.utils.text import slugify
 
 from ...attribute import ATTRIBUTE_PROPERTIES_CONFIGURATION, AttributeInputType
@@ -745,14 +746,31 @@ class AttributeValueUpdate(AttributeValueCreate):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        variants = product_models.ProductVariant.objects.filter(
-            Exists(instance.variantassignments.filter(variant_id=OuterRef("id")))
-        )
-
-        product_models.Product.objects.filter(
-            Q(Exists(instance.productassignments.filter(product_id=OuterRef("id"))))
-            | Q(Exists(variants.filter(product_id=OuterRef("id"))))
-        ).update(search_index_dirty=True)
+        with transaction.atomic():
+            variants = product_models.ProductVariant.objects.filter(
+                Exists(instance.variantassignments.filter(variant_id=OuterRef("id")))
+            )
+            # SELECT … FOR UPDATE needs to lock rows in a consistent order
+            # to avoid deadlocks between updates touching the same rows.
+            qs = (
+                product_models.Product.objects.select_for_update(of=("self",))
+                .filter(
+                    Q(
+                        Exists(
+                            instance.productassignments.filter(
+                                product_id=OuterRef("id")
+                            )
+                        )
+                    )
+                    | Q(Exists(variants.filter(product_id=OuterRef("id"))))
+                )
+                .order_by("pk")
+            )
+            # qs is executed in a subquery to make sure the SELECT statement gets
+            # properly evaluated and locks the rows in the same order every time.
+            product_models.Product.objects.filter(
+                pk__in=Subquery(qs.values("pk"))
+            ).update(search_index_dirty=True)
 
         info.context.plugins.attribute_value_updated(instance)
         info.context.plugins.attribute_updated(instance.attribute)


### PR DESCRIPTION
ℹ️ This is a 3.5 port of https://github.com/saleor/saleor/pull/10696

I want to merge this change because it fixes deadlocks on attributeValueUpdate mutation.

Testing method: script that executes 100 subprocesses at the same time that sends AttributeValueUpdate of a same attribute. Always ended up with ~10 - 20 deadlocks.

Postgres update works in a way that it creates the transaction and locks the relevant rows one by one as it goes, in arbitrary order. Locks are freed when the transaction either commits or rolls back. Because of that arbitrary locking order, deadlocks are created (by mutual dependency - thread1 has a lock on row A, but wants B. At the same time thread2 has a lock on B but wants on A).

information_source The solution is about locking the rows for the update upfront - while ensuring the locking is performed always in the same order. This can be achieved in a subquery that does a SELECT but with ORDER BY and FOR UPDATE - then the outer update statement gets a list of IDS of already correctly locked rows.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
