### PR TITLE
Add iss to JWT tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add base shipping price to `Order` - #10771 by @fowczarek
 - Add new field `audience` to App manifest. If provided, App's JWT access token will have `aud` field. - #10845 by @korycins
 - GraphQL view no longer generates error logs when the HTTP request doesn't contain a GraphQL query - #10901 by @NyanKiyoshi
+- Add `iss` field to JWT tokens - #10842 by @korycins
 
 ### GraphQL API
 

--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -30,7 +30,12 @@ def jwt_base_payload(
     exp_delta: Optional[timedelta], token_owner: str
 ) -> Dict[str, Any]:
     utc_now = datetime.utcnow()
-    payload = {"iat": utc_now, JWT_OWNER_FIELD: token_owner}
+
+    payload = {
+        "iat": utc_now,
+        JWT_OWNER_FIELD: token_owner,
+        "iss": get_jwt_manager().get_issuer(),
+    }
     if exp_delta:
         payload["exp"] = utc_now + exp_delta
     return payload

--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -9,9 +9,12 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style
+from django.urls import reverse
 from django.utils.module_loading import import_string
 from jwt import api_jws
 from jwt.algorithms import RSAAlgorithm
+
+from .utils import build_absolute_uri
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +51,10 @@ class JWTManagerBase:
 
     @classmethod
     def get_jwks(cls) -> dict:
+        return NotImplemented
+
+    @classmethod
+    def get_issuer(cls) -> str:
         return NotImplemented
 
 
@@ -173,6 +180,10 @@ class JWTManager(JWTManagerBase):
             cls.get_private_key()
         except Exception as e:
             raise ImproperlyConfigured(f"Unable to load provided PEM private key. {e}")
+
+    @classmethod
+    def get_issuer(cls) -> str:
+        return build_absolute_uri(reverse("api"))
 
 
 def get_jwt_manager() -> JWTManagerBase:

--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -7,6 +7,7 @@ import jwt
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from django.conf import settings
+from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style
 from django.urls import reverse
@@ -23,6 +24,10 @@ KID = "1"
 
 
 class JWTManagerBase:
+    @classmethod
+    def get_domain(cls) -> str:
+        return NotImplemented
+
     @classmethod
     def get_private_key(cls) -> rsa.RSAPrivateKey:
         return NotImplemented
@@ -60,6 +65,10 @@ class JWTManagerBase:
 
 class JWTManager(JWTManagerBase):
     KEY_FILE_FOR_DEBUG = ".jwt_key.pem"
+
+    @classmethod
+    def get_domain(cls) -> str:
+        return Site.objects.get_current().domain
 
     @classmethod
     def get_private_key(cls) -> rsa.RSAPrivateKey:
@@ -183,7 +192,7 @@ class JWTManager(JWTManagerBase):
 
     @classmethod
     def get_issuer(cls) -> str:
-        return build_absolute_uri(reverse("api"))
+        return build_absolute_uri(reverse("api"), domain=cls.get_domain())
 
 
 def get_jwt_manager() -> JWTManagerBase:

--- a/saleor/core/tests/test_core.py
+++ b/saleor/core/tests/test_core.py
@@ -223,6 +223,18 @@ def test_build_absolute_uri(site_settings, settings):
     assert logo_url == logo_location
 
 
+def test_build_absolute_uri_with_host(site_settings, settings):
+    # given
+    host = "test.com"
+    location = "images/close.svg"
+
+    # when
+    url = build_absolute_uri(location, host)
+
+    # then
+    assert url == f"http://{host}/{location}"
+
+
 def test_delete_sort_order_with_null_value(menu_item):
     """Ensures there is no error when trying to delete a sortable item,
     which triggers a shifting of the sort orders--which can be null."""

--- a/saleor/core/tests/test_jwt.py
+++ b/saleor/core/tests/test_jwt.py
@@ -1,9 +1,11 @@
 import graphene
 import jwt
 from cryptography.hazmat.primitives import serialization
