### PR TITLE
Fix double encoded file urls

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -759,6 +759,11 @@ class FileUpload(BaseMutation):
 
         # add unique text fragment to the file name to prevent file overriding
         file_name, format = os.path.splitext(file_data._name)
+
+        # replace spaced with an underscore to prevent replacing the spaces with encoded
+        # values by storage
+        file_name = file_name.replace(" ", "_")
+
         hash = secrets.token_hex(nbytes=4)
         new_name = f"file_upload/{file_name}_{hash}{format}"
 

--- a/saleor/graphql/core/tests/test_file_upload.py
+++ b/saleor/graphql/core/tests/test_file_upload.py
@@ -153,3 +153,30 @@ def test_file_upload_file_with_the_same_name_already_exists(
     assert file_url != f"http://{domain}/media/{image_file._name}"
     assert file_url != f"http://{domain}/media/{path}"
     assert default_storage.exists(file_url.replace(f"http://{domain}/media/", ""))
+
+
+def test_file_upload_file_name_with_space(staff_api_client, media_root):
+    # given
+    image_file, image_name = create_image("file name with spaces")
+    variables = {"image": image_name}
+    body = get_multipart_request_body(
+        FILE_UPLOAD_MUTATION, variables, image_file, image_name
+    )
+
+    # when
+    response = staff_api_client.post_multipart(body)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["fileUpload"]
+    errors = data["errors"]
+
+    assert not errors
+    assert data["uploadedFile"]["contentType"] == "image/png"
+    file_name, format = os.path.splitext(image_file._name)
+    file_name = file_name.replace(" ", "_")
+    returned_url = data["uploadedFile"]["url"]
+    file_path = urlparse(returned_url).path
+    assert file_path.startswith(f"/media/file_upload/{file_name}")
+    assert file_path.endswith(format)
+    assert default_storage.exists(file_path.lstrip("/media"))

--- a/saleor/graphql/core/tests/test_file_upload.py
+++ b/saleor/graphql/core/tests/test_file_upload.py
@@ -180,3 +180,29 @@ def test_file_upload_file_name_with_space(staff_api_client, media_root):
     assert file_path.startswith(f"/media/file_upload/{file_name}")
     assert file_path.endswith(format)
     assert default_storage.exists(file_path.lstrip("/media"))
+
+
+def test_file_upload_file_name_with_encoded_value(staff_api_client, media_root):
+    # given
+    image_file, image_name = create_image("file%20name")
+    variables = {"image": image_name}
+    body = get_multipart_request_body(
+        FILE_UPLOAD_MUTATION, variables, image_file, image_name
+    )
+
+    # when
+    response = staff_api_client.post_multipart(body)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["fileUpload"]
+    errors = data["errors"]
+
+    assert not errors
+    assert data["uploadedFile"]["contentType"] == "image/png"
+    file_name, format = os.path.splitext(image_file._name)
+    returned_url = data["uploadedFile"]["url"]
+    file_path = urlparse(returned_url).path
+    assert file_path.startswith(f"/media/file_upload/{file_name}")
+    assert file_path.endswith(format)
+    assert default_storage.exists(file_path.lstrip("/media"))

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import graphene
 from django.core.files.storage import default_storage
@@ -448,7 +448,8 @@ class File(graphene.ObjectType):
         # check if URL is absolute:
         if urlparse(root.url).netloc:
             return root.url
-        return build_absolute_uri(default_storage.url(root.url))
+        # unquote used for preventing double URL encoding
+        return build_absolute_uri(default_storage.url(unquote(root.url)))
 
 
 class PriceInput(graphene.InputObjectType):


### PR DESCRIPTION
- Update saving files in the `FileUpload` mutation - replace spaces in the file name with an underscore.
- Unquote the file URL to prevent double encoding in the file `url` resolver.

<!-- Please mention all relevant issue numbers. -->
Fixes #11103

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
