### PR TITLE
Fix generate_payment_payload function when refund data is provided

### DIFF
--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -957,11 +957,39 @@ def generate_page_payload(
     return page_payload
 
 
+def _generate_refund_data_payload(data):
+    data["order_lines_to_refund"] = [
+        {
+            "line_id": graphene.Node.to_global_id("OrderLine", line_data["line"].pk),
+            "quantity": line_data["quantity"],
+            "variant_id": graphene.Node.to_global_id(
+                "ProductVariant", line_data["variant"].pk
+            ),
+        }
+        for line_data in data["order_lines_to_refund"]
+    ]
+    data["fulfillment_lines_to_refund"] = [
+        {
+            "line_id": graphene.Node.to_global_id(
+                "FulfillmentLine", line_data["line"].pk
+            ),
+            "quantity": line_data["quantity"],
+            "replace": line_data["replace"],
+        }
+        for line_data in data["fulfillment_lines_to_refund"]
+    ]
+    return data
+
+
 @traced_payload_generator
 def generate_payment_payload(
     payment_data: "PaymentData", requestor: Optional["RequestorOrLazyObject"] = None
 ):
     data = asdict(payment_data)
+
+    if refund_data := data.get("refund_data"):
+        data["refund_data"] = _generate_refund_data_payload(refund_data)
+
     data["amount"] = quantize_price(data["amount"], data["currency"])
     payment_app_data = from_payment_app_id(data["gateway"])
     if payment_app_data:


### PR DESCRIPTION
I want to merge this change because it fixes a bug with generating payment payload for payment webhooks events when refund data is provided.

Port of #11080

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
