### PR TITLE
Do not require email when adding voucher to checkout

### DIFF
--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -34,8 +34,13 @@ def add_gift_card_code_to_checkout(
 ):
     """Add gift card data to checkout by code.
 
+    Raise ValidationError if email is not provided.
     Raise InvalidPromoCode if gift card cannot be applied.
     """
+    from ..checkout.checkout_cleaner import validate_checkout_email
+
+    validate_checkout_email(checkout)
+
     try:
         # only active gift card with currency the same as channel currency can be used
         gift_card = (

--- a/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
@@ -1,7 +1,6 @@
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....checkout.checkout_cleaner import validate_checkout_email
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import (
     fetch_checkout_info,
@@ -61,7 +60,6 @@ class CheckoutAddPromoCode(BaseMutation):
             error_class=CheckoutErrorCode,
         )
 
-        validate_checkout_email(checkout)
         manager = load_plugin_manager(info.context)
         discounts = load_discounts(info.context)
         lines, unavailable_variant_pks = fetch_checkout_lines(checkout)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -886,6 +886,29 @@ def test_checkout_add_promo_code_without_checkout_email(
     assert data["checkout"]["voucherCode"] == voucher.code
 
 
+def test_checkout_add_gift_card_without_checkout_email(
+    api_client, checkout_with_item, gift_card
+):
+    # given
+    checkout_with_item.email = None
+    checkout_with_item.save(update_fields=["email"])
+
+    gift_card.expiry_date = date.today() - timedelta(days=1)
+    gift_card.save()
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_item),
+        "promoCode": gift_card.code,
+    }
+
+    # when
+    data = _mutate_checkout_add_promo_code(api_client, variables)
+
+    # then
+    assert data["errors"]
+    assert data["errors"][0]["code"] == CheckoutErrorCode.EMAIL_NOT_SET.name
+
+
 @pytest.mark.parametrize("shipping_price", [12, 10, 5])
 def test_checkout_add_free_shipping_voucher_do_not_invalidate_shipping_method(
     shipping_price,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -866,9 +866,10 @@ def test_checkout_add_promo_code_invalidate_shipping_method(
     assert shipping_method_id not in data["checkout"]["availableShippingMethods"]
 
 
-def test_checkout_add_promo_code_no_checkout_email(
+def test_checkout_add_promo_code_without_checkout_email(
     api_client, checkout_with_item, voucher
 ):
+    # given
     checkout_with_item.email = None
     checkout_with_item.save(update_fields=["email"])
 
@@ -876,10 +877,13 @@ def test_checkout_add_promo_code_no_checkout_email(
         "id": to_global_id_or_none(checkout_with_item),
         "promoCode": voucher.code,
     }
+
+    # when
     data = _mutate_checkout_add_promo_code(api_client, variables)
 
-    assert data["errors"]
-    assert data["errors"][0]["code"] == CheckoutErrorCode.EMAIL_NOT_SET.name
+    # then
+    assert not data["errors"]
+    assert data["checkout"]["voucherCode"] == voucher.code
 
 
 @pytest.mark.parametrize("shipping_price", [12, 10, 5])


### PR DESCRIPTION
Fix https://github.com/saleor/saleor/issues/10823

This pull request removes email validation from adding the promo code to checkout.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
