### PR TITLE
Fix invalid default values for decimal fields

### DIFF
--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -328,7 +328,7 @@ class SaleChannelListing(models.Model):
     discount_value = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
-        default=0,
+        default=Decimal("0.0"),
     )
     currency = models.CharField(
         max_length=settings.DEFAULT_CURRENCY_CODE_LENGTH,
@@ -380,13 +380,13 @@ class OrderDiscount(models.Model):
     value = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
-        default=0,
+        default=Decimal("0.0"),
     )
 
     amount_value = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
-        default=0,
+        default=Decimal("0.0"),
     )
     amount = MoneyField(amount_field="amount_value", currency_field="currency")
     currency = models.CharField(

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -529,7 +529,7 @@ class OrderLine(ModelWithMetadata):
     unit_discount_value = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
-        default=0,
+        default=Decimal("0.0"),
     )
     unit_price_net = MoneyField(
         amount_field="unit_price_net_amount", currency_field="currency"

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import TYPE_CHECKING, List, Union
 
 from django.conf import settings
@@ -264,7 +265,7 @@ class ShippingMethodChannelListing(models.Model):
     minimum_order_price_amount = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
-        default=0,
+        default=Decimal("0.0"),
         blank=True,
         null=True,
     )
@@ -287,7 +288,7 @@ class ShippingMethodChannelListing(models.Model):
     price_amount = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
-        default=0,
+        default=Decimal("0.0"),
     )
 
     def get_total(self):


### PR DESCRIPTION
The default value for `DecimalField`s must be a Decimal value

Port of #11472

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
