### PR TITLE
Revert api changes for `checkoutLinesAdd.lines` and `PageFilterInput.ids`

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -11,7 +11,7 @@ from ....warehouse.reservations import get_reservation_length, is_reservation_en
 from ...core.descriptions import DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
-from ...core.types import CheckoutError, NonNullList
+from ...core.types import CheckoutError
 from ...core.validators import (
     validate_one_of_args_is_in_mutation,
     validate_variants_available_in_channel,
@@ -41,7 +41,7 @@ class CheckoutLinesAdd(BaseMutation):
             required=False,
         )
         token = UUID(description="Checkout token.", required=False)
-        lines = NonNullList(
+        lines = graphene.List(
             CheckoutLineInput,
             required=True,
             description=(

--- a/saleor/graphql/core/types/filter_input.py
+++ b/saleor/graphql/core/types/filter_input.py
@@ -1,5 +1,6 @@
 import itertools
 
+import graphene
 from django.db import models
 from django_filters.filterset import FILTER_FOR_DBFIELD_DEFAULTS, BaseFilterSet
 from graphene import Argument, InputField, InputObjectType, String
@@ -80,7 +81,14 @@ class FilterInputObjectType(InputObjectType):
             if input_class:
                 field_type = convert_form_field(filter_field)
             else:
-                field_type = convert_form_field(filter_field.field)
+                # ensure backward compatibility for filtering pages by id
+                if (
+                    cls.custom_filterset_class.__name__ == "PageFilter"
+                    and name == "ids"
+                ):
+                    field_type = graphene.List(graphene.ID, filter_field.field.required)
+                else:
+                    field_type = convert_form_field(filter_field.field)
                 field_type.description = getattr(filter_field, "help_text", "")
             kwargs = getattr(field_type, "kwargs", {})
             field_type.kwargs = kwargs

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -8380,7 +8380,7 @@ input PageFilterInput {
   search: String
   metadata: [MetadataFilter!]
   pageTypes: [ID!]
-  ids: [ID!]
+  ids: [ID]
 }
 
 type PageTypeCountableConnection {
@@ -11282,7 +11282,7 @@ type Mutation {
     """
     A list of checkout lines, each containing information about an item in the checkout.
     """
-    lines: [CheckoutLineInput!]!
+    lines: [CheckoutLineInput]!
 
     """Checkout token."""
     token: UUID


### PR DESCRIPTION
Reverte changes that were made in https://github.com/saleor/saleor/pull/9391 for `PageFilterInput.ids` and `checkoutLinesAdd.lines`.

Port of #11244

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
