### PR TITLE
Fix OIDC plugin crashing when given a JWT without an exp claim

### DIFF
--- a/saleor/plugins/openid_connect/tests/test_plugin.py
+++ b/saleor/plugins/openid_connect/tests/test_plugin.py
@@ -911,6 +911,7 @@ def test_authenticate_user_with_jwt_access_token(
     decoded_access_token["scope"] = ""
     decoded_token = MagicMock()
     decoded_token.__getitem__.side_effect = decoded_access_token.__getitem__
+    decoded_token.get.side_effect = decoded_access_token.get
 
     # mock get token from request
     monkeypatch.setattr(
@@ -1151,6 +1152,7 @@ def test_authenticate_user_with_jwt_access_token_unable_to_fetch_user_info(
 
     decoded_token = MagicMock()
     decoded_token.__getitem__.side_effect = decoded_access_token.__getitem__
+    decoded_token.get.side_effect = decoded_access_token.get
 
     # mock get token from request
     monkeypatch.setattr(
@@ -1193,6 +1195,7 @@ def test_authenticate_user_with_jwt_invalid_access_token(
 
     decoded_token = MagicMock()
     decoded_token.__getitem__.side_effect = decoded_access_token.__getitem__
+    decoded_token.get.side_effect = decoded_access_token.get
     decoded_token.validate.side_effect = JoseError()
 
     # mock get token from request

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -167,7 +167,7 @@ def get_user_from_oauth_access_token_in_jwt_format(
     user_info = get_user_info_from_cache_or_fetch(
         user_info_url,
         access_token,
-        token_payload["exp"],
+        token_payload.get("exp"),
     )
     if not user_info:
         logger.info(


### PR DESCRIPTION
This fixes a crash when Saleor is handed a valid token without an expiration claim.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
