### PR TITLE
Run method on plugins only for checkout or order channel

### DIFF
--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -313,6 +313,7 @@ class PluginsManager(PaymentInterface):
                 default_value,
                 order,
                 lines,
+                channel_slug=order.channel.slug,
             ),
             currency,
         )
@@ -371,6 +372,7 @@ class PluginsManager(PaymentInterface):
             lines,
             order,
             lines,
+            channel_slug=order.channel.slug,
         )
         return lines
 
@@ -538,12 +540,15 @@ class PluginsManager(PaymentInterface):
 
     def get_taxes_for_checkout(self, checkout_info, lines) -> Optional[TaxData]:
         return self.__run_plugin_method_until_first_success(
-            "get_taxes_for_checkout", checkout_info, lines
+            "get_taxes_for_checkout",
+            checkout_info,
+            lines,
+            channel_slug=checkout_info.channel.slug,
         )
 
     def get_taxes_for_order(self, order: "Order") -> Optional[TaxData]:
         return self.__run_plugin_method_until_first_success(
-            "get_taxes_for_order", order
+            "get_taxes_for_order", order, channel_slug=order.channel.slug
         )
 
     def apply_taxes_to_product(
@@ -1337,8 +1342,9 @@ class PluginsManager(PaymentInterface):
         self,
         method_name: str,
         *args,
+        channel_slug: Optional[str] = None,
     ):
-        plugins = self.get_plugins()
+        plugins = self.get_plugins(channel_slug=channel_slug)
         for plugin in plugins:
             result = self.__run_method_on_single_plugin(
                 plugin, method_name, None, *args
@@ -1560,6 +1566,7 @@ class PluginsManager(PaymentInterface):
             [],
             order,
             available_shipping_methods,
+            channel_slug=order.channel.slug,
         )
 
     def excluded_shipping_methods_for_checkout(
@@ -1572,6 +1579,7 @@ class PluginsManager(PaymentInterface):
             [],
             checkout,
             available_shipping_methods,
+            channel_slug=checkout.channel.slug,
         )
 
     def perform_mutation(


### PR DESCRIPTION
The checkout and order plugin methods should be run only on plugins for the order/checkout channel.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
