### PR TITLE
Replace usage of load_app with promise of app

### DIFF
--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -21,7 +21,7 @@ from ....graphql.utils import get_user_or_app_from_context
 from ....order.utils import match_orders_with_new_user
 from ...account.i18n import I18nMixin
 from ...account.types import Address, AddressInput, User
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...channel.utils import clean_channel, validate_channel
 from ...core.context import set_mutation_flag_in_context
 from ...core.enums import LanguageCodeEnum
@@ -51,7 +51,7 @@ def check_can_edit_address(context, address):
     requester = get_user_or_app_from_context(context)
     if requester and requester.has_perm(AccountPermissions.MANAGE_USERS):
         return True
-    app = load_app(context)
+    app = get_app_promise(context).get()
     if not app and context.user:
         is_owner = requester.addresses.filter(pk=address.pk).exists()
         if is_owner:

--- a/saleor/graphql/account/mutations/permission_group.py
+++ b/saleor/graphql/account/mutations/permission_group.py
@@ -17,7 +17,7 @@ from ...account.utils import (
     get_out_of_scope_permissions,
     get_out_of_scope_users,
 )
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.enums import PermissionEnum
 from ...core.mutations import ModelDeleteMutation, ModelMutation
 from ...core.types import NonNullList, PermissionGroupError
@@ -112,7 +112,7 @@ class PermissionGroupCreate(ModelMutation):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        app = load_app(context)
+        app = get_app_promise(context).get()
         if app:
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."
@@ -463,7 +463,7 @@ class PermissionGroupDelete(ModelDeleteMutation):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        app = load_app(context)
+        app = get_app_promise(context).get()
         if app:
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -23,7 +23,7 @@ from ....order.utils import match_orders_with_new_user
 from ....thumbnail import models as thumbnail_models
 from ...account.enums import AddressTypeEnum
 from ...account.types import Address, AddressInput, User
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ...core.types import AccountError, NonNullList, StaffError, Upload
 from ...core.validators.file import clean_image_file
@@ -106,7 +106,7 @@ class CustomerUpdate(CustomerCreate):
     ):
         # Retrieve the event base data
         staff_user = info.context.user
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         new_email = new_instance.email
         new_fullname = new_instance.get_full_name()
 
@@ -216,7 +216,7 @@ class StaffCreate(ModelMutation):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        app = load_app(context)
+        app = get_app_promise(context).get()
         if app:
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -16,7 +16,6 @@ from ...core.permissions import (
 from ...core.tracing import traced_resolver
 from ...payment import gateway
 from ...payment.utils import fetch_customer_id
-from ..app.dataloaders import load_app
 from ..core.utils import from_global_id_or_error
 from ..meta.resolvers import resolve_metadata
 from ..utils import format_permissions_for_display, get_user_or_app_from_context
@@ -199,9 +198,8 @@ def prepare_graphql_payment_sources_type(payment_sources):
 
 
 @traced_resolver
-def resolve_address(info, id):
+def resolve_address(info, id, app):
     user = info.context.user
-    app = load_app(info.context)
     _, address_pk = from_global_id_or_error(id, Address)
     if app and app.has_perm(AccountPermissions.MANAGE_USERS):
         return models.Address.objects.filter(pk=address_pk).first()
@@ -212,9 +210,8 @@ def resolve_address(info, id):
     )
 
 
-def resolve_addresses(info, ids):
+def resolve_addresses(info, ids, app):
     user = info.context.user
