### PR TITLE
Fix duplicated attribute values

### DIFF
--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -1,6 +1,6 @@
 import os
 import socket
-from typing import TYPE_CHECKING, Optional, Type, Union
+from typing import TYPE_CHECKING, Iterable, Optional, Type, Union
 from urllib.parse import urljoin
 
 from babel.numbers import get_territory_currencies
@@ -116,10 +116,8 @@ def generate_unique_slug(
 
     """
     slug = slugify(unidecode(slugable_value))
-    unique_slug: Union["SafeText", str] = slug
 
     ModelClass = instance.__class__
-    extension = 1
 
     search_field = f"{slug_field_name}__iregex"
     pattern = rf"{slug}-\d+$|{slug}$"
@@ -132,6 +130,16 @@ def generate_unique_slug(
         .exclude(pk=instance.pk)
         .values_list(slug_field_name, flat=True)
     )
+
+    unique_slug = prepare_unique_slug(slug, slug_values)
+
+    return unique_slug
+
+
+def prepare_unique_slug(slug: str, slug_values: Iterable):
+    """Prepare unique slug value based on provided list of existing slug values."""
+    unique_slug: Union["SafeText", str] = slug
+    extension = 1
 
     while unique_slug in slug_values:
         extension += 1

--- a/saleor/graphql/attribute/tests/test_utils.py
+++ b/saleor/graphql/attribute/tests/test_utils.py
@@ -7,7 +7,11 @@ from ....attribute import AttributeInputType
 from ....page.error_codes import PageErrorCode
 from ....product.error_codes import ProductErrorCode
 from ...product.mutations.products import AttrValuesInput
-from ..utils import AttributeAssignmentMixin, validate_attributes_input
+from ..utils import (
+    AttributeAssignmentMixin,
+    prepare_attribute_values,
+    validate_attributes_input,
+)
 
 
 @pytest.mark.parametrize("creation", [True, False])
@@ -709,6 +713,59 @@ def test_validate_attributes_input_no_values_given(
 
 
 @pytest.mark.parametrize("creation", [True, False])
+def test_validate_attributes_duplicated_values_given(
+    creation, weight_attribute, color_attribute, product_type
+):
+    # given
+    color_attribute.value_required = True
+    color_attribute.input_type = AttributeInputType.MULTISELECT
+    color_attribute.save(update_fields=["value_required"])
+
+    weight_attribute.value_required = True
+    weight_attribute.input_type = AttributeInputType.MULTISELECT
+    weight_attribute.save(update_fields=["value_required"])
+
+    input_data = [
+        (
+            weight_attribute,
+            AttrValuesInput(
+                global_id=graphene.Node.to_global_id("Attribute", weight_attribute.pk),
+                values=["test", "new", "test"],
+                file_url=None,
+                content_type=None,
+                references=[],
+            ),
+        ),
+        (
+            color_attribute,
+            AttrValuesInput(
+                global_id=graphene.Node.to_global_id("Attribute", color_attribute.pk),
+                values=["test", "test"],
+                file_url=None,
+                content_type=None,
+                references=[],
+            ),
+        ),
+    ]
+
+    attributes = product_type.variant_attributes.all()
+
+    # when
+    errors = validate_attributes_input(
+        input_data, attributes, is_page_attributes=False, creation=creation
+    )
+
+    # then
+    assert len(errors) == 1
+    error = errors[0]
+    assert error.code == ProductErrorCode.DUPLICATED_INPUT_ITEM.value
+    assert set(error.params["attributes"]) == {
+        graphene.Node.to_global_id("Attribute", attr.pk)
+        for attr in [weight_attribute, color_attribute]
+    }
+
+
+@pytest.mark.parametrize("creation", [True, False])
 def test_validate_not_required_variant_selection_attributes_input_no_values_given(
     creation, weight_attribute, color_attribute, product_type
 ):
@@ -1324,3 +1381,89 @@ def test_clean_file_url_in_attribute_assignment_mixin_invalid_url(file_url):
     # when & then
     with pytest.raises(ValidationError):
         AttributeAssignmentMixin._clean_file_url(file_url, ProductErrorCode)
+
+
+def test_prepare_attribute_values(color_attribute):
+    # given
+    existing_value = color_attribute.values.first()
+    attr_values_count = color_attribute.values.count()
+    new_value = existing_value.name.upper()
+    values = AttrValuesInput(
+        global_id=graphene.Node.to_global_id("Attribute", color_attribute.pk),
+        # we should get the new value only for the last element
+        values=[existing_value.name, existing_value.slug, new_value],
+        file_url=None,
+        content_type=None,
+        references=[],
+    )
+
+    # when
+    prepare_attribute_values(color_attribute, values)
+
+    # then
+    color_attribute.refresh_from_db()
+    assert color_attribute.values.count() == attr_values_count + 1
+    assert color_attribute.values.last().name == new_value
+
+
+def test_prepare_attribute_values_prefer_the_slug_match(color_attribute):
+    """Ensure that the value with slug match is returned as the first choice.
+
+    When the value with the matching slug is not found, the value with the matching
+    name is returned."""
+    # given
+    existing_value = color_attribute.values.first()
+    second_val = color_attribute.values.create(
+        name=existing_value.slug, slug=f"{existing_value.slug}-2"
+    )
+
+    attr_values_count = color_attribute.values.count()
+
+    values = AttrValuesInput(
+        global_id=graphene.Node.to_global_id("Attribute", color_attribute.pk),
+        # we should get the new value only for the last element
+        values=[existing_value.name, second_val.name, second_val.slug],
+        file_url=None,
+        content_type=None,
+        references=[],
+    )
+
+    # when
+    result = prepare_attribute_values(color_attribute, values)
+
+    # then
+    color_attribute.refresh_from_db()
+    assert color_attribute.values.count() == attr_values_count
+    assert result == [existing_value, existing_value, second_val]
+
+
+def test_prepare_attribute_values_that_gives_the_same_slug(color_attribute):
+    """Ensure that the unique slug for all values is created.
+
+    Ensure that when providing the two or more values that are giving the same slug
+    the integrity error is not raised."""
+    # given
+    existing_value = color_attribute.values.first()
+    attr_values_count = color_attribute.values.count()
+    new_value = "RED"
+    new_value_2 = "ReD"
+
+    values = AttrValuesInput(
+        global_id=graphene.Node.to_global_id("Attribute", color_attribute.pk),
+        # we should get the new value only for the last element
+        values=[existing_value.name, new_value, new_value_2],
+        file_url=None,
+        content_type=None,
+        references=[],
+    )
+
+    # when
+    result = prepare_attribute_values(color_attribute, values)
+
+    # then
+    color_attribute.refresh_from_db()
+    assert color_attribute.values.count() == attr_values_count + 2
+    assert len(result) == 3
+    assert result[0] == existing_value
+    assert result[1].name == new_value
+    assert result[2].name == new_value_2

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -16,14 +16,14 @@ from text_unidecode import unidecode
 from ...attribute import AttributeEntityType, AttributeInputType, AttributeType
 from ...attribute import models as attribute_models
 from ...attribute.utils import associate_attribute_values_to_instance
-from ...core.utils import generate_unique_slug
+from ...core.utils import generate_unique_slug, prepare_unique_slug
 from ...core.utils.editorjs import clean_editor_js
 from ...core.utils.url import get_default_storage_root_url
 from ...page import models as page_models
 from ...page.error_codes import PageErrorCode
 from ...product import models as product_models
 from ...product.error_codes import ProductErrorCode
-from ..core.utils import from_global_id_or_error
+from ..core.utils import from_global_id_or_error, get_duplicated_values
 from ..utils import get_nodes
 
 if TYPE_CHECKING:
@@ -359,21 +359,11 @@ class AttributeAssignmentMixin:
         cls, attribute: attribute_models.Attribute, attr_values: AttrValuesInput
     ):
         """Lazy-retrieve or create the database objects from the supplied raw values."""
-        result = []
         if not attr_values.values:
             return tuple()
-        for value in attr_values.values:
-            value_obj = attribute.values.filter(name=value).first()
-            if value_obj:
-                result.append(value_obj)
-            else:
-                instance = attribute_models.AttributeValue(
-                    attribute=attribute, name=value
-                )
-                slug = generate_unique_slug(instance, value)  # type: ignore
-                instance.slug = slug
-                instance.save()
-                result.append(instance)
+
+        result = prepare_attribute_values(attribute, attr_values)
+
         return tuple(result)
 
     @classmethod
@@ -563,6 +553,54 @@ def get_variant_selection_attributes(qs: "QuerySet") -> "QuerySet":
     )
 
 
+def prepare_attribute_values(
+    attribute: attribute_models.Attribute, attr_values: AttrValuesInput
+):
+    values = attr_values.values
+    slug_to_value_map = {}
+    name_to_value_map = {}
+    for val in attribute.values.filter(Q(name__in=values) | Q(slug__in=values)):
+        slug_to_value_map[val.slug] = val
+        name_to_value_map[val.name] = val
+
+    existing_slugs = get_existing_slugs(attribute, values)
+
+    result = []
+    values_to_create = []
+    for value in values:
+        # match the value firstly by slug then by name
+        value_obj = slug_to_value_map.get(value) or name_to_value_map.get(value)
+        if value_obj:
+            result.append(value_obj)
+        else:
+            slug = prepare_unique_slug(slugify(unidecode(value)), existing_slugs)
+            instance = attribute_models.AttributeValue(
+                attribute=attribute, name=value, slug=slug
+            )
+            result.append(instance)
+
+            values_to_create.append(instance)
+
+            # the set of existing slugs must be updated to not generate accidentally
+            # the same slug for two or more values
+            existing_slugs.add(slug)
+
+            # extend name to slug value to not create two elements with the same name
+            name_to_value_map[instance.name] = instance
+
+    attribute_models.AttributeValue.objects.bulk_create(values_to_create)
+    return result
+
+
+def get_existing_slugs(attribute: attribute_models.Attribute, values: List[str]):
+    lookup = Q()
+    for value in values:
+        lookup |= Q(slug__startswith=slugify(unidecode(value)))
+
+    existing_slugs = set(attribute.values.filter(lookup).values_list("slug", flat=True))
+    return existing_slugs
+
+
 class AttributeInputErrors:
     """Define error message and error code for given error.
 
@@ -580,6 +618,10 @@ class AttributeInputErrors:
     ERROR_BLANK_VALUE = (
         "Attribute values cannot be blank.",
         "REQUIRED",
+    )
+    ERROR_DUPLICATED_VALUES = (
+        "Duplicated attribute values are provided.",
+        "DUPLICATED_INPUT_ITEM",
     )
 
     # file errors
@@ -787,6 +829,10 @@ def validate_values(
 ):
     name_field = attribute.values.model.name.field  # type: ignore
     is_numeric = attribute.input_type == AttributeInputType.NUMERIC
+    if get_duplicated_values(values):
+        attribute_errors[AttributeInputErrors.ERROR_DUPLICATED_VALUES].append(
+            attribute_id
+        )
     for value in values:
         if value is None or (not is_numeric and not value.strip()):
             attribute_errors[AttributeInputErrors.ERROR_BLANK_VALUE].append(

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -2563,6 +2563,98 @@ def test_update_product_variant_with_matching_slugs_different_values(
     assert variant.attributes.last().values.first().slug == "small-2"
 
 
+def test_update_product_variant_with_value_that_matching_existing_slug(
+    staff_api_client,
+    product_with_variant_with_two_attributes,
+    permission_manage_products,
+):
+    product = product_with_variant_with_two_attributes
+    variant = product.variants.first()
+    sku = str(uuid4())[:12]
+    assert not variant.sku == sku
+
+    attribute_1, attribute_2 = product.product_type.variant_attributes.all()
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    attribute_1_id = graphene.Node.to_global_id("Attribute", attribute_1.pk)
+    attribute_2_id = graphene.Node.to_global_id("Attribute", attribute_2.pk)
+
+    attr_1_values_count = attribute_1.values.count()
+    attr_2_values_count = attribute_2.values.count()
+
+    variables = {
+        "id": variant_id,
+        "sku": sku,
+        "attributes": [
+            {"id": attribute_1_id, "values": [attribute_1.values.first().slug]},
+            {"id": attribute_2_id, "values": [attribute_2.values.first().slug]},
+        ],
+    }
+
+    response = staff_api_client.post_graphql(
+        QUERY_UPDATE_VARIANT_ATTRIBUTES,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantUpdate"]
+    assert not data["errors"]
+    variant.refresh_from_db()
+    assert variant.sku == sku
+    assert attribute_1.values.count() == attr_1_values_count
+    assert attribute_2.values.count() == attr_2_values_count
+    assert len(data["productVariant"]["attributes"]) == 2
+    for attr_data in data["productVariant"]["attributes"]:
+        assert len(attr_data["values"]) == 1
+
+
+def test_update_product_variant_with_value_that_matching_existing_name(
+    staff_api_client,
+    product_with_variant_with_two_attributes,
+    permission_manage_products,
+):
+    product = product_with_variant_with_two_attributes
+    variant = product.variants.first()
+    sku = str(uuid4())[:12]
+    assert not variant.sku == sku
+
+    attribute_1, attribute_2 = product.product_type.variant_attributes.all()
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    attribute_1_id = graphene.Node.to_global_id("Attribute", attribute_1.pk)
+    attribute_2_id = graphene.Node.to_global_id("Attribute", attribute_2.pk)
+
+    attr_1_values_count = attribute_1.values.count()
+    attr_2_values_count = attribute_2.values.count()
+
+    variables = {
+        "id": variant_id,
+        "sku": sku,
+        "attributes": [
+            {"id": attribute_1_id, "values": [attribute_1.values.first().name]},
+            {"id": attribute_2_id, "values": [attribute_2.values.first().name]},
+        ],
+    }
+
+    response = staff_api_client.post_graphql(
+        QUERY_UPDATE_VARIANT_ATTRIBUTES,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantUpdate"]
+    assert not data["errors"]
+    variant.refresh_from_db()
+    attribute_1.refresh_from_db()
+    attribute_2.refresh_from_db()
+    assert variant.sku == sku
+    assert attribute_1.values.count() == attr_1_values_count
+    assert attribute_2.values.count() == attr_2_values_count
+    assert len(data["productVariant"]["attributes"]) == 2
+    for attr_data in data["productVariant"]["attributes"]:
+        assert len(attr_data["values"]) == 1
+
+
 @patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
 def test_update_variant_with_boolean_attribute(
     product_variant_updated,


### PR DESCRIPTION
Fix handling the attribute value creation when providing values in product/variant/page updates or creation.
Right now there will be case-sensitive provided attribute value matching for name or slug:
- if a match exists for the slug, use that value
- if a match exists for the name, use that value
- otherwise, create a new attribute like it does in the new code (no get-or-create based on slugified name like in the old code)

Port of #10923

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
