### PR TITLE
Add number to webhook order payload

### DIFF
--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -296,6 +296,7 @@ def generate_order_payload(
     extra_dict_data = {
         "id": graphene.Node.to_global_id("Order", order.id),
         "token": str(order.id),
+        "number": order.number,
         "user_email": order.get_customer_email(),
         "created": order.created_at,
         "original": graphene.Node.to_global_id("Order", order.original_id),

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -145,6 +145,7 @@ def test_generate_order_payload(
         "id": graphene.Node.to_global_id("Order", order.id),
         "type": "Order",
         "token": str(order.id),
+        "number": order.number,
         "created": parse_django_datetime(order.created_at),
         "status": order.status,
         "origin": order.origin,


### PR DESCRIPTION
Add missing order number to webhook order payload.

Port of #10712

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
