### PR TITLE
Fix adding invalid label to meta fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### GraphQL API
 
 - Add `webhookDryRun` mutation - #11548 by @zedzior
+- Fix adding invalid label to meta fields - #11718 by @IKarbowiak
 
 ### Other changes
 

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -24,12 +24,7 @@ from ..checkout.dataloaders import CheckoutByUserAndChannelLoader, CheckoutByUse
 from ..checkout.types import Checkout, CheckoutCountableConnection
 from ..core import ResolveInfo
 from ..core.connection import CountableConnection, create_connection_slice
-from ..core.descriptions import (
-    ADDED_IN_38,
-    ADDED_IN_310,
-    DEPRECATED_IN_3X_FIELD,
-    PREVIEW_FEATURE,
-)
+from ..core.descriptions import ADDED_IN_38, ADDED_IN_310, DEPRECATED_IN_3X_FIELD
 from ..core.enums import LanguageCodeEnum
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.fields import ConnectionField, PermissionsField
@@ -45,7 +40,7 @@ from ..core.types import (
 )
 from ..core.utils import from_global_id_or_error, str_to_enum, to_global_id_or_none
 from ..giftcard.dataloaders import GiftCardsByUserLoader
-from ..meta.types import Metadata, MetadataDescription, MetadataItem, ObjectWithMetadata
+from ..meta.types import ObjectWithMetadata
 from ..order.dataloaders import OrderLineByIdLoader, OrdersByUserLoader
 from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import format_permissions_for_display, get_user_or_app_from_context
@@ -94,46 +89,11 @@ class Address(ModelObjectType[models.Address]):
         required=False, description="Address is user's default billing address."
     )
 
-    # Temporary copy of meta fields to allow specifying the correct version when
-    # fields were introduced.
-    # Will be fixed in https://github.com/saleor/saleor/issues/11702
-    private_metadata = NonNullList(
-        MetadataItem,
-        required=True,
-        description=MetadataDescription.PRIVATE_METADATA
-        + ADDED_IN_310
-        + PREVIEW_FEATURE,
-    )
-    private_metafield = graphene.String(
-        args={"key": graphene.NonNull(graphene.String)},
-        description=(
-            MetadataDescription.PRIVATE_METAFIELD + ADDED_IN_310 + PREVIEW_FEATURE
-        ),
-    )
-    private_metafields = Metadata(
-        args={"keys": NonNullList(graphene.String)},
-        description=(
-            MetadataDescription.PRIVATE_METAFIELDS + ADDED_IN_310 + PREVIEW_FEATURE
-        ),
-    )
-    metadata = NonNullList(
-        MetadataItem,
-        required=True,
-        description=(MetadataDescription.METADATA + ADDED_IN_310 + PREVIEW_FEATURE),
-    )
-    metafield = graphene.String(
-        args={"key": graphene.NonNull(graphene.String)},
-        description=(MetadataDescription.METAFIELD + ADDED_IN_310 + PREVIEW_FEATURE),
-    )
-    metafields = Metadata(
-        args={"keys": NonNullList(graphene.String)},
-        description=(MetadataDescription.METAFIELDS + ADDED_IN_310 + PREVIEW_FEATURE),
-    )
-
     class Meta:
         description = "Represents user address data."
         interfaces = [relay.Node, ObjectWithMetadata]
         model = models.Address
