### PR TITLE
Fix null metadata values in tax class migration

### DIFF
--- a/saleor/tax/migrations/0004_migrate_tax_classes.py
+++ b/saleor/tax/migrations/0004_migrate_tax_classes.py
@@ -47,7 +47,7 @@ def _populate_tax_class_name_and_metadata(obj):
         name = avatax_description or avatax_code
         metadata = {
             AVATAX_CODE_META_KEY: avatax_code,
-            AVATAX_DESCRIPTION_META_KEY: avatax_description,
+            AVATAX_DESCRIPTION_META_KEY: avatax_description or "",
         }
     elif vatlayer_code:
         name = vatlayer_code


### PR DESCRIPTION
Migration responsible for creating tax classes was wrongly assuming that `avatax.description` key is always present along with `avatax.code`, which caused an invalid metadata item to be created: `{"avatax.description": null}`. This is invalid in API as the value must be non-null. This PR fixes the migration to set an empty string instead of null in this case.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
