### PR TITLE
Workaround for failing sphinxcontrib-applehelp dependency

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -54,8 +54,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      # sphinxcontrib-applehelp added due to https://github.com/coddingtonbear/python-measurement/issues/75.
+      # To remove once the issue is resolved.
       - name: Install dependencies
         run: |
+          python -m pip install sphinxcontrib-applehelp==1.0.2
           python -m pip install wheel
           python -m pip install -r requirements_dev.txt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         exclude: ^templates/templated_email/compiled/
         exclude_types: [svg]
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get -y update \
 # Install Python dependencies
 COPY requirements_dev.txt /app/
 WORKDIR /app
+## sphinxcontrib-applehelp installed due to https://github.com/saleor/saleor/issues/11664
+RUN pip install sphinxcontrib-applehelp==1.0.2
 RUN pip install -r requirements_dev.txt
 
 ### Final image


### PR DESCRIPTION
Port of workaround from here: https://github.com/saleor/saleor/pull/11642/commits/93278b774b333fe3f0d51ca73b675807882ccda7 & https://github.com/saleor/saleor/pull/11663/files#diff-2500680f4bc6c1b75c3d4b36372bf4d64c5f603b90bfd7a5186f66a20329d16aR61
Related issue: https://github.com/saleor/saleor/issues/11664

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
