### PR TITLE
Use app-identifier for payment webhooks

### DIFF
--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1199,17 +1199,20 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
 
-        app = None
+        apps = None
         payment_app_data = from_payment_app_id(payment_information.gateway)
 
         if payment_app_data is not None:
-            app = (
-                App.objects.for_event_type(event_type)
-                .filter(pk=payment_app_data.app_pk)
-                .first()
-            )
+            if payment_app_data.app_identifier:
+                apps = App.objects.for_event_type(event_type).filter(
+                    identifier=payment_app_data.app_identifier
+                )
+            else:
+                apps = App.objects.for_event_type(event_type).filter(
+                    pk=payment_app_data.app_pk
+                )
 
-        if not app:
+        if not apps:
             logger.warning(
                 "Payment webhook for event %r failed - no active app found: %r",
                 event_type,
@@ -1226,18 +1229,22 @@ class WebhookPlugin(BasePlugin):
             raise PaymentError(
                 f"Payment with id: {payment_information.payment_id} not found."
             )
-        webhook = get_webhooks_for_event(event_type, app.webhooks.all()).first()
-        response_data = trigger_webhook_sync(
-            event_type, webhook_payload, webhook, subscribable_object=payment
-        )
-        if response_data is None:
-            raise PaymentError(
-                f"Payment method {payment_information.gateway} is not available: "
-                "no response from the app."
+
+        for app in apps:
+            webhook = get_webhooks_for_event(event_type, app.webhooks.all()).first()
+            response_data = trigger_webhook_sync(
+                event_type, webhook_payload, webhook, subscribable_object=payment
+            )
+            if response_data is None:
+                continue
+
+            return parse_payment_action_response(
+                payment_information, response_data, transaction_kind
             )
 
-        return parse_payment_action_response(
-            payment_information, response_data, transaction_kind
+        raise PaymentError(
+            f"Payment method {payment_information.gateway} is not available: "
+            "no response from the app."
         )
 
     def token_is_required_as_payment_input(self, previous_value):
@@ -1262,7 +1269,7 @@ class WebhookPlugin(BasePlugin):
             )
             if response_data:
                 app_gateways = parse_list_payment_gateways_response(
-                    response_data, webhook.app_id
+                    response_data, webhook.app.identifier  # type: ignore
                 )
                 if currency:
                     app_gateways = [
@@ -1375,7 +1382,8 @@ class WebhookPlugin(BasePlugin):
                 )
                 if response_data:
                     shipping_methods = parse_list_shipping_methods_response(
-                        response_data, webhook.app_id
+                        response_data,
+                        webhook.app_id,
                     )
                     methods.extend(shipping_methods)
         return methods

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1269,7 +1269,7 @@ class WebhookPlugin(BasePlugin):
             )
             if response_data:
                 app_gateways = parse_list_payment_gateways_response(
-                    response_data, webhook.app.identifier  # type: ignore
+                    response_data, webhook.app
                 )
                 if currency:
                     app_gateways = [

--- a/saleor/plugins/webhook/tests/test_payment_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook.py
@@ -29,7 +29,7 @@ from .utils import generate_request_headers
 def payment_invalid_app(payment_dummy):
     app = App.objects.create(name="Dummy app", is_active=True)
     gateway_id = "credit-card"
-    gateway = to_payment_app_id(app.identifier, gateway_id)
+    gateway = to_payment_app_id(app, gateway_id)
     payment_dummy.gateway = gateway
     payment_dummy.save()
     return payment_dummy
@@ -296,10 +296,10 @@ def test_get_payment_gateways(
     mock_send_request.return_value = mock_json_response
     response_data = plugin.get_payment_gateways("USD", None, None)
     expected_response_1 = parse_list_payment_gateways_response(
-        mock_json_response, payment_app.identifier
+        mock_json_response, payment_app
     )
     expected_response_2 = parse_list_payment_gateways_response(
-        mock_json_response, app_2.identifier
+        mock_json_response, app_2
     )
     assert len(response_data) == 2
     assert response_data[0] == expected_response_1[0]
@@ -340,10 +340,10 @@ def test_get_payment_gateways_multiple_webhooks_in_the_same_app(
 
     # then
     expected_response_1 = parse_list_payment_gateways_response(
-        mock_json_response, payment_app.identifier
+        mock_json_response, payment_app
     )
     expected_response_2 = parse_list_payment_gateways_response(
-        mock_json_response, payment_app.identifier
+        mock_json_response, payment_app
     )
     assert len(response_data) == 2
     assert response_data[0] == expected_response_1[0]
@@ -495,7 +495,7 @@ def test_run_payment_webhook_empty_response(mock_send_request, payment, webhook_
 def test_check_plugin_id(payment_app, webhook_plugin):
     plugin = webhook_plugin()
     assert not plugin.check_plugin_id("dummy")
-    valid_id = to_payment_app_id(payment_app.identifier, "credit-card")
+    valid_id = to_payment_app_id(payment_app, "credit-card")
     assert plugin.check_plugin_id(valid_id)
 
 

--- a/saleor/plugins/webhook/tests/test_payment_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook.py
@@ -29,7 +29,7 @@ from .utils import generate_request_headers
 def payment_invalid_app(payment_dummy):
     app = App.objects.create(name="Dummy app", is_active=True)
     gateway_id = "credit-card"
-    gateway = to_payment_app_id(app.id, gateway_id)
+    gateway = to_payment_app_id(app.identifier, gateway_id)
     payment_dummy.gateway = gateway
     payment_dummy.save()
     return payment_dummy
@@ -296,10 +296,10 @@ def test_get_payment_gateways(
     mock_send_request.return_value = mock_json_response
     response_data = plugin.get_payment_gateways("USD", None, None)
     expected_response_1 = parse_list_payment_gateways_response(
-        mock_json_response, payment_app.id
+        mock_json_response, payment_app.identifier
     )
     expected_response_2 = parse_list_payment_gateways_response(
-        mock_json_response, app_2.id
+        mock_json_response, app_2.identifier
     )
     assert len(response_data) == 2
     assert response_data[0] == expected_response_1[0]
@@ -340,10 +340,10 @@ def test_get_payment_gateways_multiple_webhooks_in_the_same_app(
 
     # then
     expected_response_1 = parse_list_payment_gateways_response(
-        mock_json_response, payment_app.id
+        mock_json_response, payment_app.identifier
     )
     expected_response_2 = parse_list_payment_gateways_response(
-        mock_json_response, payment_app.id
+        mock_json_response, payment_app.identifier
     )
     assert len(response_data) == 2
     assert response_data[0] == expected_response_1[0]
@@ -495,7 +495,7 @@ def test_run_payment_webhook_empty_response(mock_send_request, payment, webhook_
 def test_check_plugin_id(payment_app, webhook_plugin):
     plugin = webhook_plugin()
     assert not plugin.check_plugin_id("dummy")
-    valid_id = to_payment_app_id(payment_app.id, "credit-card")
+    valid_id = to_payment_app_id(payment_app.identifier, "credit-card")
     assert plugin.check_plugin_id(valid_id)
 
 

--- a/saleor/plugins/webhook/tests/test_payment_webhook_utils.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook_utils.py
@@ -15,14 +15,21 @@ from ..utils import (
 
 def test_to_payment_app_id(app):
     gateway_id = "example-gateway"
-    payment_app_id = to_payment_app_id(app.id, gateway_id)
-    assert payment_app_id == f"{APP_ID_PREFIX}:{app.pk}:{gateway_id}"
+    payment_app_id = to_payment_app_id(app.identifier, gateway_id)
+    assert payment_app_id == f"{APP_ID_PREFIX}:{app.identifier}:{gateway_id}"
 
 
-def test_from_payment_app_id():
+def test_from_payment_app_id_from_pk():
     app_id = "app:1:credit-card"
     payment_app_data = from_payment_app_id(app_id)
     assert payment_app_data.app_pk == 1
+    assert payment_app_data.name == "credit-card"
+
+
+def test_from_payment_app_id_from_identifier(app):
+    app_id = f"app:{app.identifier}:credit-card"
+    payment_app_data = from_payment_app_id(app_id)
+    assert payment_app_data.app_identifier == app.identifier
     assert payment_app_data.name == "credit-card"
 
 
@@ -36,7 +43,6 @@ def test_from_payment_app_id():
         "1:1:name",
         f"{APP_ID_PREFIX}:1",
         f"{APP_ID_PREFIX}:1:",
-        f"{APP_ID_PREFIX}:1a:name",
     ],
 )
 def test_from_payment_app_id_invalid(app_id):
@@ -53,8 +59,8 @@ def test_parse_list_payment_gateways_response(app):
             "config": [{"field": "example-key", "value": "example-value"}],
         },
     ]
-    gateways = parse_list_payment_gateways_response(response_data, app.id)
-    assert gateways[0].id == to_payment_app_id(app.id, response_data[0]["id"])
+    gateways = parse_list_payment_gateways_response(response_data, app.identifier)
+    assert gateways[0].id == to_payment_app_id(app.identifier, response_data[0]["id"])
     assert gateways[0].name == response_data[0]["name"]
     assert gateways[0].currencies == response_data[0]["currencies"]
     assert gateways[0].config == response_data[0]["config"]

--- a/saleor/plugins/webhook/utils.py
+++ b/saleor/plugins/webhook/utils.py
@@ -37,7 +37,8 @@ class PaymentAppData:
     name: str
 
 
-def to_payment_app_id(app_identifier: str, gateway_id: str) -> "str":
+def to_payment_app_id(app: "App", gateway_id: str) -> "str":
+    app_identifier = app.identifier or app.id
     return f"{APP_ID_PREFIX}:{app_identifier}:{gateway_id}"
 
 
@@ -58,7 +59,7 @@ def from_payment_app_id(app_gateway_id: str) -> Optional["PaymentAppData"]:
 
 
 def parse_list_payment_gateways_response(
-    response_data: Any, app_identifier: str
+    response_data: Any, app: "App"
 ) -> List["PaymentGateway"]:
     gateways: List[PaymentGateway] = []
     if not isinstance(response_data, list):
@@ -73,7 +74,7 @@ def parse_list_payment_gateways_response(
         if gateway_id:
             gateways.append(
                 PaymentGateway(
-                    id=to_payment_app_id(app_identifier, gateway_id),
+                    id=to_payment_app_id(app, gateway_id),
                     name=gateway_name,
                     currencies=gateway_currencies,
                     config=gateway_config,

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4560,9 +4560,7 @@ def dummy_address_data(address):
 
 @pytest.fixture
 def dummy_webhook_app_payment_data(dummy_payment_data, payment_app):
-    dummy_payment_data.gateway = to_payment_app_id(
-        payment_app.identifier, "credit-card"
-    )
+    dummy_payment_data.gateway = to_payment_app_id(payment_app, "credit-card")
     return dummy_payment_data
 
 
@@ -5150,7 +5148,7 @@ def payment_dummy(db, order_with_lines):
 @pytest.fixture
 def payment(payment_dummy, payment_app):
     gateway_id = "credit-card"
-    gateway = to_payment_app_id(payment_app.identifier, gateway_id)
+    gateway = to_payment_app_id(payment_app, gateway_id)
     payment_dummy.gateway = gateway
     payment_dummy.save()
     return payment_dummy

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4560,7 +4560,9 @@ def dummy_address_data(address):
 
 @pytest.fixture
 def dummy_webhook_app_payment_data(dummy_payment_data, payment_app):
-    dummy_payment_data.gateway = to_payment_app_id(payment_app.id, "credit-card")
+    dummy_payment_data.gateway = to_payment_app_id(
+        payment_app.identifier, "credit-card"
+    )
     return dummy_payment_data
 
 
@@ -5148,7 +5150,7 @@ def payment_dummy(db, order_with_lines):
 @pytest.fixture
 def payment(payment_dummy, payment_app):
     gateway_id = "credit-card"
-    gateway = to_payment_app_id(payment_app.id, gateway_id)
+    gateway = to_payment_app_id(payment_app.identifier, gateway_id)
     payment_dummy.gateway = gateway
     payment_dummy.save()
     return payment_dummy
@@ -5388,6 +5390,7 @@ def app(db):
     app = App.objects.create(
         name="Sample app objects",
         is_active=True,
+        identifier="saleor.app.test",
     )
     return app
 
@@ -5446,7 +5449,9 @@ def app_with_extensions(app_with_token, permission_manage_products):
 
 @pytest.fixture
 def payment_app(db, permission_manage_payments):
-    app = App.objects.create(name="Payment App", is_active=True)
+    app = App.objects.create(
+        name="Payment App", is_active=True, identifier="saleor.payment.test.app"
+    )
     app.tokens.create(name="Default")
     app.permissions.add(permission_manage_payments)
 
@@ -5466,7 +5471,9 @@ def payment_app(db, permission_manage_payments):
 
 @pytest.fixture
 def payment_app_with_subscription_webhooks(db, permission_manage_payments):
-    app = App.objects.create(name="Payment App", is_active=True)
+    app = App.objects.create(
+        name="Payment App", is_active=True, identifier="saleor.payment.test.app"
+    )
     app.tokens.create(name="Default")
     app.permissions.add(permission_manage_payments)
 


### PR DESCRIPTION
I want to merge this change because it is port of changes of: https://github.com/saleor/saleor/pull/10772

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
