### PR TITLE
GraphQL Playground: Update deps and improve text in the sharing modal

### DIFF
--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -8,19 +8,19 @@
 
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-5/dist/umd/index.css"
-    integrity="sha512-6n65lECcA9z9qAHZ5ZQPgw6qEKhRIQKICk0hY+UzDy59EyqW3o/aFBeINuY/df9BzWFBX+m8RjE3p7bFirGC5A=="
+    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-6/dist/umd/index.css"
+    integrity="sha512-lUohGNgrZS/yBQbbS+gIy2h7LL58KNQSouG9I5S4R8aolm8c4L9D32LNgsrmSEOeOScobrk9PVyPLsvKl18D5w=="
     crossorigin="anonymous"
   />
   <!-- sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc= is inline css added by the playground when opening settings -->
   <!-- sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c= is the inline code below -->
-  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-5/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-5/dist/umd/index.css 'sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc='; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-6/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-6/dist/umd/index.css 'sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc='; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
 </head>
 <body>
   <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}></div>
   <script
-    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-5/dist/umd/index.js"
-    integrity="sha512-eBfXw1/7waZZLt/cehNkjwRoGPPqhobjHfTd4HSWQbyM9luhga98rcJEBVAFL8sW2MzhMk6h5vlhRpxSr0t4Ow=="
+    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-6/dist/umd/index.js"
+    integrity="sha512-gEy+ZFwSH5sGHOMszcK9i9L7pQfPFkDHCmNOXPWzBAITd0r9yFFEsoppgCxU2PZdVkcL4Xt+SElmHdYqC713pQ=="
     crossorigin="anonymous"
   ></script>
 


### PR DESCRIPTION
I want to merge this change because it updates GraphQL Playground and text in the modal.
Changes: https://github.com/saleor/saleor-graphql-playground/compare/v2.0.0-5...v2.0.0-6

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
