### PR TITLE
Optimize memory usage of delete_expired_checkouts task

### DIFF
--- a/saleor/checkout/tasks.py
+++ b/saleor/checkout/tasks.py
@@ -8,6 +8,21 @@ from .models import Checkout
 
 task_logger = get_task_logger(__name__)
 
+# Batch size of 2000 is about ~27MB of memory usage in task.
+CHECKOUT_BATCH_SIZE = 2000
+
+
+def _batch_tokens(iterable, batch_size=1):
+    length = len(iterable)
+    for index in range(0, length, batch_size):
+        yield iterable[index : min(index + batch_size, length)]  # noqa: E203
+
+
+def queryset_in_batches(queryset):
+    tokens = queryset.values_list("token", flat=True)
+    for tokens_batch in _batch_tokens(tokens, CHECKOUT_BATCH_SIZE):
+        yield tokens_batch
+
 
 @app.task
 def delete_expired_checkouts():
@@ -23,8 +38,14 @@ def delete_expired_checkouts():
     empty_checkouts = Q(lines__isnull=True) & Q(
         last_change__lt=now - settings.EMPTY_CHECKOUTS_TIMEDELTA
     )
-    count, _ = Checkout.objects.filter(
+    qs = Checkout.objects.filter(
         empty_checkouts | expired_anonymous_checkouts | expired_user_checkout
-    ).delete()
-    if count:
-        task_logger.debug("Removed %s checkouts.", count)
+    )
+
+    deleted_count = 0
+    for tokens_batch in queryset_in_batches(qs):
+        batch_count, _ = Checkout.objects.filter(token__in=tokens_batch).delete()
+        deleted_count += batch_count
+
+    if deleted_count:
+        task_logger.debug("Removed %s checkouts.", deleted_count)


### PR DESCRIPTION
:information_source: This is a 3.5 port of https://github.com/saleor/saleor/pull/11175

I want to merge this change because it optimizes memory usage of delete_expired_checkouts task.

Memory usage :chart_with_upwards_trend:
Before: 604MB (200k objects, no batching), exec time: 25.22s
After: 27MB (200k objects, 2k batches), exec time: 23.16s

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
