### PR TITLE
Add `attribute` field to `AttributeValueTranslatableContent` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add sorting by `CREATED_AT` field. #10911 by @zedzior
   - Affected types: GiftCard, Page.
   - Deprecated `CREATION_DATE` sort field on Page type. Use `CREATED_AT` instead.
+- Add `attribute` field to `AttributeValueTranslatableContent` type. #11028 by @zedzior
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Re-enable 5 minute database connection persistence by default - #11074 + #11100 by @NyanKiyoshi
   <br/>Set `DB_CONN_MAX_AGE=0` to disable this behavior (adds overhead to requests)
 - Bump cryptography to 38.0.3: use OpenSSL 3.0.7 - #11126 by @NyanKiyoshi
+- Add `attribute` field to `AttributeValueTranslatableContent` type. #11028 by @zedzior
 
 ...
 
@@ -42,7 +43,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add sorting by `CREATED_AT` field. #10911 by @zedzior
   - Affected types: GiftCard, Page.
   - Deprecated `CREATION_DATE` sort field on Page type. Use `CREATED_AT` instead.
-- Add `attribute` field to `AttributeValueTranslatableContent` type. #11028 by @zedzior
 
 ### Other changes
 

--- a/saleor/graphql/attribute/dataloaders.py
+++ b/saleor/graphql/attribute/dataloaders.py
@@ -37,13 +37,3 @@ class AttributeValueByIdLoader(DataLoader):
             self.database_connection_name
         ).in_bulk(keys)
         return [attribute_values.get(attribute_value_id) for attribute_value_id in keys]
-
-
-class AttributesByAttributeValueIdLoader(DataLoader):
-    context_key = "attributes_by_attributevalue"
-
-    def batch_load(self, keys):
-        attributes = Attribute.objects.using(self.database_connection_name).in_bulk(
-            keys
-        )
-        return [attributes.get(attribute_id) for attribute_id in attributes]

--- a/saleor/graphql/attribute/dataloaders.py
+++ b/saleor/graphql/attribute/dataloaders.py
@@ -37,3 +37,13 @@ class AttributeValueByIdLoader(DataLoader):
             self.database_connection_name
         ).in_bulk(keys)
         return [attribute_values.get(attribute_value_id) for attribute_value_id in keys]
+
+
+class AttributesByAttributeValueIdLoader(DataLoader):
+    context_key = "attributes_by_attributevalue"
+
+    def batch_load(self, keys):
+        attributes = Attribute.objects.using(self.database_connection_name).in_bulk(
+            keys
+        )
+        return [attributes.get(attribute_id) for attribute_id in attributes]

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -19,6 +19,7 @@ ADDED_IN_35 = "\n\nAdded in Saleor 3.5."
 ADDED_IN_36 = "\n\nAdded in Saleor 3.6."
 ADDED_IN_37 = "\n\nAdded in Saleor 3.7."
 ADDED_IN_38 = "\n\nAdded in Saleor 3.8."
