### PR TITLE
Fix order discount recalculation

### DIFF
--- a/saleor/tax/calculations/checkout.py
+++ b/saleor/tax/calculations/checkout.py
@@ -83,24 +83,13 @@ def calculate_checkout_shipping(
     tax_rate: Decimal,
     prices_entered_with_tax: bool,
 ) -> TaxedMoney:
-    default_price = base_calculations.base_checkout_delivery_price(checkout_info, lines)
-    shipping_price = getattr(
-        checkout_info.delivery_method_info.delivery_method,
-        "price",
-        default_price,
+    shipping_price = base_calculations.base_checkout_delivery_price(
+        checkout_info, lines
     )
-    voucher = checkout_info.voucher
-    is_shipping_discount = voucher.type == VoucherType.SHIPPING if voucher else False
-    if is_shipping_discount:
-        shipping_price = max(
-            shipping_price - checkout_info.checkout.discount,
-            zero_money(shipping_price.currency),
-        )
-
-    shipping_price = calculate_flat_rate_tax(
+    shipping_price_taxed = calculate_flat_rate_tax(
         shipping_price, tax_rate, prices_entered_with_tax
     )
-    return quantize_price(shipping_price, shipping_price.currency)
+    return quantize_price(shipping_price_taxed, shipping_price_taxed.currency)
 
 
 def calculate_checkout_line_total(

--- a/saleor/tax/tests/test_order_calculations.py
+++ b/saleor/tax/tests/test_order_calculations.py
@@ -34,6 +34,9 @@ def test_calculations_calculate_order_total(order_with_lines):
     update_order_prices_with_flat_rates(order, lines, prices_entered_with_tax)
 
     # then
+    assert order.undiscounted_total == TaxedMoney(
+        net=Money("65.04", "USD"), gross=Money("80.00", "USD")
+    )
     assert order.total == TaxedMoney(
         net=Money("65.04", "USD"), gross=Money("80.00", "USD")
     )


### PR DESCRIPTION
This PR adds missing recalulation of the `order.undiscounted_total` model field. Also it removes duplicated logic from tax/calculate_checkout_shipping which is already done in manager.

Fixes #11002

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
