### PR TITLE
Fix assigning rates to tax classes

### DIFF
--- a/saleor/tax/migrations/0005_migrate_vatlayer.py
+++ b/saleor/tax/migrations/0005_migrate_vatlayer.py
@@ -8,6 +8,10 @@ from django.db import migrations
 VATLAYER_ID = "mirumee.taxes.vatlayer"
 
 
+# Must be the same as in 0004_migrate_tax_class.py
+TAX_CLASS_ZERO_RATE = "No Taxes"
+
+
 def _clear_country_code(country_code: str) -> Optional[str]:
     return countries.alpha2(country_code.strip()) if country_code else None
 
@@ -61,7 +65,7 @@ def create_tax_rates(apps, use_origin_country_map):
     TaxClassCountryRate = apps.get_model("tax", "TaxClassCountryRate")
     VAT = apps.get_model("django_prices_vatlayer", "VAT")
 
-    tax_classes = TaxClass.objects.all()
+    tax_classes = TaxClass.objects.exclude(name=TAX_CLASS_ZERO_RATE)
     vat_rates = VAT.objects.all()
 
     rates = {}


### PR DESCRIPTION
Migration that creates tax rates for countries were not excluding the "No taxes" tax class, as a result trying to override zero rates with different values. Now the "No taxes" class is skipped.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
