### PR TITLE
Deactivate webhook before deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Make email authentication case-insensitive. #11284 by @zedzior
 - Fix the observability reporter to obfuscate URLs. #11282 by @przlada
 - Add HTTP headers filtering to observability reporter. #11285 by @przlada
+- Deactivate Webhook before deleting and handle IntegrityErrors - #11239 @jakubkuc
 
 # 3.8.0
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11758,7 +11758,7 @@ type Mutation {
   ): WebhookCreate
 
   """
-  Deletes a webhook subscription. 
+  Deletes a webhook subscription. Deletion might fail due to webhook delivery in progress. In this case deactivates webhook 
   
   Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
   """
@@ -15569,7 +15569,7 @@ input WebhookCreateInput {
 }
 
 """
-Deletes a webhook subscription. 
+Deletes a webhook subscription. Deletion might fail due to webhook delivery in progress. In this case deactivates webhook 
 
 Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11758,7 +11758,7 @@ type Mutation {
   ): WebhookCreate
 
   """
-  Deletes a webhook subscription. Deletion might fail due to webhook delivery in progress. In this case deactivates webhook 
+  Delete a webhook. Before the deletion, the webhook is deactivated to pause any deliveries that are already scheduled. The deletion might fail if delivery is in progress. In such a case, the webhook is not deleted but remains deactivated. 
   
   Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
   """
@@ -15569,7 +15569,7 @@ input WebhookCreateInput {
 }
 
 """
