### PR TITLE
Stop sending regular payload to subscription webhooks

### DIFF
--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -78,6 +78,7 @@ def create_deliveries_for_subscriptions(
 
     :param event_type: event type which should be triggered.
     :param subscribable_object: subscribable object to process via subscription query.
+    :param webhooks: sequence of async webhooks.
     :param requestor: used in subscription webhooks to generate meta data for payload.
     :return: List of event deliveries to send via webhook tasks.
     """
@@ -186,7 +187,7 @@ def trigger_webhooks_async(
         payload = EventPayload.objects.create(payload=data)
         deliveries.extend(
             create_event_delivery_list_for_webhooks(
-                webhooks=webhooks,
+                webhooks=regular_webhooks,
                 event_payload=payload,
                 event_type=event_type,
             )

--- a/saleor/plugins/webhook/utils.py
+++ b/saleor/plugins/webhook/utils.py
@@ -4,9 +4,7 @@ import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
 from time import time
-from typing import TYPE_CHECKING, Any, List, Optional
-
-from django.db.models import QuerySet
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence
 
 from ...app.models import App
 from ...core.models import (
@@ -21,6 +19,7 @@ from ...webhook.event_types import WebhookEventSyncType
 
 if TYPE_CHECKING:
     from ...payment.interface import PaymentData
+    from ...webhook.models import Webhook
     from .tasks import WebhookResponse
 
 APP_GATEWAY_ID_PREFIX = "app"
@@ -187,7 +186,7 @@ def catch_duration_time():
 
 
 def create_event_delivery_list_for_webhooks(
-    webhooks: QuerySet,
+    webhooks: Sequence["Webhook"],
     event_payload: "EventPayload",
     event_type: str,
 ) -> List[EventDelivery]:


### PR DESCRIPTION
I want to merge this change because when there are two webhooks (regular and with subscription query) listening on the same event, the subscription query webhook will receive two payloads with every event -> one based on the subscription query and one redundant with regular payload. This change is a fix for this bug.

fixes #11494

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
