### PR TITLE
Use app identifier for shipping webhooks

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -437,6 +437,7 @@ def update_checkout_info_delivery_method_info(
 
     The attribute is lazy-evaluated avoid external API calls unless accessed.
     """
+    from ..plugins.webhook.shipping import convert_to_app_id_with_identifier
     from .utils import get_external_shipping_id
 
     delivery_method: Optional[Union[ShippingMethodData, Warehouse, Callable]] = None
@@ -460,7 +461,12 @@ def update_checkout_info_delivery_method_info(
             methods = {
                 method.id: method for method in checkout_info.all_shipping_methods
             }
-            return methods.get(external_shipping_method_id)
+            if method := methods.get(external_shipping_method_id):
+                return method
+            new_shipping_method_id = convert_to_app_id_with_identifier(
+                external_shipping_method_id
+            )
+            return methods.get(new_shipping_method_id)
 
         delivery_method = _resolve_external_method
 

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -79,7 +79,82 @@ def test_is_valid_delivery_method_external_method(
     mock_send_request, checkout_with_item, address, settings, shipping_app
 ):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    assert not shipping_app.identifier
     response_method_id = "abcd"
+    mock_json_response = [
+        {
+            "id": response_method_id,
+            "name": "Provider - Economy",
+            "amount": "10",
+            "currency": "USD",
+            "maximum_delivery_days": "7",
+        }
+    ]
+    method_id = graphene.Node.to_global_id(
+        "app", f"{shipping_app.id}:{response_method_id}"
+    )
+
+    mock_send_request.return_value = mock_json_response
+    checkout = checkout_with_item
+    checkout.shipping_address = address
+    checkout.private_metadata = {PRIVATE_META_APP_SHIPPING_ID: method_id}
+    checkout.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    delivery_method_info = checkout_info.delivery_method_info
+
+    assert delivery_method_info.is_method_in_valid_methods(checkout_info)
+
+
+@patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_is_valid_delivery_method_external_method_shipping_app_id_with_identifier(
+    mock_send_request, checkout_with_item, address, settings, shipping_app
+):
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+
+    shipping_app.identifier = "abcd"
+    shipping_app.save(update_fields=["identifier"])
+
+    response_method_id = "123"
+    mock_json_response = [
+        {
+            "id": response_method_id,
+            "name": "Provider - Economy",
+            "amount": "10",
+            "currency": "USD",
+            "maximum_delivery_days": "7",
+        }
+    ]
+    method_id = graphene.Node.to_global_id(
+        "app", f"{shipping_app.identifier}:{response_method_id}"
+    )
+
+    mock_send_request.return_value = mock_json_response
+    checkout = checkout_with_item
+    checkout.shipping_address = address
+    checkout.private_metadata = {PRIVATE_META_APP_SHIPPING_ID: method_id}
+    checkout.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    delivery_method_info = checkout_info.delivery_method_info
+
+    assert delivery_method_info.is_method_in_valid_methods(checkout_info)
+
+
+@patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_is_valid_delivery_method_external_method_old_shipping_app_id(
+    mock_send_request, checkout_with_item, address, settings, shipping_app
+):
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+
+    shipping_app.identifier = "abcd"
+    shipping_app.save(update_fields=["identifier"])
+
+    response_method_id = "123"
     mock_json_response = [
         {
             "id": response_method_id,

--- a/saleor/graphql/checkout/tests/benchmark/test_homepage.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_homepage.py
@@ -4,6 +4,7 @@ import pytest
 from django.utils import timezone
 
 from .....checkout.utils import set_external_shipping_id
+from .....plugins.webhook.shipping import to_shipping_app_id
 from ....tests.utils import get_graphql_content
 
 
@@ -148,6 +149,7 @@ def test_user_checkout_details(user_api_client, customer_checkout, count_queries
 @patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
 def test_user_checkout_details_with_external_shipping_method(
     mock_send_request,
+    app,
     user_api_client,
     customer_checkout,
     shipping_app,
@@ -155,7 +157,7 @@ def test_user_checkout_details_with_external_shipping_method(
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    external_id = "abcd"
+    external_id = to_shipping_app_id(app, "abcd")
     mock_json_response = [
         {
             "id": external_id,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1375,7 +1375,7 @@ class WebhookPlugin(BasePlugin):
                 )
                 if response_data:
                     shipping_methods = parse_list_shipping_methods_response(
-                        response_data, webhook.app_id
+                        response_data, webhook.app
                     )
                     methods.extend(shipping_methods)
         return methods

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -349,8 +349,10 @@ def test_parse_excluded_shipping_methods_response(app):
             },
         ]
     }
+
     # when
     excluded_methods = get_excluded_shipping_methods_from_response(response)
+
     # then
     assert len(excluded_methods) == 2
     assert excluded_methods[0]["id"] == "2"


### PR DESCRIPTION
Use `app.identifier` is set instead of `app.id` for shipping webhooks.

Port of #10780

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
