### PR TITLE
Make variants sale resolver use DB replica instead of writer DB

### DIFF
--- a/saleor/graphql/discount/types.py
+++ b/saleor/graphql/discount/types.py
@@ -1,6 +1,7 @@
 import graphene
 from graphene import relay
 
+from ...core.db.utils import get_database_connection_name
 from ...core.permissions import DiscountPermissions, OrderPermissions
 from ...discount import models
 from ..channel import ChannelQsContext
@@ -140,10 +141,11 @@ class Sale(ChannelContextTypeWithMetadata, ModelObjectType):
 
     @staticmethod
     def resolve_variants(root: ChannelContext[models.Sale], info, **kwargs):
-        qs = root.node.variants.all()
-        qs = ChannelQsContext(qs=qs, channel_slug=root.channel_slug)
+        readonly_qs = root.node.variants.using(get_database_connection_name(info)).all()
+
+        readonly_qs = ChannelQsContext(qs=readonly_qs, channel_slug=root.channel_slug)
         return create_connection_slice(
-            qs, info, kwargs, ProductVariantCountableConnection
+            readonly_qs, info, kwargs, ProductVariantCountableConnection
         )
 
     @staticmethod


### PR DESCRIPTION
Make variants sale resolver use DB replica instead of writer DB

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
