### PR TITLE
Fix missing psp references for some adyen payments

### DIFF
--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -650,6 +650,7 @@ class AdyenGatewayPlugin(BasePlugin):
             error=None,
             raw_response={},
             transaction_already_processed=bool(transaction_already_processed),
+            psp_reference=token,
         )
 
     def refund_payment(


### PR DESCRIPTION
Port of changes: https://github.com/saleor/saleor/pull/11662

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
