### PR TITLE
Update @saleor/graphql-playground to 2.0.0-5

### DIFF
--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -8,19 +8,19 @@
 
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-3/dist/umd/index.css"
-    integrity="sha512-kH1mn0pAf6TSZ8NiZTbg2ZZxGAlqsbvJMJFhT41nbibIObsSFY4Cn0ikrT8A6+n1TrNnE1KxxNXqjANlNVFoNw=="
+    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-4/dist/umd/index.css"
+    integrity="sha512-6n65lECcA9z9qAHZ5ZQPgw6qEKhRIQKICk0hY+UzDy59EyqW3o/aFBeINuY/df9BzWFBX+m8RjE3p7bFirGC5A=="
     crossorigin="anonymous"
   />
   <!-- sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc= is inline css added by the playground when opening settings -->
   <!-- sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c= is the inline code below -->
-  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-3/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-3/dist/umd/index.css 'sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc='; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-4/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-4/dist/umd/index.css 'sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc='; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
 </head>
 <body>
   <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}></div>
   <script
-    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-3/dist/umd/index.js"
-    integrity="sha512-htD12YuDryiSCRUWuI4ibOk2oXpTs3BYVLFheJHPEBCczM+TdXiNMePHDmn4ZVEZXcqnpJAZGA0ju9SbNRq0Sg=="
+    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-4/dist/umd/index.js"
+    integrity="sha512-Z01QIyx742956SxViEGH9+a412rIxn1l2d/yUIH+pos+BzW2VlVzHwCH2TY89m9qJRtDbOijxK3QYv7HgPu7fw=="
     crossorigin="anonymous"
   ></script>
 

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -8,19 +8,19 @@
 
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-4/dist/umd/index.css"
+    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-5/dist/umd/index.css"
     integrity="sha512-6n65lECcA9z9qAHZ5ZQPgw6qEKhRIQKICk0hY+UzDy59EyqW3o/aFBeINuY/df9BzWFBX+m8RjE3p7bFirGC5A=="
     crossorigin="anonymous"
   />
   <!-- sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc= is inline css added by the playground when opening settings -->
   <!-- sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c= is the inline code below -->
-  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-4/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-4/dist/umd/index.css 'sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc='; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-5/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-5/dist/umd/index.css 'sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc='; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
 </head>
 <body>
   <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}></div>
   <script
-    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-4/dist/umd/index.js"
-    integrity="sha512-Z01QIyx742956SxViEGH9+a412rIxn1l2d/yUIH+pos+BzW2VlVzHwCH2TY89m9qJRtDbOijxK3QYv7HgPu7fw=="
+    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-5/dist/umd/index.js"
+    integrity="sha512-eBfXw1/7waZZLt/cehNkjwRoGPPqhobjHfTd4HSWQbyM9luhga98rcJEBVAFL8sW2MzhMk6h5vlhRpxSr0t4Ow=="
     crossorigin="anonymous"
   ></script>
 

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -8,18 +8,18 @@
 
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-0/dist/umd/index.css"
-    integrity="sha512-ivOjBFuy6pAspvPNtIz/vpI8ZHAU4X2EDuRnqOWK64GwlRCwypdgbPuaGqMWt20Bg2KjcNk2Vq9kkl8+XgSb9g=="
+    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-3/dist/umd/index.css"
+    integrity="sha512-kH1mn0pAf6TSZ8NiZTbg2ZZxGAlqsbvJMJFhT41nbibIObsSFY4Cn0ikrT8A6+n1TrNnE1KxxNXqjANlNVFoNw=="
     crossorigin="anonymous"
   />
 
-  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-0/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-0/dist/umd/index.css; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-3/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-3/dist/umd/index.css 'sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc='; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
 </head>
 <body>
   <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}></div>
   <script
-    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-0/dist/umd/index.js"
-    integrity="sha512-qsKAT98vfXNeckMOMa7oXU78EKKVcfX4ukhSoDtAcQPawlyrrkoQDPYUaqjiMrstEwWtBm65PGesrNh5/q64OA=="
+    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-3/dist/umd/index.js"
+    integrity="sha512-htD12YuDryiSCRUWuI4ibOk2oXpTs3BYVLFheJHPEBCczM+TdXiNMePHDmn4ZVEZXcqnpJAZGA0ju9SbNRq0Sg=="
     crossorigin="anonymous"
   ></script>
 

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -12,7 +12,8 @@
     integrity="sha512-kH1mn0pAf6TSZ8NiZTbg2ZZxGAlqsbvJMJFhT41nbibIObsSFY4Cn0ikrT8A6+n1TrNnE1KxxNXqjANlNVFoNw=="
     crossorigin="anonymous"
   />
-
+  <!-- sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc= is inline css added by the playground when opening settings -->
+  <!-- sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c= is the inline code below -->
   <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-3/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-3/dist/umd/index.css 'sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc='; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
 </head>
 <body>


### PR DESCRIPTION
I want to merge this change because it removes console.log.
Changes: https://github.com/saleor/saleor-graphql-playground/compare/v2.0.0-0...v2.0.0-5

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
