### PR TITLE
Fix returning attributes validation errors in ProductVariantBulkCreate mutation

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -183,11 +183,18 @@ class ProductVariantBulkCreate(BaseMutation):
                     )
                     cleaned_input["attributes"] = cleaned_attributes
                 except ValidationError as exc:
-                    index_error_map[variant_index].append(
-                        ProductVariantBulkError(
-                            field="attributes", message=exc.message, code=exc.code
+                    for error in exc.error_list:
+                        attributes = (
+                            error.params.get("attributes") if error.params else None
                         )
-                    )
+                        index_error_map[variant_index].append(
+                            ProductVariantBulkError(
+                                field="attributes",
+                                message=error.message,
+                                code=error.code,
+                                attributes=attributes,
+                            )
+                        )
                     if errors is not None:
                         exc.params = {"index": variant_index}
                         errors["attributes"].append(exc)


### PR DESCRIPTION
I want to merge this change because it fixes returning errors when attribute validation fails on ProductVariantBulkCreate.

Port of #11861

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
