### PR TITLE
Handle providing empty strings as `lte` and `gte` date type

### DIFF
--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -18,6 +18,7 @@ from ..core.connection import (
 from ..core.descriptions import ADDED_IN_31, ADDED_IN_39, DEPRECATED_IN_3X_FIELD
 from ..core.enums import MeasurementUnitsEnum
 from ..core.fields import ConnectionField, FilterConnectionField, JSONString
+from ..core.scalars import Date
 from ..core.types import (
     DateRangeInput,
     DateTimeRangeInput,
@@ -60,7 +61,7 @@ class AttributeValue(ModelObjectType):
     boolean = graphene.Boolean(
         description=AttributeValueDescriptions.BOOLEAN, required=False
     )
-    date = graphene.Date(description=AttributeValueDescriptions.DATE, required=False)
+    date = Date(description=AttributeValueDescriptions.DATE, required=False)
     date_time = graphene.DateTime(
         description=AttributeValueDescriptions.DATE_TIME, required=False
     )
@@ -424,7 +425,7 @@ class AttributeValueInput(graphene.InputObjectType):
     boolean = graphene.Boolean(
         required=False, description=AttributeValueDescriptions.BOOLEAN
     )
-    date = graphene.Date(required=False, description=AttributeValueDescriptions.DATE)
+    date = Date(required=False, description=AttributeValueDescriptions.DATE)
     date_time = graphene.DateTime(
         required=False, description=AttributeValueDescriptions.DATE_TIME
     )

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -4,6 +4,7 @@ import graphene
 from graphql.error import GraphQLError
 from graphql.language import ast
 from measurement.measures import Weight
+from six import string_types
 
 from ...core.weight import (
     convert_weight_to_default_weight_unit,
@@ -125,3 +126,20 @@ class UUID(graphene.UUID):
             return super(UUID, UUID).parse_value(value)
         except ValueError as e:
             raise GraphQLError(str(e))
+
+
+# The custom Date scalar is needed as the currently used graphene 2 version is not
+# supported anymore.
+# The graphene.Date scalar is raising unhandled `IndexError` for the empty string,
+# the custom implementation prevent such situation and returns `None` instead.
+# Probably might be dropped after switching to the supported graphene version.
+class Date(graphene.Date):
+    __doc__ = graphene.Date.__doc__
+
+    @staticmethod
+    def parse_value(value):
+        # The parse_value method is overridden to handle the empty string.
+        # The current graphene version returning unhandled `IndexError`.
+        if isinstance(value, string_types) and not value:
+            return None
+        return super(Date, Date).parse_value(value)

--- a/saleor/graphql/core/tests/test_scalars.py
+++ b/saleor/graphql/core/tests/test_scalars.py
@@ -1,4 +1,7 @@
-from ...tests.utils import get_graphql_content
+import pytest
+
+from ....order.models import Order
+from ...tests.utils import get_graphql_content, get_graphql_content_from_response
 
 QUERY_CHECKOUT = """
 query getCheckout($token: UUID!) {
@@ -51,3 +54,44 @@ def test_uuid_scalar_wrong_value_passed_in_input(api_client, checkout):
     response = api_client.post_graphql(query)
     content = get_graphql_content(response, ignore_errors=True)
     assert len(content["errors"]) == 1
+
+
+@pytest.mark.parametrize(
+    "orders_filter",
+    [
+        {"created": {"gte": ""}},
+        {"created": {"lte": ""}},
+        {"created": {"gte": "", "lte": ""}},
+    ],
+)
+def test_order_query_with_filter_created_str_as_date_value(
+    orders_filter,
+    staff_api_client,
+    permission_manage_orders,
+    channel_USD,
+):
+    # given
+    query = """
+      query ($filter: OrderFilterInput!, ) {
+        orders(first: 5, filter:$filter) {
+          totalCount
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    """
+
+    Order.objects.create(channel=channel_USD)
+    variables = {"filter": orders_filter}
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content_from_response(response)
+
+    assert 'Variable "$filter" got invalid value' in content["errors"][0]["message"]

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -46,7 +46,7 @@ from ..enums import (
     WebhookErrorCode,
     WeightUnitsEnum,
 )
-from ..scalars import PositiveDecimal
+from ..scalars import Date, PositiveDecimal
 from .money import VAT
 
 # deprecated - this is temporary constant that contains the graphql types
@@ -462,8 +462,8 @@ class PriceRangeInput(graphene.InputObjectType):
 
 
 class DateRangeInput(graphene.InputObjectType):
-    gte = graphene.Date(description="Start date.", required=False)
-    lte = graphene.Date(description="End date.", required=False)
+    gte = Date(description="Start date.", required=False)
+    lte = Date(description="End date.", required=False)
 
 
 class DateTimeRangeInput(graphene.InputObjectType):

--- a/saleor/graphql/giftcard/bulk_mutations.py
+++ b/saleor/graphql/giftcard/bulk_mutations.py
@@ -14,6 +14,7 @@ from ...giftcard.utils import is_gift_card_expired
 from ..app.dataloaders import load_app
 from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
 from ..core.mutations import BaseBulkMutation, BaseMutation, ModelBulkDeleteMutation
+from ..core.scalars import Date
 from ..core.types import GiftCardError, NonNullList, PriceInput
 from ..core.validators import validate_price_precision
 from ..plugins.dataloaders import get_plugin_manager_promise
@@ -30,7 +31,7 @@ class GiftCardBulkCreateInput(graphene.InputObjectType):
         graphene.String,
         description="The gift card tags.",
     )
-    expiry_date = graphene.types.datetime.Date(description="The gift card expiry date.")
+    expiry_date = Date(description="The gift card expiry date.")
     is_active = graphene.Boolean(
         required=True, description="Determine if gift card is active."
     )

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -21,7 +21,7 @@ from ...giftcard.utils import (
 from ..app.dataloaders import load_app
 from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_INPUT, PREVIEW_FEATURE
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
-from ..core.scalars import PositiveDecimal
+from ..core.scalars import Date, PositiveDecimal
 from ..core.types import GiftCardError, NonNullList, PriceInput
 from ..core.validators import validate_price_precision, validate_required_string_field
 from ..plugins.dataloaders import get_plugin_manager_promise
@@ -46,17 +46,17 @@ class GiftCardInput(graphene.InputObjectType):
         graphene.String,
         description="The gift card tags to add." + ADDED_IN_31 + PREVIEW_FEATURE,
     )
-    expiry_date = graphene.types.datetime.Date(
+    expiry_date = Date(
         description="The gift card expiry date." + ADDED_IN_31 + PREVIEW_FEATURE
     )
 
     # DEPRECATED
-    start_date = graphene.types.datetime.Date(
+    start_date = Date(
         description=(
             f"Start date of the gift card in ISO 8601 format. {DEPRECATED_IN_3X_INPUT}"
         )
     )
-    end_date = graphene.types.datetime.Date(
+    end_date = Date(
         description=(
             "End date of the gift card in ISO 8601 format. "
             f"{DEPRECATED_IN_3X_INPUT} Use `expiryDate` from `expirySettings` instead."

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -26,6 +26,7 @@ from ..channel.dataloaders import ChannelByIdLoader
 from ..core.connection import CountableConnection
 from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_FIELD, PREVIEW_FEATURE
 from ..core.fields import PermissionsField
+from ..core.scalars import Date
 from ..core.types import ModelObjectType, Money, NonNullList
 from ..meta.types import ObjectWithMetadata
 from ..order.dataloaders import OrderByIdLoader
@@ -104,10 +105,8 @@ class GiftCardEvent(ModelObjectType):
         description="The list of old gift card tags.",
     )
     balance = graphene.Field(GiftCardEventBalance, description="The gift card balance.")
-    expiry_date = graphene.types.datetime.Date(description="The gift card expiry date.")
-    old_expiry_date = graphene.types.datetime.Date(
-        description="Previous gift card expiry date."
-    )
+    expiry_date = Date(description="The gift card expiry date.")
+    old_expiry_date = Date(description="Previous gift card expiry date.")
 
     class Meta:
         description = "History log of the gift card." + ADDED_IN_31 + PREVIEW_FEATURE
@@ -276,7 +275,7 @@ class GiftCard(ModelObjectType):
         ),
     )
     last_used_on = graphene.DateTime()
-    expiry_date = graphene.Date()
+    expiry_date = Date()
     app = graphene.Field(
         App,
         description=(

--- a/saleor/graphql/order/tests/queries/test_draft_order_with_filter.py
+++ b/saleor/graphql/order/tests/queries/test_draft_order_with_filter.py
@@ -122,6 +122,8 @@ def test_draft_order_query_with_filter_customer_fields(
         ({"created": {"lte": str(date.today())}}, 2),
         ({"created": {"lte": str(date.today() - timedelta(days=3))}}, 1),
         ({"created": {"gte": str(date.today() + timedelta(days=1))}}, 0),
+        ({"created": {"gte": None}}, 2),
+        ({"created": {"lte": None}}, 2),
     ],
 )
 def test_draft_order_query_with_filter_created_(

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -15,6 +15,7 @@ from ..core.connection import (
 from ..core.descriptions import ADDED_IN_33, DEPRECATED_IN_3X_FIELD, RICH_CONTENT
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.fields import FilterConnectionField, JSONString, PermissionsField
+from ..core.scalars import Date
 from ..core.types import ModelObjectType, NonNullList
 from ..meta.types import ObjectWithMetadata
 from ..translations.fields import TranslationField
@@ -99,7 +100,7 @@ class Page(ModelObjectType):
     seo_description = graphene.String()
     title = graphene.String(required=True)
     content = JSONString(description="Content of the page." + RICH_CONTENT)
-    publication_date = graphene.Date(
+    publication_date = Date(
         deprecation_reason=(
             f"{DEPRECATED_IN_3X_FIELD} "
             "Use the `publishedAt` field to fetch the publication date."

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -29,7 +29,7 @@ from ...core.descriptions import (
     PREVIEW_FEATURE,
 )
 from ...core.mutations import BaseMutation
-from ...core.scalars import PositiveDecimal
+from ...core.scalars import Date, PositiveDecimal
 from ...core.types import (
     CollectionChannelListingError,
     NonNullList,
@@ -57,7 +57,7 @@ class PublishableChannelListingInput(graphene.InputObjectType):
     is_published = graphene.Boolean(
         description="Determines if object is visible to customers."
     )
-    publication_date = graphene.types.datetime.Date(
+    publication_date = Date(
         description=(
             f"Publication date. ISO 8601 standard. {DEPRECATED_IN_3X_INPUT} "
             "Use `publishedAt` field instead."
@@ -78,7 +78,7 @@ class ProductChannelListingAddInput(PublishableChannelListingInput):
     is_available_for_purchase = graphene.Boolean(
         description="Determine if product should be available for purchase.",
     )
-    available_for_purchase_date = graphene.Date(
+    available_for_purchase_date = Date(
         description=(
             "A start date from which a product will be available for purchase. "
             "When not set and isAvailable is set to True, "

--- a/saleor/graphql/product/mutations/collection/collection_create.py
+++ b/saleor/graphql/product/mutations/collection/collection_create.py
@@ -12,6 +12,7 @@ from ....channel import ChannelContext
 from ....core.descriptions import ADDED_IN_38, DEPRECATED_IN_3X_INPUT, RICH_CONTENT
 from ....core.fields import JSONString
 from ....core.mutations import ModelMutation
+from ....core.scalars import Date
 from ....core.types import CollectionError, NonNullList, SeoInput, Upload
 from ....core.validators import clean_seo_fields, validate_slug_and_generate_if_needed
 from ....core.validators.file import clean_image_file
@@ -32,7 +33,7 @@ class CollectionInput(graphene.InputObjectType):
     background_image = Upload(description="Background image file.")
     background_image_alt = graphene.String(description="Alt text for an image.")
     seo = SeoInput(description="Search engine optimization fields.")
-    publication_date = graphene.Date(
+    publication_date = Date(
         description=(f"Publication date. ISO 8601 standard. {DEPRECATED_IN_3X_INPUT}")
     )
     metadata = NonNullList(

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -29,6 +29,7 @@ from ...core.descriptions import (
     PREVIEW_FEATURE,
 )
 from ...core.fields import PermissionsField
+from ...core.scalars import Date
 from ...core.types import ModelObjectType
 from ...discount.dataloaders import DiscountsByDateTimeLoader
 from ...tax.dataloaders import (
@@ -54,7 +55,7 @@ class Margin(graphene.ObjectType):
 
 class ProductChannelListing(ModelObjectType):
     id = graphene.GlobalID(required=True)
-    publication_date = graphene.Date(
+    publication_date = Date(
         deprecation_reason=(
             f"{DEPRECATED_IN_3X_FIELD} "
             "Use the `publishedAt` field to fetch the publication date."
@@ -66,7 +67,7 @@ class ProductChannelListing(ModelObjectType):
     is_published = graphene.Boolean(required=True)
     channel = graphene.Field(Channel, required=True)
     visible_in_listings = graphene.Boolean(required=True)
-    available_for_purchase = graphene.Date(
+    available_for_purchase = Date(
         deprecation_reason=(
             f"{DEPRECATED_IN_3X_FIELD} "
             "Use the `availableForPurchaseAt` field to fetch "
@@ -372,7 +373,7 @@ class ProductVariantChannelListing(ModelObjectType):
 
 class CollectionChannelListing(ModelObjectType):
     id = graphene.GlobalID(required=True)
-    publication_date = graphene.Date(
+    publication_date = Date(
         deprecation_reason=(
             f"{DEPRECATED_IN_3X_FIELD} "
             "Use the `publishedAt` field to fetch the publication date."

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -68,6 +68,7 @@ from ...core.fields import (
     JSONString,
     PermissionsField,
 )
+from ...core.scalars import Date
 from ...core.types import (
     Image,
     ModelObjectType,
@@ -926,7 +927,7 @@ class Product(ChannelContextTypeWithMetadata, ModelObjectType):
         type_name="product",
         resolver=ChannelContextType.resolve_translation,
     )
-    available_for_purchase = graphene.Date(
+    available_for_purchase = Date(
         description="Date when product is available for purchase.",
         deprecation_reason=(
             f"{DEPRECATED_IN_3X_FIELD} "


### PR DESCRIPTION
When providing an empty value as `lte` or `gte` of date type, the unhandled `IndexError ` error was raised. The error should be handled by the graphene package, but we are on not supported version so we must take care of that ourselves.

The `Date` scalar is introduced that overrides the graphene `Date` scalar, the only thing that changed is `parse_value`, and the additional validation was added for empty values.

Port of #11366

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
