### PR TITLE
Add createdBy field to TransactionItem, TransactionEvent

### DIFF
--- a/saleor/graphql/core/types/user_or_app.py
+++ b/saleor/graphql/core/types/user_or_app.py
@@ -1,0 +1,22 @@
+import graphene
+
+from ....account import models as account_models
+from ....app import models as app_models
+from ...account import types as account_types
+from ...app import types as app_types
+
+
+# The file hasn't been attached to the __init__ file as it generates the circular
+# graphql import. Graphene for Union types requires already initialized types so
+# we need to provide a fully initialized type.
+class UserOrApp(graphene.Union):
+    class Meta:
+        types = (account_types.User, app_types.App)
+
+    @classmethod
+    def resolve_type(cls, instance, info):
+        if isinstance(instance, account_models.User):
+            return account_types.User
+        if isinstance(instance, app_models.App):
+            return account_types.App
+        return super(UserOrApp, cls).resolve_type(instance, info)

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -873,7 +873,11 @@ class TransactionCreate(BaseMutation):
 
     @classmethod
     def create_transaction_event(
-        cls, transaction_event_input: dict, transaction: payment_models.TransactionItem
+        cls,
+        transaction_event_input: dict,
+        transaction: payment_models.TransactionItem,
+        user,
+        app,
     ) -> payment_models.TransactionEvent:
         reference = transaction_event_input.pop("reference", None)
         psp_reference = transaction_event_input.get("psp_reference", reference)
@@ -882,6 +886,8 @@ class TransactionCreate(BaseMutation):
             psp_reference=psp_reference,
             message=transaction_event_input.get("name", ""),
             transaction=transaction,
+            user=user if user and user.is_authenticated else None,
+            app=app,
         )
 
     @classmethod
@@ -930,7 +936,7 @@ class TransactionCreate(BaseMutation):
             cls.add_amounts_to_order(order_id, transaction_data)
 
         if transaction_event_data:
-            cls.create_transaction_event(transaction_event_data, transaction)
+            cls.create_transaction_event(transaction_event_data, transaction, user, app)
         return TransactionCreate(transaction=transaction)
 
 
@@ -1082,7 +1088,7 @@ class TransactionUpdate(TransactionCreate):
             cls.update_transaction(instance, transaction_data)
 
         if transaction_event_data := data.get("transaction_event"):
-            cls.create_transaction_event(transaction_event_data, instance)
+            cls.create_transaction_event(transaction_event_data, instance, user, app)
             if instance.order_id:
                 reference = transaction_event_data.pop("reference", None)
                 psp_reference = transaction_event_data.get("psp_reference", reference)

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -301,7 +301,7 @@ class TransactionEvent(ModelObjectType):
 
     created_by = graphene.Field(
         "saleor.graphql.core.types.user_or_app.UserOrApp",
-        description=("User or App that created the transaction." + ADDED_IN_310),
+        description=("User or App that created the transaction event." + ADDED_IN_310),
     )
 
     class Meta:

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -2,11 +2,7 @@ import graphene
 from graphene import relay
 
 from ...core.exceptions import PermissionDenied
-from ...core.permissions import (
-    AccountPermissions,
-    AuthorizationFilters,
-    OrderPermissions,
-)
+from ...core.permissions import OrderPermissions
 from ...core.tracing import traced_resolver
 from ...payment import models
 from ..account.dataloaders import UserByUserIdLoader
@@ -18,6 +14,7 @@ from ..core.descriptions import (
     ADDED_IN_34,
     ADDED_IN_36,
     ADDED_IN_38,
+    ADDED_IN_310,
     DEPRECATED_IN_3X_FIELD,
     PREVIEW_FEATURE,
 )
@@ -302,6 +299,11 @@ class TransactionEvent(ModelObjectType):
         description="The type of action related to this event." + ADDED_IN_38,
     )
 
+    created_by = graphene.Field(
+        "saleor.graphql.core.types.user_or_app.UserOrApp",
+        description=("User or App that created the transaction." + ADDED_IN_310),
+    )
+
     class Meta:
         description = "Represents transaction's event."
         interfaces = [relay.Node]
