### PR TITLE
fix `draftOrderCreate` mutation to save `shipping_method_name`

### DIFF
--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -74,7 +74,7 @@ class OrderUpdate(DraftOrderCreate):
     @classmethod
     def save(cls, info, instance, cleaned_input):
         with traced_atomic_transaction():
-            cls._save_addresses(info, instance, cleaned_input)
+            cls._save_addresses(instance, cleaned_input)
             if instance.user_email:
                 user = User.objects.filter(email=instance.user_email).first()
                 instance.user = user

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -2531,6 +2531,7 @@ DRAFT_ORDER_CREATE_MUTATION = """
                                 amount
                             }
                         }
+                        shippingMethodName
                     }
                 }
         }
@@ -2607,6 +2608,7 @@ def test_draft_order_create(
     order = Order.objects.first()
     assert order.user == customer_user
     assert order.shipping_method == shipping_method
+    assert order.shipping_method_name == shipping_method.name
     assert order.billing_address
     assert order.shipping_address
     assert order.search_vector


### PR DESCRIPTION
https://github.com/saleor/saleor/issues/10596

During `draftOrderCreate` mutation with `shippingMethod` passed in input,  `Order.shippingMethodName` is not updated. This PR fixes the bug.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
