### PR TITLE
Optimize order image payload generation

### DIFF
--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -13,8 +13,8 @@ from ..discount import OrderDiscountType
 from ..graphql.core.utils import to_global_id_or_none
 from ..product import ProductMediaTypes
 from ..product.models import DigitalContentUrl, Product, ProductMedia, ProductVariant
-from ..product.product_images import get_product_image_thumbnail_url
 from ..thumbnail import THUMBNAIL_SIZES
+from ..thumbnail.utils import get_image_or_proxy_url
 from .models import FulfillmentLine, Order, OrderLine
 
 if TYPE_CHECKING:
@@ -24,7 +24,10 @@ if TYPE_CHECKING:
 
 def get_image_payload(instance: ProductMedia):
     return {
-        size: get_product_image_thumbnail_url(instance, size)
+        # This is temporary solution, the get_product_image_thumbnail_url
+        # should be optimize - we should fetch all thumbnails at once instead of
+        # fetching thumbnails by one for each size
+        size: get_image_or_proxy_url(None, instance.id, "ProductMedia", size, None)
         for size in THUMBNAIL_SIZES
     }
 

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -666,9 +666,7 @@ def test_get_default_images_payload(product_with_image):
     thumbnail_mock.name = "thumbnail_image.jpg"
 
     media = product_with_image.media.first()
-    thumbnail = Thumbnail.objects.create(
-        product_media=media, image=thumbnail_mock, size=size
-    )
+    Thumbnail.objects.create(product_media=media, image=thumbnail_mock, size=size)
 
     media_id = graphene.Node.to_global_id("ProductMedia", media.id)
 
@@ -677,7 +675,5 @@ def test_get_default_images_payload(product_with_image):
 
     # then
     images_payload = payload["first_image"]["original"]
-    assert images_payload[size] == thumbnail.image.url
     for th_size in THUMBNAIL_SIZES:
-        if th_size != size:
-            assert images_payload[th_size] == f"/thumbnail/{media_id}/{th_size}/"
+        assert images_payload[th_size] == f"/thumbnail/{media_id}/{th_size}/"


### PR DESCRIPTION
This is a temporary solution to prevent doing many single requests to db.
The order image payload will always return the proxy url.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
