### PR TITLE
Inherit events from query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `WebhookTrigger` mutation - #11687 by @zedzior
 
 ### Other changes
+- Allow `webhookCreate` and `webhookUpdate` mutations to inherit events from `query` field - #11736 by @zedzior
 
 # 3.10.0 [Unreleased]
 

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -79,11 +79,17 @@ class WebhookCreateInput(graphene.InputObjectType):
 
 def clean_webhook_events(_info, _instance, data):
     # if `events` field is not empty, use this field. Otherwise get event types
-    # from `async_events` and `sync_events`.
+    # from `async_events` and `sync_events`. If the fields are also empty, parse events
+    # from `query`.
     events = data.get("events", [])
     if not events:
         events += data.pop("async_events", [])
         events += data.pop("sync_events", [])
+
+    query = data.get("query", [])
+    if not events and query:
+        events = get_event_type_from_subscription(query)
+
     data["events"] = events
     return data
 

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -361,14 +361,15 @@ class WebhookDryRun(BaseMutation):
         query = data.get("query")
         object_id = data.get("object_id")
 
-        event_type = get_event_type_from_subscription(query) if query else None
-        if not event_type:
+        event_types = get_event_type_from_subscription(query) if query else None
+        if not event_types:
             raise_validation_error(
                 field="query",
                 message="Can't parse an event type from query.",
                 code=WebhookDryRunErrorCode.UNABLE_TO_PARSE,
             )
 
+        event_type = event_types[0] if event_types else None
         event = WEBHOOK_TYPES_MAP.get(event_type) if event_type else None
         if not event and event_type:
             event_name = event_type[0].upper() + to_camel_case(event_type)[1:]
@@ -460,13 +461,14 @@ class WebhookTrigger(BaseMutation):
                 code=WebhookTriggerErrorCode.MISSING_QUERY,
             )
 
-        event_type = get_event_type_from_subscription(query)
-        if not event_type:
+        event_types = get_event_type_from_subscription(query)
+        if not event_types:
             raise_validation_error(
                 message="Can't parse an event type from webhook's subscription query.",
                 code=WebhookTriggerErrorCode.UNABLE_TO_PARSE,
             )
 
+        event_type = event_types[0] if event_types else None
         event = WEBHOOK_TYPES_MAP.get(event_type) if event_type else None
         if not event and event_type:
             event_name = event_type[0].upper() + to_camel_case(event_type)[1:]

--- a/saleor/graphql/webhook/tests/test_utils.py
+++ b/saleor/graphql/webhook/tests/test_utils.py
@@ -19,7 +19,7 @@ from ..utils import get_event_type_from_subscription
               }
             }
             """,
-            "order_created",
+            ["order_created"],
         ),
         (
             """
@@ -40,7 +40,7 @@ from ..utils import get_event_type_from_subscription
               }
             }
             """,
-            "order_created",
+            ["order_created"],
         ),
         (
             """
@@ -62,7 +62,7 @@ from ..utils import get_event_type_from_subscription
               }
             }
             """,
-            "order_updated",
+            ["order_updated"],
         ),
         (
             """
@@ -84,7 +84,7 @@ from ..utils import get_event_type_from_subscription
               }
             }
             """,
-            "order_updated",
+            ["order_updated"],
         ),
         (
             """
@@ -97,6 +97,30 @@ from ..utils import get_event_type_from_subscription
             }
             """,
             None,
+        ),
+        (
+            """
+            subscription {
+              event{
+                ... on OrderCreated{
+                  order{
+                    id
+                  }
+                }
+                ... on OrderFullyPaid{
+                  order{
+                    id
+                  }
+                }
+                ... on ProductCreated{
+                  product{
+                    id
+                  }
+                }
+              }
+            }
+            """,
+            ["order_created", "order_fully_paid", "product_created"],
         ),
     ],
 )

--- a/saleor/graphql/webhook/tests/test_utils.py
+++ b/saleor/graphql/webhook/tests/test_utils.py
@@ -96,7 +96,7 @@ from ..utils import get_event_type_from_subscription
                 }
             }
             """,
