### PR TITLE
Allow to use checkoutCustomerAttach.customerID by customer

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_customer_attach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_attach.py
@@ -34,8 +34,9 @@ class CheckoutCustomerAttach(BaseMutation):
         customer_id = graphene.ID(
             required=False,
             description=(
-                "ID of customer to attach to checkout. Can be used to attach customer "
-                "to checkout by staff or app. Requires IMPERSONATE_USER permission."
+                "ID of customer to attach to checkout. "
+                "Requires IMPERSONATE_USER permission when customerID is different "
+                "than the logged-in user."
             ),
         )
 
@@ -71,7 +72,13 @@ class CheckoutCustomerAttach(BaseMutation):
                 )
             )
 
-        if customer_id:
+        user_id_from_request = None
+        if not info.context.user.is_anonymous:
+            user_id_from_request = graphene.Node.to_global_id(
+                "User", info.context.user.id
+            )
+
+        if customer_id and customer_id != user_id_from_request:
             requestor = get_user_or_app_from_context(info.context)
             if not requestor.has_perm(AccountPermissions.IMPERSONATE_USER):
                 raise PermissionDenied(

--- a/saleor/graphql/checkout/mutations/checkout_customer_attach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_attach.py
@@ -35,7 +35,7 @@ class CheckoutCustomerAttach(BaseMutation):
             required=False,
             description=(
                 "ID of customer to attach to checkout. "
-                "Requires IMPERSONATE_USER permission when customerID is different "
+                "Requires IMPERSONATE_USER permission when customerId is different "
                 "than the logged-in user."
             ),
         )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13258,7 +13258,7 @@ type Mutation {
     checkoutId: ID
 
     """
-    ID of customer to attach to checkout. Requires IMPERSONATE_USER permission when customerID is different than the logged-in user.
+    ID of customer to attach to checkout. Requires IMPERSONATE_USER permission when customerId is different than the logged-in user.
     """
     customerId: ID
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13258,7 +13258,7 @@ type Mutation {
     checkoutId: ID
 
     """
-    ID of customer to attach to checkout. Can be used to attach customer to checkout by staff or app. Requires IMPERSONATE_USER permission.
+    ID of customer to attach to checkout. Requires IMPERSONATE_USER permission when customerID is different than the logged-in user.
     """
     customerId: ID
 


### PR DESCRIPTION
I want to merge this change because it is port of changes of https://github.com/saleor/saleor/pull/10793

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
