### PR TITLE
Fix the slug generated from the name shouldn't use Unicode

### DIFF
--- a/saleor/core/tests/test_core.py
+++ b/saleor/core/tests/test_core.py
@@ -242,8 +242,10 @@ def test_delete_sort_order_with_null_value(menu_item):
         ("Shirt", "shirt"),
         ("40.5", "405-2"),
         ("FM1+", "fm1-2"),
-        ("زيوت", "زيوت"),
-        ("わたし-わ にっぽん です", "わたし-わ-にっぽん-です-2"),
+        ("Ładny", "ladny"),
+        ("زيوت", "zywt"),
+        ("わたし-わ にっぽん です", "watasi-wa-nitupon-desu-2"),
+        ("Салеор", "saleor-2"),
     ],
 )
 def test_generate_unique_slug_with_slugable_field(
@@ -253,9 +255,10 @@ def test_generate_unique_slug_with_slugable_field(
         ("Paint", "paint"),
         ("Paint blue", "paint-blue"),
         ("Paint test", "paint-2"),
+        ("Saleor", "saleor"),
         ("405", "405"),
         ("FM1", "fm1"),
-        ("わたし わ にっぽん です", "わたし-わ-にっぽん-です"),
+        ("わたし わ にっぽん です", "watasi-wa-nitupon-desu"),
     ]
     for name, slug in product_names_and_slugs:
         ProductType.objects.create(

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -12,6 +12,7 @@ from django.utils.encoding import iri_to_uri
 from django.utils.text import slugify
 from django_prices_openexchangerates import exchange_currency
 from prices import MoneyRange
+from text_unidecode import unidecode
 
 task_logger = get_task_logger(__name__)
 
@@ -114,7 +115,7 @@ def generate_unique_slug(
             with the same slug that passed also additional conditions
 
     """
-    slug = slugify(slugable_value, allow_unicode=True)
+    slug = slugify(unidecode(slugable_value))
     unique_slug: Union["SafeText", str] = slug
 
     ModelClass = instance.__class__

--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from django.db.models import Exists, OuterRef, Q, Subquery
 from django.utils.text import slugify
+from text_unidecode import unidecode
 
 from ...attribute import ATTRIBUTE_PROPERTIES_CONFIGURATION, AttributeInputType
 from ...attribute import models as models
@@ -331,7 +332,7 @@ class AttributeMixin:
             cls.validate_swatch_attr_value(value_data)
 
         slug_value = value if not is_numeric_attr else value.replace(".", "_")
-        value_data["slug"] = slugify(slug_value, allow_unicode=True)
+        value_data["slug"] = slugify(unidecode(slug_value))
 
         attribute_value = models.AttributeValue(**value_data, attribute=attribute)
         try:
@@ -389,7 +390,7 @@ class AttributeMixin:
         # Check values uniqueness in case of creating new attribute.
         existing_values = attribute.values.values_list("slug", flat=True)
         for value_data in values_input:
-            slug = slugify(value_data["name"], allow_unicode=True)
+            slug = slugify(unidecode(value_data["name"]))
             if slug in existing_values:
                 msg = (
                     "Value %s already exists within this attribute."
@@ -404,8 +405,7 @@ class AttributeMixin:
                 )
 
         new_slugs = [
-            slugify(value_data["name"], allow_unicode=True)
-            for value_data in values_input
+            slugify(unidecode(value_data["name"])) for value_data in values_input
         ]
         if len(set(new_slugs)) != len(new_slugs):
             raise ValidationError(

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -13,6 +13,7 @@ from django.template.defaultfilters import truncatechars
 from django.utils import timezone
 from django.utils.text import slugify
 from graphql.error import GraphQLError
+from text_unidecode import unidecode
 
 from ...attribute import AttributeEntityType, AttributeInputType, AttributeType
 from ...attribute import models as attribute_models
@@ -363,7 +364,7 @@ class AttributeAssignmentMixin:
         return tuple(
             get_or_create(
                 attribute=attribute,
-                slug=slugify(value, allow_unicode=True),
+                slug=slugify(unidecode(value)),
                 defaults={"name": value},
             )[0]
             for value in attr_values.values
@@ -428,7 +429,7 @@ class AttributeAssignmentMixin:
         boolean = bool(attr_values.boolean)
         value, _ = get_or_create(
             attribute=attribute,
-            slug=slugify(f"{attribute.id}_{boolean}", allow_unicode=True),
+            slug=slugify(unidecode(f"{attribute.id}_{boolean}")),
             defaults={
                 "name": f"{attribute.name}: {'Yes' if boolean else 'No'}",
                 "boolean": boolean,
@@ -470,7 +471,7 @@ class AttributeAssignmentMixin:
         value_defaults: dict,
     ):
         update_or_create = attribute.values.update_or_create
-        slug = slugify(f"{instance.id}_{attribute.id}", allow_unicode=True)
+        slug = slugify(unidecode(f"{instance.id}_{attribute.id}"))
         value, _created = update_or_create(
             attribute=attribute,
             slug=slug,
@@ -512,10 +513,7 @@ class AttributeAssignmentMixin:
                     attribute=attribute,
                     reference_product=reference_product,
                     reference_page=reference_page,
-                    slug=slugify(
-                        f"{instance.id}_{ref.id}",  # type: ignore
-                        allow_unicode=True,
-                    ),
+                    slug=slugify(unidecode(f"{instance.id}_{ref.id}")),  # type: ignore
                     defaults={"name": getattr(ref, field_name)},
                 )[0]
             )

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -543,7 +543,7 @@ def test_create_category_name_with_unicode(
     data = content["data"]["categoryCreate"]
     assert not data["errors"]
     assert data["category"]["name"] == name
-    assert data["category"]["slug"] == "わたし-わ-にっぽん-です"
+    assert data["category"]["slug"] == "watasi-wa-nitupon-desu"
 
 
 def test_category_create_mutation_without_background_image(

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -600,7 +600,7 @@ def test_create_collection_name_with_unicode(
     data = content["data"]["collectionCreate"]
     assert not data["errors"]
     assert data["collection"]["name"] == name
-    assert data["collection"]["slug"] == "わたし-わ-にっぽん-です"
+    assert data["collection"]["slug"] == "watasi-wa-nitupon-desu"
 
 
 @patch("saleor.plugins.manager.PluginsManager.collection_updated")

--- a/saleor/graphql/product/tests/test_product_type_create.py
+++ b/saleor/graphql/product/tests/test_product_type_create.py
@@ -468,7 +468,7 @@ def test_create_product_type_with_unicode_in_name(
     data = content["data"]["productTypeCreate"]
     assert not data["errors"]
     assert data["productType"]["name"] == name
-    assert data["productType"]["slug"] == "わたし-わ-にっぽん-です"
+    assert data["productType"]["slug"] == "watasi-wa-nitupon-desu"
     assert data["productType"]["kind"] == kind
 
 


### PR DESCRIPTION
I want to merge this change because fixing the slug generated from the name shouldn't use Unicode. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