+from django.urls import reverse
 
 from ...tests.consts import TEST_SERVER_DOMAIN
 from ..jwt import create_access_token_for_app_extension, jwt_decode, jwt_encode
+from ..utils import build_absolute_uri
 
 
 def test_create_access_token_for_app_extension_staff_user_with_more_permissions(
@@ -44,6 +46,7 @@ def test_create_access_token_for_app_extension_staff_user_with_more_permissions(
     )
     assert int(decode_extension_id) == extension.id
     assert decoded_token["aud"] == audience
+    assert decoded_token["iss"] == build_absolute_uri(reverse("api"))
 
 
 def test_create_access_token_for_app_extension_with_more_permissions(

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -22,13 +22,13 @@ if TYPE_CHECKING:
     from django.utils.safestring import SafeText
 
 
-def build_absolute_uri(location: str) -> str:
+def build_absolute_uri(location: str, domain: Optional[str] = None) -> str:
     """Create absolute uri from location.
 
     If provided location is absolute uri by itself, it returns unchanged value,
     otherwise if provided location is relative, absolute uri is built and returned.
     """
-    host = Site.objects.get_current().domain
+    host = domain or Site.objects.get_current().domain
     protocol = "https" if settings.ENABLE_SSL else "http"
     current_uri = "%s://%s" % (protocol, host)
     location = urljoin(current_uri, location)

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from django.utils.safestring import SafeText
 
 
-def build_absolute_uri(location: str) -> Optional[str]:
+def build_absolute_uri(location: str) -> str:
     """Create absolute uri from location.
 
     If provided location is absolute uri by itself, it returns unchanged value,

--- a/saleor/graphql/account/tests/mutations/test_token_create.py
+++ b/saleor/graphql/account/tests/mutations/test_token_create.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import graphene
+from django.urls import reverse
 from freezegun import freeze_time
 
 from .....account.error_codes import AccountErrorCode
@@ -10,6 +11,7 @@ from .....core.jwt import (
     create_refresh_token,
     jwt_decode,
 )
+from .....core.utils import build_absolute_uri
 from ....tests.utils import get_graphql_content
 from ...mutations.authentication import _get_new_csrf_token
 
@@ -66,6 +68,7 @@ def test_create_token(api_client, customer_user, settings):
     assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
     assert payload["type"] == JWT_REFRESH_TYPE
     assert payload["token"] == customer_user.jwt_token_key
+    assert payload["iss"] == build_absolute_uri(reverse("api"))
 
 
 @freeze_time("2020-03-18 12:00:00")
@@ -217,3 +220,4 @@ def test_create_token_active_user_logged_before(api_client, customer_user, setti
     assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
     assert payload["type"] == JWT_REFRESH_TYPE
     assert payload["token"] == customer_user.jwt_token_key
+    assert payload["iss"] == build_absolute_uri(reverse("api"))

--- a/saleor/graphql/account/tests/mutations/test_token_refresh.py
+++ b/saleor/graphql/account/tests/mutations/test_token_refresh.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from django.urls import reverse
 from freezegun import freeze_time
 
 from .....account.error_codes import AccountErrorCode
@@ -11,6 +12,7 @@ from .....core.jwt import (
     create_refresh_token,
     jwt_decode,
 )
+from .....core.utils import build_absolute_uri
 from ....tests.utils import get_graphql_content
 from ...mutations.authentication import _get_new_csrf_token
 
@@ -83,6 +85,7 @@ def test_refresh_token_get_token_from_cookie(api_client, customer_user, settings
     )
     assert payload["type"] == JWT_ACCESS_TYPE
     assert payload["token"] == customer_user.jwt_token_key
+    assert payload["iss"] == build_absolute_uri(reverse("api"))
 
 
 @freeze_time("2020-03-18 12:00:00")

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY, patch
 import graphene
 import pytest
 import pytz
+from django.contrib.sites.models import Site
 from django.db.models.aggregates import Sum
 from django.utils import timezone
 from prices import Money
@@ -769,6 +770,7 @@ def test_checkout_complete_requires_confirmation(
 ):
     site_settings.automatically_confirm_all_new_orders = False
     site_settings.save()
+    Site.objects.clear_cache()
     payment = payment_dummy
     payment.checkout = checkout_ready_to_complete
     payment.save()

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -8,6 +8,7 @@ import before_after
 import graphene
 import pytest
 import pytz
+from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.core.files import File
 from django.db import transaction
@@ -937,6 +938,7 @@ def test_product_query_by_id_weight_returned_in_default_unit(
 
     site_settings.default_weight_unit = WeightUnits.LB
     site_settings.save(update_fields=["default_weight_unit"])
+    Site.objects.clear_cache()
 
     variables = {
         "id": graphene.Node.to_global_id("Product", product.pk),
@@ -4531,6 +4533,7 @@ def test_product_type_query_by_id_weight_returned_in_default_unit(
 
     site_settings.default_weight_unit = WeightUnits.OZ
     site_settings.save(update_fields=["default_weight_unit"])
+    Site.objects.clear_cache()
 
     variables = {"id": graphene.Node.to_global_id("ProductType", product_type.pk)}
 

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import graphene
 import pytest
 import pytz
+from django.contrib.sites.models import Site
 from django.utils.text import slugify
 from freezegun import freeze_time
 from measurement.measures import Weight
@@ -98,6 +99,7 @@ def test_fetch_variant(
     product,
     permission_manage_products,
     site_settings,
+    settings,
     channel_USD,
 ):
     # given
@@ -108,6 +110,7 @@ def test_fetch_variant(
 
     site_settings.default_weight_unit = WeightUnits.G
     site_settings.save(update_fields=["default_weight_unit"])
+    Site.objects.clear_cache()
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     variables = {"id": variant_id, "countryCode": "EU", "channel": channel_USD.slug}
@@ -154,6 +157,7 @@ def test_fetch_variant_no_stocks(
 
     site_settings.default_weight_unit = WeightUnits.G
     site_settings.save(update_fields=["default_weight_unit"])
+    Site.objects.clear_cache()
 
     warehouse = variant.stocks.first().warehouse
     # remove the warehouse channels

--- a/saleor/graphql/shipping/tests/test_shipping_zones_query.py
+++ b/saleor/graphql/shipping/tests/test_shipping_zones_query.py
@@ -1,5 +1,6 @@
 import graphene
 import pytest
+from django.contrib.sites.models import Site
 from measurement.measures import Weight
 
 from ....core.units import WeightUnits
@@ -96,6 +97,7 @@ def test_shipping_zone_query_weights_returned_in_default_unit(
 
     site_settings.default_weight_unit = WeightUnits.G
     site_settings.save(update_fields=["default_weight_unit"])
+    Site.objects.clear_cache()
 
     query = SHIPPING_ZONE_QUERY
     ID = graphene.Node.to_global_id("ShippingZone", shipping.id)

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -680,6 +680,7 @@ def test_shop_customer_set_password_url_update(
     content = get_graphql_content(response)
     data = content["data"]["shopSettingsUpdate"]
     assert not data["errors"]
+    Site.objects.clear_cache()
     site_settings = Site.objects.get_current().settings
     assert site_settings.customer_set_password_url == customer_set_password_url
 


### PR DESCRIPTION
I want to merge this change because it adds `iss` field to JWT token as described here: https://github.com/saleor/saleor/issues/10799

Testcase:
1. tokens (access, refresh) created by the `tokenCreate` mutation, should have `iss` field. Use https://jwt.io to quickly decode the tokens. The token should have `iss` field with value: ``http(s)://<saleor-domain>/graphql`
2. Install thirdparty app. As a staff user, fetch `app.accessToken` and `app.extensions.accessToken`. The token should have `iss` field with value: `http(s)://<saleor-domain>/graphql`. Use https://jwt.io to quickly decode the tokens.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
