### PR TITLE
Fix select_for_update outside transaction

### DIFF
--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -353,8 +353,8 @@ def cancel_fulfillment(
 
     Return products to corresponding stocks if warehouse was defined.
     """
-    fulfillment = Fulfillment.objects.select_for_update().get(pk=fulfillment.pk)
     with traced_atomic_transaction():
+        fulfillment = Fulfillment.objects.select_for_update().get(pk=fulfillment.pk)
         events.fulfillment_canceled_event(
             order=fulfillment.order, user=user, app=app, fulfillment=fulfillment
         )


### PR DESCRIPTION
I want to merge this change because there is a select_for_update outside transaction in `cancel_fulfillment`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
