### PR TITLE
Fix ShippingMethodChannelListingUpdate when null is send for minimum or maximum order price

### DIFF
--- a/saleor/graphql/shipping/mutations/channels.py
+++ b/saleor/graphql/shipping/mutations/channels.py
@@ -164,7 +164,7 @@ class ShippingMethodChannelListingUpdate(BaseChannelListingMutation):
 
             min_price = None
             max_price = None
-            if "minimum_order_price" in channel_input.keys():
+            if "minimum_order_price" in channel_input:
                 min_price = channel_input.pop("minimum_order_price")
                 channel_input["minimum_order_price_amount"] = min_price
                 if min_price is not None:
@@ -180,7 +180,7 @@ class ShippingMethodChannelListingUpdate(BaseChannelListingMutation):
                         }
                         errors["minimum_order_price"].append(error)
 
-            if "maximum_order_price" in channel_input.keys():
+            if "maximum_order_price" in channel_input:
                 max_price = channel_input.pop("maximum_order_price")
                 channel_input["maximum_order_price_amount"] = max_price
                 if max_price is not None:

--- a/saleor/graphql/shipping/mutations/channels.py
+++ b/saleor/graphql/shipping/mutations/channels.py
@@ -162,36 +162,39 @@ class ShippingMethodChannelListingUpdate(BaseChannelListingMutation):
                         )
                     )
 
-            min_price = channel_input.pop("minimum_order_price", None)
-            max_price = channel_input.pop("maximum_order_price", None)
-
-            if min_price is not None:
+            min_price = None
+            max_price = None
+            if "minimum_order_price" in channel_input.keys():
+                min_price = channel_input.pop("minimum_order_price")
                 channel_input["minimum_order_price_amount"] = min_price
-                try:
-                    validate_price_precision(
-                        min_price, channel_input["channel"].currency_code
-                    )
-                    validate_decimal_max_value(min_price)
-                except ValidationError as error:
-                    error.code = ShippingErrorCode.INVALID.value
-                    error.params = {
-                        "channels": [channel_id],
-                    }
-                    errors["minimum_order_price"].append(error)
+                if min_price is not None:
+                    try:
+                        validate_price_precision(
+                            min_price, channel_input["channel"].currency_code
+                        )
+                        validate_decimal_max_value(min_price)
+                    except ValidationError as error:
+                        error.code = ShippingErrorCode.INVALID.value
+                        error.params = {
+                            "channels": [channel_id],
+                        }
+                        errors["minimum_order_price"].append(error)
 
-            if max_price is not None:
+            if "maximum_order_price" in channel_input.keys():
+                max_price = channel_input.pop("maximum_order_price")
                 channel_input["maximum_order_price_amount"] = max_price
-                try:
-                    validate_price_precision(
-                        max_price, channel_input["channel"].currency_code
-                    )
-                    validate_decimal_max_value(max_price)
-                except ValidationError as error:
-                    error.code = ShippingErrorCode.INVALID.value
-                    error.params = {
-                        "channels": [channel_id],
-                    }
-                    errors["maximum_order_price"].append(error)
+                if max_price is not None:
+                    try:
+                        validate_price_precision(
+                            max_price, channel_input["channel"].currency_code
+                        )
+                        validate_decimal_max_value(max_price)
+                    except ValidationError as error:
+                        error.code = ShippingErrorCode.INVALID.value
+                        error.params = {
+                            "channels": [channel_id],
+                        }
+                        errors["maximum_order_price"].append(error)
 
             if (
                 min_price is not None

--- a/saleor/graphql/shipping/tests/test_shipping_method_channel_listing_update.py
+++ b/saleor/graphql/shipping/tests/test_shipping_method_channel_listing_update.py
@@ -101,6 +101,62 @@ def test_shipping_method_channel_listing_create_as_staff_user(
     )
 
 
+def test_shipping_method_channel_listing_update_allow_to_set_null_for_limit_fields(
+    staff_api_client,
+    shipping_method,
+    permission_manage_shipping,
+    channel_PLN,
+):
+    # given
+    shipping_method.shipping_zone.channels.add(channel_PLN)
+    shipping_method_id = graphene.Node.to_global_id(
+        "ShippingMethodType", shipping_method.pk
+    )
+    channel_listing = shipping_method.channel_listings.all()[0]
+    channel = channel_listing.channel
+    channel_id = graphene.Node.to_global_id("Channel", channel.id)
+    channel_listing.minimum_order_price_amount = 2
+    channel_listing.maximum_order_price_amount = 5
+    channel_listing.save(
+        update_fields=["minimum_order_price_amount", "maximum_order_price_amount"]
+    )
+    price = 3
+
+    variables = {
+        "id": shipping_method_id,
+        "input": {
+            "addChannels": [
+                {
+                    "channelId": channel_id,
+                    "price": price,
+                    "minimumOrderPrice": None,
+                    "maximumOrderPrice": None,
+                }
+            ]
+        },
+    }
+    # when
+
+    response = staff_api_client.post_graphql(
+        SHIPPING_METHOD_CHANNEL_LISTING_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_shipping,),
+    )
+    content = get_graphql_content(response)
+    channel_listing.refresh_from_db()
+    # then
+    data = content["data"]["shippingMethodChannelListingUpdate"]
+    shipping_method_data = data["shippingMethod"]
+    assert not data["errors"]
+    assert shipping_method_data["channelListings"][0]["price"]["amount"] == price
+    assert channel_listing.maximum_order_price_amount is None
+    assert channel_listing.minimum_order_price_amount is None
+    assert shipping_method_data["channelListings"][0]["maximumOrderPrice"] is None
+    assert (
+        shipping_method_data["channelListings"][0]["minimumOrderPrice"]["amount"] == 0
+    )
+
+
 def test_shipping_method_channel_listing_update_as_staff_user(
     staff_api_client,
     shipping_method,


### PR DESCRIPTION
I want to merge this change because it fixes bug when providing `maximum_order_price_amount` or `minimum_order_price_amount` as `null` in `ShippingMethodChannelListingUpdate` does not update `ShippingMethodChannelListing` instance.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
