### PR TITLE
Fix Heroku memory errors for Celery.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: python manage.py migrate --no-input
 web: gunicorn --bind :$PORT --workers 4 --worker-class saleor.asgi.gunicorn_worker.UvicornWorker saleor.asgi:application
-celeryworker: celery -A saleor --app=saleor.celeryconf:app worker --loglevel=info -E
+celeryworker: celery -A saleor --app=saleor.celeryconf:app worker --loglevel=info -E --concurrency 2


### PR DESCRIPTION
Add a concurrency option for Celery, otherwise, the dyno will constantly crash to memory errors.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
