### PR TITLE
Fix failing save on stripe plugin

### DIFF
--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -464,12 +464,11 @@ class StripeGatewayPlugin(BasePlugin):
     @classmethod
     def pre_save_plugin_configuration(cls, plugin_configuration: "PluginConfiguration"):
         configuration = plugin_configuration.configuration
-        flat_configuration = {item["name"]: item["value"] for item in configuration}
+        flat_configuration = {item["name"]: item for item in configuration}
 
-        api_key = flat_configuration["secret_api_key"]
-        webhook_id = flat_configuration.get("webhook_endpoint_id")
-        webhook_secret = flat_configuration.get("webhook_secret_key")
-
+        api_key = flat_configuration["secret_api_key"]["value"]
+        webhook_id = flat_configuration.get("webhook_endpoint_id", {}).get("value")
+        webhook_secret_data = flat_configuration.get("webhook_secret_key", {})
         if not plugin_configuration.active:
             if webhook_id:
                 # delete all webhook details when we disable a stripe integration.
@@ -480,12 +479,8 @@ class StripeGatewayPlugin(BasePlugin):
                 ][0]
                 webhook_id_field["value"] = ""
 
-                plugin_configuration.configuration.remove(
-                    {
-                        "name": "webhook_secret_key",
-                        "value": webhook_secret,
-                    }
-                )
+                if webhook_secret_data:
+                    plugin_configuration.configuration.remove(webhook_secret_data)
                 delete_webhook(api_key, webhook_id)
 
             return
@@ -509,7 +504,7 @@ class StripeGatewayPlugin(BasePlugin):
             return
 
         webhook = None
-        if not webhook_id and not webhook_secret:
+        if not webhook_id and not webhook_secret_data.get("value"):
             webhook = subscribe_webhook(
                 api_key, plugin_configuration.channel.slug  # type: ignore
             )
@@ -552,8 +547,8 @@ class StripeGatewayPlugin(BasePlugin):
                             "The parameter is required.",
                             code=PluginErrorCode.REQUIRED.value,
                         )
+                        for field in required_fields
                     }
-                    for field in required_fields
                 )
 
             api_key = configuration["secret_api_key"]

--- a/saleor/payment/gateways/stripe/tests/test_webhooks.py
+++ b/saleor/payment/gateways/stripe/tests/test_webhooks.py
@@ -1320,6 +1320,34 @@ def test_handle_webhook_events(
     )
 
 
+def test_handle_webhook_events(stripe_plugin, rf):
+    # given
+    webhook_type = WEBHOOK_SUCCESS_EVENT
+
+    dummy_payload = {
+        "id": "evt_1Ip9ANH1Vac4G4dbE9ch7zGS",
+    }
+
+    request = rf.post(
+        path="/webhooks/", data=dummy_payload, content_type="application/json"
+    )
+
+    stripe_signature = "1234"
+    request.META["HTTP_STRIPE_SIGNATURE"] = stripe_signature
+
+    event = Mock()
+    event.type = webhook_type
+    event.data.object = StripeObject()
+
+    plugin = stripe_plugin(webhook_secret_key=None)
+
+    # when
+    response = plugin.webhook(request, "/webhooks/", None)
+
+    # then
+    assert response.status_code == 500
+
+
 @patch("saleor.payment.gateway.refund")
 @patch("saleor.checkout.complete_checkout._get_order_data")
 def test_finalize_checkout_not_created_order_payment_refund(

--- a/saleor/payment/gateways/stripe/tests/test_webhooks.py
+++ b/saleor/payment/gateways/stripe/tests/test_webhooks.py
@@ -1320,7 +1320,7 @@ def test_handle_webhook_events(
     )
 
 
-def test_handle_webhook_events(stripe_plugin, rf):
+def test_handle_webhook_events_when_secret_is_missing(stripe_plugin, rf):
     # given
     webhook_type = WEBHOOK_SUCCESS_EVENT
 

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -53,8 +53,15 @@ def handle_webhook(
 ):
     payload = request.body
     sig_header = request.META["HTTP_STRIPE_SIGNATURE"]
-    endpoint_secret = gateway_config.connection_params["webhook_secret"]
     api_key = gateway_config.connection_params["secret_api_key"]
+    endpoint_secret = gateway_config.connection_params.get("webhook_secret")
+
+    if not endpoint_secret:
+        logger.warning("Missing webhook secret on Saleor side.")
+        response = HttpResponse(status=500)
+        response.content = "Missing webhook secret on Saleor side."
+        return response
+
     try:
         event = construct_stripe_event(
             api_key=api_key,

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -113,6 +113,7 @@ class BasePlugin:
     PLUGIN_ID = ""
     PLUGIN_DESCRIPTION = ""
     CONFIG_STRUCTURE = None
+
     CONFIGURATION_PER_CHANNEL = True
     DEFAULT_CONFIGURATION = []
     DEFAULT_ACTIVE = False
@@ -1098,12 +1099,12 @@ class BasePlugin:
 
         cls.validate_plugin_configuration(plugin_configuration)
         cls.pre_save_plugin_configuration(plugin_configuration)
+        plugin_configuration.save()
 
         if plugin_configuration.configuration:
             # Let's add a translated descriptions and labels
             cls._append_config_structure(plugin_configuration.configuration)
 
-        plugin_configuration.save()
         return plugin_configuration
 
     @classmethod

--- a/saleor/plugins/tests/test_plugins.py
+++ b/saleor/plugins/tests/test_plugins.py
@@ -140,6 +140,30 @@ def test_save_plugin_configuration_skips_new_field_when_doesnt_exsist_in_conf_st
     assert not configuration_dict.get("Token")
 
 
+def test_save_plugin_do_not_remove_the_existing_fields(plugin_configuration):
+    # given
+    not_public_field = "not-public-field"
+    not_public_value = "not-public-value"
+    plugin_configuration.configuration.append(
+        {"name": not_public_field, "value": not_public_value}
+    )
+    plugin_configuration.save()
+    cleaned_data = {"configuration": [{"name": "Token", "value": "token-data"}]}
+
+    # when
+    PluginSample.save_plugin_configuration(plugin_configuration, cleaned_data)
+
+    # then
+    plugin_configuration.refresh_from_db()
+    configuration = plugin_configuration.configuration
+    configuration_dict = {
+        c_field["name"]: c_field["value"] for c_field in configuration
+    }
+
+    assert configuration_dict.get(not_public_field)
+    assert configuration_dict[not_public_field] == not_public_value
+
+
 def test_base_plugin__update_configuration_structure_when_old_config_is_empty(
     plugin_configuration,
 ):


### PR DESCRIPTION
I want to merge this change because it fixes an issue related to turn off & turn on Stripe plugin.
We didn't save the `secret_webhook_key`, which causes a problem that we were not able to process the notification recieved from Stripe.
GH issue: https://github.com/saleor/saleor/issues/11373

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
