### PR TITLE
Fix warehouse address update to country with different validation rules

### DIFF
--- a/saleor/account/forms.py
+++ b/saleor/account/forms.py
@@ -14,11 +14,9 @@ def get_address_form(
         initial = {}
     if country_code:
         initial["phone"] = "+{}".format(country_code_for_region(country_code))
-
     address_form_class = get_address_form_class(country_code)
 
     if instance is not None:
-        address_form_class = get_address_form_class(instance.country.code)
         address_form = address_form_class(
             data, instance=instance, enable_normalization=enable_normalization, **kwargs
         )

--- a/saleor/graphql/warehouse/tests/test_warehouse.py
+++ b/saleor/graphql/warehouse/tests/test_warehouse.py
@@ -1063,7 +1063,7 @@ def test_mutation_update_warehouse_can_update_address(
     assert address.street_address_2 == "Ground floor"
 
 
-def test_mutation_update_warehouse_to_country_with_different_validation_rulse(
+def test_mutation_update_warehouse_to_country_with_different_validation_rules(
     staff_api_client, warehouse, permission_manage_products, address_usa
 ):
     # given

--- a/saleor/graphql/warehouse/tests/test_warehouse.py
+++ b/saleor/graphql/warehouse/tests/test_warehouse.py
@@ -1063,6 +1063,42 @@ def test_mutation_update_warehouse_can_update_address(
     assert address.street_address_2 == "Ground floor"
 
 
+def test_mutation_update_warehouse_to_country_with_different_validation_rulse(
+    staff_api_client, warehouse, permission_manage_products, address_usa
+):
+    # given
+    warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
+    warehouse.address = address_usa
+    warehouse.save(update_fields=["address"])
+    address_id = graphene.Node.to_global_id("Address", warehouse.address.pk)
+    variables = {
+        "id": warehouse_id,
+        "input": {
+            "name": warehouse.name,
+            "address": {
+                "streetAddress1": "Fake street",
+                "city": "London",
+                "country": "GB",
+                "postalCode": "B52 1AA",
+            },
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        MUTATION_UPDATE_WAREHOUSE,
+        variables=variables,
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+    content_address = content["data"]["updateWarehouse"]["warehouse"]["address"]
+
+    # then
+    assert len(content["data"]["updateWarehouse"]["errors"]) == 0
+    assert content_address["streetAddress1"] == "Fake street"
+    assert content_address["id"] == address_id
+
+
 @pytest.mark.parametrize(
     "input_slug, expected_slug, error_message",
     [


### PR DESCRIPTION
I want to merge this change because it fixes #11787 
That issue appeared when the address that was updated had different validation rules than the new one. 
The form that is used to validate input should be made from the country code from the input.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
