### PR TITLE
Fix updating prices in confirmed order

### DIFF
--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -234,11 +234,13 @@ class OrderUpdate(DraftOrderCreate):
             instance.user = user
         instance.search_document = prepare_order_search_document_value(instance)
         instance.save()
-        update_order_prices(
-            instance,
-            info.context.plugins,
-            info.context.site.settings.include_taxes_in_prices,
-        )
+
+        if instance.status in ORDER_EDITABLE_STATUS:
+            update_order_prices(
+                instance,
+                info.context.plugins,
+                info.context.site.settings.include_taxes_in_prices,
+            )
         transaction.on_commit(lambda: info.context.plugins.order_updated(instance))
 
 


### PR DESCRIPTION
Fix `orderUpdate` mutation to not recalculate prices for confirmed orders. It should be called only for draft and unconfirmed orders.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
