### PR TITLE
Fix SKU is changed to null value if the parameter is not specified in the input data

### DIFF
--- a/saleor/graphql/product/mutations/product_variant/product_variant_update.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_update.py
@@ -18,6 +18,7 @@ from ....core.utils import ext_ref_to_global_id_or_error
 from ....core.validators import validate_one_of_args_is_in_mutation
 from ...types import ProductVariant
 from ...utils import get_used_attribute_values_for_variant
+from ...utils import clean_variant_sku
 from .product_variant_create import ProductVariantCreate, ProductVariantInput
 
 T_INPUT_MAP = List[Tuple[attribute_models.Attribute, AttrValuesInput]]
@@ -48,6 +49,20 @@ class ProductVariantUpdate(ProductVariantCreate, ModelWithExtRefMutation):
         errors_mapping = {"price_amount": "price"}
         support_meta_field = True
         support_private_meta_field = True
+
+    @classmethod
+    def clean_input(
+        cls,
+        info: ResolveInfo,
+        instance: models.ProductVariant,
+        data: dict,
+        **kwargs,
+    ):
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+        if "sku" in cleaned_input:
+            cleaned_input["sku"] = clean_variant_sku(cleaned_input.get("sku"))
+
+        return cleaned_input
 
     @classmethod
     def clean_attributes(

--- a/saleor/graphql/product/tests/mutations/test_product_variant_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_update.py
@@ -565,10 +565,8 @@ def test_update_product_variant_without_sku_keep_it_empty(
     variant.refresh_from_db()
     content = get_graphql_content(response)
     data = content["data"]["productVariantUpdate"]
-    assert data["productVariant"]["sku"] is None
+    assert data["productVariant"]["sku"] == ""
     assert not data["errors"]
-    variant.refresh_from_db()
-    assert variant.sku is None
 
 
 @patch("saleor.plugins.manager.PluginsManager.product_variant_created")

--- a/saleor/graphql/product/utils.py
+++ b/saleor/graphql/product/utils.py
@@ -117,8 +117,8 @@ def get_draft_order_lines_data_for_variants(
 
 def clean_variant_sku(sku: Optional[str]) -> Optional[str]:
     if sku:
-        return sku.strip() or None
-    return None
+        return sku.strip() or ""
+    return ""
 
 
 def update_ordered_media(ordered_media):


### PR DESCRIPTION
SKU is changed to null value if the parameter is not specified in the input data
Fixes https://github.com/saleor/saleor/issues/11811

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
