### PR TITLE
add schemaVersion field to Shop type (#11296)

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6649,6 +6649,7 @@ type Shop {
   staffNotificationRecipients: [StaffNotificationRecipient]
   limits: LimitInfo!
   version: String!
+  schemaVersion: String!
 }
 
 type ShopAddressUpdate {

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -1610,6 +1610,25 @@ def test_version_query_as_staff_user(staff_api_client):
     assert content["data"]["shop"]["version"] == __version__
 
 
+def test_schema_version_query(api_client):
+    # given
+    query = """
+        query {
+            shop {
+                schemaVersion
+            }
+        }
+    """
+
+    # when
+    response = api_client.post_graphql(query)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["shop"]["schemaVersion"] in __version__
+    assert content["data"]["shop"]["schemaVersion"] != __version__
+
+
 def test_cannot_get_shop_limit_info_when_not_staff(user_api_client):
     query = LIMIT_INFO_QUERY
     response = user_api_client.post_graphql(query)

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -263,6 +263,11 @@ class Shop(graphene.ObjectType):
     )
     version = graphene.String(description="Saleor API version.", required=True)
 
+    schema_version = graphene.String(
+        description="Minor Saleor API version." + ADDED_IN_31,
+        required=True,
+    )
+
     class Meta:
         description = (
             "Represents a shop resource containing general shop data and configuration."
@@ -449,3 +454,8 @@ class Shop(graphene.ObjectType):
     @staff_member_or_app_required
     def resolve_version(_, _info):
         return __version__
+
+    @staticmethod
+    def resolve_schema_version(_, _info):
+        major, minor, _ = __version__.split(".", 2)
+        return f"{major}.{minor}"


### PR DESCRIPTION
This is port of https://github.com/saleor/saleor/pull/11275

I want to merge this change because I want to fetch minor version of Saleor as anonymous user.
```graphql
type Shop {
   ...
   schemaVersion: String!
}
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
