### PR TITLE
Partial DB replica emulation

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -86,19 +86,20 @@ DATABASE_CONNECTION_DEFAULT_NAME = "default"
 # TODO: For local envs will be activated in separate PR.
 # We need to update docs an saleor platform.
 # This variable should be set to `replica`
-DATABASE_CONNECTION_REPLICA_NAME = "default"
+DATABASE_CONNECTION_REPLICA_NAME = "replica"
 
 DATABASES = {
     DATABASE_CONNECTION_DEFAULT_NAME: dj_database_url.config(
         default="postgres://saleor:saleor@localhost:5432/saleor",
         conn_max_age=DB_CONN_MAX_AGE,
     ),
-    # TODO: We need to add read only user to saleor platfrom, and we need to update
-    # docs.
-    # DATABASE_CONNECTION_REPLICA_NAME: dj_database_url.config(
-    #     default="postgres://saleor_read_only:saleor@localhost:5432/saleor",
-    #     conn_max_age=DB_CONN_MAX_AGE,
-    # ),
+    DATABASE_CONNECTION_REPLICA_NAME: dj_database_url.config(
+        default="postgres://saleor:saleor@localhost:5432/saleor",
+        # TODO: We need to add read only user to saleor platform,
+        # and we need to update docs.
+        # default="postgres://saleor_read_only:saleor@localhost:5432/saleor",
+        conn_max_age=DB_CONN_MAX_AGE,
+    ),
 }
 
 DATABASE_ROUTERS = ["saleor.core.db_routers.PrimaryReplicaRouter"]


### PR DESCRIPTION
It doesn't actually restrict connection to read-only, but having two connections open (even to the same database) allow us to locally recreate bug connected with using two request contexts in one Django request (I mean synchronous webhooks' subscriptions here).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
