### PR TITLE
Add plugin manager promise

### DIFF
--- a/saleor/graphql/app/dataloaders.py
+++ b/saleor/graphql/app/dataloaders.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 from django.contrib.auth.hashers import check_password
+from promise import Promise
 
 from ...app.models import App, AppExtension, AppToken
 from ...core.auth import get_token_from_request
@@ -82,3 +83,14 @@ def load_app(context):
         return context.app
     promise = promise_app(context)
     return None if promise is None else promise.get()
+
+
+def get_app_promise(context):
+    if hasattr(context, "app"):
+        return Promise.resolve(context.app)
+
+    promise = promise_app(context)
+    if promise is None:
+        return Promise.resolve(None)
+
+    return promise

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -89,7 +89,7 @@ from ..invoice.types import Invoice
 from ..meta.types import ObjectWithMetadata
 from ..payment.enums import OrderAction, TransactionStatusEnum
 from ..payment.types import Payment, PaymentChargeStatusEnum, TransactionItem
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import load_plugin_manager, plugin_manager_promise_callback
 from ..product.dataloaders import (
     MediaByProductVariantIdLoader,
     ProductByVariantIdLoader,
@@ -1229,9 +1229,8 @@ class Order(ModelObjectType):
     @staticmethod
     @traced_resolver
     @prevent_sync_event_circular_query
-    def resolve_total(root: models.Order, info):
-        manager = load_plugin_manager(info.context)
-
+    @plugin_manager_promise_callback
+    def resolve_total(root: models.Order, info, manager):
         def _resolve_total(lines):
             return calculations.order_total(root, manager, lines)
 


### PR DESCRIPTION
I want to merge this change because it will reduce number of recursion calls when calling for plugin_manager object by utilizing `Promise.then`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
