### PR TITLE
POC -  GraphQL schema as a single point of truth for cost and sensitivity information

### DIFF
--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -28,7 +28,7 @@ from ..core.connection import CountableConnection, create_connection_slice
 from ..core.descriptions import ADDED_IN_38, DEPRECATED_IN_3X_FIELD
 from ..core.enums import LanguageCodeEnum
 from ..core.federation import federated_entity, resolve_federation_references
-from ..core.fields import ConnectionField, PermissionsField
+from ..core.fields import ConnectionField, PermissionsField, SensitiveString
 from ..core.scalars import UUID
 from ..core.types import (
     CountryDisplay,
@@ -69,11 +69,11 @@ class AddressInput(graphene.InputObjectType):
 @federated_entity("id")
 class Address(ModelObjectType):
     id = graphene.GlobalID(required=True)
-    first_name = graphene.String(required=True)
-    last_name = graphene.String(required=True)
-    company_name = graphene.String(required=True)
-    street_address_1 = graphene.String(required=True)
-    street_address_2 = graphene.String(required=True)
+    first_name = SensitiveString(required=True)
+    last_name = SensitiveString(required=True)
+    company_name = SensitiveString(required=True)
+    street_address_1 = SensitiveString(required=True)
+    street_address_2 = SensitiveString(required=True)
     city = graphene.String(required=True)
     city_area = graphene.String(required=True)
     postal_code = graphene.String(required=True)
@@ -81,7 +81,7 @@ class Address(ModelObjectType):
         CountryDisplay, required=True, description="Shop's default country."
     )
     country_area = graphene.String(required=True)
-    phone = graphene.String()
+    phone = SensitiveString()
     is_default_shipping_address = graphene.Boolean(
         required=False, description="Address is user's default shipping address."
     )

--- a/saleor/graphql/core/fields.py
+++ b/saleor/graphql/core/fields.py
@@ -1,4 +1,4 @@
-from functools import wraps
+from functools import partial, wraps
 from json import JSONDecodeError
 from typing import List, Optional, TypedDict
 
@@ -28,6 +28,10 @@ class CostField(graphene.Field):
         self.sensitive = sensitive
         self.cost = cost
         super().__init__(*args, **kwargs)
+
+
+SensitiveField = partial(CostField, cost=None, sensitive=True)
+SensitiveString = partial(CostField, graphene.String, cost=None, sensitive=True)
 
 
 class PermissionsField(CostField):

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -66,7 +66,7 @@ from ..core.descriptions import (
     PREVIEW_FEATURE,
 )
 from ..core.enums import LanguageCodeEnum
