### PR TITLE
Disable tracing of fast resolvers

### DIFF
--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -5,7 +5,6 @@ import graphene
 from django.db.models import QuerySet
 
 from ...attribute import AttributeEntityType, AttributeInputType, models
-from ...core.tracing import traced_resolver
 from ..core.connection import (
     CountableConnection,
     create_connection_slice,
@@ -66,7 +65,6 @@ class AttributeValue(ModelObjectType):
         model = models.AttributeValue
 
     @staticmethod
-    @traced_resolver
     def resolve_input_type(root: models.AttributeValue, info, *_args):
         return (
             AttributesByAttributeId(info.context)

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -871,7 +871,6 @@ class Product(ChannelContextTypeWithMetadata, ModelObjectType):
         return TaxType(tax_code=tax_data.code, description=tax_data.description)
 
     @staticmethod
-    @traced_resolver
     def resolve_thumbnail(root: ChannelContext[models.Product], info, *, size=255):
         def return_first_thumbnail(product_media):
             if product_media:
@@ -1139,7 +1138,6 @@ class Product(ChannelContextTypeWithMetadata, ModelObjectType):
         return convert_weight_to_default_weight_unit(root.node.weight)
 
     @staticmethod
-    @traced_resolver
     def resolve_is_available_for_purchase(root: ChannelContext[models.Product], info):
         if not root.channel_slug:
             return None
@@ -1157,7 +1155,6 @@ class Product(ChannelContextTypeWithMetadata, ModelObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_available_for_purchase(root: ChannelContext[models.Product], info):
         if not root.channel_slug:
             return None


### PR DESCRIPTION
I want to merge this change because we'd like to reduce the number of traces being collected from fast pieces of code, I've checked all resolvers which were removed and they all take milliseconds to complete but send like 1000 traces per larger request.

ℹ️  This is a 3.2 port of https://github.com/saleor/saleor/pull/11031

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
