### PR TITLE
Fix warehouse address update to country with different validation rules

### DIFF
--- a/saleor/account/forms.py
+++ b/saleor/account/forms.py
@@ -14,11 +14,9 @@ def get_address_form(
         initial = {}
     if country_code:
         initial["phone"] = "+{}".format(country_code_for_region(country_code))
-
     address_form_class = get_address_form_class(country_code)
 
     if instance is not None:
-        address_form_class = get_address_form_class(instance.country.code)
         address_form = address_form_class(
             data, instance=instance, enable_normalization=enable_normalization, **kwargs
         )


### PR DESCRIPTION
It is a port of #11825 to 3.11
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
