### PR TITLE
Add logic for recalculate the transaction amounts based on the events.

### DIFF
--- a/saleor/payment/tests/test_transaction_item_calculations.py
+++ b/saleor/payment/tests/test_transaction_item_calculations.py
@@ -1,0 +1,1144 @@
+from datetime import timedelta
+from decimal import Decimal
+from typing import Callable, List
+
+import pytest
+from django.utils import timezone
+
+from .. import TransactionEventType
+from ..models import TransactionEvent, TransactionItem
+from ..transaction_item_calculations import recalculate_transaction_amounts
+
+
+@pytest.fixture
+def transaction_events_generator(
+    transaction_item_created_by_app,
+) -> Callable[
+    [List[str], List[str], List[Decimal], TransactionItem], List[TransactionEvent]
+]:
+    def factory(
+        psp_references: List[str],
+        types: List[str],
+        amounts: List[Decimal],
+        transaction: TransactionItem = transaction_item_created_by_app,
+    ):
+        return TransactionEvent.objects.bulk_create(
+            TransactionEvent(
+                transaction=transaction,
+                psp_reference=reference,
+                type=event_type,
+                amount_value=amount,
+            )
+            for reference, event_type, amount in zip(psp_references, types, amounts)
+        )
+
+    return factory
+
+
+def _assert_amounts(
+    transaction: TransactionItem,
+    authorized_value=Decimal("0"),
+    charged_value=Decimal("0"),
+    refunded_value=Decimal("0"),
+    voided_value=Decimal("0"),
+    authorize_pending_value=Decimal("0"),
+    charge_pending_value=Decimal("0"),
+    refund_pending_value=Decimal("0"),
+    cancel_pending_value=Decimal("0"),
+):
+    assert transaction.authorized_value == authorized_value
+    assert transaction.charged_value == charged_value
+    assert transaction.refunded_value == refunded_value
+    assert transaction.voided_value == voided_value
+    assert transaction.authorize_pending_value == authorize_pending_value
+    assert transaction.charge_pending_value == charge_pending_value
+    assert transaction.refund_pending_value == refund_pending_value
+    assert transaction.cancel_pending_value == cancel_pending_value
+
+
+def test_with_only_authorize_success_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    authorized_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+        ],
+        amounts=[
+            authorized_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(transaction, authorized_value=authorized_value)
+
+
+def test_with_only_authorize_request_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    authorize_pending_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.AUTHORIZATION_REQUEST,
+        ],
+        amounts=[
+            authorize_pending_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(transaction, authorize_pending_value=authorize_pending_value)
+
+
+def test_with_only_authorize_failure_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    authorize_pending_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.AUTHORIZATION_FAILURE,
+        ],
+        amounts=[
+            authorize_pending_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, authorize_pending_value=Decimal("0"), authorized_value=Decimal("0")
+    )
+
+
+def test_with_authorize_request_and_success_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    authorize_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.AUTHORIZATION_REQUEST,
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+        ],
+        amounts=[authorize_value, authorize_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        authorize_pending_value=Decimal("0"),
+        authorized_value=authorize_value,
+    )
+
+
+def test_with_authorize_request_and_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    authorize_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.AUTHORIZATION_REQUEST,
+            TransactionEventType.AUTHORIZATION_FAILURE,
+        ],
+        amounts=[authorize_value, authorize_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, authorize_pending_value=Decimal("0"), authorized_value=Decimal("0")
+    )
+
+
+def test_with_authorize_success_and_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    authorize_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+            TransactionEventType.AUTHORIZATION_FAILURE,
+        ],
+        amounts=[authorize_value, authorize_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, authorize_pending_value=Decimal("0"), authorized_value=Decimal("0")
+    )
+
+
+def test_with_authorize_success_and_older_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    authorize_value = Decimal("11.00")
+    events = transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+            TransactionEventType.AUTHORIZATION_FAILURE,
+        ],
+        amounts=[authorize_value, authorize_value],
+    )
+    failure_event = events[1]
+    assert failure_event.type == TransactionEventType.AUTHORIZATION_FAILURE
+    failure_event.created_at = timezone.now() - timedelta(minutes=5)
+    failure_event.save()
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        authorize_pending_value=Decimal("0"),
+        authorized_value=authorize_value,
+    )
+
+
+def test_with_authorize_adjustment(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    authorize_value = Decimal("11.00")
+    authorize_adjustment_value = Decimal("100")
+    events = transaction_events_generator(
+        psp_references=["1", "2", "3", "4"],
+        types=[
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+            TransactionEventType.AUTHORIZATION_REQUEST,
+            TransactionEventType.AUTHORIZATION_ADJUSTMENT,
+            TransactionEventType.AUTHORIZATION_ADJUSTMENT,
+        ],
+        amounts=[
+            authorize_value,
+            authorize_value,
+            authorize_adjustment_value,
+            authorize_value,
+        ],
+    )
+
+    # set the newest time for adjustment event
+    adjustment_event = events[2]
+    assert adjustment_event.type == TransactionEventType.AUTHORIZATION_ADJUSTMENT
+    adjustment_event.created_at = timezone.now() + timedelta(minutes=5)
+    adjustment_event.save()
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        authorize_pending_value=Decimal("0"),
+        authorized_value=authorize_adjustment_value,
+    )
+
+
+def test_with_authorize_request_and_success_events_different_psp_references(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    first_authorize_value = Decimal("11.00")
+    second_authorize_value = Decimal("12.00")
+    transaction_events_generator(
+        psp_references=["1", "2", "2"],
+        types=[
+            TransactionEventType.AUTHORIZATION_REQUEST,
+            TransactionEventType.AUTHORIZATION_REQUEST,
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+        ],
+        amounts=[first_authorize_value, second_authorize_value, second_authorize_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        authorize_pending_value=first_authorize_value,
+        authorized_value=second_authorize_value,
+    )
+
+
+def test_with_only_charge_success_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    charged_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.CHARGE_SUCCESS,
+        ],
+        amounts=[
+            charged_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(transaction, charged_value=charged_value)
+
+
+def test_with_only_charge_request_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    charge_pending_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.CHARGE_REQUEST,
+        ],
+        amounts=[
+            charge_pending_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(transaction, charge_pending_value=charge_pending_value)
+
+
+def test_with_only_charge_failure_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    charge_pending_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.CHARGE_FAILURE,
+        ],
+        amounts=[
+            charge_pending_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, charge_pending_value=Decimal("0"), charged_value=Decimal("0")
+    )
+
+
+def test_with_charge_request_and_success_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    charge_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.CHARGE_REQUEST,
+            TransactionEventType.CHARGE_SUCCESS,
+        ],
+        amounts=[charge_value, charge_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        charge_pending_value=Decimal("0"),
+        charged_value=charge_value,
+    )
+
+
+def test_with_charge_request_and_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    charge_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.CHARGE_REQUEST,
+            TransactionEventType.CHARGE_FAILURE,
+        ],
+        amounts=[charge_value, charge_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, charge_pending_value=Decimal("0"), charged_value=Decimal("0")
+    )
+
+
+def test_with_charge_success_and_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    charge_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.CHARGE_SUCCESS,
+            TransactionEventType.CHARGE_FAILURE,
+        ],
+        amounts=[charge_value, charge_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, charge_pending_value=Decimal("0"), charged_value=Decimal("0")
+    )
+
+
+def test_with_charge_success_and_older_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    charge_value = Decimal("11.00")
+    events = transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.CHARGE_SUCCESS,
+            TransactionEventType.CHARGE_FAILURE,
+        ],
+        amounts=[charge_value, charge_value],
+    )
+    failure_event = events[1]
+    assert failure_event.type == TransactionEventType.CHARGE_FAILURE
+    failure_event.created_at = timezone.now() - timedelta(minutes=5)
+    failure_event.save()
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        charge_pending_value=Decimal("0"),
+        charged_value=charge_value,
+    )
+
+
+def test_with_charge_request_and_success_events_different_psp_references(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    first_charge_value = Decimal("11.00")
+    second_charge_value = Decimal("12.00")
+    transaction_events_generator(
+        psp_references=["1", "2", "2"],
+        types=[
+            TransactionEventType.CHARGE_REQUEST,
+            TransactionEventType.CHARGE_REQUEST,
+            TransactionEventType.CHARGE_SUCCESS,
+        ],
+        amounts=[first_charge_value, second_charge_value, second_charge_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        charge_pending_value=first_charge_value,
+        charged_value=second_charge_value,
+    )
+
+
+def test_with_charge_back(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    first_charge_value = Decimal("11.00")
+    second_charge_value = Decimal("12.00")
+    charge_back_value = Decimal("10.00")
+    transaction_events_generator(
+        psp_references=["1", "2", "3"],
+        types=[
+            TransactionEventType.CHARGE_SUCCESS,
+            TransactionEventType.CHARGE_SUCCESS,
+            TransactionEventType.CHARGE_BACK,
+        ],
+        amounts=[first_charge_value, second_charge_value, charge_back_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        charge_pending_value=Decimal("0"),
+        charged_value=first_charge_value + second_charge_value - charge_back_value,
+    )
+
+
+def test_with_only_refund_success_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    refunded_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.REFUND_SUCCESS,
+        ],
+        amounts=[
+            refunded_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(transaction, refunded_value=refunded_value)
+
+
+def test_with_only_refund_request_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    refund_pending_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.REFUND_REQUEST,
+        ],
+        amounts=[
+            refund_pending_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(transaction, refund_pending_value=refund_pending_value)
+
+
+def test_with_only_refund_failure_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    refund_pending_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.REFUND_FAILURE,
+        ],
+        amounts=[
+            refund_pending_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, refund_pending_value=Decimal("0"), refunded_value=Decimal("0")
+    )
+
+
+def test_with_refund_request_and_success_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    refund_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.REFUND_REQUEST,
+            TransactionEventType.REFUND_SUCCESS,
+        ],
+        amounts=[refund_value, refund_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        refund_pending_value=Decimal("0"),
+        refunded_value=refund_value,
+    )
+
+
+def test_with_refund_request_and_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    refund_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.REFUND_REQUEST,
+            TransactionEventType.REFUND_FAILURE,
+        ],
+        amounts=[refund_value, refund_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, refund_pending_value=Decimal("0"), refunded_value=Decimal("0")
+    )
+
+
+def test_with_refund_success_and_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    refund_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.REFUND_SUCCESS,
+            TransactionEventType.REFUND_FAILURE,
+        ],
+        amounts=[refund_value, refund_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, refund_pending_value=Decimal("0"), refunded_value=Decimal("0")
+    )
+
+
+def test_with_refund_success_and_older_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    refund_value = Decimal("11.00")
+    events = transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.REFUND_SUCCESS,
+            TransactionEventType.REFUND_FAILURE,
+        ],
+        amounts=[refund_value, refund_value],
+    )
+    failure_event = events[1]
+    assert failure_event.type == TransactionEventType.REFUND_FAILURE
+    failure_event.created_at = timezone.now() - timedelta(minutes=5)
+    failure_event.save()
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        refund_pending_value=Decimal("0"),
+        refunded_value=refund_value,
+    )
+
+
+def test_with_refund_request_and_success_events_different_psp_references(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    first_refund_value = Decimal("11.00")
+    second_refund_value = Decimal("12.00")
+    transaction_events_generator(
+        psp_references=["1", "2", "2"],
+        types=[
+            TransactionEventType.REFUND_REQUEST,
+            TransactionEventType.REFUND_REQUEST,
+            TransactionEventType.REFUND_SUCCESS,
+        ],
+        amounts=[first_refund_value, second_refund_value, second_refund_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        refund_pending_value=first_refund_value,
+        refunded_value=second_refund_value,
+    )
+
+
+def test_with_refund_reverse(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    first_refund_value = Decimal("11.00")
+    second_refund_value = Decimal("12.00")
+    reverse_refund = Decimal("10.00")
+    transaction_events_generator(
+        psp_references=["1", "2", "3"],
+        types=[
+            TransactionEventType.REFUND_SUCCESS,
+            TransactionEventType.REFUND_SUCCESS,
+            TransactionEventType.REFUND_REVERSE,
+        ],
+        amounts=[first_refund_value, second_refund_value, reverse_refund],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        refund_pending_value=Decimal("0"),
+        refunded_value=first_refund_value + second_refund_value - reverse_refund,
+    )
+
+
+def test_with_only_cancel_success_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    cancelled_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.CANCEL_SUCCESS,
+        ],
+        amounts=[
+            cancelled_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(transaction, voided_value=cancelled_value)
+
+
+def test_with_only_cancel_request_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    cancel_pending_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.CANCEL_REQUEST,
+        ],
+        amounts=[
+            cancel_pending_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(transaction, cancel_pending_value=cancel_pending_value)
+
+
+def test_with_only_cancel_failure_event(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    cancel_pending_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.CANCEL_FAILURE,
+        ],
+        amounts=[
+            cancel_pending_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, cancel_pending_value=Decimal("0"), voided_value=Decimal("0")
+    )
+
+
+def test_with_cancel_request_and_success_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    cancel_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.CANCEL_REQUEST,
+            TransactionEventType.CANCEL_SUCCESS,
+        ],
+        amounts=[cancel_value, cancel_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        cancel_pending_value=Decimal("0"),
+        voided_value=cancel_value,
+    )
+
+
+def test_with_cancel_request_and_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    cancel_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.CANCEL_REQUEST,
+            TransactionEventType.CANCEL_FAILURE,
+        ],
+        amounts=[cancel_value, cancel_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, cancel_pending_value=Decimal("0"), voided_value=Decimal("0")
+    )
+
+
+def test_with_cancel_success_and_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    cancel_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.CANCEL_SUCCESS,
+            TransactionEventType.CANCEL_FAILURE,
+        ],
+        amounts=[cancel_value, cancel_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction, cancel_pending_value=Decimal("0"), voided_value=Decimal("0")
+    )
+
+
+def test_with_cancel_success_and_older_failure_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    cancel_value = Decimal("11.00")
+    events = transaction_events_generator(
+        psp_references=["1", "1"],
+        types=[
+            TransactionEventType.CANCEL_SUCCESS,
+            TransactionEventType.CANCEL_FAILURE,
+        ],
+        amounts=[cancel_value, cancel_value],
+    )
+    failure_event = events[1]
+    assert failure_event.type == TransactionEventType.CANCEL_FAILURE
+    failure_event.created_at = timezone.now() - timedelta(minutes=5)
+    failure_event.save()
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        cancel_pending_value=Decimal("0"),
+        voided_value=cancel_value,
+    )
+
+
+def test_with_cancel_request_and_success_events_different_psp_references(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    first_cancel_value = Decimal("11.00")
+    second_cancel_value = Decimal("12.00")
+    transaction_events_generator(
+        psp_references=["1", "2", "2"],
+        types=[
+            TransactionEventType.CANCEL_REQUEST,
+            TransactionEventType.CANCEL_REQUEST,
+            TransactionEventType.CANCEL_SUCCESS,
+        ],
+        amounts=[first_cancel_value, second_cancel_value, second_cancel_value],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        cancel_pending_value=first_cancel_value,
+        voided_value=second_cancel_value,
+    )
+
+
+def test_event_without_psp_reference(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+    authorize_value = Decimal("110.00")
+    charge_value = Decimal("100.00")
+    first_refund_value = Decimal("30.0")
+    second_refund_value = Decimal("11.00")
+    transaction_events_generator(
+        psp_references=[None, None, None, None, "5"],
+        types=[
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+            TransactionEventType.CHARGE_SUCCESS,
+            TransactionEventType.REFUND_REQUEST,
+            TransactionEventType.REFUND_SUCCESS,
+            TransactionEventType.REFUND_SUCCESS,
+        ],
+        amounts=[
+            authorize_value,
+            charge_value,
+            first_refund_value,  # value assigned to refund requst
+            first_refund_value,
+            second_refund_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        authorized_value=authorize_value,
+        charged_value=charge_value,
+        refunded_value=first_refund_value + second_refund_value,
+    )
+
+
+def test_event_multiple_events(
+    transaction_item_created_by_app, transaction_events_generator
+):
+    # given
+    transaction = transaction_item_created_by_app
+
+    authorize_value = Decimal("200.00")
+    authorize_adjustment_value = Decimal("250.00")
+
+    first_charge_value = Decimal("59.00")
+    first_charge_pending_value = Decimal("59.00")
+    second_charge_value = Decimal("11.00")
+    charge_back_value = Decimal("5.00")
+    charge_pending_value = Decimal("13.00")
+
+    first_refund_value = Decimal("7.00")
+    first_refund_pending_value = Decimal("7.00")
+
+    second_refund_pending_value = Decimal("22.00")
+
+    refund_reverse_value = Decimal("3.00")
+
+    transaction_events_generator(
+        psp_references=[
+            None,
+            "authorization-adjustment",
+            "first-charge",
+            "first-charge",
+            "second-charge",
+            "charge-back",
+            "charge-pending",
+            "first-refund",
+            "first-refund",
+            "refund-pending",
+            "refund-reverse",
+        ],
+        types=[
+            TransactionEventType.AUTHORIZATION_SUCCESS,
+            TransactionEventType.AUTHORIZATION_ADJUSTMENT,
+            TransactionEventType.CHARGE_SUCCESS,
+            TransactionEventType.CHARGE_REQUEST,
+            TransactionEventType.CHARGE_SUCCESS,
+            TransactionEventType.CHARGE_BACK,
+            TransactionEventType.CHARGE_REQUEST,
+            TransactionEventType.REFUND_SUCCESS,
+            TransactionEventType.REFUND_REQUEST,
+            TransactionEventType.REFUND_REQUEST,
+            TransactionEventType.REFUND_REVERSE,
+        ],
+        amounts=[
+            authorize_value,
+            authorize_adjustment_value,
+            first_charge_value,
+            first_charge_pending_value,
+            second_charge_value,
+            charge_back_value,
+            charge_pending_value,
+            first_refund_value,
+            first_refund_pending_value,
+            second_refund_pending_value,
+            refund_reverse_value,
+        ],
+    )
+
+    # when
+    recalculate_transaction_amounts(transaction)
+
+    # then
+    transaction.refresh_from_db()
+    _assert_amounts(
+        transaction,
+        authorized_value=authorize_adjustment_value,
+        charged_value=first_charge_value + second_charge_value - charge_back_value,
+        refunded_value=first_refund_value - refund_reverse_value,
+        charge_pending_value=charge_pending_value,
+        refund_pending_value=second_refund_pending_value,
+    )

--- a/saleor/payment/transaction_item_calculations.py
+++ b/saleor/payment/transaction_item_calculations.py
@@ -217,8 +217,6 @@ def _handle_events_without_psp_reference(
     transaction: TransactionItem, events: List[TransactionEvent]
 ):
     for event in events:
-        # FIXME: double check what will hapen when we will call webhook
-        # and we have a webhook request without psp reference
         if event.type == TransactionEventType.AUTHORIZATION_SUCCESS:
             transaction.authorized_value += event.amount_value
         elif event.type == TransactionEventType.AUTHORIZATION_ADJUSTMENT:

--- a/saleor/payment/transaction_item_calculations.py
+++ b/saleor/payment/transaction_item_calculations.py
@@ -1,0 +1,365 @@
+from collections import defaultdict
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Dict, Iterable, List, Optional, cast
+
+from . import TransactionEventType
+from .models import TransactionEvent, TransactionItem
+
+
+@dataclass
+class BaseEvent:
+    request: Optional[TransactionEvent] = None
+    success: Optional[TransactionEvent] = None
+    failure: Optional[TransactionEvent] = None
+
+
+@dataclass
+class AuthorizationEvents(BaseEvent):
+    adjustment: Optional[TransactionEvent] = None
+
+
+@dataclass
+class ChargeEvents(BaseEvent):
+    back: Optional[TransactionEvent] = None
+
+
+@dataclass
+class RefundEvents(BaseEvent):
+    reverse: Optional[TransactionEvent] = None
+
+
+@dataclass
+class CancelEvents(BaseEvent):
+    ...
+
+
+PSPReference = str
+
+AUTHORIZATION_EVENTS = [
+    TransactionEventType.AUTHORIZATION_SUCCESS,
+    TransactionEventType.AUTHORIZATION_FAILURE,
+    TransactionEventType.AUTHORIZATION_ADJUSTMENT,
+    TransactionEventType.AUTHORIZATION_REQUEST,
+]
+
+
+@dataclass
+class ActionEventMap:
+    without_psp_reference: List[TransactionEvent]
+    authorization: Dict[PSPReference, AuthorizationEvents] = field(
+        default_factory=lambda: defaultdict(AuthorizationEvents)
+    )
+    charge: Dict[PSPReference, ChargeEvents] = field(
+        default_factory=lambda: defaultdict(ChargeEvents)
+    )
+    refund: Dict[PSPReference, RefundEvents] = field(
+        default_factory=lambda: defaultdict(RefundEvents)
+    )
+    cancel: Dict[PSPReference, CancelEvents] = field(
+        default_factory=lambda: defaultdict(CancelEvents)
+    )
+
+
+def _should_increase_pending_amount(
+    request: Optional[TransactionEvent],
+    success: Optional[TransactionEvent],
+    failure: Optional[TransactionEvent],
+) -> bool:
+    if request:
+        # the pending amount should be increased only when we don't
+        # have any failure/success event with the psp reference
+        if not failure and not success:
+            return True
+    return False
+
+
+def _should_increse_amount(
+    success: Optional[TransactionEvent], failure: Optional[TransactionEvent]
+) -> bool:
+    if success and failure:
+        # in case of having success and failure events for the same psp reference
+        # we take into account the success transaction only when we don't have
+        # newer failure event
+        if success.created_at > failure.created_at:
+            return True
+    elif success:
+        return True
+    return False
+
+
+def _recalculate_base_amounts(
+    transaction: TransactionItem,
+    request: Optional[TransactionEvent],
+    success: Optional[TransactionEvent],
+    failure: Optional[TransactionEvent],
+    pending_amount_field_name: str,
+    amount_field_name: str,
+):
+
+    if _should_increase_pending_amount(request, success, failure):
+        request = cast(TransactionEvent, request)
+        pending_value = getattr(transaction, pending_amount_field_name)
+        setattr(
+            transaction, pending_amount_field_name, pending_value + request.amount_value
+        )
+
+    if _should_increse_amount(success, failure):
+        success = cast(TransactionEvent, success)
+        current_value = getattr(transaction, amount_field_name)
+        setattr(transaction, amount_field_name, current_value + success.amount_value)
+
+
+def _recalculate_authorization_amounts(
+    transaction: TransactionItem, authorization_events: AuthorizationEvents
+):
+    success = authorization_events.success
+    failure = authorization_events.failure
+    request = authorization_events.request
+    adjustment = authorization_events.adjustment
+
+    if adjustment:
+        # adjustment event overwrites the total amount of authorized
+        # value.
+        transaction.authorized_value = adjustment.amount_value
+
+    _recalculate_base_amounts(
+        transaction,
+        request,
+        success,
+        failure,
+        pending_amount_field_name="authorize_pending_value",
+        amount_field_name="authorized_value",
+    )
+
+
+def _recalculate_charge_amounts(
+    transaction: TransactionItem, charge_events: ChargeEvents
+):
+    success = charge_events.success
+    failure = charge_events.failure
+    request = charge_events.request
+    back = charge_events.back
+
+    if back:
+        transaction.charged_value -= back.amount_value
+
+    _recalculate_base_amounts(
+        transaction,
+        request,
+        success,
+        failure,
+        pending_amount_field_name="charge_pending_value",
+        amount_field_name="charged_value",
+    )
+
+
+def _recalculate_refund_amounts(
+    transaction: TransactionItem, refund_events: RefundEvents
+):
+    success = refund_events.success
+    failure = refund_events.failure
+    request = refund_events.request
+    reverse = refund_events.reverse
+
+    if reverse:
+        transaction.refunded_value -= reverse.amount_value
+
+    _recalculate_base_amounts(
+        transaction,
+        request,
+        success,
+        failure,
+        pending_amount_field_name="refund_pending_value",
+        amount_field_name="refunded_value",
+    )
+
+
+def _recalculate_cancel_amounts(
+    transaction: TransactionItem, cancel_events: CancelEvents
+):
+    success = cancel_events.success
+    failure = cancel_events.failure
+    request = cancel_events.request
+
+    _recalculate_base_amounts(
+        transaction,
+        request,
+        success,
+        failure,
+        pending_amount_field_name="cancel_pending_value",
+        amount_field_name="voided_value",
+    )
+
+
+def _get_authorize_events(events: Iterable[TransactionEvent]) -> List[TransactionEvent]:
+    authorize_events: List[TransactionEvent] = [
+        event for event in events if event.type in AUTHORIZATION_EVENTS
+    ]
+    auth_adjustment_event: Optional[TransactionEvent] = next(
+        (
+            event
+            for event in reversed(authorize_events)
+            if event.type == TransactionEventType.AUTHORIZATION_ADJUSTMENT
+        ),
+        None,
+    )
+    # in case of having authorization_adjustment, the transaction's authorized
+    # amount is overwriten by provided amount. In that case we need to skip the older
+    # event than the newest authorization_adjustment.
+    if auth_adjustment_event:
+        adujstment_event_index = authorize_events.index(auth_adjustment_event)
+        authorize_events = authorize_events[adujstment_event_index:]
+    return authorize_events
+
+
+def _handle_events_without_psp_reference(
+    transaction: TransactionItem, events: List[TransactionEvent]
+):
+    for event in events:
+        # FIXME: double check what will hapen when we will call webhook
+        # and we have a webhook request without psp reference
+        if event.type == TransactionEventType.AUTHORIZATION_SUCCESS:
+            transaction.authorized_value += event.amount_value
+        elif event.type == TransactionEventType.AUTHORIZATION_ADJUSTMENT:
+            transaction.authorized_value = event.amount_value
+
+        elif event.type == TransactionEventType.CHARGE_SUCCESS:
+            transaction.charged_value += event.amount_value
+        elif event.type == TransactionEventType.CHARGE_BACK:
+            transaction.charged_value -= event.amount_value
+
+        elif event.type == TransactionEventType.REFUND_SUCCESS:
+            transaction.refunded_value += event.amount_value
+        elif event.type == TransactionEventType.REFUND_REVERSE:
+            transaction.refunded_value -= event.amount_value
+
+        elif event.type == TransactionEventType.CANCEL_SUCCESS:
+            transaction.voided_value += event.amount_value
+
+
+def _initilize_action_map(events: Iterable[TransactionEvent]) -> ActionEventMap:
+    event_map = ActionEventMap(without_psp_reference=[])
+    authorize_events = _get_authorize_events(events)
+    events_without_authorize: List[TransactionEvent] = [
+        event for event in events if event.type not in AUTHORIZATION_EVENTS
+    ]
+
+    for event in authorize_events:
+        psp_reference = event.psp_reference
+        if not psp_reference:
+            event_map.without_psp_reference.append(event)
+        elif event.type == TransactionEventType.AUTHORIZATION_REQUEST:
+            event_map.authorization[psp_reference].request = event
+        elif event.type == TransactionEventType.AUTHORIZATION_SUCCESS:
+            event_map.authorization[psp_reference].success = event
+        elif event.type == TransactionEventType.AUTHORIZATION_FAILURE:
+            event_map.authorization[psp_reference].failure = event
+        elif event.type == TransactionEventType.AUTHORIZATION_ADJUSTMENT:
+            event_map.authorization[psp_reference].adjustment = event
+
+    for event in events_without_authorize:
+        psp_reference = event.psp_reference
+        if not psp_reference:
+            event_map.without_psp_reference.append(event)
+        elif event.type == TransactionEventType.CHARGE_REQUEST:
+            event_map.charge[psp_reference].request = event
+        elif event.type == TransactionEventType.CHARGE_SUCCESS:
+            event_map.charge[psp_reference].success = event
+        elif event.type == TransactionEventType.CHARGE_FAILURE:
+            event_map.charge[psp_reference].failure = event
+        elif event.type == TransactionEventType.CHARGE_BACK:
+            event_map.charge[psp_reference].back = event
+
+        elif event.type == TransactionEventType.REFUND_REQUEST:
+            event_map.refund[psp_reference].request = event
+        elif event.type == TransactionEventType.REFUND_FAILURE:
+            event_map.refund[psp_reference].failure = event
+        elif event.type == TransactionEventType.REFUND_SUCCESS:
+            event_map.refund[psp_reference].success = event
+        elif event.type == TransactionEventType.REFUND_REVERSE:
+            event_map.refund[psp_reference].reverse = event
+
+        elif event.type == TransactionEventType.CANCEL_REQUEST:
+            event_map.cancel[psp_reference].request = event
+        elif event.type == TransactionEventType.CANCEL_SUCCESS:
+            event_map.cancel[psp_reference].success = event
+        elif event.type == TransactionEventType.CANCEL_FAILURE:
+            event_map.cancel[psp_reference].failure = event
+
+    return event_map
+
+
+def _set_transaction_amounts_to_zero(transaction: TransactionItem):
+    transaction.authorized_value = Decimal("0")
+    transaction.charged_value = Decimal("0")
+    transaction.refunded_value = Decimal("0")
+    transaction.voided_value = Decimal("0")
+
+    transaction.authorize_pending_value = Decimal("0")
+    transaction.charge_pending_value = Decimal("0")
+    transaction.refund_pending_value = Decimal("0")
+    transaction.cancel_pending_value = Decimal("0")
+
+
+def recalculate_transaction_amounts(transaction: TransactionItem):
+    """Recalculate transaction amounts.
+
+    The function calculates the transaction amounts based on the amounts that
+    are stored in transaction's events. It groups the events based on the
+    psp reference and the type of the action (like authorization, or charge).
+    The grouping is mandatory to properly match the set of events based on the
+    same type and psp reference and correctly increase the amounts.
+
+    In case of having the event of type authorize_adjustment, any authorize
+    events older than the `authorize_adjustment` will be skipped. The
+    `authorize_adjustment` overwrites the amount of authorization.
+
+    The pending amount is increased only when the `request` event exists for
+    a given psp reference. In case of having a success or failure event for
+    the same psp reference as the request event, it assumes that the requested
+    amount has been already processed. The pending amount will not be increased.
+
+    The transaction amount is increased when the success event exists. In case
+    of having a failure event for the same psp reference, the creation time will
+    be used to determine which event is newer. If the failure event is newer, the
+    success event will be ignored.
+
+    There is a possibility of having events that don't have psp reference (for
+    example the events created by Saleor to keep correct amounts). In that case
+    the event amounts will be included in the transaction amounts.
+    """
+
+    events: Iterable[TransactionEvent] = transaction.events.order_by(
+        "created_at"
+    ).exclude(type__isnull=True)
+
+    action_map = _initilize_action_map(events)
+    _set_transaction_amounts_to_zero(transaction)
+
+    _handle_events_without_psp_reference(transaction, action_map.without_psp_reference)
+
+    for authorize_events in action_map.authorization.values():
+        _recalculate_authorization_amounts(transaction, authorize_events)
+
+    for charge_events in action_map.charge.values():
+        _recalculate_charge_amounts(transaction, charge_events)
+
+    for refund_events in action_map.refund.values():
+        _recalculate_refund_amounts(transaction, refund_events)
+
+    for cancel_events in action_map.cancel.values():
+        _recalculate_cancel_amounts(transaction, cancel_events)
+
+    transaction.save(
+        update_fields=[
+            "authorized_value",
+            "charged_value",
+            "refunded_value",
+            "voided_value",
+            "authorize_pending_value",
+            "charge_pending_value",
+            "refund_pending_value",
+            "cancel_pending_value",
+        ]
+    )


### PR DESCRIPTION
I want to merge this change because it adds a logic to re-calculate the amounts as described in #10350 section(6.4).
It is not yet connected to the mutation as I didn't want to add too many lines in single PR.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
