### PR TITLE
Bump certifi to 2022.12.07

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -309,7 +309,7 @@ zstd = ["zstandard"]
 
 [[package]]
 name = "certifi"
-version = "2022.5.18.1"
+version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -2983,8 +2983,8 @@ celery = [
     {file = "celery-5.2.6.tar.gz", hash = "sha256:d1398cadf30f576266b34370e28e880306ec55f7a4b6307549b0ae9c15663481"},
 ]
 certifi = [
-    {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},
-    {file = "certifi-2022.5.18.1.tar.gz", hash = "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7"},
+    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
+    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
 ]
 cffi = [
     {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ brotlicffi==1.0.9.2 ; platform_python_implementation != "CPython" and python_ver
 cachetools==5.1.0 ; python_version >= "3.9" and python_version < "3.10"
 celery==5.2.6 ; python_version >= "3.9" and python_version < "3.10"
 celery[redis]==5.2.6 ; python_version >= "3.9" and python_version < "3.10"
-certifi==2022.5.18.1 ; python_version >= "3.9" and python_version < "3.10"
+certifi==2022.12.7 ; python_version >= "3.9" and python_version < "3.10"
 cffi==1.15.0 ; python_version >= "3.9" and python_version < "3.10"
 charset-normalizer==2.0.12 ; python_version >= "3.9" and python_version < "3.10"
 click-didyoumean==0.3.0 ; python_version >= "3.9" and python_version < "3.10"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -22,7 +22,7 @@ brotlicffi==1.0.9.2 ; platform_python_implementation != "CPython" and python_ver
 cachetools==5.1.0 ; python_version >= "3.9" and python_version < "3.10"
 celery==5.2.6 ; python_version >= "3.9" and python_version < "3.10"
 celery[redis]==5.2.6 ; python_version >= "3.9" and python_version < "3.10"
-certifi==2022.5.18.1 ; python_version >= "3.9" and python_version < "3.10"
+certifi==2022.12.7 ; python_version >= "3.9" and python_version < "3.10"
 cffi==1.15.0 ; python_version >= "3.9" and python_version < "3.10"
 cfgv==3.3.1 ; python_version >= "3.9" and python_version < "3.10"
 charset-normalizer==2.0.12 ; python_version >= "3.9" and python_version < "3.10"


### PR DESCRIPTION
This updates `certifi` dependency resolving CVE-2022-23491
Details: https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/oxX69KFvsm4/m/yLohoVqtCgAJ
