### PR TITLE
Add sphinxcontrib-applehelp to test migration workflow

### DIFF
--- a/.github/workflows/test-migrations-compatibility.yml
+++ b/.github/workflows/test-migrations-compatibility.yml
@@ -44,8 +44,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      # sphinxcontrib-applehelp added due to https://github.com/coddingtonbear/python-measurement/issues/75.
+      # To remove once the issue is resolved.
       - name: Install dependencies
         run: |
+          python -m pip install sphinxcontrib-applehelp==1.0.2
           python -m pip install wheel
           python -m pip install -r requirements_dev.txt
 


### PR DESCRIPTION
I want to merge this change because porting fix from PyTest workflow to test migration workflow. 
Port #11663

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
