### PR TITLE
Fix playground CSP for demo if deployed under proxied domain

### DIFF
--- a/saleor/demo/views.py
+++ b/saleor/demo/views.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.shortcuts import render
 
-from ..graphql.views import API_PATH, GraphQLView
+from ..graphql.views import GraphQLView
 
 EXAMPLE_QUERY = """# Welcome to Saleor GraphQL API!
 #
@@ -29,8 +29,9 @@ EXAMPLE_QUERY = """# Welcome to Saleor GraphQL API!
 
 class DemoGraphQLView(GraphQLView):
     def render_playground(self, request):
+        pwa_origin = settings.PWA_ORIGINS[0]
         ctx = {
             "query": EXAMPLE_QUERY,
-            "api_url": request.build_absolute_uri(str(API_PATH)),
+            "api_url": f"https://{pwa_origin}/graphql/",
         }
         return render(request, "graphql/playground.html", ctx)


### PR DESCRIPTION
I want to merge this change because it fixes CORS and CSP issues when graphql playground is accessed via proxied domain

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
