### PR TITLE
add schemaVersion field to Shop type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Expose manifest in the `App` type (#10055) (f0f944066)
 - Deprecate `configurationUrl` and `dataPrivacy` fields in apps (#10046) (68bd7c8a2)
 - Fix `ProductVariant.created` resolver (#10072) (6c77053a9)
+- Add `schemaVersion` field to `Shop` type. #11275 by @zedzior
 
 ### Saleor Apps
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7494,6 +7494,13 @@ type Shop {
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   version: String!
+
+  """
+  Minor Saleor API version.
+  
+  Added in Saleor 3.5.
+  """
+  schemaVersion: String!
 }
 
 """

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -1610,6 +1610,25 @@ def test_version_query_as_staff_user(staff_api_client):
     assert content["data"]["shop"]["version"] == __version__
 
 
+def test_schema_version_query(api_client):
+    # given
+    query = """
+        query {
+            shop {
+                schemaVersion
+            }
+        }
+    """
+
+    # when
+    response = api_client.post_graphql(query)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["shop"]["schemaVersion"] in __version__
+    assert content["data"]["shop"]["schemaVersion"] != __version__
+
+
 def test_cannot_get_shop_limit_info_when_not_staff(user_api_client):
     query = LIMIT_INFO_QUERY
     response = user_api_client.post_graphql(query)

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -486,4 +486,5 @@ class Shop(graphene.ObjectType):
 
     @staticmethod
     def resolve_schema_version(_, _info):
-        return f'{__version__.split(".")[0]}.{__version__.split(".")[1]}'
+        major, minor, _ = __version__.split(".", 2)
+        return f"{major}.{minor}"

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -15,7 +15,12 @@ from ...core.utils import build_absolute_uri
 from ...site import models as site_models
 from ..account.types import Address, AddressInput, StaffNotificationRecipient
 from ..checkout.types import PaymentGateway
-from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_INPUT, PREVIEW_FEATURE
+from ..core.descriptions import (
+    ADDED_IN_31,
+    ADDED_IN_35,
+    DEPRECATED_IN_3X_INPUT,
+    PREVIEW_FEATURE,
+)
 from ..core.enums import LanguageCodeEnum, WeightUnitsEnum
 from ..core.fields import PermissionsField
 from ..core.types import (
@@ -295,6 +300,10 @@ class Shop(graphene.ObjectType):
             AuthorizationFilters.AUTHENTICATED_APP,
         ],
     )
+    schema_version = graphene.String(
+        description="Minor Saleor API version." + ADDED_IN_35,
+        required=True,
+    )
 
     class Meta:
         description = (
@@ -474,3 +483,7 @@ class Shop(graphene.ObjectType):
     @staticmethod
     def resolve_version(_, _info):
         return __version__
+
+    @staticmethod
+    def resolve_schema_version(_, _info):
+        return f'{__version__.split(".")[0]}.{__version__.split(".")[1]}'


### PR DESCRIPTION
This is port of https://github.com/saleor/saleor/pull/11275

I want to merge this change because I want to fetch minor version of Saleor as anonymous user.
```graphql
type Shop {
   ...
   schemaVersion: String!
}
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
