### PR TITLE
Include reserved stocks in product availability

### DIFF
--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -9,7 +9,7 @@ import pytz
 from django.db.models import Exists, FloatField, OuterRef, Q, Subquery, Sum
 from django.db.models.expressions import ExpressionWrapper
 from django.db.models.fields import IntegerField
-from django.db.models.functions import Cast, Coalesce
+from django.db.models.functions import Cast
 from django.utils import timezone
 
 from ...attribute import AttributeInputType
@@ -34,7 +34,7 @@ from ...product.models import (
     ProductVariantChannelListing,
 )
 from ...product.search import search_products
-from ...warehouse.models import Allocation, Stock, Warehouse
+from ...warehouse.models import Stock, Warehouse
 from ..channel.filters import get_channel_slug_from_filter_data
 from ..core.descriptions import ADDED_IN_38
 from ..core.filters import (
@@ -331,18 +331,13 @@ def filter_products_by_collections(qs, collection_pks):
 
 
 def filter_products_by_stock_availability(qs, stock_availability, channel_slug):
-    allocations = (
-        Allocation.objects.values("stock_id")
-        .filter(quantity_allocated__gt=0, stock_id=OuterRef("pk"))
-        .values_list(Sum("quantity_allocated"))
-    )
-    allocated_subquery = Subquery(queryset=allocations, output_field=IntegerField())
-
     stocks = (
         Stock.objects.for_channel_and_country(channel_slug)
-        .filter(quantity__gt=Coalesce(allocated_subquery, 0))
+        .annotate_available_quantity_including_reservations()
+        .filter(available_quantity_including_reservations__gt=0)
         .values("product_variant_id")
     )
+
     variants = ProductVariant.objects.filter(
         Exists(stocks.filter(product_variant_id=OuterRef("pk")))
     ).values("product_id")

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -222,6 +222,25 @@ class StockQuerySet(models.QuerySet):
             )
         )
 
+    def annotate_available_quantity_including_reservations(self):
+        return self.annotate(
+            available_quantity_including_reservations=F("quantity")
+            - Coalesce(
+                Sum(
+                    "allocations__quantity_allocated",
+                    filter=Q(allocations__quantity_allocated__gt=0),
+                ),
+                0,
+            )
+            - Coalesce(
+                Sum(
+                    "reservations__quantity_reserved",
+                    filter=Q(reservations__reserved_until__gt=timezone.now()),
+                ),
+                0,
+            )
+        )
+
     def for_channel_and_click_and_collect(self, channel_slug: str):
         """Return the stocks for a given channel for a click and collect.
 

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -222,25 +222,6 @@ class StockQuerySet(models.QuerySet):
             )
         )
 
-    def annotate_available_quantity_including_reservations(self):
-        return self.annotate(
-            available_quantity_including_reservations=F("quantity")
-            - Coalesce(
-                Sum(
-                    "allocations__quantity_allocated",
-                    filter=Q(allocations__quantity_allocated__gt=0),
-                ),
-                0,
-            )
-            - Coalesce(
-                Sum(
-                    "reservations__quantity_reserved",
-                    filter=Q(reservations__reserved_until__gt=timezone.now()),
-                ),
-                0,
-            )
-        )
-
     def for_channel_and_click_and_collect(self, channel_slug: str):
         """Return the stocks for a given channel for a click and collect.
 


### PR DESCRIPTION
I want to merge this change because, whenever I query products, with `stockAvailability` filter, I want to have reserved stocks taken into consideration.

This PR changes logic for the filter from: 
**available quantity = quantity - quantity allocated**
to:
**available quantity = quantity - quantity allocated - quantity reserved**

Issue: https://github.com/saleor/saleor/issues/10877

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
