### PR TITLE
Make `CheckoutLinesUpdate` backwards compatible

### DIFF
--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -18,6 +18,7 @@ from ..types import Checkout
 from .checkout_create import CheckoutLineInput
 from .utils import (
     check_lines_quantity,
+    check_lines_quantity_requirement,
     check_permissions_for_custom_prices,
     get_checkout,
     group_quantity_and_custom_prices_by_variants,
@@ -160,6 +161,7 @@ class CheckoutLinesAdd(BaseMutation):
         cls, _root, info, lines, checkout_id=None, token=None, id=None, replace=False
     ):
         check_permissions_for_custom_prices(info.context.app, lines)
+        cls.check_lines_quantity_requirement(lines)
 
         checkout = get_checkout(
             cls,
@@ -200,3 +202,11 @@ class CheckoutLinesAdd(BaseMutation):
         )
         manager.checkout_updated(checkout)
         return CheckoutLinesAdd(checkout=checkout)
+
+    @classmethod
+    def check_lines_quantity_requirement(cls, lines):
+        """Validate if the quantity is provided for each line.
+
+        The quantity value is required only for `add` mutation.
+        """
+        check_lines_quantity_requirement(lines)

--- a/saleor/graphql/checkout/mutations/checkout_lines_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_update.py
@@ -3,51 +3,14 @@ from django.forms import ValidationError
 
 from ....checkout.error_codes import CheckoutErrorCode
 from ....warehouse.reservations import is_reservation_enabled
-from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
-from ...core.scalars import UUID
-from ...core.types import CheckoutError, NonNullList
+from ...core.types import CheckoutError
 from ..types import Checkout
-from .checkout_create import CheckoutLineInput
 from .checkout_lines_add import CheckoutLinesAdd
 from .utils import check_lines_quantity
 
 
-class CheckoutLineUpdateInput(CheckoutLineInput):
-    quantity = graphene.Int(
-        required=False,
-        description=(
-            "The number of items purchased. "
-            "Optional for apps, required for any other users."
-        ),
-    )
-
-
 class CheckoutLinesUpdate(CheckoutLinesAdd):
     checkout = graphene.Field(Checkout, description="An updated checkout.")
-
-    class Arguments:
-        id = graphene.ID(
-            description="The checkout's ID." + ADDED_IN_34,
-            required=False,
-        )
-        token = UUID(
-            description=f"Checkout token.{DEPRECATED_IN_3X_INPUT} Use `id` instead.",
-            required=False,
-        )
-        checkout_id = graphene.ID(
-            required=False,
-            description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use `id` instead."
-            ),
-        )
-        lines = NonNullList(
-            CheckoutLineUpdateInput,
-            required=True,
-            description=(
-                "A list of checkout lines, each containing information about "
-                "an item in the checkout."
-            ),
-        )
 
     class Meta:
         description = "Updates checkout line in the existing checkout."
@@ -132,3 +95,7 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
         return super().perform_mutation(
             root, info, lines, checkout_id, token, id, replace=True
         )
+
+    @classmethod
+    def check_lines_quantity_requirement(cls, lines):
+        pass

--- a/saleor/graphql/checkout/mutations/utils.py
+++ b/saleor/graphql/checkout/mutations/utils.py
@@ -96,6 +96,20 @@ def update_checkout_shipping_method_if_invalid(
         clear_delivery_method(checkout_info)
 
 
+def check_lines_quantity_requirement(lines):
+    """Validate if the quantity is provided for each line."""
+    for line in lines:
+        if line.get("quantity") is None:
+            raise ValidationError(
+                {
+                    "quantity": ValidationError(
+                        "The quantity value is required.",
+                        code=CheckoutErrorCode.REQUIRED.value,
+                    )
+                }
+            )
+
+
 def check_lines_quantity(
     variants,
     quantities,

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -521,7 +521,7 @@ def test_add_billing_address_to_checkout(
 MUTATION_CHECKOUT_LINES_UPDATE = (
     FRAGMENT_CHECKOUT_LINE
     + """
-        mutation updateCheckoutLine($id: ID, $lines: [CheckoutLineUpdateInput!]!){
+        mutation updateCheckoutLine($id: ID, $lines: [CheckoutLineInput!]!){
           checkoutLinesUpdate(id: $id, lines: $lines) {
             checkout {
               id

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_update.py
@@ -11,7 +11,7 @@ from ...mutations.utils import update_checkout_shipping_method_if_invalid
 
 MUTATION_CHECKOUT_LINES_UPDATE = """
     mutation checkoutLinesUpdate(
-            $checkoutId: ID, $token: UUID, $lines: [CheckoutLineUpdateInput!]!) {
+            $checkoutId: ID, $token: UUID, $lines: [CheckoutLineInput!]!) {
         checkoutLinesUpdate(checkoutId: $checkoutId, token: $token, lines: $lines) {
             checkout {
                 token

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -19,7 +19,7 @@ from ...mutations.utils import update_checkout_shipping_method_if_invalid
 
 MUTATION_CHECKOUT_LINES_UPDATE = """
     mutation checkoutLinesUpdate(
-            $id: ID, $lines: [CheckoutLineUpdateInput!]!) {
+            $id: ID, $lines: [CheckoutLineInput!]!) {
         checkoutLinesUpdate(id: $id, lines: $lines) {
             checkout {
                 id

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13065,7 +13065,7 @@ type Mutation {
     """
     A list of checkout lines, each containing information about an item in the checkout.
     """
-    lines: [CheckoutLineUpdateInput!]!
+    lines: [CheckoutLineInput]!
 
     """
     Checkout token.
@@ -19167,7 +19167,7 @@ input CheckoutCreateInput {
 
 input CheckoutLineInput {
   """The number of items purchased."""
-  quantity: Int!
+  quantity: Int
 
   """ID of the product variant."""
   variantId: ID!
@@ -19257,25 +19257,6 @@ type CheckoutLinesUpdate {
   checkout: Checkout
   checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
-}
-
-input CheckoutLineUpdateInput {
-  """
-  The number of items purchased. Optional for apps, required for any other users.
-  """
-  quantity: Int
-
-  """ID of the product variant."""
-  variantId: ID!
-
-  """
-  Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.
-  
-  Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
-  price: PositiveDecimal
 }
 
 """Remove a gift card or a voucher from a checkout."""


### PR DESCRIPTION
- Use `CheckoutLineInput` in `CheckoutLinesUpdate`
- Make `quantity` optional in `CheckoutLineInput`
- Validate the `quantity` for `CheckoutCreate` and `CheckoutLinesAdd`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