+        metadata_since = ADDED_IN_310
 
     @staticmethod
     def resolve_country(root: models.Address, _info: ResolveInfo):

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -27,6 +27,7 @@ from ..core.connection import CountableConnection
 from ..core.descriptions import (
     ADDED_IN_31,
     ADDED_IN_34,
+    ADDED_IN_35,
     ADDED_IN_38,
     ADDED_IN_39,
     DEPRECATED_IN_3X_FIELD,
@@ -136,6 +137,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
         description = "Represents an item in the checkout."
         interfaces = [graphene.relay.Node, ObjectWithMetadata]
         model = models.CheckoutLine
+        metadata_since = ADDED_IN_35
 
     @staticmethod
     def resolve_variant(root: models.CheckoutLine, info: ResolveInfo):

--- a/saleor/graphql/core/types/model.py
+++ b/saleor/graphql/core/types/model.py
@@ -58,7 +58,10 @@ class ModelObjectType(Generic[MT], ObjectType):
 
     @classmethod
     def update_meta_fields_descriptions(cls, metadata_since):
-        """Set correct `ADDED_IN_X` label for meta fields."""
+        """Set correct `ADDED_IN_X` label for meta fields.
+
+        Default metadata label in Added in Saleor 3.3.
+        """
         added_label = metadata_since or ADDED_IN_33
         for field_name, field in cls._meta.fields.items():
             if field_name in [

--- a/saleor/graphql/core/types/model.py
+++ b/saleor/graphql/core/types/model.py
@@ -1,14 +1,17 @@
+import copy
 from typing import Generic, Optional, Type, TypeVar
 from uuid import UUID
 
 from django.db.models import Model, Q
 from graphene.types.objecttype import ObjectType, ObjectTypeOptions
 
+from ..descriptions import ADDED_IN_33, PREVIEW_FEATURE
 from . import TYPES_WITH_DOUBLE_ID_AVAILABLE
 
 
 class ModelObjectOptions(ObjectTypeOptions):
     model = None
+    metadata_since = None
 
 
 MT = TypeVar("MT", bound=Model)
@@ -40,6 +43,7 @@ class ModelObjectType(Generic[MT], ObjectType):
                 )
 
             _meta.model = options.pop("model")
+            _meta.metadata_since = options.pop("metadata_since", None)
 
         super(ModelObjectType, cls).__init_subclass_with_meta__(
             interfaces=interfaces,
@@ -48,6 +52,31 @@ class ModelObjectType(Generic[MT], ObjectType):
             _meta=_meta,
             **options,
         )
+
+        if "ObjectWithMetadata" in {interface._meta.name for interface in interfaces}:
+            cls.update_meta_fields_descriptions(_meta.metadata_since)
+
+    @classmethod
+    def update_meta_fields_descriptions(cls, metadata_since):
+        """Set correct `ADDED_IN_X` label for meta fields."""
+        added_label = metadata_since or ADDED_IN_33
+        for field_name, field in cls._meta.fields.items():
+            if field_name in [
+                "private_metafield",
+                "private_metafields",
+                "metafield",
+                "metafields",
+            ]:
+                # each meta fields had reference to the same field so deepcopy
+                # is required, otherwise the description is changed in each model
+                # that inherits the `ObjectWithMetadata` interface
+                field = copy.deepcopy(field)
+                field.description = field.description + added_label + PREVIEW_FEATURE
+                cls._meta.fields[field_name] = field
+            elif metadata_since and field_name in ["private_metadata", "metadata"]:
+                field = copy.deepcopy(field)
+                field.description = field.description + metadata_since + PREVIEW_FEATURE
+                cls._meta.fields[field_name] = field
 
     @classmethod
     def get_node(cls, _, id) -> Optional[MT]:

--- a/saleor/graphql/meta/types.py
+++ b/saleor/graphql/meta/types.py
@@ -8,7 +8,6 @@ from ...checkout.utils import get_or_create_checkout_metadata
 from ...core.models import ModelWithMetadata
 from ..channel import ChannelContext
 from ..core import ResolveInfo
-from ..core.descriptions import ADDED_IN_33, PREVIEW_FEATURE
 from ..core.types import NonNullList
 from .resolvers import (
     check_private_metadata_privilege,
@@ -72,32 +71,46 @@ class ObjectWithMetadata(graphene.Interface):
     private_metadata = NonNullList(
         MetadataItem,
         required=True,
-        description=MetadataDescription.PRIVATE_METADATA,
+        description=(
+            "List of private metadata items. Requires staff permissions to access."
+        ),
     )
     private_metafield = graphene.String(
         args={"key": graphene.NonNull(graphene.String)},
         description=(
-            MetadataDescription.PRIVATE_METAFIELD + ADDED_IN_33 + PREVIEW_FEATURE
+            "A single key from private metadata. "
+            "Requires staff permissions to access.\n\n"
+            "Tip: Use GraphQL aliases to fetch multiple keys."
         ),
     )
     private_metafields = Metadata(
         args={"keys": NonNullList(graphene.String)},
         description=(
-            MetadataDescription.PRIVATE_METAFIELDS + ADDED_IN_33 + PREVIEW_FEATURE
+            "Private metadata. Requires staff permissions to access. "
+            "Use `keys` to control which fields you want to include. "
+            "The default is to include everything."
         ),
     )
     metadata = NonNullList(
         MetadataItem,
         required=True,
-        description=(MetadataDescription.METADATA),
+        description=(
+            "List of public metadata items. Can be accessed without permissions."
+        ),
     )
     metafield = graphene.String(
         args={"key": graphene.NonNull(graphene.String)},
-        description=(MetadataDescription.METAFIELD + ADDED_IN_33 + PREVIEW_FEATURE),
+        description=(
+            "A single key from public metadata.\n\n"
+            "Tip: Use GraphQL aliases to fetch multiple keys."
+        ),
     )
     metafields = Metadata(
         args={"keys": NonNullList(graphene.String)},
-        description=(MetadataDescription.METAFIELDS + ADDED_IN_33 + PREVIEW_FEATURE),
+        description=(
+            "Public metadata. Use `keys` to control which fields you want to include. "
+            "The default is to include everything."
+        ),
     )
 
     @staticmethod

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -59,6 +59,7 @@ from ..core.connection import CountableConnection
 from ..core.descriptions import (
     ADDED_IN_31,
     ADDED_IN_34,
+    ADDED_IN_35,
     ADDED_IN_38,
     ADDED_IN_39,
     ADDED_IN_310,
@@ -632,6 +633,7 @@ class OrderLine(ModelObjectType[models.OrderLine]):
         description = "Represents order line of particular order."
         model = models.OrderLine
         interfaces = [relay.Node, ObjectWithMetadata]
+        metadata_since = ADDED_IN_35
 
     @staticmethod
     @traced_resolver

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2535,19 +2535,11 @@ interface ObjectWithMetadata {
   A single key from private metadata. Requires staff permissions to access.
   
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   privateMetafields(keys: [String!]): Metadata
 
@@ -2558,19 +2550,11 @@ interface ObjectWithMetadata {
   A single key from public metadata.
   
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   metafields(keys: [String!]): Metadata
 }
@@ -4624,19 +4608,11 @@ type ShippingMethod implements Node & ObjectWithMetadata {
   A single key from private metadata. Requires staff permissions to access.
   
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   privateMetafield(key: String!): String
 
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   privateMetafields(keys: [String!]): Metadata
 
@@ -4647,19 +4623,11 @@ type ShippingMethod implements Node & ObjectWithMetadata {
   A single key from public metadata.
   
   Tip: Use GraphQL aliases to fetch multiple keys.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   metafield(key: String!): String
 
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
-  
-  Added in Saleor 3.3.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   metafields(keys: [String!]): Metadata
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9075,7 +9075,13 @@ type GiftCardTag implements Node {
 type CheckoutLine implements Node & ObjectWithMetadata {
   id: ID!
 
-  """List of private metadata items. Requires staff permissions to access."""
+  """
+  List of private metadata items. Requires staff permissions to access.
+  
+  Added in Saleor 3.5.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
   privateMetadata: [MetadataItem!]!
 
   """
@@ -9083,7 +9089,7 @@ type CheckoutLine implements Node & ObjectWithMetadata {
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.3.
+  Added in Saleor 3.5.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -9092,13 +9098,19 @@ type CheckoutLine implements Node & ObjectWithMetadata {
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.3.
+  Added in Saleor 3.5.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   privateMetafields(keys: [String!]): Metadata
 
-  """List of public metadata items. Can be accessed without permissions."""
+  """
+  List of public metadata items. Can be accessed without permissions.
+  
+  Added in Saleor 3.5.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
   metadata: [MetadataItem!]!
 
   """
@@ -9106,7 +9118,7 @@ type CheckoutLine implements Node & ObjectWithMetadata {
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.3.
+  Added in Saleor 3.5.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -9115,7 +9127,7 @@ type CheckoutLine implements Node & ObjectWithMetadata {
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.3.
+  Added in Saleor 3.5.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -9657,7 +9669,13 @@ type FulfillmentLine implements Node {
 type OrderLine implements Node & ObjectWithMetadata {
   id: ID!
 
-  """List of private metadata items. Requires staff permissions to access."""
+  """
+  List of private metadata items. Requires staff permissions to access.
+  
+  Added in Saleor 3.5.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
   privateMetadata: [MetadataItem!]!
 
   """
@@ -9665,7 +9683,7 @@ type OrderLine implements Node & ObjectWithMetadata {
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.3.
+  Added in Saleor 3.5.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -9674,13 +9692,19 @@ type OrderLine implements Node & ObjectWithMetadata {
   """
   Private metadata. Requires staff permissions to access. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.3.
+  Added in Saleor 3.5.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   privateMetafields(keys: [String!]): Metadata
 
-  """List of public metadata items. Can be accessed without permissions."""
+  """
+  List of public metadata items. Can be accessed without permissions.
+  
+  Added in Saleor 3.5.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
   metadata: [MetadataItem!]!
 
   """
@@ -9688,7 +9712,7 @@ type OrderLine implements Node & ObjectWithMetadata {
   
   Tip: Use GraphQL aliases to fetch multiple keys.
   
-  Added in Saleor 3.3.
+  Added in Saleor 3.5.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -9697,7 +9721,7 @@ type OrderLine implements Node & ObjectWithMetadata {
   """
   Public metadata. Use `keys` to control which fields you want to include. The default is to include everything.
   
-  Added in Saleor 3.3.
+  Added in Saleor 3.5.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """


### PR DESCRIPTION
The problem is that for the interface the fields are initialed once, and the same fields are added to each type that is using this reference, so changing the type meta fields description is changing the description in all types that are using this interface. Because of that, I decide to do deepcopy on those fields to allow specifying custom descriptions. 

Also, I fixed the metadata fields description on `CheckoutLine` and `OrderLine` that was added in 3.5.

Fixes https://github.com/saleor/saleor/issues/11702

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
