### PR TITLE
fix parameters in stripe update payment method 

### DIFF
--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -189,6 +189,7 @@ def update_payment_method(
                 payment_method_id,
                 api_key=api_key,
                 metadata=metadata,
+                stripe_version=STRIPE_API_VERSION,
             )
         except StripeError as error:
             logger.warning(

--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -27,6 +27,9 @@ from .consts import (
 logger = logging.getLogger(__name__)
 
 
+stripe.api_version = STRIPE_API_VERSION
+
+
 @contextmanager
 def stripe_opentracing_trace(span_name):
     with opentracing_trace(
@@ -39,7 +42,7 @@ def is_secret_api_key_valid(api_key: str):
     """Call api to check if api_key is a correct key."""
     try:
         with stripe_opentracing_trace("stripe.WebhookEndpoint.list"):
-            stripe.WebhookEndpoint.list(api_key, stripe_version=STRIPE_API_VERSION)
+            stripe.WebhookEndpoint.list(api_key)
         return True
     except AuthenticationError:
         return False
@@ -73,7 +76,6 @@ def subscribe_webhook(api_key: str, channel_slug: str) -> Optional[StripeObject]
                 url=webhook_url,
                 enabled_events=WEBHOOK_EVENTS,
                 metadata={METADATA_IDENTIFIER: domain},
-                stripe_version=STRIPE_API_VERSION,
             )
         except StripeError as error:
             logger.warning(
@@ -89,7 +91,6 @@ def delete_webhook(api_key: str, webhook_id: str):
             stripe.WebhookEndpoint.delete(
                 webhook_id,
                 api_key=api_key,
-                stripe_version=STRIPE_API_VERSION,
             )
     except InvalidRequestError:
         # webhook doesn't exist
@@ -107,11 +108,11 @@ def get_or_create_customer(
                 return stripe.Customer.retrieve(
                     customer_id,
                     api_key=api_key,
-                    stripe_version=STRIPE_API_VERSION,
                 )
         with stripe_opentracing_trace("stripe.Customer.create"):
             return stripe.Customer.create(
-                api_key=api_key, email=customer_email, stripe_version=STRIPE_API_VERSION
+                api_key=api_key,
+                email=customer_email,
             )
     except StripeError as error:
         logger.warning(
@@ -167,7 +168,6 @@ def create_payment_intent(
                 amount=price_to_minor_unit(amount, currency),
                 currency=currency,
                 capture_method=capture_method,
-                stripe_version=STRIPE_API_VERSION,
                 **additional_params,
             )
         return intent, None
@@ -189,7 +189,6 @@ def update_payment_method(
                 payment_method_id,
                 api_key=api_key,
                 metadata=metadata,
-                stripe_version=STRIPE_API_VERSION,
             )
         except StripeError as error:
             logger.warning(
@@ -206,7 +205,6 @@ def list_customer_payment_methods(
             payment_methods = stripe.PaymentMethod.list(
                 api_key=api_key,
                 customer=customer_id,
-                stripe_version=STRIPE_API_VERSION,
                 type="card",  # we support only cards for now
             )
         return payment_methods, None
@@ -222,7 +220,6 @@ def retrieve_payment_intent(
             payment_intent = stripe.PaymentIntent.retrieve(
                 payment_intent_id,
                 api_key=api_key,
-                stripe_version=STRIPE_API_VERSION,
             )
         return payment_intent, None
     except StripeError as error:
@@ -242,7 +239,6 @@ def capture_payment_intent(
                 payment_intent_id,
                 amount_to_capture=amount_to_capture,
                 api_key=api_key,
-                stripe_version=STRIPE_API_VERSION,
             )
         return payment_intent, None
     except StripeError as error:
@@ -262,7 +258,6 @@ def refund_payment_intent(
                 payment_intent=payment_intent_id,
                 amount=amount_to_refund,
                 api_key=api_key,
-                stripe_version=STRIPE_API_VERSION,
             )
         return refund, None
     except StripeError as error:
@@ -281,7 +276,6 @@ def cancel_payment_intent(
             payment_intent = stripe.PaymentIntent.cancel(
                 payment_intent_id,
                 api_key=api_key,
-                stripe_version=STRIPE_API_VERSION,
             )
         return payment_intent, None
     except StripeError as error:

--- a/saleor/payment/gateways/stripe/tests/test_plugin.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin.py
@@ -21,7 +21,6 @@ from ..consts import (
     AUTOMATIC_CAPTURE_METHOD,
     MANUAL_CAPTURE_METHOD,
     PROCESSING_STATUS,
-    STRIPE_API_VERSION,
     SUCCESS_STATUS,
 )
 
@@ -212,7 +211,6 @@ def test_process_payment(
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
     assert not mocked_customer.called
 
@@ -280,13 +278,11 @@ def test_process_payment_with_customer(
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=customer_user.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
         email=customer_user.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -380,13 +376,11 @@ def test_process_payment_with_customer_and_future_usage(
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
         email=customer_user.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -459,13 +453,11 @@ def test_process_payment_with_customer_and_future_usage_no_store(
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
         email=customer_user.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -558,13 +550,11 @@ def test_process_payment_with_customer_and_payment_method(
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
         email=customer_user.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -657,13 +647,11 @@ def test_process_payment_with_payment_method_types(
         },
         payment_method_types=["p24", "card"],
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
         email=customer_user.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -757,13 +745,11 @@ def test_process_payment_offline(
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
         email=customer_user.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -862,13 +848,11 @@ def test_process_payment_with_customer_and_payment_method_raises_authentication_
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
         email=customer_user.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -942,13 +926,11 @@ def test_process_payment_with_customer_and_payment_method_raises_error(
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
         email=customer_user.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -1008,7 +990,6 @@ def test_process_payment_with_disabled_order_auto_confirmation(
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -1064,7 +1045,6 @@ def test_process_payment_with_manual_capture(
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -1105,7 +1085,6 @@ def test_process_payment_with_error(
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 

--- a/saleor/payment/gateways/stripe/tests/test_plugin_deprecated.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin_deprecated.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock, patch
 
 from .... import TransactionKind
 from ....utils import create_payment_information, price_to_minor_unit
-from ..consts import AUTOMATIC_CAPTURE_METHOD, STRIPE_API_VERSION, SUCCESS_STATUS
+from ..consts import AUTOMATIC_CAPTURE_METHOD, SUCCESS_STATUS
 
 
 @patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
@@ -72,11 +72,9 @@ def test_process_payment_with_customer_and_future_usage(
             "payment_id": payment_info.graphql_payment_id,
         },
         receipt_email=payment_stripe_for_checkout.checkout.email,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
         email=customer_user.email,
-        stripe_version=STRIPE_API_VERSION,
     )

--- a/saleor/payment/gateways/stripe/tests/test_stripe_api.py
+++ b/saleor/payment/gateways/stripe/tests/test_stripe_api.py
@@ -189,6 +189,7 @@ def test_update_payment_method(mocked_payment_method):
         payment_method_id,
         api_key=api_key,
         metadata=metadata,
+        stripe_version=STRIPE_API_VERSION,
     )
 
 

--- a/saleor/payment/gateways/stripe/tests/test_stripe_api.py
+++ b/saleor/payment/gateways/stripe/tests/test_stripe_api.py
@@ -11,7 +11,6 @@ from ..consts import (
     AUTOMATIC_CAPTURE_METHOD,
     MANUAL_CAPTURE_METHOD,
     METADATA_IDENTIFIER,
-    STRIPE_API_VERSION,
     WEBHOOK_EVENTS,
 )
 from ..stripe_api import (
@@ -46,7 +45,7 @@ def test_is_secret_api_key_valid_correct_key(mocked_webhook):
     api_key = "correct_key"
     assert is_secret_api_key_valid(api_key) is True
 
-    mocked_webhook.list.assert_called_with(api_key, stripe_version=STRIPE_API_VERSION)
+    mocked_webhook.list.assert_called_with(api_key)
 
 
 @patch(
@@ -65,7 +64,6 @@ def test_subscribe_webhook_returns_webhook_object(mocked_webhook, channel_USD):
         url=expected_url,
         enabled_events=WEBHOOK_EVENTS,
         metadata={METADATA_IDENTIFIER: "mirumee.com"},
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -78,7 +76,8 @@ def test_delete_webhook(mocked_webhook):
     delete_webhook(api_key, "webhook_id")
 
     mocked_webhook.delete.assert_called_with(
-        "webhook_id", api_key=api_key, stripe_version=STRIPE_API_VERSION
+        "webhook_id",
+        api_key=api_key,
     )
 
 
@@ -98,7 +97,6 @@ def test_create_payment_intent_returns_intent_object(mocked_payment_intent):
         amount="1000",
         currency="USD",
         capture_method=AUTOMATIC_CAPTURE_METHOD,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     assert isinstance(intent, StripeObject)
@@ -123,7 +121,6 @@ def test_create_payment_intent_with_customer(mocked_payment_intent):
         currency="USD",
         capture_method=AUTOMATIC_CAPTURE_METHOD,
         customer=customer,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     assert isinstance(intent, StripeObject)
@@ -146,7 +143,6 @@ def test_create_payment_intent_manual_auto_capture(mocked_payment_intent):
         amount="1000",
         currency="USD",
         capture_method=MANUAL_CAPTURE_METHOD,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -166,7 +162,6 @@ def test_create_payment_intent_returns_error(mocked_payment_intent):
         amount="1000",
         currency="USD",
         capture_method=AUTOMATIC_CAPTURE_METHOD,
-        stripe_version=STRIPE_API_VERSION,
     )
     assert intent is None
     assert error
@@ -189,7 +184,6 @@ def test_update_payment_method(mocked_payment_method):
         payment_method_id,
         api_key=api_key,
         metadata=metadata,
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -207,7 +201,6 @@ def test_retrieve_payment_intent(mocked_payment_intent):
     mocked_payment_intent.retrieve.assert_called_with(
         payment_intent_id,
         api_key=api_key,
-        stripe_version=STRIPE_API_VERSION,
     )
     assert isinstance(intent, StripeObject)
 
@@ -227,7 +220,6 @@ def test_retrieve_payment_intent_stripe_returns_error(mocked_payment_intent):
     mocked_payment_intent.retrieve.assert_called_with(
         payment_intent_id,
         api_key=api_key,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     assert error == expected_error
@@ -251,7 +243,6 @@ def test_capture_payment_intent(mocked_payment_intent):
         payment_intent_id,
         amount_to_capture=amount,
         api_key=api_key,
-        stripe_version=STRIPE_API_VERSION,
     )
     assert isinstance(intent, StripeObject)
 
@@ -275,7 +266,6 @@ def test_capture_payment_intent_stripe_returns_error(mocked_payment_intent):
         payment_intent_id,
         amount_to_capture=amount,
         api_key=api_key,
-        stripe_version=STRIPE_API_VERSION,
     )
 
     assert error == expected_error
@@ -299,7 +289,6 @@ def test_refund_payment_intent(mocked_refund):
         payment_intent=payment_intent_id,
         amount=amount,
         api_key=api_key,
-        stripe_version=STRIPE_API_VERSION,
     )
     assert isinstance(intent, StripeObject)
 
@@ -323,7 +312,6 @@ def test_refund_payment_intent_returns_error(mocked_refund):
         payment_intent=payment_intent_id,
         amount=amount,
         api_key=api_key,
-        stripe_version=STRIPE_API_VERSION,
     )
     assert error == expected_error
 
@@ -341,9 +329,7 @@ def test_cancel_payment_intent(mocked_payment_intent):
         api_key=api_key, payment_intent_id=payment_intent_id
     )
 
-    mocked_payment_intent.cancel.assert_called_with(
-        payment_intent_id, api_key=api_key, stripe_version=STRIPE_API_VERSION
-    )
+    mocked_payment_intent.cancel.assert_called_with(payment_intent_id, api_key=api_key)
     assert isinstance(intent, StripeObject)
 
 
@@ -361,9 +347,7 @@ def test_cancel_payment_intent_stripe_returns_error(mocked_payment_intent):
         api_key=api_key, payment_intent_id=payment_intent_id
     )
 
-    mocked_payment_intent.cancel.assert_called_with(
-        payment_intent_id, api_key=api_key, stripe_version=STRIPE_API_VERSION
-    )
+    mocked_payment_intent.cancel.assert_called_with(payment_intent_id, api_key=api_key)
 
     assert error == expected_error
 
@@ -384,9 +368,7 @@ def test_get_or_create_customer_retrieve(mocked_customer):
     )
 
     assert isinstance(customer, StripeObject)
-    mocked_customer.retrieve.assert_called_with(
-        customer_id, api_key=api_key, stripe_version=STRIPE_API_VERSION
-    )
+    mocked_customer.retrieve.assert_called_with(customer_id, api_key=api_key)
 
 
 @patch(
@@ -408,9 +390,7 @@ def test_get_or_create_customer_failed_retrieve(mocked_customer):
     )
 
     assert customer is None
-    mocked_customer.retrieve.assert_called_with(
-        customer_id, api_key=api_key, stripe_version=STRIPE_API_VERSION
-    )
+    mocked_customer.retrieve.assert_called_with(customer_id, api_key=api_key)
 
 
 @patch(
@@ -427,9 +407,7 @@ def test_get_or_create_customer_create(mocked_customer):
     )
 
     assert isinstance(customer, StripeObject)
-    mocked_customer.create.assert_called_with(
-        email=customer_email, api_key=api_key, stripe_version=STRIPE_API_VERSION
-    )
+    mocked_customer.create.assert_called_with(email=customer_email, api_key=api_key)
 
 
 @patch(
@@ -448,9 +426,7 @@ def test_get_or_create_customer_failed_create(mocked_customer):
     )
 
     assert customer is None
-    mocked_customer.create.assert_called_with(
-        email=customer_email, api_key=api_key, stripe_version=STRIPE_API_VERSION
-    )
+    mocked_customer.create.assert_called_with(email=customer_email, api_key=api_key)
 
 
 @patch(
@@ -471,7 +447,6 @@ def test_list_customer_payment_methods(mocked_payment_method):
         api_key=api_key,
         customer=customer_id,
         type="card",
-        stripe_version=STRIPE_API_VERSION,
     )
 
 
@@ -496,7 +471,6 @@ def test_list_customer_payment_methods_failed_to_fetch(mocked_payment_method):
         api_key=api_key,
         customer=customer_id,
         type="card",
-        stripe_version=STRIPE_API_VERSION,
     )
 
 


### PR DESCRIPTION
I want to merge this change because every stripe method call should pass the API version
fixes #11758 

⚠️ EDIT ⚠️ 
Changed this PR to set stripe version globally instead of passing it in parameters

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
