### PR TITLE
Order/Checkout prices shouldn't be available in sync subscription-based webhooks

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -135,6 +135,7 @@ class CheckoutLine(ModelObjectType):
         )
 
     @staticmethod
+    @prevent_sync_event_circular_query
     def resolve_unit_price(root, info):
         manager = load_plugin_manager(info.context)
 
@@ -218,6 +219,7 @@ class CheckoutLine(ModelObjectType):
 
     @staticmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     def resolve_total_price(root, info):
         manager = load_plugin_manager(info.context)
 
@@ -534,7 +536,7 @@ class Checkout(ModelObjectType):
 
     @staticmethod
     @traced_resolver
-    # TODO: We should optimize it in/after PR#5819
+    @prevent_sync_event_circular_query
     def resolve_total_price(root: models.Checkout, info):
         manager = load_plugin_manager(info.context)
 
@@ -566,7 +568,7 @@ class Checkout(ModelObjectType):
 
     @staticmethod
     @traced_resolver
-    # TODO: We should optimize it in/after PR#5819
+    @prevent_sync_event_circular_query
     def resolve_subtotal_price(root: models.Checkout, info):
         manager = load_plugin_manager(info.context)
 
@@ -598,7 +600,7 @@ class Checkout(ModelObjectType):
 
     @staticmethod
     @traced_resolver
-    # TODO: We should optimize it in/after PR#5819
+    @prevent_sync_event_circular_query
     def resolve_shipping_price(root: models.Checkout, info):
         manager = load_plugin_manager(info.context)
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -648,6 +648,7 @@ class OrderLine(ModelObjectType):
 
     @staticmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     def resolve_unit_price(root: models.OrderLine, info):
         manager = load_plugin_manager(info.context)
 
@@ -667,6 +668,7 @@ class OrderLine(ModelObjectType):
 
     @staticmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     def resolve_undiscounted_unit_price(root: models.OrderLine, info):
         manager = load_plugin_manager(info.context)
 
@@ -707,6 +709,7 @@ class OrderLine(ModelObjectType):
 
     @staticmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     def resolve_total_price(root: models.OrderLine, info):
         manager = load_plugin_manager(info.context)
 
@@ -722,6 +725,7 @@ class OrderLine(ModelObjectType):
 
     @staticmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     def resolve_undiscounted_total_price(root: models.OrderLine, info):
         manager = load_plugin_manager(info.context)
 
@@ -1165,6 +1169,7 @@ class Order(ModelObjectType):
 
     @staticmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     def resolve_shipping_price(root: models.Order, info):
         manager = load_plugin_manager(info.context)
 
@@ -1179,6 +1184,7 @@ class Order(ModelObjectType):
 
     @staticmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     def resolve_shipping_tax_rate(root: models.Order, info):
         manager = load_plugin_manager(info.context)
 
@@ -1224,6 +1230,7 @@ class Order(ModelObjectType):
 
     @staticmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     def resolve_total(root: models.Order, info):
         manager = load_plugin_manager(info.context)
 
@@ -1236,6 +1243,7 @@ class Order(ModelObjectType):
 
     @staticmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     def resolve_undiscounted_total(root: models.Order, info):
         manager = load_plugin_manager(info.context)
 


### PR DESCRIPTION
I want to merge this change because Order/Checkout prices shouldn't be available in sync subscription-based webhooks. It  could cause circular calls. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
