### PR TITLE
Use search_index_dirty on ProductTypeUpdate mutation

### DIFF
--- a/saleor/graphql/product/mutations/product_type_update.py
+++ b/saleor/graphql/product/mutations/product_type_update.py
@@ -2,7 +2,6 @@ import graphene
 
 from ....core.permissions import ProductTypePermissions
 from ....product import models
-from ....product.search import update_products_search_vector
 from ....product.tasks import update_variants_names
 from ...core.types import ProductError
 from ..types import ProductType
@@ -43,5 +42,6 @@ class ProductTypeUpdate(ProductTypeCreate):
             "product_attributes" in cleaned_input
             or "variant_attributes" in cleaned_input
         ):
-            products = models.Product.objects.filter(product_type=instance)
-            update_products_search_vector(products)
+            models.Product.objects.filter(product_type=instance).update(
+                search_index_dirty=True
+            )


### PR DESCRIPTION
backport: https://github.com/saleor/saleor/pull/10972

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
