### PR TITLE
Fix double encoded file urls

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -831,6 +831,11 @@ class FileUpload(BaseMutation):
 
         # add unique text fragment to the file name to prevent file overriding
         file_name, format = os.path.splitext(file_data._name)
+
+        # replace spaced with an underscore to prevent replacing the spaces with encoded
+        # values by storage
+        file_name = file_name.replace(" ", "_")
+
         hash = secrets.token_hex(nbytes=4)
         new_name = f"file_upload/{file_name}_{hash}{format}"
 

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import graphene
 from django.core.files.storage import default_storage
@@ -440,7 +440,8 @@ class File(graphene.ObjectType):
         # check if URL is absolute:
         if urlparse(root.url).netloc:
             return root.url
-        return build_absolute_uri(default_storage.url(root.url))
+        # unquote used for preventing double URL encoding
+        return build_absolute_uri(default_storage.url(unquote(root.url)))
 
 
 class PriceInput(graphene.InputObjectType):


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/11104

- Update saving files in the `FileUpload` mutation - replace spaces in the file name with an underscore.
- Unquote the file URL to prevent double encoding in the file `url` resolver.
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