+ADDED_IN_39 = "\n\nAdded in Saleor 3.9."
 
 
 PREVIEW_FEATURE = (

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6624,7 +6624,7 @@ type AttributeValueTranslatableContent implements Node {
   """
   Associated attribute that can be translated.
   
-  Added in Saleor 3.8.
+  Added in Saleor 3.9.
   """
   attribute: AttributeTranslatableContent
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6620,6 +6620,27 @@ type AttributeValueTranslatableContent implements Node {
 
   """Represents a value of an attribute."""
   attributeValue: AttributeValue @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+
+  """
+  Associated attribute that can be translated.
+  
+  Added in Saleor 3.8.
+  """
+  attribute: AttributeTranslatableContent
+}
+
+type AttributeTranslatableContent implements Node {
+  id: ID!
+  name: String!
+
+  """Returns translated attribute fields for the given language code."""
+  translation(
+    """A language code to return the translation for attribute."""
+    languageCode: LanguageCodeEnum!
+  ): AttributeTranslation
+
+  """Custom attribute of a product."""
+  attribute: Attribute @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type CollectionTranslatableContent implements Node {
@@ -6680,20 +6701,6 @@ type CategoryTranslatableContent implements Node {
 
   """Represents a single category of products."""
   category: Category @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
-}
-
-type AttributeTranslatableContent implements Node {
-  id: ID!
-  name: String!
-
-  """Returns translated attribute fields for the given language code."""
-  translation(
-    """A language code to return the translation for attribute."""
-    languageCode: LanguageCodeEnum!
-  ): AttributeTranslation
-
-  """Custom attribute of a product."""
-  attribute: Attribute @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type ProductVariantTranslatableContent implements Node {

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -14,9 +14,9 @@ from ...page import models as page_models
 from ...product import models as product_models
 from ...shipping import models as shipping_models
 from ...site import models as site_models
-from ..attribute.dataloaders import AttributesByAttributeValueIdLoader
+from ..attribute.dataloaders import AttributesByAttributeId
 from ..channel import ChannelContext
-from ..core.descriptions import ADDED_IN_38, DEPRECATED_IN_3X_FIELD, RICH_CONTENT
+from ..core.descriptions import ADDED_IN_39, DEPRECATED_IN_3X_FIELD, RICH_CONTENT
 from ..core.enums import LanguageCodeEnum
 from ..core.fields import JSONString, PermissionsField
 from ..core.types import LanguageDisplay, ModelObjectType, NonNullList
@@ -124,7 +124,7 @@ class AttributeValueTranslatableContent(ModelObjectType):
     )
     attribute = graphene.Field(
         AttributeTranslatableContent,
-        description="Associated attribute that can be translated." + ADDED_IN_38,
+        description="Associated attribute that can be translated." + ADDED_IN_39,
     )
 
     class Meta:
@@ -137,7 +137,7 @@ class AttributeValueTranslatableContent(ModelObjectType):
 
     @staticmethod
     def resolve_attribute(root: attribute_models.AttributeValue, info):
-        return AttributesByAttributeValueIdLoader(info.context).load(root.attribute_id)
+        return AttributesByAttributeId(info.context).load(root.attribute_id)
 
 
 class ProductVariantTranslation(BaseTranslationType):

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -15,7 +15,7 @@ from ...product import models as product_models
 from ...shipping import models as shipping_models
 from ...site import models as site_models
 from ..channel import ChannelContext
-from ..core.descriptions import DEPRECATED_IN_3X_FIELD, RICH_CONTENT
+from ..core.descriptions import ADDED_IN_38, DEPRECATED_IN_3X_FIELD, RICH_CONTENT
 from ..core.enums import LanguageCodeEnum
 from ..core.fields import JSONString, PermissionsField
 from ..core.types import LanguageDisplay, ModelObjectType, NonNullList
@@ -76,31 +76,6 @@ class AttributeValueTranslation(BaseTranslationType):
         interfaces = [graphene.relay.Node]
 
 
-class AttributeValueTranslatableContent(ModelObjectType):
-    id = graphene.GlobalID(required=True)
-    name = graphene.String(required=True)
-    rich_text = JSONString(description="Attribute value." + RICH_CONTENT)
-    plain_text = graphene.String(description="Attribute plain text value.")
-    translation = TranslationField(
-        AttributeValueTranslation, type_name="attribute value"
-    )
-    attribute_value = graphene.Field(
-        "saleor.graphql.attribute.types.AttributeValue",
-        description="Represents a value of an attribute.",
-        deprecation_reason=(
-            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
-        ),
-    )
-
-    class Meta:
-        model = attribute_models.AttributeValue
-        interfaces = [graphene.relay.Node]
-
-    @staticmethod
-    def resolve_attribute_value(root: attribute_models.AttributeValue, _info):
-        return root
-
-
 class AttributeTranslation(BaseTranslationType):
     id = graphene.GlobalID(required=True)
     name = graphene.String(required=True)
@@ -129,6 +104,39 @@ class AttributeTranslatableContent(ModelObjectType):
     @staticmethod
     def resolve_attribute(root: attribute_models.Attribute, _info):
         return root
+
+
+class AttributeValueTranslatableContent(ModelObjectType):
+    id = graphene.GlobalID(required=True)
+    name = graphene.String(required=True)
+    rich_text = JSONString(description="Attribute value." + RICH_CONTENT)
+    plain_text = graphene.String(description="Attribute plain text value.")
+    translation = TranslationField(
+        AttributeValueTranslation, type_name="attribute value"
+    )
+    attribute_value = graphene.Field(
+        "saleor.graphql.attribute.types.AttributeValue",
+        description="Represents a value of an attribute.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
+        ),
+    )
+    attribute = graphene.Field(
+        AttributeTranslatableContent,
+        description="Associated attribute that can be translated." + ADDED_IN_38,
+    )
+
+    class Meta:
+        model = attribute_models.AttributeValue
+        interfaces = [graphene.relay.Node]
+
+    @staticmethod
+    def resolve_attribute_value(root: attribute_models.AttributeValue, _info):
+        return root
+
+    @staticmethod
+    def resolve_attribute(root: attribute_models.AttributeValue, _info):
+        return root.attribute
 
 
 class ProductVariantTranslation(BaseTranslationType):

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -14,6 +14,7 @@ from ...page import models as page_models
 from ...product import models as product_models
 from ...shipping import models as shipping_models
 from ...site import models as site_models
+from ..attribute.dataloaders import AttributesByAttributeValueIdLoader
 from ..channel import ChannelContext
 from ..core.descriptions import ADDED_IN_38, DEPRECATED_IN_3X_FIELD, RICH_CONTENT
 from ..core.enums import LanguageCodeEnum
@@ -135,8 +136,8 @@ class AttributeValueTranslatableContent(ModelObjectType):
         return root
 
     @staticmethod
-    def resolve_attribute(root: attribute_models.AttributeValue, _info):
-        return root.attribute
+    def resolve_attribute(root: attribute_models.AttributeValue, info):
+        return AttributesByAttributeValueIdLoader(info.context).load(root.attribute_id)
 
 
 class ProductVariantTranslation(BaseTranslationType):


### PR DESCRIPTION
I want to merge this change because, I want to query the attribute details of each attribute value returned in the `attributeValues` field from `ProductTranslatableContent`, `ProductVariantTranslatableContent` or `PageTranslatableContent` (subtypes of `TranslatableItem`).

https://github.com/saleor/saleor-dashboard/issues/2400
https://github.com/saleor/saleor/issues/10983

API changes:
```
type AttributeValueTranslatableContent {
  id: ID!
  name: String!
  richText: JSONString
  plainText: String
  translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation

  # New field
  attribute: AttributeTranslatableContent!
}
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
