### PR TITLE
Fix method for getting image thumbnail

### DIFF
--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -18,14 +18,7 @@ from django.core.mail.backends.smtp import EmailBackend
 from django.core.validators import EmailValidator
 from django_prices.utils.locale import get_locale_data
 
-from ..product.models import ProductMedia
-from ..product.product_images import get_product_image_placeholder
-from ..thumbnail.models import Thumbnail
-from ..thumbnail.utils import (
-    get_thumbnail_size,
-    prepare_image_proxy_url,
-    prepare_thumbnail_file_name,
-)
+from ..thumbnail.utils import get_thumbnail_size
 from .base_plugin import ConfigurationTypeField
 from .error_codes import PluginErrorCode
 
@@ -149,17 +142,10 @@ def format_datetime(this, date, date_format=None):
     return date.strftime(date_format)
 
 
-def get_product_image_thumbnail(this, size, image):
+def get_product_image_thumbnail(this, size, image_data):
     """Use provided size to get a correct image."""
-    size = get_thumbnail_size(size)
-    thumbnail_file_name = prepare_thumbnail_file_name(image.name, size, None)
-    thumbnail = Thumbnail.objects.filter(image__name=thumbnail_file_name).first()
-    if thumbnail:
-        return thumbnail.image.url
-    media = ProductMedia.objects.filter(image__name=image.name).first()
-    if not media:
-        return get_product_image_placeholder(size)
-    return prepare_image_proxy_url(media.id, "ProductMedia", size, None)
+    expected_size = get_thumbnail_size(size)
+    return image_data["original"][expected_size]
 
 
 def compare(this, val1, compare_operator, val2):

--- a/saleor/plugins/tests/test_email_common.py
+++ b/saleor/plugins/tests/test_email_common.py
@@ -3,8 +3,10 @@ from unittest.mock import patch
 import pytest
 from django.core.exceptions import ValidationError
 
+from ...order.notifications import get_image_payload
 from ..email_common import (
     DEFAULT_EMAIL_CONFIGURATION,
+    get_product_image_thumbnail,
     validate_default_email_configuration,
 )
 from ..error_codes import PluginErrorCode
@@ -59,3 +61,14 @@ def test_validate_default_email_configuration_backend_raises(
             " Make sure that you provided correct values."
             " [Errno 61] Connection refused"
         )
+
+
+def test_get_product_image_thumbnail(product_with_image):
+    # given
+    image_data = {"original": get_image_payload(product_with_image.media.first())}
+
+    # when
+    thumbnail = get_product_image_thumbnail(None, 100, image_data)
+
+    # then
+    assert thumbnail == image_data["original"][128]


### PR DESCRIPTION
Fix invalid `get_product_image_thumbnail` email common method.

The method was accidentally changed in https://github.com/saleor/saleor/pull/9988

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
