### PR TITLE
Improve validation of reporting transaction events

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -42,8 +42,6 @@ from ...payment.gateway import (
     request_refund_action,
 )
 from ...payment.transaction_item_calculations import recalculate_transaction_amounts
-from ...permission.auth_filters import AuthorizationFilters
-from ...permission.enums import OrderPermissions, PaymentPermissions
 from ...payment.utils import (
     authorization_success_already_exists,
     create_failed_transaction_event,
@@ -51,6 +49,8 @@ from ...payment.utils import (
     get_already_existing_event,
     is_currency_supported,
 )
+from ...permission.auth_filters import AuthorizationFilters
+from ...permission.enums import OrderPermissions, PaymentPermissions
 from ..account.i18n import I18nMixin
 from ..app.dataloaders import get_app_promise
 from ..channel.utils import validate_channel

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -19946,6 +19946,7 @@ enum TransactionEventReportErrorCode {
   GRAPHQL_ERROR
   NOT_FOUND
   INCORRECT_DETAILS
+  ALREADY_EXISTS
 }
 
 """

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -53,3 +53,4 @@ class TransactionEventReportErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
     INCORRECT_DETAILS = "incorrect_details"
+    ALREADY_EXISTS = "already_exists"

--- a/saleor/payment/migrations/0040_auto_20220922_1146.py
+++ b/saleor/payment/migrations/0040_auto_20220922_1146.py
@@ -140,6 +140,11 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name="transactionevent",
+            name="include_in_calculations",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="transactionevent",
             name="type",
             field=models.CharField(
                 blank=True,

--- a/saleor/payment/models.py
+++ b/saleor/payment/models.py
@@ -180,6 +180,7 @@ class TransactionEvent(models.Model):
     app = models.ForeignKey(
         "app.App", related_name="+", on_delete=models.SET_NULL, null=True, blank=True
     )
+    include_in_calculations = models.BooleanField(default=False)
 
     class Meta:
         ordering = ("pk",)

--- a/saleor/payment/transaction_item_calculations.py
+++ b/saleor/payment/transaction_item_calculations.py
@@ -96,7 +96,6 @@ def _recalculate_base_amounts(
     pending_amount_field_name: str,
     amount_field_name: str,
 ):
-
     if _should_increase_pending_amount(request, success, failure):
         request = cast(TransactionEvent, request)
         pending_value = getattr(transaction, pending_amount_field_name)
@@ -330,7 +329,7 @@ def recalculate_transaction_amounts(transaction: TransactionItem):
 
     events: Iterable[TransactionEvent] = transaction.events.order_by(
         "created_at"
-    ).exclude(type__isnull=True)
+    ).exclude(include_in_calculations=False)
 
     action_map = _initilize_action_map(events)
     _set_transaction_amounts_to_zero(transaction)

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -815,5 +815,7 @@ def handle_transaction_request_task(self, delivery_id, app_name, request_event_i
         )
         response_data = None
     create_transaction_event_from_request_and_webhook_response(
-        request_event, response_data
+        request_event,
+        delivery.webhook.app,
+        response_data,
     )


### PR DESCRIPTION
I want to merge this change because:
- record any failure of reporting new event
- de-duplicate the event and validate the provided amount
- checking the existence of transaction event of type: authorize_success

More details: #10350

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