@@ -322,6 +324,14 @@ class TransactionEvent(ModelObjectType):
     @staticmethod
     def resolve_name(root: models.TransactionEvent, info):
         return root.message
+
+    @staticmethod
+    def resolve_created_by(root: models.TransactionItem, info):
+        if root.app_id:
+            return AppByIdLoader(info.context).load(root.app_id)
+        if root.user_id:
+            return UserByUserIdLoader(info.context).load(root.user_id)
+        return None
 
 
 class TransactionItem(ModelObjectType):
@@ -366,27 +376,9 @@ class TransactionItem(ModelObjectType):
     events = NonNullList(
         TransactionEvent, required=True, description="List of all transaction's events."
     )
-    user = graphene.Field(
-        "saleor.graphql.account.types.User",
-        description=(
-            "User who created the transaction."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
-            + "\n\nRequires one of the following permissions: "
-            f"{AccountPermissions.MANAGE_USERS.name}, "
-            f"{AccountPermissions.MANAGE_STAFF.name}, "
-            f"{AuthorizationFilters.OWNER.name}."
-        ),
-    )
-    app = PermissionsField(
-        "saleor.graphql.app.types.App",
-        description=(
-            "App that created the transaction." + ADDED_IN_38 + PREVIEW_FEATURE
-        ),
-        permissions=[
-            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
-            AuthorizationFilters.AUTHENTICATED_APP,
-        ],
+    created_by = graphene.Field(
+        "saleor.graphql.core.types.user_or_app.UserOrApp",
+        description=("User or App that created the transaction." + ADDED_IN_310),
     )
     external_url = graphene.String(
         description=(
@@ -434,26 +426,11 @@ class TransactionItem(ModelObjectType):
         return TransactionEventByTransactionIdLoader(info.context).load(root.id)
 
     @staticmethod
-    def resolve_user(root: models.TransactionItem, info):
-        def _resolve_user(event_user):
-            requester = get_user_or_app_from_context(info.context)
-            if (
-                requester == event_user
-                or requester.has_perm(AccountPermissions.MANAGE_USERS)
-                or requester.has_perm(AccountPermissions.MANAGE_STAFF)
-            ):
-                return event_user
-            return None
-
-        if not root.user_id:
-            return None
-
-        return UserByUserIdLoader(info.context).load(root.user_id).then(_resolve_user)
-
-    @staticmethod
-    def resolve_app(root: models.TransactionItem, info):
+    def resolve_created_by(root: models.TransactionItem, info):
         if root.app_id:
             return AppByIdLoader(info.context).load(root.app_id)
+        if root.user_id:
+            return UserByUserIdLoader(info.context).load(root.user_id)
         return None
 
     @staticmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10483,7 +10483,7 @@ type TransactionEvent implements Node {
   type: TransactionEventTypeEnum
 
   """
-  User or App that created the transaction.
+  User or App that created the transaction event.
   
   Added in Saleor 3.10.
   """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9147,26 +9147,11 @@ type TransactionItem implements Node & ObjectWithMetadata {
   events: [TransactionEvent!]!
 
   """
-  User who created the transaction.
+  User or App that created the transaction.
   
-  Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
-  Requires one of the following permissions: MANAGE_USERS, MANAGE_STAFF, OWNER.
+  Added in Saleor 3.10.
   """
-  user: User
-
-  """
-  App that created the transaction.
-  
-  Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
-  """
-  app: App
+  createdBy: UserOrApp
 
   """
   The url that will allow to redirect user to payment provider page with transaction details.
@@ -10496,6 +10481,13 @@ type TransactionEvent implements Node {
   Added in Saleor 3.8.
   """
   type: TransactionEventTypeEnum
+
+  """
+  User or App that created the transaction.
+  
+  Added in Saleor 3.10.
+  """
+  createdBy: UserOrApp
 }
 
 """
@@ -10535,6 +10527,8 @@ enum TransactionEventTypeEnum {
   CANCEL_FAILURE
   CANCEL_REQUEST
 }
+
+union UserOrApp = User | App
 
 type CheckoutCountableConnection {
   """Pagination data for this connection."""


### PR DESCRIPTION
I want to merge this change because it adds `createdBy` field to `TransactionItem` and `TransactionEvent`. As described in 
#10350 section 2.2.2 and 2.2.3
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
