### PR TITLE
Add filter and sortBy to category.products #10917

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
-# 3.9.0 [Unreleased]
+# 3.9.0
 
 ### Highlights
 
@@ -34,6 +34,9 @@ All notable, unreleased changes to this project will be documented in this file.
   - `variant`- allow fetching the single variant by the product variant `id` or `sku`
 - Allow sorting media of the product - #10537 by @kadewu
 - Allow assigning attribute value using its ID. Add to `AttributeValueInput` dedicated field for each input type. #11206 by @zedzior
+- Add ability to filter and sort products of a category - #10917 by @yemeksepeti-cihankarluk, @ogunheper
+  - Add `filter` argument to `Category.products`
+  - Add `sortBy` argument to `Category.products`
 
 ### Saleor Apps
 

--- a/saleor/graphql/product/tests/test_category_filtering.py
+++ b/saleor/graphql/product/tests/test_category_filtering.py
@@ -1,6 +1,13 @@
+import graphene
 import pytest
 
-from ....product.models import Category
+from ....product.models import (
+    Category,
+    Product,
+    ProductChannelListing,
+    ProductVariantChannelListing,
+)
+from ....warehouse.models import Stock, Warehouse
 from ...tests.utils import get_graphql_content
 
 
@@ -66,3 +73,486 @@ def test_categories_with_filtering(
     content = get_graphql_content(response)
     categories_nodes = content["data"]["categories"]["edges"]
     assert len(categories_nodes) == categories_count
+
+
+GET_FILTERED_PRODUCTS_CATEGORY_QUERY = """
+query ($id: ID!, $channel: String, $filters: ProductFilterInput) {
+  category(id: $id) {
+    id
+    name
+    products(first: 5, channel: $channel, filter: $filters) {
+      edges {
+        node {
+          id
+          name
+          channel
+          attributes {
+            attribute {
+              choices(first: 10) {
+                edges {
+                  node {
+                    slug
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "channel, filter_channel, count, indexes_of_products_in_result",
+    [
+        ("channel_USD.slug", "channel_USD.slug", 2, [1, 2]),
+        ("channel_USD.slug", "channel_PLN.slug", 2, [1, 2]),
+        ("channel_PLN.slug", "channel_USD.slug", 1, [0]),
+        ("channel_PLN.slug", "channel_PLN.slug", 1, [0]),
+    ],
+)
+def test_category_filter_products_by_channel(
+    channel,
+    filter_channel,
+    count,
+    indexes_of_products_in_result,
+    user_api_client,
+    category,
+    product_list,
+    channel_USD,
+    channel_PLN,
+):
+    # given
+    first_product = product_list[0]
+
+    ProductChannelListing.objects.filter(
+        product=first_product,
+    ).update(channel=channel_PLN)
+
+    ProductVariantChannelListing.objects.filter(
+        variant=first_product.variants.first(),
+    ).update(channel=channel_PLN)
+
+    product_ids = [
+        graphene.Node.to_global_id("Product", product_list[index].pk)
+        for index in indexes_of_products_in_result
+    ]
+
+    variables = {
+        "id": graphene.Node.to_global_id("Category", category.pk),
+        "channel": eval(channel),
+        "filters": {"channel": eval(filter_channel)},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        GET_FILTERED_PRODUCTS_CATEGORY_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products = content["data"]["category"]["products"]["edges"]
+    assert len(products) == count
+    assert [product["node"]["id"] for product in products] == product_ids
+
+
+@pytest.mark.parametrize(
+    "is_published, count, indexes_of_products_in_result",
+    [
+        (True, 2, [1, 2]),
+        (False, 1, [0]),
+    ],
+)
+def test_category_filter_products_by_is_published(
+    is_published,
+    count,
+    indexes_of_products_in_result,
+    staff_api_client,
+    permission_manage_products,
+    category,
+    product_list_published,
+    channel_USD,
+):
+    # given
+    ProductChannelListing.objects.filter(
+        product=product_list_published[0],
+    ).update(is_published=False)
+
+    product_ids = [
+        graphene.Node.to_global_id("Product", product_list_published[index].pk)
+        for index in indexes_of_products_in_result
+    ]
+
+    variables = {
+        "id": graphene.Node.to_global_id("Category", category.pk),
+        "channel": channel_USD.slug,
+        "filters": {"isPublished": is_published},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        GET_FILTERED_PRODUCTS_CATEGORY_QUERY,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products = content["data"]["category"]["products"]["edges"]
+    assert len(products) == count
+    assert [product["node"]["id"] for product in products] == product_ids
+
+
+def test_category_filter_products_by_multiple_attributes(
+    user_api_client,
+    category,
+    product_with_two_variants,
+    product_with_multiple_values_attributes,
+    channel_USD,
+):
+    # given
+    product_with_multiple_values_attributes_id = graphene.Node.to_global_id(
+        "Product", product_with_multiple_values_attributes.pk
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("Category", category.pk),
+        "channel": channel_USD.slug,
+        "filters": {"attributes": [{"slug": "modes", "values": ["eco"]}]},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        GET_FILTERED_PRODUCTS_CATEGORY_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products = content["data"]["category"]["products"]["edges"]
+
+    assert len(products) == 1
+    assert products[0]["node"]["id"] == product_with_multiple_values_attributes_id
+    assert products[0]["node"]["attributes"] == [
+        {
+            "attribute": {
+                "choices": {
+                    "edges": [
+                        {"node": {"slug": "eco"}},
+                        {"node": {"slug": "power"}},
+                    ]
+                }
+            }
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "stock_availability, count, indexes_of_products_in_result",
+    [
+        ("OUT_OF_STOCK", 2, [1, 2]),
+        ("IN_STOCK", 1, [0]),
+    ],
+)
+def test_category_filter_products_by_stock_availability(
+    stock_availability,
+    count,
+    indexes_of_products_in_result,
+    user_api_client,
+    category,
+    product_list,
+    channel_USD,
+):
+    # given
+    for index, product in enumerate(product_list):
+        if index == 0:
+            continue
+        stock = product.variants.first().stocks.first()
+        stock.quantity_allocated = stock.quantity
+        stock.quantity = 0
+        stock.save(update_fields=["quantity", "quantity_allocated"])
+
+    product_ids = [
+        graphene.Node.to_global_id("Product", product_list[index].pk)
+        for index in indexes_of_products_in_result
+    ]
+
+    variables = {
+        "id": graphene.Node.to_global_id("Category", category.pk),
+        "channel": channel_USD.slug,
+        "filters": {"stockAvailability": stock_availability},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        GET_FILTERED_PRODUCTS_CATEGORY_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products = content["data"]["category"]["products"]["edges"]
+
+    assert len(products) == count
+    assert [product["node"]["id"] for product in products] == product_ids
+
+
+@pytest.mark.parametrize(
+    "quantity_input, warehouse_indexes, count, indexes_of_products_in_result",
+    [
+        ({"lte": "80", "gte": "20"}, [1, 2], 1, [1]),
+        ({"lte": "120", "gte": "40"}, [1, 2], 1, [0]),
+        ({"gte": "10"}, [1], 1, [1]),
+        ({"gte": "110"}, [2], 0, []),
+        (None, [1], 1, [1]),
+        (None, [2], 2, [0, 1]),
+        ({"lte": "210", "gte": "70"}, [], 1, [0]),
+        ({"lte": "90"}, [], 1, [1]),
+        ({"lte": "90", "gte": "75"}, [], 0, []),
+    ],
+)
+def test_category_filter_products_by_stocks(
+    quantity_input,
+    warehouse_indexes,
+    count,
+    indexes_of_products_in_result,
+    user_api_client,
+    category,
+    product_with_single_variant,
+    product_with_two_variants,
+    warehouse,
+    channel_USD,
+):
+    # given
+    first_product = product_with_single_variant
+    second_product = product_with_two_variants
+    products = [first_product, second_product]
+
+    first_warehouse = warehouse
+
+    second_warehouse = Warehouse.objects.get(pk=first_warehouse.pk)
+    second_warehouse.slug = "second-warehouse"
+    second_warehouse.pk = None
+    second_warehouse.save()
+
+    third_warehouse = Warehouse.objects.get(pk=first_warehouse.pk)
+    third_warehouse.slug = "third-warehouse"
+    third_warehouse.pk = None
+    third_warehouse.save()
+
+    warehouses = [first_warehouse, second_warehouse, third_warehouse]
+    warehouse_ids = [
+        graphene.Node.to_global_id("Warehouse", warehouses[index].pk)
+        for index in warehouse_indexes
+    ]
+
+    Stock.objects.bulk_create(
+        [
+            Stock(
+                warehouse=third_warehouse,
+                product_variant=first_product.variants.first(),
+                quantity=100,
+            ),
+            Stock(
+                warehouse=second_warehouse,
+                product_variant=second_product.variants.first(),
+                quantity=10,
+            ),
+            Stock(
+                warehouse=third_warehouse,
+                product_variant=second_product.variants.first(),
+                quantity=25,
+            ),
+            Stock(
+                warehouse=third_warehouse,
+                product_variant=second_product.variants.last(),
+                quantity=30,
+            ),
+        ]
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("Category", category.pk),
+        "channel": channel_USD.slug,
+        "filters": {
+            "stocks": {"quantity": quantity_input, "warehouseIds": warehouse_ids}
+        },
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        GET_FILTERED_PRODUCTS_CATEGORY_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_result = content["data"]["category"]["products"]["edges"]
+    product_ids = {
+        graphene.Node.to_global_id("Product", products[index].pk)
+        for index in indexes_of_products_in_result
+    }
+
+    assert len(products_result) == count
+    assert {node["node"]["id"] for node in products_result} == product_ids
+
+
+@pytest.mark.parametrize(
+    "is_published, count, indexes_of_products_in_result",
+    [
+        (True, 1, [1]),
+        (False, 0, []),
+    ],
+)
+def test_category_filter_products_search_by_sku(
+    is_published,
+    count,
+    indexes_of_products_in_result,
+    user_api_client,
+    category,
+    product_with_two_variants,
+    product_with_default_variant,
+    channel_USD,
+):
+    # given
+    products = [product_with_two_variants, product_with_default_variant]
+
+    ProductChannelListing.objects.filter(
+        product=product_with_default_variant, channel=channel_USD
+    ).update(is_published=is_published)
+
+    variables = {
+        "id": graphene.Node.to_global_id("Category", category.pk),
+        "channel": channel_USD.slug,
+        "filters": {"search": "1234"},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        GET_FILTERED_PRODUCTS_CATEGORY_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products_result = content["data"]["category"]["products"]["edges"]
+    product_ids = {
+        graphene.Node.to_global_id("Product", products[index].pk)
+        for index in indexes_of_products_in_result
+    }
+
+    assert len(products_result) == count
+    assert {node["node"]["id"] for node in products_result} == product_ids
+
+
+def test_category_filter_products_by_price(
+    user_api_client,
+    category,
+    product_list,
+    permission_manage_products,
+    channel_USD,
+):
+    # given
+    product_list[0].variants.first().channel_listings.filter().update(price_amount=None)
+    second_product_id = graphene.Node.to_global_id("Product", product_list[1].pk)
+
+    # when
+    variables = {
+        "id": graphene.Node.to_global_id("Category", category.pk),
+        "channel": channel_USD.slug,
+        "filters": {"price": {"gte": 5, "lte": 25}, "channel": channel_USD.slug},
+    }
+
+    response = user_api_client.post_graphql(
+        GET_FILTERED_PRODUCTS_CATEGORY_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products = content["data"]["category"]["products"]["edges"]
+
+    assert len(products) == 1
+    assert products[0]["node"]["id"] == second_product_id
+
+
+def test_category_filter_products_by_ids(
+    user_api_client,
+    category,
+    product_list,
+    channel_USD,
+):
+    # given
+    product_ids = [
+        graphene.Node.to_global_id("Product", product.pk) for product in product_list
+    ][:2]
+
+    variables = {
+        "id": graphene.Node.to_global_id("Category", category.pk),
+        "channel": channel_USD.slug,
+        "filters": {"ids": product_ids},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        GET_FILTERED_PRODUCTS_CATEGORY_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products = content["data"]["category"]["products"]["edges"]
+
+    assert len(products) == 2
+    assert [node["node"]["id"] for node in products] == product_ids
+
+
+GET_SORTED_PRODUCTS_CATEGORY_QUERY = """
+query ($id: ID!, $channel: String, $filters: ProductFilterInput, $sortBy: ProductOrder){
+  category(id: $id) {
+    id
+    products(first: 10, channel: $channel, sortBy: $sortBy, filter: $filters) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_category_sort_products_by_name(
+    user_api_client,
+    category,
+    product_list,
+    channel_USD,
+):
+    # given
+    variables = {
+        "id": graphene.Node.to_global_id("Category", category.pk),
+        "channel": channel_USD.slug,
+        "filters": {"channel": channel_USD.slug},
+        "sortBy": {"direction": "DESC", "field": "NAME"},
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        GET_SORTED_PRODUCTS_CATEGORY_QUERY,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    products = content["data"]["category"]["products"]["edges"]
+
+    assert [node["node"]["id"] for node in products] == [
+        graphene.Node.to_global_id("Product", product.pk)
+        for product in Product.objects.order_by("-name")
+    ]

--- a/saleor/graphql/product/types/categories.py
+++ b/saleor/graphql/product/types/categories.py
@@ -10,10 +10,14 @@ from ....product.models import ALL_PRODUCTS_PERMISSIONS
 from ....thumbnail.utils import get_image_or_proxy_url, get_thumbnail_size
 from ...channel import ChannelQsContext
 from ...channel.utils import get_default_channel_slug_or_graphql_error
-from ...core.connection import CountableConnection, create_connection_slice
-from ...core.descriptions import DEPRECATED_IN_3X_FIELD, RICH_CONTENT
+from ...core.connection import (
+    CountableConnection,
+    create_connection_slice,
+    filter_connection_queryset,
+)
+from ...core.descriptions import ADDED_IN_39, DEPRECATED_IN_3X_FIELD, RICH_CONTENT
 from ...core.federation import federated_entity, resolve_federation_references
-from ...core.fields import ConnectionField, JSONString
+from ...core.fields import ConnectionField, FilterConnectionField, JSONString
 from ...core.types import Image, ModelObjectType, ThumbnailField
 from ...meta.types import ObjectWithMetadata
 from ...translations.fields import TranslationField
@@ -23,6 +27,8 @@ from ..dataloaders import (
     CategoryChildrenByCategoryIdLoader,
     ThumbnailByCategoryIdSizeAndFormatLoader,
 )
+from ..filters import ProductFilterInput
+from ..sorters import ProductOrder
 from .products import ProductCountableConnection
 
 
@@ -46,8 +52,12 @@ class Category(ModelObjectType):
         lambda: CategoryCountableConnection,
         description="List of ancestors of the category.",
     )
-    products = ConnectionField(
+    products = FilterConnectionField(
         ProductCountableConnection,
+        filter=ProductFilterInput(
+            description="Filtering options for products." + ADDED_IN_39
+        ),
+        sort_by=ProductOrder(description="Sort products." + ADDED_IN_39),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
@@ -146,6 +156,9 @@ class Category(ModelObjectType):
             qs = qs.filter(channel_listings__channel__slug=channel)
         qs = qs.filter(category__in=tree)
         qs = ChannelQsContext(qs=qs, channel_slug=channel)
+
+        kwargs["channel"] = channel
+        qs = filter_connection_queryset(qs, kwargs)
         return create_connection_slice(qs, info, kwargs, ProductCountableConnection)
 
     @staticmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5648,6 +5648,20 @@ type Category implements Node & ObjectWithMetadata {
   List of products in the category. Requires the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
   """
   products(
+    """
+    Filtering options for products.
+    
+    Added in Saleor 3.9.
+    """
+    filter: ProductFilterInput
+
+    """
+    Sort products.
+    
+    Added in Saleor 3.9.
+    """
+    sortBy: ProductOrder
+
     """Slug of a channel for which the data should be returned."""
     channel: String
 
@@ -5716,6 +5730,228 @@ type CategoryCountableEdge {
 
   """A cursor for use in pagination."""
   cursor: String!
+}
+
+input ProductFilterInput {
+  isPublished: Boolean
+  collections: [ID!]
+  categories: [ID!]
+  hasCategory: Boolean
+  attributes: [AttributeInput!]
+
+  """Filter by variants having specific stock status."""
+  stockAvailability: StockAvailability
+  stocks: ProductStockFilterInput
+  search: String
+  metadata: [MetadataFilter!]
+
+  """
+  Filter by the publication date. 
+  
+  Added in Saleor 3.8.
+  """
+  publishedFrom: DateTime
+
+  """
+  Filter by availability for purchase. 
+  
+  Added in Saleor 3.8.
+  """
+  isAvailable: Boolean
+
+  """
+  Filter by the date of availability for purchase. 
+  
+  Added in Saleor 3.8.
+  """
+  availableFrom: DateTime
+
+  """
+  Filter by visibility in product listings. 
+  
+  Added in Saleor 3.8.
+  """
+  isVisibleInListing: Boolean
+  price: PriceRangeInput
+
+  """Filter by the lowest variant price after discounts."""
+  minimalPrice: PriceRangeInput
+
+  """Filter by when was the most recent update."""
+  updatedAt: DateTimeRangeInput
+  productTypes: [ID!]
+
+  """Filter on whether product is a gift card or not."""
+  giftCard: Boolean
+  ids: [ID!]
+  hasPreorderedVariants: Boolean
+  slugs: [String!]
+
+  """
+  Specifies the channel by which the data should be filtered. 
+  
+  DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
+  """
+  channel: String
+}
+
+input AttributeInput {
+  """Internal representation of an attribute name."""
+  slug: String!
+
+  """Internal representation of a value (unique per attribute)."""
+  values: [String!]
+
+  """The range that the returned values should be in."""
+  valuesRange: IntRangeInput
+
+  """The date/time range that the returned values should be in."""
+  dateTime: DateTimeRangeInput
+
+  """
+  The date range that the returned values should be in. In case of date/time attributes, the UTC midnight of the given date is used.
+  """
+  date: DateRangeInput
+
+  """The boolean value of the attribute."""
+  boolean: Boolean
+}
+
+input IntRangeInput {
+  """Value greater than or equal to."""
+  gte: Int
+
+  """Value less than or equal to."""
+  lte: Int
+}
+
+input DateTimeRangeInput {
+  """Start date."""
+  gte: DateTime
+
+  """End date."""
+  lte: DateTime
+}
+
+input DateRangeInput {
+  """Start date."""
+  gte: Date
+
+  """End date."""
+  lte: Date
+}
+
+enum StockAvailability {
+  IN_STOCK
+  OUT_OF_STOCK
+}
+
+input ProductStockFilterInput {
+  warehouseIds: [ID!]
+  quantity: IntRangeInput
+}
+
+input PriceRangeInput {
+  """Price greater than or equal to."""
+  gte: Float
+
+  """Price less than or equal to."""
+  lte: Float
+}
+
+input ProductOrder {
+  """Specifies the direction in which to sort products."""
+  direction: OrderDirection!
+
+  """
+  Specifies the channel in which to sort the data.
+  
+  DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
+  """
+  channel: String
+
+  """
+  Sort product by the selected attribute's values.
+  Note: this doesn't take translations into account yet.
+  """
+  attributeId: ID
+
+  """Sort products by the selected field."""
+  field: ProductOrderField
+}
+
+enum ProductOrderField {
+  """Sort products by name."""
+  NAME
+
+  """
+  Sort products by rank. Note: This option is available only with the `search` filter.
+  """
+  RANK
+
+  """
+  Sort products by price.
+  
+  This option requires a channel filter to work as the values can vary between channels.
+  """
+  PRICE
+
+  """
+  Sort products by a minimal price of a product's variant.
+  
+  This option requires a channel filter to work as the values can vary between channels.
+  """
+  MINIMAL_PRICE
+
+  """Sort products by update date."""
+  LAST_MODIFIED
+
+  """Sort products by update date."""
+  DATE
+
+  """Sort products by type."""
+  TYPE
+
+  """
+  Sort products by publication status.
+  
+  This option requires a channel filter to work as the values can vary between channels.
+  """
+  PUBLISHED
+
+  """
+  Sort products by publication date.
+  
+  This option requires a channel filter to work as the values can vary between channels.
+  """
+  PUBLICATION_DATE
+
+  """
+  Sort products by publication date.
+  
+  This option requires a channel filter to work as the values can vary between channels.
+  """
+  PUBLISHED_AT
+
+  """Sort products by update date."""
+  LAST_MODIFIED_AT
+
+  """
+  Sort products by collection. Note: This option is available only for the `Collection.products` query.
+  
+  This option requires a channel filter to work as the values can vary between channels.
+  """
+  COLLECTION
+
+  """Sort products by rating."""
+  RATING
+
+  """
+  Sort products by creation date.
+  
+  Added in Saleor 3.8.
+  """
+  CREATED_AT
 }
 
 """Represents an image."""
@@ -6471,228 +6707,6 @@ type Collection implements Node & ObjectWithMetadata {
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   channelListings: [CollectionChannelListing!]
-}
-
-input ProductFilterInput {
-  isPublished: Boolean
-  collections: [ID!]
-  categories: [ID!]
-  hasCategory: Boolean
-  attributes: [AttributeInput!]
-
-  """Filter by variants having specific stock status."""
-  stockAvailability: StockAvailability
-  stocks: ProductStockFilterInput
-  search: String
-  metadata: [MetadataFilter!]
-
-  """
-  Filter by the publication date. 
-  
-  Added in Saleor 3.8.
-  """
-  publishedFrom: DateTime
-
-  """
-  Filter by availability for purchase. 
-  
-  Added in Saleor 3.8.
-  """
-  isAvailable: Boolean
-
-  """
-  Filter by the date of availability for purchase. 
-  
-  Added in Saleor 3.8.
-  """
-  availableFrom: DateTime
-
-  """
-  Filter by visibility in product listings. 
-  
-  Added in Saleor 3.8.
-  """
-  isVisibleInListing: Boolean
-  price: PriceRangeInput
-
-  """Filter by the lowest variant price after discounts."""
-  minimalPrice: PriceRangeInput
-
-  """Filter by when was the most recent update."""
-  updatedAt: DateTimeRangeInput
-  productTypes: [ID!]
-
-  """Filter on whether product is a gift card or not."""
-  giftCard: Boolean
-  ids: [ID!]
-  hasPreorderedVariants: Boolean
-  slugs: [String!]
-
-  """
-  Specifies the channel by which the data should be filtered. 
-  
-  DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
-  """
-  channel: String
-}
-
-input AttributeInput {
-  """Internal representation of an attribute name."""
-  slug: String!
-
-  """Internal representation of a value (unique per attribute)."""
-  values: [String!]
-
-  """The range that the returned values should be in."""
-  valuesRange: IntRangeInput
-
-  """The date/time range that the returned values should be in."""
-  dateTime: DateTimeRangeInput
-
-  """
-  The date range that the returned values should be in. In case of date/time attributes, the UTC midnight of the given date is used.
-  """
-  date: DateRangeInput
-
-  """The boolean value of the attribute."""
-  boolean: Boolean
-}
-
-input IntRangeInput {
-  """Value greater than or equal to."""
-  gte: Int
-
-  """Value less than or equal to."""
-  lte: Int
-}
-
-input DateTimeRangeInput {
-  """Start date."""
-  gte: DateTime
-
-  """End date."""
-  lte: DateTime
-}
-
-input DateRangeInput {
-  """Start date."""
-  gte: Date
-
-  """End date."""
-  lte: Date
-}
-
-enum StockAvailability {
-  IN_STOCK
-  OUT_OF_STOCK
-}
-
-input ProductStockFilterInput {
-  warehouseIds: [ID!]
-  quantity: IntRangeInput
-}
-
-input PriceRangeInput {
-  """Price greater than or equal to."""
-  gte: Float
-
-  """Price less than or equal to."""
-  lte: Float
-}
-
-input ProductOrder {
-  """Specifies the direction in which to sort products."""
-  direction: OrderDirection!
-
-  """
-  Specifies the channel in which to sort the data.
-  
-  DEPRECATED: this field will be removed in Saleor 4.0. Use root-level channel argument instead.
-  """
-  channel: String
-
-  """
-  Sort product by the selected attribute's values.
-  Note: this doesn't take translations into account yet.
-  """
-  attributeId: ID
-
-  """Sort products by the selected field."""
-  field: ProductOrderField
-}
-
-enum ProductOrderField {
-  """Sort products by name."""
-  NAME
-
-  """
-  Sort products by rank. Note: This option is available only with the `search` filter.
-  """
-  RANK
-
-  """
-  Sort products by price.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  PRICE
-
-  """
-  Sort products by a minimal price of a product's variant.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  MINIMAL_PRICE
-
-  """Sort products by update date."""
-  LAST_MODIFIED
-
-  """Sort products by update date."""
-  DATE
-
-  """Sort products by type."""
-  TYPE
-
-  """
-  Sort products by publication status.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  PUBLISHED
-
-  """
-  Sort products by publication date.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  PUBLICATION_DATE
-
-  """
-  Sort products by publication date.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  PUBLISHED_AT
-
-  """Sort products by update date."""
-  LAST_MODIFIED_AT
-
-  """
-  Sort products by collection. Note: This option is available only for the `Collection.products` query.
-  
-  This option requires a channel filter to work as the values can vary between channels.
-  """
-  COLLECTION
-
-  """Sort products by rating."""
-  RATING
-
-  """
-  Sort products by creation date.
-  
-  Added in Saleor 3.8.
-  """
-  CREATED_AT
 }
 
 type CollectionTranslation implements Node {


### PR DESCRIPTION
>  **Note:** This is a 3.9 port of #10997 

I want to merge this change because it adds filtering and sorting capabilities to category.products query.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
