### PR TITLE
Prevent multiple `checkoutPaymentCreate` calls and creating an order for inactive payment

### DIFF
--- a/saleor/checkout/error_codes.py
+++ b/saleor/checkout/error_codes.py
@@ -29,3 +29,4 @@ class CheckoutErrorCode(Enum):
     UNAVAILABLE_VARIANT_IN_CHANNEL = "unavailable_variant_in_channel"
     EMAIL_NOT_SET = "email_not_set"
     NO_LINES = "no_lines"
+    INACTIVE_PAYMENT = "inactive_payment"

--- a/saleor/graphql/payment/tests/mutations/test_payment_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_payment_create.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+import before_after
 import graphene
 import pytest
 
@@ -583,3 +584,46 @@ def test_checkout_add_payment_checkout_without_lines(
     assert len(errors) == 1
     assert errors[0]["field"] == "lines"
     assert errors[0]["code"] == PaymentErrorCode.NO_CHECKOUT_LINES.name
+
+
+def test_checkout_add_payment_run_multiple_times(
+    user_api_client, checkout_without_shipping_required, address
+):
+    # given
+    checkout = checkout_without_shipping_required
+    checkout.billing_address = address
+    checkout.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.checkout_total(
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
+    )
+    variables = {
+        "token": checkout.token,
+        "input": {
+            "gateway": DUMMY_GATEWAY,
+            "token": "sample-token",
+            "amount": total.gross.amount,
+        },
+    }
+
+    # call CheckoutPaymentCreate mutation during the first mutation call processing
+    def call_payment_create_mutation(*args, **kwargs):
+        user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
+
+    # when
+    with before_after.before(
+        "saleor.graphql.payment.mutations.cancel_active_payments",
+        call_payment_create_mutation,
+    ):
+        response = user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutPaymentCreate"]
+    assert not data["errors"]
+    payments = Payment.objects.filter(checkout=checkout)
+    assert payments.count() == 2
+    assert payments.filter(is_active=True).count() == 1

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1147,6 +1147,7 @@ enum CheckoutErrorCode {
   UNAVAILABLE_VARIANT_IN_CHANNEL
   EMAIL_NOT_SET
   NO_LINES
+  INACTIVE_PAYMENT
 }
 
 input CheckoutFilterInput {

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2617,7 +2617,7 @@ def product_without_shipping(category, warehouse, channel_USD):
         visible_in_listings=True,
         available_for_purchase=datetime.date(1999, 1, 1),
     )
-    variant = ProductVariant.objects.create(product=product, sku="SKU_B")
+    variant = ProductVariant.objects.create(product=product, sku="SKU_E")
     ProductVariantChannelListing.objects.create(
         variant=variant,
         channel=channel_USD,


### PR DESCRIPTION
- Add transaction for cancelation and creation of payments in `checkoutPaymentCreate`
- Ensure that payment is still active before creating the order in `complete_checkout`

<!-- Please mention all relevant issue numbers. -->
Fixes #11132, #11133

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
