### PR TITLE
Fix setup_context_use function to handle ReadOnlyMiddleware

### DIFF
--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -55,6 +55,8 @@ def get_database_connection_name(context: SaleorContext) -> str:
 
 
 def setup_context_user(context: SaleorContext) -> None:
-    if getattr(context.user, "_wrapped", None) is empty:
+    if hasattr(context.user, "_wrapped") and (
+        context.user._wrapped is empty or context.user._wrapped is None  # type: ignore
+    ):
         context.user._setup()  # type: ignore
         context.user = context.user._wrapped  # type: ignore


### PR DESCRIPTION
Port of #11011

I want to merge this change because it fixes an issue with unwrapping `SimpleLazyObject` for `context.user` when `ReadOnlyMiddleware` is activated.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