-    app = load_app(info.context)
     ids = [
         from_global_id_or_error(address_id, Address, raise_error=True)[1]
         for address_id in ids

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ...core.permissions import AccountPermissions, OrderPermissions
+from ..app.dataloaders import app_promise_callback
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.types import FilterInputObjectType
@@ -208,8 +209,9 @@ class AccountQueries(graphene.ObjectType):
         return resolve_user(info, id, email)
 
     @staticmethod
-    def resolve_address(_root, info, *, id):
-        return resolve_address(info, id)
+    @app_promise_callback
+    def resolve_address(_root, info, app, *, id):
+        return resolve_address(info, id, app)
 
 
 class AccountMutations(graphene.ObjectType):

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -20,7 +20,7 @@ from ...core.tracing import traced_resolver
 from ...order import OrderStatus
 from ...thumbnail.utils import get_image_or_proxy_url, get_thumbnail_size
 from ..account.utils import check_is_owner_or_has_one_of_perms
-from ..app.dataloaders import AppByIdLoader
+from ..app.dataloaders import AppByIdLoader, get_app_promise
 from ..app.types import App
 from ..checkout.dataloaders import CheckoutByUserAndChannelLoader, CheckoutByUserLoader
 from ..checkout.types import Checkout, CheckoutCountableConnection
@@ -140,15 +140,18 @@ class Address(ModelObjectType):
     def __resolve_references(roots: List["Address"], info):
         from .resolvers import resolve_addresses
 
+        app = get_app_promise(info.context).get()
+
         root_ids = [root.id for root in roots]
         addresses = {
-            address.id: address for address in resolve_addresses(info, root_ids)
+            address.id: address for address in resolve_addresses(info, root_ids, app)
         }
 
         result = []
         for root_id in root_ids:
             _, root_id = from_global_id_or_error(root_id, Address)
             result.append(addresses.get(int(root_id)))
+
         return result
 
 

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -17,7 +17,7 @@ from ...core.permissions import (
     AuthorizationFilters,
     has_one_of_permissions,
 )
-from ..app.dataloaders import load_app
+from ..app.dataloaders import get_app_promise
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
@@ -72,7 +72,7 @@ class CustomerDeleteMixin(UserDeleteMixin):
 
     @classmethod
     def post_process(cls, info, deleted_count=1):
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         account_events.customer_deleted_event(
             staff_user=info.context.user,
             app=app,
@@ -86,7 +86,7 @@ class StaffDeleteMixin(UserDeleteMixin):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        if load_app(context):
+        if get_app_promise(context).get():
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."
             )

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -7,7 +7,7 @@ from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.types import FilterInputObjectType, NonNullList
 from ..core.utils import from_global_id_or_error
-from .dataloaders import AppByIdLoader, AppExtensionByIdLoader, load_app
+from .dataloaders import AppByIdLoader, AppExtensionByIdLoader, app_promise_callback
 from .filters import AppExtensionFilter, AppFilter
 from .mutations import (
     AppActivate,
@@ -119,8 +119,9 @@ class AppQueries(graphene.ObjectType):
         return create_connection_slice(qs, info, kwargs, AppCountableConnection)
 
     @staticmethod
-    def resolve_app(_root, info, *, id=None):
-        if app := load_app(info.context):
+    @app_promise_callback
+    def resolve_app(_root, info, app, *, id=None):
+        if app:
             if not id:
                 return app
             _, app_id = from_global_id_or_error(id, only_type="App")

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -21,7 +21,7 @@ from ....core import analytics
 from ....core.permissions import AccountPermissions
 from ....order import models as order_models
 from ...account.i18n import I18nMixin
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.descriptions import ADDED_IN_34, ADDED_IN_38, DEPRECATED_IN_3X_INPUT
 from ...core.fields import JSONString
 from ...core.mutations import BaseMutation
@@ -266,7 +266,7 @@ class CheckoutComplete(BaseMutation, I18nMixin):
             store_source=store_source,
             discounts=discounts,
             user=customer,
-            app=load_app(info.context),
+            app=get_app_promise(info.context).get(),
             site_settings=site.settings,
             tracking_code=tracking_code,
             redirect_url=data.get("redirect_url"),

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -11,7 +11,7 @@ from ....product import models as product_models
 from ....warehouse.reservations import get_reservation_length, is_reservation_enabled
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...channel.utils import clean_channel
 from ...core.descriptions import (
     ADDED_IN_31,
@@ -179,7 +179,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
     def clean_checkout_lines(
         cls, info, lines, country, channel
     ) -> Tuple[List[product_models.ProductVariant], List["CheckoutLineData"]]:
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         site = get_site_promise(info.context).get()
         check_permissions_for_custom_prices(app, lines)
         variant_ids = [line["variant_id"] for line in lines]

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -10,7 +10,7 @@ from ....checkout.fetch import (
 )
 from ....checkout.utils import add_variants_to_checkout, invalidate_checkout_prices
 from ....warehouse.reservations import get_reservation_length, is_reservation_enabled
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -172,7 +172,7 @@ class CheckoutLinesAdd(BaseMutation):
     def perform_mutation(
         cls, _root, info, lines, checkout_id=None, token=None, id=None, replace=False
     ):
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         check_permissions_for_custom_prices(app, lines)
 
         checkout = get_checkout(

--- a/saleor/graphql/checkout/mutations/checkout_lines_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_update.py
@@ -5,7 +5,7 @@ from django.forms import ValidationError
 
 from ....checkout.error_codes import CheckoutErrorCode
 from ....warehouse.reservations import is_reservation_enabled
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...checkout.types import CheckoutLine
 from ...core.descriptions import (
     ADDED_IN_31,
@@ -131,7 +131,7 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
         discounts,
         replace,
     ):
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         # if the requestor is not app, the quantity is required for all lines
         if not app:
             if any(

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -8,7 +8,7 @@ from ....core import analytics
 from ....core.exceptions import GiftCardNotApplicable, InsufficientStock
 from ....core.permissions import CheckoutPermissions
 from ....discount.models import NotApplicable
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.descriptions import ADDED_IN_32, ADDED_IN_38, PREVIEW_FEATURE
 from ...core.mutations import BaseMutation
 from ...core.types import Error, NonNullList
@@ -126,7 +126,7 @@ class OrderCreateFromCheckout(BaseMutation):
             discounts=discounts,
             manager=manager,
         )
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         try:
             order = create_order_from_checkout(
                 checkout_info=checkout_info,

--- a/saleor/graphql/context.py
+++ b/saleor/graphql/context.py
@@ -9,7 +9,7 @@ from ..app.models import App
 from ..core.auth import get_token_from_request
 from ..core.jwt import jwt_decode_with_exception_handler
 from .api import API_PATH
-from .app.dataloaders import load_app
+from .app.dataloaders import get_app_promise
 from .core import SaleorContext
 
 
@@ -41,7 +41,7 @@ def set_decoded_auth_token(request: SaleorContext):
 
 def set_app_on_context(request: SaleorContext):
     if request.path == API_PATH and not hasattr(request, "app"):
-        request.app = load_app(request)
+        request.app = get_app_promise(request).get()
 
 
 def get_user(request: SaleorContext) -> UserType:

--- a/saleor/graphql/csv/mutations.py
+++ b/saleor/graphql/csv/mutations.py
@@ -7,7 +7,7 @@ from ...core.permissions import GiftcardPermissions, ProductPermissions
 from ...csv import models as csv_models
 from ...csv.events import export_started_event
 from ...csv.tasks import export_gift_cards_task, export_products_task
-from ..app.dataloaders import load_app
+from ..app.dataloaders import get_app_promise
 from ..attribute.types import Attribute
 from ..channel.types import Channel
 from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
@@ -130,7 +130,7 @@ class ExportProducts(BaseExportMutation):
         export_info = cls.get_export_info(input["export_info"])
         file_type = input["file_type"]
 
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         kwargs = {"app": app} if app else {"user": info.context.user}
 
         export_file = csv_models.ExportFile.objects.create(**kwargs)
@@ -199,7 +199,7 @@ class ExportGiftCards(BaseExportMutation):
         scope = cls.get_scope(input, GiftCard)
         file_type = input["file_type"]
 
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         kwargs = {"app": app} if app else {"user": info.context.user}
 
         export_file = csv_models.ExportFile.objects.create(**kwargs)

--- a/saleor/graphql/giftcard/bulk_mutations.py
+++ b/saleor/graphql/giftcard/bulk_mutations.py
@@ -11,7 +11,7 @@ from ...core.utils.validators import is_date_in_future
 from ...giftcard import events, models
 from ...giftcard.error_codes import GiftCardErrorCode
 from ...giftcard.utils import is_gift_card_expired
-from ..app.dataloaders import load_app
+from ..app.dataloaders import get_app_promise
 from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
 from ..core.mutations import BaseBulkMutation, BaseMutation, ModelBulkDeleteMutation
 from ..core.types import GiftCardError, NonNullList, PriceInput
@@ -130,7 +130,7 @@ class GiftCardBulkCreate(BaseMutation):
     def create_instances(cleaned_input, info):
         count = cleaned_input.pop("count")
         balance = cleaned_input.pop("balance")
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         gift_cards = models.GiftCard.objects.bulk_create(
             [
                 models.GiftCard(code=generate_promo_code(), **cleaned_input)
@@ -207,7 +207,7 @@ class GiftCardBulkActivate(BaseBulkMutation):
     def bulk_action(cls, info, queryset):
         queryset = queryset.filter(is_active=False)
         gift_card_ids = [gift_card.id for gift_card in queryset]
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         queryset.update(is_active=True)
         events.gift_cards_activated_event(
             gift_card_ids, user=info.context.user, app=app
@@ -235,7 +235,7 @@ class GiftCardBulkDeactivate(BaseBulkMutation):
     @classmethod
     @traced_atomic_transaction()
     def bulk_action(cls, info, queryset):
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         queryset = queryset.filter(is_active=True)
         gift_card_ids = [gift_card.id for gift_card in queryset]
         queryset.update(is_active=False)

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -18,7 +18,7 @@ from ...giftcard.utils import (
     deactivate_gift_card,
     is_gift_card_expired,
 )
-from ..app.dataloaders import load_app
+from ..app.dataloaders import get_app_promise
 from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_INPUT, PREVIEW_FEATURE
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.scalars import PositiveDecimal
@@ -168,7 +168,7 @@ class GiftCardCreate(ModelMutation):
         if user:
             cleaned_input["created_by"] = user
             cleaned_input["created_by_email"] = user.email
-        cleaned_input["app"] = load_app(info.context)
+        cleaned_input["app"] = get_app_promise(info.context).get()
 
     @classmethod
     def clean_expiry_date(cls, cleaned_input, instance):
@@ -220,7 +220,7 @@ class GiftCardCreate(ModelMutation):
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
         user = info.context.user
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         events.gift_card_issued_event(
             gift_card=instance,
             user=user,
@@ -331,7 +331,7 @@ class GiftCardUpdate(GiftCardCreate):
         cls._save_m2m(info, instance, cleaned_input)
 
         user = info.context.user
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         if "initial_balance_amount" in cleaned_input:
             events.gift_card_balance_reset_event(instance, old_instance, user, app)
         if "expiry_date" in cleaned_input:
@@ -405,7 +405,7 @@ class GiftCardDeactivate(BaseMutation):
         create_event = gift_card.is_active
         deactivate_gift_card(gift_card)
         if create_event:
-            app = load_app(info.context)
+            app = get_app_promise(info.context).get()
             events.gift_card_deactivated_event(
                 gift_card=gift_card,
                 user=info.context.user,
@@ -439,7 +439,7 @@ class GiftCardActivate(BaseMutation):
         create_event = not gift_card.is_active
         activate_gift_card(gift_card)
         if create_event:
-            app = load_app(info.context)
+            app = get_app_promise(info.context).get()
             events.gift_card_activated_event(
                 gift_card=gift_card,
                 user=info.context.user,
@@ -515,7 +515,7 @@ class GiftCardResend(BaseMutation):
         user = info.context.user
         if not user:
             user = None
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         send_gift_card_notification(
             user,
@@ -571,7 +571,7 @@ class GiftCardAddNote(BaseMutation):
     def perform_mutation(cls, _root, info, **data):
         gift_card = cls.get_node_or_error(info, data.get("id"), only_type=GiftCard)
         cleaned_input = cls.clean_input(info, gift_card, data)
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         event = events.gift_card_note_added_event(
             gift_card=gift_card,
             user=info.context.user,

--- a/saleor/graphql/invoice/mutations.py
+++ b/saleor/graphql/invoice/mutations.py
@@ -7,7 +7,7 @@ from ...invoice import events, models
 from ...invoice.error_codes import InvoiceErrorCode
 from ...invoice.notifications import send_invoice
 from ...order import events as order_events
-from ..app.dataloaders import load_app
+from ..app.dataloaders import get_app_promise
 from ..core.mutations import ModelDeleteMutation, ModelMutation
 from ..core.types import InvoiceError
 from ..order.types import Order
@@ -83,7 +83,7 @@ class InvoiceRequest(ModelMutation):
         invoice = manager.invoice_request(
             order=order, invoice=shallow_invoice, number=data.get("number")
         )
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         if invoice and invoice.status == JobStatus.SUCCESS:
             order_events.invoice_generated_event(
                 order=order,
@@ -173,7 +173,7 @@ class InvoiceCreate(ModelMutation):
         invoice.order = order
         invoice.status = JobStatus.SUCCESS
         invoice.save()
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         events.invoice_created_event(
             user=info.context.user,
             app=app,
@@ -211,7 +211,7 @@ class InvoiceRequestDelete(ModelMutation):
         invoice.save(update_fields=["status", "updated_at"])
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.invoice_delete, invoice)
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         events.invoice_requested_deletion_event(
             user=info.context.user, app=app, invoice=invoice
         )
@@ -234,7 +234,7 @@ class InvoiceDelete(ModelDeleteMutation):
     def perform_mutation(cls, _root, info, **data):
         invoice = cls.get_instance(info, **data)
         response = super().perform_mutation(_root, info, **data)
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         events.invoice_deleted_event(
             user=info.context.user, app=app, invoice_id=invoice.pk
         )
@@ -292,7 +292,7 @@ class InvoiceUpdate(ModelMutation):
         )
         instance.status = JobStatus.SUCCESS
         instance.save(update_fields=["external_url", "number", "updated_at", "status"])
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         order_events.invoice_updated_event(
             order=instance.order,
             user=info.context.user,
@@ -347,7 +347,7 @@ class InvoiceSendNotification(ModelMutation):
     def perform_mutation(cls, _root, info, **data):
         instance = cls.get_instance(info, **data)
         cls.clean_instance(info, instance)
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         send_invoice(
             invoice=instance,

--- a/saleor/graphql/order/bulk_mutations/orders.py
+++ b/saleor/graphql/order/bulk_mutations/orders.py
@@ -3,7 +3,7 @@ import graphene
 from ....core.permissions import OrderPermissions
 from ....order import models
 from ....order.actions import cancel_order
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseBulkMutation
 from ...core.types import NonNullList, OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -36,6 +36,6 @@ class OrderBulkCancel(BaseBulkMutation):
             cancel_order(
                 order=order,
                 user=info.context.user,
-                app=load_app(info.context),
+                app=get_app_promise(info.context).get(),
                 manager=manager,
             )

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -17,7 +17,7 @@ from ....order.search import prepare_order_search_vector_value
 from ....order.utils import get_order_country
 from ....warehouse.management import allocate_preorders, allocate_stocks
 from ....warehouse.reservations import is_reservation_enabled
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -132,7 +132,7 @@ class DraftOrderComplete(BaseMutation):
                 payment=order.get_last_payment(),
                 lines_data=order_lines_info,
             )
-            app = load_app(info.context)
+            app = get_app_promise(info.context).get()
             transaction.on_commit(
                 lambda: order_created(
                     order_info=order_info,

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -21,7 +21,7 @@ from ....order.utils import (
 )
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...channel.types import Channel
 from ...core.descriptions import ADDED_IN_36, PREVIEW_FEATURE
 from ...core.mutations import ModelMutation
@@ -329,7 +329,7 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
     @classmethod
     def save(cls, info, instance, cleaned_input):
         manager = get_plugin_manager_promise(info.context).get()
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         site = get_site_promise(info.context).get()
         return cls._save_draft_order(
             info,

--- a/saleor/graphql/order/mutations/draft_order_update.py
+++ b/saleor/graphql/order/mutations/draft_order_update.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from ....core.permissions import OrderPermissions
 from ....order import OrderStatus, models
 from ....order.error_codes import OrderErrorCode
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
@@ -58,7 +58,7 @@ class DraftOrderUpdate(DraftOrderCreate):
     @classmethod
     def save(cls, info, instance, cleaned_input):
         manager = get_plugin_manager_promise(info.context).get()
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         site = get_site_promise(info.context).get()
         return cls._save_draft_order(
             info,

--- a/saleor/graphql/order/mutations/fulfillment_approve.py
+++ b/saleor/graphql/order/mutations/fulfillment_approve.py
@@ -6,7 +6,7 @@ from ....core.permissions import OrderPermissions
 from ....order import FulfillmentStatus
 from ....order.actions import approve_fulfillment
 from ....order.error_codes import OrderErrorCode
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.descriptions import ADDED_IN_31
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -63,7 +63,7 @@ class FulfillmentApprove(BaseMutation):
 
         order = fulfillment.order
         manager = get_plugin_manager_promise(info.context).get()
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         site = get_site_promise(info.context).get()
         try:
             fulfillment = approve_fulfillment(

--- a/saleor/graphql/order/mutations/fulfillment_cancel.py
+++ b/saleor/graphql/order/mutations/fulfillment_cancel.py
@@ -6,7 +6,7 @@ from ....giftcard.utils import order_has_gift_card_lines
 from ....order import FulfillmentStatus
 from ....order.actions import cancel_fulfillment, cancel_waiting_fulfillment
 from ....order.error_codes import OrderErrorCode
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -91,7 +91,7 @@ class FulfillmentCancel(BaseMutation):
 
         cls.validate_fulfillment(fulfillment, warehouse)
 
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         if fulfillment.status == FulfillmentStatus.WAITING_FOR_APPROVAL:
             fulfillment = cancel_waiting_fulfillment(

--- a/saleor/graphql/order/mutations/fulfillment_refund_products.py
+++ b/saleor/graphql/order/mutations/fulfillment_refund_products.py
@@ -5,7 +5,7 @@ from ....order import FulfillmentStatus
 from ....order import models as order_models
 from ....order.actions import create_refund_fulfillment
 from ....payment import PaymentError
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.scalars import PositiveDecimal
 from ...core.types import NonNullList, OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -135,7 +135,7 @@ class FulfillmentRefundProducts(FulfillmentRefundAndReturnProductBase):
         order = cleaned_input["order"]
         manager = get_plugin_manager_promise(info.context).get()
         try:
-            app = load_app(info.context)
+            app = get_app_promise(info.context).get()
             refund_fulfillment = create_refund_fulfillment(
                 info.context.user,
                 app,

--- a/saleor/graphql/order/mutations/fulfillment_return_products.py
+++ b/saleor/graphql/order/mutations/fulfillment_return_products.py
@@ -5,7 +5,7 @@ from ....order import FulfillmentStatus
 from ....order import models as order_models
 from ....order.actions import create_fulfillments_for_returned_products
 from ....payment import PaymentError
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.scalars import PositiveDecimal
 from ...core.types import NonNullList, OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -158,7 +158,7 @@ class FulfillmentReturnProducts(FulfillmentRefundAndReturnProductBase):
         order = cleaned_input["order"]
         manager = get_plugin_manager_promise(info.context).get()
         try:
-            app = load_app(info.context)
+            app = get_app_promise(info.context).get()
             response = create_fulfillments_for_returned_products(
                 info.context.user,
                 app,

--- a/saleor/graphql/order/mutations/fulfillment_update_tracking.py
+++ b/saleor/graphql/order/mutations/fulfillment_update_tracking.py
@@ -3,7 +3,7 @@ import graphene
 from ....core.permissions import OrderPermissions
 from ....order.actions import fulfillment_tracking_updated
 from ....order.notifications import send_fulfillment_update
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -38,7 +38,7 @@ class FulfillmentUpdateTracking(BaseMutation):
         fulfillment.tracking_number = tracking_number
         fulfillment.save()
         order = fulfillment.order
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         fulfillment_tracking_updated(
             fulfillment,

--- a/saleor/graphql/order/mutations/order_add_note.py
+++ b/saleor/graphql/order/mutations/order_add_note.py
@@ -5,7 +5,7 @@ from ....core.permissions import OrderPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....order import events
 from ....order.error_codes import OrderErrorCode
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ...core.validators import validate_required_string_field
@@ -59,7 +59,7 @@ class OrderAddNote(BaseMutation):
     def perform_mutation(cls, _root, info, **data):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
         cleaned_input = cls.clean_input(info, order, data)
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             event = events.order_note_added_event(

--- a/saleor/graphql/order/mutations/order_cancel.py
+++ b/saleor/graphql/order/mutations/order_cancel.py
@@ -6,7 +6,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....giftcard.utils import deactivate_order_gift_cards
 from ....order.actions import cancel_order
 from ....order.error_codes import OrderErrorCode
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -42,7 +42,7 @@ class OrderCancel(BaseMutation):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
         clean_order_cancel(order)
         user = info.context.user
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             cancel_order(

--- a/saleor/graphql/order/mutations/order_capture.py
+++ b/saleor/graphql/order/mutations/order_capture.py
@@ -7,7 +7,7 @@ from ....order.error_codes import OrderErrorCode
 from ....order.fetch import fetch_order_info
 from ....payment import PaymentError, TransactionKind, gateway
 from ....payment.gateway import request_charge_action
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import OrderError
@@ -59,7 +59,7 @@ class OrderCapture(BaseMutation):
 
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
 
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         if payment_transactions := list(order.payment_transactions.all()):
             try:

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -10,7 +10,7 @@ from ....order.error_codes import OrderErrorCode
 from ....order.fetch import fetch_order_info
 from ....payment import PaymentError, gateway
 from ....payment.gateway import request_charge_action
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import ModelMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -64,7 +64,7 @@ class OrderConfirm(ModelMutation):
         order_info = fetch_order_info(order)
         payment = order_info.payment
         manager = get_plugin_manager_promise(info.context).get()
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         with traced_atomic_transaction():
             if payment_transactions := list(order.payment_transactions.all()):
                 try:

--- a/saleor/graphql/order/mutations/order_discount_add.py
+++ b/saleor/graphql/order/mutations/order_discount_add.py
@@ -7,7 +7,7 @@ from ....order import events
 from ....order.calculations import fetch_order_prices_if_expired
 from ....order.error_codes import OrderErrorCode
 from ....order.utils import create_order_discount_for_order, get_order_discounts
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
@@ -60,7 +60,7 @@ class OrderDiscountAdd(OrderDiscountCommon):
         reason = input.get("reason")
         value_type = input.get("value_type")
         value = input.get("value")
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         with traced_atomic_transaction():
             order_discount = create_order_discount_for_order(
                 order, reason, value_type, value

--- a/saleor/graphql/order/mutations/order_discount_delete.py
+++ b/saleor/graphql/order/mutations/order_discount_delete.py
@@ -5,7 +5,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....order import events
 from ....order.search import update_order_search_vector
 from ....order.utils import invalidate_order_prices, remove_order_discount_from_order
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.types import OrderError
 from ..types import Order
 from .order_discount_common import OrderDiscountCommon
@@ -31,7 +31,7 @@ class OrderDiscountDelete(OrderDiscountCommon):
             info, data.get("discount_id"), only_type="OrderDiscount"
         )
         order = order_discount.order
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
 
         cls.validate_order(info, order)
         with traced_atomic_transaction():

--- a/saleor/graphql/order/mutations/order_discount_update.py
+++ b/saleor/graphql/order/mutations/order_discount_update.py
@@ -6,7 +6,7 @@ from ....core.permissions import OrderPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....order import events
 from ....order.calculations import fetch_order_prices_if_expired
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Order
@@ -69,7 +69,7 @@ class OrderDiscountUpdate(OrderDiscountCommon):
                 # on OrderDiscount.
                 fetch_order_prices_if_expired(order, manager, force_update=True)
                 order_discount.refresh_from_db()
-                app = load_app(info.context)
+                app = get_app_promise(info.context).get()
                 events.order_discount_updated_event(
                     order=order,
                     user=info.context.user,

--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -9,7 +9,7 @@ from ....core.permissions import OrderPermissions
 from ....order import models as order_models
 from ....order.actions import create_fulfillments
 from ....order.error_codes import OrderErrorCode
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.descriptions import ADDED_IN_36
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, OrderError
@@ -245,7 +245,7 @@ class OrderFulfill(BaseMutation):
 
         context = info.context
         user = context.user
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         lines_for_warehouses = cleaned_input["lines_for_warehouses"]
         notify_customer = cleaned_input.get("notify_customer", True)

--- a/saleor/graphql/order/mutations/order_line_delete.py
+++ b/saleor/graphql/order/mutations/order_line_delete.py
@@ -11,7 +11,7 @@ from ....order.utils import (
     invalidate_order_prices,
     recalculate_order_weight,
 )
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -75,7 +75,7 @@ class OrderLineDelete(EditableOrderValidationMixin, BaseMutation):
                     "updated_at",
                 ]
             # Create the removal event
-            app = load_app(info.context)
+            app = get_app_promise(info.context).get()
             events.order_removed_products_event(
                 order=order,
                 user=info.context.user,

--- a/saleor/graphql/order/mutations/order_line_discount_remove.py
+++ b/saleor/graphql/order/mutations/order_line_discount_remove.py
@@ -4,7 +4,7 @@ from ....core.permissions import OrderPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....order import events
 from ....order.utils import invalidate_order_prices, remove_discount_from_order_line
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
@@ -52,7 +52,7 @@ class OrderLineDiscountRemove(OrderDiscountCommon):
                 manager=manager,
                 tax_included=tax_included,
             )
-            app = load_app(info.context)
+            app = get_app_promise(info.context).get()
             events.order_line_discount_removed_event(
                 order=order,
                 user=info.context.user,

--- a/saleor/graphql/order/mutations/order_line_discount_update.py
+++ b/saleor/graphql/order/mutations/order_line_discount_update.py
@@ -6,7 +6,7 @@ from ....core.permissions import OrderPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....order import events
 from ....order.utils import invalidate_order_prices, update_discount_for_order_line
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
@@ -63,7 +63,7 @@ class OrderLineDiscountUpdate(OrderDiscountCommon):
         site = get_site_promise(info.context).get()
         order_line_before_update = copy.deepcopy(order_line)
         tax_included = site.settings.include_taxes_in_prices
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         with traced_atomic_transaction():
             update_discount_for_order_line(
                 order_line,

--- a/saleor/graphql/order/mutations/order_line_update.py
+++ b/saleor/graphql/order/mutations/order_line_update.py
@@ -12,7 +12,7 @@ from ....order.utils import (
     invalidate_order_prices,
     recalculate_order_weight,
 )
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import ModelMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -64,7 +64,7 @@ class OrderLineUpdate(EditableOrderValidationMixin, ModelMutation):
             if instance.order.is_unconfirmed()
             else None
         )
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         with traced_atomic_transaction():
             line_info = OrderLineInfo(
                 line=instance,

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -16,7 +16,7 @@ from ....order.utils import (
     invalidate_order_prices,
     recalculate_order_weight,
 )
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, OrderError
 from ...discount.dataloaders import load_discounts
@@ -153,7 +153,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         lines_to_add = cls.validate_lines(info, data, existing_lines_info)
         variants = [line.variant for line in lines_to_add]
         cls.validate_variants(order, variants)
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         site = get_site_promise(info.context).get()
         discounts = load_discounts(info.context)

--- a/saleor/graphql/order/mutations/order_mark_as_paid.py
+++ b/saleor/graphql/order/mutations/order_mark_as_paid.py
@@ -6,7 +6,7 @@ from ....order.actions import clean_mark_order_as_paid, mark_order_as_paid
 from ....order.calculations import fetch_order_prices_if_expired
 from ....order.error_codes import OrderErrorCode
 from ....order.search import update_order_search_vector
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -45,7 +45,7 @@ class OrderMarkAsPaid(BaseMutation):
         transaction_reference = data.get("transaction_reference")
         cls.clean_billing_address(order)
         user = info.context.user
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         try_payment_action(order, user, app, None, clean_mark_order_as_paid, order)
 
         mark_order_as_paid(order, user, app, manager, transaction_reference)

--- a/saleor/graphql/order/mutations/order_refund.py
+++ b/saleor/graphql/order/mutations/order_refund.py
@@ -8,7 +8,7 @@ from ....order.actions import order_refunded
 from ....order.error_codes import OrderErrorCode
 from ....payment import PaymentError, TransactionKind, gateway
 from ....payment.gateway import request_refund_action
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types import OrderError
@@ -71,7 +71,7 @@ class OrderRefund(BaseMutation):
 
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
         clean_order_refund(order)
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         if payment_transactions := list(order.payment_transactions.all()):
             # We use the last transaction as we don't have a possibility to

--- a/saleor/graphql/order/mutations/order_void.py
+++ b/saleor/graphql/order/mutations/order_void.py
@@ -6,7 +6,7 @@ from ....order.actions import order_voided
 from ....order.error_codes import OrderErrorCode
 from ....payment import PaymentError, TransactionKind, gateway
 from ....payment.gateway import request_void_action
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -43,7 +43,7 @@ class OrderVoid(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         if payment_transactions := list(order.payment_transactions.all()):
             # We use the last transaction as we don't have a possibility to

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -35,7 +35,7 @@ from ...payment.gateway import (
 )
 from ...payment.utils import create_payment, is_currency_supported
 from ..account.i18n import I18nMixin
-from ..app.dataloaders import load_app
+from ..app.dataloaders import get_app_promise
 from ..channel.utils import validate_channel
 from ..checkout.mutations.utils import get_checkout
 from ..checkout.types import Checkout
@@ -839,7 +839,7 @@ class TransactionCreate(BaseMutation):
         else:
             transaction_data["order_id"] = order_or_checkout_instance.pk
             if transaction_event_data:
-                app = load_app(info.context)
+                app = get_app_promise(info.context).get()
                 transaction_event(
                     order=order_or_checkout_instance,
                     user=info.context.user,
@@ -951,7 +951,7 @@ class TransactionUpdate(TransactionCreate):
         if transaction_event_data := data.get("transaction_event"):
             cls.create_transaction_event(transaction_event_data, instance)
             if instance.order_id:
-                app = load_app(info.context)
+                app = get_app_promise(info.context).get()
                 transaction_event(
                     order=instance.order,
                     user=info.context.user,
@@ -1032,7 +1032,7 @@ class TransactionRequestAction(BaseMutation):
             if transaction.order_id
             else transaction.checkout.channel.slug
         )
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         action_kwargs = {
             "channel_slug": channel_slug,

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -28,7 +28,7 @@ from ....product.utils import delete_categories
 from ....product.utils.variants import generate_and_set_variant_name
 from ....warehouse import models as warehouse_models
 from ....warehouse.error_codes import StockErrorCode
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...channel import ChannelContext
 from ...channel.types import Channel
 from ...core.descriptions import ADDED_IN_38
@@ -170,7 +170,7 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
             pk__in=draft_order_lines_data.line_pks
         ).delete()
 
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         # run order event for deleted lines
         for order, order_lines in draft_order_lines_data.order_to_lines_mapping.items():
             order_events.order_line_product_removed_event(
@@ -647,7 +647,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
             pk__in=draft_order_lines_data.line_pks
         ).delete()
 
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         # run order event for deleted lines
         for order, order_lines in draft_order_lines_data.order_to_lines_mapping.items():
             order_events.order_line_variant_removed_event(

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -32,7 +32,7 @@ from ....product.utils import delete_categories, get_products_ids_without_varian
 from ....product.utils.variants import generate_and_set_variant_name
 from ....thumbnail import models as thumbnail_models
 from ....warehouse.management import deactivate_preorder_for_variant
-from ...app.dataloaders import load_app
+from ...app.dataloaders import get_app_promise
 from ...attribute.types import AttributeValueInput
 from ...attribute.utils import AttributeAssignmentMixin, AttrValuesInput
 from ...channel import ChannelContext
@@ -821,7 +821,7 @@ class ProductDelete(ModelDeleteMutation):
                 pk__in=draft_order_lines_data.line_pks
             ).delete()
 
-            app = load_app(info.context)
+            app = get_app_promise(info.context).get()
             # run order event for deleted lines
             for (
                 order,
@@ -1313,7 +1313,7 @@ class ProductVariantDelete(ModelDeleteMutation):
             ).delete()
 
             # run order event for deleted lines
-            app = load_app(info.context)
+            app = get_app_promise(info.context).get()
             for (
                 order,
                 order_lines,

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from ...core.permissions import AppPermission, AuthorizationFilters
 from ...webhook import models
 from ...webhook.error_codes import WebhookErrorCode
-from ..app.dataloaders import load_app
+from ..app.dataloaders import get_app_promise
 from ..core.descriptions import ADDED_IN_32, DEPRECATED_IN_3X_INPUT, PREVIEW_FEATURE
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types import NonNullList, WebhookError
@@ -112,7 +112,7 @@ class WebhookCreate(ModelMutation):
     @classmethod
     def get_instance(cls, info, **data):
         instance = super().get_instance(info, **data)
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         instance.app = app
         return instance
 
@@ -247,7 +247,7 @@ class WebhookDelete(ModelDeleteMutation):
         node_id = data["id"]
         object_id = cls.get_global_id_or_error(node_id)
 
-        app = load_app(info.context)
+        app = get_app_promise(info.context).get()
         if app:
             if not app.is_active:
                 raise ValidationError(

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -9,14 +9,12 @@ from ...core.tracing import traced_resolver
 from ...webhook import models, payloads
 from ...webhook.deprecated_event_types import WebhookEventType
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
-from ..app.dataloaders import load_app
 from ..core.utils import from_global_id_or_error
 from ..discount.dataloaders import load_discounts
 from .types import Webhook, WebhookEvent
 
 
-def resolve_webhook(info, id):
-    app = load_app(info.context)
+def resolve_webhook(info, id, app):
     _, id = from_global_id_or_error(id, Webhook)
     if app:
         return app.webhooks.filter(id=id).first()
@@ -34,8 +32,7 @@ def resolve_webhook_events():
 
 
 @traced_resolver
-def resolve_sample_payload(info, event_name):
-    app = load_app(info.context)
+def resolve_sample_payload(info, event_name, app):
     user = info.context.user
     required_permission = WebhookEventAsyncType.PERMISSIONS.get(
         event_name, WebhookEventSyncType.PERMISSIONS.get(event_name)

--- a/saleor/graphql/webhook/schema.py
+++ b/saleor/graphql/webhook/schema.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ...core.permissions import AppPermission, AuthorizationFilters
+from ..app.dataloaders import app_promise_callback
 from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.fields import JSONString, PermissionsField
 from ..core.types import NonNullList
@@ -44,12 +45,14 @@ class WebhookQueries(graphene.ObjectType):
     )
 
     @staticmethod
-    def resolve_webhook_sample_payload(_root, info, **data):
-        return resolve_sample_payload(info, data["event_type"])
+    @app_promise_callback
+    def resolve_webhook_sample_payload(_root, info, app, **data):
+        return resolve_sample_payload(info, data["event_type"], app)
 
     @staticmethod
-    def resolve_webhook(_root, info, **data):
-        return resolve_webhook(info, data["id"])
+    @app_promise_callback
+    def resolve_webhook(_root, info, app, **data):
+        return resolve_webhook(info, data["id"], app)
 
     @staticmethod
     def resolve_webhook_events(_root, _info):


### PR DESCRIPTION
I want to merge this change because it will reduce number of recursion calls when calling for app object by utilizing `Promise.then`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
