### PR TITLE
Fix issue with checkout complete for free shippng voucher without tax class

### DIFF
--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -27,7 +27,9 @@ def get_image_payload(instance: ProductMedia):
         # This is temporary solution, the get_product_image_thumbnail_url
         # should be optimize - we should fetch all thumbnails at once instead of
         # fetching thumbnails by one for each size
-        str(size): get_image_or_proxy_url(None, instance.id, "ProductMedia", size, None)
+        str(size): get_image_or_proxy_url(
+            None, str(instance.id), "ProductMedia", size, None
+        )
         for size in THUMBNAIL_SIZES
     }
 
@@ -94,10 +96,10 @@ def get_product_variant_payload(variant: ProductVariant):
 
 
 def get_order_line_payload(line: "OrderLine"):
-    digital_url = ""
+    digital_url = None
     if line.is_digital:
         content = DigitalContentUrl.objects.filter(line=line).first()
-        digital_url = content.get_absolute_url() if content else None  # type: ignore
+        digital_url = content.get_absolute_url() if content else None
     variant_dependent_fields = {}
     if line.variant:
         variant_dependent_fields = {
@@ -108,11 +110,11 @@ def get_order_line_payload(line: "OrderLine"):
 
     return {
         "id": to_global_id_or_none(line),
-        "product": variant_dependent_fields.get("product"),  # type: ignore
+        "product": variant_dependent_fields.get("product"),
         "product_name": line.product_name,
         "translated_product_name": line.translated_product_name or line.product_name,
         "variant_name": line.variant_name,
-        "variant": variant_dependent_fields.get("variant"),  # type: ignore
+        "variant": variant_dependent_fields.get("variant"),
         "translated_variant_name": line.translated_variant_name or line.variant_name,
         "product_sku": line.product_sku,
         "product_variant_id": line.product_variant_id,

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -518,7 +518,7 @@ def generate_request_data_from_checkout(
     if not lines:
         return {}
 
-    discount_amount = 0
+    discount_amount = Decimal("0")
     if voucher := checkout_info.voucher:
         # for apply_once_per_order vouchers the discount is already applied on lines
         applicable_discount = (
@@ -534,7 +534,9 @@ def generate_request_data_from_checkout(
             }
 
         discount_amount = (
-            checkout_info.checkout.discount.amount if applicable_discount else 0
+            checkout_info.checkout.discount.amount
+            if applicable_discount
+            else Decimal("0")
         )
 
     currency = checkout_info.checkout.currency

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -49,6 +49,8 @@ DEFAULT_TAX_DESCRIPTION = "Unmapped Other SKU - taxable default"
 
 TAX_CODE_NON_TAXABLE_PRODUCT = "NT"
 
+SHIPPING_ITEM_CODE = "Shipping"
+
 
 @dataclass
 class AvataxConfiguration:
@@ -262,7 +264,7 @@ def append_shipping_to_data(
             quantity=1,
             amount=shipping_price_amount,
             tax_code=shipping_tax_code,
-            item_code="Shipping",
+            item_code=SHIPPING_ITEM_CODE,
             prices_entered_with_tax=prices_entered_with_tax,
             discounted=discounted,
         )
@@ -515,15 +517,25 @@ def generate_request_data_from_checkout(
     )
     if not lines:
         return {}
-    voucher = checkout_info.voucher
-    # for apply_once_per_order vouchers the discount is already applied on lines
-    discount_amount = (
-        checkout_info.checkout.discount.amount
-        if voucher
-        and voucher.type != VoucherType.SPECIFIC_PRODUCT
-        and not voucher.apply_once_per_order
-        else 0
-    )
+
+    discount_amount = 0
+    if voucher := checkout_info.voucher:
+        # for apply_once_per_order vouchers the discount is already applied on lines
+        applicable_discount = (
+            voucher.type != VoucherType.SPECIFIC_PRODUCT
+            and not voucher.apply_once_per_order
+        )
+
+        if voucher.type == VoucherType.SHIPPING:
+            # when the taxes are not calculated on shipping method, the shipping
+            # discount cannot by applied by plugin
+            applicable_discount = applicable_discount and SHIPPING_ITEM_CODE in {
+                line["itemCode"] for line in lines
+            }
+
+        discount_amount = (
+            checkout_info.checkout.discount.amount if applicable_discount else 0
+        )
 
     currency = checkout_info.checkout.currency
     customer_email = cast(str, checkout_info.get_customer_email())

--- a/saleor/plugins/avatax/tests/cassettes/test_avatax/test_preprocess_order_creation_shipping_voucher_no_tax_class_on_delivery_method.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_avatax/test_preprocess_order_creation_shipping_voucher_no_tax_class_on_delivery_method.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
+      "lines": [{"quantity": 3, "amount": "15.00", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "123", "discounted": false, "description": "Test product",
+      "ref1": "123"}], "code": "8ab4d1d2-13a5-4bb0-8994-c267e13e93f1", "date": "2023-01-23",
+      "customerCode": 0, "discount": null, "addresses": {"shipFrom": {"line1": "Teczowa
+      7", "line2": "", "city": "Wroclaw", "region": "", "country": "PL", "postalCode":
+      "53-601"}, "shipTo": {"line1": "O\u0142awska 10", "line2": "", "city": "WROC\u0141AW",
+      "region": "", "country": "PL", "postalCode": "53-105"}}, "commit": false, "currencyCode":
+      "USD", "email": "user@email.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '697'
+      User-Agent:
+      - python-requests/2.28.2
+    method: POST
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: '{"id":0,"code":"8ab4d1d2-13a5-4bb0-8994-c267e13e93f1","companyId":7799660,"date":"2023-01-23","paymentDate":"2023-01-23","status":"Temporary","type":"SalesOrder","batchCode":"","currencyCode":"USD","exchangeRateCurrencyCode":"USD","customerUsageType":"","entityUseCode":"","customerVendorCode":"0","customerCode":"0","exemptNo":"","reconciled":false,"locationCode":"","reportingLocationCode":"","purchaseOrderNo":"","referenceCode":"","salespersonCode":"","totalAmount":12.2,"totalExempt":0.0,"totalDiscount":0.0,"totalTax":2.8,"totalTaxable":12.2,"totalTaxCalculated":2.8,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2023-01-23","exchangeRate":1.0,"email":"user@email.com","modifiedDate":"2023-01-23T14:04:35.140459Z","modifiedUserId":6479978,"taxDate":"2023-01-23","lines":[{"id":0,"transactionId":0,"lineNumber":"1","customerUsageType":"","entityUseCode":"","description":"Test
+        product","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"itemCode":"123","lineAmount":12.2000,"quantity":3.0,"ref1":"123","ref2":"","reportingDate":"2023-01-23","tax":2.8,"taxableAmount":12.2,"taxCalculated":2.8,"taxCode":"O9999999","taxCodeId":9111,"taxDate":"2023-01-23","taxIncluded":true,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"PL","region":"PL","exemptAmount":0.0,"jurisCode":"PL","jurisName":"POLAND","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0,"rate":0.230000,"tax":2.8,"taxableAmount":12.2,"taxType":"Output","taxSubTypeId":"O","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxCalculated":2.8,"rateType":"Standard","rateTypeCode":"S","unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":12.2,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":2.8,"reportingTaxCalculated":2.8,"liabilityType":"Seller"}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLS-230C","vatNumberTypeId":0}],"addresses":[{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Olawska
+        10","line2":"","line3":"","city":"WROCLAW","region":"","postalCode":"53-105","country":"PL","taxRegionId":205102,"latitude":"","longitude":""},{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Teczowa
+        7","line2":"","line3":"","city":"Wroclaw","region":"","postalCode":"53-601","country":"PL","taxRegionId":205102,"latitude":"","longitude":""}],"summary":[{"country":"PL","region":"PL","jurisType":"Country","jurisCode":"PL","jurisName":"POLAND","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Output","taxSubType":"O","taxName":"Standard
+        Rate","rateType":"Standard","taxable":12.2,"rate":0.230000,"tax":2.8,"taxCalculated":2.8,"nonTaxable":0.0,"exemption":0.0}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 23 Jan 2023 14:04:35 GMT
+      Location:
+      - /api/v2/companies/7799660/transactions/0
+      ServerDuration:
+      - '00:00:00.0170292'
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      api-supported-versions:
+      - '2.0'
+      cache-control:
+      - private, no-cache, no-store
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - 95c1e231-c726-4ecf-975c-559a4ab2e65a
+      x-correlation-id:
+      - 95c1e231-c726-4ecf-975c-559a4ab2e65a
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1


### PR DESCRIPTION
Fix an issue calculating taxes for `checkoutComplete` for free shipping without taxes and with the avalara plugin turned on.

Fixes https://github.com/saleor/saleor/issues/11786

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
