### PR TITLE
Add changelog checker to github workflows

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,20 @@
+name: "Changelog check"
+on:
+  pull_request:
+    branches:
+      - 'main'
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
+    # as defined in the (optional) "skipLabels" property.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@83e1e992a730c447cca6e9ecf8e7b21cb9a7463e
+      with:
+        skipLabels: "skip changelog,dependencies,rfc"

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
     - uses: dangoslen/changelog-enforcer@83e1e992a730c447cca6e9ecf8e7b21cb9a7463e
       with:
-        skipLabels: "skip changelog,dependencies,rfc"
+        skipLabels: "skip changelog,dependencies,bot"


### PR DESCRIPTION
I want to merge this change because this github workflow will ensure that changelog is being updated when needed.
For now it is skipped for PRs labeled:
`skip changelog` - new label that will explicitly skip this workflow (will be added after merging this PR)
`dependencies` - We don't need changelog checked for bumping dependencies 
`bot` - for PRs added by bot (dependencies) 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