-            None,
+            [],
         ),
         (
             """

--- a/saleor/graphql/webhook/utils.py
+++ b/saleor/graphql/webhook/utils.py
@@ -1,58 +1,69 @@
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from graphene.utils.str_converters import to_snake_case
-from graphql import parse, print_ast
-from graphql.error.syntax_error import GraphQLSyntaxError
+from graphql import parse
 from graphql.language.ast import Document
 
 
-def get_event_type_from_subscription(query: str) -> Optional[str]:
+def get_event_type_from_subscription(query: str) -> Optional[List[str]]:
     try:
         ast = parse(query)
-        subscription = None
-        fragments = get_event_fragments_from_query(ast)
+        subscription = get_subscription(ast)
+        if not subscription:
+            return None
 
-        for definition in ast.definitions:
-            if (
-                hasattr(definition, "operation")
-                and definition.operation == "subscription"
-            ):
-                subscription = definition
+        event_field = get_event_field_from_subscription(subscription)
+        if not event_field:
+            return None
 
-        if subscription:
-            subscription_string = print_ast(subscription)
+        events = get_events(event_field)
+        if not events:
+            return None
 
-            if fragments:
-                for fragment_name, event_type in fragments.items():
-                    if fragment_name in subscription_string:
-                        return to_snake_case(event_type)
+        fragments = get_event_fragment_names_from_query(ast)
+        if fragments:
+            events = [fragments.get(event, event) for event in events]
 
-            event_type = (
-                "".join(subscription_string.split())
-                .split("event{...on")[1]
-                .split("{")[0]
-            )
-            return to_snake_case(event_type)
-        return None
-    except (GraphQLSyntaxError, IndexError):
+        return list(map(to_snake_case, events))
+
+    except Exception:
         return None
 
 
-def get_event_fragments_from_query(ast: Document) -> Optional[Dict[str, str]]:
+def get_event_field_from_subscription(field):
+    if hasattr(field, "selection_set"):
+        fields = field.selection_set.selections
+        for f in fields:
+            if f.name.value == "event":
+                return f
+            get_event_field_from_subscription(f)
+
+
+def get_subscription(ast):
+    for definition in ast.definitions:
+        if hasattr(definition, "operation") and definition.operation == "subscription":
+            return definition
+    return None
+
+
+def get_events(field):
+    fields = field.selection_set.selections
+    events = []
+    for field in fields:
+        if hasattr(field, "name"):
+            events.append(field.name.value)
+        if hasattr(field, "type_condition"):
+            events.append(field.type_condition.name.value)
+    return events
+
+
+def get_event_fragment_names_from_query(ast: Document) -> Optional[Dict[str, str]]:
     fragments = {}
     for definition in ast.definitions:
-        try:
-            if (
-                definition.__class__.__name__ == "FragmentDefinition"
-                and definition.type_condition.name.value == "Event"
-            ):
-                fragment_string = print_ast(definition)
-                event_type = (
-                    "".join(fragment_string.split())
-                    .split("Event{...on")[1]
-                    .split("{")[0]
-                )
-                fragments[definition.name.value] = event_type
-        except IndexError:
-            continue
+        if (
+            definition.__class__.__name__ == "FragmentDefinition"
+            and definition.type_condition.name.value == "Event"
+        ):
+            event = definition.selection_set.selections[0].type_condition.name.value
+            fragments[definition.name.value] = event
     return fragments

--- a/saleor/graphql/webhook/utils.py
+++ b/saleor/graphql/webhook/utils.py
@@ -5,20 +5,20 @@ from graphql import parse
 from graphql.language.ast import Document
 
 
-def get_event_type_from_subscription(query: str) -> Optional[List[str]]:
+def get_event_type_from_subscription(query: str) -> List[str]:
     try:
         ast = parse(query)
         subscription = get_subscription(ast)
         if not subscription:
-            return None
+            return []
 
         event_field = get_event_field_from_subscription(subscription)
         if not event_field:
-            return None
+            return []
 
         events = get_events(event_field)
         if not events:
-            return None
+            return []
 
         fragments = get_event_fragment_names_from_query(ast)
         if fragments:
@@ -27,7 +27,7 @@ def get_event_type_from_subscription(query: str) -> Optional[List[str]]:
         return list(map(to_snake_case, events))
 
     except Exception:
-        return None
+        return []
 
 
 def get_event_field_from_subscription(field):


### PR DESCRIPTION
https://github.com/saleor/saleor/issues/11456

I want to merge this change, because I want to get events directly from `query`, instead of providing it in separate fields, like `asyncEvents` and `syncEvents`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
