### PR TITLE
Extend Invoice object types with Order reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - `User`
     - `Warehouse`
 - Extend invoice object types with `Order` references - #11505 by @przlada
-  - Add `Invoice.orderId` field
+  - Add `Invoice.order` field
   - Add `InvoiceRequested.order`, `InvoiceDeleted.order` and `InvoiceSent.order` fields
 
 ### Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable, unreleased changes to this project will be documented in this file.
     - `Order`
     - `User`
     - `Warehouse`
+- Extend invoice object types with `Order` references - #11505 by @przlada
+  - Add `Invoice.orderId` field
+  - Add `InvoiceRequested.order`, `InvoiceDeleted.order` and `InvoiceSent.order` fields
 
 ### Other changes
 - Fix fetching the `checkout.availableCollectionPoints` - #11489 by @IKarbowiak

--- a/saleor/graphql/invoice/tests/test_invoice_create.py
+++ b/saleor/graphql/invoice/tests/test_invoice_create.py
@@ -22,6 +22,7 @@ INVOICE_CREATE_MUTATION = """
                 status
                 number
                 url
+                orderId
             }
             errors {
                 field
@@ -35,8 +36,9 @@ INVOICE_CREATE_MUTATION = """
 def test_create_invoice(staff_api_client, permission_manage_orders, order):
     number = "01/12/2020/TEST"
     url = "http://www.example.com"
+    order_id = graphene.Node.to_global_id("Order", order.pk)
     variables = {
-        "orderId": graphene.Node.to_global_id("Order", order.pk),
+        "orderId": order_id,
         "number": number,
         "url": url,
     }
@@ -45,6 +47,7 @@ def test_create_invoice(staff_api_client, permission_manage_orders, order):
     )
     content = get_graphql_content(response)
     invoice = Invoice.objects.get(order=order, status=JobStatus.SUCCESS)
