### PR TITLE
Add exif image validation

### DIFF
--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -26,7 +26,7 @@ from ...account.enums import AddressTypeEnum
 from ...account.types import Address, AddressInput, User
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ...core.types import AccountError, NonNullList, StaffError, Upload
-from ...core.utils import add_hash_to_file_name, validate_image_file
+from ...core.validators.file import clean_image_file
 from ...utils.validators import check_for_duplicates
 from ..utils import (
     CustomerDeleteMixin,
@@ -642,11 +642,10 @@ class UserAvatarUpdate(BaseMutation):
         permissions = (AuthorizationFilters.AUTHENTICATED_STAFF_USER,)
 
     @classmethod
-    def perform_mutation(cls, _root, info, image):
+    def perform_mutation(cls, _root, info, **data):
         user = info.context.user
-        image_data = info.context.FILES.get(image)
-        validate_image_file(image_data, "image", AccountErrorCode)
-        add_hash_to_file_name(image_data)
+        data["image"] = info.context.FILES.get(data["image"])
+        image_data = clean_image_file(data, "image", AccountErrorCode)
         if user.avatar:
             user.avatar.delete()
             thumbnail_models.Thumbnail.objects.filter(user_id=user.id).delete()

--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -24,8 +24,8 @@ from ..core.fields import JSONString
 from ..core.inputs import ReorderInput
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types import AttributeError, NonNullList
-from ..core.utils import validate_slug_and_generate_if_needed
 from ..core.utils.reordering import perform_reordering
+from ..core.validators import validate_slug_and_generate_if_needed
 from .descriptions import AttributeDescriptions, AttributeValueDescriptions
 from .enums import AttributeEntityTypeEnum, AttributeInputTypeEnum, AttributeTypeEnum
 from .types import Attribute, AttributeValue

--- a/saleor/graphql/core/tests/test_core.py
+++ b/saleor/graphql/core/tests/test_core.py
@@ -1,23 +1,19 @@
 import enum
 import os
-from io import BytesIO
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import django_filters
 import graphene
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
 from graphene import InputField
 from micawber import ProviderException, ProviderRegistry
-from PIL import Image
 
 from ....core.utils.validators import get_oembed_data
 from ....product import ProductMediaTypes
-from ....product.error_codes import ProductErrorCode
-from ....product.models import Category, Product, ProductChannelListing
+from ....product.models import Product, ProductChannelListing
 from ...tests.utils import get_graphql_content, get_graphql_content_from_response
 from ...utils import requestor_is_superuser
 from ...utils.filters import filter_range_field, reporting_period_to_date
@@ -25,28 +21,8 @@ from ..enums import ReportingPeriod
 from ..filters import EnumFilter
 from ..mutations import BaseMutation
 from ..types import FilterInputObjectType
-from ..utils import (
-    add_hash_to_file_name,
-    clean_seo_fields,
-    get_duplicated_values,
-    get_filename_from_url,
-    is_image_mimetype,
-    is_supported_image_mimetype,
-    snake_to_camel_case,
-    validate_image_file,
-    validate_image_url,
-    validate_slug_and_generate_if_needed,
-)
+from ..utils import add_hash_to_file_name, get_duplicated_values, snake_to_camel_case
 from . import ErrorTest
-
-
-def test_clean_seo_fields():
-    title = "lady title"
-    description = "fantasy description"
-    data = {"seo": {"title": title, "description": description}}
-    clean_seo_fields(data)
-    assert data["seo_title"] == title
-    assert data["seo_description"] == description
 
 
 def test_user_error_field_name_for_related_object(
@@ -204,269 +180,6 @@ def test_mutation_invalid_permission_in_meta(_mocked, should_fail, permissions_v
 
     with pytest.raises(ImproperlyConfigured):
         _run_test()
-
-
-@pytest.mark.parametrize(
-    "cleaned_input",
-    [
-        {"slug": None, "name": "test"},
-        {"slug": "", "name": "test"},
-        {"slug": ""},
-        {"slug": None},
-    ],
-)
-def test_validate_slug_and_generate_if_needed_raises_errors(category, cleaned_input):
-    with pytest.raises(ValidationError):
-        validate_slug_and_generate_if_needed(category, "name", cleaned_input)
-
-
-@pytest.mark.parametrize(
-    "cleaned_input", [{"slug": "test-slug"}, {"slug": "test-slug", "name": "test"}]
-)
-def test_validate_slug_and_generate_if_needed_not_raises_errors(
-    category, cleaned_input
-):
-    validate_slug_and_generate_if_needed(category, "name", cleaned_input)
-
-
-@pytest.mark.parametrize(
-    "cleaned_input",
-    [
-        {"slug": None, "name": "test"},
-        {"slug": "", "name": "test"},
-        {"slug": ""},
-        {"slug": None},
-        {"slug": "test-slug"},
-        {"slug": "test-slug", "name": "test"},
-    ],
-)
-def test_validate_slug_and_generate_if_needed_generate_slug(cleaned_input):
-    category = Category(name="test")
-    validate_slug_and_generate_if_needed(category, "name", cleaned_input)
-
-
-def test_validate_image_file():
-    # given
-    img_data = BytesIO()
-    image = Image.new("RGB", size=(1, 1))
-    image.save(img_data, format="JPEG")
-    img = SimpleUploadedFile("product.jpg", img_data.getvalue(), "image/jpeg")
-    field = "image"
-
-    # when
-    result = validate_image_file(img, field, ProductErrorCode)
-
-    # then
-    assert not result
-
-
-def test_validate_image_file_invalid_content_type():
-    # given
-    img_data = BytesIO()
-    image = Image.new("RGB", size=(1, 1))
-    image.save(img_data, format="JPEG")
-    img = SimpleUploadedFile("product.jpg", img_data.getvalue(), "text/plain")
-    field = "image"
-
-    # when
-    with pytest.raises(ValidationError) as exc:
-        validate_image_file(img, field, ProductErrorCode)
-
-    # then
-    assert exc.value.args[0][field].message == "Invalid file type."
-
-
-def test_validate_image_file_no_file():
-    # given
-    field = "image"
-
-    # when
-    with pytest.raises(ValidationError) as exc:
-        validate_image_file(None, field, ProductErrorCode)
-
-    # then
-    assert exc.value.args[0][field].message == "File is required."
-
-
-def test_validate_image_file_no_file_extension():
-    # given
-    img_data = BytesIO()
-    image = Image.new("RGB", size=(1, 1))
-    image.save(img_data, format="JPEG")
-    img = SimpleUploadedFile("product", img_data.getvalue(), "image/jpeg")
-    field = "image"
-
-    # when
-    with pytest.raises(ValidationError) as exc:
-        validate_image_file(img, field, ProductErrorCode)
-
-    # then
-    assert exc.value.args[0][field].message == "Lack of file extension."
-
-
-def test_validate_image_file_invalid_file_extension():
-    # given
-    img_data = BytesIO()
-    image = Image.new("RGB", size=(1, 1))
-    image.save(img_data, format="JPEG")
-    img = SimpleUploadedFile("product.txt", img_data.getvalue(), "image/jpeg")
-    field = "image"
-
-    # when
-    with pytest.raises(ValidationError) as exc:
-        validate_image_file(img, field, ProductErrorCode)
-
-    # then
-    assert (
-        exc.value.args[0][field].message
-        == "Invalid file extension. Image file required."
-    )
-
-
-def test_validate_image_file_file_extension_not_supported_by_thumbnails():
-    # given
-    img_data = BytesIO()
-    image = Image.new("RGB", size=(1, 1))
-    image.save(img_data, format="JPEG")
-    img = SimpleUploadedFile("product.pxr", img_data.getvalue(), "image/jpeg")
-    field = "image"
-
-    # when
-    with pytest.raises(ValidationError) as exc:
-        validate_image_file(img, field, ProductErrorCode)
-
-    # then
-    assert (
-        exc.value.args[0][field].message
-        == "Invalid file extension. Image file required."
-    )
-
-
-def test_get_filename_from_url_unique():
-    # given
-    file_format = "jpg"
-    file_name = "lenna"
-    url = f"http://example.com/{file_name}.{file_format}"
-
-    # when
-    result = get_filename_from_url(url)
-
-    # then
-    assert result.startswith(file_name)
-    assert result.endswith(file_format)
-    assert result != f"{file_name}.{file_format}"
-
-
-def test_is_image_mimetype_valid_mimetype():
-    # given
-    valid_mimetype = "image/jpeg"
-
-    # when
-    result = is_image_mimetype(valid_mimetype)
-
-    # then
-    assert result
-
-
-def test_is_image_mimetype_invalid_mimetype():
-    # given
-    invalid_mimetype = "application/javascript"
-
-    # when
-    result = is_image_mimetype(invalid_mimetype)
-
-    # then
-    assert not result
-
-
-def test_is_supported_image_mimetype_valid_mimetype():
-    # given
-    valid_mimetype = "image/jpeg"
-
-    # when
-    result = is_supported_image_mimetype(valid_mimetype)
-
-    # then
-    assert result
-
-
-def test_is_supported_image_mimetype_invalid_mimetype():
-    # given
-    invalid_mimetype = "application/javascript"
-
-    # when
-    result = is_supported_image_mimetype(invalid_mimetype)
-
-    # then
-    assert not result
-
-
-def test_validate_image_url_valid_image_response(monkeypatch):
-    # given
-    valid_image_response_mock = Mock()
-    valid_image_response_mock.headers = {"content-type": "image/jpeg"}
-    monkeypatch.setattr(
-        "saleor.graphql.core.utils.requests.head",
-        Mock(return_value=valid_image_response_mock),
-    )
-    field = "image"
-    dummy_url = "http://example.com/valid_url.jpg"
-
-    # when
-    result = validate_image_url(
-        dummy_url,
-        field,
-        ProductErrorCode.INVALID,
-    )
-
-    # then
-    assert result is None
-
-
-def test_validate_image_url_invalid_mimetype_response(monkeypatch):
-    # given
-    invalid_response_mock = Mock()
-    invalid_response_mock.headers = {"content-type": "application/json"}
-    monkeypatch.setattr(
-        "saleor.graphql.core.utils.requests.head",
-        Mock(return_value=invalid_response_mock),
-    )
-    field = "image"
-    dummy_url = "http://example.com/invalid_url.json"
-
-    # when
-    with pytest.raises(ValidationError) as exc:
-        validate_image_url(
-            dummy_url,
-            field,
-            ProductErrorCode.INVALID,
-        )
-
-    # then
-    assert exc.value.args[0][field].message == "Invalid file type."
-
-
-def test_validate_image_url_response_without_content_headers(monkeypatch):
-    # given
-    invalid_response_mock = Mock()
-    invalid_response_mock.headers = {}
-    monkeypatch.setattr(
-        "saleor.graphql.core.utils.requests.head",
-        Mock(return_value=invalid_response_mock),
-    )
-    field = "image"
-    dummy_url = "http://example.com/broken_url"
-
-    # when
-    with pytest.raises(ValidationError) as exc:
-        validate_image_url(
-            dummy_url,
-            field,
-            ProductErrorCode.INVALID,
-        )
-
-    # then
-    assert exc.value.args[0][field].message == "Invalid file type."
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/core/tests/test_file_upload.py
+++ b/saleor/graphql/core/tests/test_file_upload.py
@@ -42,7 +42,7 @@ def test_file_upload_by_staff(staff_api_client, site_settings, media_root):
     errors = data["errors"]
 
     assert not errors
-    assert data["uploadedFile"]["contentType"] == "image/png"
+    assert data["uploadedFile"]["contentType"] == "image/jpeg"
     file_name, format = os.path.splitext(image_file._name)
     returned_url = data["uploadedFile"]["url"]
     file_path = urlparse(returned_url).path
@@ -83,7 +83,7 @@ def test_file_upload_by_app(app_api_client, media_root):
     errors = data["errors"]
 
     assert not errors
-    assert data["uploadedFile"]["contentType"] == "image/png"
+    assert data["uploadedFile"]["contentType"] == "image/jpeg"
     file_name, format = os.path.splitext(image_file._name)
     returned_url = data["uploadedFile"]["url"]
     file_path = urlparse(returned_url).path
@@ -109,7 +109,7 @@ def test_file_upload_by_superuser(superuser_api_client, media_root):
     errors = data["errors"]
 
     assert not errors
-    assert data["uploadedFile"]["contentType"] == "image/png"
+    assert data["uploadedFile"]["contentType"] == "image/jpeg"
     file_name, format = os.path.splitext(image_file._name)
     returned_url = data["uploadedFile"]["url"]
     file_path = urlparse(returned_url).path
@@ -148,7 +148,7 @@ def test_file_upload_file_with_the_same_name_already_exists(
 
     domain = site_settings.site.domain
     assert not errors
-    assert data["uploadedFile"]["contentType"] == "image/png"
+    assert data["uploadedFile"]["contentType"] == "image/jpeg"
     file_url = data["uploadedFile"]["url"]
     assert file_url != f"http://{domain}/media/{image_file._name}"
     assert file_url != f"http://{domain}/media/{path}"
@@ -172,7 +172,7 @@ def test_file_upload_file_name_with_space(staff_api_client, media_root):
     errors = data["errors"]
 
     assert not errors
-    assert data["uploadedFile"]["contentType"] == "image/png"
+    assert data["uploadedFile"]["contentType"] == "image/jpeg"
     file_name, format = os.path.splitext(image_file._name)
     file_name = file_name.replace(" ", "_")
     returned_url = data["uploadedFile"]["url"]
@@ -199,7 +199,7 @@ def test_file_upload_file_name_with_encoded_value(staff_api_client, media_root):
     errors = data["errors"]
 
     assert not errors
-    assert data["uploadedFile"]["contentType"] == "image/png"
+    assert data["uploadedFile"]["contentType"] == "image/jpeg"
     file_name, format = os.path.splitext(image_file._name)
     returned_url = data["uploadedFile"]["url"]
     file_path = urlparse(returned_url).path

--- a/saleor/graphql/core/tests/test_file_validation.py
+++ b/saleor/graphql/core/tests/test_file_validation.py
@@ -1,0 +1,282 @@
+from io import BytesIO
+from unittest.mock import Mock
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image
+
+from ....product.error_codes import ProductErrorCode
+from ..validators.file import (
+    clean_image_file,
+    get_filename_from_url,
+    is_image_mimetype,
+    is_supported_image_mimetype,
+    validate_image_url,
+)
+
+
+def test_get_filename_from_url_unique():
+    # given
+    file_format = "jpg"
+    file_name = "lenna"
+    url = f"http://example.com/{file_name}.{file_format}"
+
+    # when
+    result = get_filename_from_url(url)
+
+    # then
+    assert result.startswith(file_name)
+    assert result.endswith(file_format)
+    assert result != f"{file_name}.{file_format}"
+
+
+def test_is_image_mimetype_valid_mimetype():
+    # given
+    valid_mimetype = "image/jpeg"
+
+    # when
+    result = is_image_mimetype(valid_mimetype)
+
+    # then
+    assert result
+
+
+def test_is_image_mimetype_invalid_mimetype():
+    # given
+    invalid_mimetype = "application/javascript"
+
+    # when
+    result = is_image_mimetype(invalid_mimetype)
+
+    # then
+    assert not result
+
+
+def test_is_supported_image_mimetype_valid_mimetype():
+    # given
+    valid_mimetype = "image/jpeg"
+
+    # when
+    result = is_supported_image_mimetype(valid_mimetype)
+
+    # then
+    assert result
+
+
+def test_is_supported_image_mimetype_invalid_mimetype():
+    # given
+    invalid_mimetype = "application/javascript"
+
+    # when
+    result = is_supported_image_mimetype(invalid_mimetype)
+
+    # then
+    assert not result
+
+
+def test_validate_image_url_valid_image_response(monkeypatch):
+    # given
+    valid_image_response_mock = Mock()
+    valid_image_response_mock.headers = {"content-type": "image/jpeg"}
+    monkeypatch.setattr(
+        "saleor.graphql.core.validators.file.requests.head",
+        Mock(return_value=valid_image_response_mock),
+    )
+    field = "image"
+
+    # when
+    dummy_url = "http://example.com/valid_url.jpg"
+
+    # then
+    validate_image_url(
+        dummy_url,
+        field,
+        ProductErrorCode.INVALID.value,
+    )
+
+
+def test_validate_image_url_invalid_mimetype_response(monkeypatch):
+    # given
+    invalid_response_mock = Mock()
+    invalid_response_mock.headers = {"content-type": "application/json"}
+    monkeypatch.setattr(
+        "saleor.graphql.core.validators.file.requests.head",
+        Mock(return_value=invalid_response_mock),
+    )
+    field = "image"
+    dummy_url = "http://example.com/invalid_url.json"
+
+    # when
+    with pytest.raises(ValidationError) as exc:
+        validate_image_url(
+            dummy_url,
+            field,
+            ProductErrorCode.INVALID.value,
+        )
+
+    # then
+    assert exc.value.args[0][field].message == "Invalid file type."
+
+
+def test_validate_image_url_response_without_content_headers(monkeypatch):
+    # given
+    invalid_response_mock = Mock()
+    invalid_response_mock.headers = {}
+    monkeypatch.setattr(
+        "saleor.graphql.core.validators.file.requests.head",
+        Mock(return_value=invalid_response_mock),
+    )
+    field = "image"
+    dummy_url = "http://example.com/broken_url"
+
+    # when
+    with pytest.raises(ValidationError) as exc:
+        validate_image_url(
+            dummy_url,
+            field,
+            ProductErrorCode.INVALID.value,
+        )
+
+    # then
+    assert exc.value.args[0][field].message == "Invalid file type."
+
+
+def test_clean_image_file():
+    # given
+    img_data = BytesIO()
+    image = Image.new("RGB", size=(1, 1))
+    image.save(img_data, format="JPEG")
+    field = "image"
+
+    # when
+    img = SimpleUploadedFile("product.jpg", img_data.getvalue(), "image/jpeg")
+
+    # then
+    clean_image_file({field: img}, field, ProductErrorCode)
+
+
+def test_clean_image_file_invalid_content_type():
+    # given
+    img_data = BytesIO()
+    image = Image.new("RGB", size=(1, 1))
+    image.save(img_data, format="JPEG")
+    img = SimpleUploadedFile("product.jpg", img_data.getvalue(), "text/plain")
+    field = "image"
+
+    # when
+    with pytest.raises(ValidationError) as exc:
+        clean_image_file({field: img}, field, ProductErrorCode)
+
+    # then
+    assert exc.value.args[0][field].message == "Invalid file type."
+
+
+def test_clean_image_file_no_file():
+    # given
+    field = "image"
+
+    # when
+    with pytest.raises(ValidationError) as exc:
+        clean_image_file({field: None}, field, ProductErrorCode)
+
+    # then
+    assert exc.value.args[0][field].message == "File is required."
+
+
+def test_clean_image_file_no_file_extension():
+    # given
+    img_data = BytesIO()
+    image = Image.new("RGB", size=(1, 1))
+    image.save(img_data, format="JPEG")
+    img = SimpleUploadedFile("product", img_data.getvalue(), "image/jpeg")
+    field = "image"
+
+    # when
+    with pytest.raises(ValidationError) as exc:
+        clean_image_file({field: img}, field, ProductErrorCode)
+
+    # then
+    assert exc.value.args[0][field].message == "Lack of file extension."
+
+
+def test_clean_image_file_invalid_file_extension():
+    # given
+    img_data = BytesIO()
+    image = Image.new("RGB", size=(1, 1))
+    image.save(img_data, format="JPEG")
+    img = SimpleUploadedFile("product.txt", img_data.getvalue(), "image/jpeg")
+    field = "image"
+
+    # when
+    with pytest.raises(ValidationError) as exc:
+        clean_image_file({field: img}, field, ProductErrorCode)
+
+    # then
+    assert (
+        exc.value.args[0][field].message
+        == "Invalid file extension. Image file required."
+    )
+
+
+def test_clean_image_file_file_extension_not_supported_by_thumbnails():
+    # given
+    img_data = BytesIO()
+    image = Image.new("RGB", size=(1, 1))
+    image.save(img_data, format="JPEG")
+    img = SimpleUploadedFile("product.pxr", img_data.getvalue(), "image/jpeg")
+    field = "image"
+
+    # when
+    with pytest.raises(ValidationError) as exc:
+        clean_image_file({field: img}, field, ProductErrorCode)
+
+    # then
+    assert (
+        exc.value.args[0][field].message
+        == "Invalid file extension. Image file required."
+    )
+
+
+def test_clean_image_file_issue_with_file_opening(monkeypatch):
+    # given
+    img_data = BytesIO()
+    image = Image.new("RGB", size=(1, 1))
+    image.save(img_data, format="JPEG")
+    field = "image"
+
+    error_msg = "Test syntax error"
+    image_file_mock = Mock(side_effect=SyntaxError(error_msg))
+    monkeypatch.setattr(
+        "saleor.graphql.core.validators.file.Image.open", image_file_mock
+    )
+    img = SimpleUploadedFile("product.jpg", img_data.getvalue(), "image/jpeg")
+
+    # when
+    with pytest.raises(ValidationError) as exc:
+        clean_image_file({field: img}, field, ProductErrorCode)
+
+    # then
+    assert error_msg in exc.value.args[0][field].message
+
+
+def test_clean_image_file_exif_validation_raising_error(monkeypatch):
+    # given
+    img_data = BytesIO()
+    image = Image.new("RGB", size=(1, 1))
+    image.save(img_data, format="JPEG")
+    field = "image"
+
+    error_msg = "Test syntax error"
+    image_file_mock = Mock(side_effect=SyntaxError(error_msg))
+    monkeypatch.setattr(
+        "saleor.graphql.core.validators.file._validate_image_exif", image_file_mock
+    )
+    img = SimpleUploadedFile("product.jpg", img_data.getvalue(), "image/jpeg")
+
+    # when
+    with pytest.raises(ValidationError) as exc:
+        clean_image_file({field: img}, field, ProductErrorCode)
+
+    # then
+    assert error_msg in exc.value.args[0][field].message

--- a/saleor/graphql/core/utils/__init__.py
+++ b/saleor/graphql/core/utils/__init__.py
@@ -1,37 +1,14 @@
 import binascii
-import mimetypes
 import os
 import secrets
-from enum import Enum
-from typing import TYPE_CHECKING, Type, Union
-from uuid import UUID
+from typing import Union
 
 import graphene
-import requests
-from django.core.exceptions import ValidationError
-from django.core.files.uploadedfile import SimpleUploadedFile
 from graphene import ObjectType
 from graphql.error import GraphQLError
-from PIL import Image
 
-from ....core.utils import generate_unique_slug
 from ....plugins.webhook.utils import APP_ID_PREFIX
-from ....thumbnail import MIME_TYPE_TO_PIL_IDENTIFIER
-
-if TYPE_CHECKING:
-    # flake8: noqa
-    from django.db.models import Model
-
-
-Image.init()
-
-
-def clean_seo_fields(data):
-    """Extract and assign seo fields to given dictionary."""
-    seo_fields = data.pop("seo", None)
-    if seo_fields:
-        data["seo_title"] = seo_fields.get("title")
-        data["seo_description"] = seo_fields.get("description")
+from ..validators import validate_if_int_or_uuid
 
 
 def snake_to_camel_case(name):
@@ -47,136 +24,6 @@ def str_to_enum(name):
     return name.replace(" ", "_").replace("-", "_").upper()
 
 
-def is_image_mimetype(mimetype: str) -> bool:
-    """Check if mimetype is image."""
-    if mimetype is None:
-        return False
-    return mimetype.startswith("image/")
-
-
-def is_supported_image_mimetype(mimetype: str) -> bool:
-    """Check if mimetype is a mimetype that thumbnails support."""
-    if mimetype is None:
-        return False
-    return mimetype in MIME_TYPE_TO_PIL_IDENTIFIER.keys()
-
-
-def is_image_url(url: str) -> bool:
-    """Check if file URL seems to be an image."""
-    if url.endswith(".webp"):
-        # webp is not recognized by mimetypes as image
-        # https://bugs.python.org/issue38902
-        return True
-    filetype = mimetypes.guess_type(url)[0]
-    return filetype is not None and is_image_mimetype(filetype)
-
-
-def validate_image_url(url: str, field_name: str, error_code: str) -> None:
-    """Check if remote file has content type of image.
-
-    Instead of the whole file, only the headers are fetched.
-    """
-    head = requests.head(url)
-    header = head.headers
-    content_type = header.get("content-type")
-    if content_type is None or not is_supported_image_mimetype(content_type):
-        raise ValidationError(
-            {field_name: ValidationError("Invalid file type.", code=error_code)}
-        )
-
-
-def get_filename_from_url(url: str) -> str:
-    """Prepare unique filename for file from URL to avoid overwritting."""
-    file_name = os.path.basename(url)
-    name, format = os.path.splitext(file_name)
-    hash = secrets.token_hex(nbytes=4)
-    return f"{name}_{hash}{format}"
-
-
-def validate_image_file(file, field_name, error_class) -> None:
-    """Validate if the file is an image supported by thumbnails."""
-    if not file:
-        raise ValidationError(
-            {
-                field_name: ValidationError(
-                    "File is required.", code=error_class.REQUIRED
-                )
-            }
-        )
-    if not is_supported_image_mimetype(file.content_type):
-        raise ValidationError(
-            {
-                field_name: ValidationError(
-                    "Invalid file type.", code=error_class.INVALID
-                )
-            }
-        )
-    _validate_image_format(file, field_name, error_class)
-
-
-def _validate_image_format(file, field_name, error_class):
-    """Validate image file format."""
-    allowed_extensions = get_allowed_extensions()
-    _file_name, format = os.path.splitext(file._name)
-    if not format:
-        raise ValidationError(
-            {
-                field_name: ValidationError(
-                    "Lack of file extension.", code=error_class.INVALID
-                )
-            }
-        )
-    elif format not in allowed_extensions:
-        raise ValidationError(
-            {
-                field_name: ValidationError(
-                    "Invalid file extension. Image file required.",
-                    code=error_class.INVALID,
-                )
-            }
-        )
-
-
-def get_allowed_extensions():
-    """Return image extension lists that are supported by thumbnails."""
-    return [
-        ext.lower()
-        for ext, file_type in Image.EXTENSION.items()
-        if file_type.upper() in MIME_TYPE_TO_PIL_IDENTIFIER.values()
-    ]
-
-
-def validate_slug_and_generate_if_needed(
-    instance: Type["Model"],
-    slugable_field: str,
-    cleaned_input: dict,
-    slug_field_name: str = "slug",
-) -> dict:
-    """Validate slug from input and generate in create mutation if is not given."""
-
-    # update mutation - just check if slug value is not empty
-    # _state.adding is True only when it's new not saved instance.
-    if not instance._state.adding:  # type: ignore
-        validate_slug_value(cleaned_input)
-        return cleaned_input
-
-    # create mutation - generate slug if slug value is empty
-    slug = cleaned_input.get(slug_field_name)
-    if not slug and slugable_field in cleaned_input:
-        slug = generate_unique_slug(instance, cleaned_input[slugable_field])
-        cleaned_input[slug_field_name] = slug
-    return cleaned_input
-
-
-def validate_slug_value(cleaned_input, slug_field_name: str = "slug"):
-    if slug_field_name in cleaned_input:
-        slug = cleaned_input[slug_field_name]
-        if not slug:
-            raise ValidationError(
-                f"{slug_field_name.capitalize()} value cannot be blank."
-            )
-
-
 def get_duplicates_items(first_list, second_list):
     """Return items that appear on both provided lists."""
     if first_list and second_list:
@@ -187,29 +34,6 @@ def get_duplicates_items(first_list, second_list):
 def get_duplicated_values(values):
     """Return set of duplicated values."""
     return {value for value in values if values.count(value) > 1}
-
-
-def validate_required_string_field(cleaned_input, field_name: str):
-    """Strip and validate field value."""
-    field_value = cleaned_input.get(field_name)
-    field_value = field_value.strip() if field_value else ""
-    if field_value:
-        cleaned_input[field_name] = field_value
-    else:
-        raise ValidationError(f"{field_name.capitalize()} is required.")
-    return cleaned_input
-
-
-def validate_if_int_or_uuid(id):
-    result = True
-    try:
-        int(id)
-    except ValueError:
-        try:
-            UUID(id)
-        except (AttributeError, ValueError):
-            result = False
-    return result
 
 
 def from_global_id_or_error(

--- a/saleor/graphql/core/validators/__init__.py
+++ b/saleor/graphql/core/validators/__init__.py
@@ -1,14 +1,18 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Type
+from uuid import UUID
 
 import graphene
 from django.core.exceptions import ValidationError
 from django_prices.utils.formatting import get_currency_fraction
 from graphql.error import GraphQLError
 
+from ....core.utils import generate_unique_slug
 from ....product.models import ProductVariantChannelListing
 
 if TYPE_CHECKING:
     from decimal import Decimal
+
+    from django.db.models import Model
 
 
 def validate_one_of_args_is_in_mutation(error_class, *args):
@@ -102,3 +106,65 @@ def validate_end_is_after_start(start_date, end_date):
 
     if start_date > end_date:
         raise ValidationError("End date cannot be before the start date.")
+
+
+def validate_slug_and_generate_if_needed(
+    instance: Type["Model"],
+    slugable_field: str,
+    cleaned_input: dict,
+    slug_field_name: str = "slug",
+) -> dict:
+    """Validate slug from input and generate in create mutation if is not given."""
+
+    # update mutation - just check if slug value is not empty
+    # _state.adding is True only when it's new not saved instance.
+    if not instance._state.adding:  # type: ignore
+        validate_slug_value(cleaned_input)
+        return cleaned_input
+
+    # create mutation - generate slug if slug value is empty
+    slug = cleaned_input.get(slug_field_name)
+    if not slug and slugable_field in cleaned_input:
+        slug = generate_unique_slug(instance, cleaned_input[slugable_field])
+        cleaned_input[slug_field_name] = slug
+    return cleaned_input
+
+
+def validate_slug_value(cleaned_input, slug_field_name: str = "slug"):
+    if slug_field_name in cleaned_input:
+        slug = cleaned_input[slug_field_name]
+        if not slug:
+            raise ValidationError(
+                f"{slug_field_name.capitalize()} value cannot be blank."
+            )
+
+
+def clean_seo_fields(data):
+    """Extract and assign seo fields to given dictionary."""
+    seo_fields = data.pop("seo", None)
+    if seo_fields:
+        data["seo_title"] = seo_fields.get("title")
+        data["seo_description"] = seo_fields.get("description")
+
+
+def validate_required_string_field(cleaned_input, field_name: str):
+    """Strip and validate field value."""
+    field_value = cleaned_input.get(field_name)
+    field_value = field_value.strip() if field_value else ""
+    if field_value:
+        cleaned_input[field_name] = field_value
+    else:
+        raise ValidationError(f"{field_name.capitalize()} is required.")
+    return cleaned_input
+
+
+def validate_if_int_or_uuid(id):
+    result = True
+    try:
+        int(id)
+    except ValueError:
+        try:
+            UUID(id)
+        except (AttributeError, ValueError):
+            result = False
+    return result

--- a/saleor/graphql/core/validators/file.py
+++ b/saleor/graphql/core/validators/file.py
@@ -1,0 +1,147 @@
+import mimetypes
+import os
+import secrets
+
+import requests
+from django.core.exceptions import ValidationError
+from PIL import Image, UnidentifiedImageError
+
+from ....thumbnail import MIME_TYPE_TO_PIL_IDENTIFIER
+from ..utils import add_hash_to_file_name
+
+Image.init()
+
+
+def is_image_mimetype(mimetype: str) -> bool:
+    """Check if mimetype is image."""
+    if mimetype is None:
+        return False
+    return mimetype.startswith("image/")
+
+
+def is_supported_image_mimetype(mimetype: str) -> bool:
+    """Check if mimetype is a mimetype that thumbnails support."""
+    if mimetype is None:
+        return False
+    return mimetype in MIME_TYPE_TO_PIL_IDENTIFIER.keys()
+
+
+def is_image_url(url: str) -> bool:
+    """Check if file URL seems to be an image."""
+    if url.endswith(".webp"):
+        # webp is not recognized by mimetypes as image
+        # https://bugs.python.org/issue38902
+        return True
+    filetype = mimetypes.guess_type(url)[0]
+    return filetype is not None and is_image_mimetype(filetype)
+
+
+def validate_image_url(url: str, field_name: str, error_code: str) -> None:
+    """Check if remote file has content type of image.
+
+    Instead of the whole file, only the headers are fetched.
+    """
+    head = requests.head(url)
+    header = head.headers
+    content_type = header.get("content-type")
+    if content_type is None or not is_supported_image_mimetype(content_type):
+        raise ValidationError(
+            {field_name: ValidationError("Invalid file type.", code=error_code)}
+        )
+
+
+def get_filename_from_url(url: str) -> str:
+    """Prepare unique filename for file from URL to avoid overwritting."""
+    file_name = os.path.basename(url)
+    name, format = os.path.splitext(file_name)
+    hash = secrets.token_hex(nbytes=4)
+    return f"{name}_{hash}{format}"
+
+
+def clean_image_file(cleaned_input, img_field_name, error_class):
+    """Extract and clean uploaded image file.
+
+    Validate if the file is an image supported by thumbnails.
+    """
+    img_file = cleaned_input.get(img_field_name)
+    if not img_file:
+        raise ValidationError(
+            {
+                img_field_name: ValidationError(
+                    "File is required.", code=error_class.REQUIRED
+                )
+            }
+        )
+    if not is_supported_image_mimetype(img_file.content_type):
+        raise ValidationError(
+            {
+                img_field_name: ValidationError(
+                    "Invalid file type.", code=error_class.INVALID
+                )
+            }
+        )
+
+    _validate_image_format(img_file, img_field_name, error_class)
+    try:
+        with Image.open(img_file) as image:
+            _validate_image_exif(image, img_field_name, error_class)
+    except (SyntaxError, TypeError, UnidentifiedImageError) as e:
+        raise ValidationError(
+            {
+                img_field_name: ValidationError(
+                    "Invalid file. The following error was raised during the attempt "
+                    f"of opening the file: {str(e)}",
+                    code=error_class.INVALID.value,
+                )
+            }
+        )
+
+    add_hash_to_file_name(img_file)
+    return img_file
+
+
+def _validate_image_format(file, field_name, error_class):
+    """Validate image file format."""
+    allowed_extensions = _get_allowed_extensions()
+    _file_name, format = os.path.splitext(file._name)
+    if not format:
+        raise ValidationError(
+            {
+                field_name: ValidationError(
+                    "Lack of file extension.", code=error_class.INVALID
+                )
+            }
+        )
+    elif format not in allowed_extensions:
+        raise ValidationError(
+            {
+                field_name: ValidationError(
+                    "Invalid file extension. Image file required.",
+                    code=error_class.INVALID,
+                )
+            }
+        )
+
+
+def _get_allowed_extensions():
+    """Return image extension lists that are supported by thumbnails."""
+    return [
+        ext.lower()
+        for ext, file_type in Image.EXTENSION.items()
+        if file_type.upper() in MIME_TYPE_TO_PIL_IDENTIFIER.values()
+    ]
+
+
+def _validate_image_exif(img, field_name, error_class):
+    try:
+        img.getexif()
+    except (SyntaxError, TypeError, UnidentifiedImageError) as e:
+        raise ValidationError(
+            {
+                field_name: ValidationError(
+                    "Invalid file. The following error was raised during the attempt "
+                    f"of getting the exchangeable image file data: {str(e)}.",
+                    code=error_class.INVALID.value,
+                )
+            }
+        )

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -22,8 +22,7 @@ from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_INPUT, PREVIEW_FEA
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.scalars import PositiveDecimal
 from ..core.types import GiftCardError, NonNullList, PriceInput
-from ..core.utils import validate_required_string_field
-from ..core.validators import validate_price_precision
+from ..core.validators import validate_price_precision, validate_required_string_field
 from ..utils.validators import check_for_duplicates
 from .types import GiftCard, GiftCardEvent
 

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -15,8 +15,8 @@ from ...product import models as product_models
 from ..channel import ChannelContext
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types import MenuError, NonNullList
-from ..core.utils import validate_slug_and_generate_if_needed
 from ..core.utils.reordering import perform_reordering
+from ..core.validators import validate_slug_and_generate_if_needed
 from ..page.types import Page
 from ..product.types import Category, Collection
 from .dataloaders import MenuItemsByParentMenuLoader

--- a/saleor/graphql/order/mutations/order_add_note.py
+++ b/saleor/graphql/order/mutations/order_add_note.py
@@ -8,7 +8,7 @@ from ....order import events
 from ....order.error_codes import OrderErrorCode
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
-from ...core.utils import validate_required_string_field
+from ...core.validators import validate_required_string_field
 from ..types import Order, OrderEvent
 from .utils import get_webhook_handler_by_order_status
 

--- a/saleor/graphql/page/mutations/pages.py
+++ b/saleor/graphql/page/mutations/pages.py
@@ -19,7 +19,7 @@ from ...core.descriptions import ADDED_IN_33, DEPRECATED_IN_3X_INPUT, RICH_CONTE
 from ...core.fields import JSONString
 from ...core.mutations import ModelDeleteMutation, ModelMutation
 from ...core.types import NonNullList, PageError, SeoInput
-from ...core.utils import clean_seo_fields, validate_slug_and_generate_if_needed
+from ...core.validators import clean_seo_fields, validate_slug_and_generate_if_needed
 from ...utils.validators import check_for_duplicates
 from ..types import Page, PageType
 

--- a/saleor/graphql/product/mutations/product_type_create.py
+++ b/saleor/graphql/product/mutations/product_type_create.py
@@ -8,7 +8,7 @@ from ....product.error_codes import ProductErrorCode
 from ...core.mutations import ModelMutation
 from ...core.scalars import WeightScalar
 from ...core.types import NonNullList, ProductError
-from ...core.utils import validate_slug_and_generate_if_needed
+from ...core.validators import validate_slug_and_generate_if_needed
 from ..enums import ProductTypeKindEnum
 from ..types import ProductType
 

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -9711,6 +9711,7 @@ def test_product_media_create_mutation(
     permission_manage_products,
     media_root,
 ):
+    staff_api_client.user.user_permissions.add(permission_manage_products)
     image_file, image_name = create_image()
     variables = {
         "product": graphene.Node.to_global_id("Product", product.id),
@@ -9720,9 +9721,7 @@ def test_product_media_create_mutation(
     body = get_multipart_request_body(
         PRODUCT_MEDIA_CREATE_QUERY, variables, image_file, image_name
     )
-    response = staff_api_client.post_multipart(
-        body, permissions=[permission_manage_products]
-    )
+    response = staff_api_client.post_multipart(body)
     get_graphql_content(response)
     product.refresh_from_db()
     product_image = product.media.last()

--- a/saleor/graphql/warehouse/mutations.py
+++ b/saleor/graphql/warehouse/mutations.py
@@ -10,7 +10,7 @@ from ...warehouse.validation import validate_warehouse_count  # type: ignore
 from ..account.i18n import I18nMixin
 from ..core.mutations import ModelDeleteMutation, ModelMutation
 from ..core.types import NonNullList, WarehouseError
-from ..core.utils import (
+from ..core.validators import (
     validate_required_string_field,
     validate_slug_and_generate_if_needed,
 )

--- a/saleor/product/tests/utils.py
+++ b/saleor/product/tests/utils.py
@@ -8,7 +8,7 @@ def create_image(image_name="product2"):
     img_data = BytesIO()
     image = Image.new("RGB", size=(1, 1), color=(255, 0, 0, 0))
     image.save(img_data, format="JPEG")
-    image = SimpleUploadedFile(image_name + ".jpg", img_data.getvalue(), "image/png")
+    image = SimpleUploadedFile(image_name + ".jpg", img_data.getvalue(), "image/jpeg")
     return image, image_name
 
 


### PR DESCRIPTION
- Clean the `graphql/core/utils/__init__.py` file
- Extract file validation-related methods to `graphql/core/validators/file.py`
- Extend the file validation - open the file with `PIL` and get the `exif` data

Port of #11224

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
