### PR TITLE
Fix attribute value matching during attribute update

### DIFF
--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -143,14 +143,14 @@ class AttributeAssignmentMixin:
     def _pre_save_values(
         cls, attribute: attribute_models.Attribute, attr_values: AttrValuesInput
     ):
-        """Lazy-retrieve or create the database objects from the supplied raw values."""
-        get_or_create = attribute.values.get_or_create
+        """Lazy-update or create the database objects from the supplied raw values."""
+        update_or_create = attribute.values.update_or_create
 
         if not attr_values.values:
             return tuple()
 
         return tuple(
-            get_or_create(
+            update_or_create(
                 attribute=attribute,
                 slug=slugify(value, allow_unicode=True),
                 defaults={"name": value},


### PR DESCRIPTION
I want to merge this change because if we use `productVariantUpdate` mutation and update attribute values our changed values would not change if slug for the value was unchanged (e.g. slug for both "12L" and "12.L" values is "12L").
 It is because `get_or_create` was used and if id and slug matched it returned the instance instead of updating it with the new value.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
