### PR TITLE
Fix crash in custom django-celery-beat scheduler entries

### DIFF
--- a/saleor/schedulers/schedulers.py
+++ b/saleor/schedulers/schedulers.py
@@ -50,13 +50,11 @@ class CustomModelEntry(ModelEntry):
     @classmethod
     def from_entry(cls, name, app=None, **entry):
         # Super method has 'PeriodicTask' hardcoded
-        return cls(
-            models.CustomPeriodicTask._default_manager.update_or_create(
-                name=name,
-                defaults=cls._unpack_fields(**entry),
-            ),
-            app=app,
+        obj, created = models.CustomPeriodicTask._default_manager.update_or_create(
+            name=name,
+            defaults=cls._unpack_fields(**entry),
         )
+        return cls(obj, app=app)
 
 
 class BaseScheduler(celery.beat.Scheduler):


### PR DESCRIPTION
This fixes `django-celery-beat` startup crashes when using custom database scheduler. This crash would happen when trying to load `django-celery-beat` rows from database due to a breaking change introduced at https://github.com/celery/django-celery-beat/commit/626c2a06331a039250ea4026812bf1ede26907cc#diff-30f45e7eed4aafe79dbc3b004881b237faf4393938b769fff25325364384bced (`django-celery-beat==2.4.0`).

Stacktrace:
```
AttributeError: tuple object has no attribute name
  File "django_celery_beat/schedulers.py", line 315, in update_from_dict
    entry = self.Entry.from_entry(name,
  File "saleor/schedulers/schedulers.py", line 53, in from_entry
    return cls(
  File "django_celery_beat/schedulers.py", line 50, in __init__
    self.name = model.name
```

Issue was introduced by https://github.com/saleor/saleor/commit/1f145853f9856ac5c92b65afd35873e4198af31d

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
