### PR TITLE
Fix raising an error in `productVariantBulkCreate` for empty attribute list

### DIFF
--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -469,14 +469,15 @@ class ProductVariantBulkCreate(BaseMutation):
         sku_list = []
         used_attribute_values = get_used_variants_attribute_values(product)
         for index, variant_data in enumerate(variants):
-            try:
-                cls.validate_duplicated_attribute_values(
-                    variant_data.attributes, used_attribute_values
-                )
-            except ValidationError as exc:
-                errors["attributes"].append(
-                    ValidationError(exc.message, exc.code, params={"index": index})
-                )
+            if variant_data.attributes:
+                try:
+                    cls.validate_duplicated_attribute_values(
+                        variant_data.attributes, used_attribute_values
+                    )
+                except ValidationError as exc:
+                    errors["attributes"].append(
+                        ValidationError(exc.message, exc.code, params={"index": index})
+                    )
 
             variant_data["product_type"] = product.product_type
             variant_data["product"] = product

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -4916,8 +4916,12 @@ def test_product_variant_bulk_create_only_not_variant_selection_attributes(
 
 
 def test_product_variant_bulk_create_empty_attribute(
-    staff_api_client, product, size_attribute, permission_manage_products
+    staff_api_client,
+    product_with_single_variant,
+    size_attribute,
+    permission_manage_products,
 ):
+    product = product_with_single_variant
     product_variant_count = ProductVariant.objects.count()
     product_id = graphene.Node.to_global_id("Product", product.pk)
     variants = [{"sku": str(uuid4())[:12], "attributes": []}]

--- a/saleor/graphql/product/utils.py
+++ b/saleor/graphql/product/utils.py
@@ -64,7 +64,8 @@ def get_used_variants_attribute_values(product):
     used_attribute_values = []
     for variant in variants:
         attribute_values = get_used_attribute_values_for_variant(variant)
-        used_attribute_values.append(attribute_values)
+        if attribute_values:
+            used_attribute_values.append(attribute_values)
     return used_attribute_values
 
 


### PR DESCRIPTION
Use the same attribute validation in `productVariantBulkCreate` as is in `productVariantCreate` - do not raise a `ValidationError` for empty attribute list.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
