### PR TITLE
Add manage.py clearorders command

### DIFF
--- a/saleor/core/management/commands/clearorders.py
+++ b/saleor/core/management/commands/clearorders.py
@@ -1,0 +1,45 @@
+"""Clear the transactions data preserving shop's catalog and configuration.
+
+This command clears the database from data such as orders, checkouts, payments and 
+optionally customer accounts. It doesn't remove shop's catalog (products, variants) nor
+configuration, such as: warehouses, shipping zones, staff accounts, plugin configurations etc.
+"""
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from ....account.models import User
+from ....checkout.models import Checkout
+from ....order.models import Order
+from ....payment.models import Payment, Transaction
+
+
+class Command(BaseCommand):
+    help = "Removes transactions data preserving shop's catalog and configuration."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--delete-customers",
+            action="store_true",
+            help="Delete cutomers user accounts (doesn't delete staff and superuser accounts).",
+        )
+
+    def handle(self, **options):
+        Checkout.objects.all().delete()
+        self.stdout.write("Removed checkouts")
+
+        Transaction.objects.all().delete()
+        self.stdout.write("Removed transactions")
+
+        Payment.objects.all().delete()
+        self.stdout.write("Removed payments")
+
+        Order.objects.all().delete()
+        self.stdout.write("Removed orders")
+
+        should_delete_customers = options.get("delete_customers")
+        if should_delete_customers:
+            # Delete all users except for staff members.
+            staff = User.objects.filter(Q(is_staff=True) | Q(is_superuser=True))
+            User.objects.exclude(pk__in=staff).delete()
+            self.stdout.write("Removed customers")


### PR DESCRIPTION
I want to merge this change because it allows customers to cleanup database after placing test orders without loosing catalog data.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
