### PR TITLE
Fix handling file url of file attribute values

### DIFF
--- a/saleor/core/tests/test_url.py
+++ b/saleor/core/tests/test_url.py
@@ -1,7 +1,9 @@
 from collections import OrderedDict
 from urllib.parse import urlencode
 
-from ..utils.url import prepare_url
+from django.conf import settings
+
+from ..utils.url import get_default_storage_root_url, prepare_url
 
 
 def test_prepare_url():
@@ -16,3 +18,11 @@ def test_prepare_url_with_existing_query():
     params = urlencode(OrderedDict({"param3": "abc", "param4": "xyz"}))
     result = prepare_url(params, redirect_url)
     assert result == f"{redirect_url}&param3=abc&param4=xyz"
+
+
+def test_get_default_storage_root_url(site_settings):
+    # when
+    root_url = get_default_storage_root_url()
+
+    # then
+    assert root_url == f"http://{site_settings.site.domain}{settings.MEDIA_URL}"

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from django.utils.safestring import SafeText
 
 
-def build_absolute_uri(location: str) -> Optional[str]:
+def build_absolute_uri(location: str) -> str:
     """Create absolute uri from location.
 
     If provided location is absolute uri by itself, it returns unchanged value,

--- a/saleor/core/utils/url.py
+++ b/saleor/core/utils/url.py
@@ -2,7 +2,10 @@ from urllib.parse import urlparse, urlsplit
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.files.storage import default_storage
 from django.http.request import split_domain_port, validate_host
+
+from . import build_absolute_uri
 
 
 def validate_storefront_url(url):
@@ -36,3 +39,13 @@ def prepare_url(params: str, redirect_url: str) -> str:
         params = f"{current_params}&{params}"
     split_url = split_url._replace(query=params)
     return split_url.geturl()
+
+
+def get_default_storage_root_url():
+    """Return the absolute root URL for default storage."""
+    # We cannot do simple `storage.url("")`, as the `AzureStorage` url method requires
+    # at least one printable character that is not a slash or space.
+    # Because of that, the `url` method is called for a `path` value, and then
+    # `path` is stripped to get the actual root URL
+    tmp_path = "path"
+    return build_absolute_uri(default_storage.url(tmp_path)).rstrip(tmp_path)

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -37,7 +37,6 @@ from ....core.utils.url import prepare_url
 from ....order import OrderStatus
 from ....order.models import FulfillmentStatus, Order
 from ....product.tests.utils import create_image
-from ....tests.consts import TEST_SERVER_DOMAIN
 from ....thumbnail.models import Thumbnail
 from ....webhook.event_types import WebhookEventAsyncType
 from ....webhook.payloads import (
@@ -780,7 +779,7 @@ USER_AVATAR_QUERY = """
 
 
 def test_query_user_avatar_with_size_and_format_proxy_url_returned(
-    staff_api_client, media_root, permission_manage_staff
+    staff_api_client, media_root, permission_manage_staff, site_settings
 ):
     # given
     user = staff_api_client.user
