### PR TITLE
Allow to update/delete product variant by providing SKU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add optional field `audience` to mutation `tokenCreate`. If provided, the created tokens will have key `aud` with value: `custom:{audience-input-value}` - #10845 by @korycins
 - Use `AttributeValue.name` instead of `AttributeValue.slug` to determine uniqueness of a value instance for dropdown and multiselect attributes. - #10881 by @jakubkuc
 - Add ability to pass metadata directly in create/update mutations for product app models - #10689 by @SzymJ
+- Add ability to update and delete `ProductVariant` by SKU - #10861 by @SzymJ
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add optional field `audience` to mutation `tokenCreate`. If provided, the created tokens will have key `aud` with value: `custom:{audience-input-value}` - #10845 by @korycins
 - Use `AttributeValue.name` instead of `AttributeValue.slug` to determine uniqueness of a value instance for dropdown and multiselect attributes. - #10881 by @jakubkuc
 - Add ability to pass metadata directly in create/update mutations for product app models - #10689 by @SzymJ
-- Add ability to use SKU argument in `ProductVariantUpdate`, `ProductVariantDelete`, `ProductVariantBulkDelete`, `productVariantStocksUpdate`, `productVariantStocksDelete`, `productVariantChannelListingUpdate` mutations - #10861 by @SzymJ
+- Add ability to use SKU argument in `productVariantUpdate`, `productVariantDelete`, `productVariantBulkDelete`, `productVariantStocksUpdate`, `productVariantStocksDelete`, `productVariantChannelListingUpdate` mutations - #10861 by @SzymJ
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add optional field `audience` to mutation `tokenCreate`. If provided, the created tokens will have key `aud` with value: `custom:{audience-input-value}` - #10845 by @korycins
 - Use `AttributeValue.name` instead of `AttributeValue.slug` to determine uniqueness of a value instance for dropdown and multiselect attributes. - #10881 by @jakubkuc
 - Add ability to pass metadata directly in create/update mutations for product app models - #10689 by @SzymJ
-- Add ability to update and delete `ProductVariant` by SKU - #10861 by @SzymJ
+- Add ability to use SKU argument in `ProductVariantUpdate`, `ProductVariantDelete`, `ProductVariantBulkDelete`, `productVariantStocksUpdate`, `productVariantStocksDelete`, `productVariantChannelListingUpdate` mutations - #10861 by @SzymJ
 
 ### Other changes
 

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -819,16 +819,16 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
     class Arguments:
         variant_id = graphene.ID(
             required=False,
-            description="ID of a product variant for which stocks will be created.",
+            description="ID of a product variant for which stocks will be updated.",
         )
         sku = graphene.String(
             required=False,
-            description="SKU of product variant for which stocks will be deleted.",
+            description="SKU of product variant for which stocks will be updated.",
         )
         stocks = NonNullList(
             StockInput,
             required=True,
-            description="Input list of stocks to create.",
+            description="Input list of stocks to create or update.",
         )
 
     @classmethod
@@ -844,7 +844,7 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
 
         if variant_id:
             variant = cls.get_node_or_error(info, variant_id, only_type=ProductVariant)
-        else:
+        if sku:
             variant = models.ProductVariant.objects.filter(sku=sku).first()
             if not variant:
                 raise ValidationError(
@@ -914,7 +914,9 @@ class ProductVariantStocksDelete(BaseMutation):
             required=False,
             description="SKU of product variant for which stocks will be deleted.",
         )
-        warehouse_ids = NonNullList(graphene.ID)
+        warehouse_ids = NonNullList(
+            graphene.ID, description="Input list of warehouse IDs."
+        )
 
     class Meta:
         description = "Delete stocks from product variant."
@@ -935,7 +937,7 @@ class ProductVariantStocksDelete(BaseMutation):
 
         if variant_id:
             variant = cls.get_node_or_error(info, variant_id, only_type=ProductVariant)
