### PR TITLE
change thumbnails sizes keys to str

### DIFF
--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -27,7 +27,9 @@ def get_image_payload(instance: ProductMedia):
         # This is temporary solution, the get_product_image_thumbnail_url
         # should be optimize - we should fetch all thumbnails at once instead of
         # fetching thumbnails by one for each size
-        size: get_image_or_proxy_url(None, instance.id, "ProductMedia", size, None)
+        str(size): get_image_or_proxy_url(
+            None, str(instance.id), "ProductMedia", size, None
+        )
         for size in THUMBNAIL_SIZES
     }
 

--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -27,9 +27,7 @@ def get_image_payload(instance: ProductMedia):
         # This is temporary solution, the get_product_image_thumbnail_url
         # should be optimize - we should fetch all thumbnails at once instead of
         # fetching thumbnails by one for each size
-        str(size): get_image_or_proxy_url(
-            None, str(instance.id), "ProductMedia", size, None
-        )
+        str(size): get_image_or_proxy_url(None, instance.id, "ProductMedia", size, None)
         for size in THUMBNAIL_SIZES
     }
 

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -679,4 +679,4 @@ def test_get_default_images_payload(product_with_image):
     # then
     images_payload = payload["first_image"]["original"]
     for th_size in THUMBNAIL_SIZES:
-        assert images_payload[th_size] == f"/thumbnail/{media_id}/{th_size}/"
+        assert images_payload[str(th_size)] == f"/thumbnail/{media_id}/{th_size}/"

--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -145,7 +145,7 @@ def format_datetime(this, date, date_format=None):
 def get_product_image_thumbnail(this, size, image_data):
     """Use provided size to get a correct image."""
     expected_size = get_thumbnail_size(size)
-    return image_data["original"][expected_size]
+    return image_data["original"][str(expected_size)]
 
 
 def compare(this, val1, compare_operator, val2):

--- a/saleor/plugins/tests/test_email_common.py
+++ b/saleor/plugins/tests/test_email_common.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 import pytest
@@ -71,4 +72,16 @@ def test_get_product_image_thumbnail(product_with_image):
     thumbnail = get_product_image_thumbnail(None, 100, image_data)
 
     # then
-    assert thumbnail == image_data["original"][128]
+    assert thumbnail == image_data["original"]["128"]
+
+
+def test_get_product_image_thumbnail_simulate_json_dump_and_load(product_with_image):
+    # given
+    image_data = {"original": get_image_payload(product_with_image.media.first())}
+    image_data = json.dumps(image_data)
+    image_data = json.loads(image_data)
+    # when
+    thumbnail = get_product_image_thumbnail(None, 100, image_data)
+
+    # then
+    assert thumbnail == image_data["original"]["128"]


### PR DESCRIPTION
I want to merge this change because it prevents bugs where image size keys type in image payload is invalid due to json decoding and encoding in templates. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
