### PR TITLE
Fix Avalara calls not validating the checkout

### DIFF
--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -287,7 +287,9 @@ class AvataxPlugin(BasePlugin):
     ) -> TaxedMoney:
         base_shipping_price = previous_value
 
-        response = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
+        response = self._get_checkout_tax_data(
+            checkout_info, lines, discounts, self.config
+        )
         if response is None:
             return previous_value
 
@@ -389,7 +391,9 @@ class AvataxPlugin(BasePlugin):
             _get_prices_entered_with_tax_for_checkout, checkout_info
         )
 
-        taxes_data = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
+        taxes_data = self._get_checkout_tax_data(
+            checkout_info, lines, discounts, self.config
+        )
         variant = checkout_line_info.variant
 
         return self._calculate_checkout_line_total_price(
@@ -521,7 +525,9 @@ class AvataxPlugin(BasePlugin):
         variant = checkout_line_info.variant
 
         quantity = checkout_line_info.line.quantity
-        taxes_data = get_checkout_tax_data(checkout_info, lines, discounts, self.config)
+        taxes_data = self._get_checkout_tax_data(
+            checkout_info, lines, discounts, self.config
+        )
         default_total = previous_value * quantity
         taxed_total_price = self._calculate_checkout_line_total_price(
             taxes_data,

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -4880,3 +4880,101 @@ def test_assign_tax_code_to_object_meta_no_obj_id(
         META_CODE_KEY: tax_code,
         META_DESCRIPTION_KEY: description,
     }
+
+
+@patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
+def test_calculate_checkout_shipping_validates_checkout(
+    mocked_func, settings, channel_USD, plugin_configuration, checkout_with_item
+):
+    # given
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    plugin_configuration(channel=channel_USD)
+    manager = get_plugins_manager()
+    checkout = checkout_with_item
+    lines, _ = fetch_checkout_lines(checkout)
+
+    checkout.shipping_method = None
+    checkout.save(update_fields=["shipping_method"])
+
+    for line in lines:
+        line.product_type.is_shipping_required = True
+        line.product_type.save()
+
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+
+    # when
+    manager.calculate_checkout_shipping(
+        checkout_info,
+        lines,
+        checkout.shipping_address,
+        discounts=[],
+    )
+
+    # then
+    assert not mocked_func.called
+
+
+@patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
+def test_calculate_checkout_line_total_validates_checkout(
+    mocked_func, settings, channel_USD, plugin_configuration, checkout_with_item
+):
+    # given
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    plugin_configuration(channel=channel_USD)
+    manager = get_plugins_manager()
+    checkout = checkout_with_item
+    lines, _ = fetch_checkout_lines(checkout)
+
+    checkout.shipping_method = None
+    checkout.save(update_fields=["shipping_method"])
+
+    for line in lines:
+        line.product_type.is_shipping_required = True
+        line.product_type.save()
+
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+
+    # when
+    manager.calculate_checkout_line_total(
+        checkout_info,
+        lines,
+        lines[0],
+        checkout.shipping_address,
+        discounts=[],
+    )
+
+    # then
+    assert not mocked_func.called
+
+
+@patch("saleor.plugins.avatax.plugin.get_checkout_tax_data")
+def test_calculate_checkout_line_unit_price_validates_checkout(
+    mocked_func, settings, channel_USD, plugin_configuration, checkout_with_item
+):
+    # given
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    plugin_configuration(channel=channel_USD)
+    manager = get_plugins_manager()
+    checkout = checkout_with_item
+    lines, _ = fetch_checkout_lines(checkout)
+
+    checkout.shipping_method = None
+    checkout.save(update_fields=["shipping_method"])
+
+    for line in lines:
+        line.product_type.is_shipping_required = True
+        line.product_type.save()
+
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+
+    # when
+    manager.calculate_checkout_line_unit_price(
+        checkout_info,
+        lines,
+        lines[0],
+        checkout.shipping_address,
+        discounts=[],
+    )
+
+    # then
+    assert not mocked_func.called


### PR DESCRIPTION
Some Avalara calls were not running checkout validation, which was probably broken as a result of a 
lousy rebase with main branch ¯\_(ツ)_/¯

Fixes #10998

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
