### PR TITLE
Unify the transaction amount fields names

### DIFF
--- a/saleor/graphql/order/tests/benchmark/test_order.py
+++ b/saleor/graphql/order/tests/benchmark/test_order.py
@@ -92,6 +92,9 @@ FRAGMENT_ORDER_DETAILS = (
         total {
           ...Price
         }
+        totalCharged {
+          amount
+        }
         totalCaptured {
           amount
         }

--- a/saleor/graphql/order/tests/mutations/test_order_capture.py
+++ b/saleor/graphql/order/tests/mutations/test_order_capture.py
@@ -18,6 +18,9 @@ ORDER_CAPTURE_MUTATION = """
                     paymentStatus
                     paymentStatusDisplay
                     isPaid
+                    totalCharged {
+                        amount
+                    }
                     totalCaptured {
                         amount
                     }
@@ -64,6 +67,7 @@ def test_order_capture(
     assert data["paymentStatusDisplay"] == payment_status_display
     assert data["isPaid"]
     assert data["totalCaptured"]["amount"] == float(amount)
+    assert data["totalCharged"]["amount"] == float(amount)
 
     event_captured, event_order_fully_paid = order.events.all()
 

--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -51,7 +51,15 @@ query OrdersQuery {
                     amount
                     currency
                 }
+                totalCharged{
+                    amount
+                    currency
+                }
                 totalCaptured{
+                    amount
+                    currency
+                }
+                totalCanceled{
                     amount
                     currency
                 }
@@ -667,6 +675,15 @@ def test_order_query_with_transactions_details(
                 charged_value=Decimal("15"),
                 available_actions=[TransactionAction.REFUND],
             ),
+            TransactionItem(
+                order_id=order.id,
+                status="Captured",
+                type="Credit card",
+                psp_reference="111",
+                currency="USD",
+                canceled_value=Decimal("19"),
+                available_actions=[],
+            ),
         ]
     )
     update_order_authorize_data(order)
@@ -707,6 +724,8 @@ def test_order_query_with_transactions_details(
     assert len(order_data["payments"]) == order.payments.count()
     assert Decimal(order_data["totalAuthorized"]["amount"]) == Decimal("25")
     assert Decimal(order_data["totalCaptured"]["amount"]) == Decimal("15")
+    assert Decimal(order_data["totalCharged"]["amount"]) == Decimal("15")
+    assert Decimal(order_data["totalCanceled"]["amount"]) == Decimal("19")
 
     assert Decimal(str(order_data["totalBalance"]["amount"])) == Decimal("-83.4")
 

--- a/saleor/graphql/order/tests/queries/test_order_amounts.py
+++ b/saleor/graphql/order/tests/queries/test_order_amounts.py
@@ -12,6 +12,14 @@ query OrdersQuery {
                     amount
                     currency
                 }
+                totalCanceled{
+                    amount
+                    currency
+                }
+                totalCharged{
+                    amount
+                    currency
+                }
                 totalCaptured{
                     amount
                     currency

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -672,7 +672,12 @@ class TransactionUpdateInput(graphene.InputObjectType):
     amount_authorized = MoneyInput(description="Amount authorized by this transaction.")
     amount_charged = MoneyInput(description="Amount charged by this transaction.")
     amount_refunded = MoneyInput(description="Amount refunded by this transaction.")
-    amount_voided = MoneyInput(description="Amount voided by this transaction.")
+    amount_voided = MoneyInput(
+        description="Amount voided by this transaction."
+        + DEPRECATED_IN_3X_INPUT
+        + "Use `amountCanceled` instead."
+    )
+    amount_canceled = MoneyInput(description="Amount canceled by this transaction.")
 
     metadata = graphene.List(
         graphene.NonNull(MetadataInput),
@@ -780,8 +785,11 @@ class TransactionCreate(BaseMutation):
             cleaned_data["charged_value"] = amount_charged["amount"]
         if amount_refunded := cleaned_data.pop("amount_refunded", None):
             cleaned_data["refunded_value"] = amount_refunded["amount"]
-        if amount_voided := cleaned_data.pop("amount_voided", None):
-            cleaned_data["voided_value"] = amount_voided["amount"]
+
+        if amount_canceled := cleaned_data.pop("amount_canceled", None):
+            cleaned_data["canceled_value"] = amount_canceled["amount"]
+        elif amount_voided := cleaned_data.pop("amount_voided", None):
+            cleaned_data["canceled_value"] = amount_voided["amount"]
 
     @classmethod
     def cleanup_metadata_data(cls, cleaned_data: dict):
@@ -818,6 +826,7 @@ class TransactionCreate(BaseMutation):
             "amount_authorized",
             "amount_charged",
             "amount_refunded",
+            "amount_canceled",
             "amount_voided",
         ]
         errors = {}

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -38,6 +38,10 @@ mutation TransactionCreate(
                     amount
                     currency
                 }
+                canceledAmount{
+                    currency
+                    amount
+                }
                 voidedAmount{
                     currency
                     amount
@@ -311,7 +315,8 @@ def test_transaction_create_for_checkout_by_app(
     [
         ("amountAuthorized", "authorized_value"),
         ("amountCharged", "charged_value"),
-        ("amountVoided", "voided_value"),
+        ("amountVoided", "canceled_value"),
+        ("amountCanceled", "canceled_value"),
         ("amountRefunded", "refunded_value"),
     ],
 )
@@ -368,7 +373,7 @@ def test_transaction_create_multiple_amounts_provided_by_app(
     authorized_value = Decimal("10")
     charged_value = Decimal("11")
     refunded_value = Decimal("12")
-    voided_value = Decimal("13")
+    canceled_value = Decimal("13")
 
     variables = {
         "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
@@ -389,8 +394,8 @@ def test_transaction_create_multiple_amounts_provided_by_app(
                 "amount": refunded_value,
                 "currency": "USD",
             },
-            "amountVoided": {
-                "amount": voided_value,
+            "amountCanceled": {
+                "amount": canceled_value,
                 "currency": "USD",
             },
         },
@@ -411,11 +416,11 @@ def test_transaction_create_multiple_amounts_provided_by_app(
     assert data["authorizedAmount"]["amount"] == authorized_value
     assert data["chargedAmount"]["amount"] == charged_value
     assert data["refundedAmount"]["amount"] == refunded_value
-    assert data["voidedAmount"]["amount"] == voided_value
+    assert data["canceledAmount"]["amount"] == canceled_value
 
     assert transaction.authorized_value == authorized_value
     assert transaction.charged_value == charged_value
-    assert transaction.voided_value == voided_value
+    assert transaction.canceled_value == canceled_value
     assert transaction.refunded_value == refunded_value
 
 
@@ -512,7 +517,8 @@ def test_transaction_create_missing_permission_by_app(order_with_lines, app_api_
     [
         ("amountAuthorized", "authorized_value"),
         ("amountCharged", "charged_value"),
-        ("amountVoided", "voided_value"),
+        ("amountVoided", "canceled_value"),
+        ("amountCanceled", "canceled_value"),
         ("amountRefunded", "refunded_value"),
     ],
 )
@@ -991,7 +997,8 @@ def test_transaction_create_for_checkout_by_staff(
     [
         ("amountAuthorized", "authorized_value"),
         ("amountCharged", "charged_value"),
-        ("amountVoided", "voided_value"),
+        ("amountVoided", "canceled_value"),
+        ("amountCanceled", "canceled_value"),
         ("amountRefunded", "refunded_value"),
     ],
 )
@@ -1048,7 +1055,7 @@ def test_transaction_create_multiple_amounts_provided_by_staff(
     authorized_value = Decimal("10")
     charged_value = Decimal("11")
     refunded_value = Decimal("12")
-    voided_value = Decimal("13")
+    canceled_value = Decimal("13")
 
     variables = {
         "id": graphene.Node.to_global_id("Order", order_with_lines.pk),
@@ -1070,7 +1077,7 @@ def test_transaction_create_multiple_amounts_provided_by_staff(
                 "currency": "USD",
             },
             "amountVoided": {
-                "amount": voided_value,
+                "amount": canceled_value,
                 "currency": "USD",
             },
         },
@@ -1091,11 +1098,12 @@ def test_transaction_create_multiple_amounts_provided_by_staff(
     assert data["authorizedAmount"]["amount"] == authorized_value
     assert data["chargedAmount"]["amount"] == charged_value
     assert data["refundedAmount"]["amount"] == refunded_value
-    assert data["voidedAmount"]["amount"] == voided_value
+    assert data["voidedAmount"]["amount"] == canceled_value
+    assert data["canceledAmount"]["amount"] == canceled_value
 
     assert transaction.authorized_value == authorized_value
     assert transaction.charged_value == charged_value
-    assert transaction.voided_value == voided_value
+    assert transaction.canceled_value == canceled_value
     assert transaction.refunded_value == refunded_value
 
 
@@ -1193,7 +1201,8 @@ def test_transaction_create_missing_permission_by_staff(
     [
         ("amountAuthorized", "authorized_value"),
         ("amountCharged", "charged_value"),
-        ("amountVoided", "voided_value"),
+        ("amountVoided", "canceled_value"),
+        ("amountCanceled", "canceled_value"),
         ("amountRefunded", "refunded_value"),
     ],
 )

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -42,6 +42,10 @@ mutation TransactionUpdate(
                     currency
                     amount
                 }
+                canceledAmount{
+                    currency
+                    amount
+                }
                 chargedAmount{
                     currency
                     amount
@@ -348,7 +352,8 @@ def test_transaction_update_available_actions_by_app(
     [
         ("amountAuthorized", "authorizedAmount", "authorized_value", Decimal("12")),
         ("amountCharged", "chargedAmount", "charged_value", Decimal("13")),
-        ("amountVoided", "voidedAmount", "voided_value", Decimal("14")),
+        ("amountCanceled", "canceledAmount", "canceled_value", Decimal("14")),
+        ("amountVoided", "voidedAmount", "canceled_value", Decimal("14")),
         ("amountRefunded", "refundedAmount", "refunded_value", Decimal("15")),
     ],
 )
@@ -697,7 +702,7 @@ def test_transaction_update_multiple_amounts_provided_by_app(
     authorized_value = Decimal("10")
     charged_value = Decimal("11")
     refunded_value = Decimal("12")
-    voided_value = Decimal("13")
+    canceled_value = Decimal("13")
 
     variables = {
         "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
@@ -714,8 +719,8 @@ def test_transaction_update_multiple_amounts_provided_by_app(
                 "amount": refunded_value,
                 "currency": "USD",
             },
-            "amountVoided": {
-                "amount": voided_value,
+            "amountCanceled": {
+                "amount": canceled_value,
                 "currency": "USD",
             },
         },
@@ -733,11 +738,12 @@ def test_transaction_update_multiple_amounts_provided_by_app(
     assert data["authorizedAmount"]["amount"] == authorized_value
     assert data["chargedAmount"]["amount"] == charged_value
     assert data["refundedAmount"]["amount"] == refunded_value
-    assert data["voidedAmount"]["amount"] == voided_value
+    assert data["voidedAmount"]["amount"] == canceled_value
+    assert data["canceledAmount"]["amount"] == canceled_value
 
     assert transaction.authorized_value == authorized_value
     assert transaction.charged_value == charged_value
-    assert transaction.voided_value == voided_value
+    assert transaction.canceled_value == canceled_value
     assert transaction.refunded_value == refunded_value
 
 
@@ -769,7 +775,8 @@ def test_transaction_update_for_order_missing_permission_by_app(
     [
         ("amountAuthorized", "authorized_value"),
         ("amountCharged", "charged_value"),
-        ("amountVoided", "voided_value"),
+        ("amountVoided", "canceled_value"),
+        ("amountCanceled", "canceled_value"),
         ("amountRefunded", "refunded_value"),
     ],
 )
@@ -1150,7 +1157,8 @@ def test_transaction_update_available_actions_by_staff(
     [
         ("amountAuthorized", "authorizedAmount", "authorized_value", Decimal("12")),
         ("amountCharged", "chargedAmount", "charged_value", Decimal("13")),
-        ("amountVoided", "voidedAmount", "voided_value", Decimal("14")),
+        ("amountVoided", "voidedAmount", "canceled_value", Decimal("14")),
+        ("amountCanceled", "canceledAmount", "canceled_value", Decimal("14")),
         ("amountRefunded", "refundedAmount", "refunded_value", Decimal("15")),
     ],
 )
@@ -1499,7 +1507,7 @@ def test_transaction_update_multiple_amounts_provided_by_staff(
     authorized_value = Decimal("10")
     charged_value = Decimal("11")
     refunded_value = Decimal("12")
-    voided_value = Decimal("13")
+    canceled_value = Decimal("13")
 
     variables = {
         "id": graphene.Node.to_global_id("TransactionItem", transaction.pk),
@@ -1516,8 +1524,8 @@ def test_transaction_update_multiple_amounts_provided_by_staff(
                 "amount": refunded_value,
                 "currency": "USD",
             },
-            "amountVoided": {
-                "amount": voided_value,
+            "amountCanceled": {
+                "amount": canceled_value,
                 "currency": "USD",
             },
         },
@@ -1535,11 +1543,12 @@ def test_transaction_update_multiple_amounts_provided_by_staff(
     assert data["authorizedAmount"]["amount"] == authorized_value
     assert data["chargedAmount"]["amount"] == charged_value
     assert data["refundedAmount"]["amount"] == refunded_value
-    assert data["voidedAmount"]["amount"] == voided_value
+    assert data["voidedAmount"]["amount"] == canceled_value
+    assert data["canceledAmount"]["amount"] == canceled_value
 
     assert transaction.authorized_value == authorized_value
     assert transaction.charged_value == charged_value
-    assert transaction.voided_value == voided_value
+    assert transaction.canceled_value == canceled_value
     assert transaction.refunded_value == refunded_value
 
 
@@ -1571,7 +1580,8 @@ def test_transaction_update_for_order_missing_permission_by_staff(
     [
         ("amountAuthorized", "authorized_value"),
         ("amountCharged", "charged_value"),
-        ("amountVoided", "voided_value"),
+        ("amountVoided", "canceled_value"),
+        ("amountCanceled", "canceled_value"),
         ("amountRefunded", "refunded_value"),
     ],
 )

--- a/saleor/graphql/payment/tests/queries/test_transaction.py
+++ b/saleor/graphql/payment/tests/queries/test_transaction.py
@@ -23,6 +23,10 @@ TRANSACTION_QUERY = """
                 currency
                 amount
             }
