### PR TITLE
Recalculate order amount fields for transactions

### DIFF
--- a/saleor/graphql/order/tests/queries/test_order_with_filter.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_filter.py
@@ -1043,9 +1043,9 @@ def test_order_query_with_filter_search_by_product_sku_multi_order_lines(
             1,
         ),
         (
-            {"authorized_value": Decimal("00")},
-            [OrderAuthorizeStatusEnum.PARTIAL.name],
-            0,
+            {"authorized_value": Decimal("0")},
+            [OrderAuthorizeStatusEnum.NONE.name],
+            1,
         ),
         (
             {"authorized_value": Decimal("100")},
@@ -1064,8 +1064,8 @@ def test_order_query_with_filter_search_by_product_sku_multi_order_lines(
         ),
         (
             {"authorized_value": Decimal("10"), "charged_value": Decimal("90")},
-            [OrderAuthorizeStatusEnum.FULL.name],
-            2,
+            [OrderAuthorizeStatusEnum.PARTIAL.name],
+            1,
         ),
     ],
 )

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -394,13 +394,16 @@ def test_transaction_update_for_order_increases_order_total_authorized_by_app(
 ):
     # given
     transaction = transaction_item_created_by_app
+    transaction.authorized_value = Decimal("10")
+    transaction.order_id = order_with_lines.pk
+    transaction.save()
     previously_authorized_value = Decimal("90")
     old_transaction = order_with_lines.payment_transactions.create(
         authorized_value=previously_authorized_value, currency=order_with_lines.currency
     )
-    update_order_authorize_data(
-        order_with_lines,
-    )
+
+    update_order_authorize_data(order_with_lines)
+
     assert (
         order_with_lines.total_authorized_amount
         == previously_authorized_value + transaction.authorized_value


### PR DESCRIPTION
I want to merge this change because it adds a missing recalculation of the order amounts & statuses, when the any changes happen for the transactions attached to the order.
It also change the assumption, how we define the order.authorize_status and order.charge_status. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
