### PR TITLE
Replace usage of load_plugin_manager with promise of plugin manager

### DIFF
--- a/saleor/core/tests/test_dataloaders.py
+++ b/saleor/core/tests/test_dataloaders.py
@@ -1,6 +1,6 @@
 from django.core.handlers.base import BaseHandler
 
-from ...graphql.plugins.dataloaders import load_plugin_manager
+from ...graphql.plugins.dataloaders import get_plugin_manager_promise
 
 
 def test_plugins_manager_loader_loads_requestor_in_plugin(rf, customer_user, settings):
@@ -12,7 +12,7 @@ def test_plugins_manager_loader_loads_requestor_in_plugin(rf, customer_user, set
     handler = BaseHandler()
     handler.load_middleware()
     handler.get_response(request)
-    manager = load_plugin_manager(request)
+    manager = get_plugin_manager_promise(request).get()
     plugin = manager.all_plugins.pop()
 
     assert isinstance(plugin.requestor, type(customer_user))
@@ -30,7 +30,7 @@ def test_plugins_manager_loader_requestor_in_plugin_when_no_app_and_user_in_req_
     handler = BaseHandler()
     handler.load_middleware()
     handler.get_response(request)
-    manager = load_plugin_manager(request)
+    manager = get_plugin_manager_promise(request).get()
     plugin = manager.all_plugins.pop()
 
     assert not plugin.requestor

--- a/saleor/graphql/account/bulk_mutations.py
+++ b/saleor/graphql/account/bulk_mutations.py
@@ -8,7 +8,7 @@ from ...account.error_codes import AccountErrorCode
 from ...core.permissions import AccountPermissions
 from ..core.mutations import BaseBulkMutation, ModelBulkDeleteMutation
 from ..core.types import AccountError, NonNullList, StaffError
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from .types import User
 from .utils import CustomerDeleteMixin, StaffDeleteMixin
 
@@ -42,7 +42,7 @@ class CustomerBulkDelete(CustomerDeleteMixin, UserBulkDelete):
     def bulk_action(cls, info, queryset):
         instances = list(queryset)
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for instance in instances:
             manager.customer_deleted(instance)
 
@@ -87,7 +87,7 @@ class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
     def bulk_action(cls, info, queryset):
         instances = list(queryset)
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for instance in instances:
             manager.staff_deleted(instance)
 

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -21,7 +21,7 @@ from ...core.enums import LanguageCodeEnum
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ...core.types import AccountError, NonNullList
 from ...meta.mutations import MetadataInput
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..enums import AddressTypeEnum
 from ..i18n import I18nMixin
 from ..types import Address, AddressInput, User
@@ -137,7 +137,7 @@ class AccountRegister(ModelMutation):
         user.search_document = search.prepare_user_search_document_value(
             user, attach_addresses_data=False
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             if settings.ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL:
                 user.is_active = False
@@ -223,7 +223,7 @@ class AccountRequestDeletion(BaseMutation):
         channel_slug = clean_channel(
             data.get("channel"), error_class=AccountErrorCode
         ).slug
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         notifications.send_account_delete_confirmation_notification(
             redirect_url, user, manager, channel_slug=channel_slug
         )
@@ -316,7 +316,7 @@ class AccountAddressCreate(ModelMutation, I18nMixin):
             cls.save(info, address, cleaned_input)
             cls._save_m2m(info, address, cleaned_input)
             if address_type:
-                manager = load_plugin_manager(info.context)
+                manager = get_plugin_manager_promise(info.context).get()
                 utils.change_user_default_address(user, address, address_type, manager)
         return AccountAddressCreate(user=user, address=address)
 
@@ -328,7 +328,7 @@ class AccountAddressCreate(ModelMutation, I18nMixin):
         instance.user_addresses.add(user)
         user.search_document = search.prepare_user_search_document_value(user)
         user.save(update_fields=["search_document", "updated_at"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.customer_updated, user)
         cls.call_event(manager.address_created, instance)
 
@@ -393,7 +393,7 @@ class AccountSetDefaultAddress(BaseMutation):
             address_type = AddressType.BILLING
         else:
             address_type = AddressType.SHIPPING
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         utils.change_user_default_address(user, address, address_type, manager)
         cls.call_event(manager.customer_updated, user)
         return cls(user=user)
@@ -466,7 +466,7 @@ class RequestEmailChange(BaseMutation):
             "user_pk": user.pk,
         }
         token = create_token(token_payload, settings.JWT_TTL_REQUEST_EMAIL_CHANGE)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         notifications.send_request_user_change_email_notification(
             redirect_url,
             user,
@@ -541,7 +541,7 @@ class ConfirmEmailChange(BaseMutation):
 
         assign_user_gift_cards(user)
         match_orders_with_new_user(user)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         notifications.send_user_change_email_notification(
             old_email, user, manager, channel_slug=channel_slug
         )

--- a/saleor/graphql/account/mutations/authentication.py
+++ b/saleor/graphql/account/mutations/authentication.py
@@ -28,7 +28,7 @@ from ...core.descriptions import ADDED_IN_38, PREVIEW_FEATURE
 from ...core.fields import JSONString
 from ...core.mutations import BaseMutation
 from ...core.types import AccountError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import User
 
 
@@ -374,7 +374,7 @@ class ExternalAuthenticationUrl(BaseMutation):
         request = info.context
         plugin_id = data["plugin_id"]
         input_data = data["input"]
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         return cls(
             authentication_data=manager.external_authentication_url(
                 plugin_id, input_data, request
@@ -413,7 +413,7 @@ class ExternalObtainAccessTokens(BaseMutation):
         request = info.context
         plugin_id = data["plugin_id"]
         input_data = data["input"]
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         access_tokens_response = manager.external_obtain_access_tokens(
             plugin_id, input_data, request
         )
@@ -463,7 +463,7 @@ class ExternalRefresh(BaseMutation):
         request = info.context
         plugin_id = data["plugin_id"]
         input_data = data["input"]
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         access_tokens_response = manager.external_refresh(
             plugin_id, input_data, request
         )
@@ -503,7 +503,7 @@ class ExternalLogout(BaseMutation):
         request = info.context
         plugin_id = data["plugin_id"]
         input_data = data["input"]
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         return cls(logout_data=manager.external_logout(plugin_id, input_data, request))
 
 
@@ -535,6 +535,6 @@ class ExternalVerify(BaseMutation):
         request = info.context
         plugin_id = data["plugin_id"]
         input_data = data["input"]
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         user, data = manager.external_verify(plugin_id, input_data, request)
         return cls(user=user, is_valid=bool(user), verify_data=data)

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -32,7 +32,7 @@ from ...core.mutations import (
     validation_error_to_error_type,
 )
 from ...core.types import AccountError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from .authentication import CreateToken
 
 BILLING_ADDRESS_FIELD = "default_billing_address"
@@ -80,7 +80,7 @@ class SetPassword(CreateToken):
     @classmethod
     def mutate(cls, root, info, **data):
         set_mutation_flag_in_context(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         result = manager.perform_mutation(
             mutation_cls=cls, root=root, info=info, data=data
         )
@@ -195,7 +195,7 @@ class RequestPasswordReset(BaseMutation):
             channel_slug = validate_channel(
                 channel_slug, error_class=AccountErrorCode
             ).slug
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         send_password_reset_notification(
             redirect_url,
             user,
@@ -332,7 +332,7 @@ class BaseAddressUpdate(ModelMutation, I18nMixin):
         user = address.user_addresses.first()
         user.search_document = prepare_user_search_document_value(user)
         user.save(update_fields=["search_document", "updated_at"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.customer_updated, user)
         address = manager.change_user_address(address, None, user)
         cls.call_event(manager.address_updated, address)
@@ -395,7 +395,7 @@ class BaseAddressDelete(ModelDeleteMutation):
         response = cls.success_response(instance)
 
         response.user = user
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.customer_updated, user)
         cls.call_event(manager.address_deleted, instance)
         return response
@@ -488,7 +488,7 @@ class BaseCustomerCreate(ModelMutation, I18nMixin):
     @traced_atomic_transaction()
     def save(cls, info, instance, cleaned_input):
         default_shipping_address = cleaned_input.get(SHIPPING_ADDRESS_FIELD)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         if default_shipping_address:
             default_shipping_address = manager.change_user_address(
                 default_shipping_address, "shipping", instance

--- a/saleor/graphql/account/mutations/permission_group.py
+++ b/saleor/graphql/account/mutations/permission_group.py
@@ -21,7 +21,7 @@ from ...app.dataloaders import load_app
 from ...core.enums import PermissionEnum
 from ...core.mutations import ModelDeleteMutation, ModelMutation
 from ...core.types import NonNullList, PermissionGroupError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...utils.validators import check_for_duplicates
 from ..types import Group
 
@@ -76,7 +76,7 @@ class PermissionGroupCreate(ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.permission_group_created, instance)
 
     @classmethod
@@ -228,7 +228,7 @@ class PermissionGroupUpdate(PermissionGroupCreate):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.permission_group_updated, instance)
 
     @classmethod
@@ -446,7 +446,7 @@ class PermissionGroupDelete(ModelDeleteMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.permission_group_deleted, instance)
 
     @classmethod

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -19,7 +19,6 @@ from ...payment.utils import fetch_customer_id
 from ..app.dataloaders import load_app
 from ..core.utils import from_global_id_or_error
 from ..meta.resolvers import resolve_metadata
-from ..plugins.dataloaders import load_plugin_manager
 from ..utils import format_permissions_for_display, get_user_or_app_from_context
 from .types import Address, AddressValidationData, ChoiceValue, User
 from .utils import (
@@ -159,8 +158,7 @@ def resolve_address_validation_rules(
 
 
 @traced_resolver
-def resolve_payment_sources(info, user: models.User, channel_slug: str):
-    manager = load_plugin_manager(info.context)
+def resolve_payment_sources(_info, user: models.User, manager, channel_slug: str):
     stored_customer_accounts = (
         (gtw.id, fetch_customer_id(user, gtw.id))
         for gtw in gateway.list_gateways(manager, channel_slug)

--- a/saleor/graphql/app/mutations.py
+++ b/saleor/graphql/app/mutations.py
@@ -19,7 +19,7 @@ from ..core.enums import PermissionEnum
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types import AppError, NonNullList
 from ..decorators import staff_member_required
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import get_user_or_app_from_context, requestor_is_superuser
 from .types import App, AppInstallation, AppToken, Manifest
 from .utils import ensure_can_manage_permissions
@@ -178,7 +178,7 @@ class AppCreate(ModelMutation):
         cls._save_m2m(info, instance, cleaned_input)
         response = cls.success_response(instance)
         response.auth_token = auth_token
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.app_installed, instance)
         return response
 
@@ -225,7 +225,7 @@ class AppUpdate(ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.app_updated, instance)
 
 
@@ -253,7 +253,7 @@ class AppDelete(ModelDeleteMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.app_deleted, instance)
 
 
@@ -274,7 +274,7 @@ class AppActivate(ModelMutation):
         app = cls.get_instance(info, **data)
         app.is_active = True
         cls.save(info, app, cleaned_input=None)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.app_status_changed, app)
         return cls.success_response(app)
 
@@ -296,7 +296,7 @@ class AppDeactivate(ModelMutation):
         app = cls.get_instance(info, **data)
         app.is_active = False
         cls.save(info, app, cleaned_input=None)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.app_status_changed, app)
         return cls.success_response(app)
 

--- a/saleor/graphql/attribute/bulk_mutations.py
+++ b/saleor/graphql/attribute/bulk_mutations.py
@@ -7,7 +7,7 @@ from ...product import models as product_models
 from ...product.search import update_products_search_vector
 from ..core.mutations import ModelBulkDeleteMutation
 from ..core.types import AttributeError, NonNullList
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import resolve_global_ids_to_primary_keys
 from .types import Attribute, AttributeValue
 
@@ -67,7 +67,7 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
     def bulk_action(cls, info, queryset):
         attributes = list(queryset)
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for attribute in attributes:
             manager.attribute_deleted(attribute)
 
@@ -105,7 +105,7 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
         attributes = {value.attribute for value in queryset}
         values = list(queryset)
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for value in values:
             manager.attribute_value_deleted(value)
         for attribute in attributes:

--- a/saleor/graphql/channel/mutations.py
+++ b/saleor/graphql/channel/mutations.py
@@ -21,7 +21,7 @@ from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types import ChannelError, ChannelErrorCode, NonNullList
 from ..core.utils import get_duplicated_values, get_duplicates_items
 from ..core.utils.reordering import perform_reordering
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils.validators import check_for_duplicates
 from ..warehouse.types import Warehouse
 from .enums import AllocationStrategyEnum
@@ -120,7 +120,7 @@ class ChannelCreate(ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.channel_created, instance)
 
 
@@ -242,7 +242,7 @@ class ChannelUpdate(ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.channel_updated, instance)
 
 
@@ -333,7 +333,7 @@ class ChannelDelete(ModelDeleteMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.channel_deleted, instance)
 
     @classmethod
@@ -502,7 +502,7 @@ class ChannelActivate(BaseMutation):
         cls.clean_channel_availability(channel)
         channel.is_active = True
         channel.save(update_fields=["is_active"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.channel_status_changed, channel)
         return ChannelActivate(channel=channel)
 
@@ -537,7 +537,7 @@ class ChannelDeactivate(BaseMutation):
         cls.clean_channel_availability(channel)
         channel.is_active = False
         channel.save(update_fields=["is_active"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.channel_status_changed, channel)
         return ChannelDeactivate(channel=channel)
 

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -20,7 +20,7 @@ from ..discount.dataloaders import (
     VoucherInfoByVoucherCodeLoader,
     load_discounts,
 )
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from ..product.dataloaders import (
     CollectionsByVariantIdLoader,
     ProductByVariantIdLoader,
@@ -200,7 +200,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
 
     def batch_load(self, keys):
         def with_checkout(data):
-            checkouts, checkout_line_infos = data
+            checkouts, checkout_line_infos, manager = data
             from ..channel.dataloaders import ChannelByIdLoader
 
             channel_pks = [checkout.channel_id for checkout in checkouts]
@@ -302,7 +302,6 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                             all_shipping_methods=[],
                             voucher=voucher,
                         )
-                        manager = load_plugin_manager(self.context)
                         discounts = load_discounts(self.context)
                         shipping_method_listings = [
                             listing
@@ -345,7 +344,10 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
         checkout_line_infos = CheckoutLinesInfoByCheckoutTokenLoader(
             self.context
         ).load_many(keys)
-        return Promise.all([checkouts, checkout_line_infos]).then(with_checkout)
+        manager = get_plugin_manager_promise(self.context)
+        return Promise.all([checkouts, checkout_line_infos, manager]).then(
+            with_checkout
+        )
 
 
 class CheckoutLineByIdLoader(DataLoader):

--- a/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
@@ -13,7 +13,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...discount.dataloaders import load_discounts
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Checkout
 from .utils import get_checkout, update_checkout_shipping_method_if_invalid
 
@@ -60,7 +60,7 @@ class CheckoutAddPromoCode(BaseMutation):
             error_class=CheckoutErrorCode,
         )
 
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         discounts = load_discounts(info.context)
         lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
 

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -18,7 +18,7 @@ from ...core.descriptions import (
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...discount.dataloaders import load_discounts
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Checkout
 from .checkout_create import CheckoutAddressValidationRules
 from .checkout_shipping_address_update import CheckoutShippingAddressUpdate
@@ -92,7 +92,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
                 "enable_fields_normalization", True
             ),
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             billing_address.save()
             change_address_updated_fields = change_billing_address_in_checkout(

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -31,7 +31,7 @@ from ...core.validators import validate_one_of_args_is_in_mutation
 from ...discount.dataloaders import load_discounts
 from ...meta.mutations import MetadataInput
 from ...order.types import Order
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ...utils import get_user_or_app_from_context
 from ..types import Checkout
@@ -219,7 +219,7 @@ class CheckoutComplete(BaseMutation, I18nMixin):
 
         validate_checkout_email(checkout)
 
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
         if unavailable_variant_pks:
             not_available_variants_ids = {

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -26,7 +26,7 @@ from ...core.mutations import ModelMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import CheckoutError, NonNullList
 from ...core.validators import validate_variants_available_in_channel
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...product.types import ProductVariant
 from ...site.dataloaders import get_site_promise
 from ..types import Checkout
@@ -350,7 +350,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         if channel:
             data["input"]["channel"] = channel
         response = super().perform_mutation(_root, info, **data)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.checkout_created, response.checkout)
         response.created = True
         return response

--- a/saleor/graphql/checkout/mutations/checkout_customer_attach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_attach.py
@@ -8,7 +8,7 @@ from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...utils import get_user_or_app_from_context
 from ..types import Checkout
 from .utils import get_checkout
@@ -102,6 +102,6 @@ class CheckoutCustomerAttach(BaseMutation):
         checkout.user = customer
         checkout.email = customer.email
         checkout.save(update_fields=["email", "user", "last_change"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.checkout_updated, checkout)
         return CheckoutCustomerAttach(checkout=checkout)

--- a/saleor/graphql/checkout/mutations/checkout_customer_detach.py
+++ b/saleor/graphql/checkout/mutations/checkout_customer_detach.py
@@ -7,7 +7,7 @@ from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...utils import get_user_or_app_from_context
 from ..types import Checkout
 from .utils import get_checkout
@@ -61,6 +61,6 @@ class CheckoutCustomerDetach(BaseMutation):
 
         checkout.user = None
         checkout.save(update_fields=["user", "last_change"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.checkout_updated, checkout)
         return CheckoutCustomerDetach(checkout=checkout)

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -33,7 +33,7 @@ from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...core.utils import from_global_id_or_error
 from ...discount.dataloaders import load_discounts
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...shipping.types import ShippingMethod
 from ...warehouse.types import Warehouse
 from ..types import Checkout
@@ -278,7 +278,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             error_class=CheckoutErrorCode,
         )
 
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
         if unavailable_variant_pks:
             not_available_variants_ids = {

--- a/saleor/graphql/checkout/mutations/checkout_email_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_email_update.py
@@ -6,7 +6,7 @@ from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Checkout
 from .utils import get_checkout
 
@@ -66,6 +66,6 @@ class CheckoutEmailUpdate(BaseMutation):
         checkout.email = email
         cls.clean_instance(info, checkout)
         checkout.save(update_fields=["email", "last_change"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.checkout_updated, checkout)
         return CheckoutEmailUpdate(checkout=checkout)

--- a/saleor/graphql/checkout/mutations/checkout_language_code_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_language_code_update.py
@@ -6,7 +6,7 @@ from ...core.enums import LanguageCodeEnum
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Checkout
 from .utils import get_checkout
 
@@ -53,6 +53,6 @@ class CheckoutLanguageCodeUpdate(BaseMutation):
 
         checkout.language_code = language_code
         checkout.save(update_fields=["language_code", "last_change"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.checkout_updated, checkout)
         return CheckoutLanguageCodeUpdate(checkout=checkout)

--- a/saleor/graphql/checkout/mutations/checkout_line_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_line_delete.py
@@ -8,7 +8,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...discount.dataloaders import load_discounts
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Checkout, CheckoutLine
 from .utils import get_checkout, update_checkout_shipping_method_if_invalid
 
@@ -58,7 +58,7 @@ class CheckoutLineDelete(BaseMutation):
         if line and line in checkout.lines.all():
             line.delete()
 
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         lines, _ = fetch_checkout_lines(checkout)
         discounts = load_discounts(info.context)
         checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -17,7 +17,7 @@ from ...core.scalars import UUID
 from ...core.types import CheckoutError, NonNullList
 from ...core.validators import validate_variants_available_in_channel
 from ...discount.dataloaders import load_discounts
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...product.types import ProductVariant
 from ...site.dataloaders import get_site_promise
 from ..types import Checkout
@@ -183,7 +183,7 @@ class CheckoutLinesAdd(BaseMutation):
             id=id,
             error_class=CheckoutErrorCode,
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         discounts = load_discounts(info.context)
         variants = cls._get_variants_from_lines_input(lines)
         shipping_channel_listings = checkout.channel.shipping_method_listings.all()

--- a/saleor/graphql/checkout/mutations/checkout_lines_delete.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_delete.py
@@ -9,7 +9,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError, NonNullList
 from ...discount.dataloaders import load_discounts
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...utils import resolve_global_ids_to_primary_keys
 from ..types import Checkout
 from .utils import get_checkout, update_checkout_shipping_method_if_invalid
@@ -78,7 +78,7 @@ class CheckoutLinesDelete(BaseMutation):
 
         lines, _ = fetch_checkout_lines(checkout)
 
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         discounts = load_discounts(info.context)
         checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
         update_checkout_shipping_method_if_invalid(checkout_info, lines)

--- a/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_remove_promo_code.py
@@ -21,7 +21,7 @@ from ...core.validators import validate_one_of_args_is_in_mutation
 from ...discount.dataloaders import load_discounts
 from ...discount.types import Voucher
 from ...giftcard.types import GiftCard
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Checkout
 from .utils import get_checkout
 
@@ -85,7 +85,7 @@ class CheckoutRemovePromoCode(BaseMutation):
             error_class=CheckoutErrorCode,
         )
 
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         discounts = load_discounts(info.context)
         checkout_info = fetch_checkout_info(checkout, [], discounts, manager)
 

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -30,7 +30,7 @@ from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...discount.dataloaders import load_discounts
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Checkout
 from .checkout_create import CheckoutAddressValidationRules
@@ -157,7 +157,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
                 "enable_fields_normalization", True
             ),
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         discounts = load_discounts(info.context)
         shipping_channel_listings = checkout.channel.shipping_method_listings.all()
         checkout_info = fetch_checkout_info(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -21,7 +21,7 @@ from ...core.scalars import UUID
 from ...core.types import CheckoutError
 from ...core.utils import from_global_id_or_error
 from ...discount.dataloaders import load_discounts
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...shipping.types import ShippingMethod
 from ..types import Checkout
 from .utils import ERROR_DOES_NOT_SHIP, clean_delivery_method, get_checkout
@@ -86,7 +86,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             error_class=CheckoutErrorCode,
         )
 
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
 
         lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
         if unavailable_variant_pks:

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -15,7 +15,7 @@ from ...core.types import Error, NonNullList
 from ...discount.dataloaders import load_discounts
 from ...meta.mutations import MetadataInput
 from ...order.types import Order
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..enums import OrderCreateFromCheckoutErrorCode
 from ..types import Checkout
 from ..utils import prepare_insufficient_stock_checkout_validation_error
@@ -112,7 +112,7 @@ class OrderCreateFromCheckout(BaseMutation):
 
         tracking_code = analytics.get_client_id(info.context)
 
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         discounts = load_discounts(info.context)
         checkout_lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
         checkout_info = fetch_checkout_info(

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -28,7 +28,7 @@ from ...core.permissions import (
 from ...core.utils.events import call_event
 from ..meta.permissions import PRIVATE_META_PERMISSION_MAP, PUBLIC_META_PERMISSION_MAP
 from ..payment.utils import metadata_contains_empty_key
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import get_nodes, resolve_global_ids_to_primary_keys
 from .context import set_mutation_flag_in_context, setup_context_user
 from .descriptions import DEPRECATED_IN_3X_FIELD
@@ -381,7 +381,7 @@ class BaseMutation(graphene.Mutation):
 
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         result = manager.perform_mutation(
             mutation_cls=cls, root=root, info=info, data=data
         )
@@ -781,7 +781,7 @@ class BaseBulkMutation(BaseMutation):
 
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         result = manager.perform_mutation(
             mutation_cls=cls, root=root, info=info, data=data
         )

--- a/saleor/graphql/core/schema.py
+++ b/saleor/graphql/core/schema.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from .mutations import FileUpload
 from .types import NonNullList, TaxType
 
@@ -11,7 +11,7 @@ class CoreQueries(graphene.ObjectType):
     )
 
     def resolve_tax_types(self, info):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         return [
             TaxType(description=tax.description, tax_code=tax.code)
             for tax in manager.get_tax_rate_type_choices()

--- a/saleor/graphql/discount/bulk_mutations.py
+++ b/saleor/graphql/discount/bulk_mutations.py
@@ -5,7 +5,7 @@ from ...discount import models
 from ...discount.utils import fetch_catalogue_info
 from ..core.mutations import ModelBulkDeleteMutation
 from ..core.types import DiscountError, NonNullList
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from .mutations.utils import convert_catalogue_info_to_global_ids
 from .types import Sale, Voucher
 
@@ -31,7 +31,7 @@ class SaleBulkDelete(ModelBulkDeleteMutation):
             for sale in list(queryset)
         ]
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for sale, previous_catalogue in sales_and_catalogues:
             manager.sale_deleted(sale, previous_catalogue)
 
@@ -54,6 +54,6 @@ class VoucherBulkDelete(ModelBulkDeleteMutation):
     def bulk_action(cls, info, queryset):
         vouchers = list(queryset)
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for voucher in vouchers:
             manager.voucher_deleted(voucher)

--- a/saleor/graphql/discount/mutations/sale_add_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale_add_catalogues.py
@@ -3,7 +3,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....discount.utils import fetch_catalogue_info
 from ...channel import ChannelContext
 from ...core.types import DiscountError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Sale
 from .sale_base_catalogue import SaleBaseCatalogueMutation
 from .utils import convert_catalogue_info_to_global_ids
@@ -22,7 +22,7 @@ class SaleAddCatalogues(SaleBaseCatalogueMutation):
             info, data.get("id"), only_type=Sale, field="sale_id"
         )
         previous_catalogue = fetch_catalogue_info(sale)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             cls.add_catalogues_to_node(sale, data.get("input"))
             current_catalogue = fetch_catalogue_info(sale)

--- a/saleor/graphql/discount/mutations/sale_create.py
+++ b/saleor/graphql/discount/mutations/sale_create.py
@@ -16,7 +16,7 @@ from ...core.mutations import ModelMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import DiscountError, NonNullList
 from ...core.validators import validate_end_is_after_start
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..enums import DiscountValueTypeEnum
 from ..types import Sale
 from .utils import convert_catalogue_info_to_global_ids
@@ -93,7 +93,7 @@ class SaleCreate(SaleUpdateDiscountedPriceMixin, ModelMutation):
         with traced_atomic_transaction():
             response = super().perform_mutation(_root, info, **data)
             instance = getattr(response, cls._meta.return_field_name).node
-            manager = load_plugin_manager(info.context)
+            manager = get_plugin_manager_promise(info.context).get()
             cls.send_sale_notifications(manager, instance)
         return response
 

--- a/saleor/graphql/discount/mutations/sale_delete.py
+++ b/saleor/graphql/discount/mutations/sale_delete.py
@@ -6,7 +6,7 @@ from ....discount import models
 from ....discount.utils import fetch_catalogue_info
 from ....graphql.core.mutations import ModelDeleteMutation
 from ...core.types import DiscountError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Sale
 from .sale_create import SaleUpdateDiscountedPriceMixin
 from .utils import convert_catalogue_info_to_global_ids
@@ -29,7 +29,7 @@ class SaleDelete(SaleUpdateDiscountedPriceMixin, ModelDeleteMutation):
         node_id = data.get("id")
         instance = cls.get_node_or_error(info, node_id, only_type=Sale)
         previous_catalogue = fetch_catalogue_info(instance)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             response = super().perform_mutation(_root, info, **data)
             cls.call_event(

--- a/saleor/graphql/discount/mutations/sale_remove_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale_remove_catalogues.py
@@ -3,7 +3,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....discount.utils import fetch_catalogue_info
 from ....graphql.channel import ChannelContext
 from ...core.types import DiscountError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Sale
 from .sale_base_catalogue import SaleBaseCatalogueMutation
 from .utils import convert_catalogue_info_to_global_ids
@@ -22,7 +22,7 @@ class SaleRemoveCatalogues(SaleBaseCatalogueMutation):
             info, data.get("id"), only_type=Sale, field="sale_id"
         )
         previous_catalogue = fetch_catalogue_info(sale)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             cls.remove_catalogues_from_node(sale, data.get("input"))
             current_catalogue = fetch_catalogue_info(sale)

--- a/saleor/graphql/discount/mutations/sale_update.py
+++ b/saleor/graphql/discount/mutations/sale_update.py
@@ -9,7 +9,7 @@ from ....discount import models
 from ....discount.utils import fetch_catalogue_info
 from ...core.mutations import ModelMutation
 from ...core.types import DiscountError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Sale
 from .sale_create import SaleInput, SaleUpdateDiscountedPriceMixin
 from .utils import convert_catalogue_info_to_global_ids
@@ -36,7 +36,7 @@ class SaleUpdate(SaleUpdateDiscountedPriceMixin, ModelMutation):
         previous_catalogue = fetch_catalogue_info(instance)
         previous_end_date = instance.end_date
         data = data.get("input")
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cleaned_input = cls.clean_input(info, instance, data)
         with traced_atomic_transaction():
             instance = cls.construct_instance(instance, cleaned_input)

--- a/saleor/graphql/discount/mutations/voucher_add_catalogues.py
+++ b/saleor/graphql/discount/mutations/voucher_add_catalogues.py
@@ -4,7 +4,7 @@ from ....core.permissions import DiscountPermissions
 from ...channel import ChannelContext
 from ...core.descriptions import ADDED_IN_31
 from ...core.types import DiscountError, NonNullList
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Voucher
 from .sale_base_discount_catalogue import BaseDiscountCatalogueMutation
 
@@ -69,7 +69,7 @@ class VoucherAddCatalogues(VoucherBaseCatalogueMutation):
         cls.add_catalogues_to_node(voucher, input_data)
 
         if input_data:
-            manager = load_plugin_manager(info.context)
+            manager = get_plugin_manager_promise(info.context).get()
             cls.call_event(manager.voucher_updated, voucher)
 
         return VoucherAddCatalogues(voucher=voucher)

--- a/saleor/graphql/discount/mutations/voucher_channel_listing_update.py
+++ b/saleor/graphql/discount/mutations/voucher_channel_listing_update.py
@@ -12,7 +12,7 @@ from ...channel.mutations import BaseChannelListingMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import DiscountError, NonNullList
 from ...core.validators import validate_price_precision
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Voucher
 
 
@@ -196,7 +196,7 @@ class VoucherChannelListingUpdate(BaseChannelListingMutation):
             raise ValidationError(errors)
 
         cls.save(voucher, cleaned_input)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.voucher_updated, voucher)
 
         return VoucherChannelListingUpdate(

--- a/saleor/graphql/discount/mutations/voucher_create.py
+++ b/saleor/graphql/discount/mutations/voucher_create.py
@@ -10,7 +10,7 @@ from ...core.descriptions import ADDED_IN_31
 from ...core.mutations import ModelMutation
 from ...core.types import DiscountError, NonNullList
 from ...core.validators import validate_end_is_after_start
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..enums import DiscountValueTypeEnum, VoucherTypeEnum
 from ..types import Voucher
 
@@ -119,5 +119,5 @@ class VoucherCreate(ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.voucher_created, instance)

--- a/saleor/graphql/discount/mutations/voucher_delete.py
+++ b/saleor/graphql/discount/mutations/voucher_delete.py
@@ -6,7 +6,7 @@ from ....core.permissions import DiscountPermissions
 from ...channel import ChannelContext
 from ...core.mutations import ModelDeleteMutation
 from ...core.types import DiscountError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Voucher
 
 
@@ -30,5 +30,5 @@ class VoucherDelete(ModelDeleteMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.voucher_deleted, instance)

--- a/saleor/graphql/discount/mutations/voucher_remove_catalogues.py
+++ b/saleor/graphql/discount/mutations/voucher_remove_catalogues.py
@@ -1,6 +1,6 @@
 from ....core.permissions import DiscountPermissions
 from ...core.types import DiscountError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Voucher
 from .voucher_add_catalogues import VoucherBaseCatalogueMutation
 
@@ -21,7 +21,7 @@ class VoucherRemoveCatalogues(VoucherBaseCatalogueMutation):
         cls.remove_catalogues_from_node(voucher, input_data)
 
         if input_data:
-            manager = load_plugin_manager(info.context)
+            manager = get_plugin_manager_promise(info.context).get()
             cls.call_event(manager.voucher_updated, voucher)
 
         return VoucherRemoveCatalogues(voucher=voucher)

--- a/saleor/graphql/discount/mutations/voucher_update.py
+++ b/saleor/graphql/discount/mutations/voucher_update.py
@@ -3,7 +3,7 @@ import graphene
 from ....core.permissions import DiscountPermissions
 from ....discount import models
 from ...core.types import DiscountError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Voucher
 from .voucher_create import VoucherCreate, VoucherInput
 
@@ -25,5 +25,5 @@ class VoucherUpdate(VoucherCreate):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.voucher_updated, instance)

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -24,7 +24,7 @@ from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.scalars import PositiveDecimal
 from ..core.types import GiftCardError, NonNullList, PriceInput
 from ..core.validators import validate_price_precision, validate_required_string_field
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils.validators import check_for_duplicates
 from .types import GiftCard, GiftCardEvent
 
@@ -226,7 +226,7 @@ class GiftCardCreate(ModelMutation):
             user=user,
             app=app,
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         if note := cleaned_input.get("note"):
             events.gift_card_note_added_event(
                 gift_card=instance, user=user, app=app, message=note
@@ -340,7 +340,7 @@ class GiftCardUpdate(GiftCardCreate):
             )
         if tags_updated:
             events.gift_card_tags_updated_event(instance, old_tags, user, app)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.gift_card_updated, instance)
         return cls.success_response(instance)
 
@@ -379,7 +379,7 @@ class GiftCardDelete(ModelDeleteMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.gift_card_deleted, instance)
 
 
@@ -411,7 +411,7 @@ class GiftCardDeactivate(BaseMutation):
                 user=info.context.user,
                 app=app,
             )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.gift_card_status_changed, gift_card)
         return GiftCardDeactivate(gift_card=gift_card)
 
@@ -445,7 +445,7 @@ class GiftCardActivate(BaseMutation):
                 user=info.context.user,
                 app=app,
             )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.gift_card_status_changed, gift_card)
         return GiftCardActivate(gift_card=gift_card)
 
@@ -516,7 +516,7 @@ class GiftCardResend(BaseMutation):
         if not user:
             user = None
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         send_gift_card_notification(
             user,
             app,
@@ -578,6 +578,6 @@ class GiftCardAddNote(BaseMutation):
             app=app,
             message=cleaned_input["message"],
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.gift_card_updated, gift_card)
         return GiftCardAddNote(gift_card=gift_card, event=event)

--- a/saleor/graphql/invoice/mutations.py
+++ b/saleor/graphql/invoice/mutations.py
@@ -11,7 +11,7 @@ from ..app.dataloaders import load_app
 from ..core.mutations import ModelDeleteMutation, ModelMutation
 from ..core.types import InvoiceError
 from ..order.types import Order
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from .types import Invoice
 from .utils import is_event_active_for_any_plugin
 
@@ -64,7 +64,7 @@ class InvoiceRequest(ModelMutation):
             info, data["order_id"], only_type=Order, field="orderId"
         )
         cls.clean_order(order)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         if not is_event_active_for_any_plugin("invoice_request", manager.all_plugins):
             raise ValidationError(
                 {
@@ -209,7 +209,7 @@ class InvoiceRequestDelete(ModelMutation):
         invoice = cls.get_node_or_error(info, data["id"], only_type=Invoice)
         invoice.status = JobStatus.PENDING
         invoice.save(update_fields=["status", "updated_at"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.invoice_delete, invoice)
         app = load_app(info.context)
         events.invoice_requested_deletion_event(
@@ -348,7 +348,7 @@ class InvoiceSendNotification(ModelMutation):
         instance = cls.get_instance(info, **data)
         cls.clean_instance(info, instance)
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         send_invoice(
             invoice=instance,
             staff_user=info.context.user,

--- a/saleor/graphql/menu/bulk_mutations.py
+++ b/saleor/graphql/menu/bulk_mutations.py
@@ -4,7 +4,7 @@ from ...core.permissions import MenuPermissions
 from ...menu import models
 from ..core.mutations import ModelBulkDeleteMutation
 from ..core.types import MenuError, NonNullList
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from .types import Menu, MenuItem
 
 
@@ -26,7 +26,7 @@ class MenuBulkDelete(ModelBulkDeleteMutation):
     def bulk_action(cls, info, queryset):
         menus = list(queryset)
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for menu in menus:
             manager.menu_deleted(menu)
 
@@ -49,6 +49,6 @@ class MenuItemBulkDelete(ModelBulkDeleteMutation):
     def bulk_action(cls, info, queryset):
         menu_items = list(queryset)
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for menu_item in menu_items:
             manager.menu_item_deleted(menu_item)

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -17,7 +17,7 @@ from ..core.types import MenuError, NonNullList
 from ..core.utils.reordering import perform_reordering
 from ..core.validators import validate_slug_and_generate_if_needed
 from ..page.types import Page
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from ..product.types import Category, Collection
 from ..site.dataloaders import get_site_promise
 from .dataloaders import MenuItemsByParentMenuLoader
@@ -133,7 +133,7 @@ class MenuCreate(ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.menu_created, instance)
 
     @classmethod
@@ -164,7 +164,7 @@ class MenuUpdate(ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.menu_updated, instance)
 
     @classmethod
@@ -187,7 +187,7 @@ class MenuDelete(ModelDeleteMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.menu_deleted, instance)
 
     @classmethod
@@ -236,7 +236,7 @@ class MenuItemCreate(ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.menu_item_created, instance)
 
     @classmethod
@@ -298,7 +298,7 @@ class MenuItemUpdate(MenuItemCreate):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.menu_item_updated, instance)
 
 
@@ -316,7 +316,7 @@ class MenuItemDelete(ModelDeleteMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.menu_item_deleted, instance)
 
     @classmethod
@@ -472,7 +472,7 @@ class MenuItemMove(BaseMutation):
         menu = cls.get_node_or_error(info, menu, only_type=Menu, field="menu", qs=qs)
 
         operations = cls.clean_moves(info, menu, moves)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             for operation in operations:
                 cls.perform_change_parent_operation(operation)

--- a/saleor/graphql/meta/extra_methods.py
+++ b/saleor/graphql/meta/extra_methods.py
@@ -1,68 +1,68 @@
 from ...product.models import Product, ProductVariant
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 
 
 def extra_checkout_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.checkout_updated(instance)
     manager.checkout_metadata_updated(instance)
 
 
 def extra_collection_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.collection_metadata_updated(instance)
 
 
 def extra_fulfillment_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.fulfillment_metadata_updated(instance)
 
 
 def extra_gift_card_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.gift_card_metadata_updated(instance)
 
 
 def extra_order_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.order_metadata_updated(instance)
 
 
 def extra_product_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.product_updated(instance)
     manager.product_metadata_updated(instance)
 
 
 def extra_variant_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.product_variant_updated(instance)
     manager.product_variant_metadata_updated(instance)
 
 
 def extra_shipping_zone_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.shipping_zone_metadata_updated(instance)
 
 
 def extra_transaction_item_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.transaction_item_metadata_updated(instance)
 
 
 def extra_user_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.customer_updated(instance)
     manager.customer_metadata_updated(instance)
 
 
 def extra_warehouse_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.warehouse_metadata_updated(instance)
 
 
 def extra_voucher_actions(instance, info, **data):
-    manager = load_plugin_manager(info.context)
+    manager = get_plugin_manager_promise(info.context).get()
     manager.voucher_metadata_updated(instance)
 
 

--- a/saleor/graphql/notifications/mutations/external_notification_trigger.py
+++ b/saleor/graphql/notifications/mutations/external_notification_trigger.py
@@ -16,7 +16,7 @@ from ...core.fields import JSONString
 from ...core.mutations import BaseMutation
 from ...core.types import ExternalNotificationError, NonNullList
 from ...notifications.error_codes import ExternalNotificationErrorCodes
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 
 
 class ExternalNotificationTriggerInput(graphene.InputObjectType):
@@ -67,7 +67,7 @@ class ExternalNotificationTrigger(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         plugin_id = data.get("plugin_id")
         channel_slug = validate_and_get_channel(data, ExternalNotificationErrorCodes)
         if data_input := data.get("input"):

--- a/saleor/graphql/order/bulk_mutations/orders.py
+++ b/saleor/graphql/order/bulk_mutations/orders.py
@@ -6,7 +6,7 @@ from ....order.actions import cancel_order
 from ...app.dataloaders import load_app
 from ...core.mutations import BaseBulkMutation
 from ...core.types import NonNullList, OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..mutations.order_cancel import clean_order_cancel
 from ..types import Order
 
@@ -31,7 +31,7 @@ class OrderBulkCancel(BaseBulkMutation):
 
     @classmethod
     def bulk_action(cls, info, queryset):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for order in queryset:
             cancel_order(
                 order=order,

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -20,7 +20,7 @@ from ....warehouse.reservations import is_reservation_enabled
 from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Order
 from ..utils import (
@@ -66,7 +66,7 @@ class DraftOrderComplete(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, id):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         order = cls.get_node_or_error(
             info,
             id,

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -27,7 +27,7 @@ from ...core.descriptions import ADDED_IN_36, PREVIEW_FEATURE
 from ...core.mutations import ModelMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import NonNullList, OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...product.types import ProductVariant
 from ...shipping.utils import get_shipping_model_by_object_id
 from ...site.dataloaders import get_site_promise
@@ -115,7 +115,7 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
         billing_address = data.pop("billing_address", None)
         redirect_url = data.pop("redirect_url", None)
         channel_id = data.pop("channel_id", None)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         site = get_site_promise(info.context).get()
         shipping_method = get_shipping_model_by_object_id(
             object_id=data.pop("shipping_method", None), raise_error=False
@@ -328,7 +328,7 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
 
     @classmethod
     def save(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         app = load_app(info.context)
         site = get_site_promise(info.context).get()
         return cls._save_draft_order(

--- a/saleor/graphql/order/mutations/draft_order_delete.py
+++ b/saleor/graphql/order/mutations/draft_order_delete.py
@@ -7,7 +7,7 @@ from ....order import OrderStatus, models
 from ....order.error_codes import OrderErrorCode
 from ...core.mutations import ModelDeleteMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
 
 
@@ -38,7 +38,7 @@ class DraftOrderDelete(ModelDeleteMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         order = cls.get_instance(info, **data)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             response = super().perform_mutation(_root, info, **data)
             cls.call_event(manager.draft_order_deleted, order)

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -6,7 +6,7 @@ from ....order import OrderStatus, models
 from ....order.error_codes import OrderErrorCode
 from ...app.dataloaders import load_app
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Order
 from .draft_order_create import DraftOrderCreate, DraftOrderInput
@@ -57,7 +57,7 @@ class DraftOrderUpdate(DraftOrderCreate):
 
     @classmethod
     def save(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         app = load_app(info.context)
         site = get_site_promise(info.context).get()
         return cls._save_draft_order(

--- a/saleor/graphql/order/mutations/fulfillment_approve.py
+++ b/saleor/graphql/order/mutations/fulfillment_approve.py
@@ -10,7 +10,7 @@ from ...app.dataloaders import load_app
 from ...core.descriptions import ADDED_IN_31
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Fulfillment, Order
 from ..utils import prepare_insufficient_stock_order_validation_errors
@@ -62,7 +62,7 @@ class FulfillmentApprove(BaseMutation):
         cls.clean_input(info, fulfillment)
 
         order = fulfillment.order
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         app = load_app(info.context)
         site = get_site_promise(info.context).get()
         try:

--- a/saleor/graphql/order/mutations/fulfillment_cancel.py
+++ b/saleor/graphql/order/mutations/fulfillment_cancel.py
@@ -9,7 +9,7 @@ from ....order.error_codes import OrderErrorCode
 from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Fulfillment, Order
 
 
@@ -92,7 +92,7 @@ class FulfillmentCancel(BaseMutation):
         cls.validate_fulfillment(fulfillment, warehouse)
 
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         if fulfillment.status == FulfillmentStatus.WAITING_FOR_APPROVAL:
             fulfillment = cancel_waiting_fulfillment(
                 fulfillment,

--- a/saleor/graphql/order/mutations/fulfillment_refund_products.py
+++ b/saleor/graphql/order/mutations/fulfillment_refund_products.py
@@ -8,7 +8,7 @@ from ....payment import PaymentError
 from ...app.dataloaders import load_app
 from ...core.scalars import PositiveDecimal
 from ...core.types import NonNullList, OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Fulfillment, Order
 from .fulfillment_refund_and_return_product_base import (
     FulfillmentRefundAndReturnProductBase,
@@ -133,7 +133,7 @@ class FulfillmentRefundProducts(FulfillmentRefundAndReturnProductBase):
     def perform_mutation(cls, _root, info, **data):
         cleaned_input = cls.clean_input(info, data.get("order"), data.get("input"))
         order = cleaned_input["order"]
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         try:
             app = load_app(info.context)
             refund_fulfillment = create_refund_fulfillment(

--- a/saleor/graphql/order/mutations/fulfillment_return_products.py
+++ b/saleor/graphql/order/mutations/fulfillment_return_products.py
@@ -8,7 +8,7 @@ from ....payment import PaymentError
 from ...app.dataloaders import load_app
 from ...core.scalars import PositiveDecimal
 from ...core.types import NonNullList, OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Fulfillment, Order
 from .fulfillment_refund_and_return_product_base import (
     FulfillmentRefundAndReturnProductBase,
@@ -156,7 +156,7 @@ class FulfillmentReturnProducts(FulfillmentRefundAndReturnProductBase):
     def perform_mutation(cls, _root, info, **data):
         cleaned_input = cls.clean_input(info, data.get("order"), data.get("input"))
         order = cleaned_input["order"]
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         try:
             app = load_app(info.context)
             response = create_fulfillments_for_returned_products(

--- a/saleor/graphql/order/mutations/fulfillment_update_tracking.py
+++ b/saleor/graphql/order/mutations/fulfillment_update_tracking.py
@@ -6,7 +6,7 @@ from ....order.notifications import send_fulfillment_update
 from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Fulfillment, Order
 from .order_fulfill import FulfillmentUpdateTrackingInput
 
@@ -39,7 +39,7 @@ class FulfillmentUpdateTracking(BaseMutation):
         fulfillment.save()
         order = fulfillment.order
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         fulfillment_tracking_updated(
             fulfillment,
             info.context.user,

--- a/saleor/graphql/order/mutations/order_add_note.py
+++ b/saleor/graphql/order/mutations/order_add_note.py
@@ -9,7 +9,7 @@ from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ...core.validators import validate_required_string_field
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order, OrderEvent
 from .utils import get_webhook_handler_by_order_status
 
@@ -60,7 +60,7 @@ class OrderAddNote(BaseMutation):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
         cleaned_input = cls.clean_input(info, order, data)
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             event = events.order_note_added_event(
                 order=order,

--- a/saleor/graphql/order/mutations/order_cancel.py
+++ b/saleor/graphql/order/mutations/order_cancel.py
@@ -9,7 +9,7 @@ from ....order.error_codes import OrderErrorCode
 from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
 
 
@@ -43,7 +43,7 @@ class OrderCancel(BaseMutation):
         clean_order_cancel(order)
         user = info.context.user
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             cancel_order(
                 order=order,

--- a/saleor/graphql/order/mutations/order_capture.py
+++ b/saleor/graphql/order/mutations/order_capture.py
@@ -11,7 +11,7 @@ from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Order
 from .utils import clean_payment, try_payment_action
@@ -60,7 +60,7 @@ class OrderCapture(BaseMutation):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
 
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         if payment_transactions := list(order.payment_transactions.all()):
             try:
                 # We use the last transaction as we don't have a possibility to

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -13,7 +13,7 @@ from ....payment.gateway import request_charge_action
 from ...app.dataloaders import load_app
 from ...core.mutations import ModelMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Order
 
@@ -63,7 +63,7 @@ class OrderConfirm(ModelMutation):
         order.save(update_fields=["status", "updated_at"])
         order_info = fetch_order_info(order)
         payment = order_info.payment
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         app = load_app(info.context)
         with traced_atomic_transaction():
             if payment_transactions := list(order.payment_transactions.all()):

--- a/saleor/graphql/order/mutations/order_discount_add.py
+++ b/saleor/graphql/order/mutations/order_discount_add.py
@@ -9,7 +9,7 @@ from ....order.error_codes import OrderErrorCode
 from ....order.utils import create_order_discount_for_order, get_order_discounts
 from ...app.dataloaders import load_app
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
 from .order_discount_common import OrderDiscountCommon, OrderDiscountCommonInput
 
@@ -52,7 +52,7 @@ class OrderDiscountAdd(OrderDiscountCommon):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         order = cls.get_node_or_error(info, data.get("order_id"), only_type=Order)
         input = data.get("input", {})
         cls.validate(info, order, input)

--- a/saleor/graphql/order/mutations/order_discount_update.py
+++ b/saleor/graphql/order/mutations/order_discount_update.py
@@ -8,7 +8,7 @@ from ....order import events
 from ....order.calculations import fetch_order_prices_if_expired
 from ...app.dataloaders import load_app
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
 from .order_discount_common import OrderDiscountCommon, OrderDiscountCommonInput
 
@@ -41,7 +41,7 @@ class OrderDiscountUpdate(OrderDiscountCommon):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         order_discount = cls.get_node_or_error(
             info, data.get("discount_id"), only_type="OrderDiscount"
         )

--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -14,7 +14,7 @@ from ...core.descriptions import ADDED_IN_36
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, OrderError
 from ...core.utils import get_duplicated_values
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ...warehouse.types import Warehouse
 from ..types import Fulfillment, Order, OrderLine
@@ -246,7 +246,7 @@ class OrderFulfill(BaseMutation):
         context = info.context
         user = context.user
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         lines_for_warehouses = cleaned_input["lines_for_warehouses"]
         notify_customer = cleaned_input.get("notify_customer", True)
         allow_stock_to_be_exceeded = cleaned_input.get(

--- a/saleor/graphql/order/mutations/order_line_delete.py
+++ b/saleor/graphql/order/mutations/order_line_delete.py
@@ -14,7 +14,7 @@ from ....order.utils import (
 from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order, OrderLine
 from .utils import EditableOrderValidationMixin, get_webhook_handler_by_order_status
 
@@ -36,7 +36,7 @@ class OrderLineDelete(EditableOrderValidationMixin, BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, id):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         line = cls.get_node_or_error(
             info,
             id,

--- a/saleor/graphql/order/mutations/order_line_discount_remove.py
+++ b/saleor/graphql/order/mutations/order_line_discount_remove.py
@@ -6,7 +6,7 @@ from ....order import events
 from ....order.utils import invalidate_order_prices, remove_discount_from_order_line
 from ...app.dataloaders import load_app
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Order, OrderLine
 from .order_discount_common import OrderDiscountCommon
@@ -44,7 +44,7 @@ class OrderLineDiscountRemove(OrderDiscountCommon):
         )
         order = order_line.order
         cls.validate(info, order)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             remove_discount_from_order_line(
                 order_line,

--- a/saleor/graphql/order/mutations/order_line_discount_update.py
+++ b/saleor/graphql/order/mutations/order_line_discount_update.py
@@ -8,7 +8,7 @@ from ....order import events
 from ....order.utils import invalidate_order_prices, update_discount_for_order_line
 from ...app.dataloaders import load_app
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Order, OrderLine
 from .order_discount_common import OrderDiscountCommon, OrderDiscountCommonInput
@@ -59,7 +59,7 @@ class OrderLineDiscountUpdate(OrderDiscountCommon):
         reason = input.get("reason")
         value_type = input.get("value_type")
         value = input.get("value")
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         site = get_site_promise(info.context).get()
         order_line_before_update = copy.deepcopy(order_line)
         tax_included = site.settings.include_taxes_in_prices

--- a/saleor/graphql/order/mutations/order_line_update.py
+++ b/saleor/graphql/order/mutations/order_line_update.py
@@ -15,7 +15,7 @@ from ....order.utils import (
 from ...app.dataloaders import load_app
 from ...core.mutations import ModelMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order, OrderLine
 from .draft_order_create import OrderLineInput
 from .utils import EditableOrderValidationMixin, get_webhook_handler_by_order_status
@@ -58,7 +58,7 @@ class OrderLineUpdate(EditableOrderValidationMixin, ModelMutation):
 
     @classmethod
     def save(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         warehouse_pk = (
             instance.allocations.first().stock.warehouse.pk
             if instance.order.is_unconfirmed()

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -20,7 +20,7 @@ from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, OrderError
 from ...discount.dataloaders import load_discounts
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...product.types import ProductVariant
 from ...site.dataloaders import get_site_promise
 from ..types import Order, OrderLine
@@ -154,7 +154,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         variants = [line.variant for line in lines_to_add]
         cls.validate_variants(order, variants)
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         site = get_site_promise(info.context).get()
         discounts = load_discounts(info.context)
         with traced_atomic_transaction():

--- a/saleor/graphql/order/mutations/order_mark_as_paid.py
+++ b/saleor/graphql/order/mutations/order_mark_as_paid.py
@@ -9,7 +9,7 @@ from ....order.search import update_order_search_vector
 from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
 from .utils import try_payment_action
 
@@ -40,7 +40,7 @@ class OrderMarkAsPaid(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         order, _ = fetch_order_prices_if_expired(order, manager)
         transaction_reference = data.get("transaction_reference")
         cls.clean_billing_address(order)

--- a/saleor/graphql/order/mutations/order_refund.py
+++ b/saleor/graphql/order/mutations/order_refund.py
@@ -12,7 +12,7 @@ from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
 from .utils import clean_payment, try_payment_action
 
@@ -72,7 +72,7 @@ class OrderRefund(BaseMutation):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
         clean_order_refund(order)
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         if payment_transactions := list(order.payment_transactions.all()):
             # We use the last transaction as we don't have a possibility to
             # provide way of handling multiple transaction here

--- a/saleor/graphql/order/mutations/order_update.py
+++ b/saleor/graphql/order/mutations/order_update.py
@@ -11,7 +11,7 @@ from ....order.search import prepare_order_search_vector_value
 from ....order.utils import invalidate_order_prices
 from ...account.types import AddressInput
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
 from .draft_order_create import DraftOrderCreate
 
@@ -81,7 +81,7 @@ class OrderUpdate(DraftOrderCreate):
             instance.search_vector = FlatConcatSearchVector(
                 *prepare_order_search_vector_value(instance)
             )
-            manager = load_plugin_manager(info.context)
+            manager = get_plugin_manager_promise(info.context).get()
             if cls.should_invalidate_prices(instance, cleaned_input, False):
                 invalidate_order_prices(instance)
 

--- a/saleor/graphql/order/mutations/order_update_shipping.py
+++ b/saleor/graphql/order/mutations/order_update_shipping.py
@@ -10,7 +10,7 @@ from ....shipping import models as shipping_models
 from ....shipping.utils import convert_to_shipping_method_data
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...shipping.types import ShippingMethod
 from ..types import Order
 from .utils import EditableOrderValidationMixin, clean_order_update_shipping
@@ -141,7 +141,7 @@ class OrderUpdateShipping(EditableOrderValidationMixin, BaseMutation):
             method,
             shipping_channel_listing,
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         clean_order_update_shipping(order, shipping_method_data, manager)
 
         order.shipping_method = method

--- a/saleor/graphql/order/mutations/order_void.py
+++ b/saleor/graphql/order/mutations/order_void.py
@@ -9,7 +9,7 @@ from ....payment.gateway import request_void_action
 from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
 from .utils import clean_payment, try_payment_action
 
@@ -44,7 +44,7 @@ class OrderVoid(BaseMutation):
     def perform_mutation(cls, _root, info, **data):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         if payment_transactions := list(order.payment_transactions.all()):
             # We use the last transaction as we don't have a possibility to
             # provide way of handling multiple transaction here

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -89,7 +89,10 @@ from ..invoice.types import Invoice
 from ..meta.types import ObjectWithMetadata
 from ..payment.enums import OrderAction, TransactionStatusEnum
 from ..payment.types import Payment, PaymentChargeStatusEnum, TransactionItem
-from ..plugins.dataloaders import load_plugin_manager, plugin_manager_promise_callback
+from ..plugins.dataloaders import (
+    get_plugin_manager_promise,
+    plugin_manager_promise_callback,
+)
 from ..product.dataloaders import (
     MediaByProductVariantIdLoader,
     ProductByVariantIdLoader,
@@ -646,17 +649,16 @@ class OrderLine(ModelObjectType):
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_unit_price(root: models.OrderLine, info):
-        manager = load_plugin_manager(info.context)
-
         def _resolve_unit_price(data):
-            order, lines = data
+            order, lines, manager = data
             return calculations.order_line_unit(
                 order, root, manager, lines
             ).price_with_discounts
 
         order = OrderByIdLoader(info.context).load(root.order_id)
         lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
-        return Promise.all([order, lines]).then(_resolve_unit_price)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(_resolve_unit_price)
 
     @staticmethod
     def resolve_quantity_to_fulfill(root: models.OrderLine, info):
@@ -666,17 +668,18 @@ class OrderLine(ModelObjectType):
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_undiscounted_unit_price(root: models.OrderLine, info):
-        manager = load_plugin_manager(info.context)
-
         def _resolve_undiscounted_unit_price(data):
-            order, lines = data
+            order, lines, manager = data
             return calculations.order_line_unit(
                 order, root, manager, lines
             ).undiscounted_price
 
         order = OrderByIdLoader(info.context).load(root.order_id)
         lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
-        return Promise.all([order, lines]).then(_resolve_undiscounted_unit_price)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(
+            _resolve_undiscounted_unit_price
+        )
 
     @staticmethod
     def resolve_unit_discount_type(root: models.OrderLine, _info):
@@ -693,47 +696,46 @@ class OrderLine(ModelObjectType):
     @staticmethod
     @traced_resolver
     def resolve_tax_rate(root: models.OrderLine, info):
-        manager = load_plugin_manager(info.context)
-
         def _resolve_tax_rate(data):
-            order, lines = data
+            order, lines, manager = data
             return calculations.order_line_tax_rate(order, root, manager, lines)
 
         order = OrderByIdLoader(info.context).load(root.order_id)
         lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
-        return Promise.all([order, lines]).then(_resolve_tax_rate)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(_resolve_tax_rate)
 
     @staticmethod
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_total_price(root: models.OrderLine, info):
-        manager = load_plugin_manager(info.context)
-
         def _resolve_total_price(data):
-            order, lines = data
+            order, lines, manager = data
             return calculations.order_line_total(
                 order, root, manager, lines
             ).price_with_discounts
 
         order = OrderByIdLoader(info.context).load(root.order_id)
         lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
-        return Promise.all([order, lines]).then(_resolve_total_price)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(_resolve_total_price)
 
     @staticmethod
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_undiscounted_total_price(root: models.OrderLine, info):
-        manager = load_plugin_manager(info.context)
-
         def _resolve_undiscounted_total_price(data):
-            order, lines = data
+            order, lines, manager = data
             return calculations.order_line_total(
                 order, root, manager, lines
             ).undiscounted_price
 
         order = OrderByIdLoader(info.context).load(root.order_id)
         lines = OrderLinesByOrderIdLoader(info.context).load(root.order_id)
-        return Promise.all([order, lines]).then(_resolve_undiscounted_total_price)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([order, lines, manager]).then(
+            _resolve_undiscounted_total_price
+        )
 
     @staticmethod
     def resolve_translated_product_name(root: models.OrderLine, _info):
@@ -1167,31 +1169,26 @@ class Order(ModelObjectType):
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_shipping_price(root: models.Order, info):
-        manager = load_plugin_manager(info.context)
-
-        def _resolve_shipping_price(lines):
+        def _resolve_shipping_price(data):
+            lines, manager = data
             return calculations.order_shipping(root, manager, lines)
 
-        return (
-            OrderLinesByOrderIdLoader(info.context)
-            .load(root.id)
-            .then(_resolve_shipping_price)
-        )
+        lines = OrderLinesByOrderIdLoader(info.context).load(root.id)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([lines, manager]).then(_resolve_shipping_price)
 
     @staticmethod
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_shipping_tax_rate(root: models.Order, info):
-        manager = load_plugin_manager(info.context)
-
-        def _resolve_shipping_tax_rate(lines):
+        def _resolve_shipping_tax_rate(data):
+            lines, manager = data
             return calculations.order_shipping_tax_rate(root, manager, lines)
 
-        return (
-            OrderLinesByOrderIdLoader(info.context)
-            .load(root.id)
-            .then(_resolve_shipping_tax_rate)
-        )
+        lines = OrderLinesByOrderIdLoader(info.context).load(root.id)
+        manager = get_plugin_manager_promise(info.context)
+
+        return Promise.all([lines, manager]).then(_resolve_shipping_tax_rate)
 
     @staticmethod
     def resolve_actions(root: models.Order, info):
@@ -1215,16 +1212,14 @@ class Order(ModelObjectType):
     @staticmethod
     @traced_resolver
     def resolve_subtotal(root: models.Order, info):
-        manager = load_plugin_manager(info.context)
-
-        def _resolve_subtotal(order_lines):
+        def _resolve_subtotal(data):
+            order_lines, manager = data
             return calculations.order_subtotal(root, manager, order_lines)
 
-        return (
-            OrderLinesByOrderIdLoader(info.context)
-            .load(root.id)
-            .then(_resolve_subtotal)
-        )
+        order_lines = OrderLinesByOrderIdLoader(info.context).load(root.id)
+        manager = get_plugin_manager_promise(info.context)
+
+        return Promise.all([order_lines, manager]).then(_resolve_subtotal)
 
     @staticmethod
     @traced_resolver
@@ -1242,16 +1237,12 @@ class Order(ModelObjectType):
     @traced_resolver
     @prevent_sync_event_circular_query
     def resolve_undiscounted_total(root: models.Order, info):
-        manager = load_plugin_manager(info.context)
-
         def _resolve_undiscounted_total(lines):
             return calculations.order_undiscounted_total(root, manager, lines)
 
-        return (
-            OrderLinesByOrderIdLoader(info.context)
-            .load(root.id)
-            .then(_resolve_undiscounted_total)
-        )
+        lines = OrderLinesByOrderIdLoader(info.context).load(root.id)
+        manager = get_plugin_manager_promise(info.context)
+        return Promise.all([lines, manager]).then(_resolve_undiscounted_total)
 
     @staticmethod
     def resolve_total_authorized(root: models.Order, info):
@@ -1443,12 +1434,16 @@ class Order(ModelObjectType):
     @traced_resolver
     def resolve_can_finalize(root: models.Order, info):
         if root.status == OrderStatus.DRAFT:
-            manager = load_plugin_manager(info.context)
-            country = get_order_country(root)
-            try:
-                validate_draft_order(root, country, manager)
-            except ValidationError:
-                return False
+
+            def _validate_draft_order(manager):
+                country = get_order_country(root)
+                try:
+                    validate_draft_order(root, country, manager)
+                except ValidationError:
+                    return False
+                return True
+
+            return get_plugin_manager_promise(info.context).then(_validate_draft_order)
         return True
 
     @staticmethod
@@ -1547,9 +1542,9 @@ class Order(ModelObjectType):
     @prevent_sync_event_circular_query
     # TODO: We should optimize it in/after PR#5819
     def resolve_shipping_methods(cls, root: models.Order, info):
-        manager = load_plugin_manager(info.context)
+        def with_channel(data):
+            channel, manager = data
 
-        def with_channel(channel):
             def with_listings(channel_listings):
                 return get_valid_shipping_methods_for_order(
                     root, channel_listings, manager
@@ -1561,7 +1556,10 @@ class Order(ModelObjectType):
                 .then(with_listings)
             )
 
-        return ChannelByIdLoader(info.context).load(root.channel_id).then(with_channel)
+        channel = ChannelByIdLoader(info.context).load(root.channel_id)
+        manager = get_plugin_manager_promise(info.context)
+
+        return Promise.all([channel, manager]).then(with_channel)
 
     @classmethod
     @traced_resolver
@@ -1625,12 +1623,17 @@ class Order(ModelObjectType):
     @traced_resolver
     def resolve_errors(root: models.Order, info):
         if root.status == OrderStatus.DRAFT:
-            country = get_order_country(root)
-            manager = load_plugin_manager(info.context)
-            try:
-                validate_draft_order(root, country, manager)
-            except ValidationError as e:
-                return validation_error_to_error_type(e, OrderError)
+
+            def _validate_order(manager):
+                country = get_order_country(root)
+                try:
+                    validate_draft_order(root, country, manager)
+                except ValidationError as e:
+                    return validation_error_to_error_type(e, OrderError)
+                return []
+
+            return get_plugin_manager_promise(info.context).then(_validate_order)
+
         return []
 
 

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -9,7 +9,7 @@ from ...core.tracing import traced_atomic_transaction
 from ...page import models
 from ..core.mutations import BaseBulkMutation, ModelBulkDeleteMutation
 from ..core.types import NonNullList, PageError
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from .types import Page, PageType
 
 
@@ -97,7 +97,7 @@ class PageTypeBulkDelete(ModelBulkDeleteMutation):
     def bulk_action(cls, info, queryset):
         page_types = list(queryset)
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for pt in page_types:
             transaction.on_commit(lambda: manager.page_type_deleted(pt))
 

--- a/saleor/graphql/page/mutations/pages.py
+++ b/saleor/graphql/page/mutations/pages.py
@@ -19,7 +19,7 @@ from ...core.fields import JSONString
 from ...core.mutations import ModelDeleteMutation, ModelMutation
 from ...core.types import NonNullList, PageError, SeoInput
 from ...core.validators import clean_seo_fields, validate_slug_and_generate_if_needed
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...utils.validators import check_for_duplicates
 from ..types import Page, PageType
 
@@ -134,7 +134,7 @@ class PageCreate(ModelMutation):
     @classmethod
     def save(cls, info, instance, cleaned_input):
         super().save(info, instance, cleaned_input)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.page_created, instance)
 
 
@@ -164,7 +164,7 @@ class PageUpdate(PageCreate):
     @classmethod
     def save(cls, info, instance, cleaned_input):
         super(PageCreate, cls).save(info, instance, cleaned_input)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.page_updated, instance)
 
 
@@ -183,7 +183,7 @@ class PageDelete(ModelDeleteMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         page = cls.get_instance(info, **data)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             cls.delete_assigned_attribute_values(page)
             response = super().perform_mutation(_root, info, **data)
@@ -285,7 +285,7 @@ class PageTypeCreate(PageTypeMixin, ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.page_type_created, instance)
 
 
@@ -346,7 +346,7 @@ class PageTypeUpdate(PageTypeMixin, ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.page_type_updated, instance)
 
 
@@ -381,5 +381,5 @@ class PageTypeDelete(ModelDeleteMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.page_type_deleted, instance)

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -51,7 +51,7 @@ from ..core.scalars import UUID, PositiveDecimal
 from ..core.types import common as common_types
 from ..discount.dataloaders import load_discounts
 from ..meta.mutations import MetadataInput
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import get_user_or_app_from_context
 from .enums import StorePaymentMethodEnum, TransactionActionEnum, TransactionStatusEnum
 from .types import Payment, PaymentInitialized, TransactionItem
@@ -247,7 +247,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         data = data["input"]
         gateway = data["gateway"]
 
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.validate_gateway(manager, gateway, checkout)
         cls.validate_return_url(data)
 
@@ -375,7 +375,7 @@ class PaymentCapture(BaseMutation):
             if payment.order
             else payment.checkout.channel.slug
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         try:
             gateway.capture(
                 payment,
@@ -406,7 +406,7 @@ class PaymentRefund(PaymentCapture):
             if payment.order
             else payment.checkout.channel.slug
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         try:
             gateway.refund(
                 payment,
@@ -442,7 +442,7 @@ class PaymentVoid(BaseMutation):
             if payment.order
             else payment.checkout.channel.slug
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         try:
             gateway.void(payment, manager, channel_slug=channel_slug)
             payment.refresh_from_db()
@@ -501,7 +501,7 @@ class PaymentInitialize(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, gateway, channel, payment_data):
         cls.validate_channel(channel_slug=channel)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         try:
             response = manager.initialize_payment(
                 gateway, payment_data, channel_slug=channel
@@ -563,7 +563,7 @@ class PaymentCheckBalance(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         gateway_id = data["input"]["gateway_id"]
         money = data["input"]["card"].get("money", {})
 
@@ -1033,7 +1033,7 @@ class TransactionRequestAction(BaseMutation):
             else transaction.checkout.channel.slug
         )
         app = load_app(info.context)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         action_kwargs = {
             "channel_slug": channel_slug,
             "user": info.context.user,

--- a/saleor/graphql/plugins/dataloaders.py
+++ b/saleor/graphql/plugins/dataloaders.py
@@ -3,7 +3,7 @@ from functools import partial, wraps
 
 from ...plugins.manager import get_plugins_manager
 from ...plugins.models import EmailTemplate
-from ..app.dataloaders import get_app_promise, load_app
+from ..app.dataloaders import get_app_promise
 from ..core.dataloaders import DataLoader
 
 
@@ -36,15 +36,6 @@ class AnonymousPluginManagerLoader(DataLoader):
 
     def batch_load(self, keys):
         return [get_plugins_manager() for key in keys]
-
-
-def load_plugin_manager(request):
-    app = load_app(request)
-    user = request.user
-    requestor = app or user
-    if requestor is None:
-        return AnonymousPluginManagerLoader(request).load("Anonymous").get()
-    return PluginManagerByRequestorDataloader(request).load(requestor).get()
 
 
 def plugin_manager_promise(request, app):

--- a/saleor/graphql/plugins/mutations.py
+++ b/saleor/graphql/plugins/mutations.py
@@ -7,7 +7,7 @@ from ...plugins.manager import get_plugins_manager
 from ..channel.types import Channel
 from ..core.mutations import BaseMutation
 from ..core.types import NonNullList, PluginError
-from .dataloaders import load_plugin_manager
+from .dataloaders import get_plugin_manager_promise
 from .resolvers import resolve_plugin
 from .types import Plugin
 
@@ -61,7 +61,7 @@ class PluginUpdate(BaseMutation):
         channel_slug = channel.slug if channel_id else None
         input_data = data.get("input")
 
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         plugin = manager.get_plugin(plugin_id, channel_slug)
         if not plugin or plugin.HIDDEN is True:
             raise ValidationError(
@@ -98,7 +98,7 @@ class PluginUpdate(BaseMutation):
         plugin_id = cleaned_data["plugin"].PLUGIN_ID
         channel_slug = cleaned_data["channel_slug"]
         input_data = cleaned_data["data"]
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         manager.save_plugin_configuration(plugin_id, channel_slug, input_data)
         manager = get_plugins_manager()
         return PluginUpdate(plugin=resolve_plugin(plugin_id, manager))

--- a/saleor/graphql/plugins/schema.py
+++ b/saleor/graphql/plugins/schema.py
@@ -4,7 +4,7 @@ from ...core.permissions import PluginsPermissions
 from ...core.tracing import traced_resolver
 from ..core.connection import create_connection_slice
 from ..core.fields import ConnectionField, PermissionsField
-from .dataloaders import load_plugin_manager
+from .dataloaders import plugin_manager_promise_callback
 from .filters import PluginFilterInput
 from .mutations import PluginUpdate
 from .resolvers import resolve_plugin, resolve_plugins
@@ -36,14 +36,14 @@ class PluginsQueries(graphene.ObjectType):
 
     @staticmethod
     @traced_resolver
-    def resolve_plugin(_root, info, **data):
-        manager = load_plugin_manager(info.context)
+    @plugin_manager_promise_callback
+    def resolve_plugin(_root, info, manager, **data):
         return resolve_plugin(data.get("id"), manager)
 
     @staticmethod
     @traced_resolver
-    def resolve_plugins(_root, info, **kwargs):
-        manager = load_plugin_manager(info.context)
+    @plugin_manager_promise_callback
+    def resolve_plugins(_root, info, manager, **kwargs):
         qs = resolve_plugins(manager, **kwargs)
         return create_connection_slice(qs, info, kwargs, PluginCountableConnection)
 

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -46,7 +46,7 @@ from ...core.validators import (
     validate_one_of_args_is_in_mutation,
     validate_price_precision,
 )
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...warehouse.dataloaders import (
     StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader,
 )
@@ -90,7 +90,7 @@ class CategoryBulkDelete(ModelBulkDeleteMutation):
 
     @classmethod
     def bulk_action(cls, info, queryset):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         delete_categories(queryset.values_list("pk", flat=True), manager)
 
 
@@ -116,7 +116,7 @@ class CollectionBulkDelete(ModelBulkDeleteMutation):
             .filter(collections__in=collections_ids)
             .distinct()
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for collection in queryset.iterator():
             manager.collection_deleted(collection)
         queryset.delete()
@@ -198,7 +198,7 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
 
         products = [product for product in queryset]
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for product in products:
             variants = product_variant_map.get(product.id, [])
             manager.product_deleted(product, variants)
@@ -568,7 +568,7 @@ class ProductVariantBulkCreate(BaseMutation):
         ]
 
         update_product_search_vector(product)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         transaction.on_commit(
             lambda: [
                 manager.product_variant_created(instance.node) for instance in instances
@@ -637,7 +637,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
         cls.delete_assigned_attribute_values(pks)
         cls.delete_product_channel_listings_without_available_variants(product_pks, pks)
         response = super().perform_mutation(_root, info, ids, **data)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         transaction.on_commit(
             lambda: [manager.product_variant_deleted(variant) for variant in variants]
         )
@@ -742,7 +742,7 @@ class ProductVariantStocksCreate(BaseMutation):
     @classmethod
     @traced_atomic_transaction()
     def perform_mutation(cls, _root, info, **data):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         errors = defaultdict(list)
         stocks = data["stocks"]
         variant = cls.get_node_or_error(
@@ -864,7 +864,7 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
                 warehouse_ids, "warehouse", only_type=Warehouse
             )
 
-            manager = load_plugin_manager(info.context)
+            manager = get_plugin_manager_promise(info.context).get()
             cls.update_or_create_variant_stocks(variant, stocks, warehouses, manager)
 
         StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader(
@@ -933,7 +933,7 @@ class ProductVariantStocksDelete(BaseMutation):
             ProductErrorCode, "sku", sku, "variant_id", variant_id
         )
 
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
 
         if variant_id:
             variant = cls.get_node_or_error(info, variant_id, only_type=ProductVariant)

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -40,7 +40,7 @@ from ...core.validators import (
     validate_one_of_args_is_in_mutation,
     validate_price_precision,
 )
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...utils.validators import check_for_duplicates
 from ..types.products import Collection, Product, ProductVariant
 
@@ -337,7 +337,7 @@ class ProductChannelListingUpdate(BaseChannelListingMutation):
             cls.update_channels(product, cleaned_input.get("update_channels", []))
             cls.remove_channels(product, cleaned_input.get("remove_channels", []))
             product = ProductModel.objects.prefetched_for_webhook().get(pk=product.pk)
-            manager = load_plugin_manager(info.context)
+            manager = get_plugin_manager_promise(info.context).get()
             cls.call_event(manager.product_updated, product)
 
     @classmethod
@@ -515,7 +515,7 @@ class ProductVariantChannelListingUpdate(BaseMutation):
                     defaults=defaults,
                 )
             update_product_discounted_price_task.delay(variant.product_id)
-            manager = load_plugin_manager(info.context)
+            manager = get_plugin_manager_promise(info.context).get()
             cls.call_event(manager.product_variant_updated, variant)
 
     @classmethod

--- a/saleor/graphql/product/mutations/digital_contents.py
+++ b/saleor/graphql/product/mutations/digital_contents.py
@@ -11,7 +11,7 @@ from ...core.descriptions import ADDED_IN_38
 from ...core.mutations import BaseMutation, ModelMutation
 from ...core.types import NonNullList, ProductError, Upload
 from ...meta.mutations import MetadataInput
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import DigitalContent, DigitalContentUrl, ProductVariant
 
 
@@ -164,7 +164,7 @@ class DigitalContentDelete(BaseMutation):
         set_mutation_flag_in_context(info.context)
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         result = manager.perform_mutation(
             mutation_cls=cls, root=root, info=info, data=data
         )

--- a/saleor/graphql/product/mutations/product_type_create.py
+++ b/saleor/graphql/product/mutations/product_type_create.py
@@ -9,7 +9,7 @@ from ...core.mutations import ModelMutation
 from ...core.scalars import WeightScalar
 from ...core.types import NonNullList, ProductError
 from ...core.validators import validate_slug_and_generate_if_needed
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..enums import ProductTypeKindEnum
 from ..types import ProductType
 
@@ -96,7 +96,7 @@ class ProductTypeCreate(ModelMutation):
 
         tax_code = cleaned_input.pop("tax_code", "")
         if tax_code:
-            manager = load_plugin_manager(info.context)
+            manager = get_plugin_manager_promise(info.context).get()
             manager.assign_tax_code_to_object_meta(instance, tax_code)
 
         cls.validate_attributes(cleaned_input)

--- a/saleor/graphql/shipping/bulk_mutations.py
+++ b/saleor/graphql/shipping/bulk_mutations.py
@@ -4,7 +4,7 @@ from ...core.permissions import ShippingPermissions
 from ...shipping import models
 from ..core.mutations import ModelBulkDeleteMutation
 from ..core.types import NonNullList, ShippingError
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from .types import ShippingMethod, ShippingZone
 
 
@@ -28,7 +28,7 @@ class ShippingZoneBulkDelete(ModelBulkDeleteMutation):
     def bulk_action(cls, info, queryset):
         zones = [zone for zone in queryset]
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for zone in zones:
             manager.shipping_zone_deleted(zone)
 
@@ -70,6 +70,6 @@ class ShippingPriceBulkDelete(ModelBulkDeleteMutation):
     def bulk_action(cls, info, queryset):
         shipping_methods = [sm for sm in queryset]
         queryset.delete()
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         for method in shipping_methods:
             manager.shipping_price_deleted(method)

--- a/saleor/graphql/shipping/mutations/channels.py
+++ b/saleor/graphql/shipping/mutations/channels.py
@@ -16,7 +16,7 @@ from ...channel.mutations import BaseChannelListingMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import NonNullList, ShippingError
 from ...core.validators import validate_decimal_max_value, validate_price_precision
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...shipping.utils import get_shipping_model_by_object_id
 from ..types import ShippingMethodType
 
@@ -255,7 +255,7 @@ class ShippingMethodChannelListingUpdate(BaseChannelListingMutation):
             raise ValidationError(errors)
 
         cls.save(info, shipping_method, cleaned_input)
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.shipping_price_updated, shipping_method)
 
         return ShippingMethodChannelListingUpdate(

--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -23,7 +23,7 @@ from ...core.fields import JSONString
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ...core.scalars import WeightScalar
 from ...core.types import NonNullList, ShippingError
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...product import types as product_types
 from ...shipping import types as shipping_types
 from ...utils import resolve_global_ids_to_primary_keys
@@ -365,7 +365,7 @@ class ShippingZoneCreate(ShippingZoneMixin, ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, _cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.shipping_zone_created, instance)
 
     @classmethod
@@ -393,7 +393,7 @@ class ShippingZoneUpdate(ShippingZoneMixin, ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, _cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.shipping_zone_updated, instance)
 
     @classmethod
@@ -418,7 +418,7 @@ class ShippingZoneDelete(ModelDeleteMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, _cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.shipping_zone_deleted, instance)
 
     @classmethod
@@ -630,7 +630,7 @@ class ShippingPriceCreate(ShippingPriceMixin, ShippingMethodTypeMixin, ModelMuta
 
     @classmethod
     def post_save_action(cls, info, instance, _cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.shipping_price_created, instance)
 
     @classmethod
@@ -669,7 +669,7 @@ class ShippingPriceUpdate(ShippingPriceMixin, ShippingMethodTypeMixin, ModelMuta
 
     @classmethod
     def post_save_action(cls, info, instance, _cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.shipping_price_updated, instance)
 
     @classmethod
@@ -710,7 +710,7 @@ class ShippingPriceDelete(BaseMutation):
         shipping_zone = shipping_method.shipping_zone
         shipping_method.delete()
         shipping_method.id = shipping_method_id
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.shipping_price_deleted, shipping_method)
 
         return ShippingPriceDelete(
@@ -766,7 +766,7 @@ class ShippingPriceExcludeProducts(BaseMutation):
         shipping_method.excluded_products.set(
             (current_excluded_products | product_to_exclude).distinct()
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.shipping_price_updated, shipping_method)
 
         return ShippingPriceExcludeProducts(
@@ -808,7 +808,7 @@ class ShippingPriceRemoveProductFromExclude(BaseMutation):
             shipping_method.excluded_products.set(
                 shipping_method.excluded_products.exclude(id__in=product_db_ids)
             )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.shipping_price_updated, shipping_method)
 
         return ShippingPriceExcludeProducts(

--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -19,7 +19,7 @@ from ..core.types import (
     ShopError,
     TimePeriodInputType,
 )
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from ..site.dataloaders import get_site_promise
 from .enums import GiftCardSettingsExpiryTypeEnum
 from .types import GiftCardSettings, OrderSettings, Shop
@@ -234,7 +234,7 @@ class ShopFetchTaxRates(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         if not manager.fetch_taxes_data():
             raise ValidationError(
                 "Could not fetch tax rates. Make sure you have supplied a "

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -32,7 +32,7 @@ from ..core.types import (
     TimePeriod,
 )
 from ..core.utils import str_to_enum
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import plugin_manager_promise_callback
 from ..shipping.types import ShippingMethod
 from ..site.dataloaders import load_site_callback
 from ..translations.fields import TranslationField
@@ -314,16 +314,16 @@ class Shop(graphene.ObjectType):
 
     @staticmethod
     @traced_resolver
+    @plugin_manager_promise_callback
     def resolve_available_payment_gateways(
-        _, info, currency: Optional[str] = None, channel: Optional[str] = None
+        _, _info, manager, currency: Optional[str] = None, channel: Optional[str] = None
     ):
-        manager = load_plugin_manager(info.context)
         return manager.list_payment_gateways(currency=currency, channel_slug=channel)
 
     @staticmethod
     @traced_resolver
-    def resolve_available_external_authentications(_, info):
-        manager = load_plugin_manager(info.context)
+    @plugin_manager_promise_callback
+    def resolve_available_external_authentications(_, _info, manager):
         return manager.list_external_authentications(active_only=True)
 
     @staticmethod

--- a/saleor/graphql/tax/mutations/tax_exemption_manage.py
+++ b/saleor/graphql/tax/mutations/tax_exemption_manage.py
@@ -13,7 +13,7 @@ from ...core.descriptions import ADDED_IN_38, PREVIEW_FEATURE
 from ...core.types import Error
 from ...core.types.taxes import TaxSourceObject
 from ...discount.dataloaders import load_discounts
-from ...plugins.dataloaders import load_plugin_manager
+from ...plugins.dataloaders import get_plugin_manager_promise
 
 TaxExemptionManageErrorCode = graphene.Enum.from_enum(
     error_codes.TaxExemptionManageErrorCode
@@ -72,7 +72,7 @@ class TaxExemptionManage(BaseMutation):
 
     @classmethod
     def _invalidate_checkout_prices(cls, info, checkout):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         discounts = load_discounts(info.context)
 
         checkout_info = fetch_checkout_info(checkout, [], discounts, manager)

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -25,7 +25,7 @@ from ..core.types import TranslationError
 from ..core.utils import from_global_id_or_error
 from ..discount.types import Sale, Voucher
 from ..menu.types import MenuItem
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from ..product.types import Category, Collection, Product, ProductVariant
 from ..shipping.types import ShippingMethodType
 from ..shop.types import Shop
@@ -130,7 +130,7 @@ class BaseTranslateMutation(ModelMutation):
         translation, created = instance.translations.update_or_create(
             language_code=data["language_code"], defaults=data["input"]
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
 
         if created:
             cls.call_event(manager.translation_created, translation)
@@ -208,7 +208,7 @@ class ProductTranslate(BaseTranslateMutation):
         node_id = cls.clean_node_id(**data)[0]
         product = cls.get_node_or_error(info, node_id, only_type=Product)
         cls.validate_input(data["input"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             translation, created = product.translations.update_or_create(
                 language_code=data["language_code"], defaults=data["input"]
@@ -275,7 +275,7 @@ class ProductVariantTranslate(BaseTranslateMutation):
             pk=variant_pk
         )
         cls.validate_input(data["input"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             translation, created = variant.translations.update_or_create(
                 language_code=data["language_code"], defaults=data["input"]
@@ -504,7 +504,7 @@ class ShopSettingsTranslate(BaseMutation):
         site = get_site_promise(info.context).get()
         instance = site.settings
         validate_input_against_model(SiteSettings, data["input"])
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             translation, created = instance.translations.update_or_create(
                 language_code=language_code, defaults=data.get("input")

--- a/saleor/graphql/warehouse/mutations.py
+++ b/saleor/graphql/warehouse/mutations.py
@@ -16,7 +16,7 @@ from ..core.validators import (
     validate_required_string_field,
     validate_slug_and_generate_if_needed,
 )
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from ..shipping.types import ShippingZone
 from .types import Warehouse, WarehouseCreateInput, WarehouseUpdateInput
 
@@ -108,7 +108,7 @@ class WarehouseCreate(WarehouseMixin, ModelMutation, I18nMixin):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.warehouse_created, instance)
 
 
@@ -269,7 +269,7 @@ class WarehouseUpdate(WarehouseMixin, ModelMutation, I18nMixin):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.warehouse_updated, instance)
 
 
@@ -287,7 +287,7 @@ class WarehouseDelete(ModelDeleteMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         node_id = data.get("id")
         model_type = cls.get_type_for_model()
         instance = cls.get_node_or_error(info, node_id, only_type=model_type)
@@ -323,5 +323,5 @@ class WarehouseDelete(ModelDeleteMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.warehouse_deleted, instance)

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -8,7 +8,7 @@ from ..app.dataloaders import load_app
 from ..core.descriptions import ADDED_IN_32, DEPRECATED_IN_3X_INPUT, PREVIEW_FEATURE
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types import NonNullList, WebhookError
-from ..plugins.dataloaders import load_plugin_manager
+from ..plugins.dataloaders import get_plugin_manager_promise
 from . import enums
 from .subscription_payload import validate_query
 from .types import EventDelivery, Webhook
@@ -285,6 +285,6 @@ class EventDeliveryRetry(BaseMutation):
             data["id"],
             only_type=EventDelivery,
         )
-        manager = load_plugin_manager(info.context)
+        manager = get_plugin_manager_promise(info.context).get()
         manager.event_delivery_retry(delivery)
         return EventDeliveryRetry(delivery=delivery)

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -12,7 +12,6 @@ from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ..app.dataloaders import load_app
 from ..core.utils import from_global_id_or_error
 from ..discount.dataloaders import load_discounts
-from ..plugins.dataloaders import load_plugin_manager
 from .types import Webhook, WebhookEvent
 
 
@@ -49,8 +48,7 @@ def resolve_sample_payload(info, event_name):
     raise PermissionDenied(permissions=[required_permission])
 
 
-def resolve_shipping_methods_for_checkout(info, checkout):
-    manager = load_plugin_manager(info.context)
+def resolve_shipping_methods_for_checkout(info, checkout, manager):
     discounts = load_discounts(info.context)
     lines, _ = fetch_checkout_lines(checkout)
     shipping_channel_listings = checkout.channel.shipping_method_listings.all()

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -37,6 +37,7 @@ from ..core.scalars import PositiveDecimal
 from ..core.types import NonNullList
 from ..payment.enums import TransactionActionEnum
 from ..payment.types import TransactionItem
+from ..plugins.dataloaders import plugin_manager_promise_callback
 from ..shipping.dataloaders import ShippingMethodChannelListingByChannelSlugLoader
 from ..shipping.types import ShippingMethod
 from ..translations import types as translation_types
@@ -1474,9 +1475,10 @@ class ShippingListMethodsForCheckout(ObjectType, CheckoutBase):
     )
 
     @staticmethod
-    def resolve_shipping_methods(root, info):
+    @plugin_manager_promise_callback
+    def resolve_shipping_methods(root, info, manager):
         _, checkout = root
-        return resolve_shipping_methods_for_checkout(info, checkout)
+        return resolve_shipping_methods_for_checkout(info, checkout, manager)
 
     class Meta:
         interfaces = (Event,)
@@ -1512,9 +1514,10 @@ class CheckoutFilterShippingMethods(ObjectType, CheckoutBase):
     )
 
     @staticmethod
-    def resolve_shipping_methods(root, info):
+    @plugin_manager_promise_callback
+    def resolve_shipping_methods(root, info, manager):
         _, checkout = root
-        return resolve_shipping_methods_for_checkout(info, checkout)
+        return resolve_shipping_methods_for_checkout(info, checkout, manager)
 
     class Meta:
         interfaces = (Event,)


### PR DESCRIPTION
I want to merge this change because it will reduce number of recursion calls when calling for plugin_manager object by utilizing `Promise.then`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