@@ -803,14 +802,18 @@ def test_query_user_avatar_with_size_and_format_proxy_url_returned(
     # then
     content = get_graphql_content(response)
     data = content["data"]["user"]
+    domain = site_settings.site.domain
     assert (
         data["avatar"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{user_uuid}/128/{format.lower()}/"
+        == f"http://{domain}/thumbnail/{user_uuid}/128/{format.lower()}/"
     )
 
 
 def test_query_user_avatar_with_size_proxy_url_returned(
-    staff_api_client, media_root, permission_manage_staff
+    staff_api_client,
+    media_root,
+    permission_manage_staff,
+    site_settings,
 ):
     # given
     user = staff_api_client.user
@@ -833,12 +836,12 @@ def test_query_user_avatar_with_size_proxy_url_returned(
     data = content["data"]["user"]
     assert (
         data["avatar"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{user_uuid}/128/"
+        == f"http://{site_settings.site.domain}/thumbnail/{user_uuid}/128/"
     )
 
 
 def test_query_user_avatar_with_size_thumbnail_url_returned(
-    staff_api_client, media_root, permission_manage_staff
+    staff_api_client, media_root, permission_manage_staff, site_settings
 ):
     # given
     user = staff_api_client.user
@@ -864,12 +867,12 @@ def test_query_user_avatar_with_size_thumbnail_url_returned(
     data = content["data"]["user"]
     assert (
         data["avatar"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
 def test_query_user_avatar_only_format_provided_original_image_returned(
-    staff_api_client, media_root, permission_manage_staff
+    staff_api_client, media_root, permission_manage_staff, site_settings
 ):
     # given
     user = staff_api_client.user
@@ -893,12 +896,12 @@ def test_query_user_avatar_only_format_provided_original_image_returned(
     data = content["data"]["user"]
     assert (
         data["avatar"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/media/user-avatars/{avatar_mock.name}"
+        == f"http://{site_settings.site.domain}/media/user-avatars/{avatar_mock.name}"
     )
 
 
 def test_query_user_avatar_no_size_value(
-    staff_api_client, media_root, permission_manage_staff
+    staff_api_client, media_root, permission_manage_staff, site_settings
 ):
     # given
     user = staff_api_client.user
@@ -920,7 +923,7 @@ def test_query_user_avatar_no_size_value(
     data = content["data"]["user"]
     assert (
         data["avatar"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/media/user-avatars/{avatar_mock.name}"
+        == f"http://{site_settings.site.domain}/media/user-avatars/{avatar_mock.name}"
     )
 
 
@@ -5379,7 +5382,9 @@ def test_user_avatar_update_mutation_permission(api_client):
     assert_no_permission(response)
 
 
-def test_user_avatar_update_mutation(monkeypatch, staff_api_client, media_root):
+def test_user_avatar_update_mutation(
+    monkeypatch, staff_api_client, media_root, site_settings
+):
     # given
     query = USER_AVATAR_UPDATE_MUTATION
 
@@ -5400,7 +5405,7 @@ def test_user_avatar_update_mutation(monkeypatch, staff_api_client, media_root):
 
     assert user.avatar
     assert data["user"]["avatar"]["url"].startswith(
-        f"http://{TEST_SERVER_DOMAIN}/media/user-avatars/avatar"
+        f"http://{site_settings.site.domain}/media/user-avatars/avatar"
     )
     img_name, format = os.path.splitext(image_file._name)
     file_name = user.avatar.name
@@ -5409,7 +5414,9 @@ def test_user_avatar_update_mutation(monkeypatch, staff_api_client, media_root):
     assert file_name.endswith(format)
 
 
-def test_user_avatar_update_mutation_image_exists(staff_api_client, media_root):
+def test_user_avatar_update_mutation_image_exists(
+    staff_api_client, media_root, site_settings
+):
     # given
     query = USER_AVATAR_UPDATE_MUTATION
 
@@ -5438,7 +5445,7 @@ def test_user_avatar_update_mutation_image_exists(staff_api_client, media_root):
 
     assert user.avatar != avatar_mock
     assert data["user"]["avatar"]["url"].startswith(
-        f"http://{TEST_SERVER_DOMAIN}/media/user-avatars/new_image"
+        f"http://{site_settings.site.domain}/media/user-avatars/new_image"
     )
     assert not user.thumbnails.exists()
 

--- a/saleor/graphql/attribute/tests/test_utils.py
+++ b/saleor/graphql/attribute/tests/test_utils.py
@@ -1,5 +1,7 @@
 import graphene
 import pytest
+from django.conf import settings
+from django.core.exceptions import ValidationError
 
 from ....attribute import AttributeInputType
 from ....page.error_codes import PageErrorCode
@@ -1296,17 +1298,30 @@ def test_validate_numeric_attributes_input_for_product_more_than_one_value_given
     }
 
 
+def test_clean_file_url_in_attribute_assignment_mixin(site_settings):
+    # given
+    name = "Test.jpg"
+    domain = site_settings.site.domain
+    url = f"http://{domain}{settings.MEDIA_URL}{name}"
+
+    # when
+    result = AttributeAssignmentMixin._clean_file_url(url, ProductErrorCode)
+
+    # then
+    assert result == name
+
+
 @pytest.mark.parametrize(
-    "file_url, expected_value",
+    "file_url",
     [
-        ("http://localhost:8000/media/Test.jpg", "Test.jpg"),
-        ("/media/Test.jpg", "Test.jpg"),
-        ("Test.jpg", "Test.jpg"),
-        ("", ""),
-        ("/ab/cd.jpg", "/ab/cd.jpg"),
+        "http://localhost:8000/media/Test.jpg",
+        "/media/Test.jpg",
+        "Test.jpg",
+        "",
+        "/ab/cd.jpg",
     ],
 )
-def test_clean_file_url_in_attribute_assignment_mixin(file_url, expected_value):
-    result = AttributeAssignmentMixin._clean_file_url(file_url)
-
-    assert result == expected_value
+def test_clean_file_url_in_attribute_assignment_mixin_invalid_url(file_url):
+    # when & then
+    with pytest.raises(ValidationError):
+        AttributeAssignmentMixin._clean_file_url(file_url, ProductErrorCode)

--- a/saleor/graphql/attribute/tests/test_utils.py
+++ b/saleor/graphql/attribute/tests/test_utils.py
@@ -1317,7 +1317,6 @@ def test_clean_file_url_in_attribute_assignment_mixin(site_settings):
         "http://localhost:8000/media/Test.jpg",
         "/media/Test.jpg",
         "Test.jpg",
-        "",
         "/ab/cd.jpg",
     ],
 )

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -238,10 +238,8 @@ class AttributeAssignmentMixin:
     @staticmethod
     def _clean_file_url(file_url: Optional[str], error_class):
         # extract storage path from file URL
-        storage_root_url = build_absolute_uri(default_storage.base_url)
-        if file_url is not None and not file_url.startswith(
-            storage_root_url  # type: ignore
-        ):
+        storage_root_url = build_absolute_uri(default_storage.url("/"))
+        if file_url and not file_url.startswith(storage_root_url):  # type: ignore
             raise ValidationError(
                 "The file_url must be the path to the default storage.",
                 code=error_class.INVALID.value,

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
 
 import graphene
 from django.core.exceptions import ValidationError
-from django.core.files.storage import default_storage
 from django.db.models import Q
 from django.template.defaultfilters import truncatechars
 from django.utils import timezone
@@ -17,8 +16,9 @@ from text_unidecode import unidecode
 from ...attribute import AttributeEntityType, AttributeInputType, AttributeType
 from ...attribute import models as attribute_models
 from ...attribute.utils import associate_attribute_values_to_instance
-from ...core.utils import build_absolute_uri, generate_unique_slug
+from ...core.utils import generate_unique_slug
 from ...core.utils.editorjs import clean_editor_js
+from ...core.utils.url import get_default_storage_root_url
 from ...page import models as page_models
 from ...page.error_codes import PageErrorCode
 from ...product import models as product_models
@@ -237,7 +237,7 @@ class AttributeAssignmentMixin:
     @staticmethod
     def _clean_file_url(file_url: Optional[str], error_class):
         # extract storage path from file URL
-        storage_root_url = build_absolute_uri(default_storage.url(""))
+        storage_root_url = get_default_storage_root_url()
         if file_url and not file_url.startswith(storage_root_url):  # type: ignore
             raise ValidationError(
                 "The file_url must be the path to the default storage.",

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -3,7 +3,6 @@ from collections import defaultdict, namedtuple
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
-from urllib.parse import urlparse
 
 import graphene
 from django.core.exceptions import ValidationError
@@ -238,16 +237,14 @@ class AttributeAssignmentMixin:
     @staticmethod
     def _clean_file_url(file_url: Optional[str], error_class):
         # extract storage path from file URL
-        storage_root_url = build_absolute_uri(default_storage.url("/"))
+        storage_root_url = build_absolute_uri(default_storage.url(""))
         if file_url and not file_url.startswith(storage_root_url):  # type: ignore
             raise ValidationError(
                 "The file_url must be the path to the default storage.",
                 code=error_class.INVALID.value,
             )
         return (
-            re.sub(f"^{default_storage.base_url}", "", urlparse(file_url).path)
-            if file_url is not None
-            else file_url
+            re.sub(storage_root_url, "", file_url) if file_url is not None else file_url
         )
 
     @classmethod

--- a/saleor/graphql/core/tests/test_file_upload.py
+++ b/saleor/graphql/core/tests/test_file_upload.py
@@ -4,7 +4,6 @@ from urllib.parse import urlparse
 from django.core.files.storage import default_storage
 
 from ....product.tests.utils import create_image
-from ....tests.consts import TEST_SERVER_DOMAIN
 from ...tests.utils import (
     assert_no_permission,
     get_graphql_content,
@@ -120,7 +119,7 @@ def test_file_upload_by_superuser(superuser_api_client, media_root):
 
 
 def test_file_upload_file_with_the_same_name_already_exists(
-    staff_api_client, media_root
+    staff_api_client, media_root, site_settings
 ):
     """Ensure that when the file with the same name as uploaded file,
     already exists, the file name will be renamed and save as another file.
@@ -147,11 +146,10 @@ def test_file_upload_file_with_the_same_name_already_exists(
     data = content["data"]["fileUpload"]
     errors = data["errors"]
 
+    domain = site_settings.site.domain
     assert not errors
     assert data["uploadedFile"]["contentType"] == "image/png"
     file_url = data["uploadedFile"]["url"]
-    assert file_url != f"http://{TEST_SERVER_DOMAIN}/media/{image_file._name}"
-    assert file_url != f"http://{TEST_SERVER_DOMAIN}/media/{path}"
-    assert default_storage.exists(
-        file_url.replace(f"http://{TEST_SERVER_DOMAIN}/media/", "")
-    )
+    assert file_url != f"http://{domain}/media/{image_file._name}"
+    assert file_url != f"http://{domain}/media/{path}"
+    assert default_storage.exists(file_url.replace(f"http://{domain}/media/", ""))

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -4,6 +4,7 @@ import graphene
 from django.core.files.storage import default_storage
 
 from ....core.tracing import traced_resolver
+from ....core.utils import build_absolute_uri
 from ...account.enums import AddressTypeEnum
 from ..descriptions import ADDED_IN_36, PREVIEW_FEATURE
 from ..enums import (
@@ -426,7 +427,7 @@ class Image(graphene.ObjectType):
     def resolve_url(root, info):
         if urlparse(root.url).netloc:
             return root.url
-        return info.context.build_absolute_uri(default_storage.url(root.url))
+        return build_absolute_uri(root.url)
 
 
 class File(graphene.ObjectType):
@@ -440,7 +441,7 @@ class File(graphene.ObjectType):
         # check if URL is absolute:
         if urlparse(root.url).netloc:
             return root.url
-        return info.context.build_absolute_uri(default_storage.url(root.url))
+        return build_absolute_uri(default_storage.url(root.url))
 
 
 class PriceInput(graphene.InputObjectType):

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -1,7 +1,7 @@
-from urllib.parse import urljoin
+from urllib.parse import urlparse
 
 import graphene
-from django.conf import settings
+from django.core.files.storage import default_storage
 
 from ....core.tracing import traced_resolver
 from ...account.enums import AddressTypeEnum
@@ -424,7 +424,9 @@ class Image(graphene.ObjectType):
 
     @staticmethod
     def resolve_url(root, info):
-        return info.context.build_absolute_uri(urljoin(settings.MEDIA_URL, root.url))
+        if urlparse(root.url).netloc:
+            return root.url
+        return info.context.build_absolute_uri(default_storage.url(root.url))
 
 
 class File(graphene.ObjectType):
@@ -435,7 +437,10 @@ class File(graphene.ObjectType):
 
     @staticmethod
     def resolve_url(root, info):
-        return info.context.build_absolute_uri(urljoin(settings.MEDIA_URL, root.url))
+        # check if URL is absolute:
+        if urlparse(root.url).netloc:
+            return root.url
+        return info.context.build_absolute_uri(default_storage.url(root.url))
 
 
 class PriceInput(graphene.InputObjectType):

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -48,7 +48,6 @@ from ....plugins.base_plugin import ExcludedShippingMethod
 from ....plugins.manager import PluginsManager, get_plugins_manager
 from ....product.models import ProductVariant, ProductVariantChannelListing
 from ....shipping.models import ShippingMethod, ShippingMethodChannelListing
-from ....tests.consts import TEST_SERVER_DOMAIN
 from ....tests.utils import flush_post_commit_hooks
 from ....thumbnail.models import Thumbnail
 from ....warehouse.models import Allocation, PreorderAllocation, Stock, Warehouse
@@ -1344,6 +1343,7 @@ def test_order_query_product_image_size_and_format_given_proxy_url_returned(
     permission_manage_orders,
     order_line,
     product_with_image,
+    site_settings,
 ):
     # given
     order_line.variant.product = product_with_image
@@ -1364,9 +1364,10 @@ def test_order_query_product_image_size_and_format_given_proxy_url_returned(
     order_data = content["data"]["orders"]["edges"][0]["node"]
     media_id = graphene.Node.to_global_id("ProductMedia", media.pk)
     assert len(order_data["lines"]) == 1
+    domain = site_settings.site.domain
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{media_id}/128/{format.lower()}/"
+        == f"http://{domain}/thumbnail/{media_id}/128/{format.lower()}/"
     )
 
 
@@ -1375,6 +1376,7 @@ def test_order_query_product_image_size_given_proxy_url_returned(
     permission_manage_orders,
     order_line,
     product_with_image,
+    site_settings,
 ):
     # given
     order_line.variant.product = product_with_image
@@ -1395,7 +1397,7 @@ def test_order_query_product_image_size_given_proxy_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{media_id}/128/"
+        == f"http://{site_settings.site.domain}/thumbnail/{media_id}/128/"
     )
 
 
@@ -1404,6 +1406,7 @@ def test_order_query_product_image_size_given_thumbnail_url_returned(
     permission_manage_orders,
     order_line,
     product_with_image,
+    site_settings,
 ):
     # given
     order_line.variant.product = product_with_image
@@ -1428,7 +1431,7 @@ def test_order_query_product_image_size_given_thumbnail_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
@@ -1437,6 +1440,7 @@ def test_order_query_variant_image_size_and_format_given_proxy_url_returned(
     permission_manage_orders,
     order_line,
     variant_with_image,
+    site_settings,
 ):
     # given
     order_line.variant = variant_with_image
@@ -1457,9 +1461,10 @@ def test_order_query_variant_image_size_and_format_given_proxy_url_returned(
     order_data = content["data"]["orders"]["edges"][0]["node"]
     media_id = graphene.Node.to_global_id("ProductMedia", media.pk)
     assert len(order_data["lines"]) == 1
+    domain = site_settings.site.domain
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{media_id}/128/{format.lower()}/"
+        == f"http://{domain}/thumbnail/{media_id}/128/{format.lower()}/"
     )
 
 
@@ -1468,6 +1473,7 @@ def test_order_query_variant_image_size_given_proxy_url_returned(
     permission_manage_orders,
     order_line,
     variant_with_image,
+    site_settings,
 ):
     # given
     order_line.variant = variant_with_image
@@ -1488,7 +1494,7 @@ def test_order_query_variant_image_size_given_proxy_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{media_id}/128/"
+        == f"http://{site_settings.site.domain}/thumbnail/{media_id}/128/"
     )
 
 
@@ -1497,6 +1503,7 @@ def test_order_query_variant_image_size_given_thumbnail_url_returned(
     permission_manage_orders,
     order_line,
     variant_with_image,
+    site_settings,
 ):
     # given
     order_line.variant = variant_with_image
@@ -1521,7 +1528,7 @@ def test_order_query_variant_image_size_given_thumbnail_url_returned(
     assert len(order_data["lines"]) == 1
     assert (
         order_data["lines"][0]["thumbnail"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -605,7 +605,7 @@ class OrderLine(ModelObjectType):
                 url = get_image_or_proxy_url(
                     thumbnail, image.id, "ProductMedia", size, format
                 )
-                return Image(alt=image.alt, url=info.context.build_absolute_uri(url))
+                return Image(alt=image.alt, url=url)
 
             return (
                 ThumbnailByProductMediaIdSizeAndFormatLoader(info.context)

--- a/saleor/graphql/page/tests/mutations/test_page_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_create.py
@@ -3,13 +3,13 @@ from unittest import mock
 
 import graphene
 import pytz
+from django.conf import settings
 from django.utils.functional import SimpleLazyObject
 from django.utils.text import slugify
 from freezegun import freeze_time
 
 from .....page.error_codes import PageErrorCode
 from .....page.models import Page, PageType
-from .....tests.consts import TEST_SERVER_DOMAIN
 from .....tests.utils import dummy_editorjs
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_page_payload
@@ -356,7 +356,11 @@ def test_page_create_mutation_empty_attribute_value(
 
 
 def test_create_page_with_file_attribute(
-    staff_api_client, permission_manage_pages, page_type, page_file_attribute
+    staff_api_client,
+    permission_manage_pages,
+    page_type,
+    page_file_attribute,
+    site_settings,
 ):
     # given
     page_slug = "test-slug"
@@ -373,6 +377,9 @@ def test_create_page_with_file_attribute(
     attr_value = page_file_attribute.values.first()
 
     values_count = page_file_attribute.values.count()
+    file_url = (
+        f"http://{site_settings.site.domain}{settings.MEDIA_URL}{attr_value.file_url}"
+    )
 
     # test creating root page
     variables = {
@@ -382,7 +389,7 @@ def test_create_page_with_file_attribute(
             "isPublished": page_is_published,
             "slug": page_slug,
             "pageType": page_type_id,
-            "attributes": [{"id": file_attribute_id, "file": attr_value.file_url}],
+            "attributes": [{"id": file_attribute_id, "file": file_url}],
         }
     }
 
@@ -410,7 +417,7 @@ def test_create_page_with_file_attribute(
                 "slug": f"{attr_value.slug}-2",
                 "name": attr_value.name,
                 "file": {
-                    "url": f"http://{TEST_SERVER_DOMAIN}/media/{attr_value.file_url}",
+                    "url": file_url,
                     "contentType": None,
                 },
                 "reference": None,
@@ -427,7 +434,11 @@ def test_create_page_with_file_attribute(
 
 
 def test_create_page_with_file_attribute_new_attribute_value(
-    staff_api_client, permission_manage_pages, page_type, page_file_attribute
+    staff_api_client,
+    permission_manage_pages,
+    page_type,
+    page_file_attribute,
+    site_settings,
 ):
     # given
     page_slug = "test-slug"
@@ -442,6 +453,7 @@ def test_create_page_with_file_attribute_new_attribute_value(
     file_attribute_id = graphene.Node.to_global_id("Attribute", page_file_attribute.pk)
     page_type.page_attributes.add(page_file_attribute)
     new_value = "new_test_value.txt"
+    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{new_value}"
     new_value_content_type = "text/plain"
 
     values_count = page_file_attribute.values.count()
@@ -457,7 +469,7 @@ def test_create_page_with_file_attribute_new_attribute_value(
             "attributes": [
                 {
                     "id": file_attribute_id,
-                    "file": new_value,
+                    "file": file_url,
                     "contentType": new_value_content_type,
                 }
             ],
@@ -489,7 +501,7 @@ def test_create_page_with_file_attribute_new_attribute_value(
                 "reference": None,
                 "name": new_value,
                 "file": {
-                    "url": f"http://{TEST_SERVER_DOMAIN}/media/" + new_value,
+                    "url": file_url,
                     "contentType": new_value_content_type,
                 },
                 "plainText": None,

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -4,6 +4,7 @@ from unittest import mock
 import graphene
 import pytest
 import pytz
+from django.conf import settings
 from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 from django.utils.text import slugify
@@ -13,7 +14,6 @@ from .....attribute.models import AttributeValue
 from .....attribute.utils import associate_attribute_values_to_instance
 from .....page.error_codes import PageErrorCode
 from .....page.models import Page
-from .....tests.consts import TEST_SERVER_DOMAIN
 from .....tests.utils import dummy_editorjs
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_page_payload
@@ -248,23 +248,24 @@ def test_update_page_only_title(staff_api_client, permission_manage_pages, page)
 
 
 def test_update_page_with_file_attribute_value(
-    staff_api_client, permission_manage_pages, page, page_file_attribute
+    staff_api_client, permission_manage_pages, page, page_file_attribute, site_settings
 ):
     # given
     query = UPDATE_PAGE_MUTATION
 
     page_type = page.page_type
     page_type.page_attributes.add(page_file_attribute)
-    new_value = "test.txt"
     page_file_attribute_id = graphene.Node.to_global_id(
         "Attribute", page_file_attribute.pk
     )
 
     page_id = graphene.Node.to_global_id("Page", page.id)
+    file_name = "test.txt"
+    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{file_name}"
 
     variables = {
         "id": page_id,
-        "input": {"attributes": [{"id": page_file_attribute_id, "file": new_value}]},
+        "input": {"attributes": [{"id": page_file_attribute_id, "file": file_url}]},
     }
 
     # when
@@ -282,12 +283,12 @@ def test_update_page_with_file_attribute_value(
         "attribute": {"slug": page_file_attribute.slug},
         "values": [
             {
-                "slug": slugify(new_value),
-                "name": new_value,
+                "slug": slugify(file_name),
+                "name": file_name,
                 "plainText": None,
                 "reference": None,
                 "file": {
-                    "url": f"http://{TEST_SERVER_DOMAIN}/media/" + new_value,
+                    "url": file_url,
                     "contentType": None,
                 },
             }
@@ -297,7 +298,7 @@ def test_update_page_with_file_attribute_value(
 
 
 def test_update_page_with_file_attribute_new_value_is_not_created(
-    staff_api_client, permission_manage_pages, page, page_file_attribute
+    staff_api_client, permission_manage_pages, page, page_file_attribute, site_settings
 ):
     # given
     query = UPDATE_PAGE_MUTATION
@@ -311,14 +312,12 @@ def test_update_page_with_file_attribute_new_value_is_not_created(
     associate_attribute_values_to_instance(page, page_file_attribute, existing_value)
 
     page_id = graphene.Node.to_global_id("Page", page.id)
+    domain = site_settings.site.domain
+    file_url = f"http://{domain}{settings.MEDIA_URL}{existing_value.file_url}"
 
     variables = {
         "id": page_id,
-        "input": {
-            "attributes": [
-                {"id": page_file_attribute_id, "file": existing_value.file_url}
-            ]
-        },
+        "input": {"attributes": [{"id": page_file_attribute_id, "file": file_url}]},
     }
 
     # when
@@ -341,9 +340,7 @@ def test_update_page_with_file_attribute_new_value_is_not_created(
                 "plainText": None,
                 "reference": None,
                 "file": {
-                    "url": (
-                        f"http://{TEST_SERVER_DOMAIN}/media/{existing_value.file_url}"
-                    ),
+                    "url": file_url,
                     "contentType": existing_value.content_type,
                 },
             }

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -784,7 +784,7 @@ def test_products_media_for_federation_query_count(
         ],
     }
 
-    with django_assert_num_queries(1):
+    with django_assert_num_queries(3):
         response = api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         assert len(content["data"]["_entities"]) == 1

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -14,7 +14,6 @@ from ....core.utils.json_serializer import CustomJsonEncoder
 from ....product.error_codes import ProductErrorCode
 from ....product.models import Category, Product, ProductChannelListing
 from ....product.tests.utils import create_image, create_pdf_file_with_image_ext
-from ....tests.consts import TEST_SERVER_DOMAIN
 from ....tests.utils import dummy_editorjs
 from ....thumbnail.models import Thumbnail
 from ....webhook.event_types import WebhookEventAsyncType
@@ -718,6 +717,7 @@ def test_category_update_background_image_mutation(
     category,
     permission_manage_products,
     media_root,
+    site_settings,
 ):
     # given
     alt_text = "Alt text for an image."
@@ -768,7 +768,7 @@ def test_category_update_background_image_mutation(
     assert category.background_image.file
     assert data["category"]["backgroundImage"]["alt"] == image_alt
     assert data["category"]["backgroundImage"]["url"].startswith(
-        f"http://{TEST_SERVER_DOMAIN}/media/category-backgrounds/{image_name}"
+        f"http://{site_settings.site.domain}/media/category-backgrounds/{image_name}"
     )
 
     # ensure that thumbnails for old background image has been deleted
@@ -1280,7 +1280,7 @@ FETCH_CATEGORY_QUERY = """
 
 
 def test_category_image_query_with_size_and_format_proxy_url_returned(
-    user_api_client, non_default_category, media_root
+    user_api_client, non_default_category, media_root, site_settings
 ):
     # given
     alt_text = "Alt text for an image."
@@ -1308,14 +1308,14 @@ def test_category_image_query_with_size_and_format_proxy_url_returned(
 
     data = content["data"]["category"]
     assert data["backgroundImage"]["alt"] == alt_text
-    assert (
-        data["backgroundImage"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{category_id}/128/{format.lower()}/"
+    assert data["backgroundImage"]["url"] == (
+        f"http://{site_settings.site.domain}/thumbnail/{category_id}/"
+        f"128/{format.lower()}/"
     )
 
 
 def test_category_image_query_with_size_proxy_url_returned(
-    user_api_client, non_default_category, media_root
+    user_api_client, non_default_category, media_root, site_settings
 ):
     # given
     alt_text = "Alt text for an image."
@@ -1343,12 +1343,12 @@ def test_category_image_query_with_size_proxy_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{category_id}/{size}/"
+        == f"http://{site_settings.site.domain}/thumbnail/{category_id}/{size}/"
     )
 
 
 def test_category_image_query_with_size_thumbnail_url_returned(
-    user_api_client, non_default_category, media_root
+    user_api_client, non_default_category, media_root, site_settings
 ):
     # given
     alt_text = "Alt text for an image."
@@ -1380,12 +1380,12 @@ def test_category_image_query_with_size_thumbnail_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
 def test_category_image_query_only_format_provided_original_image_returned(
-    user_api_client, non_default_category, media_root
+    user_api_client, non_default_category, media_root, site_settings
 ):
     # given
     alt_text = "Alt text for an image."
@@ -1413,13 +1413,14 @@ def test_category_image_query_only_format_provided_original_image_returned(
     data = content["data"]["category"]
     assert data["backgroundImage"]["alt"] == alt_text
     expected_url = (
-        f"http://{TEST_SERVER_DOMAIN}/media/category-backgrounds/{background_mock.name}"
+        f"http://{site_settings.site.domain}/media/"
+        f"category-backgrounds/{background_mock.name}"
     )
     assert data["backgroundImage"]["url"] == expected_url
 
 
 def test_category_image_query_no_size_value_original_image_returned(
-    user_api_client, non_default_category, media_root
+    user_api_client, non_default_category, media_root, site_settings
 ):
     # given
     alt_text = "Alt text for an image."
@@ -1444,7 +1445,8 @@ def test_category_image_query_no_size_value_original_image_returned(
     data = content["data"]["category"]
     assert data["backgroundImage"]["alt"] == alt_text
     expected_url = (
-        f"http://{TEST_SERVER_DOMAIN}/media/category-backgrounds/{background_mock.name}"
+        f"http://{site_settings.site.domain}/media/"
+        f"category-backgrounds/{background_mock.name}"
     )
     assert data["backgroundImage"]["url"] == expected_url
 

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -9,7 +9,6 @@ from graphql_relay import to_global_id
 from ....product.error_codes import CollectionErrorCode, ProductErrorCode
 from ....product.models import Collection, Product
 from ....product.tests.utils import create_image, create_pdf_file_with_image_ext
-from ....tests.consts import TEST_SERVER_DOMAIN
 from ....tests.utils import dummy_editorjs
 from ....thumbnail.models import Thumbnail
 from ...core.enums import ThumbnailFormatEnum
@@ -683,6 +682,7 @@ def test_update_collection_with_background_image(
     collection_with_image,
     permission_manage_products,
     media_root,
+    site_settings,
 ):
     # given
     image_file, image_name = create_image()
@@ -725,7 +725,7 @@ def test_update_collection_with_background_image(
     collection = Collection.objects.get(slug=slug)
     assert data["collection"]["backgroundImage"]["alt"] == image_alt
     assert data["collection"]["backgroundImage"]["url"].startswith(
-        f"http://{TEST_SERVER_DOMAIN}/media/collection-backgrounds/{image_name}"
+        f"http://{site_settings.site.domain}/media/collection-backgrounds/{image_name}"
     )
 
     # ensure that thumbnails for old background image has been deleted
@@ -1242,7 +1242,7 @@ FETCH_COLLECTION_QUERY = """
 
 
 def test_collection_image_query_with_size_and_format_proxy_url_returned(
-    user_api_client, published_collection, media_root, channel_USD
+    user_api_client, published_collection, media_root, channel_USD, site_settings
 ):
     # given
     alt_text = "Alt text for an image."
@@ -1272,14 +1272,13 @@ def test_collection_image_query_with_size_and_format_proxy_url_returned(
 
     data = content["data"]["collection"]
     assert data["backgroundImage"]["alt"] == alt_text
-    expected_url = (
-        f"http://{TEST_SERVER_DOMAIN}/thumbnail/{collection_id}/128/{format.lower()}/"
-    )
+    domain = site_settings.site.domain
+    expected_url = f"http://{domain}/thumbnail/{collection_id}/128/{format.lower()}/"
     assert data["backgroundImage"]["url"] == expected_url
 
 
 def test_collection_image_query_with_size_proxy_url_returned(
-    user_api_client, published_collection, media_root, channel_USD
+    user_api_client, published_collection, media_root, channel_USD, site_settings
 ):
     # given
     alt_text = "Alt text for an image."
@@ -1308,12 +1307,12 @@ def test_collection_image_query_with_size_proxy_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/thumbnail/{collection_id}/{size}/"
+        == f"http://{site_settings.site.domain}/thumbnail/{collection_id}/{size}/"
     )
 
 
 def test_collection_image_query_with_size_thumbnail_url_returned(
-    user_api_client, published_collection, media_root, channel_USD
+    user_api_client, published_collection, media_root, channel_USD, site_settings
 ):
     # given
     alt_text = "Alt text for an image."
@@ -1346,12 +1345,12 @@ def test_collection_image_query_with_size_thumbnail_url_returned(
     assert data["backgroundImage"]["alt"] == alt_text
     assert (
         data["backgroundImage"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/media/thumbnails/{thumbnail_mock.name}"
+        == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
     )
 
 
 def test_collection_image_query_only_format_provided_original_image_returned(
-    user_api_client, published_collection, media_root, channel_USD
+    user_api_client, published_collection, media_root, channel_USD, site_settings
 ):
     # given
     alt_text = "Alt text for an image."
@@ -1380,14 +1379,14 @@ def test_collection_image_query_only_format_provided_original_image_returned(
     data = content["data"]["collection"]
     assert data["backgroundImage"]["alt"] == alt_text
     expected_url = (
-        f"http://{TEST_SERVER_DOMAIN}"
+        f"http://{site_settings.site.domain}"
         f"/media/collection-backgrounds/{background_mock.name}"
     )
     assert data["backgroundImage"]["url"] == expected_url
 
 
 def test_collection_image_query_no_size_value_original_image_returned(
-    user_api_client, published_collection, media_root, channel_USD
+    user_api_client, published_collection, media_root, channel_USD, site_settings
 ):
     # given
     alt_text = "Alt text for an image."
@@ -1413,7 +1412,7 @@ def test_collection_image_query_no_size_value_original_image_returned(
     data = content["data"]["collection"]
     assert data["backgroundImage"]["alt"] == alt_text
     expected_url = (
-        f"http://{TEST_SERVER_DOMAIN}"
+        f"http://{site_settings.site.domain}"
         f"/media/collection-backgrounds/{background_mock.name}"
     )
     assert data["backgroundImage"]["url"] == expected_url

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import graphene
 import pytest
 import pytz
+from django.conf import settings
 from django.utils.text import slugify
 from freezegun import freeze_time
 from measurement.measures import Weight
@@ -20,7 +21,6 @@ from ....order import OrderEvents, OrderStatus
 from ....order.models import OrderEvent, OrderLine
 from ....product.error_codes import ProductErrorCode
 from ....product.models import Product, ProductChannelListing, ProductVariant
-from ....tests.consts import TEST_SERVER_DOMAIN
 from ....tests.utils import dummy_editorjs, flush_post_commit_hooks
 from ....warehouse.error_codes import StockErrorCode
 from ....warehouse.models import Allocation, Stock, Warehouse
@@ -834,6 +834,7 @@ def test_create_variant_with_file_attribute(
     file_attribute,
     permission_manage_products,
     warehouse,
+    site_settings,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -844,6 +845,8 @@ def test_create_variant_with_file_attribute(
     product_type.variant_attributes.add(file_attribute)
     file_attr_id = graphene.Node.to_global_id("Attribute", file_attribute.id)
     existing_value = file_attribute.values.first()
+    domain = site_settings.site.domain
+    file_url = f"http://{domain}{settings.MEDIA_URL}{existing_value.file_url}"
 
     values_count = file_attribute.values.count()
 
@@ -860,7 +863,7 @@ def test_create_variant_with_file_attribute(
             "sku": sku,
             "stocks": stocks,
             "weight": weight,
-            "attributes": [{"id": file_attr_id, "file": existing_value.file_url}],
+            "attributes": [{"id": file_attr_id, "file": file_url}],
             "trackInventory": True,
         }
     }
@@ -966,6 +969,7 @@ def test_create_variant_with_file_attribute_new_value(
     file_attribute,
     permission_manage_products,
     warehouse,
+    site_settings,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -976,6 +980,7 @@ def test_create_variant_with_file_attribute_new_value(
     product_type.variant_attributes.add(file_attribute)
     file_attr_id = graphene.Node.to_global_id("Attribute", file_attribute.id)
     new_value = "new_value.txt"
+    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{new_value}"
 
     values_count = file_attribute.values.count()
 
@@ -992,7 +997,7 @@ def test_create_variant_with_file_attribute_new_value(
             "sku": sku,
             "stocks": stocks,
             "weight": weight,
-            "attributes": [{"id": file_attr_id, "file": new_value}],
+            "attributes": [{"id": file_attr_id, "file": file_url}],
             "trackInventory": True,
         }
     }
@@ -1187,6 +1192,7 @@ def test_create_variant_with_page_reference_attribute_no_references_given(
     product_type_page_reference_attribute,
     permission_manage_products,
     warehouse,
+    site_settings,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -1200,6 +1206,7 @@ def test_create_variant_with_page_reference_attribute_no_references_given(
     ref_attr_id = graphene.Node.to_global_id(
         "Attribute", product_type_page_reference_attribute.id
     )
+    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}test.jpg"
 
     values_count = product_type_page_reference_attribute.values.count()
 
@@ -1215,7 +1222,7 @@ def test_create_variant_with_page_reference_attribute_no_references_given(
             "product": product_id,
             "sku": sku,
             "stocks": stocks,
-            "attributes": [{"id": ref_attr_id, "file": "test.jpg"}],
+            "attributes": [{"id": ref_attr_id, "file": file_url}],
             "trackInventory": True,
         }
     }
@@ -1349,6 +1356,7 @@ def test_create_variant_with_product_reference_attribute_no_references_given(
     product_type_product_reference_attribute,
     permission_manage_products,
     warehouse,
+    site_settings,
 ):
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -1362,6 +1370,7 @@ def test_create_variant_with_product_reference_attribute_no_references_given(
     ref_attr_id = graphene.Node.to_global_id(
         "Attribute", product_type_product_reference_attribute.id
     )
+    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}test.jpg"
 
     values_count = product_type_product_reference_attribute.values.count()
 
@@ -1377,7 +1386,7 @@ def test_create_variant_with_product_reference_attribute_no_references_given(
             "product": product_id,
             "sku": sku,
             "stocks": stocks,
-            "attributes": [{"id": ref_attr_id, "file": "test.jpg"}],
+            "attributes": [{"id": ref_attr_id, "file": file_url}],
             "trackInventory": True,
         }
     }
@@ -1518,6 +1527,7 @@ def test_create_variant_with_variant_reference_attribute_no_references_given(
     product_type_variant_reference_attribute,
     permission_manage_products,
     warehouse,
+    site_settings,
 ):
     # given
     query = CREATE_VARIANT_MUTATION
@@ -1532,6 +1542,7 @@ def test_create_variant_with_variant_reference_attribute_no_references_given(
     ref_attr_id = graphene.Node.to_global_id(
         "Attribute", product_type_variant_reference_attribute.id
     )
+    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}test.jpg"
 
     values_count = product_type_variant_reference_attribute.values.count()
 
@@ -1547,7 +1558,7 @@ def test_create_variant_with_variant_reference_attribute_no_references_given(
             "product": product_id,
             "sku": sku,
             "stocks": stocks,
-            "attributes": [{"id": ref_attr_id, "file": "test.jpg"}],
+            "attributes": [{"id": ref_attr_id, "file": file_url}],
             "trackInventory": True,
         }
     }
@@ -3248,6 +3259,7 @@ def test_update_product_variant_with_current_file_attribute(
     product_with_variant_with_file_attribute,
     file_attribute,
     permission_manage_products,
+    site_settings,
 ):
     product = product_with_variant_with_file_attribute
     variant = product.variants.first()
@@ -3260,12 +3272,15 @@ def test_update_product_variant_with_current_file_attribute(
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     file_attribute_id = graphene.Node.to_global_id("Attribute", file_attribute.pk)
+    file_url = (
+        f"http://{site_settings.site.domain}{settings.MEDIA_URL}{second_value.file_url}"
+    )
 
     variables = {
         "id": variant_id,
         "sku": sku,
         "price": 15,
-        "attributes": [{"id": file_attribute_id, "file": second_value.file_url}],
+        "attributes": [{"id": file_attribute_id, "file": file_url}],
     }
 
     response = staff_api_client.post_graphql(
@@ -3294,6 +3309,7 @@ def test_update_product_variant_with_duplicated_file_attribute(
     product_with_variant_with_file_attribute,
     file_attribute,
     permission_manage_products,
+    site_settings,
 ):
     product = product_with_variant_with_file_attribute
     variant = product.variants.first()
@@ -3317,11 +3333,13 @@ def test_update_product_variant_with_duplicated_file_attribute(
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     file_attribute_id = graphene.Node.to_global_id("Attribute", file_attribute.pk)
+    domain = site_settings.site.domain
+    file_url = f"http://{domain}{settings.MEDIA_URL}{file_attr_value.file_url}"
 
     variables = {
         "id": variant_id,
         "price": 15,
-        "attributes": [{"id": file_attribute_id, "file": file_attr_value.file_url}],
+        "attributes": [{"id": file_attribute_id, "file": file_url}],
         "sku": sku,
     }
 
@@ -3345,6 +3363,7 @@ def test_update_product_variant_with_file_attribute_new_value_is_not_created(
     product_with_variant_with_file_attribute,
     file_attribute,
     permission_manage_products,
+    site_settings,
 ):
     product = product_with_variant_with_file_attribute
     variant = product.variants.first()
@@ -3358,12 +3377,14 @@ def test_update_product_variant_with_file_attribute_new_value_is_not_created(
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     file_attribute_id = graphene.Node.to_global_id("Attribute", file_attribute.pk)
+    domain = site_settings.site.domain
+    file_url = f"http://{domain}{settings.MEDIA_URL}{existing_value.file_url}"
 
     variables = {
         "id": variant_id,
         "sku": sku,
         "price": 15,
-        "attributes": [{"id": file_attribute_id, "file": existing_value.file_url}],
+        "attributes": [{"id": file_attribute_id, "file": file_url}],
     }
 
     response = staff_api_client.post_graphql(
@@ -3384,10 +3405,7 @@ def test_update_product_variant_with_file_attribute_new_value_is_not_created(
     value_data = variant_data["attributes"][0]["values"][0]
     assert value_data["slug"] == existing_value.slug
     assert value_data["name"] == existing_value.name
-    assert (
-        value_data["file"]["url"]
-        == f"http://{TEST_SERVER_DOMAIN}/media/{existing_value.file_url}"
-    )
+    assert value_data["file"]["url"] == file_url
     assert value_data["file"]["contentType"] == existing_value.content_type
 
 

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -15,7 +15,7 @@ from ....core.permissions import (
     has_one_of_permissions,
 )
 from ....core.tracing import traced_resolver
-from ....core.utils import get_currency_for_country
+from ....core.utils import build_absolute_uri, get_currency_for_country
 from ....core.weight import convert_weight_to_default_weight_unit
 from ....product import models
 from ....product.models import ALL_PRODUCTS_PERMISSIONS
@@ -927,7 +927,7 @@ class Product(ChannelContextTypeWithMetadata, ModelObjectType):
                 url = get_image_or_proxy_url(
                     thumbnail, image.id, "ProductMedia", size, format
                 )
-                return Image(alt=image.alt, url=info.context.build_absolute_uri(url))
+                return Image(alt=image.alt, url=url)
 
             return (
                 ThumbnailByProductMediaIdSizeAndFormatLoader(info.context)
@@ -1729,7 +1729,7 @@ class ProductMedia(ModelObjectType):
             return
 
         if not size:
-            return info.context.build_absolute_uri(root.image.url)
+            return build_absolute_uri(root.image.url)
 
         format = format.lower() if format else None
         size = get_thumbnail_size(size)
@@ -1738,7 +1738,7 @@ class ProductMedia(ModelObjectType):
             url = get_image_or_proxy_url(
                 thumbnail, root.id, "ProductMedia", size, format
             )
-            return info.context.build_absolute_uri(url)
+            return build_absolute_uri(url)
 
         return (
             ThumbnailByProductMediaIdSizeAndFormatLoader(info.context)
@@ -1779,7 +1779,7 @@ class ProductImage(graphene.ObjectType):
             return
 
         if not size:
-            return info.context.build_absolute_uri(root.image.url)
+            return build_absolute_uri(root.image.url)
 
         format = format.lower() if format else None
         size = get_thumbnail_size(size)
@@ -1788,7 +1788,7 @@ class ProductImage(graphene.ObjectType):
             url = get_image_or_proxy_url(
                 thumbnail, root.id, "ProductMedia", size, format
             )
-            return info.context.build_absolute_uri(url)
+            return build_absolute_uri(url)
 
         return (
             ThumbnailByProductMediaIdSizeAndFormatLoader(info.context)

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -11,6 +11,7 @@ from ...account import models as account_models
 from ...channel import models as channel_models
 from ...core.permissions import AuthorizationFilters, SitePermissions, get_permissions
 from ...core.tracing import traced_resolver
+from ...core.utils import build_absolute_uri
 from ...site import models as site_models
 from ..account.types import Address, AddressInput, StaffNotificationRecipient
 from ..checkout.types import PaymentGateway
@@ -338,7 +339,7 @@ class Shop(graphene.ObjectType):
         return Domain(
             host=site.domain,
             ssl_enabled=settings.ENABLE_SSL,
-            url=info.context.build_absolute_uri("/"),
+            url=build_absolute_uri("/"),
         )
 
     @staticmethod

--- a/saleor/tests/consts.py
+++ b/saleor/tests/consts.py
@@ -1,1 +1,0 @@
-TEST_SERVER_DOMAIN = "testserver"

--- a/saleor/webhook/observability/payloads.py
+++ b/saleor/webhook/observability/payloads.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from graphene.utils.str_converters import to_camel_case as str_to_camel_case
 from graphql import get_operation_ast
 
+from ...core.utils import build_absolute_uri
 from .. import traced_payload_generator
 from ..event_types import WebhookEventSyncType
 from .exceptions import ApiCallTruncationError, EventDeliveryAttemptTruncationError
@@ -154,7 +155,7 @@ def generate_api_call_payload(
         request=ApiCallRequest(
             id=str(uuid.uuid4()),
             method=request.method or "",
-            url=request.build_absolute_uri(request.get_full_path()),
+            url=build_absolute_uri(request.get_full_path()),  # type: ignore
             time=getattr(request, "request_time", timezone.now()).timestamp(),
             headers=serialize_headers(dict(request.headers)),
             content_length=int(request.headers.get("Content-Length") or 0),

--- a/saleor/webhook/observability/tests/test_payloads.py
+++ b/saleor/webhook/observability/tests/test_payloads.py
@@ -9,7 +9,6 @@ from django.http import JsonResponse
 from django.utils import timezone
 
 from ....core import EventDeliveryStatus
-from ....tests.consts import TEST_SERVER_DOMAIN
 from ....webhook.event_types import WebhookEventAsyncType
 from ..exceptions import TruncationError
 from ..obfuscation import MASK
@@ -229,7 +228,7 @@ def test_serialize_headers(headers, expected):
     assert serialize_headers(headers) == expected
 
 
-def test_generate_api_call_payload(app, rf, gql_operation_factory):
+def test_generate_api_call_payload(app, rf, gql_operation_factory, site_settings):
     request = rf.post(
         "/graphql", data={"request": "data"}, content_type="application/json"
     )
@@ -254,7 +253,7 @@ def test_generate_api_call_payload(app, rf, gql_operation_factory):
         request=ApiCallRequest(
             id=request_id,
             method="POST",
-            url=f"http://{TEST_SERVER_DOMAIN}/graphql",
+            url=f"http://{site_settings.site.domain}/graphql",
             time=request.request_time.timestamp(),
             content_length=19,
             headers=[


### PR DESCRIPTION
Update `file_url` handling in values of file attributes
- reject URLs that do not start from the URLs root
- URL root is taken from the current storage
- use storage when resolving the URL

<!-- Please mention all relevant issue numbers. -->
Resolves #10831

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
