### PR TITLE
Add ability to set a custom Celery queue for async webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Other changes
 - Move checkout metadata to separate model - #11264  by @jakubkuc
+- Add ability to set a custom Celery queue for async webhook - #XXXXX by @NyanKiyoshi
 
 # 3.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Other changes
 - Move checkout metadata to separate model - #11264  by @jakubkuc
-- Add ability to set a custom Celery queue for async webhook - #XXXXX by @NyanKiyoshi
+- Add ability to set a custom Celery queue for async webhook - #11511 by @NyanKiyoshi
 
 # 3.9.0
 

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -452,6 +452,7 @@ def send_webhook_using_scheme_method(
 
 
 @app.task(
+    queue=settings.WEBHOOK_CELERY_QUEUE_NAME,
     bind=True,
     retry_backoff=10,
     retry_kwargs={"max_retries": 5},

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -794,6 +794,12 @@ PRODUCT_MAX_INDEXED_VARIANTS = 1000
 
 executor.SubscriberExecutionContext = PatchedSubscriberExecutionContext  # type: ignore
 
+# Optional queue names for Celery tasks.
+# Set None to route to the default queue, or a string value to use a separate one
+#
+# Queue name for update search vector
 UPDATE_SEARCH_VECTOR_INDEX_QUEUE_NAME = os.environ.get(
     "UPDATE_SEARCH_VECTOR_INDEX_QUEUE_NAME", None
 )
+# Queue name for "async webhook" events
+WEBHOOK_CELERY_QUEUE_NAME = os.environ.get("WEBHOOK_CELERY_QUEUE_NAME", None)


### PR DESCRIPTION
This allows to change the queue for "async" webhooks to something else than the main one. Such setting allows to make I/O optimized queues and ensure important tasks have high priority.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
