### PR TITLE
Fix ShippingMethodChannelListingUpdate minimum_order_price resolver

### DIFF
--- a/saleor/graphql/shipping/tests/mutations/test_shipping_method_channel_listing_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_method_channel_listing_update.py
@@ -150,6 +150,7 @@ def test_shipping_method_channel_listing_update_allow_to_set_null_for_limit_fiel
     )
     content = get_graphql_content(response)
     channel_listing.refresh_from_db()
+
     # then
     data = content["data"]["shippingMethodChannelListingUpdate"]
     shipping_method_data = data["shippingMethod"]
@@ -158,9 +159,7 @@ def test_shipping_method_channel_listing_update_allow_to_set_null_for_limit_fiel
     assert channel_listing.maximum_order_price_amount is None
     assert channel_listing.minimum_order_price_amount is None
     assert shipping_method_data["channelListings"][0]["maximumOrderPrice"] is None
-    assert (
-        shipping_method_data["channelListings"][0]["minimumOrderPrice"]["amount"] == 0
-    )
+    assert shipping_method_data["channelListings"][0]["minimumOrderPrice"] is None
 
 
 @freeze_time("2022-05-12 12:00:00")

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -65,6 +65,13 @@ class ShippingMethodChannelListing(ModelObjectType):
     def resolve_channel(root: models.ShippingMethodChannelListing, info):
         return ChannelByIdLoader(info.context).load(root.channel_id)
 
+    @staticmethod
+    def resolve_minimum_order_price(root: models.ShippingMethodChannelListing, info):
+        if root.minimum_order_price_amount is None:
+            return None
+        else:
+            return root.minimum_order_price
+
 
 class ShippingMethodPostalCodeRule(ModelObjectType):
     start = graphene.String(description="Start address range.")

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -44,6 +44,7 @@ def _applicable_price_based_methods(price: Money, qs, channel_id):
 
     price_based = Q(shipping_method_id__in=qs_shipping_method)
     channel_filter = Q(channel_id=channel_id)
+    min_price_is_null = Q(minimum_order_price_amount__isnull=True)
     min_price_matched = Q(minimum_order_price_amount__lte=price.amount)
     no_price_limit = Q(maximum_order_price_amount__isnull=True)
     max_price_matched = Q(maximum_order_price_amount__gte=price.amount)
@@ -51,7 +52,7 @@ def _applicable_price_based_methods(price: Money, qs, channel_id):
     applicable_price_based_methods = ShippingMethodChannelListing.objects.filter(
         channel_filter
         & price_based
-        & min_price_matched
+        & (min_price_is_null | min_price_matched)
         & (no_price_limit | max_price_matched)
     ).values_list("shipping_method__id", flat=True)
     return qs_shipping_method.filter(id__in=applicable_price_based_methods)


### PR DESCRIPTION
I want to merge this change because it fixes the resolver when `minimum_order_price=None` in `ShippingMethodChannelListing`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
