### PR TITLE
Fix propagating voucher value when tax calculation is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add ability to set a custom Celery queue for async webhook - #11511 by @NyanKiyoshi
 - Remove `CUSTOMER_UPDATED` webhook trigger from address mutations - #11395 by @jakubkuc
 - Drop `Django.Auth` - #11305 by @fowczarek
+- Propagate voucher discount between checkout lines when charge_taxes is disabled - #11632 by @maarcingebala
 
 # 3.9.0
 

--- a/saleor/checkout/base_calculations.py
+++ b/saleor/checkout/base_calculations.py
@@ -235,3 +235,85 @@ def base_checkout_subtotal(
     ]
 
     return sum(line_totals, zero_money(currency))
+
+
+def apply_checkout_discount_on_checkout_line(
+    checkout_info: "CheckoutInfo",
+    lines: Iterable["CheckoutLineInfo"],
+    checkout_line_info: "CheckoutLineInfo",
+    discounts: Iterable["DiscountInfo"],
+    line_unit_price: Money,
+):
+    """Calculate the checkout line price with discounts.
+
+    Include the entire order voucher discount.
+    The discount amount is calculated for every line proportionally to
+    the rate of total line price to checkout total price.
+    """
+    voucher = checkout_info.voucher
+    if (
+        not voucher
+        or voucher.apply_once_per_order
+        or voucher.type in [VoucherType.SHIPPING, VoucherType.SPECIFIC_PRODUCT]
+    ):
+        return line_unit_price
+
+    line_quantity = checkout_line_info.line.quantity
+    total_discount_amount = checkout_info.checkout.discount_amount
+    line_total_price = line_unit_price * line_quantity
+    currency = checkout_info.checkout.currency
+
+    lines = list(lines)
+
+    # if the checkout has a single line, the whole discount amount will be applied
+    # to this line
+    if len(lines) == 1:
+        return max(
+            (line_total_price - Money(total_discount_amount, currency)) / line_quantity,
+            zero_money(currency),
+        )
+
+    # if the checkout has more lines we need to propagate the discount amount
+    # proportionally to total prices of items
+    lines_total_prices = [
+        calculate_base_line_unit_price(
+            line_info,
+            checkout_info.channel,
+            discounts,
+        ).amount
+        * line_info.line.quantity
+        for line_info in lines
+        if line_info.line.id != checkout_line_info.line.id
+    ]
+
+    total_price = sum(lines_total_prices) + line_total_price.amount
+
+    last_element = lines[-1].line.id == checkout_line_info.line.id
+    if last_element:
+        discount_amount = _calculate_discount_for_last_element(
+            lines_total_prices, total_price, total_discount_amount, currency
+        )
+    else:
+        discount_amount = line_total_price.amount / total_price * total_discount_amount
+    return max(
+        (line_total_price - Money(discount_amount, currency)) / line_quantity,
+        zero_money(currency),
+    )
+
+
+def _calculate_discount_for_last_element(
+    lines_total_prices, total_price, total_discount_amount, currency
+):
+    """Calculate the discount for last element.
+
+    If the given line is last on the list we should calculate the discount by difference
+    between total discount amount and sum of discounts applied to rest of the lines,
+    otherwise the sum of discounts won't be equal to the discount amount.
+    """
+    sum_of_discounts_other_elements = sum(
+        [
+            line_total_price / total_price * total_discount_amount
+            for line_total_price in lines_total_prices
+        ]
+    )
+    return total_discount_amount - sum_of_discounts_other_elements

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 from prices import Money, TaxedMoney
 
+from ...checkout.utils import add_promo_code_to_checkout
 from ...core.prices import quantize_price
 from ...core.taxes import TaxData, TaxLineData, zero_taxed_money
 from ...plugins.manager import get_plugins_manager
@@ -16,7 +17,11 @@ from ..base_calculations import (
     base_checkout_delivery_price,
     calculate_base_line_total_price,
 )
-from ..calculations import _apply_tax_data, fetch_checkout_prices_if_expired
+from ..calculations import (
+    _apply_tax_data,
+    _get_checkout_base_prices,
+    fetch_checkout_prices_if_expired,
+)
 from ..fetch import CheckoutLineInfo, fetch_checkout_info, fetch_checkout_lines
 
 
@@ -257,6 +262,61 @@ def test_fetch_checkout_prices_if_expired_flat_rates_and_no_tax_calc_strategy(
     mocked_update_checkout_prices_with_flat_rates.assert_called_once()
     assert line.tax_rate == Decimal("0.2300")
     assert checkout.shipping_tax_rate == Decimal("0.2300")
+
+
+def test_get_checkout_base_prices_no_charge_taxes_with_voucher(
+    checkout_with_item, voucher_percentage
+):
+    # given
+    checkout = checkout_with_item
+    channel = checkout.channel
+    lines, _ = fetch_checkout_lines(checkout)
+    line_info = list(lines)[0]
+    variant = line_info.variant
+    product_price = variant.get_price(
+        line_info.product, [], channel, line_info.channel_listing, []
+    )
+
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+
+    add_promo_code_to_checkout(
+        manager,
+        checkout_info,
+        lines,
+        voucher_percentage.code,
+        [],
+    )
+    voucher_value = voucher_percentage.channel_listings.get(
+        channel=channel.pk
+    ).discount_value
+
+    checkout.refresh_from_db()
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+
+    # when
+    _get_checkout_base_prices(checkout, checkout_info, lines, [])
+    checkout.save()
+    checkout.lines.bulk_update(
+        [line_info.line for line_info in lines],
+        [
+            "total_price_net_amount",
+            "total_price_gross_amount",
+            "tax_rate",
+        ],
+    )
+    checkout.refresh_from_db()
+
+    line = checkout.lines.all()[0]
+
+    # then
+    expected_price = quantize_price(
+        (100 - voucher_value) / 100 * product_price, checkout.currency
+    )
+    expected_price = TaxedMoney(net=expected_price, gross=expected_price)
+    assert line.tax_rate == Decimal("0.0")
+    line_unit_price = line.total_price / line.quantity
+    assert line_unit_price == expected_price
 
 
 @freeze_time("2020-12-12 12:00:00")


### PR DESCRIPTION
This PR fixes an issue with voucher amount not being propagated between checkout/order lines when tax calculation is disabled. The solution was to reuse `apply_checkout_discount_on_checkout_line` function from flat rates in calculations that are run when taxes are disabled.

Steps to reproduce:
- Disable "Charge taxes" setting for a channel.
- Create a "All Products" voucher without any other limits.
- Create a checkout and apply the voucher.
- Checkout line totals should be decreased to proportionally include the voucher's value.

Example:
<img width="979" alt="image" src="https://user-images.githubusercontent.com/5421321/210396225-b039d3a8-cb16-4be0-9d65-9cb0b7824d49.png">
Each product costs 9.60, voucher is 3%, so once it is applied, line unit price should be 9.31.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
