### PR TITLE
Remove preorders, discounts and addresses in clearorders command

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -947,6 +947,7 @@ def _create_staff_user(staff_password, email=None, superuser=False):
             User(email=email, first_name=first_name, last_name=last_name), address
         ),
     )
+    staff_user.addresses.add(address)
     return staff_user
 
 


### PR DESCRIPTION
Backport of https://github.com/saleor/saleor/pull/11805

* Remove order discounts and preorder items in clearorders command

* Delete unassigned addresses

* Fix populatedb

* Delete debug print

* Fix CI

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
