### PR TITLE
Add Celery beat expiration option in update product search entry

### DIFF
--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -122,7 +122,10 @@ def _get_preorder_variants_to_clean():
     )
 
 
-@app.task(queue=settings.UPDATE_SEARCH_VECTOR_INDEX_QUEUE_NAME, expires=20)
+@app.task(
+    queue=settings.UPDATE_SEARCH_VECTOR_INDEX_QUEUE_NAME,
+    expires=settings.BEAT_UPDATE_SEARCH_EXPIRE_AFTER_SEC,
+)
 def update_products_search_vector_task():
     products = Product.objects.filter(search_index_dirty=True).order_by()[
         :PRODUCTS_BATCH_SIZE

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -546,6 +546,16 @@ CELERY_TASK_ROUTES = {
     },
 }
 
+# Defines after how many seconds should the task triggered by the Celery beat
+# entry 'update-products-search-vectors' expire if it wasn't picked up by a worker.
+BEAT_UPDATE_SEARCH_EXPIRE_AFTER_SEC = 20
+
+# Defines the Celery beat scheduler entries.
+#
+# Note: if a Celery task triggered by a Celery beat entry has an expiration
+# @task(expires=...), the Celery beat scheduler entry should also define
+# the expiration value. This makes sure if the task or scheduling is wrapped
+# by custom code (e.g., a Saleor fork), the expiration is still present.
 CELERY_BEAT_SCHEDULE = {
     "delete-empty-allocations": {
         "task": "saleor.warehouse.tasks.delete_empty_allocations_task",
@@ -586,6 +596,7 @@ CELERY_BEAT_SCHEDULE = {
     "update-products-search-vectors": {
         "task": "saleor.product.tasks.update_products_search_vector_task",
         "schedule": timedelta(seconds=20),
+        "options": {"expires": BEAT_UPDATE_SEARCH_EXPIRE_AFTER_SEC},
     },
 }
 


### PR DESCRIPTION
This adds a 20s expiration option in the Celery beat entry of `update-products-search-vectors` in order to have an expiration set if the actual task is not directly called.


# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
