### PR TITLE
Fix payload for send_user_change_email_notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Just so you know, changes mentioned in this section are in a preview state and c
 - Allow `webhookCreate` and `webhookUpdate` mutations to inherit events from `query` field - #11736 by @zedzior
 - Add new `PRODUCT_VARIANT_STOCK_UPDATED` event - #11665 by @jakubkuc
 - Disable websocket support by default in `uvicorn` worker configuration - #11785 by @NyanKiyoshi
+- Fix send user email change notification - #11840 by @jakubkuc
 
 # 3.10.0 [Unreleased]
 

--- a/saleor/account/notifications.py
+++ b/saleor/account/notifications.py
@@ -105,11 +105,13 @@ def send_request_user_change_email_notification(
 
 
 def send_user_change_email_notification(recipient_email, user, manager, channel_slug):
-    """Trigger sending a email change notification for the given user."""
+    """Trigger sending an email change notification for the given user."""
     payload = {
         "user": get_default_user_payload(user),
         "recipient_email": recipient_email,
         "channel_slug": channel_slug,
+        "old_email": recipient_email,
+        "new_email": user.email,
         **get_site_context(),
     }
     manager.notify(
@@ -122,7 +124,7 @@ def send_user_change_email_notification(recipient_email, user, manager, channel_
 def send_account_delete_confirmation_notification(
     redirect_url, user, manager, channel_slug
 ):
-    """Trigger sending a account delete notification for the given user."""
+    """Trigger sending an account delete notification for the given user."""
     token = account_delete_token_generator.make_token(user)
     params = urlencode({"token": token})
     delete_url = prepare_url(params, redirect_url)

--- a/saleor/account/tests/test_notifications.py
+++ b/saleor/account/tests/test_notifications.py
@@ -78,6 +78,8 @@ def test_send_email_changed_notification(
         "user": get_default_user_payload(customer_user),
         "recipient_email": old_email,
         "channel_slug": channel_PLN.slug,
+        "old_email": old_email,
+        "new_email": customer_user.email,
         **get_site_context_payload(site_settings.site),
     }
 

--- a/saleor/plugins/user_email/tasks.py
+++ b/saleor/plugins/user_email/tasks.py
@@ -77,8 +77,8 @@ def send_user_change_email_notification_task(
         template_str=template,
     )
     event_parameters = {
-        "old_email": payload["old_email"],
-        "new_email": payload["new_email"],
+        "old_email": payload.get("old_email"),
+        "new_email": payload.get("new_email"),
     }
 
     account_events.customer_email_changed_event(

--- a/saleor/plugins/user_email/tests/test_tasks.py
+++ b/saleor/plugins/user_email/tests/test_tasks.py
@@ -221,9 +221,12 @@ def test_send_request_email_change_email_task_custom_template(
     )
 
 
+@mock.patch(
+    "saleor.plugins.user_email.tasks.account_events.customer_email_changed_event"
+)
 @mock.patch("saleor.plugins.email_common.send_mail")
 def test_send_user_change_email_notification_task_default_template(
-    mocked_send_mail, user_email_dict_config, customer_user
+    mocked_send_mail, mocked_email_changed_task, user_email_dict_config, customer_user
 ):
     recipient_email = "user@example.com"
     payload = {
@@ -238,9 +241,16 @@ def test_send_user_change_email_notification_task_default_template(
     send_user_change_email_notification_task(
         recipient_email, payload, user_email_dict_config, "subject", "template"
     )
-
+    expected_task_payload = {
+        "old_email": payload["old_email"],
+        "new_email": payload["new_email"],
+    }
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
+    # confirm that email changed task was triggered
+    assert mocked_email_changed_task.called_once_with(
+        customer_user.id, expected_task_payload
+    )
 
 
 @mock.patch("saleor.plugins.user_email.tasks.send_email")


### PR DESCRIPTION
I want to merge this change because it fixes the payload for `send_user_change_email_notification` which previously made `customer_email_changed_event` unable to be triggered because it gave `keyError` trying to retrieve non-existent data from the payload. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