-Deletes a webhook subscription. Deletion might fail due to webhook delivery in progress. In this case deactivates webhook 
+Delete a webhook. Before the deletion, the webhook is deactivated to pause any deliveries that are already scheduled. The deletion might fail if delivery is in progress. In such a case, the webhook is not deleted but remains deactivated. 
 
 Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15522,6 +15522,7 @@ enum WebhookErrorCode {
   NOT_FOUND
   REQUIRED
   UNIQUE
+  DELETE_FAILED
 }
 
 input WebhookCreateInput {

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -233,7 +233,8 @@ class WebhookDelete(ModelDeleteMutation):
         id = graphene.ID(required=True, description="ID of a webhook to delete.")
 
     class Meta:
-        description = "Deletes a webhook subscription."
+        description = "Deletes a webhook subscription. Deletion might fail due to " \
+                      "webhook delivery in progress. In this case deactivates webhook"
         model = models.Webhook
         object_type = Webhook
         permissions = (
@@ -252,7 +253,7 @@ class WebhookDelete(ModelDeleteMutation):
                 code=WebhookErrorCode.INVALID,
             )
         webhook = cls.get_node_or_error(info, data.get("id"), only_type=Webhook)
-        if app and webhook.app.id != app.id:
+        if app and webhook.app_id != app.id:
             raise ValidationError(
                 f"Couldn't resolve to a node: {webhook.app.id}",
                 code=WebhookErrorCode.GRAPHQL_ERROR,

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -234,8 +234,10 @@ class WebhookDelete(ModelDeleteMutation):
 
     class Meta:
         description = (
-            "Deletes a webhook subscription. Deletion might fail due to "
-            "webhook delivery in progress. In this case deactivates webhook"
+            "Delete a webhook. Before the deletion, the webhook is deactivated to "
+            "pause any deliveries that are already scheduled. The deletion might fail "
+            "if delivery is in progress. In such a case, the webhook is not deleted "
+            "but remains deactivated."
         )
         model = models.Webhook
         object_type = Webhook

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -247,15 +247,16 @@ class WebhookDelete(ModelDeleteMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         app = get_app_promise(info.context).get()
+        node_id = data.get("id")
         if app and not app.is_active:
             raise ValidationError(
                 "App needs to be active to delete webhook",
                 code=WebhookErrorCode.INVALID,
             )
-        webhook = cls.get_node_or_error(info, data.get("id"), only_type=Webhook)
+        webhook = cls.get_node_or_error(info, node_id, only_type=Webhook)
         if app and webhook.app_id != app.id:
             raise ValidationError(
-                f"Couldn't resolve to a node: {webhook.app.id}",
+                f"Couldn't resolve to a node: {node_id}",
                 code=WebhookErrorCode.GRAPHQL_ERROR,
             )
         webhook.is_active = False

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -245,35 +245,30 @@ class WebhookDelete(ModelDeleteMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        node_id = data["id"]
-        object_id = cls.get_global_id_or_error(node_id)
-
         app = get_app_promise(info.context).get()
-        webhook = None
-        if app:
-            if not app.is_active:
-                raise ValidationError(
-                    "App needs to be active to delete webhook",
-                    code=WebhookErrorCode.INVALID,
-                )
-            try:
-                webhook = app.webhooks.get(id=object_id)
-            except models.Webhook.DoesNotExist:
-                raise ValidationError(
-                    f"Couldn't resolve to a node: {node_id}",
-                    code=WebhookErrorCode.GRAPHQL_ERROR,
-                )
+        if app and not app.is_active:
+            raise ValidationError(
+                "App needs to be active to delete webhook",
+                code=WebhookErrorCode.INVALID,
+            )
+        webhook = cls.get_node_or_error(info, data.get("id"), only_type=Webhook)
+        if app and webhook.app.id != app.id:
+            raise ValidationError(
+                f"Couldn't resolve to a node: {webhook.app.id}",
+                code=WebhookErrorCode.GRAPHQL_ERROR,
+            )
+        webhook.is_active = False
+        webhook.save(update_fields=["is_active"])
+
         try:
-            webhook = webhook or models.Webhook.objects.get(object_id)
-            webhook.is_active = False
-            webhook.save(update_fields=["is_active"])
             response = super().perform_mutation(_root, info, **data)
         except IntegrityError:
             raise ValidationError(
                 "Webhook couldn't be deleted at this time due to running task."
                 "Webhook deactivated. Try deleting Webhook later",
-                code=WebhookErrorCode.GRAPHQL_ERROR,
+                code=WebhookErrorCode.DELETE_FAILED,
             )
+
         return response
 
 

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -255,7 +255,9 @@ class WebhookDelete(ModelDeleteMutation):
                     code=WebhookErrorCode.INVALID,
                 )
             try:
-                app.webhooks.get(id=object_id)
+                webhook = app.webhooks.get(id=object_id)
+                webhook.is_active = False
+                webhook.save(update_fields=["is_active"])
             except models.Webhook.DoesNotExist:
                 raise ValidationError(
                     f"Couldn't resolve to a node: {node_id}",

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -233,8 +233,10 @@ class WebhookDelete(ModelDeleteMutation):
         id = graphene.ID(required=True, description="ID of a webhook to delete.")
 
     class Meta:
-        description = "Deletes a webhook subscription. Deletion might fail due to " \
-                      "webhook delivery in progress. In this case deactivates webhook"
+        description = (
+            "Deletes a webhook subscription. Deletion might fail due to "
+            "webhook delivery in progress. In this case deactivates webhook"
+        )
         model = models.Webhook
         object_type = Webhook
         permissions = (

--- a/saleor/graphql/webhook/tests/test_webhook.py
+++ b/saleor/graphql/webhook/tests/test_webhook.py
@@ -319,7 +319,8 @@ def test_webhook_delete_deactivates_before_deletion(
     get_graphql_content(response)
 
     # then
-    assert Webhook.objects.all().first().is_active is False
+    webhook.refresh_from_db()
+    assert webhook.is_active is False
 
 
 def test_webhook_delete_when_app_doesnt_exist(app_api_client, app):

--- a/saleor/graphql/webhook/tests/test_webhook.py
+++ b/saleor/graphql/webhook/tests/test_webhook.py
@@ -1,7 +1,8 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import graphene
 import pytest
+from django.db import IntegrityError
 
 from ....app.models import App
 from ....webhook.models import Webhook
@@ -291,7 +292,7 @@ def test_webhook_delete_by_app_and_missing_webhook(app_api_client, webhook):
     response = app_api_client.post_graphql(query, variables=variables)
     content = get_graphql_content(response)
     errors = content["data"]["webhookDelete"]["errors"]
-    assert errors[0]["code"] == "GRAPHQL_ERROR"
+    assert errors[0]["code"] == "NOT_FOUND"
 
 
 def test_webhook_delete_by_inactive_app(app_api_client, webhook):
@@ -320,6 +321,31 @@ def test_webhook_delete_deactivates_before_deletion(
 
     # then
     webhook.refresh_from_db()
+    assert webhook.is_active is False
+
+
+@patch("saleor.webhook.models.Webhook.delete")
+def test_webhook_delete_raises_integrity_error(mocked_delete, app_api_client, webhook):
+    # given
+    query = WEBHOOK_DELETE_BY_APP
+    mocked_delete.side_effect = IntegrityError(Mock(return_value={"as": "sa"}))
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {"id": webhook_id}
+
+    # when
+    response = app_api_client.post_graphql(query, variables=variables)
+    content = get_graphql_content(response)
+
+    # then
+    webhook.refresh_from_db()
+    errors = content["data"]["webhookDelete"]["errors"]
+    assert len(errors) == 1
+    assert (
+        errors[0]["message"] == "Webhook couldn't be deleted at this time due to "
+        "running task.Webhook deactivated. "
+        "Try deleting Webhook later"
+    )
+    assert errors[0]["code"] == "DELETE_FAILED"
     assert webhook.is_active is False
 
 

--- a/saleor/graphql/webhook/tests/test_webhook.py
+++ b/saleor/graphql/webhook/tests/test_webhook.py
@@ -305,6 +305,23 @@ def test_webhook_delete_by_inactive_app(app_api_client, webhook):
     assert_no_permission(response)
 
 
+@patch("saleor.webhook.models.Webhook.delete")
+def test_webhook_delete_deactivates_before_deletion(
+    mocked_delete, app_api_client, webhook
+):
+    # given
+    query = WEBHOOK_DELETE_BY_APP
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {"id": webhook_id}
+
+    # when
+    response = app_api_client.post_graphql(query, variables=variables)
+    get_graphql_content(response)
+
+    # then
+    assert Webhook.objects.all().first().is_active is False
+
+
 def test_webhook_delete_when_app_doesnt_exist(app_api_client, app):
     app.delete()
 

--- a/saleor/webhook/error_codes.py
+++ b/saleor/webhook/error_codes.py
@@ -7,3 +7,4 @@ class WebhookErrorCode(Enum):
     NOT_FOUND = "not_found"
     REQUIRED = "required"
     UNIQUE = "unique"
+    DELETE_FAILED = "delete_failed"


### PR DESCRIPTION
Discussion and reviews for this cherry-picks are in #11239 

I want to merge this change because it prevents issue where using WebhookDelete mutation while tasks that create EventDeliveryAttempt are queued resulted in IntegrityError.

The most simple resolution was to deactivate Webhook before deleting it in mutation. send_webhook_request_async task is checking if webhook is_active so this should prevent this situation.

Tasks:
I want to add tests after a discussion regarding edge-case.

Things to discuss:
⚠️ There is a small window for this solution to fail - when Webhook deactivation will happen between the is_active check and attempt creating/updating in send_webhook_request_async task. I'm not quite sure how to handle this case. Should I add more webhook activity checks inside send_webhook_request_async task or maybe catch this edge-case exception to fail gracefully? Any ideas?

Second thing: Do we want to do the sam analogically for deleting App? (deactivate webhook in app deletion)

https://github.com/saleor/saleor/issues/11227
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
