### PR TITLE
Fix double avatax requests for created order

### DIFF
--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -112,7 +112,7 @@ def order_created(
                 manager=manager,
             )
     site_settings = Site.objects.get_current().settings
-    if site_settings.automatically_confirm_all_new_orders:
+    if site_settings.automatically_confirm_all_new_orders or from_draft:
         order_confirmed(order, user, app, manager)
 
 

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -355,8 +355,8 @@ class AvataxPlugin(BasePlugin):
             raise TaxError(customer_msg)
         return previous_value
 
-    def order_created(self, order: "Order", previous_value: Any) -> Any:
-        if not self.active or order.is_unconfirmed():
+    def order_confirmed(self, order: "Order", previous_value: Any) -> Any:
+        if not self.active:
             return previous_value
         request_data = get_order_request_data(order, self.config)
         if not request_data:
@@ -369,9 +369,6 @@ class AvataxPlugin(BasePlugin):
             transaction_url, request_data, asdict(self.config), order.id
         )
         return previous_value
-
-    def order_confirmed(self, order: "Order", previous_value: Any) -> Any:
-        return self.order_created(order, previous_value)
 
     def calculate_checkout_line_total(
         self,

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -3388,7 +3388,7 @@ def test_show_taxes_on_storefront(plugin_configuration):
 
 @patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
-def test_order_created(
+def test_order_confirmed(
     api_post_request_task_mock, order, order_line, plugin_configuration
 ):
     # given
@@ -3404,7 +3404,7 @@ def test_order_created(
     manager = get_plugins_manager()
 
     # when
-    manager.order_created(order)
+    manager.order_confirmed(order)
 
     # then
     address = order.billing_address


### PR DESCRIPTION
Port of changes: https://github.com/saleor/saleor/pull/11509

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