+    assert order_id == content["data"]["invoiceCreate"]["invoice"]["orderId"]
     assert invoice.url == content["data"]["invoiceCreate"]["invoice"]["url"]
     assert invoice.number == content["data"]["invoiceCreate"]["invoice"]["number"]
     assert (

--- a/saleor/graphql/invoice/tests/test_invoice_create.py
+++ b/saleor/graphql/invoice/tests/test_invoice_create.py
@@ -22,7 +22,9 @@ INVOICE_CREATE_MUTATION = """
                 status
                 number
                 url
-                orderId
+                order {
+                    id
+                }
             }
             errors {
                 field
@@ -47,7 +49,7 @@ def test_create_invoice(staff_api_client, permission_manage_orders, order):
     )
     content = get_graphql_content(response)
     invoice = Invoice.objects.get(order=order, status=JobStatus.SUCCESS)
-    assert order_id == content["data"]["invoiceCreate"]["invoice"]["orderId"]
+    assert order_id == content["data"]["invoiceCreate"]["invoice"]["order"]["id"]
     assert invoice.url == content["data"]["invoiceCreate"]["invoice"]["url"]
     assert invoice.number == content["data"]["invoiceCreate"]["invoice"]["number"]
     assert (

--- a/saleor/graphql/invoice/types.py
+++ b/saleor/graphql/invoice/types.py
@@ -12,8 +12,14 @@ class Invoice(ModelObjectType):
     updated_at = graphene.DateTime(required=True)
     message = graphene.String()
     url = graphene.String(description="URL to download an invoice.")
+    order_id = graphene.ID()
 
     class Meta:
         description = "Represents an Invoice."
         interfaces = [ObjectWithMetadata, Job, graphene.relay.Node]
         model = models.Invoice
+
+    @staticmethod
+    def resolve_order_id(root: models.Invoice, info):
+        order_id = root.order_id
+        return graphene.Node.to_global_id("Order", order_id) if order_id else None

--- a/saleor/graphql/invoice/types.py
+++ b/saleor/graphql/invoice/types.py
@@ -3,6 +3,7 @@ import graphene
 from ...invoice import models
 from ..core.types import Job, ModelObjectType
 from ..meta.types import ObjectWithMetadata
+from ..order.dataloaders import OrderByIdLoader
 
 
 class Invoice(ModelObjectType):
@@ -12,7 +13,10 @@ class Invoice(ModelObjectType):
     updated_at = graphene.DateTime(required=True)
     message = graphene.String()
     url = graphene.String(description="URL to download an invoice.")
-    order_id = graphene.ID()
+    order = graphene.Field(
+        "saleor.graphql.order.types.Order",
+        description="Order related to the invoice.",
+    )
 
     class Meta:
         description = "Represents an Invoice."
@@ -20,6 +24,5 @@ class Invoice(ModelObjectType):
         model = models.Invoice
 
     @staticmethod
-    def resolve_order_id(root: models.Invoice, info):
-        order_id = root.order_id
-        return graphene.Node.to_global_id("Order", order_id) if order_id else None
+    def resolve_order(root: models.Invoice, info):
+        return OrderByIdLoader(info.context).load(root.order_id)

--- a/saleor/graphql/invoice/types.py
+++ b/saleor/graphql/invoice/types.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ...invoice import models
+from ..core.descriptions import ADDED_IN_310
 from ..core.types import Job, ModelObjectType
 from ..meta.types import ObjectWithMetadata
 from ..order.dataloaders import OrderByIdLoader
@@ -15,7 +16,7 @@ class Invoice(ModelObjectType):
     url = graphene.String(description="URL to download an invoice.")
     order = graphene.Field(
         "saleor.graphql.order.types.Order",
-        description="Order related to the invoice.",
+        description="Order related to the invoice." + ADDED_IN_310,
     )
 
     class Meta:

--- a/saleor/graphql/query_cost_map.py
+++ b/saleor/graphql/query_cost_map.py
@@ -190,6 +190,9 @@ COST_MAP = {
         "permissions": {"complexity": 1},
         "users": {"complexity": 1},
     },
+    "Invoice": {
+        "order": {"complexity": 1},
+    },
     "Menu": {
         "items": {"complexity": 1},
     },
@@ -211,7 +214,7 @@ COST_MAP = {
         "events": {"complexity": 1},
         "fulfillments": {"complexity": 1},
         "giftCards": {"complexity": 1},
-        "invoices": {"complexity": 1},
+        "invoices": {"complexity": 10},
         "lines": {"complexity": 1},
         "payments": {"complexity": 1},
         "shippingAddress": {"complexity": 1},

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9888,7 +9888,11 @@ type Invoice implements ObjectWithMetadata & Job & Node {
   """URL to download an invoice."""
   url: String
 
-  """Order related to the invoice."""
+  """
+  Order related to the invoice.
+  
+  Added in Saleor 3.10.
+  """
   order: Order
 }
 
@@ -24910,7 +24914,11 @@ type InvoiceRequested implements Event {
   """The invoice the event relates to."""
   invoice: Invoice
 
-  """Order related to the invoice."""
+  """
+  Order related to the invoice.
+  
+  Added in Saleor 3.10.
+  """
   order: Order!
 }
 
@@ -24937,7 +24945,11 @@ type InvoiceDeleted implements Event {
   """The invoice the event relates to."""
   invoice: Invoice
 
-  """Order related to the invoice."""
+  """
+  Order related to the invoice.
+  
+  Added in Saleor 3.10.
+  """
   order: Order
 }
 
@@ -24964,7 +24976,11 @@ type InvoiceSent implements Event {
   """The invoice the event relates to."""
   invoice: Invoice
 
-  """Order related to the invoice."""
+  """
+  Order related to the invoice.
+  
+  Added in Saleor 3.10.
+  """
   order: Order
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -24906,6 +24906,9 @@ type InvoiceRequested implements Event {
 
   """The invoice the event relates to."""
   invoice: Invoice
+
+  """Order related to the invoice."""
+  order: Order!
 }
 
 """
@@ -24930,6 +24933,9 @@ type InvoiceDeleted implements Event {
 
   """The invoice the event relates to."""
   invoice: Invoice
+
+  """Order related to the invoice."""
+  order: Order
 }
 
 """
@@ -24954,6 +24960,9 @@ type InvoiceSent implements Event {
 
   """The invoice the event relates to."""
   invoice: Invoice
+
+  """Order related to the invoice."""
+  order: Order
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9887,7 +9887,9 @@ type Invoice implements ObjectWithMetadata & Job & Node {
 
   """URL to download an invoice."""
   url: String
-  orderId: ID
+
+  """Order related to the invoice."""
+  order: Order
 }
 
 interface Job {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9887,6 +9887,7 @@ type Invoice implements ObjectWithMetadata & Job & Node {
 
   """URL to download an invoice."""
   url: String
+  orderId: ID
 }
 
 interface Job {

--- a/saleor/graphql/tests/queries/fragments.py
+++ b/saleor/graphql/tests/queries/fragments.py
@@ -107,6 +107,16 @@ fragment InvoiceDetails on Invoice {
   id
   status
   number
+  orderId
+}
+"""
+
+INVOICE_ORDER_DETAILS = """
+fragment InvoiceOrderDetails on Order {
+  id
+  number
+  userEmail
+  isPaid
 }
 """
 

--- a/saleor/graphql/tests/queries/fragments.py
+++ b/saleor/graphql/tests/queries/fragments.py
@@ -107,7 +107,9 @@ fragment InvoiceDetails on Invoice {
   id
   status
   number
-  orderId
+  order {
+    id
+  }
 }
 """
 

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -790,14 +790,29 @@ class InvoiceBase(AbstractType):
         "saleor.graphql.invoice.types.Invoice",
         description="The invoice the event relates to.",
     )
+    order = graphene.Field(
+        "saleor.graphql.order.types.Order",
+        description="Order related to the invoice.",
+    )
 
     @staticmethod
     def resolve_invoice(root, _info):
         _, invoice = root
         return invoice
 
+    @staticmethod
+    def resolve_order(root, _info):
+        _, invoice = root
+        return invoice.order
+
 
 class InvoiceRequested(ObjectType, InvoiceBase):
+    order = graphene.Field(
+        "saleor.graphql.order.types.Order",
+        required=True,
+        description="Order related to the invoice.",
+    )
+
     class Meta:
         interfaces = (Event,)
         description = (

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -35,6 +35,7 @@ from ..core.descriptions import (
 )
 from ..core.scalars import PositiveDecimal
 from ..core.types import NonNullList
+from ..order.dataloaders import OrderByIdLoader
 from ..payment.enums import TransactionActionEnum
 from ..payment.types import TransactionItem
 from ..plugins.dataloaders import plugin_manager_promise_callback
@@ -803,7 +804,7 @@ class InvoiceBase(AbstractType):
     @staticmethod
     def resolve_order(root, _info):
         _, invoice = root
-        return invoice.order
+        return OrderByIdLoader(_info.context).load(invoice.order_id)
 
 
 class InvoiceRequested(ObjectType, InvoiceBase):

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -31,6 +31,7 @@ from ..core.descriptions import (
     ADDED_IN_36,
     ADDED_IN_37,
     ADDED_IN_38,
+    ADDED_IN_310,
     PREVIEW_FEATURE,
 )
 from ..core.scalars import PositiveDecimal
@@ -793,7 +794,7 @@ class InvoiceBase(AbstractType):
     )
     order = graphene.Field(
         "saleor.graphql.order.types.Order",
-        description="Order related to the invoice.",
+        description="Order related to the invoice." + ADDED_IN_310,
     )
 
     @staticmethod
@@ -811,7 +812,7 @@ class InvoiceRequested(ObjectType, InvoiceBase):
     order = graphene.Field(
         "saleor.graphql.order.types.Order",
         required=True,
-        description="Order related to the invoice.",
+        description="Order related to the invoice." + ADDED_IN_310,
     )
 
     class Meta:

--- a/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
@@ -232,14 +232,26 @@ def generate_permission_group_payload(group):
     }
 
 
-def generate_invoice_payload(invoice):
-    return {
+def generate_invoice_payload(invoice, order=None):
+    order_id = None
+    if invoice.order:
+        order_id = graphene.Node.to_global_id("Order", invoice.order.id)
+    payload = {
         "invoice": {
             "id": graphene.Node.to_global_id("Invoice", invoice.pk),
             "status": invoice.status.upper(),
             "number": invoice.number,
+            "orderId": order_id,
         }
     }
+    if order:
+        payload["order"] = {
+            "id": order_id,
+            "number": str(order.number),
+            "userEmail": order.user_email,
+            "isPaid": order.is_fully_paid(),
+        }
+    return payload
 
 
 def generate_category_payload(category):

--- a/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
@@ -234,8 +234,8 @@ def generate_permission_group_payload(group):
 
 def generate_invoice_payload(invoice, order=None):
     order_id = None
-    if invoice.order:
-        order_id = graphene.Node.to_global_id("Order", invoice.order.id)
+    if invoice.order_id:
+        order_id = graphene.Node.to_global_id("Order", invoice.order_id)
     payload = {
         "invoice": {
             "id": graphene.Node.to_global_id("Invoice", invoice.pk),

--- a/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
@@ -232,24 +232,23 @@ def generate_permission_group_payload(group):
     }
 
 
-def generate_invoice_payload(invoice, order=None):
-    order_id = None
-    if invoice.order_id:
-        order_id = graphene.Node.to_global_id("Order", invoice.order_id)
+def generate_invoice_payload(invoice):
     payload = {
         "invoice": {
             "id": graphene.Node.to_global_id("Invoice", invoice.pk),
             "status": invoice.status.upper(),
             "number": invoice.number,
-            "orderId": order_id,
+            "order": None,
         }
     }
-    if order:
+    if invoice.order_id:
+        order_id = graphene.Node.to_global_id("Order", invoice.order_id)
+        payload["invoice"]["order"] = {"id": order_id}
         payload["order"] = {
             "id": order_id,
-            "number": str(order.number),
-            "userEmail": order.user_email,
-            "isPaid": order.is_fully_paid(),
+            "number": str(invoice.order.number),
+            "userEmail": invoice.order.user_email,
+            "isPaid": invoice.order.is_fully_paid(),
         }
     return payload
 

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -944,12 +944,16 @@ SALE_TOGGLE = (
 
 INVOICE_REQUESTED = (
     fragments.INVOICE_DETAILS
+    + fragments.INVOICE_ORDER_DETAILS
     + """
     subscription{
       event{
         ...on InvoiceRequested{
           invoice{
             ...InvoiceDetails
+          }
+          order {
+            ...InvoiceOrderDetails
           }
         }
       }
@@ -959,12 +963,16 @@ INVOICE_REQUESTED = (
 
 INVOICE_DELETED = (
     fragments.INVOICE_DETAILS
+    + fragments.INVOICE_ORDER_DETAILS
     + """
     subscription{
       event{
         ...on InvoiceDeleted{
           invoice{
             ...InvoiceDetails
+          }
+          order {
+            ...InvoiceOrderDetails
           }
         }
       }
@@ -974,12 +982,16 @@ INVOICE_DELETED = (
 
 INVOICE_SENT = (
     fragments.INVOICE_DETAILS
+    + fragments.INVOICE_ORDER_DETAILS
     + """
     subscription{
       event{
         ...on InvoiceSent{
           invoice{
             ...InvoiceDetails
+          }
+          order {
+            ...InvoiceOrderDetails
           }
         }
       }

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1227,7 +1227,7 @@ def test_invoice_requested(fulfilled_order, subscription_invoice_requested_webho
     webhooks = [subscription_invoice_requested_webhook]
     event_type = WebhookEventAsyncType.INVOICE_REQUESTED
     invoice = fulfilled_order.invoices.first()
-    expected_payload = generate_invoice_payload(invoice)
+    expected_payload = generate_invoice_payload(invoice, fulfilled_order)
 
     # when
     deliveries = create_deliveries_for_subscriptions(event_type, invoice, webhooks)
@@ -1243,7 +1243,7 @@ def test_invoice_deleted(fulfilled_order, subscription_invoice_deleted_webhook):
     webhooks = [subscription_invoice_deleted_webhook]
     event_type = WebhookEventAsyncType.INVOICE_DELETED
     invoice = fulfilled_order.invoices.first()
-    expected_payload = generate_invoice_payload(invoice)
+    expected_payload = generate_invoice_payload(invoice, fulfilled_order)
 
     # when
     deliveries = create_deliveries_for_subscriptions(event_type, invoice, webhooks)
@@ -1259,7 +1259,7 @@ def test_invoice_sent(fulfilled_order, subscription_invoice_sent_webhook):
     webhooks = [subscription_invoice_sent_webhook]
     event_type = WebhookEventAsyncType.INVOICE_SENT
     invoice = fulfilled_order.invoices.first()
-    expected_payload = generate_invoice_payload(invoice)
+    expected_payload = generate_invoice_payload(invoice, fulfilled_order)
 
     # when
     deliveries = create_deliveries_for_subscriptions(event_type, invoice, webhooks)

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1227,7 +1227,7 @@ def test_invoice_requested(fulfilled_order, subscription_invoice_requested_webho
     webhooks = [subscription_invoice_requested_webhook]
     event_type = WebhookEventAsyncType.INVOICE_REQUESTED
     invoice = fulfilled_order.invoices.first()
-    expected_payload = generate_invoice_payload(invoice, fulfilled_order)
+    expected_payload = generate_invoice_payload(invoice)
 
     # when
     deliveries = create_deliveries_for_subscriptions(event_type, invoice, webhooks)
@@ -1243,7 +1243,7 @@ def test_invoice_deleted(fulfilled_order, subscription_invoice_deleted_webhook):
     webhooks = [subscription_invoice_deleted_webhook]
     event_type = WebhookEventAsyncType.INVOICE_DELETED
     invoice = fulfilled_order.invoices.first()
-    expected_payload = generate_invoice_payload(invoice, fulfilled_order)
+    expected_payload = generate_invoice_payload(invoice)
 
     # when
     deliveries = create_deliveries_for_subscriptions(event_type, invoice, webhooks)
@@ -1259,7 +1259,7 @@ def test_invoice_sent(fulfilled_order, subscription_invoice_sent_webhook):
     webhooks = [subscription_invoice_sent_webhook]
     event_type = WebhookEventAsyncType.INVOICE_SENT
     invoice = fulfilled_order.invoices.first()
-    expected_payload = generate_invoice_payload(invoice, fulfilled_order)
+    expected_payload = generate_invoice_payload(invoice)
 
     # when
     deliveries = create_deliveries_for_subscriptions(event_type, invoice, webhooks)


### PR DESCRIPTION
I want to merge this change because it fixes #11491 by making the following:

- [`Invoice`](https://docs.saleor.io/docs/3.x/api-reference/objects/invoice) has new field `order: Order`
- [`InvoiceRequested`](https://docs.saleor.io/docs/3.x/api-reference/objects/invoice-requested) subscription allows querying `order: Order!` in the payload
- [`InvoiceDeleted`](https://docs.saleor.io/docs/3.x/api-reference/objects/invoice-deleted) and [`InvoiceSent`](https://docs.saleor.io/docs/3.x/api-reference/objects/invoice-sent) subscriptions allow querying `order: Order` in the payload

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