-        else:
+        if sku:
             variant = models.ProductVariant.objects.filter(sku=sku).first()
             if not variant:
                 raise ValidationError(

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -31,6 +31,7 @@ from ....warehouse.error_codes import StockErrorCode
 from ...app.dataloaders import load_app
 from ...channel import ChannelContext
 from ...channel.types import Channel
+from ...core.descriptions import ADDED_IN_38
 from ...core.mutations import BaseMutation, ModelBulkDeleteMutation, ModelMutation
 from ...core.types import (
     BulkProductError,
@@ -41,7 +42,10 @@ from ...core.types import (
     StockError,
 )
 from ...core.utils import get_duplicated_values
-from ...core.validators import validate_price_precision
+from ...core.validators import (
+    validate_one_of_args_is_in_mutation,
+    validate_price_precision,
+)
 from ...plugins.dataloaders import load_plugin_manager
 from ...warehouse.dataloaders import (
     StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader,
@@ -580,8 +584,13 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = NonNullList(
             graphene.ID,
-            required=True,
+            required=False,
             description="List of product variant IDs to delete.",
+        )
+        skus = NonNullList(
+            graphene.String,
+            required=False,
+            description="List of product variant SKUs to delete." + ADDED_IN_38,
         )
 
     class Meta:
@@ -594,11 +603,19 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
 
     @classmethod
     @traced_atomic_transaction()
-    def perform_mutation(cls, _root, info, ids, **data):
-        try:
-            pks = cls.get_global_ids_or_error(ids, ProductVariant)
-        except ValidationError as error:
-            return 0, error
+    def perform_mutation(cls, _root, info, ids=None, skus=None, **data):
+        validate_one_of_args_is_in_mutation(ProductErrorCode, "skus", skus, "ids", ids)
+
+        if ids:
+            try:
+                pks = cls.get_global_ids_or_error(ids, ProductVariant)
+            except ValidationError as error:
+                return 0, error
+        if skus:
+            pks = models.ProductVariant.objects.filter(sku__in=skus).values_list(
+                "pk", flat=True
+            )
+            ids = [graphene.Node.to_global_id("ProductVariant", pk) for pk in pks]
 
         draft_order_lines_data = get_draft_order_lines_data_for_variants(pks)
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1291,15 +1291,16 @@ class ProductVariantDelete(ModelDeleteMutation):
 
         if node_sku := data.get("sku"):
             instance = models.ProductVariant.objects.filter(sku=node_sku).first()
-            data["id"] = graphene.Node.to_global_id("ProductVariant", instance.id)
             if not instance:
                 raise ValidationError(
                     {
                         "sku": ValidationError(
-                            "Couldn't resolve to a node: %s" % node_id, code="not_found"
+                            "Couldn't resolve to a node: %s" % node_sku,
+                            code="not_found",
                         )
                     }
                 )
+            data["id"] = graphene.Node.to_global_id("ProductVariant", instance.id)
 
         draft_order_lines_data = get_draft_order_lines_data_for_variants([instance.pk])
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1189,7 +1189,7 @@ class ProductVariantUpdate(ProductVariantCreate):
         )
         sku = graphene.String(
             required=False,
-            description="ID of a product variant to update." + ADDED_IN_38,
+            description="SKU of a product variant to update." + ADDED_IN_38,
         )
         input = ProductVariantInput(
             required=True, description="Fields required to update a product variant."

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -59,6 +59,7 @@ from ...core.utils import (
     validate_slug_and_generate_if_needed,
 )
 from ...core.utils.reordering import perform_reordering
+from ...core.validators import validate_one_of_args_is_in_mutation
 from ...meta.mutations import MetadataInput
 from ...plugins.dataloaders import load_plugin_manager
 from ...warehouse.types import Warehouse
@@ -1099,18 +1100,52 @@ class ProductVariantCreate(ModelMutation):
         """
 
         object_id = data.get("id")
-        if object_id and data.get("attributes"):
+        object_sku = data.get("sku")
+        if (object_id or object_sku) and data.get("attributes"):
             # Prefetches needed by AttributeAssignmentMixin and
             # associate_attribute_values_to_instance
             qs = cls.Meta.model.objects.prefetch_related(
                 "product__product_type__variant_attributes__values",
                 "product__product_type__attributevariant",
             )
-            return cls.get_node_or_error(
+
+            if object_id:
+                return cls.get_node_or_error(
+                    info, object_id, only_type="ProductVariant", qs=qs
+                )
+            if object_sku:
+                instance = qs.filter(sku=object_sku).first()
+                if not instance:
+                    raise ValidationError(
+                        {
+                            "sku": ValidationError(
+                                "Couldn't resolve to a node: %s" % object_sku,
+                                code="not_found",
+                            )
+                        }
+                    )
+                return instance
+
+        qs = data.get("qs")
+        if object_id:
+            instance = cls.get_node_or_error(
                 info, object_id, only_type="ProductVariant", qs=qs
             )
+        elif object_sku:
+            instance = models.ProductVariant.objects.filter(sku=object_sku).first()
+            if not instance:
+                raise ValidationError(
+                    {
+                        "sku": ValidationError(
+                            "Couldn't resolve to a node: %s" % object_sku,
+                            code="not_found",
+                        )
+                    }
+                )
+        else:
+            instance = cls._meta.model()
 
-        return super().get_instance(info, **data)
+        return instance
 
     @classmethod
     def save(cls, info, instance, cleaned_input):
@@ -1159,7 +1194,11 @@ class ProductVariantCreate(ModelMutation):
 class ProductVariantUpdate(ProductVariantCreate):
     class Arguments:
         id = graphene.ID(
-            required=True, description="ID of a product variant to update."
+            required=False, description="ID of a product variant to update."
+        )
+        sku = graphene.String(
+            required=False,
+            description="ID of a product variant to update." + ADDED_IN_38,
         )
         input = ProductVariantInput(
             required=True, description="Fields required to update a product variant."
@@ -1212,11 +1251,22 @@ class ProductVariantUpdate(ProductVariantCreate):
             attributes_data, used_attribute_values
         )
 
+    @classmethod
+    def perform_mutation(cls, _root, info, **data):
+        validate_one_of_args_is_in_mutation(
+            ProductErrorCode, "sku", data.get("sku"), "id", data.get("id")
+        )
+        return super().perform_mutation(_root, info, **data)
+
 
 class ProductVariantDelete(ModelDeleteMutation):
     class Arguments:
         id = graphene.ID(
-            required=True, description="ID of a product variant to delete."
+            required=False, description="ID of a product variant to delete."
+        )
+        sku = graphene.String(
+            required=False,
+            description="ID of a product variant to delete." + ADDED_IN_38,
         )
 
     class Meta:
@@ -1242,8 +1292,23 @@ class ProductVariantDelete(ModelDeleteMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        node_id = data.get("id")
-        instance = cls.get_node_or_error(info, node_id, only_type=ProductVariant)
+        validate_one_of_args_is_in_mutation(
+            ProductErrorCode, "sku", data.get("sku"), "id", data.get("id")
+        )
+        if node_id := data.get("id"):
+            instance = cls.get_node_or_error(info, node_id, only_type=ProductVariant)
+
+        if node_sku := data.get("sku"):
+            instance = models.ProductVariant.objects.filter(sku=node_sku).first()
+            data["id"] = graphene.Node.to_global_id("ProductVariant", instance.id)
+            if not instance:
+                raise ValidationError(
+                    {
+                        "sku": ValidationError(
+                            "Couldn't resolve to a node: %s" % node_id, code="not_found"
+                        )
+                    }
+                )
 
         draft_order_lines_data = get_draft_order_lines_data_for_variants([instance.pk])
 

--- a/saleor/graphql/product/tests/benchmark/test_variant_stocks.py
+++ b/saleor/graphql/product/tests/benchmark/test_variant_stocks.py
@@ -140,33 +140,36 @@ def test_product_variants_stocks_create_with_single_webhook_called(
     product_variant_back_in_stock_webhook_mock.assert_called_with(Stock.objects.last())
 
 
-@pytest.mark.django_db
-@pytest.mark.count_queries(autouse=False)
-def test_product_variants_stocks_update(
-    staff_api_client, variant, warehouse, permission_manage_products, count_queries
-):
-    query = """
-    mutation ProductVariantStocksUpdate($variantId: ID!, $stocks: [StockInput!]!){
-            productVariantStocksUpdate(variantId: $variantId, stocks: $stocks){
-                productVariant{
-                    stocks{
-                        quantity
-                        quantityAllocated
-                        id
-                        warehouse{
-                            slug
-                        }
+PRODUCT_VARIANT_STOCKS_UPDATE_MUTATION = """
+mutation ProductVariantStocksUpdate(
+    $variantId: ID, $sku: String, $stocks: [StockInput!]!){
+        productVariantStocksUpdate(variantId: $variantId, sku: $sku, stocks: $stocks){
+            productVariant{
+                stocks{
+                    quantity
+                    quantityAllocated
+                    id
+                    warehouse{
+                        slug
                     }
                 }
-                errors{
-                    code
-                    field
-                    message
-                    index
-                }
+            }
+            errors{
+                code
+                field
+                message
+                index
             }
         }
-    """
+    }
+"""
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_product_variants_stocks_update_byid(
+    staff_api_client, variant, warehouse, permission_manage_products, count_queries
+):
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     second_warehouse = Warehouse.objects.get(pk=warehouse.pk)
     second_warehouse.slug = "second warehouse"
@@ -189,7 +192,7 @@ def test_product_variants_stocks_update(
     ]
     variables = {"variantId": variant_id, "stocks": stocks}
     response = staff_api_client.post_graphql(
-        query,
+        PRODUCT_VARIANT_STOCKS_UPDATE_MUTATION,
         variables,
         permissions=[permission_manage_products],
     )
@@ -203,19 +206,47 @@ def test_product_variants_stocks_update(
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-@patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
-def test_product_variants_stocks_delete(
-    product_variant_out_of_stock_webhook_mock,
-    staff_api_client,
-    variant,
-    warehouse,
-    permission_manage_products,
-    count_queries,
+def test_product_variants_stocks_update_by_sku(
+    staff_api_client, variant, warehouse, permission_manage_products, count_queries
 ):
-    query = """
-    mutation ProductVariantStocksDelete($variantId: ID!, $warehouseIds: [ID!]!){
+    second_warehouse = Warehouse.objects.get(pk=warehouse.pk)
+    second_warehouse.slug = "second warehouse"
+    second_warehouse.pk = None
+    second_warehouse.save()
+
+    Stock.objects.create(product_variant=variant, warehouse=warehouse, quantity=10)
+
+    stocks_count = variant.stocks.count()
+
+    stocks = [
+        {
+            "warehouse": graphene.Node.to_global_id("Warehouse", warehouse.id),
+            "quantity": 20,
+        },
+        {
+            "warehouse": graphene.Node.to_global_id("Warehouse", second_warehouse.id),
+            "quantity": 100,
+        },
+    ]
+    variables = {"sku": variant.sku, "stocks": stocks}
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_STOCKS_UPDATE_MUTATION,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantStocksUpdate"]
+
+    assert not data["errors"]
+    assert len(data["productVariant"]["stocks"]) == len(stocks)
+    assert variant.stocks.count() == stocks_count + 1
+
+
+PRODUCT_VARIANT_STOCKS_DELETE_MUTATION = """
+    mutation ProductVariantStocksDelete(
+        $variantId: ID, $sku: String, $warehouseIds: [ID!]!){
             productVariantStocksDelete(
-                variantId: $variantId, warehouseIds: $warehouseIds
+                variantId: $variantId, sku: $sku, warehouseIds: $warehouseIds
             ){
                 productVariant{
                     stocks{
@@ -234,6 +265,19 @@ def test_product_variants_stocks_delete(
             }
         }
     """
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+@patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
+def test_product_variants_stocks_delete_by_id(
+    product_variant_out_of_stock_webhook_mock,
+    staff_api_client,
+    variant,
+    warehouse,
+    permission_manage_products,
+    count_queries,
+):
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     second_warehouse = Warehouse.objects.get(pk=warehouse.pk)
     second_warehouse.slug = "second warehouse"
@@ -253,7 +297,53 @@ def test_product_variants_stocks_delete(
 
     variables = {"variantId": variant_id, "warehouseIds": warehouse_ids}
     response = staff_api_client.post_graphql(
-        query,
+        PRODUCT_VARIANT_STOCKS_DELETE_MUTATION,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantStocksDelete"]
+
+    assert not data["stockErrors"]
+    assert (
+        len(data["productVariant"]["stocks"])
+        == variant.stocks.count()
+        == stocks_count - 1
+    )
+    assert stock_to_delete not in Stock.objects.all()
+    product_variant_out_of_stock_webhook_mock.assert_called_once_with(stock_to_delete)
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+@patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
+def test_product_variants_stocks_delete_by_sku(
+    product_variant_out_of_stock_webhook_mock,
+    staff_api_client,
+    variant,
+    warehouse,
+    permission_manage_products,
+    count_queries,
+):
+    second_warehouse = Warehouse.objects.get(pk=warehouse.pk)
+    second_warehouse.slug = "second warehouse"
+    second_warehouse.pk = None
+    second_warehouse.save()
+
+    Stock.objects.bulk_create(
+        [
+            Stock(product_variant=variant, warehouse=warehouse, quantity=10),
+            Stock(product_variant=variant, warehouse=second_warehouse, quantity=140),
+        ]
+    )
+    stock_to_delete = Stock.objects.last()
+    stocks_count = variant.stocks.count()
+
+    warehouse_ids = [graphene.Node.to_global_id("Warehouse", second_warehouse.id)]
+
+    variables = {"sku": variant.sku, "warehouseIds": warehouse_ids}
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_STOCKS_DELETE_MUTATION,
         variables,
         permissions=[permission_manage_products],
     )

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -2349,7 +2349,7 @@ def test_product_variant_update_with_new_attributes(
 
 @patch("saleor.plugins.manager.PluginsManager.product_variant_created")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
-def test_update_product_variant(
+def test_update_product_variant_by_id(
     product_variant_updated_webhook_mock,
     product_variant_created_webhook_mock,
     staff_api_client,
@@ -2384,7 +2384,6 @@ def test_update_product_variant(
                     }
                 }
             }
-
     """
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
@@ -2416,6 +2415,122 @@ def test_update_product_variant(
         product.variants.last()
     )
     product_variant_created_webhook_mock.assert_not_called()
+
+
+UPDATE_VARIANT_BY_SKU = """
+ mutation updateVariant (
+            $sku: String!,
+            $newSku: String!,
+            $quantityLimitPerCustomer: Int!
+            $trackInventory: Boolean!,
+            $attributes: [AttributeValueInput!]) {
+                productVariantUpdate(
+                    sku: $sku,
+                    input: {
+                        sku: $newSku,
+                        trackInventory: $trackInventory,
+                        attributes: $attributes,
+                        quantityLimitPerCustomer: $quantityLimitPerCustomer,
+                    }) {
+                    productVariant {
+                        name
+                        sku
+                        quantityLimitPerCustomer
+                        channelListings {
+                            channel {
+                                slug
+                            }
+                        }
+                    }
+                    errors {
+                      field
+                      message
+                      attributes
+                      code
+                    }
+                }
+            }
+
+"""
+
+
+@patch("saleor.plugins.manager.PluginsManager.product_variant_created")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
+def test_update_product_variant_by_sku(
+    product_variant_updated_webhook_mock,
+    product_variant_created_webhook_mock,
+    staff_api_client,
+    product,
+    size_attribute,
+    permission_manage_products,
+):
+    #   given
+    variant = product.variants.first()
+    attribute_id = graphene.Node.to_global_id("Attribute", size_attribute.pk)
+    sku = "test sku"
+    quantity_limit_per_customer = 5
+    attr_value = "S"
+
+    variables = {
+        "sku": variant.sku,
+        "newSku": sku,
+        "trackInventory": True,
+        "quantityLimitPerCustomer": quantity_limit_per_customer,
+        "attributes": [{"id": attribute_id, "values": [attr_value]}],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        UPDATE_VARIANT_BY_SKU, variables, permissions=[permission_manage_products]
+    )
+    variant.refresh_from_db()
+    content = get_graphql_content(response)
+    flush_post_commit_hooks()
+    data = content["data"]["productVariantUpdate"]["productVariant"]
+
+    # then
+    assert data["name"] == variant.name
+    assert data["sku"] == sku
+    assert data["quantityLimitPerCustomer"] == quantity_limit_per_customer
+    product_variant_updated_webhook_mock.assert_called_once_with(
+        product.variants.last()
+    )
+    product_variant_created_webhook_mock.assert_not_called()
+
+
+def test_update_product_variant_by_sku_return_error_when_sku_dont_exists(
+    staff_api_client,
+    product,
+    size_attribute,
+    permission_manage_products,
+):
+    # given
+    variant = product.variants.first()
+    attribute_id = graphene.Node.to_global_id("Attribute", size_attribute.pk)
+    sku = "test sku"
+    quantity_limit_per_customer = 5
+    attr_value = "S"
+
+    variables = {
+        "sku": "randomSku",
+        "newSku": sku,
+        "trackInventory": True,
+        "quantityLimitPerCustomer": quantity_limit_per_customer,
+        "attributes": [{"id": attribute_id, "values": [attr_value]}],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        UPDATE_VARIANT_BY_SKU, variables, permissions=[permission_manage_products]
+    )
+    variant.refresh_from_db()
+    content = get_graphql_content(response)
+    flush_post_commit_hooks()
+    data = content["data"]["productVariantUpdate"]
+
+    # then
+    assert data["errors"][0]["field"] == "sku"
+    assert data["errors"][0]["code"] == "NOT_FOUND"
 
 
 def test_update_product_variant_with_negative_weight(
@@ -3969,6 +4084,50 @@ def test_update_product_variant_can_not_turn_off_preorder(
     assert data["sku"] == sku
     assert data["preorder"]["globalThreshold"] == variant.preorder_global_threshold
     assert data["preorder"]["endDate"] is None
+
+
+DELETE_VARIANT_BY_SKU_MUTATION = """
+    mutation variantDelete($sku: String) {
+        productVariantDelete(sku: $sku) {
+            productVariant {
+                sku
+                id
+            }
+            }
+        }
+"""
+
+
+@patch("saleor.plugins.manager.PluginsManager.product_variant_deleted")
+@patch("saleor.order.tasks.recalculate_orders_task.delay")
+def test_delete_variant_by_sku(
+    mocked_recalculate_orders_task,
+    product_variant_deleted_webhook_mock,
+    staff_api_client,
+    product,
+    permission_manage_products,
+):
+    # given
+    variant = product.variants.first()
+    variant_sku = variant.sku
+    variables = {"sku": variant_sku}
+
+    # when
+    response = staff_api_client.post_graphql(
+        DELETE_VARIANT_BY_SKU_MUTATION,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+    flush_post_commit_hooks()
+    data = content["data"]["productVariantDelete"]
+
+    # then
+    product_variant_deleted_webhook_mock.assert_called_once_with(variant)
+    assert data["productVariant"]["sku"] == variant_sku
+    with pytest.raises(variant._meta.model.DoesNotExist):
+        variant.refresh_from_db()
+    mocked_recalculate_orders_task.assert_not_called()
 
 
 DELETE_VARIANT_MUTATION = """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11801,6 +11801,8 @@ type Mutation {
 
     """ID of product variant for which stocks will be deleted."""
     variantId: ID
+
+    """Input list of warehouse IDs."""
     warehouseIds: [ID!]
   ): ProductVariantStocksDelete
 
@@ -11810,13 +11812,13 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantStocksUpdate(
-    """SKU of product variant for which stocks will be deleted."""
+    """SKU of product variant for which stocks will be updated."""
     sku: String
 
-    """Input list of stocks to create."""
+    """Input list of stocks to create or update."""
     stocks: [StockInput!]!
 
-    """ID of a product variant for which stocks will be created."""
+    """ID of a product variant for which stocks will be updated."""
     variantId: ID
   ): ProductVariantStocksUpdate
 
@@ -11833,7 +11835,7 @@ type Mutation {
     input: ProductVariantInput!
 
     """
-    ID of a product variant to update.
+    SKU of a product variant to update.
     
     Added in Saleor 3.8.
     """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11740,7 +11740,7 @@ type Mutation {
     id: ID
 
     """
-    ID of a product variant to delete.
+    SKU of a product variant to delete.
     
     Added in Saleor 3.8.
     """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11737,7 +11737,14 @@ type Mutation {
   """
   productVariantDelete(
     """ID of a product variant to delete."""
-    id: ID!
+    id: ID
+
+    """
+    ID of a product variant to delete.
+    
+    Added in Saleor 3.8.
+    """
+    sku: String
   ): ProductVariantDelete
 
   """
@@ -11760,7 +11767,14 @@ type Mutation {
   """
   productVariantBulkDelete(
     """List of product variant IDs to delete."""
-    ids: [ID!]!
+    ids: [ID!]
+
+    """
+    List of product variant SKUs to delete.
+    
+    Added in Saleor 3.8.
+    """
+    skus: [String!]
   ): ProductVariantBulkDelete
 
   """
@@ -11807,10 +11821,17 @@ type Mutation {
   """
   productVariantUpdate(
     """ID of a product variant to update."""
-    id: ID!
+    id: ID
 
     """Fields required to update a product variant."""
     input: ProductVariantInput!
+
+    """
+    ID of a product variant to update.
+    
+    Added in Saleor 3.8.
+    """
+    sku: String
   ): ProductVariantUpdate
 
   """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11796,8 +11796,11 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantStocksDelete(
+    """SKU of product variant for which stocks will be deleted."""
+    sku: String
+
     """ID of product variant for which stocks will be deleted."""
-    variantId: ID!
+    variantId: ID
     warehouseIds: [ID!]
   ): ProductVariantStocksDelete
 
@@ -11807,11 +11810,14 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productVariantStocksUpdate(
+    """SKU of product variant for which stocks will be deleted."""
+    sku: String
+
     """Input list of stocks to create."""
     stocks: [StockInput!]!
 
     """ID of a product variant for which stocks will be created."""
-    variantId: ID!
+    variantId: ID
   ): ProductVariantStocksUpdate
 
   """
@@ -11868,12 +11874,19 @@ type Mutation {
   """
   productVariantChannelListingUpdate(
     """ID of a product variant to update."""
-    id: ID!
+    id: ID
 
     """
     List of fields required to create or upgrade product variant channel listings.
     """
     input: [ProductVariantChannelListingAddInput!]!
+
+    """
+    SKU of a product variant to update.
+    
+    Added in Saleor 3.8.
+    """
+    sku: String
   ): ProductVariantChannelListingUpdate
 
   """


### PR DESCRIPTION
I want to merge this change because it adds the possibility to update/delete `ProductVariants` by using `SKU`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
