### PR TITLE
Fix filter data with 0 value is not working issue

### DIFF
--- a/saleor/graphql/core/tests/test_core.py
+++ b/saleor/graphql/core/tests/test_core.py
@@ -430,12 +430,13 @@ def test_validate_image_url_response_without_content_headers(monkeypatch):
     "value, count, product_indexes",
     [
         ({"lte": 50, "gte": 25}, 1, [2]),
-        ({"lte": 25}, 2, [0, 1]),
-        ({"lte": 10}, 1, [0]),
+        ({"lte": 25}, 3, [0, 1, 3]),
+        ({"lte": 10}, 2, [0, 3]),
         ({"gte": 40}, 0, []),
+        ({"lte": 0, "gte": 0}, 1, [3]),
     ],
 )
-def test_filter_range_field(value, count, product_indexes, product_list):
+def test_filter_range_field(value, count, product_indexes, product_with_zero_discount):
     qs = ProductChannelListing.objects.all().order_by("pk")
     field = "discounted_price_amount"
 

--- a/saleor/graphql/utils/filters.py
+++ b/saleor/graphql/utils/filters.py
@@ -21,10 +21,10 @@ def filter_by_period(queryset, period, field_name):
 
 def filter_range_field(qs, field, value):
     gte, lte = value.get("gte"), value.get("lte")
-    if gte:
+    if gte is not None:
         lookup = {f"{field}__gte": gte}
         qs = qs.filter(**lookup)
-    if lte:
+    if lte is not None:
         lookup = {f"{field}__lte": lte}
         qs = qs.filter(**lookup)
     return qs

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3268,26 +3268,6 @@ def product_with_images(product_type, category, media_root, channel_USD):
 
 
 @pytest.fixture
-def product_with_zero_discount(product_list, product_type, category, channel_USD):
-    product = Product.objects.create(
-        name="Test product 4",
-        slug="test-product-4",
-        product_type=product_type,
-        category=category,
-    )
-    ProductChannelListing.objects.create(
-        product=product,
-        channel=channel_USD,
-        is_published=True,
-        discounted_price_amount=0,
-        currency=channel_USD.currency_code,
-        visible_in_listings=True,
-        available_for_purchase_at=(datetime.datetime(1999, 1, 1, tzinfo=pytz.UTC)),
-    )
-    return product_list
-
-
-@pytest.fixture
 def voucher_without_channel(db):
     return Voucher.objects.create(code="mirumee")
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3268,6 +3268,26 @@ def product_with_images(product_type, category, media_root, channel_USD):
 
 
 @pytest.fixture
+def product_with_zero_discount(product_list, product_type, category, channel_USD):
+    product = Product.objects.create(
+        name="Test product 4",
+        slug="test-product-4",
+        product_type=product_type,
+        category=category,
+    )
+    ProductChannelListing.objects.create(
+        product=product,
+        channel=channel_USD,
+        is_published=True,
+        discounted_price_amount=0,
+        currency=channel_USD.currency_code,
+        visible_in_listings=True,
+        available_for_purchase_at=(datetime.datetime(1999, 1, 1, tzinfo=pytz.UTC)),
+    )
+    return product_list
+
+
+@pytest.fixture
 def voucher_without_channel(db):
     return Voucher.objects.create(code="mirumee")
 


### PR DESCRIPTION
I want to merge this change because to fix Unable to filter customers with 0 orders issue

fixes #10832 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