-from ..core.fields import PermissionsField
+from ..core.fields import CostField, PermissionsField
 from ..core.mutations import validation_error_to_error_type
 from ..core.scalars import PositiveDecimal
 from ..core.types import (
@@ -845,7 +845,7 @@ class Order(ModelObjectType):
     created = graphene.DateTime(required=True)
     updated_at = graphene.DateTime(required=True)
     status = OrderStatusEnum(required=True)
-    user = graphene.Field(
+    user = CostField(
         User,
         description=(
             "User who placed the order. This field is set only for orders placed by "
@@ -855,9 +855,10 @@ class Order(ModelObjectType):
             f"{OrderPermissions.MANAGE_ORDERS.name}, "
             f"{AuthorizationFilters.OWNER.name}."
         ),
+        cost={"complexity": 1},
     )
     tracking_client_id = graphene.String(required=True)
-    billing_address = graphene.Field(
+    billing_address = CostField(
         "saleor.graphql.account.types.Address",
         description=(
             "Billing address. The full data can be access for orders created "
@@ -865,8 +866,9 @@ class Order(ModelObjectType):
             f"permissions: {OrderPermissions.MANAGE_ORDERS.name}, "
             f"{AuthorizationFilters.OWNER.name}."
         ),
+        cost={"complexity": 1},
     )
-    shipping_address = graphene.Field(
+    shipping_address = CostField(
         "saleor.graphql.account.types.Address",
         description=(
             "Shipping address. The full data can be access for orders created "
@@ -874,15 +876,22 @@ class Order(ModelObjectType):
             f"permissions: {OrderPermissions.MANAGE_ORDERS.name}, "
             f"{AuthorizationFilters.OWNER.name}."
         ),
+        cost={"complexity": 1},
     )
     shipping_method_name = graphene.String()
     collection_point_name = graphene.String()
-    channel = graphene.Field(Channel, required=True)
-    fulfillments = NonNullList(
-        Fulfillment, required=True, description="List of shipments for the order."
+    channel = CostField(Channel, required=True, cost={"complexity": 1})
+    fulfillments = CostField(
+        NonNullList(Fulfillment),
+        required=True,
+        description="List of shipments for the order.",
+        cost={"complexity": 1},
     )
-    lines = NonNullList(
-        lambda: OrderLine, required=True, description="List of order lines."
+    lines = CostField(
+        NonNullList(lambda: OrderLine),
+        required=True,
+        description="List of order lines.",
+        cost={"complexity": 1},
     )
     actions = NonNullList(
         OrderAction,
@@ -891,34 +900,38 @@ class Order(ModelObjectType):
         ),
         required=True,
     )
-    available_shipping_methods = NonNullList(
-        ShippingMethod,
+    available_shipping_methods = CostField(
+        NonNullList(ShippingMethod),
         description="Shipping methods that can be used with this order.",
         required=False,
         deprecation_reason="Use `shippingMethods`, this field will be removed in 4.0",
+        cost={"complexity": 1},
     )
-    shipping_methods = NonNullList(
-        ShippingMethod,
+    shipping_methods = CostField(
+        NonNullList(ShippingMethod),
         description="Shipping methods related to this order.",
         required=True,
+        cost={"complexity": 1},
     )
-    available_collection_points = NonNullList(
-        Warehouse,
+    available_collection_points = CostField(
+        NonNullList(Warehouse),
         description=(
             "Collection points that can be used for this order."
             + ADDED_IN_31
             + PREVIEW_FEATURE
         ),
         required=True,
+        cost={"complexity": 1},
     )
-    invoices = NonNullList(
-        Invoice,
+    invoices = CostField(
+        NonNullList(Invoice),
         description=(
             "List of order invoices. Can be fetched for orders created in Saleor 3.2 "
             "and later, for other orders requires one of the following permissions: "
             f"{OrderPermissions.MANAGE_ORDERS.name}, {AuthorizationFilters.OWNER.name}."
         ),
         required=True,
+        cost={"complexity": 1},
     )
     number = graphene.String(
         description="User-friendly number of an order.", required=True
@@ -954,8 +967,8 @@ class Order(ModelObjectType):
         ),
         required=True,
     )
-    transactions = NonNullList(
-        TransactionItem,
+    transactions = CostField(
+        NonNullList(TransactionItem),
         description=(
             "List of transactions for the order. Requires one of the "
             "following permissions: MANAGE_ORDERS, HANDLE_PAYMENTS."
@@ -963,9 +976,13 @@ class Order(ModelObjectType):
             + PREVIEW_FEATURE
         ),
         required=True,
+        cost={"complexity": 1},
     )
-    payments = NonNullList(
-        Payment, description="List of payments for the order.", required=True
+    payments = CostField(
+        NonNullList(Payment),
+        description="List of payments for the order.",
+        required=True,
+        cost={"complexity": 1},
     )
     total = graphene.Field(
         TaxedMoney, description="Total amount of the order.", required=True
@@ -976,10 +993,11 @@ class Order(ModelObjectType):
     shipping_price = graphene.Field(
         TaxedMoney, description="Total price of shipping.", required=True
     )
-    shipping_method = graphene.Field(
+    shipping_method = CostField(
         ShippingMethod,
         description="Shipping method for this order.",
         deprecation_reason=(f"{DEPRECATED_IN_3X_FIELD} Use `deliveryMethod` instead."),
+        cost={"complexity": 1},
     )
     shipping_price = graphene.Field(
         TaxedMoney, description="Total price of shipping.", required=True
@@ -1025,9 +1043,12 @@ class Order(ModelObjectType):
         required=True,
         deprecation_reason=(f"{DEPRECATED_IN_3X_FIELD} Use `id` instead."),
     )
-    voucher = graphene.Field(Voucher)
-    gift_cards = NonNullList(
-        GiftCard, description="List of user gift cards.", required=True
+    voucher = CostField(Voucher, cost={"complexity": 1})
+    gift_cards = CostField(
+        NonNullList(GiftCard),
+        description="List of user gift cards.",
+        required=True,
+        cost={"complexity": 1},
     )
     customerNote = graphene.Boolean(required=True)
     customer_note = graphene.String(required=True)
@@ -1059,6 +1080,7 @@ class Order(ModelObjectType):
         description="List of events associated with the order.",
         permissions=[OrderPermissions.MANAGE_ORDERS],
         required=True,
+        cost={"complexity": 1},
     )
     total_balance = graphene.Field(
         Money,
@@ -1077,13 +1099,14 @@ class Order(ModelObjectType):
     is_shipping_required = graphene.Boolean(
         description="Returns True, if order requires shipping.", required=True
     )
-    delivery_method = graphene.Field(
+    delivery_method = CostField(
         DeliveryMethod,
         description=(
             "The delivery method selected for this order."
             + ADDED_IN_31
             + PREVIEW_FEATURE
         ),
+        cost={"complexity": 1},
     )
     language_code = graphene.String(
         deprecation_reason=(
@@ -1114,10 +1137,11 @@ class Order(ModelObjectType):
             f"{DEPRECATED_IN_3X_FIELD} Use the `discounts` field instead. "
         ),
     )
-    discounts = NonNullList(
-        "saleor.graphql.discount.types.OrderDiscount",
+    discounts = CostField(
+        NonNullList("saleor.graphql.discount.types.OrderDiscount"),
         description="List of all discounts assigned to the order.",
         required=True,
+        cost={"complexity": 1},
     )
     errors = NonNullList(
         OrderError,

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -14,7 +14,7 @@ from ..core.connection import (
 )
 from ..core.descriptions import ADDED_IN_33, DEPRECATED_IN_3X_FIELD, RICH_CONTENT
 from ..core.federation import federated_entity, resolve_federation_references
-from ..core.fields import FilterConnectionField, JSONString, PermissionsField
+from ..core.fields import CostField, FilterConnectionField, JSONString, PermissionsField
 from ..core.scalars import Date
 from ..core.types import ModelObjectType, NonNullList
 from ..meta.types import ObjectWithMetadata
@@ -33,8 +33,10 @@ class PageType(ModelObjectType):
     id = graphene.GlobalID(required=True)
     name = graphene.String(required=True)
     slug = graphene.String(required=True)
-    attributes = NonNullList(
-        Attribute, description="Page attributes of that page type."
+    attributes = CostField(
+        NonNullList(Attribute),
+        description="Page attributes of that page type.",
+        cost={"complexity": 1},
     )
     available_attributes = FilterConnectionField(
         AttributeCountableConnection,
@@ -43,6 +45,7 @@ class PageType(ModelObjectType):
         permissions=[
             PagePermissions.MANAGE_PAGES,
         ],
+        cost={"complexity": 1, "multipliers": ["first", "last"]},
     )
     has_pages = PermissionsField(
         graphene.Boolean,
@@ -111,7 +114,7 @@ class Page(ModelObjectType):
     )
     is_published = graphene.Boolean(required=True)
     slug = graphene.String(required=True)
-    page_type = graphene.Field(PageType, required=True)
+    page_type = CostField(PageType, required=True, cost={"complexity": 1})
     created = graphene.DateTime(required=True)
     content_json = JSONString(
         description="Content of the page." + RICH_CONTENT,
@@ -119,10 +122,11 @@ class Page(ModelObjectType):
         required=True,
     )
     translation = TranslationField(PageTranslation, type_name="page")
-    attributes = NonNullList(
-        SelectedAttribute,
+    attributes = CostField(
+        NonNullList(SelectedAttribute),
         required=True,
         description="List of attributes assigned to this product.",
+        cost={"complexity": 1},
     )
 
     class Meta:

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -8,7 +8,7 @@ from ...payment import models
 from ..checkout.dataloaders import CheckoutByTokenLoader
 from ..core.connection import CountableConnection
 from ..core.descriptions import ADDED_IN_31, ADDED_IN_34, ADDED_IN_36, PREVIEW_FEATURE
-from ..core.fields import JSONString, PermissionsField
+from ..core.fields import JSONString, PermissionsField, SensitiveField
 from ..core.types import ModelObjectType, Money, NonNullList
 from ..meta.permissions import public_payment_permissions
 from ..meta.resolvers import resolve_metadata
@@ -143,7 +143,7 @@ class Payment(ModelObjectType):
         description="Maximum amount of money that can be refunded.",
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )
-    credit_card = graphene.Field(
+    credit_card = SensitiveField(
         CreditCard, description="The details of the card used for this payment."
     )
 

--- a/saleor/graphql/schema_maps.py
+++ b/saleor/graphql/schema_maps.py
@@ -1,0 +1,43 @@
+from typing import Dict, Set, Tuple
+
+from graphene.types.definitions import GrapheneObjectType
+from graphene.utils.str_converters import to_camel_case
+from graphql.type.definition import GraphQLType
+
+from .api import schema
+from .core.fields import CostField, FieldCost
+
+TypeMap = Dict[str, GraphQLType]
+SensitiveFieldsMap = Dict[str, Set[str]]
+FieldsCostMap = Dict[str, Dict[str, FieldCost]]
+
+
+def _get_field_name(name: str, camelcase=True) -> str:
+    if camelcase:
+        return to_camel_case(name)
+    return name
+
+
+def generate_schema_maps(
+    type_map: TypeMap, camelcase=True
+) -> Tuple[SensitiveFieldsMap, FieldsCostMap]:
+    sensitive_map: SensitiveFieldsMap = {}
+    cost_map: FieldsCostMap = {}
+
+    for type_name, gql_type in type_map.items():
+        if not isinstance(gql_type, GrapheneObjectType):
+            continue
+        for field_name, field in gql_type.graphene_type._meta.fields.items():
+            if not isinstance(field, CostField):
+                continue
+            field_name = field.name or _get_field_name(field_name, camelcase)
+            if field_name not in gql_type.fields:
+                continue
+            if field.sensitive:
+                sensitive_map.setdefault(type_name, set()).add(field_name)
+            if field.cost is not None:
+                cost_map.setdefault(type_name, {})[field_name] = field.cost
+    return sensitive_map, cost_map
+
+
+SENSITIVE_FIELDS_MAP, COST_MAP = generate_schema_maps(schema.get_type_map())


### PR DESCRIPTION
It is a POC of adding additional data to the GraphQL schema. The goal is to create a single point of truth for cost and sensitivity information and stop maintaining separate maps. 

### Cost data
The proposed solution is based on creating a new custom graphene field class `CostField`:
**From this:**
```python
COST_MAP = {
    "Page": {
        "attributes": {"complexity": 1},
        "pageType": {"complexity": 1},
    },
    "PageType": {
        "attributes": {"complexity": 1},
        "availableAttributes": {"complexity": 1, "multipliers": ["first", "last"]},
    },
}
```
**To this:**
```python
class Page(ModelObjectType):
    attributes = CostField(
        NonNullList(SelectedAttribute),
        required=True,
        description="List of attributes assigned to this product.",
        cost={"complexity": 1},
    )
    page_type = CostField(PageType, required=True, cost={"complexity": 1})

@federated_entity("id")
class PageType(ModelObjectType):
    attributes = CostField(
        NonNullList(Attribute),
        description="Page attributes of that page type.",
        cost={"complexity": 1},
    )
    available_attributes = FilterConnectionField(
        AttributeCountableConnection,
        filter=AttributeFilterInput(),
        description="Attributes that can be assigned to the page type.",
        permissions=[
            PagePermissions.MANAGE_PAGES,
        ],
        cost={"complexity": 1, "multipliers": ["first", "last"]},
    )
```
### Sensitive data

Sensitive fields can be pinpointed like that:
```python
@federated_entity("id")
class Address(ModelObjectType):
    first_name = SensitiveString(required=True)
    last_name = SensitiveString(required=True)
    company_name = SensitiveString(required=True)
    street_address_1 = SensitiveString(required=True)
    street_address_2 = SensitiveString(required=True)
    phone = SensitiveString()
```
```python
class Payment(ModelObjectType):
    credit_card = SensitiveField(
        CreditCard, description="The details of the card used for this payment."
    )
```
**Resulting with:**
```python
SENSITIVE_GQL_FIELDS = {
    "Address": {
        "firstName",
        "lastName",
        "companyName",
        "streetAddress1",
        "streetAddress2",
        "phone",
    },
    "Payment": {"creditCard"},
}
```
### Typing

Type information is added to `CostField` class and its subclasses. Thanks to that, cost data is validated by the type checker (`mypy`), which prevents misspells.
<img width="780" alt="Zrzut ekranu 2022-12-13 o 13 17 08" src="https://user-images.githubusercontent.com/6453010/207340709-2a3baf77-6b01-4200-962f-8f6f49300133.png">

## Summary 

`generate_schema_maps` function generates `SENSITIVE_FIELDS_MAP` and `COST_MAP` based on GraphQl schema, which the observability reporter and query cost validator could then use.

This is my proposed solution. Please take a look and comment on it. If this method gets accepted, I will add unit tests, move all cost and sensitivity information to the schema, and drop `SENSITIVE_FIELDS_MAP` and `COST_MAP`.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
