### PR TITLE
Disable websocket support in uvicorn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Other changes
 - Allow `webhookCreate` and `webhookUpdate` mutations to inherit events from `query` field - #11736 by @zedzior
+- Disable websocket support by default in uvicorn worker configuration - #XXXX by @NyanKiyoshi
 
 # 3.10.0 [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Other changes
 - Allow `webhookCreate` and `webhookUpdate` mutations to inherit events from `query` field - #11736 by @zedzior
-- Disable websocket support by default in uvicorn worker configuration - #XXXX by @NyanKiyoshi
+- Disable websocket support by default in uvicorn worker configuration - #11785 by @NyanKiyoshi
 
 # 3.10.0 [Unreleased]
 

--- a/saleor/asgi/gunicorn_worker.py
+++ b/saleor/asgi/gunicorn_worker.py
@@ -2,6 +2,10 @@ from uvicorn.workers import UvicornWorker as BaseUvicornWorker
 
 
 class UvicornWorker(BaseUvicornWorker):
-    # Override default config args, that cannot be passed as gunicorn parameters,
-    # to disable lifespan, not supported by django
-    CONFIG_KWARGS = {"loop": "uvloop", "http": "httptools", "lifespan": "off"}
+    # Override default config args, that cannot be passed as gunicorn parameters.
+    CONFIG_KWARGS = {
+        "loop": "uvloop",
+        "http": "httptools",
+        "lifespan": "off",
+        "ws": "none",
+    }


### PR DESCRIPTION
Django does not support websocket protocol. This changes the uvicorn configuration to not forward websocket connection to Django.

See: https://github.com/encode/uvicorn/blob/255dcde6a381b032dfe496aa8db4a89a04e623ea/docs/settings.md#implementation



<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
