### PR TITLE
Remove stock rows from lock during checkoutComplete

### DIFF
--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -1295,9 +1295,7 @@ def test_complete_checkout_0_total_captured_payment_creates_expected_events(
 
 
 @mock.patch("saleor.checkout.complete_checkout._create_order")
-@mock.patch(
-    "saleor.checkout.complete_checkout._process_payment",
-)
+@mock.patch("saleor.checkout.complete_checkout._process_payment")
 def test_complete_checkout_action_required_voucher_once_per_customer(
     mocked_process_payment,
     mocked_create_order,

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -19,7 +19,6 @@ from ....checkout.fetch import (
 from ....checkout.utils import is_shipping_required
 from ....core import analytics
 from ....core.permissions import AccountPermissions
-from ....core.transactions import transaction_with_commit_on_errors
 from ....order import models as order_models
 from ...account.i18n import I18nMixin
 from ...app.dataloaders import load_app
@@ -172,108 +171,107 @@ class CheckoutComplete(BaseMutation, I18nMixin):
         validate_one_of_args_is_in_mutation(
             CheckoutErrorCode, "checkout_id", checkout_id, "token", token, "id", id
         )
-
         tracking_code = analytics.get_client_id(info.context)
-        with transaction_with_commit_on_errors():
-            try:
-                checkout = get_checkout(
-                    cls,
-                    info,
-                    checkout_id=checkout_id,
-                    token=token,
-                    id=id,
-                    error_class=CheckoutErrorCode,
-                )
-            except ValidationError as e:
-                # DEPRECATED
-                if id or checkout_id:
-                    id = id or checkout_id
-                    token = cls.get_global_id_or_error(
-                        id, only_type=Checkout, field="id" if id else "checkout_id"
-                    )
 
-                order = order_models.Order.objects.get_by_checkout_token(token)
-                if order:
-                    if not order.channel.is_active:
-                        raise ValidationError(
-                            {
-                                "channel": ValidationError(
-                                    "Cannot complete checkout with inactive channel.",
-                                    code=CheckoutErrorCode.CHANNEL_INACTIVE.value,
-                                )
-                            }
-                        )
-                    # The order is already created. We return it as a success
-                    # checkoutComplete response. Order is anonymized for not logged in
-                    # user
-                    return CheckoutComplete(
-                        order=order, confirmation_needed=False, confirmation_data={}
-                    )
-                raise e
-
-            metadata = data.get("metadata")
-            if metadata is not None:
-                cls.check_metadata_permissions(
-                    info,
-                    id or checkout_id or graphene.Node.to_global_id("Checkout", token),
-                )
-                cls.validate_metadata_keys(metadata)
-
-            validate_checkout_email(checkout)
-
-            manager = load_plugin_manager(info.context)
-            lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
-            if unavailable_variant_pks:
-                not_available_variants_ids = {
-                    graphene.Node.to_global_id("ProductVariant", pk)
-                    for pk in unavailable_variant_pks
-                }
-                raise ValidationError(
-                    {
-                        "lines": ValidationError(
-                            "Some of the checkout lines variants are unavailable.",
-                            code=CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.value,
-                            params={"variants": not_available_variants_ids},
-                        )
-                    }
-                )
-            if not lines:
-                raise ValidationError(
-                    {
-                        "lines": ValidationError(
-                            "Cannot complete checkout without lines.",
-                            code=CheckoutErrorCode.NO_LINES.value,
-                        )
-                    }
-                )
-            discounts = load_discounts(info.context)
-            checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
-
-            cls.validate_checkout_addresses(checkout_info, lines)
-
-            requestor = get_user_or_app_from_context(info.context)
-            if requestor and requestor.has_perm(AccountPermissions.IMPERSONATE_USER):
-                # Allow impersonating user and process a checkout by using user details
-                # assigned to checkout.
-                customer = checkout.user
-            else:
-                customer = info.context.user
-
-            site = get_site_promise(info.context).get()
-            order, action_required, action_data = complete_checkout(
-                manager=manager,
-                checkout_info=checkout_info,
-                lines=lines,
-                payment_data=data.get("payment_data", {}),
-                store_source=store_source,
-                discounts=discounts,
-                user=customer,
-                app=load_app(info.context),
-                site_settings=site.settings,
-                tracking_code=tracking_code,
-                redirect_url=data.get("redirect_url"),
-                metadata_list=data.get("metadata"),
+        try:
+            checkout = get_checkout(
+                cls,
+                info,
+                checkout_id=checkout_id,
+                token=token,
+                id=id,
+                error_class=CheckoutErrorCode,
             )
+        except ValidationError as e:
+            # DEPRECATED
+            if id or checkout_id:
+                id = id or checkout_id
+                token = cls.get_global_id_or_error(
+                    id, only_type=Checkout, field="id" if id else "checkout_id"
+                )
+
+            order = order_models.Order.objects.get_by_checkout_token(token)
+            if order:
+                if not order.channel.is_active:
+                    raise ValidationError(
+                        {
+                            "channel": ValidationError(
+                                "Cannot complete checkout with inactive channel.",
+                                code=CheckoutErrorCode.CHANNEL_INACTIVE.value,
+                            )
+                        }
+                    )
+                # The order is already created. We return it as a success
+                # checkoutComplete response. Order is anonymized for not logged in
+                # user
+                return CheckoutComplete(
+                    order=order, confirmation_needed=False, confirmation_data={}
+                )
+            raise e
+
+        metadata = data.get("metadata")
+        if metadata is not None:
+            cls.check_metadata_permissions(
+                info,
+                id or checkout_id or graphene.Node.to_global_id("Checkout", token),
+            )
+            cls.validate_metadata_keys(metadata)
+
+        validate_checkout_email(checkout)
+
+        manager = load_plugin_manager(info.context)
+        lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
+        if unavailable_variant_pks:
+            not_available_variants_ids = {
+                graphene.Node.to_global_id("ProductVariant", pk)
+                for pk in unavailable_variant_pks
+            }
+            raise ValidationError(
+                {
+                    "lines": ValidationError(
+                        "Some of the checkout lines variants are unavailable.",
+                        code=CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.value,
+                        params={"variants": not_available_variants_ids},
+                    )
+                }
+            )
+        if not lines:
+            raise ValidationError(
+                {
+                    "lines": ValidationError(
+                        "Cannot complete checkout without lines.",
+                        code=CheckoutErrorCode.NO_LINES.value,
+                    )
+                }
+            )
+        discounts = load_discounts(info.context)
+        checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
+
+        cls.validate_checkout_addresses(checkout_info, lines)
+
+        requestor = get_user_or_app_from_context(info.context)
+        if requestor and requestor.has_perm(AccountPermissions.IMPERSONATE_USER):
+            # Allow impersonating user and process a checkout by using user details
+            # assigned to checkout.
+            customer = checkout.user
+        else:
+            customer = info.context.user
+
+        site = get_site_promise(info.context).get()
+        order, action_required, action_data = complete_checkout(
+            manager=manager,
+            checkout_info=checkout_info,
+            lines=lines,
+            payment_data=data.get("payment_data", {}),
+            store_source=store_source,
+            discounts=discounts,
+            user=customer,
+            app=load_app(info.context),
+            site_settings=site.settings,
+            tracking_code=tracking_code,
+            redirect_url=data.get("redirect_url"),
+            metadata_list=data.get("metadata"),
+        )
         # If gateway returns information that additional steps are required we need
         # to inform the frontend and pass all required data
         return CheckoutComplete(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY, patch
 import graphene
 import pytest
 import pytz
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db.models.aggregates import Sum
 from django.utils import timezone
@@ -302,12 +303,13 @@ def test_checkout_complete(
     assert GiftCardEvent.objects.filter(
         gift_card=gift_card, type=GiftCardEvents.USED_IN_ORDER
     )
-
     assert not Checkout.objects.filter(
         pk=checkout.pk
     ).exists(), "Checkout should have been deleted"
     order_confirmed_mock.assert_called_once_with(order)
     _recalculate_order_prices_mock.assert_not_called()
+
+    assert not len(Reservation.objects.all())
 
 
 @pytest.mark.integration
@@ -1739,7 +1741,6 @@ def test_checkout_complete_payment_payment_total_different_than_checkout(
 def test_order_already_exists(
     user_api_client, checkout_ready_to_complete, payment_dummy, order_with_lines
 ):
-
     checkout = checkout_ready_to_complete
     order_with_lines.checkout_token = checkout.token
     order_with_lines.save()
@@ -3198,3 +3199,111 @@ def test_checkout_complete_with_not_normalized_billing_address(
     assert billing_address
     assert billing_address.city == "WASHINGTON"
     assert billing_address.country_area == "DC"
+
+
+@patch.object(PluginsManager, "process_payment")
+def test_checkout_complete_check_reservations_create(
+    mocked_process_payment,
+    user_api_client,
+    checkout_with_item,
+    address,
+    payment_dummy,
+    shipping_method,
+    action_required_gateway_response,
+):
+    # given
+    mocked_process_payment.return_value = action_required_gateway_response
+
+    checkout = checkout_with_item
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.checkout_total(
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
+    )
+    payment = payment_dummy
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.checkout = checkout
+    payment.save()
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "redirectUrl": "https://www.example.com",
+    }
+
+    orders_count = Order.objects.count()
+    assert not len(Reservation.objects.all())
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+    assert data["confirmationNeeded"] is True
+
+    reservations = Reservation.objects.all()
+    assert len(reservations) == 1
+    assert reservations[0].checkout_line.checkout.token == checkout.token
+    assert reservations[0].reserved_until <= timezone.now() + timedelta(
+        seconds=settings.RESERVE_DURATION
+    )
+    assert Order.objects.count() == orders_count
+
+
+def test_checkout_complete_reservations_drop(
+    site_settings,
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    payment_dummy,
+    address,
+    shipping_method,
+):
+    # given
+    assert not gift_card.last_used_on
+
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.tax_exemption = True
+    checkout.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+    site_settings.automatically_confirm_all_new_orders = True
+    site_settings.save()
+    payment = payment_dummy
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.checkout = checkout
+    payment.save()
+    assert not payment.transactions.exists()
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+    assert not len(Reservation.objects.all())

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -721,6 +721,11 @@ if (
 WEBHOOK_TIMEOUT = 10
 WEBHOOK_SYNC_TIMEOUT = 20
 
+# Since we split checkout complete logic into two separate transactions, in order to
+# mimic stock lock, we apply short reservation for the stocks. The value represents
+# time of the reservation in seconds.
+RESERVE_DURATION = 45
+
 # Initialize a simple and basic Jaeger Tracing integration
 # for open-tracing if enabled.
 #


### PR DESCRIPTION
This is a 3.8 port of https://github.com/saleor/saleor/pull/11069

I want to merge this change, because currently, when two users complete their checkouts, which contain the same product variant, the code can brake. It is result of `select … for update` statement, which apply lock for stock rows.

This PR solves the problem, by:
1. splitting transaction to have a potential long lasting payment call out of transaction (unlock stock rows)
2. add additional reservation for the short time to mimic the lock

Previous flow:
```mermaid
graph TD
    subgraph transaction 1
    A[start mutation] --> B[validate checkout]
    B --> C[check stocks availability]
    C --> D[process payment]
    D --> E[create order]
    end
```

New flow:
```mermaid
graph TD
    subgraph transaction 1
    A[start mutation] --> B[validate checkout]
    B --> C[check stocks availability]
    C --> D[create additional reservation]
    end
    D --> E[process payment]
    E --> F[validate checkout again]
    subgraph transaction 2
    F --> G[compare pre-payment and post-payment checkout]
    G --> H[create order]
    end
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