+            canceledAmount{
+                currency
+                amount
+            }
             voidedAmount{
                 currency
                 amount
@@ -98,7 +102,8 @@ def _assert_transaction_fields(content, transaction_item, event):
         data["authorizedAmount"]["amount"] == transaction_item.amount_authorized.amount
     )
     assert data["refundedAmount"]["amount"] == transaction_item.amount_refunded.amount
-    assert data["voidedAmount"]["amount"] == transaction_item.amount_voided.amount
+    assert data["voidedAmount"]["amount"] == transaction_item.amount_canceled.amount
+    assert data["canceledAmount"]["amount"] == transaction_item.amount_canceled.amount
     assert data["chargedAmount"]["amount"] == transaction_item.amount_charged.amount
     assert len(data["events"]) == 1
     assert data["events"][0]["id"] == to_global_id_or_none(event)

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -367,7 +367,15 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
         ),
     )
     voided_amount = graphene.Field(
-        Money, required=True, description="Total amount voided for this payment."
+        Money,
+        required=True,
+        description="Total amount voided for this payment. "
+        + DEPRECATED_IN_3X_FIELD
+        + "Use `canceledAmount` instead.",
+    )
+
+    canceled_amount = graphene.Field(
+        Money, required=True, description="Total amount canceled for this payment."
     )
     cancel_pending_amount = graphene.Field(
         Money,
@@ -449,7 +457,11 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
 
     @staticmethod
     def resolve_voided_amount(root: models.TransactionItem, _info):
-        return root.amount_voided
+        return root.amount_canceled
+
+    @staticmethod
+    def resolve_canceled_amount(root: models.TransactionItem, _info):
+        return root.amount_canceled
 
     @staticmethod
     def resolve_cancel_pending_amount(root: models.TransactionItem, _info):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9354,8 +9354,13 @@ type TransactionItem implements Node & ObjectWithMetadata {
   """
   refundPendingAmount: Money!
 
-  """Total amount voided for this payment."""
+  """
+  Total amount voided for this payment. This field will be removed in Saleor 4.0.Use `canceledAmount` instead.
+  """
   voidedAmount: Money!
+
+  """Total amount canceled for this payment."""
+  canceledAmount: Money!
 
   """
   Total amount of ongoing cancel requests for the transaction.
@@ -9667,8 +9672,16 @@ type Order implements Node & ObjectWithMetadata {
   """Amount authorized for the order."""
   totalAuthorized: Money!
 
-  """Amount captured by payment."""
+  """
+  Amount captured for the order. This field will be removed in Saleor 4.0.Use `totalCharged` instead
+  """
   totalCaptured: Money!
+
+  """Amount charged for the order."""
+  totalCharged: Money!
+
+  """Amount canceled for the order."""
+  totalCanceled: Money!
 
   """
   List of events associated with the order.
@@ -19720,8 +19733,15 @@ input TransactionCreateInput {
   """Amount refunded by this transaction."""
   amountRefunded: MoneyInput
 
-  """Amount voided by this transaction."""
+  """
+  Amount voided by this transaction.
+  
+  DEPRECATED: this field will be removed in Saleor 4.0.Use `amountCanceled` instead.
+  """
   amountVoided: MoneyInput
+
+  """Amount canceled by this transaction."""
+  amountCanceled: MoneyInput
 
   """Payment public metadata."""
   metadata: [MetadataInput!]
@@ -19825,8 +19845,15 @@ input TransactionUpdateInput {
   """Amount refunded by this transaction."""
   amountRefunded: MoneyInput
 
-  """Amount voided by this transaction."""
+  """
+  Amount voided by this transaction.
+  
+  DEPRECATED: this field will be removed in Saleor 4.0.Use `amountCanceled` instead.
+  """
   amountVoided: MoneyInput
+
+  """Amount canceled by this transaction."""
+  amountCanceled: MoneyInput
 
   """Payment public metadata."""
   metadata: [MetadataInput!]

--- a/saleor/payment/migrations/0040_auto_20220922_1146.py
+++ b/saleor/payment/migrations/0040_auto_20220922_1146.py
@@ -59,6 +59,11 @@ class Migration(migrations.Migration):
             old_name="reference",
             new_name="psp_reference",
         ),
+        migrations.RenameField(
+            model_name="transactionitem",
+            old_name="voided_value",
+            new_name="canceled_value",
+        ),
         migrations.AddField(
             model_name="transactionitem",
             name="external_url",

--- a/saleor/payment/models.py
+++ b/saleor/payment/models.py
@@ -62,8 +62,10 @@ class TransactionItem(ModelWithMetadata):
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
         default=Decimal("0"),
     )
-    amount_voided = MoneyField(amount_field="voided_value", currency_field="currency")
-    voided_value = models.DecimalField(
+    amount_canceled = MoneyField(
+        amount_field="canceled_value", currency_field="currency"
+    )
+    canceled_value = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
         default=Decimal("0"),

--- a/saleor/payment/tests/test_transaction_item_calculations.py
+++ b/saleor/payment/tests/test_transaction_item_calculations.py
@@ -40,7 +40,7 @@ def _assert_amounts(
     authorized_value=Decimal("0"),
     charged_value=Decimal("0"),
     refunded_value=Decimal("0"),
-    voided_value=Decimal("0"),
+    canceled_value=Decimal("0"),
     authorize_pending_value=Decimal("0"),
     charge_pending_value=Decimal("0"),
     refund_pending_value=Decimal("0"),
@@ -49,7 +49,7 @@ def _assert_amounts(
     assert transaction.authorized_value == authorized_value
     assert transaction.charged_value == charged_value
     assert transaction.refunded_value == refunded_value
-    assert transaction.voided_value == voided_value
+    assert transaction.canceled_value == canceled_value
     assert transaction.authorize_pending_value == authorize_pending_value
     assert transaction.charge_pending_value == charge_pending_value
     assert transaction.refund_pending_value == refund_pending_value
@@ -813,7 +813,7 @@ def test_with_only_cancel_success_event(
 ):
     # given
     transaction = transaction_item_created_by_app
-    cancelled_value = Decimal("11.00")
+    canceled_value = Decimal("11.00")
     transaction_events_generator(
         psp_references=[
             "1",
@@ -822,7 +822,7 @@ def test_with_only_cancel_success_event(
             TransactionEventType.CANCEL_SUCCESS,
         ],
         amounts=[
-            cancelled_value,
+            canceled_value,
         ],
     )
 
@@ -831,7 +831,7 @@ def test_with_only_cancel_success_event(
 
     # then
     transaction.refresh_from_db()
-    _assert_amounts(transaction, voided_value=cancelled_value)
+    _assert_amounts(transaction, canceled_value=canceled_value)
 
 
 def test_with_only_cancel_request_event(
@@ -884,7 +884,7 @@ def test_with_only_cancel_failure_event(
     # then
     transaction.refresh_from_db()
     _assert_amounts(
-        transaction, cancel_pending_value=Decimal("0"), voided_value=Decimal("0")
+        transaction, cancel_pending_value=Decimal("0"), canceled_value=Decimal("0")
     )
 
 
@@ -911,7 +911,7 @@ def test_with_cancel_request_and_success_events(
     _assert_amounts(
         transaction,
         cancel_pending_value=Decimal("0"),
-        voided_value=cancel_value,
+        canceled_value=cancel_value,
     )
 
 
@@ -936,7 +936,7 @@ def test_with_cancel_request_and_failure_events(
     # then
     transaction.refresh_from_db()
     _assert_amounts(
-        transaction, cancel_pending_value=Decimal("0"), voided_value=Decimal("0")
+        transaction, cancel_pending_value=Decimal("0"), canceled_value=Decimal("0")
     )
 
 
@@ -961,7 +961,7 @@ def test_with_cancel_success_and_failure_events(
     # then
     transaction.refresh_from_db()
     _assert_amounts(
-        transaction, cancel_pending_value=Decimal("0"), voided_value=Decimal("0")
+        transaction, cancel_pending_value=Decimal("0"), canceled_value=Decimal("0")
     )
 
 
@@ -992,7 +992,7 @@ def test_with_cancel_success_and_older_failure_events(
     _assert_amounts(
         transaction,
         cancel_pending_value=Decimal("0"),
-        voided_value=cancel_value,
+        canceled_value=cancel_value,
     )
 
 
@@ -1021,7 +1021,7 @@ def test_with_cancel_request_and_success_events_different_psp_references(
     _assert_amounts(
         transaction,
         cancel_pending_value=first_cancel_value,
-        voided_value=second_cancel_value,
+        canceled_value=second_cancel_value,
     )
 
 

--- a/saleor/payment/transaction_item_calculations.py
+++ b/saleor/payment/transaction_item_calculations.py
@@ -188,7 +188,7 @@ def _recalculate_cancel_amounts(
         success,
         failure,
         pending_amount_field_name="cancel_pending_value",
-        amount_field_name="voided_value",
+        amount_field_name="canceled_value",
     )
 
 
@@ -233,7 +233,7 @@ def _handle_events_without_psp_reference(
             transaction.refunded_value -= event.amount_value
 
         elif event.type == TransactionEventType.CANCEL_SUCCESS:
-            transaction.voided_value += event.amount_value
+            transaction.canceled_value += event.amount_value
 
 
 def _initilize_action_map(events: Iterable[TransactionEvent]) -> ActionEventMap:
@@ -292,7 +292,7 @@ def _set_transaction_amounts_to_zero(transaction: TransactionItem):
     transaction.authorized_value = Decimal("0")
     transaction.charged_value = Decimal("0")
     transaction.refunded_value = Decimal("0")
-    transaction.voided_value = Decimal("0")
+    transaction.canceled_value = Decimal("0")
 
     transaction.authorize_pending_value = Decimal("0")
     transaction.charge_pending_value = Decimal("0")
@@ -354,7 +354,7 @@ def recalculate_transaction_amounts(transaction: TransactionItem):
             "authorized_value",
             "charged_value",
             "refunded_value",
-            "voided_value",
+            "canceled_value",
             "authorize_pending_value",
             "charge_pending_value",
             "refund_pending_value",

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -1464,7 +1464,10 @@ def generate_transaction_action_request_payload(
                 transaction.refunded_value, transaction.currency
             ),
             "voided_value": quantize_price(
-                transaction.voided_value, transaction.currency
+                transaction.canceled_value, transaction.currency
+            ),
+            "canceled_value": quantize_price(
+                transaction.canceled_value, transaction.currency
             ),
             "order_id": graphql_order_id,
             "checkout_id": graphql_checkout_id,

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -2076,7 +2076,8 @@ def test_generate_transaction_action_request_payload_for_order(
                 quantize_price(transaction.authorized_value, currency)
             ),
             "refunded_value": str(quantize_price(transaction.refunded_value, currency)),
-            "voided_value": str(quantize_price(transaction.voided_value, currency)),
+            "voided_value": str(quantize_price(transaction.canceled_value, currency)),
+            "canceled_value": str(quantize_price(transaction.canceled_value, currency)),
             "order_id": graphene.Node.to_global_id("Order", order.pk),
             "checkout_id": None,
             "created_at": parse_django_datetime(transaction.created_at),
@@ -2166,7 +2167,8 @@ def test_generate_transaction_action_request_payload_for_checkout(
                 quantize_price(transaction.authorized_value, currency)
             ),
             "refunded_value": str(quantize_price(transaction.refunded_value, currency)),
-            "voided_value": str(quantize_price(transaction.voided_value, currency)),
+            "voided_value": str(quantize_price(transaction.canceled_value, currency)),
+            "canceled_value": str(quantize_price(transaction.canceled_value, currency)),
             "order_id": None,
             "checkout_id": graphene.Node.to_global_id("Checkout", checkout.pk),
             "created_at": parse_django_datetime(transaction.created_at),


### PR DESCRIPTION
I want to merge this change because we had a missmatch between names. The PR cleans it up to always use `cancel` instead of `void`, and `charge` instead of `capture`


Note: labels `ADDED_IN_XX` will be added in the future
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
