### PR TITLE
Bump certifi to 2022.12.07

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -368,7 +368,7 @@ zstd = ["zstandard"]
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -3182,8 +3182,8 @@ celery = [
     {file = "celery-5.2.7.tar.gz", hash = "sha256:fafbd82934d30f8a004f81e8f7a062e31413a23d444be8ee3326553915958c6d"},
 ]
 certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
+    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
 ]
 cffi = [
     {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ brotlicffi==1.0.9.2 ; platform_python_implementation != "CPython" and python_ver
 cachetools==5.2.0 ; python_version >= "3.9" and python_version < "3.10"
 celery==5.2.7 ; python_version >= "3.9" and python_version < "3.10"
 celery[redis]==5.2.7 ; python_version >= "3.9" and python_version < "3.10"
-certifi==2022.6.15 ; python_version >= "3.9" and python_version < "3.10"
+certifi==2022.12.7 ; python_version >= "3.9" and python_version < "3.10"
 cffi==1.15.1 ; python_version >= "3.9" and python_version < "3.10"
 charset-normalizer==2.1.0 ; python_version >= "3.9" and python_version < "3.10"
 click-didyoumean==0.3.0 ; python_version >= "3.9" and python_version < "3.10"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -27,7 +27,7 @@ brotlicffi==1.0.9.2 ; platform_python_implementation != "CPython" and python_ver
 cachetools==5.2.0 ; python_version >= "3.9" and python_version < "3.10"
 celery==5.2.7 ; python_version >= "3.9" and python_version < "3.10"
 celery[redis]==5.2.7 ; python_version >= "3.9" and python_version < "3.10"
-certifi==2022.6.15 ; python_version >= "3.9" and python_version < "3.10"
+certifi==2022.12.7 ; python_version >= "3.9" and python_version < "3.10"
 cffi==1.15.1 ; python_version >= "3.9" and python_version < "3.10"
 cfgv==3.3.1 ; python_version >= "3.9" and python_version < "3.10"
 charset-normalizer==2.1.0 ; python_version >= "3.9" and python_version < "3.10"


### PR DESCRIPTION
This updates `certifi` dependency resolving CVE-2022-23491
Details: https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/oxX69KFvsm4/m/yLohoVqtCgAJ
