### PR TITLE
Drop update_taxes_for_order_lines

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -636,7 +636,6 @@ def create_order_lines(order, discounts, how_many=10):
         )
         warehouse = next(warehouse_iter)
         increase_stock(line, warehouse, line.quantity, allocate=True)
-    manager.update_taxes_for_order_lines(order, lines)
     OrderLine.objects.bulk_update(
         lines,
         [
@@ -697,7 +696,6 @@ def create_order_lines_with_preorder(order, discounts, how_many=1):
                 quantity=line.quantity,
             )
         )
-    manager.update_taxes_for_order_lines(order, lines)
     PreorderAllocation.objects.bulk_create(preorder_allocations)
 
     OrderLine.objects.bulk_update(

--- a/saleor/order/calculations.py
+++ b/saleor/order/calculations.py
@@ -56,10 +56,6 @@ def _recalculate_order_prices(
             except TaxError:
                 pass
 
-    # Plugins like Vatlayer don't implement Order line calculation instead of implement
-    # `update_taxes_for_order_lines`
-    manager.update_taxes_for_order_lines(order, list(lines))
-
     try:
         order.shipping_price = manager.calculate_order_shipping(order)
         order.shipping_tax_rate = manager.get_order_shipping_tax_rate(

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -7,7 +7,6 @@ from prices import Money, TaxedMoney
 
 from ...core.prices import quantize_price
 from ...core.taxes import TaxData, TaxError, TaxLineData, zero_taxed_money
-from ...plugins.manager import get_plugins_manager
 from ...tax import TaxCalculationStrategy
 from ...tax.calculations.order import update_order_prices_with_flat_rates
 from .. import OrderStatus, calculations
@@ -125,22 +124,6 @@ def test_recalculate_order_prices(order_with_lines, order_lines, tax_data):
         assert line.total_price == line_total.price_with_discounts
         assert line.undiscounted_total_price == line_total.undiscounted_price
         assert tax_rate == line.tax_rate
-
-
-@patch("saleor.plugins.manager.PluginsManager.update_taxes_for_order_lines")
-def test_recalculate_order_prices_calls_update_taxes_for_order_lines(
-    mocked_update_taxes_for_order_lines, order_with_lines, order_lines
-):
-    # given
-    order = order_with_lines
-    manager = get_plugins_manager()
-    lines = list(order_lines)
-
-    # when
-    calculations._recalculate_order_prices(manager, order, lines)
-
-    # then
-    mocked_update_taxes_for_order_lines.assert_called_once_with(order, lines)
 
 
 @pytest.mark.parametrize(

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -258,8 +258,6 @@ def create_order_line(
         variant=variant,
     )
 
-    manager.update_taxes_for_order_lines(order, list(order.lines.all()))
-
     unit_discount = line.undiscounted_unit_price - line.unit_price
     if unit_discount.gross:
         sale_id = get_sale_id_applied_as_a_discount(

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -237,14 +237,6 @@ class BasePlugin:
 
     authorize_payment: Callable[["PaymentData", Any], GatewayResponse]
 
-    #  Update order lines taxes.
-    #
-    #  Overwrite this method if you need to apply specific logic for applying taxes on
-    #  order lines. Return Iterable["OrderLine"].
-    update_taxes_for_order_lines: Callable[
-        ["Order", List["OrderLine"], List["OrderLine"]], List["OrderLine"]
-    ]
-
     #  Calculate checkout line total.
     #
     #  Overwrite this method if you need to apply specific logic for the calculation

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -364,20 +364,6 @@ class PluginsManager(PaymentInterface):
             channel_slug=order.channel.slug,
         ).quantize(Decimal(".0001"))
 
-    def update_taxes_for_order_lines(
-        self,
-        order: "Order",
-        lines: List["OrderLine"],
-    ):
-        lines = self.__run_method_on_plugins(
-            "update_taxes_for_order_lines",
-            lines,
-            order,
-            lines,
-            channel_slug=order.channel.slug,
-        )
-        return lines
-
     def calculate_checkout_line_total(
         self,
         checkout_info: "CheckoutInfo",


### PR DESCRIPTION
Drop `update_taxes_for_order_lines` which was only added to manager to calculate taxes with Vatlayer. Since Vatlayer is dropped with introducing flat rates, we don't need this function anymore.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
