### PR TITLE
Fix using tax code from product and product type's tax class

### DIFF
--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -26,6 +26,7 @@ from ...warehouse.models import Warehouse
 if TYPE_CHECKING:
     from ...checkout.fetch import CheckoutInfo, CheckoutLineInfo
     from ...order.models import Order
+    from ...product.models import Product, ProductType
     from ...tax.models import TaxClass
 
 
@@ -281,17 +282,9 @@ def generate_request_data_from_checkout_lines(
     )
 
     for line_info in lines_info:
-        tax_code = None
         product = line_info.product
         product_type = line_info.product_type
-
-        if product.tax_class:
-            tax_code = retrieve_tax_code_from_meta(product.tax_class, default=None)
-        elif product_type.tax_class:
-            tax_code = retrieve_tax_code_from_meta(product_type.tax_class)
-        else:
-            tax_code = DEFAULT_TAX_CODE
-
+        tax_code = _get_product_tax_code(product, product_type)
         is_non_taxable_product = tax_code == TAX_CODE_NON_TAXABLE_PRODUCT
 
         tax_override_data = {}
@@ -380,17 +373,10 @@ def get_order_lines_data(
     for line in lines:
         if not line.variant:
             continue
+
         product = line.variant.product
         product_type = line.variant.product.product_type
-
-        tax_code = None
-        if product.tax_class:
-            tax_code = retrieve_tax_code_from_meta(product.tax_class, default=None)
-        elif product_type.tax_class:
-            tax_code = retrieve_tax_code_from_meta(product_type.tax_class)
-        else:
-            tax_code = DEFAULT_TAX_CODE
-
+        tax_code = _get_product_tax_code(product, product_type)
         prices_data = base_order_calculations.base_order_line_total(line)
 
         if prices_entered_with_tax:
@@ -666,6 +652,17 @@ def get_cached_tax_codes_or_fetch(
             tax_codes = generate_tax_codes_dict(response)
             cache.set(TAX_CODES_CACHE_KEY, tax_codes, cache_time)
     return tax_codes
+
+
+def _get_product_tax_code(product: "Product", product_type: "ProductType"):
+    tax_code = None
+    if product.tax_class:
+        tax_code = retrieve_tax_code_from_meta(product.tax_class, default=None)
+    elif product_type.tax_class:
+        tax_code = retrieve_tax_code_from_meta(product_type.tax_class)
+    else:
+        tax_code = DEFAULT_TAX_CODE
+    return tax_code
 
 
 def retrieve_tax_code_from_meta(

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3842,13 +3842,20 @@ def recalculate_order(order):
 
 @pytest.fixture
 def order_with_lines(
-    order, product_type, category, shipping_zone, warehouse, channel_USD
+    order,
+    product_type,
+    category,
+    shipping_zone,
+    warehouse,
+    channel_USD,
+    default_tax_class,
 ):
     product = Product.objects.create(
         name="Test product",
         slug="test-product-8",
         product_type=product_type,
         category=category,
+        tax_class=default_tax_class,
     )
     ProductChannelListing.objects.create(
         product=product,


### PR DESCRIPTION
Fix Avalara to use tax code from product's or product type's tax class.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
