### PR TITLE
Fix stock events triggers

### DIFF
--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -890,13 +890,15 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
             stock, is_created = warehouse_models.Stock.objects.get_or_create(
                 product_variant=variant, warehouse=warehouse
             )
-
-            if is_created or (stock.quantity <= 0 and stock_data["quantity"] > 0):
+            if is_created or (
+                (stock.quantity - stock.quantity_allocated) <= 0 < stock_data["quantity"]):
                 transaction.on_commit(
                     lambda: manager.product_variant_back_in_stock(stock)
                 )
 
-            if stock_data["quantity"] <= 0:
+            if stock_data["quantity"] <= 0 or (
+                stock_data["quantity"] - stock.quantity_allocated <= 0
+            ):
                 transaction.on_commit(
                     lambda: manager.product_variant_out_of_stock(stock)
                 )

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -891,7 +891,10 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
                 product_variant=variant, warehouse=warehouse
             )
             if is_created or (
-                (stock.quantity - stock.quantity_allocated) <= 0 < stock_data["quantity"]):
+                (stock.quantity - stock.quantity_allocated)
+                <= 0
+                < stock_data["quantity"]
+            ):
                 transaction.on_commit(
                     lambda: manager.product_variant_back_in_stock(stock)
                 )

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
@@ -8,7 +8,7 @@ from django.db.models import Sum
 from .....plugins.manager import get_plugins_manager
 from .....tests.utils import flush_post_commit_hooks
 from .....warehouse.error_codes import StockErrorCode
-from .....warehouse.models import Stock, Warehouse
+from .....warehouse.models import Stock, Warehouse, Allocation
 from ....tests.utils import get_graphql_content
 from ...bulk_mutations.products import ProductVariantStocksUpdate
 from ...utils import create_stocks
@@ -358,6 +358,74 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
     product_variant_stock_out_of_stock_webhook.assert_called_once_with(
         Stock.objects.all()[1]
     )
+
+
+@patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
+def test_update_or_create_variant_with_back_in_stock_webhooks_with_allocations(
+    product_variant_stock_out_of_stock_webhook,
+    product_variant_back_in_stock_webhook,
+    settings,
+    variant,
+    warehouse,
+):
+    stock_quantity = 4
+    stock = Stock.objects.create(
+        warehouse=warehouse,
+        product_variant=variant,
+        quantity=stock_quantity)
+
+    # given
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    plugins = get_plugins_manager()
+    stock.quantity_allocated = stock_quantity
+    stock.save(update_fields=['quantity_allocated'])
+    stocks_data = [
+        {"quantity": stock.quantity_allocated + 1},
+    ]
+
+    # when
+    ProductVariantStocksUpdate.update_or_create_variant_stocks(
+        variant, stocks_data, [warehouse], plugins
+    )
+    # then
+    flush_post_commit_hooks()
+    product_variant_back_in_stock_webhook.assert_called_once_with(stock)
+    product_variant_stock_out_of_stock_webhook.assert_not_called()
+
+
+@patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")
+def test_update_or_create_variant_with_out_of_stock_webhooks_with_allocations(
+    product_variant_stock_out_of_stock_webhook,
+    product_variant_back_in_stock_webhook,
+    settings,
+    variant,
+    warehouse,
+):
+    stock_quantity = 4
+    stock = Stock.objects.create(
+        warehouse=warehouse,
+        product_variant=variant,
+        quantity=stock_quantity)
+
+    # given
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    plugins = get_plugins_manager()
+    stock.quantity_allocated = stock_quantity - 1
+    stock.save(update_fields=['quantity_allocated'])
+    stocks_data = [
+        {"quantity": stock.quantity_allocated},
+    ]
+
+    # when
+    ProductVariantStocksUpdate.update_or_create_variant_stocks(
+        variant, stocks_data, [warehouse], plugins
+    )
+    # then
+    flush_post_commit_hooks()
+    product_variant_stock_out_of_stock_webhook.assert_called_once_with(stock)
+    product_variant_back_in_stock_webhook.assert_not_called()
 
 
 @patch("saleor.plugins.manager.PluginsManager.product_variant_back_in_stock")

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
@@ -8,7 +8,7 @@ from django.db.models import Sum
 from .....plugins.manager import get_plugins_manager
 from .....tests.utils import flush_post_commit_hooks
 from .....warehouse.error_codes import StockErrorCode
-from .....warehouse.models import Stock, Warehouse, Allocation
+from .....warehouse.models import Stock, Warehouse
 from ....tests.utils import get_graphql_content
 from ...bulk_mutations.products import ProductVariantStocksUpdate
 from ...utils import create_stocks
@@ -371,15 +371,14 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_with_allocations(
 ):
     stock_quantity = 4
     stock = Stock.objects.create(
-        warehouse=warehouse,
-        product_variant=variant,
-        quantity=stock_quantity)
+        warehouse=warehouse, product_variant=variant, quantity=stock_quantity
+    )
 
     # given
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     plugins = get_plugins_manager()
     stock.quantity_allocated = stock_quantity
-    stock.save(update_fields=['quantity_allocated'])
+    stock.save(update_fields=["quantity_allocated"])
     stocks_data = [
         {"quantity": stock.quantity_allocated + 1},
     ]
@@ -405,15 +404,14 @@ def test_update_or_create_variant_with_out_of_stock_webhooks_with_allocations(
 ):
     stock_quantity = 4
     stock = Stock.objects.create(
-        warehouse=warehouse,
-        product_variant=variant,
-        quantity=stock_quantity)
+        warehouse=warehouse, product_variant=variant, quantity=stock_quantity
+    )
 
     # given
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     plugins = get_plugins_manager()
     stock.quantity_allocated = stock_quantity - 1
-    stock.save(update_fields=['quantity_allocated'])
+    stock.save(update_fields=["quantity_allocated"])
     stocks_data = [
         {"quantity": stock.quantity_allocated},
     ]


### PR DESCRIPTION
I want to merge this change because it is port of #11714
It fixes `PRODUCT_VARIANT_OUT_OF_STOCK` and `PRODUCT_VARIANT_BACK_IN_STOCK` webhooks triggers to also handle stock allocations.
# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
