### PR TITLE
Prevent multiple `checkoutPaymentCreate` calls and creating an order for inactive payment 

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -70,6 +70,7 @@ from .checkout_cleaner import (
     clean_checkout_shipping,
 )
 from .fetch import CheckoutInfo, CheckoutLineInfo
+from .models import Checkout
 from .utils import get_voucher_for_checkout_info
 
 if TYPE_CHECKING:
@@ -78,7 +79,6 @@ if TYPE_CHECKING:
     from ..discount.models import Voucher
     from ..plugins.manager import PluginsManager
     from ..site.models import SiteSettings
-    from .models import Checkout
 
 
 def _process_voucher_data_for_order(checkout_info: "CheckoutInfo") -> dict:
@@ -1224,9 +1224,19 @@ def complete_checkout(
         )
         reservations = _reserve_stocks_without_availability_check(checkout_info, lines)
 
+    # Fetch the checkout with a lock just to ensure that no payment is created
+    # for this checkout right now.
+    with transaction.atomic():
+        (
+            Checkout.objects.select_for_update()
+            .filter(pk=checkout_info.checkout.pk)
+            .first()
+        )
+
     # Process payments out of transaction to unlock stock rows for another user,
     # who potentially can order the same product variants.
     txn = None
+    channel_slug = checkout_info.channel.slug
     if payment:
         txn = _process_payment(
             payment=payment,
@@ -1235,8 +1245,19 @@ def complete_checkout(
             payment_data=payment_data,
             order_data=order_data,
             manager=manager,
-            channel_slug=checkout_info.channel.slug,
+            channel_slug=channel_slug,
         )
+
+        # As payment processing might take a while, we need to check if the payment
+        # doesn't become inactive in the meantime. If it's inactive we need to refund
+        # the payment.
+        payment.refresh_from_db()
+        if not payment.is_active:
+            gateway.payment_refund_or_void(payment, manager, channel_slug=channel_slug)
+            raise ValidationError(
+                f"The payment with pspReference: {payment.psp_reference} is inactive.",
+                code=CheckoutErrorCode.INACTIVE_PAYMENT.value,
+            )
 
     with transaction_with_commit_on_errors():
         # Run pre-payment checks to make sure, that nothing has changed to the

--- a/saleor/checkout/error_codes.py
+++ b/saleor/checkout/error_codes.py
@@ -29,6 +29,7 @@ class CheckoutErrorCode(Enum):
     UNAVAILABLE_VARIANT_IN_CHANNEL = "unavailable_variant_in_channel"
     EMAIL_NOT_SET = "email_not_set"
     NO_LINES = "no_lines"
+    INACTIVE_PAYMENT = "inactive_payment"
 
 
 class OrderCreateFromCheckoutErrorCode(Enum):

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from unittest.mock import ANY, patch
 
+import before_after
 import graphene
 import pytest
 import pytz
@@ -3165,3 +3166,76 @@ def test_checkout_complete_reservations_drop(
     data = content["data"]["checkoutComplete"]
     assert not data["errors"]
     assert not len(Reservation.objects.all())
+
+
+@pytest.mark.django_db(transaction=True)
+def test_checkout_complete_payment_create_create_run_in_meantime(
+    site_settings,
+    user_api_client,
+    checkout_without_shipping_required,
+    gift_card,
+    payment_dummy,
+    address,
+    shipping_method,
+):
+    # given
+    checkout = checkout_without_shipping_required
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.store_value_in_metadata(items={"accepted": "true"})
+    checkout.store_value_in_private_metadata(items={"accepted": "false"})
+    checkout.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+    site_settings.automatically_confirm_all_new_orders = True
+    site_settings.save()
+    payment = payment_dummy
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.checkout = checkout
+    payment.save()
+    assert not payment.transactions.exists()
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # Call CheckoutPaymentCreate mutation during the CheckoutComplete call processing.
+    # It should cause deactivation of current payment and creation of new one.
+    def call_payment_create_mutation(*args, **kwargs):
+        from ....payment.tests.mutations.test_checkout_payment_create import (
+            CREATE_PAYMENT_MUTATION,
+            DUMMY_GATEWAY,
+        )
+
+        variables = {
+            "id": to_global_id_or_none(checkout),
+            "input": {
+                "gateway": DUMMY_GATEWAY,
+                "token": "sample-token",
+                "amount": total.gross.amount,
+            },
+        }
+
+        user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
+
+    # when
+    with before_after.before(
+        "saleor.checkout.complete_checkout._get_order_data",
+        call_payment_create_mutation,
+    ):
+        response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == CheckoutErrorCode.INACTIVE_PAYMENT.name

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -19496,6 +19496,7 @@ enum CheckoutErrorCode {
   UNAVAILABLE_VARIANT_IN_CHANNEL
   EMAIL_NOT_SET
   NO_LINES
+  INACTIVE_PAYMENT
 }
 
 """Update billing address in the existing checkout."""

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2808,7 +2808,7 @@ def product_without_shipping(category, warehouse, channel_USD):
         visible_in_listings=True,
         available_for_purchase_at=datetime.datetime(1999, 1, 1, tzinfo=pytz.UTC),
     )
-    variant = ProductVariant.objects.create(product=product, sku="SKU_B")
+    variant = ProductVariant.objects.create(product=product, sku="SKU_E")
     ProductVariantChannelListing.objects.create(
         variant=variant,
         channel=channel_USD,


### PR DESCRIPTION
- Add transaction for cancelation and creation of payments in `checkoutPaymentCreate`
- Ensure that payment is still active before creating the order in `complete_checkout`

Port of #11139

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
