### PR TITLE
Optimize disk IOPS on attribute value update

### DIFF
--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import graphene
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
-from django.db.models import Exists, OuterRef, Q, Subquery
+from django.db.models import Exists, OuterRef, Q
 from django.utils.text import slugify
 from text_unidecode import unidecode
 
@@ -29,6 +29,7 @@ from ..core.utils.reordering import perform_reordering
 from .descriptions import AttributeDescriptions, AttributeValueDescriptions
 from .enums import AttributeEntityTypeEnum, AttributeInputTypeEnum, AttributeTypeEnum
 from .types import Attribute, AttributeValue
+from .utils import queryset_in_batches
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
@@ -757,22 +758,25 @@ class AttributeValueUpdate(AttributeValueCreate):
             qs = (
                 product_models.Product.objects.select_for_update(of=("self",))
                 .filter(
-                    Q(
-                        Exists(
-                            instance.productassignments.filter(
-                                product_id=OuterRef("id")
+                    Q(search_index_dirty=False)
+                    & (
+                        Q(
+                            Exists(
+                                instance.productassignments.filter(
+                                    product_id=OuterRef("id")
+                                )
                             )
                         )
+                        | Q(Exists(variants.filter(product_id=OuterRef("id"))))
                     )
-                    | Q(Exists(variants.filter(product_id=OuterRef("id"))))
                 )
                 .order_by("pk")
             )
-            # qs is executed in a subquery to make sure the SELECT statement gets
-            # properly evaluated and locks the rows in the same order every time.
-            product_models.Product.objects.filter(
-                pk__in=Subquery(qs.values("pk"))
-            ).update(search_index_dirty=True)
+            PRODUCTS_BATCH_SIZE = 10000
+            for batch_pks in queryset_in_batches(qs, PRODUCTS_BATCH_SIZE):
+                product_models.Product.objects.filter(pk__in=batch_pks).update(
+                    search_index_dirty=True
+                )
 
         info.context.plugins.attribute_value_updated(instance)
         info.context.plugins.attribute_updated(instance.attribute)

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -892,3 +892,22 @@ def prepare_error_list_from_error_attribute_mapping(
         errors.append(error)
 
     return errors
+
+
+def queryset_in_batches(queryset, batch_size):
+    """Slice a queryset into batches.
+
+    Input queryset should be sorted be pk.
+    """
+    start_pk = 0
+
+    while True:
+        qs = queryset.filter(pk__gt=start_pk)[:batch_size]
+        pks = list(qs.values_list("pk", flat=True))
+
+        if not pks:
+            break
+
+        yield pks
+
+        start_pk = pks[-1]


### PR DESCRIPTION
:information_source: This is a 3.7 port of https://github.com/saleor/saleor/pull/11232
I want to merge this change because it optimizes query on attribute value update to not rely on the disk cache.

Optimizes two things:

Postgres no longer keeps the hashtable in memory which caused it to cross the limit and start using the disk cache.
Only update the rows that had `search_index_dirty` as `False`, limiting the affected rows count drastically.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
