### PR TITLE
Revert "Downgrade buildkit version"

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -95,14 +95,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          # Use v0.10.x due to v0.11 failing randomly
-          # Tags: https://hub.docker.com/r/moby/buildkit/tags
-          # Tickets:
-          # - https://github.com/docker/build-push-action/issues/761
-          # - https://github.com/moby/buildkit/issues/3347
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
 
       - name: Cache Docker layers
         uses: actions/cache@v2


### PR DESCRIPTION
This reverts commit 2ad2427584a9c993c2b704d5cb1de93d8b8c465e.

Buildkit v0.11.2 resolves the issue (https://github.com/moby/buildkit/releases/tag/v0.11.2).
