### PR TITLE
Order subtotal should be able to trigger price recalculation

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -36,11 +36,7 @@ from ...order.utils import (
 )
 from ...payment import ChargeStatus
 from ...payment.dataloaders import PaymentsByOrderIdLoader
-from ...payment.model_helpers import (
-    get_last_payment,
-    get_subtotal,
-    get_total_authorized,
-)
+from ...payment.model_helpers import get_last_payment, get_total_authorized
 from ...product import ProductMediaTypes
 from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ...shipping.interface import ShippingMethodData
@@ -1213,8 +1209,10 @@ class Order(ModelObjectType):
     @staticmethod
     @traced_resolver
     def resolve_subtotal(root: models.Order, info):
+        manager = load_plugin_manager(info.context)
+
         def _resolve_subtotal(order_lines):
-            return get_subtotal(order_lines, root.currency)
+            return calculations.order_subtotal(root, manager, order_lines)
 
         return (
             OrderLinesByOrderIdLoader(info.context)

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -863,6 +863,34 @@ def test_order_total(mocked_fetch_order_prices_if_expired):
 
 
 @patch("saleor.order.calculations.fetch_order_prices_if_expired")
+def test_order_subtotal(mocked_fetch_order_prices_if_expired):
+    # given
+    currency = "USD"
+    manager = Mock()
+    expected_line_totals = [
+        TaxedMoney(Money(Decimal("1.00"), currency), Money(Decimal("1.00"), currency)),
+        TaxedMoney(Money(Decimal("2.00"), currency), Money(Decimal("2.00"), currency)),
+        TaxedMoney(Money(Decimal("4.00"), currency), Money(Decimal("4.00"), currency)),
+    ]
+    order = Mock(currency=currency)
+    lines = []
+    for expected_line_total in expected_line_totals:
+        line = Mock(total_price=expected_line_total, currency=currency)
+        lines.append(line)
+    mocked_fetch_order_prices_if_expired.return_value = (order, lines)
+
+    # when
+    subtotal = calculations.order_subtotal(order, manager, lines)
+
+    # then
+    expected_subtotal = quantize_price(
+        TaxedMoney(Money(Decimal("7.00"), currency), Money(Decimal("7.00"), currency)),
+        currency,
+    )
+    assert subtotal == expected_subtotal
+
+
+@patch("saleor.order.calculations.fetch_order_prices_if_expired")
 def test_order_undiscounted_total(mocked_fetch_order_prices_if_expired):
     # given
     expected_undiscounted_total = Decimal("1234.0000")

--- a/saleor/payment/model_helpers.py
+++ b/saleor/payment/model_helpers.py
@@ -1,5 +1,5 @@
 from operator import attrgetter
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Iterable, List
 
 from ..core.taxes import zero_money, zero_taxed_money
 from .models import Payment
@@ -24,6 +24,6 @@ def get_total_authorized(payments: List[Payment], fallback_currency: str):
     return zero_money(fallback_currency)
 
 
-def get_subtotal(order_lines: List["OrderLine"], fallback_currency: str):
+def get_subtotal(order_lines: Iterable["OrderLine"], fallback_currency: str):
     subtotal_iterator = (line.total_price for line in order_lines)
     return sum(subtotal_iterator, zero_taxed_money(currency=fallback_currency))


### PR DESCRIPTION
I want to merge this change because Order subtotal should be able to trigger price recalculation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
