### PR TITLE
Do not allow updating checkout delivery method with the method without channel listing

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -84,6 +84,16 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
                 channel=checkout_info.channel,
             ).first(),
         )
+        if shipping_method and not delivery_method:
+            raise ValidationError(
+                {
+                    "delivery_method_id": ValidationError(
+                        "This shipping method is not applicable in the given channel.",
+                        code=CheckoutErrorCode.DELIVERY_METHOD_NOT_APPLICABLE.value,
+                    )
+                }
+            )
+
         cls._check_delivery_method(
             checkout_info, lines, shipping_method=delivery_method, collection_point=None
         )

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -318,6 +318,7 @@ def test_checkout_delivery_method_update_shipping_zone_without_channel(
     address,
 ):
     shipping_method.shipping_zone.channels.clear()
+    shipping_method.channel_listings.all().delete()
     checkout = checkout_with_item
     checkout.shipping_address = address
     checkout.save(update_fields=["shipping_address"])


### PR DESCRIPTION
Raise a `ValdiationError` in `CheckoutDeliveryMethodUpdate` for the shipping method without channel listing.

Port of #10801

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
