### PR TITLE
Fix typo in admin email templates

### DIFF
--- a/saleor/plugins/admin_email/default_email_templates/export_failed.html
+++ b/saleor/plugins/admin_email/default_email_templates/export_failed.html
@@ -225,7 +225,7 @@
 
       <div
          style="font-family:Helvetica, Arial;font-size:10px;line-height:1.2rem;text-align:center;color:#7f7b93;"
-      >This is an automatically generated e-mail, please do not reply. <br />Certain messages, like this one, are essectial to service operations.</div>
+      >This is an automatically generated e-mail, please do not reply. <br />Certain messages, like this one, are essential to service operations.</div>
 
                 </td>
               </tr>

--- a/saleor/plugins/admin_email/default_email_templates/export_success.html
+++ b/saleor/plugins/admin_email/default_email_templates/export_success.html
@@ -263,7 +263,7 @@
 
       <div
          style="font-family:Helvetica, Arial;font-size:10px;line-height:1.2rem;text-align:center;color:#7f7b93;"
-      >This is an automatically generated e-mail, please do not reply. <br />Certain messages, like this one, are essectial to service operations.</div>
+      >This is an automatically generated e-mail, please do not reply. <br />Certain messages, like this one, are essential to service operations.</div>
 
                 </td>
               </tr>

--- a/saleor/plugins/admin_email/default_email_templates/password_reset.html
+++ b/saleor/plugins/admin_email/default_email_templates/password_reset.html
@@ -287,7 +287,7 @@
 
       <div
          style="font-family:Helvetica, Arial;font-size:10px;line-height:1.2rem;text-align:center;color:#7f7b93;"
-      >This is an automatically generated e-mail, please do not reply. <br />Certain messages, like this one, are essectial to service operations.</div>
+      >This is an automatically generated e-mail, please do not reply. <br />Certain messages, like this one, are essential to service operations.</div>
 
                 </td>
               </tr>

--- a/saleor/plugins/admin_email/default_email_templates/set_password.html
+++ b/saleor/plugins/admin_email/default_email_templates/set_password.html
@@ -263,7 +263,7 @@
 
       <div
          style="font-family:Helvetica, Arial;font-size:10px;line-height:1.2rem;text-align:center;color:#7f7b93;"
-      >This is an automatically generated e-mail, please do not reply. <br />Certain messages, like this one, are essectial to service operations.</div>
+      >This is an automatically generated e-mail, please do not reply. <br />Certain messages, like this one, are essential to service operations.</div>
 
                 </td>
               </tr>

--- a/saleor/plugins/admin_email/default_email_templates/staff_confirm_order.html
+++ b/saleor/plugins/admin_email/default_email_templates/staff_confirm_order.html
@@ -417,7 +417,7 @@
 
       <div
          style="font-family:Helvetica, Arial;font-size:10px;line-height:1.2rem;text-align:center;color:#7f7b93;"
-      >This is an automatically generated e-mail, please do not reply. <br />Certain messages, like this one, are essectial to service operations.</div>
+      >This is an automatically generated e-mail, please do not reply. <br />Certain messages, like this one, are essential to service operations.</div>
 
                 </td>
               </tr>


### PR DESCRIPTION
Fix the typo `essectial` in the footer.

Related PR: https://github.com/saleor/saleor-admin-email-templates/pull/2

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
