### PR TITLE
Add support for multiple headers containig IPs to be assigned to OT span

### DIFF
--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -176,8 +176,13 @@ class GraphQLView(View):
             span.set_tag("http.useragent", request.META.get("HTTP_USER_AGENT", ""))
             span.set_tag("span.type", "web")
 
-            request_ips = request.META.get(settings.REAL_IP_ENVIRON, "")
-            for ip in request_ips.split(","):
+            request_ips = []
+            for header in settings.REAL_IP_ENVIRON:
+                ips = request.META.get(header)
+                if ips:
+                    request_ips.extend(ips.split(","))
+
+            for ip in request_ips:
                 if is_valid_ipv4(ip):
                     span.set_tag(opentracing.tags.PEER_HOST_IPV4, ip)
                 elif is_valid_ipv6(ip):

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -190,7 +190,7 @@ class GraphQLView(View):
                 break
             for additional_ip_header in additional_ip_headers:
                 if request_ips := request.META.get(additional_ip_header):
-                    span.set_tag(f"ip_{additional_ip_header}", request_ips)
+                    span.set_tag(f"ip_{additional_ip_header}", request_ips[:100])
 
             response = self._handle_query(request)
             span.set_tag(opentracing.tags.HTTP_STATUS_CODE, response.status_code)

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -176,10 +176,10 @@ class GraphQLView(View):
             span.set_tag("http.useragent", request.META.get("HTTP_USER_AGENT", ""))
             span.set_tag("span.type", "web")
 
-            ip_headers = settings.REAL_IP_ENVIRON
-            main_ip_header = ip_headers.pop(0)
+            main_ip_header = settings.REAL_IP_ENVIRON[0]
+            additional_ip_headers = settings.REAL_IP_ENVIRON[1:]
 
-            request_ips = request.META.get(main_ip_header.pop(0), "")
+            request_ips = request.META.get(main_ip_header, "")
             for ip in request_ips.split(","):
                 if is_valid_ipv4(ip):
                     span.set_tag(opentracing.tags.PEER_HOST_IPV4, ip)
@@ -188,7 +188,7 @@ class GraphQLView(View):
                 else:
                     continue
                 break
-            for additional_ip_header in ip_headers:
+            for additional_ip_header in additional_ip_headers:
                 if request_ips := request.META.get(additional_ip_header):
                     span.set_tag(f"ip_{additional_ip_header}", request_ips)
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -618,7 +618,7 @@ if OBSERVABILITY_ACTIVE:
 
 # Change this value if your application is running behind a proxy,
 # e.g. HTTP_CF_Connecting_IP for Cloudflare or X_FORWARDED_FOR
-REAL_IP_ENVIRON = os.environ.get("REAL_IP_ENVIRON", "REMOTE_ADDR")
+REAL_IP_ENVIRON = get_list(os.environ.get("REAL_IP_ENVIRON", "REMOTE_ADDR"))
 
 # Slugs for menus precreated in Django migrations
 DEFAULT_MENUS = {"top_menu_name": "navbar", "bottom_menu_name": "footer"}


### PR DESCRIPTION
I want to merge this change because it adds support for setting OpenTracing Span IPs from multiple HTTP headers 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
