### PR TITLE
Allow all staff users and apps read tax data

### DIFF
--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -11,10 +11,8 @@ from promise import Promise
 from ....attribute import models as attribute_models
 from ....core.permissions import (
     AuthorizationFilters,
-    CheckoutPermissions,
     OrderPermissions,
     ProductPermissions,
-    ProductTypePermissions,
     has_one_of_permissions,
 )
 from ....core.tracing import traced_resolver
@@ -938,10 +936,7 @@ class Product(ChannelContextTypeWithMetadata, ModelObjectType):
             "type use this tax class, unless it's overridden in the `Product` type."
         ),
         required=False,
-        permissions=[
-            CheckoutPermissions.MANAGE_TAXES,
-            ProductPermissions.MANAGE_PRODUCTS,
-        ],
+        permissions=[AuthorizationFilters.AUTHENTICATED_STAFF_USER],
     )
 
     class Meta:
@@ -1509,11 +1504,7 @@ class ProductType(ModelObjectType):
             "type use this tax class, unless it's overridden in the `Product` type."
         ),
         required=False,
-        permissions=[
-            CheckoutPermissions.MANAGE_TAXES,
-            ProductPermissions.MANAGE_PRODUCTS,
-            ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
-        ],
+        permissions=[AuthorizationFilters.AUTHENTICATED_STAFF_USER],
     )
     variant_attributes = NonNullList(
         Attribute,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -102,7 +102,7 @@ type Query {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires one of the following permissions: MANAGE_TAXES.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxConfiguration(
     """ID of a tax configuration."""
@@ -116,7 +116,7 @@ type Query {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires one of the following permissions: MANAGE_TAXES.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxConfigurations(
     """Filtering options for tax configurations."""
@@ -142,7 +142,7 @@ type Query {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires one of the following permissions: MANAGE_TAXES.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass(
     """ID of a tax class."""
@@ -156,7 +156,7 @@ type Query {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires one of the following permissions: MANAGE_TAXES.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClasses(
     """Sort tax classes."""
@@ -181,14 +181,14 @@ type Query {
   """
   Tax class rates grouped by country.
   
-  Requires one of the following permissions: MANAGE_TAXES.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxCountryConfiguration(
     """Country for which to return tax class rates."""
     countryCode: CountryCode!
   ): TaxCountryConfiguration
 
-  "\\n\\nRequires one of the following permissions: MANAGE_TAXES."
+  "\\n\\nRequires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP."
   taxCountryConfigurations: [TaxCountryConfiguration!]
 
   """
@@ -4859,7 +4859,7 @@ type Product implements Node & ObjectWithMetadata {
   """
   Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
   
-  Requires one of the following permissions: MANAGE_TAXES, MANAGE_PRODUCTS.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
   taxClass: TaxClass
 }
@@ -4949,7 +4949,7 @@ type ProductType implements Node & ObjectWithMetadata {
   """
   Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
   
-  Requires one of the following permissions: MANAGE_TAXES, MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
   """
   taxClass: TaxClass
 

--- a/saleor/graphql/tax/schema.py
+++ b/saleor/graphql/tax/schema.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import graphene
 from django_countries.fields import Country
 
-from ...core.permissions.enums import CheckoutPermissions
+from ...core.permissions import AuthorizationFilters
 from ...tax import models
 from ..account.enums import CountryCodeEnum
 from ..core.connection import create_connection_slice, filter_connection_queryset
@@ -38,7 +38,10 @@ class TaxQueries(graphene.ObjectType):
         id=graphene.Argument(
             graphene.ID, description="ID of a tax configuration.", required=True
         ),
-        permissions=[CheckoutPermissions.MANAGE_TAXES],
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        ],
     )
     tax_configurations = FilterConnectionField(
         TaxConfigurationCountableConnection,
@@ -46,7 +49,10 @@ class TaxQueries(graphene.ObjectType):
         filter=TaxConfigurationFilterInput(
             description="Filtering options for tax configurations."
         ),
-        permissions=[CheckoutPermissions.MANAGE_TAXES],
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        ],
     )
     tax_class = PermissionsField(
         TaxClass,
@@ -54,14 +60,20 @@ class TaxQueries(graphene.ObjectType):
         id=graphene.Argument(
             graphene.ID, description="ID of a tax class.", required=True
         ),
-        permissions=[CheckoutPermissions.MANAGE_TAXES],
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        ],
     )
     tax_classes = FilterConnectionField(
         TaxClassCountableConnection,
         description="List of tax classes." + ADDED_IN_39 + PREVIEW_FEATURE,
         sort_by=TaxClassSortingInput(description="Sort tax classes."),
         filter=TaxClassFilterInput(description="Filtering options for tax classes."),
-        permissions=[CheckoutPermissions.MANAGE_TAXES],
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        ],
     )
     tax_country_configuration = PermissionsField(
         TaxCountryConfiguration,
@@ -71,7 +83,10 @@ class TaxQueries(graphene.ObjectType):
             required=True,
         ),
         description="Tax class rates grouped by country.",
-        permissions=[CheckoutPermissions.MANAGE_TAXES],
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        ],
     )
     tax_country_configurations = PermissionsField(
         NonNullList(
@@ -79,7 +94,10 @@ class TaxQueries(graphene.ObjectType):
             description="A list of countries with grouped tax class rates.",
             required=True,
         ),
-        permissions=[CheckoutPermissions.MANAGE_TAXES],
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        ],
     )
 
     @staticmethod

--- a/saleor/graphql/tax/tests/fragments.py
+++ b/saleor/graphql/tax/tests/fragments.py
@@ -22,10 +22,6 @@ TAX_CONFIGURATION_FRAGMENT = """
       key
       value
     }
-    privateMetadata {
-      key
-      value
-    }
   }
 """
 
@@ -42,10 +38,6 @@ TAX_CLASS_FRAGMENT = """
       rate
     }
     metadata {
-      key
-      value
-    }
-    privateMetadata {
       key
       value
     }

--- a/saleor/graphql/tax/tests/queries/test_tax_classes.py
+++ b/saleor/graphql/tax/tests/queries/test_tax_classes.py
@@ -22,22 +22,20 @@ QUERY = (
 )
 
 
-def test_tax_classes_query_no_permissions(staff_api_client):
+def test_tax_classes_query_no_permissions(user_api_client):
     # when
-    response = staff_api_client.post_graphql(QUERY, {}, permissions=[])
+    response = user_api_client.post_graphql(QUERY, {}, permissions=[])
 
     # then
     assert_no_permission(response)
 
 
-def test_tax_classes_query_staff_user(staff_api_client, permission_manage_taxes):
+def test_tax_classes_query_staff_user(staff_api_client):
     # given
     total_count = TaxClass.objects.count()
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY, {}, permissions=[permission_manage_taxes]
-    )
+    response = staff_api_client.post_graphql(QUERY, {})
 
     # then
     content = get_graphql_content(response)
@@ -47,14 +45,12 @@ def test_tax_classes_query_staff_user(staff_api_client, permission_manage_taxes)
     assert edges[0]["node"]
 
 
-def test_tax_classes_query_app(app_api_client, permission_manage_taxes):
+def test_tax_classes_query_app(app_api_client):
     # given
     total_count = TaxClass.objects.count()
 
     # when
-    response = app_api_client.post_graphql(
-        QUERY, {}, permissions=[permission_manage_taxes]
-    )
+    response = app_api_client.post_graphql(QUERY, {})
 
     # then
     content = get_graphql_content(response)
@@ -64,15 +60,13 @@ def test_tax_classes_query_app(app_api_client, permission_manage_taxes):
     assert edges[0]["node"]
 
 
-def test_tax_classes_filter_by_ids(staff_api_client, permission_manage_taxes):
+def test_tax_classes_filter_by_ids(staff_api_client):
     # given
     id = graphene.Node.to_global_id("TaxClass", TaxClass.objects.first().pk)
     ids = [id]
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY, {"filter": {"ids": ids}}, permissions=[permission_manage_taxes]
-    )
+    response = staff_api_client.post_graphql(QUERY, {"filter": {"ids": ids}})
 
     # then
     content = get_graphql_content(response)
@@ -82,16 +76,12 @@ def test_tax_classes_filter_by_ids(staff_api_client, permission_manage_taxes):
 
 
 @pytest.mark.parametrize("country, count", [("PL", 1), ("US", 0)])
-def test_tax_classes_filter_by_countries(
-    country, count, staff_api_client, permission_manage_taxes
-):
+def test_tax_classes_filter_by_countries(country, count, staff_api_client):
     # given
     filter = {"filter": {"countries": [country]}}
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY, filter, permissions=[permission_manage_taxes]
-    )
+    response = staff_api_client.post_graphql(QUERY, filter)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/tax/tests/queries/test_tax_configurations.py
+++ b/saleor/graphql/tax/tests/queries/test_tax_configurations.py
@@ -21,24 +21,20 @@ QUERY = (
 )
 
 
-def test_tax_configurations_query_no_permissions(channel_USD, staff_api_client):
+def test_tax_configurations_query_no_permissions(channel_USD, user_api_client):
     # when
-    response = staff_api_client.post_graphql(QUERY, {}, permissions=[])
+    response = user_api_client.post_graphql(QUERY, {}, permissions=[])
 
     # then
     assert_no_permission(response)
 
 
-def test_tax_configurations_query_staff_user(
-    channel_USD, staff_api_client, permission_manage_taxes
-):
+def test_tax_configurations_query_staff_user(channel_USD, staff_api_client):
     # given
     total_count = TaxConfiguration.objects.count()
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY, {}, permissions=[permission_manage_taxes]
-    )
+    response = staff_api_client.post_graphql(QUERY, {})
 
     # then
     content = get_graphql_content(response)
@@ -48,16 +44,12 @@ def test_tax_configurations_query_staff_user(
     assert edges[0]["node"]
 
 
-def test_tax_configurations_query_app(
-    channel_USD, app_api_client, permission_manage_taxes
-):
+def test_tax_configurations_query_app(channel_USD, app_api_client):
     # given
     total_count = TaxConfiguration.objects.count()
 
     # when
-    response = app_api_client.post_graphql(
-        QUERY, {}, permissions=[permission_manage_taxes]
-    )
+    response = app_api_client.post_graphql(QUERY, {})
 
     # then
     content = get_graphql_content(response)
@@ -67,9 +59,7 @@ def test_tax_configurations_query_app(
     assert edges[0]["node"]
 
 
-def test_tax_configurations_filter(
-    channel_USD, staff_api_client, permission_manage_taxes
-):
+def test_tax_configurations_filter(channel_USD, staff_api_client):
     # given
     id = graphene.Node.to_global_id(
         "TaxConfiguration", TaxConfiguration.objects.first().pk
@@ -77,9 +67,7 @@ def test_tax_configurations_filter(
     ids = [id]
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY, {"ids": ids}, permissions=[permission_manage_taxes]
-    )
+    response = staff_api_client.post_graphql(QUERY, {"ids": ids})
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/tax/tests/queries/test_tax_country_configuration.py
+++ b/saleor/graphql/tax/tests/queries/test_tax_country_configuration.py
@@ -41,12 +41,12 @@ def _test_field_resolvers(
         assert expected_rate_data in data["taxClassCountryRates"]
 
 
-def test_tax_country_configuration_query_no_permissions(staff_api_client):
+def test_tax_country_configuration_query_no_permissions(user_api_client):
     # given
     country_code = "PL"
 
     # when
-    response = staff_api_client.post_graphql(
+    response = user_api_client.post_graphql(
         QUERY, {"countryCode": country_code}, permissions=[]
     )
 
@@ -54,17 +54,13 @@ def test_tax_country_configuration_query_no_permissions(staff_api_client):
     assert_no_permission(response)
 
 
-def test_tax_country_configuration_query_staff_user(
-    staff_api_client, permission_manage_taxes
-):
+def test_tax_country_configuration_query_staff_user(staff_api_client):
     # given
     country_code = "PL"
     country_rates = TaxClassCountryRate.objects.filter(country="PL")
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY, {"countryCode": country_code}, permissions=[permission_manage_taxes]
-    )
+    response = staff_api_client.post_graphql(QUERY, {"countryCode": country_code})
 
     # then
     content = get_graphql_content(response)
@@ -73,15 +69,13 @@ def test_tax_country_configuration_query_staff_user(
     )
 
 
-def test_tax_country_configuration_query_app(app_api_client, permission_manage_taxes):
+def test_tax_country_configuration_query_app(app_api_client):
     # given
     country_code = "PL"
     country_rates = TaxClassCountryRate.objects.filter(country="PL")
 
     # when
-    response = app_api_client.post_graphql(
-        QUERY, {"countryCode": country_code}, permissions=[permission_manage_taxes]
-    )
+    response = app_api_client.post_graphql(QUERY, {"countryCode": country_code})
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/tax/tests/queries/test_tax_country_configurations.py
+++ b/saleor/graphql/tax/tests/queries/test_tax_country_configurations.py
@@ -20,32 +20,26 @@ def _test_field_resolvers(data: dict):
     assert len(data["taxCountryConfigurations"]) == len(configured_countries)
 
 
-def test_tax_country_configurations_query_no_permissions(staff_api_client):
+def test_tax_country_configurations_query_no_permissions(user_api_client):
     # when
-    response = staff_api_client.post_graphql(QUERY, {}, permissions=[])
+    response = user_api_client.post_graphql(QUERY, {}, permissions=[])
 
     # then
     assert_no_permission(response)
 
 
-def test_tax_country_configurations_query_staff_user(
-    staff_api_client, permission_manage_taxes
-):
+def test_tax_country_configurations_query_staff_user(staff_api_client):
     # when
-    response = staff_api_client.post_graphql(
-        QUERY, {}, permissions=[permission_manage_taxes]
-    )
+    response = staff_api_client.post_graphql(QUERY, {})
 
     # then
     content = get_graphql_content(response)
     _test_field_resolvers(content["data"])
 
 
-def test_tax_country_configurations_query_app(app_api_client, permission_manage_taxes):
+def test_tax_country_configurations_query_app(app_api_client):
     # when
-    response = app_api_client.post_graphql(
-        QUERY, {}, permissions=[permission_manage_taxes]
-    )
+    response = app_api_client.post_graphql(QUERY, {})
 
     # then
     content = get_graphql_content(response)

--- a/saleor/tax/tests/fixtures.py
+++ b/saleor/tax/tests/fixtures.py
@@ -19,6 +19,10 @@ def default_tax_class(db):
                 META_CODE_KEY: DEFAULT_TAX_CODE,
                 META_DESCRIPTION_KEY: "Default tax code",
             },
+            "private_metadata": {
+                META_CODE_KEY: DEFAULT_TAX_CODE,
+                META_DESCRIPTION_KEY: "Default tax code",
+            },
         },
     )
     TaxClassCountryRate.objects.bulk_create(


### PR DESCRIPTION
Tax classes and tax configuration should be accessible to read for any staff member or app. To manage it, MANAGE_TAXES permission is required.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
