### PR TITLE
Include fully qualified API URL in communication between Saleor and Apps

### DIFF
--- a/saleor/app/headers.py
+++ b/saleor/app/headers.py
@@ -1,0 +1,11 @@
+class AppHeaders:
+    DOMAIN = "Saleor-Domain"
+    EVENT_TYPE = "Saleor-Event"
+    SIGNATURE = "Saleor-Signature"
+    API_URL = "Saleor-Api-Url"
+
+
+class DeprecatedAppHeaders:
+    DOMAIN = "X-Saleor-Domain"
+    EVENT_TYPE = "X-Saleor-Event"
+    SIGNATURE = "X-Saleor-Signature"

--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -1,8 +1,11 @@
 import requests
 from django.conf import settings
 from django.contrib.sites.models import Site
+from django.urls import reverse
 
+from ..app.headers import AppHeaders, DeprecatedAppHeaders
 from ..core.permissions import get_permission_names
+from ..core.utils import build_absolute_uri
 from ..plugins.manager import PluginsManager
 from ..webhook.models import Webhook, WebhookEvent
 from .manifest_validations import clean_manifest_data
@@ -17,8 +20,9 @@ def send_app_token(target_url: str, token: str):
     headers = {
         "Content-Type": "application/json",
         # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
-        "x-saleor-domain": domain,
-        "saleor-domain": domain,
+        DeprecatedAppHeaders.DOMAIN: domain,
+        AppHeaders.DOMAIN: domain,
+        AppHeaders.API_URL: build_absolute_uri(reverse("api"), domain),
     }
     json_data = {"auth_token": token}
     response = requests.post(

--- a/saleor/app/management/commands/create_app.py
+++ b/saleor/app/management/commands/create_app.py
@@ -5,8 +5,11 @@ import requests
 from django.contrib.sites.models import Site
 from django.core.management import BaseCommand, CommandError
 from django.core.management.base import CommandParser
+from django.urls import reverse
 from requests.exceptions import RequestException
 
+from ....app.headers import AppHeaders, DeprecatedAppHeaders
+from ....core.utils import build_absolute_uri
 from ...models import App
 from .utils import clean_permissions
 
@@ -42,8 +45,9 @@ class Command(BaseCommand):
         domain = Site.objects.get_current().domain
         headers = {
             # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
-            "x-saleor-domain": domain,
-            "saleor-domain": domain,
+            DeprecatedAppHeaders.DOMAIN: domain,
+            AppHeaders.DOMAIN: domain,
+            AppHeaders.API_URL: build_absolute_uri(reverse("api"), domain),
         }
         try:
             response = requests.post(target_url, json=data, headers=headers, timeout=15)

--- a/saleor/app/tests/test_app_commands.py
+++ b/saleor/app/tests/test_app_commands.py
@@ -60,8 +60,9 @@ def test_creates_app_from_manifest_sends_token(monkeypatch):
         headers={
             "Content-Type": "application/json",
             # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
-            "x-saleor-domain": "mirumee.com",
-            "saleor-domain": "mirumee.com",
+            "X-Saleor-Domain": "mirumee.com",
+            "Saleor-Domain": "mirumee.com",
+            "Saleor-Api-Url": "http://mirumee.com/graphql/",
         },
         json={"auth_token": ANY},
         timeout=ANY,
@@ -122,8 +123,9 @@ def test_sends_data_to_target_url(monkeypatch):
         target_url,
         headers={
             # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
-            "x-saleor-domain": "mirumee.com",
-            "saleor-domain": "mirumee.com",
+            "X-Saleor-Domain": "mirumee.com",
+            "Saleor-Domain": "mirumee.com",
+            "Saleor-Api-Url": "http://mirumee.com/graphql/",
         },
         json={"auth_token": ANY},
         timeout=ANY,

--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import graphene
 import pytest
@@ -24,7 +24,8 @@ def test_install_app_created_app(
     mocked_get_response.json.return_value = app_manifest
 
     monkeypatch.setattr(requests, "get", Mock(return_value=mocked_get_response))
-    monkeypatch.setattr("saleor.app.installation_utils.send_app_token", Mock())
+    mocked_post = Mock()
+    monkeypatch.setattr(requests, "post", mocked_post)
 
     app_installation.permissions.set([permission_manage_products])
 
@@ -32,6 +33,18 @@ def test_install_app_created_app(
     app, _ = install_app(app_installation, activate=True)
 
     # then
+    mocked_post.assert_called_once_with(
+        app_manifest["tokenTargetUrl"],
+        headers={
+            "Content-Type": "application/json",
+            # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
+            "X-Saleor-Domain": "mirumee.com",
+            "Saleor-Domain": "mirumee.com",
+            "Saleor-Api-Url": "http://mirumee.com/graphql/",
+        },
+        json={"auth_token": ANY},
+        timeout=ANY,
+    )
     assert App.objects.get().id == app.id
     assert list(app.permissions.all()) == [permission_manage_products]
 

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -22,13 +22,13 @@ if TYPE_CHECKING:
     from django.utils.safestring import SafeText
 
 
-def build_absolute_uri(location: str) -> str:
+def build_absolute_uri(location: str, domain: Optional[str] = None) -> str:
     """Create absolute uri from location.
 
     If provided location is absolute uri by itself, it returns unchanged value,
     otherwise if provided location is relative, absolute uri is built and returned.
     """
-    host = Site.objects.get_current().domain
+    host = domain or Site.objects.get_current().domain
     protocol = "https" if settings.ENABLE_SSL else "http"
     current_uri = "%s://%s" % (protocol, host)
     location = urljoin(current_uri, location)

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -13,13 +13,16 @@ from celery import group
 from celery.exceptions import MaxRetriesExceededError, Retry
 from celery.utils.log import get_task_logger
 from django.conf import settings
+from django.urls import reverse
 from google.cloud import pubsub_v1
 from requests.exceptions import RequestException
 
+from ...app.headers import AppHeaders, DeprecatedAppHeaders
 from ...celeryconf import app
 from ...core import EventDeliveryStatus
 from ...core.models import EventDelivery, EventPayload
 from ...core.tracing import webhooks_opentracing_trace
+from ...core.utils import build_absolute_uri
 from ...graphql.webhook.subscription_payload import (
     generate_payload_from_subscription,
     initialize_request,
@@ -292,12 +295,13 @@ def send_webhook_using_http(
     headers = {
         "Content-Type": "application/json",
         # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
-        "X-Saleor-Event": event_type,
-        "X-Saleor-Domain": domain,
-        "X-Saleor-Signature": signature,
-        "Saleor-Event": event_type,
-        "Saleor-Domain": domain,
-        "Saleor-Signature": signature,
+        DeprecatedAppHeaders.EVENT_TYPE: event_type,
+        DeprecatedAppHeaders.DOMAIN: domain,
+        DeprecatedAppHeaders.SIGNATURE: signature,
+        AppHeaders.EVENT_TYPE: event_type,
+        AppHeaders.DOMAIN: domain,
+        AppHeaders.SIGNATURE: signature,
+        AppHeaders.API_URL: build_absolute_uri(reverse("api"), domain),
     }
     try:
         response = requests.post(
@@ -353,6 +357,10 @@ def send_webhook_using_aws_sqs(target_url, message, domain, signature, event_typ
 
     msg_attributes = {
         "SaleorDomain": {"DataType": "String", "StringValue": domain},
+        "SaleorApiUrl": {
+            "DataType": "String",
+            "StringValue": build_absolute_uri(reverse("api"), domain),
+        },
         "EventType": {"DataType": "String", "StringValue": event_type},
     }
     if signature:
@@ -390,6 +398,7 @@ def send_webhook_using_google_cloud_pubsub(
                 topic_name,
                 message,
                 saleorDomain=domain,
+                saleorApiUrl=build_absolute_uri(reverse("api"), domain),
                 eventType=event_type,
                 signature=signature,
             )

--- a/saleor/plugins/webhook/tests/test_webhook_protocols.py
+++ b/saleor/plugins/webhook/tests/test_webhook_protocols.py
@@ -63,6 +63,10 @@ def test_trigger_webhooks_with_aws_sqs(
         "QueueUrl": f"https://sqs.us-east-1.amazonaws.com/account_id/{queue_name}",
         "MessageAttributes": {
             "SaleorDomain": {"DataType": "String", "StringValue": "mirumee.com"},
+            "SaleorApiUrl": {
+                "DataType": "String",
+                "StringValue": "http://mirumee.com/graphql/",
+            },
             "EventType": {"DataType": "String", "StringValue": "order_created"},
             "Signature": {"DataType": "String", "StringValue": expected_signature},
         },
@@ -128,6 +132,10 @@ def test_trigger_webhooks_with_aws_sqs_and_secret_key(
         QueueUrl="https://sqs.us-east-1.amazonaws.com/account_id/queue_name",
         MessageAttributes={
             "SaleorDomain": {"DataType": "String", "StringValue": "mirumee.com"},
+            "SaleorApiUrl": {
+                "DataType": "String",
+                "StringValue": "http://mirumee.com/graphql/",
+            },
             "EventType": {"DataType": "String", "StringValue": "order_created"},
             "Signature": {"DataType": "String", "StringValue": expected_signature},
         },
@@ -162,6 +170,7 @@ def test_trigger_webhooks_with_google_pub_sub(
         "projects/saleor/topics/test",
         expected_data.encode("utf-8"),
         saleorDomain="mirumee.com",
+        saleorApiUrl="http://mirumee.com/graphql/",
         eventType=WebhookEventAsyncType.ORDER_CREATED,
         signature=expected_signature,
     )
@@ -198,6 +207,7 @@ def test_trigger_webhooks_with_google_pub_sub_and_secret_key(
         "projects/saleor/topics/test",
         message.encode("utf-8"),
         saleorDomain="mirumee.com",
+        saleorApiUrl="http://mirumee.com/graphql/",
         eventType=WebhookEventAsyncType.ORDER_CREATED,
         signature=expected_signature,
     )
@@ -241,6 +251,7 @@ def test_trigger_webhooks_with_http(
         "Saleor-Event": "order_created",
         "Saleor-Domain": "mirumee.com",
         "Saleor-Signature": expected_signature,
+        "Saleor-Api-Url": "http://mirumee.com/graphql/",
     }
 
     mock_request.assert_called_once_with(
@@ -284,6 +295,7 @@ def test_trigger_webhooks_with_http_and_secret_key(
         "Saleor-Event": "order_created",
         "Saleor-Domain": "mirumee.com",
         "Saleor-Signature": expected_signature,
+        "Saleor-Api-Url": "http://mirumee.com/graphql/",
     }
 
     mock_request.assert_called_once_with(
@@ -325,6 +337,7 @@ def test_trigger_webhooks_with_http_and_secret_key_as_empty_string(
         "Saleor-Event": "order_created",
         "Saleor-Domain": "mirumee.com",
         "Saleor-Signature": expected_signature,
+        "Saleor-Api-Url": "http://mirumee.com/graphql/",
     }
 
     signature_headers = jwt.get_unverified_header(expected_signature)

--- a/saleor/plugins/webhook/tests/utils.py
+++ b/saleor/plugins/webhook/tests/utils.py
@@ -8,4 +8,5 @@ def generate_request_headers(event_type, domain, signature):
         "Saleor-Event": event_type,
         "Saleor-Domain": domain,
         "Saleor-Signature": signature,
+        "Saleor-Api-Url": f"http://{domain}/graphql/",
     }


### PR DESCRIPTION
I want to merge this change because it is port of #11223

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
