### PR TITLE
Re-enable Django database connection reuse

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -80,13 +80,13 @@ DATABASE_CONNECTION_REPLICA_NAME = "default"
 
 DATABASES = {
     DATABASE_CONNECTION_DEFAULT_NAME: dj_database_url.config(
-        default="postgres://saleor:saleor@localhost:5432/saleor", conn_max_age=0
+        default="postgres://saleor:saleor@localhost:5432/saleor", conn_max_age=600
     ),
     # TODO: We need to add read only user to saleor platfrom, and we need to update
     # docs.
     # DATABASE_CONNECTION_REPLICA_NAME: dj_database_url.config(
     #     default="postgres://saleor_read_only:saleor@localhost:5432/saleor",
-    #     conn_max_age=0,
+    #     conn_max_age=600,
     # ),
 }
 


### PR DESCRIPTION
Django 4.0 was reverted to 3.2 at 1f145853f9856ac5c92b65afd35873e4198af31d, connection reuse should be re-enabled in 3.2

This reverts commit 50d7c634ea5d5bb0cc7f30e8064d24a3b3d18e26.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
