### PR TITLE
Fix drop Django Auth migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get -y update \
 # Install Python dependencies
 COPY requirements_dev.txt /app/
 WORKDIR /app
+## sphinxcontrib-applehelp installed due to https://github.com/saleor/saleor/issues/11664
+RUN pip install sphinxcontrib-applehelp==1.0.2
 RUN pip install -r requirements_dev.txt
 
 ### Final image

--- a/saleor/app/migrations/0018_auto_20221122_1148.py
+++ b/saleor/app/migrations/0018_auto_20221122_1148.py
@@ -5,7 +5,9 @@ from django.db import migrations, models
 # Forward helpers
 DROP_OLD_CONSTRAINTS = """
 ALTER TABLE app_app_permissions
-    DROP CONSTRAINT account_serviceaccou_permission_id_449791f0_fk_auth_perm;
+    DROP CONSTRAINT IF EXISTS account_serviceaccou_permission_id_449791f0_fk_auth_perm;
+ALTER TABLE app_app_permissions
+    DROP CONSTRAINT IF EXISTS app_app_permissions_permission_id_defe4a88_fk_auth_perm;
 
 ALTER TABLE app_appextension_permissions
     DROP CONSTRAINT app_appextension_per_permission_id_cb6c3ce0_fk_auth_perm;


### PR DESCRIPTION
I want to merge this change because fixing migration introduced in #11305 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
