### PR TITLE
Add query_identifier to tracing

### DIFF
--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -192,3 +192,153 @@ def test_tracing_mutation_hashing(
     span = _get_graphql_span(tracer.finished_spans())
     hash = hashlib.md5(span.tags["graphql.query"].encode("utf-8")).hexdigest()
     assert span.tags["graphql.query_fingerprint"] == f"mutation:cancelOrder:{hash}"
+
+
+@patch("saleor.graphql.views.opentracing.global_tracer")
+def test_tracing_query_identifier_for_query(
+    tracing_mock,
+    staff_api_client,
+    permission_manage_products,
+):
+    tracer = MockTracer()
+    tracing_mock.return_value = tracer
+    query = """
+        query test {
+          products(first: 5, channel:"default-channel") {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+          otherProducts: products(first: 5, channel:"default-channel") {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+          me{
+            id
+          }
+        }
+    """
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    staff_api_client.post_graphql(query)
+    span = _get_graphql_span(tracer.finished_spans())
+    assert span.tags["graphql.query_identifier"] == "me, products"
+
+
+@patch("saleor.graphql.views.opentracing.global_tracer")
+def test_tracing_query_identifier_with_fragment(
+    tracing_mock,
+    staff_api_client,
+    permission_manage_products,
+):
+    tracer = MockTracer()
+    tracing_mock.return_value = tracer
+    query = """
+        fragment ProductVariant on ProductVariant {
+          id
+        }
+        query test {
+          products(first:5) {
+            edges{
+              node{
+                id
+                name
+                variants {
+                  ...ProductVariant
+                }
+              }
+            }
+          }
+        }
+    """
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    staff_api_client.post_graphql(query)
+    span = _get_graphql_span(tracer.finished_spans())
+    assert span.tags["graphql.query_identifier"] == "products"
+
+
+@patch("saleor.graphql.views.opentracing.global_tracer")
+def test_tracing_query_identifier_for_unnamed_mutation(
+    tracing_mock,
+    staff_api_client,
+):
+    tracer = MockTracer()
+    tracing_mock.return_value = tracer
+    query = """
+        mutation{
+          tokenCreate(email: "admin@example.com", password:"admin"){
+            token
+          }
+        }
+    """
+    staff_api_client.post_graphql(query)
+    span = _get_graphql_span(tracer.finished_spans())
+    assert span.tags["graphql.query_identifier"] == "tokenCreate"
+
+
+@patch("saleor.graphql.views.opentracing.global_tracer")
+def test_tracing_query_identifier_for_named_mutation(
+    tracing_mock,
+    staff_api_client,
+):
+    tracer = MockTracer()
+    tracing_mock.return_value = tracer
+    query = """
+        mutation MutationName{
+          tokenCreate(email: "admin@example.com", password:"admin"){
+            token
+          }
+        }
+    """
+    staff_api_client.post_graphql(query)
+    span = _get_graphql_span(tracer.finished_spans())
+    assert span.tags["graphql.query_identifier"] == "tokenCreate"
+
+
+@patch("saleor.graphql.views.opentracing.global_tracer")
+def test_tracing_query_identifier_for_many_mutations(
+    tracing_mock,
+    staff_api_client,
+):
+    tracer = MockTracer()
+    tracing_mock.return_value = tracer
+    query = """
+      mutation {
+        tokenCreate(email: "admin@example.com", password:"admin"){
+          token
+          refreshToken
+          csrfToken
+        }
+        deleteWarehouse(id:""){
+          errors{
+            field
+          }
+        }
+      }
+    """
+    staff_api_client.post_graphql(query)
+    span = _get_graphql_span(tracer.finished_spans())
+    assert span.tags["graphql.query_identifier"] == "deleteWarehouse, tokenCreate"
+
+
+@patch("saleor.graphql.views.opentracing.global_tracer")
+def test_tracing_query_identifier_undefined(
+    tracing_mock,
+    staff_api_client,
+    permission_manage_products,
+):
+    tracer = MockTracer()
+    tracing_mock.return_value = tracer
+    query = """
+        fragment ProductVariant on ProductVariant {
+          id
+        }
+    """
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    staff_api_client.post_graphql(query)
+    span = _get_graphql_span(tracer.finished_spans())
+    assert span.tags["graphql.query_identifier"] == "undefined"

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -27,7 +27,7 @@ from .api import API_PATH, schema
 from .context import get_context_value
 from .core.validators.query_cost import validate_query_cost
 from .query_cost_map import COST_MAP
-from .utils import format_error, query_fingerprint
+from .utils import format_error, query_fingerprint, query_identifier
 
 INT_ERROR_MSG = "Int cannot represent non 32-bit signed integer value"
 
@@ -295,6 +295,7 @@ class GraphQLView(View):
             if document is not None:
                 raw_query_string = document.document_string
                 span.set_tag("graphql.query", raw_query_string)
+                span.set_tag("graphql.query_identifier", query_identifier(document))
                 span.set_tag("graphql.query_fingerprint", query_fingerprint(document))
                 try:
                     query_contains_schema = self.check_if_query_contains_only_schema(


### PR DESCRIPTION
I want to merge this change because adding query identifier to tracing.

Port #10913 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
