### PR TITLE
Add ability to set a custom Celery queue for async webhook

### DIFF
--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -452,6 +452,7 @@ def send_webhook_using_scheme_method(
 
 
 @app.task(
+    queue=settings.WEBHOOK_CELERY_QUEUE_NAME,
     bind=True,
     retry_backoff=10,
     retry_kwargs={"max_retries": 5},

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -793,6 +793,12 @@ PRODUCT_MAX_INDEXED_VARIANTS = 1000
 
 executor.SubscriberExecutionContext = PatchedSubscriberExecutionContext  # type: ignore
 
+# Optional queue names for Celery tasks.
+# Set None to route to the default queue, or a string value to use a separate one
+#
+# Queue name for update search vector
 UPDATE_SEARCH_VECTOR_INDEX_QUEUE_NAME = os.environ.get(
     "UPDATE_SEARCH_VECTOR_INDEX_QUEUE_NAME", None
 )
+# Queue name for "async webhook" events
+WEBHOOK_CELERY_QUEUE_NAME = os.environ.get("WEBHOOK_CELERY_QUEUE_NAME", None)


### PR DESCRIPTION
Add ability to set a custom Celery queue for async webhook

This allows to change the queue for "async" webhooks to something else than the main one. Such setting allows to make I/O optimized queues and ensure important tasks have high priority.

*Cherry pick of #11511 (6ab8ad1723b5c38bee44b14880296f4269136223)*
