### PR TITLE
Validate stock reservations only for lines provided in checkoutLinesUpdate

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -237,15 +237,17 @@ def add_variants_to_checkout(
 
     if reservation_length and to_reserve:
         updated_lines_ids = [line.pk for line in to_reserve + to_delete]
-        to_update_reserved_until = []
 
+        # Validation for stock reservation should be performed on new and updated lines.
+        # For already existing lines only reserved_until should be updated.
+        lines_to_update_reservation_time = []
         for line in checkout_lines:
             if line.pk not in updated_lines_ids:
-                to_update_reserved_until.append(line)
+                lines_to_update_reservation_time.append(line)
 
         reserve_stocks_and_preorders(
             to_reserve,
-            to_update_reserved_until,
+            lines_to_update_reservation_time,
             variants,
             country_code,
             channel,

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -237,13 +237,15 @@ def add_variants_to_checkout(
 
     if reservation_length and to_reserve:
         updated_lines_ids = [line.pk for line in to_reserve + to_delete]
+        to_update_reserved_until = []
+
         for line in checkout_lines:
             if line.pk not in updated_lines_ids:
-                to_reserve.append(line)
-                variants.append(line.variant)
+                to_update_reserved_until.append(line)
 
         reserve_stocks_and_preorders(
             to_reserve,
+            to_update_reserved_until,
             variants,
             country_code,
             channel,

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -596,7 +596,6 @@ def test_update_checkout_lines(
             },
         ],
     }
-
     response = get_graphql_content(
         api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
     )
@@ -658,7 +657,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-    with django_assert_num_queries(53):
+    with django_assert_num_queries(54):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -672,7 +671,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(53):
+    with django_assert_num_queries(54):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],
@@ -915,7 +914,7 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(52):
+    with django_assert_num_queries(53):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -928,7 +927,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(52):
+    with django_assert_num_queries(53):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -361,6 +361,7 @@ def test_checkout_lines_add_new_variant_updates_other_lines_reservations_expirat
     checkout = checkout_line_with_one_reservation.checkout
     line = checkout_line_with_one_reservation
     reservation = line.reservations.get()
+
     lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 2
 
@@ -384,6 +385,8 @@ def test_checkout_lines_add_new_variant_updates_other_lines_reservations_expirat
     response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
     content = get_graphql_content(response)
     data = content["data"]["checkoutLinesAdd"]
+    reservation.refresh_from_db()
+
     assert not data["errors"]
     checkout.refresh_from_db()
     lines, _ = fetch_checkout_lines(checkout)
@@ -395,20 +398,10 @@ def test_checkout_lines_add_new_variant_updates_other_lines_reservations_expirat
     assert new_line.quantity == 3
     assert calculate_checkout_quantity(lines) == 5
 
-    updated_reservation = Reservation.objects.get(checkout_line__variant=variant)
-    assert updated_reservation.checkout_line == line
-    assert updated_reservation.quantity_reserved == line.quantity
-    assert updated_reservation.reserved_until > reservation.reserved_until
-
     other_reservation = Reservation.objects.get(checkout_line__variant=variant_other)
     assert other_reservation.checkout_line == new_line
     assert other_reservation.quantity_reserved == new_line.quantity
-    assert other_reservation.reserved_until > reservation.reserved_until
-
-    assert updated_reservation.reserved_until == other_reservation.reserved_until
-
-    with pytest.raises(Reservation.DoesNotExist):
-        reservation.refresh_from_db()
+    assert reservation.reserved_until == other_reservation.reserved_until
 
 
 def test_checkout_lines_add_existing_variant(user_api_client, checkout_with_item):

--- a/saleor/warehouse/reservations.py
+++ b/saleor/warehouse/reservations.py
@@ -22,7 +22,7 @@ StockData = namedtuple("StockData", ["pk", "quantity"])
 @traced_atomic_transaction()
 def reserve_stocks_and_preorders(
     checkout_lines: Iterable["CheckoutLine"],
-    lines_to_update_reservation_reserved_until: Iterable["CheckoutLine"],
+    lines_to_update_reservation_time: Iterable["CheckoutLine"],
     variants: Iterable["ProductVariant"],
     country_code: str,
     channel: "Channel",
@@ -56,9 +56,11 @@ def reserve_stocks_and_preorders(
             reserved_until,
             replace=replace,
         )
-        if lines_to_update_reservation_reserved_until:
+
+        # Refresh reserved_until for already existing lines
+        if lines_to_update_reservation_time:
             Reservation.objects.filter(
-                checkout_line__in=lines_to_update_reservation_reserved_until
+                checkout_line__in=lines_to_update_reservation_time
             ).update(reserved_until=reserved_until)
 
     if preorder_lines:
@@ -70,9 +72,11 @@ def reserve_stocks_and_preorders(
             reserved_until,
             replace=replace,
         )
-        if lines_to_update_reservation_reserved_until:
+
+        # Refresh reserved_until for already existing lines
+        if lines_to_update_reservation_time:
             PreorderReservation.objects.filter(
-                checkout_line__in=lines_to_update_reservation_reserved_until
+                checkout_line__in=lines_to_update_reservation_time
             ).update(reserved_until=reserved_until)
 
 

--- a/saleor/warehouse/reservations.py
+++ b/saleor/warehouse/reservations.py
@@ -22,6 +22,7 @@ StockData = namedtuple("StockData", ["pk", "quantity"])
 @traced_atomic_transaction()
 def reserve_stocks_and_preorders(
     checkout_lines: Iterable["CheckoutLine"],
+    lines_to_update_reservation_reserved_until: Iterable["CheckoutLine"],
     variants: Iterable["ProductVariant"],
     country_code: str,
     channel: "Channel",
@@ -44,15 +45,21 @@ def reserve_stocks_and_preorders(
         else:
             stock_lines.append(line)
 
+    reserved_until = timezone.now() + timedelta(minutes=length_in_minutes)
+
     if stock_lines:
         reserve_stocks(
             stock_lines,
             stock_variants,
             country_code,
             channel,
-            length_in_minutes,
+            reserved_until,
             replace=replace,
         )
+        if lines_to_update_reservation_reserved_until:
+            Reservation.objects.filter(
+                checkout_line__in=lines_to_update_reservation_reserved_until
+            ).update(reserved_until=reserved_until)
 
     if preorder_lines:
         reserve_preorders(
@@ -60,9 +67,13 @@ def reserve_stocks_and_preorders(
             preorder_variants,
             country_code,
             channel.slug,
-            length_in_minutes,
+            reserved_until,
             replace=replace,
         )
+        if lines_to_update_reservation_reserved_until:
+            PreorderReservation.objects.filter(
+                checkout_line__in=lines_to_update_reservation_reserved_until
+            ).update(reserved_until=reserved_until)
 
 
 def reserve_stocks(
@@ -70,7 +81,7 @@ def reserve_stocks(
     variants: Iterable["ProductVariant"],
     country_code: str,
     channel: "Channel",
-    length_in_minutes: int,
+    reserved_until: datetime,
     *,
     replace: bool = True,
 ):
@@ -84,8 +95,6 @@ def reserve_stocks(
     checkout_lines = get_checkout_lines_to_reserve(checkout_lines, variants_map)
     if not checkout_lines:
         return
-
-    reserved_until = timezone.now() + timedelta(minutes=length_in_minutes)
 
     stocks = list(
         Stock.objects.select_for_update(of=("self",))
@@ -222,7 +231,7 @@ def reserve_preorders(
     variants: Iterable["ProductVariant"],
     country_code: str,
     channel_slug: str,
-    length_in_minutes: int,
+    reserved_until: datetime,
     *,
     replace: bool = True,
 ):
@@ -230,8 +239,6 @@ def reserve_preorders(
     variants_ids = [line.variant_id for line in checkout_lines]
     variants = [variant for variant in variants if variant.pk in variants_ids]
     variants_map = {variant.id: variant for variant in variants}
-
-    reserved_until = timezone.now() + timedelta(minutes=length_in_minutes)
 
     all_variants_channel_listings = (
         ProductVariantChannelListing.objects.filter(variant__in=variants)

--- a/saleor/warehouse/tests/test_preorder_reservations_management.py
+++ b/saleor/warehouse/tests/test_preorder_reservations_management.py
@@ -24,7 +24,7 @@ def test_reserve_preorders(checkout_line_with_preorder_item, channel_USD):
         [checkout_line.variant],
         COUNTRY_CODE,
         channel_USD.slug,
-        RESERVATION_LENGTH,
+        timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
     )
 
     reservation = PreorderReservation.objects.get(checkout_line=checkout_line)
@@ -43,7 +43,7 @@ def test_preorder_reservation_skips_prev_reservation_delete_if_replace_is_disabl
             [checkout_line.variant],
             COUNTRY_CODE,
             channel_USD.slug,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
             replace=False,
         )
 
@@ -53,7 +53,7 @@ def test_preorder_reservation_skips_prev_reservation_delete_if_replace_is_disabl
             [checkout_line.variant],
             COUNTRY_CODE,
             channel_USD.slug,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
         )
 
 
@@ -76,7 +76,7 @@ def test_preorder_reservation_removes_previous_reservations_for_checkout(
         [checkout_line.variant],
         COUNTRY_CODE,
         channel_USD.slug,
-        RESERVATION_LENGTH,
+        timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
     )
 
     with pytest.raises(PreorderReservation.DoesNotExist):
@@ -100,7 +100,7 @@ def test_preorder_reservation_fails_if_there_is_not_enough_channel_threshold_ava
             [checkout_line.variant],
             COUNTRY_CODE,
             channel_USD.slug,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
         )
 
 
@@ -132,7 +132,7 @@ def test_preorder_reservation_fails_if_channel_threshold_was_allocated(
             [checkout_line.variant],
             COUNTRY_CODE,
             channel_USD.slug,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
         )
 
 
@@ -169,7 +169,7 @@ def test_preorder_reservation_fails_if_channel_threshold_was_reserved(
             [checkout_line.variant],
             COUNTRY_CODE,
             channel_USD.slug,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
         )
 
 
@@ -209,7 +209,7 @@ def test_preorder_reservation_fails_if_global_threshold_was_allocated(
             [checkout_line.variant],
             COUNTRY_CODE,
             channel_USD.slug,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
         )
 
 
@@ -255,7 +255,7 @@ def test_preorder_reservation_fails_if_global_threshold_was_reserved(
             [checkout_line.variant],
             COUNTRY_CODE,
             channel_USD.slug,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
         )
 
 
@@ -275,5 +275,5 @@ def test_preorder_reservation_fails_if_there_is_not_enough_global_threshold_avai
             [checkout_line.variant],
             COUNTRY_CODE,
             channel_USD.slug,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
         )

--- a/saleor/warehouse/tests/test_stock_reservations_management.py
+++ b/saleor/warehouse/tests/test_stock_reservations_management.py
@@ -155,7 +155,7 @@ def test_multiple_stocks_reserved_if_single_stock_is_not_enough_sorting_order_st
         [checkout_line.variant],
         COUNTRY_CODE,
         channel_USD,
-        RESERVATION_LENGTH,
+        timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
     )
 
     # then

--- a/saleor/warehouse/tests/test_stock_reservations_management.py
+++ b/saleor/warehouse/tests/test_stock_reservations_management.py
@@ -26,7 +26,7 @@ def test_reserve_stocks(checkout_line, channel_USD):
         [checkout_line.variant],
         COUNTRY_CODE,
         channel_USD,
-        RESERVATION_LENGTH,
+        timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
     )
 
     stock.refresh_from_db()
@@ -45,7 +45,7 @@ def test_stocks_reservation_skips_prev_reservation_delete_if_replace_is_disabled
             [checkout_line.variant],
             COUNTRY_CODE,
             channel_USD,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
             replace=False,
         )
 
@@ -55,7 +55,7 @@ def test_stocks_reservation_skips_prev_reservation_delete_if_replace_is_disabled
             [checkout_line.variant],
             COUNTRY_CODE,
             channel_USD,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
         )
 
 
@@ -88,7 +88,7 @@ def test_multiple_stocks_reserved_if_single_stock_is_not_enough_highest_stock_st
         [checkout_line.variant],
         COUNTRY_CODE,
         channel_USD,
-        RESERVATION_LENGTH,
+        timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
     )
 
     stock.refresh_from_db()
@@ -195,7 +195,7 @@ def test_stocks_reservation_removes_previous_reservations_for_checkout(
         [checkout_line.variant],
         COUNTRY_CODE,
         channel_USD,
-        RESERVATION_LENGTH,
+        timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
     )
 
     with pytest.raises(Reservation.DoesNotExist):
@@ -218,7 +218,7 @@ def test_stock_reservation_fails_if_there_is_not_enough_stock_available(
             [checkout_line.variant],
             COUNTRY_CODE,
             channel_USD,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
         )
 
 
@@ -255,7 +255,7 @@ def test_stock_reservation_accounts_for_order_allocations(
             [variant],
             COUNTRY_CODE,
             channel_USD,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
         )
 
 
@@ -292,5 +292,5 @@ def test_stock_reservation_accounts_for_order_allocations_and_reservations(
             [variant],
             COUNTRY_CODE,
             channel_USD,
-            RESERVATION_LENGTH,
+            timezone.now() + timedelta(minutes=RESERVATION_LENGTH),
         )


### PR DESCRIPTION
I want to merge this change because it fixes error when new line is added to checkout but stock reservations for already existing lines are re-validated.

Port of #10701
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
