### PR TITLE
Use app identifier instead of foreign key for transactions

### DIFF
--- a/saleor/graphql/app/dataloaders.py
+++ b/saleor/graphql/app/dataloaders.py
@@ -44,6 +44,19 @@ class AppExtensionByAppIdLoader(DataLoader):
         return [extensions_map.get(app_id, []) for app_id in keys]
 
 
+class AppsByAppIdentifierLoader(DataLoader):
+    context_key = "apps_by_app_identifier"
+
+    def batch_load(self, keys):
+        apps = App.objects.using(self.database_connection_name).filter(
+            identifier__in=keys
+        )
+        apps_map = defaultdict(list)
+        for app in apps:
+            apps_map[app.identifier].append(app)
+        return [apps_map.get(app_identifier, []) for app_identifier in keys]
+
+
 class AppByTokenLoader(DataLoader):
     context_key = "app_by_token"
 

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -878,7 +878,7 @@ class TransactionCreate(BaseMutation):
         return payment_models.TransactionItem.objects.create(
             **transaction_input,
             user=user if user and user.is_authenticated else None,
-            app=app,
+            app_identifier=app.identifier if app else None,
         )
 
     @classmethod
@@ -897,7 +897,7 @@ class TransactionCreate(BaseMutation):
             message=transaction_event_input.get("name", ""),
             transaction=transaction,
             user=user if user and user.is_authenticated else None,
-            app=app,
+            app_identifier=app.identifier if app else None,
         )
 
     @classmethod
@@ -1329,7 +1329,7 @@ class TransactionEventReport(ModelMutation):
             "external_url": external_url or "",
             "message": message or "",
             "transaction": transaction,
-            "app": app,
+            "app_identifier": app.identifier if app else None,
             "user": user,
             "include_in_calculations": True,
         }

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -195,7 +195,7 @@ def test_transaction_create_for_order_by_app(
     assert transaction.private_metadata == {
         private_metadata["key"]: private_metadata["value"]
     }
-    assert transaction.app == app_api_client.app
+    assert transaction.app_identifier == app_api_client.app.identifier
     assert transaction.user is None
     assert transaction.external_url == external_url
 
@@ -351,7 +351,7 @@ def test_transaction_create_for_checkout_by_app(
         private_metadata["key"]: private_metadata["value"]
     }
     assert transaction.external_url == external_url
-    assert transaction.app == app_api_client.app
+    assert transaction.app_identifier == app_api_client.app.identifier
     assert transaction.user is None
 
 
@@ -757,7 +757,7 @@ def test_creates_transaction_event_for_order_by_app(
     assert event.message == event_name
     assert event.status == event_status
     assert event.psp_reference == event_psp_reference
-    assert event.app == app_api_client.app
+    assert event.app_identifier == app_api_client.app.identifier
     assert event.user is None
 
 
@@ -824,7 +824,7 @@ def test_creates_transaction_event_for_checkout_by_app(
     assert event.message == event_name
     assert event.status == event_status
     assert event.psp_reference == event_psp_reference
-    assert event.app == app_api_client.app
+    assert event.app_identifier == app_api_client.app.identifier
     assert event.user is None
 
 
@@ -883,7 +883,7 @@ def test_transaction_create_for_order_by_staff(
         private_metadata["key"]: private_metadata["value"]
     }
     assert transaction.user == staff_api_client.user
-    assert not transaction.app
+    assert not transaction.app_identifier
 
 
 def test_transaction_create_for_order_updates_order_total_authorized_by_staff(
@@ -1033,7 +1033,7 @@ def test_transaction_create_for_checkout_by_staff(
     assert transaction.private_metadata == {
         private_metadata["key"]: private_metadata["value"]
     }
-    assert transaction.app is None
+    assert transaction.app_identifier is None
     assert transaction.user == staff_api_client.user
 
 
@@ -1440,7 +1440,7 @@ def test_creates_transaction_event_for_order_by_staff(
     assert event.status == event_status
     assert event.psp_reference == event_psp_reference
     assert event.user == staff_api_client.user
-    assert event.app is None
+    assert event.app_identifier is None
 
 
 def test_creates_transaction_event_for_checkout_by_staff(
@@ -1507,7 +1507,7 @@ def test_creates_transaction_event_for_checkout_by_staff(
     assert event.status == event_status
     assert event.psp_reference == event_psp_reference
     assert event.user == staff_api_client.user
-    assert event.app is None
+    assert event.app_identifier is None
 
 
 def test_transaction_create_external_url_incorrect_url_format_by_app(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -119,7 +119,7 @@ def test_transaction_event_report_by_app(
     assert event.created_at == event_time
     assert event.external_url == external_url
     assert event.transaction == transaction_item_created_by_app
-    assert event.app == app_api_client.app
+    assert event.app_identifier == app_api_client.app.identifier
     assert event.user is None
 
 
@@ -189,7 +189,7 @@ def test_transaction_event_report_by_user(
     assert event.created_at == event_time
     assert event.external_url == external_url
     assert event.transaction == transaction_item_created_by_user
-    assert event.app is None
+    assert event.app_identifier is None
     assert event.user == staff_api_client.user
 
     transaction_item_created_by_user.refresh_from_db()
@@ -246,9 +246,10 @@ def test_transaction_event_report_called_by_non_app_owner(
     # given
     second_app = app_api_client.app
     second_app.pk = None
+    second_app.identifier = "different-identifier"
     second_app.save()
-    transaction_item_created_by_app.app = second_app
-    transaction_item_created_by_app.save(update_fields=["app"])
+    transaction_item_created_by_app.app_identifier = second_app.identifier
+    transaction_item_created_by_app.save(update_fields=["app_identifier"])
 
     transaction_id = to_global_id_or_none(transaction_item_created_by_app)
     variables = {

--- a/saleor/graphql/payment/tests/mutations/test_transaction_update.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_update.py
@@ -101,7 +101,7 @@ def test_only_owner_can_update_its_transaction_by_app(
 ):
     # given
     transaction = transaction_item_created_by_app
-    transaction.app = external_app
+    transaction.app_identifier = external_app.identifier
     transaction.save()
 
     status = "Captured for 10$"
@@ -900,7 +900,7 @@ def test_creates_transaction_event_for_order_by_app(
     assert event.message == event_name
     assert event.status == event_status
     assert event.psp_reference == event_reference
-    assert event.app == app_api_client.app
+    assert event.app_identifier == app_api_client.app.identifier
     assert event.user is None
 
 
@@ -1705,7 +1705,7 @@ def test_creates_transaction_event_for_order_by_staff(
     assert event.message == event_name
     assert event.status == event_status
     assert event.psp_reference == event_reference
-    assert event.app is None
+    assert event.app_identifier is None
     assert event.user == staff_api_client.user
 
 

--- a/saleor/graphql/payment/tests/queries/test_transaction.py
+++ b/saleor/graphql/payment/tests/queries/test_transaction.py
@@ -122,7 +122,7 @@ def _assert_transaction_fields_created_by(content, transaction_item, event, crea
 
 
 def test_transaction_created_by_app_query_by_app(
-    app_api_client, transaction_item_created_by_app, permission_manage_payments
+    app_api_client, transaction_item_created_by_app, permission_manage_payments, app
 ):
     # given
     event = TransactionEvent.objects.create(transaction=transaction_item_created_by_app)
@@ -140,12 +140,12 @@ def test_transaction_created_by_app_query_by_app(
         content,
         transaction_item_created_by_app,
         event,
-        transaction_item_created_by_app.app,
+        app,
     )
 
 
 def test_transaction_creted_by_app_query_no_order(
-    app_api_client, transaction_item_created_by_app, permission_manage_payments
+    app_api_client, transaction_item_created_by_app, permission_manage_payments, app
 ):
     # given
     transaction_item_created_by_app.order = None
@@ -166,12 +166,12 @@ def test_transaction_creted_by_app_query_no_order(
         content,
         transaction_item_created_by_app,
         event,
-        transaction_item_created_by_app.app,
+        app,
     )
 
 
 def test_transaction_created_by_app_query_by_staff(
-    staff_api_client, transaction_item_created_by_app, permission_manage_payments
+    staff_api_client, transaction_item_created_by_app, permission_manage_payments, app
 ):
     # given
     event = TransactionEvent.objects.create(transaction=transaction_item_created_by_app)
@@ -189,7 +189,7 @@ def test_transaction_created_by_app_query_by_staff(
         content,
         transaction_item_created_by_app,
         event,
-        transaction_item_created_by_app.app,
+        app,
     )
 
 
@@ -412,7 +412,7 @@ def test_transaction_event_by_app(
         type=TransactionEventType.CHARGE_SUCCESS,
         amount_value=Decimal("10.00"),
         external_url=f"http://`{TEST_SERVER_DOMAIN}/test",
-        app=app_api_client.app,
+        app_identifier=app_api_client.app.identifier,
     )
 
     variables = {"id": to_global_id_or_none(transaction_item_created_by_app)}

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -5,7 +5,7 @@ from ...core.exceptions import PermissionDenied
 from ...payment import models
 from ...permission.enums import OrderPermissions
 from ..account.dataloaders import UserByUserIdLoader
-from ..app.dataloaders import AppByIdLoader
+from ..app.dataloaders import AppsByAppIdentifierLoader
 from ..checkout.dataloaders import CheckoutByTokenLoader
 from ..core.connection import CountableConnection
 from ..core.descriptions import (
@@ -327,8 +327,18 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
 
     @staticmethod
     def resolve_created_by(root: models.TransactionItem, info):
-        if root.app_id:
-            return AppByIdLoader(info.context).load(root.app_id)
+        if root.app_identifier:
+
+            def get_first_app(apps):
+                if apps:
+                    return apps[0]
+                return None
+
+            return (
+                AppsByAppIdentifierLoader(info.context)
+                .load(root.app_identifier)
+                .then(get_first_app)
+            )
         if root.user_id:
             return UserByUserIdLoader(info.context).load(root.user_id)
         return None
@@ -487,8 +497,18 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
 
     @staticmethod
     def resolve_created_by(root: models.TransactionItem, info):
-        if root.app_id:
-            return AppByIdLoader(info.context).load(root.app_id)
+        if root.app_identifier:
+
+            def get_first_app(apps):
+                if apps:
+                    return apps[0]
+                return None
+
+            return (
+                AppsByAppIdentifierLoader(info.context)
+                .load(root.app_identifier)
+                .then(get_first_app)
+            )
         if root.user_id:
             return UserByUserIdLoader(info.context).load(root.user_id)
         return None

--- a/saleor/graphql/payment/utils.py
+++ b/saleor/graphql/payment/utils.py
@@ -19,13 +19,13 @@ def check_if_requestor_has_access(
     # Previously we didn't require app/user attached to transaction. We can't
     # determine which app/user is an owner of the transaction. So for transaction
     # without attached owner we require only HANDLE_PAYMENTS.
-    if not transaction.user_id and not transaction.app_id:
+    if not transaction.user_id and not transaction.app_identifier:
         return True
 
     if user and transaction.user_id == user.id:
         return True
 
-    if app and transaction.app_id == app.id:
+    if app and transaction.app_identifier == app.identifier:
         return True
 
     return False

--- a/saleor/payment/gateway.py
+++ b/saleor/payment/gateway.py
@@ -194,11 +194,15 @@ def _create_transaction_data(
     action_value: Optional[Decimal],
     request_event: TransactionEvent,
 ):
+    app_owner = None
+    if transaction.app_identifier:
+        app_owner = App.objects.filter(identifier=transaction.app_identifier).first()
     return TransactionActionData(
         transaction=transaction,
         action_type=action_type,
         action_value=action_value,
         event=request_event,
+        transaction_app_owner=app_owner,
     )
 
 
@@ -220,10 +224,10 @@ def _request_payment_action(
     )
 
     webhooks = None
-    if transaction_action_data.transaction.app_id:
+    if transaction_action_data.transaction_app_owner:
         webhooks = get_webhooks_for_event(
             event_type=event_type,
-            apps_ids=[transaction_action_data.transaction.app_id],
+            apps_ids=[transaction_action_data.transaction_app_owner.pk],
         )
 
     if (

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -3,13 +3,15 @@ from datetime import datetime
 from decimal import Decimal
 from enum import Enum
 from functools import cached_property
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from ..order import FulfillmentLineData
 from ..order.fetch import OrderLineInfo
 from ..payment.models import TransactionEvent, TransactionItem
 from . import TransactionEventType
 
+if TYPE_CHECKING:
+    from ..app.models import App
 JSONValue = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 JSONType = Union[Dict[str, JSONValue], List[JSONValue]]
 
@@ -19,6 +21,7 @@ class TransactionActionData:
     action_type: str
     transaction: TransactionItem
     event: "TransactionEvent"
+    transaction_app_owner: Optional["App"]
     action_value: Optional[Decimal] = None
 
 

--- a/saleor/payment/migrations/0040_auto_20220922_1146.py
+++ b/saleor/payment/migrations/0040_auto_20220922_1146.py
@@ -17,14 +17,8 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name="transactionitem",
-            name="app",
-            field=models.ForeignKey(
-                blank=True,
-                null=True,
-                on_delete=models.deletion.SET_NULL,
-                related_name="+",
-                to="app.app",
-            ),
+            name="app_identifier",
+            field=models.CharField(blank=True, max_length=256, null=True),
         ),
         migrations.AddField(
             model_name="transactionitem",
@@ -129,14 +123,8 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name="transactionevent",
-            name="app",
-            field=models.ForeignKey(
-                blank=True,
-                null=True,
-                on_delete=django.db.models.deletion.SET_NULL,
-                related_name="+",
-                to="app.app",
-            ),
+            name="app_identifier",
+            field=models.CharField(blank=True, max_length=256, null=True),
         ),
         migrations.AddField(
             model_name="transactionevent",

--- a/saleor/payment/models.py
+++ b/saleor/payment/models.py
@@ -127,9 +127,7 @@ class TransactionItem(ModelWithMetadata):
         on_delete=models.SET_NULL,
         related_name="+",
     )
-    app = models.ForeignKey(
-        "app.App", related_name="+", on_delete=models.SET_NULL, null=True, blank=True
-    )
+    app_identifier = models.CharField(blank=True, null=True, max_length=256)
 
     class Meta:
         ordering = ("pk",)
@@ -176,10 +174,8 @@ class TransactionEvent(models.Model):
         on_delete=models.SET_NULL,
         related_name="+",
     )
+    app_identifier = models.CharField(blank=True, null=True, max_length=256)
 
-    app = models.ForeignKey(
-        "app.App", related_name="+", on_delete=models.SET_NULL, null=True, blank=True
-    )
     include_in_calculations = models.BooleanField(default=False)
 
     class Meta:

--- a/saleor/payment/tests/test_gateway.py
+++ b/saleor/payment/tests/test_gateway.py
@@ -369,7 +369,7 @@ def test_request_charge_action_missing_active_event(
 
 @patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
 @patch("saleor.plugins.manager.PluginsManager.transaction_action_request")
-def test_request_charge_action_with_transaction_action_requesy(
+def test_request_charge_action_with_transaction_action_request(
     mocked_transaction_request, mocked_is_active, order, staff_user
 ):
     # given
@@ -409,6 +409,7 @@ def test_request_charge_action_with_transaction_action_requesy(
             action_type=TransactionAction.CHARGE,
             action_value=action_value,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         channel_slug=order.channel.slug,
     )
@@ -462,6 +463,7 @@ def test_request_charge_action_on_order(
             action_type=TransactionAction.CHARGE,
             action_value=action_value,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         order.channel.slug,
     )
@@ -515,6 +517,7 @@ def test_request_charge_action_by_app(
             action_type=TransactionAction.CHARGE,
             action_value=action_value,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         order.channel.slug,
     )
@@ -568,6 +571,7 @@ def test_request_charge_action_on_checkout(
             action_type=TransactionAction.CHARGE,
             action_value=action_value,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         checkout.channel.slug,
     )
@@ -650,6 +654,7 @@ def test_request_refund_action_with_transaction_action_request(
             action_type=TransactionAction.REFUND,
             action_value=action_value,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         channel_slug=order.channel.slug,
     )
@@ -703,6 +708,7 @@ def test_request_refund_action_on_order(
             action_type=TransactionAction.REFUND,
             action_value=action_value,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         order.channel.slug,
     )
@@ -756,6 +762,7 @@ def test_request_refund_action_by_app(
             action_type=TransactionAction.REFUND,
             action_value=action_value,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         order.channel.slug,
     )
@@ -810,6 +817,7 @@ def test_request_refund_action_on_checkout(
             action_type=TransactionAction.REFUND,
             action_value=action_value,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         checkout.channel.slug,
     )
@@ -891,6 +899,7 @@ def test_request_cancelation_action_on_order(
             action_type=TransactionAction.CANCEL,
             action_value=None,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         order.channel.slug,
     )
@@ -941,6 +950,7 @@ def test_request_cancelation_action_with_transaction_action_request(
             action_type=TransactionAction.CANCEL,
             action_value=None,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         channel_slug=order.channel.slug,
     )
@@ -991,6 +1001,7 @@ def test_request_cancelation_action_by_app(
             action_type=TransactionAction.CANCEL,
             action_value=None,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         order.channel.slug,
     )
@@ -1043,6 +1054,7 @@ def test_request_cancelation_action_on_checkout(
             action_type=TransactionAction.CANCEL,
             action_value=None,
             event=requested_event,
+            transaction_app_owner=None,
         ),
         checkout.channel.slug,
     )

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -362,6 +362,7 @@ def test_create_failed_transaction_event(transaction_item_created_by_app):
 
 def test_create_transaction_event_from_request_and_webhook_response_with_psp_reference(
     transaction_item_created_by_app,
+    app,
 ):
     # given
     request_event = TransactionEvent.objects.create(
@@ -375,7 +376,7 @@ def test_create_transaction_event_from_request_and_webhook_response_with_psp_ref
 
     # when
     create_transaction_event_from_request_and_webhook_response(
-        request_event, transaction_item_created_by_app.app, response_data
+        request_event, app, response_data
     )
 
     # then
@@ -387,6 +388,7 @@ def test_create_transaction_event_from_request_and_webhook_response_with_psp_ref
 @freeze_time("2018-05-31 12:00:01")
 def test_create_transaction_event_from_request_and_webhook_response_part_event(
     transaction_item_created_by_app,
+    app,
 ):
     # given
     request_event = TransactionEvent.objects.create(
@@ -405,7 +407,7 @@ def test_create_transaction_event_from_request_and_webhook_response_part_event(
 
     # when
     event = create_transaction_event_from_request_and_webhook_response(
-        request_event, transaction_item_created_by_app.app, response_data
+        request_event, app, response_data
     )
 
     # then
@@ -423,7 +425,7 @@ def test_create_transaction_event_from_request_and_webhook_response_part_event(
 
 @freeze_time("2018-05-31 12:00:01")
 def test_create_transaction_event_from_request_updates_order_charge(
-    transaction_item_created_by_app, order_with_lines
+    transaction_item_created_by_app, app, order_with_lines
 ):
     # given
     order = order_with_lines
@@ -451,7 +453,7 @@ def test_create_transaction_event_from_request_updates_order_charge(
 
     # when
     create_transaction_event_from_request_and_webhook_response(
-        request_event, transaction_item_created_by_app.app, response_data
+        request_event, app, response_data
     )
 
     # then
@@ -462,7 +464,7 @@ def test_create_transaction_event_from_request_updates_order_charge(
 
 @freeze_time("2018-05-31 12:00:01")
 def test_create_transaction_event_from_request_updates_order_authorize(
-    transaction_item_created_by_app, order_with_lines
+    transaction_item_created_by_app, app, order_with_lines
 ):
     # given
     order = order_with_lines
@@ -490,7 +492,7 @@ def test_create_transaction_event_from_request_updates_order_authorize(
 
     # when
     create_transaction_event_from_request_and_webhook_response(
-        request_event, transaction_item_created_by_app.app, response_data
+        request_event, app, response_data
     )
 
     # then
@@ -502,6 +504,7 @@ def test_create_transaction_event_from_request_updates_order_authorize(
 @freeze_time("2018-05-31 12:00:01")
 def test_create_transaction_event_from_request_and_webhook_response_full_event(
     transaction_item_created_by_app,
+    app,
 ):
     # given
     request_event = TransactionEvent.objects.create(
@@ -532,7 +535,7 @@ def test_create_transaction_event_from_request_and_webhook_response_full_event(
 
     # when
     event = create_transaction_event_from_request_and_webhook_response(
-        request_event, transaction_item_created_by_app.app, response_data
+        request_event, app, response_data
     )
 
     # then
@@ -550,6 +553,7 @@ def test_create_transaction_event_from_request_and_webhook_response_full_event(
 
 def test_create_transaction_event_from_request_and_webhook_response_incorrect_data(
     transaction_item_created_by_app,
+    app,
 ):
     # given
     request_event = TransactionEvent.objects.create(
@@ -562,7 +566,7 @@ def test_create_transaction_event_from_request_and_webhook_response_incorrect_da
 
     # when
     failed_event = create_transaction_event_from_request_and_webhook_response(
-        request_event, transaction_item_created_by_app.app, response_data
+        request_event, app, response_data
     )
 
     # then
@@ -579,6 +583,7 @@ def test_create_transaction_event_from_request_and_webhook_response_incorrect_da
 @freeze_time("2018-05-31 12:00:01")
 def test_create_transaction_event_from_request_and_webhook_response_twice_auth(
     transaction_item_created_by_app,
+    app,
 ):
     # given
     transaction_item_created_by_app.events.create(
@@ -613,7 +618,7 @@ def test_create_transaction_event_from_request_and_webhook_response_twice_auth(
 
     # when
     failed_event = create_transaction_event_from_request_and_webhook_response(
-        request_event, transaction_item_created_by_app.app, response_data
+        request_event, app, response_data
     )
 
     # then
@@ -628,6 +633,7 @@ def test_create_transaction_event_from_request_and_webhook_response_twice_auth(
 @freeze_time("2018-05-31 12:00:01")
 def test_create_transaction_event_from_request_and_webhook_response_same_event(
     transaction_item_created_by_app,
+    app,
 ):
     # given
     expected_psp_reference = "psp:122:222"
@@ -662,7 +668,7 @@ def test_create_transaction_event_from_request_and_webhook_response_same_event(
 
     # when
     event = create_transaction_event_from_request_and_webhook_response(
-        request_event, transaction_item_created_by_app.app, response_data
+        request_event, app, response_data
     )
 
     # then
@@ -676,6 +682,7 @@ def test_create_transaction_event_from_request_and_webhook_response_same_event(
 @freeze_time("2018-05-31 12:00:01")
 def test_create_transaction_event_from_request_and_webhook_response_differnt_amout(
     transaction_item_created_by_app,
+    app,
 ):
     # given
     expected_psp_reference = "psp:122:222"
@@ -711,7 +718,7 @@ def test_create_transaction_event_from_request_and_webhook_response_differnt_amo
 
     # when
     failed_event = create_transaction_event_from_request_and_webhook_response(
-        request_event, transaction_item_created_by_app.app, response_data
+        request_event, app, response_data
     )
 
     # then

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -938,7 +938,7 @@ def create_transaction_event_from_request_and_webhook_response(
             currency=request_event.currency,
             transaction_id=request_event.transaction_id,
             message=response_event.message,
-            app=app,
+            app_identifier=app.identifier,
             include_in_calculations=True,
         )
         with transaction.atomic():

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1307,7 +1307,7 @@ class WebhookPlugin(BasePlugin):
         if not self.active:
             return previous_value
 
-        if not transaction_data.transaction.app_id:
+        if not transaction_data.transaction_app_owner:
             logger.warning(
                 f"Transaction request skipped for "
                 f"{transaction_data.transaction.psp_reference}. "

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -733,7 +733,7 @@ def trigger_transaction_request(
             transaction_data.transaction.id,
         )
         return None
-    if not transaction_data.transaction.app_id:
+    if not transaction_data.transaction_app_owner:
         create_failed_transaction_event(
             transaction_data.event,
             cause=(
@@ -743,7 +743,7 @@ def trigger_transaction_request(
         )
         return None
     webhook = get_webhooks_for_event(
-        event_type, apps_ids=[transaction_data.transaction.app_id]
+        event_type, apps_ids=[transaction_data.transaction_app_owner.pk]
     ).first()
     if not webhook:
         create_failed_transaction_event(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_action_request_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_action_request_subscription.py
@@ -94,6 +94,7 @@ def test_transaction_refund_action_request(
         action_type=TransactionAction.REFUND,
         action_value=action_value,
         event=request_event,
+        transaction_app_owner=None,
     )
     # when
     deliveries = create_deliveries_for_subscriptions(
@@ -166,6 +167,7 @@ def test_transaction_charge_action_request(
         action_type=TransactionAction.CHARGE,
         action_value=action_value,
         event=request_event,
+        transaction_app_owner=None,
     )
     # when
     deliveries = create_deliveries_for_subscriptions(
@@ -234,7 +236,10 @@ def test_transaction_void_action_request(
     transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.id)
 
     transaction_data = TransactionActionData(
-        transaction=transaction, action_type=TransactionAction.VOID, event=request_event
+        transaction=transaction,
+        action_type=TransactionAction.VOID,
+        event=request_event,
+        transaction_app_owner=None,
     )
     # when
     deliveries = create_deliveries_for_subscriptions(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_cancelation_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_cancelation_requested.py
@@ -65,7 +65,10 @@ def test_transaction_void_request(order, webhook_app, permission_manage_payments
     transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.id)
 
     transaction_data = TransactionActionData(
-        transaction=transaction, action_type=TransactionAction.VOID, event=request_event
+        transaction=transaction,
+        action_type=TransactionAction.VOID,
+        event=request_event,
+        transaction_app_owner=None,
     )
     # when
     deliveries = create_deliveries_for_subscriptions(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_charge_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_charge_requested.py
@@ -70,6 +70,7 @@ def test_transaction_charge_request(order, webhook_app, permission_manage_paymen
         action_type=TransactionAction.CHARGE,
         action_value=action_value,
         event=request_event,
+        transaction_app_owner=None,
     )
     # when
     deliveries = create_deliveries_for_subscriptions(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_refund_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_refund_requested.py
@@ -70,6 +70,7 @@ def test_transaction_refund_request(order, webhook_app, permission_manage_paymen
         action_type=TransactionAction.REFUND,
         action_value=action_value,
         event=request_event,
+        transaction_app_owner=None,
     )
     # when
     deliveries = create_deliveries_for_subscriptions(

--- a/saleor/plugins/webhook/tests/test_tasks.py
+++ b/saleor/plugins/webhook/tests/test_tasks.py
@@ -34,13 +34,16 @@ def mocked_webhook_response():
 @freeze_time("2022-06-11 12:50")
 @mock.patch("saleor.plugins.webhook.tasks.handle_transaction_request_task.delay")
 def test_trigger_transaction_request(
-    mocked_task, transaction_item_created_by_app, staff_user, permission_manage_payments
+    mocked_task,
+    transaction_item_created_by_app,
+    staff_user,
+    permission_manage_payments,
+    app,
 ):
     # given
     event = transaction_item_created_by_app.events.create(
         type=TransactionEventType.REFUND_REQUEST
     )
-    app = transaction_item_created_by_app.app
     app.permissions.set([permission_manage_payments])
 
     webhook = app.webhooks.create(
@@ -53,6 +56,7 @@ def test_trigger_transaction_request(
         action_type="refund",
         action_value=Decimal("10.00"),
         event=event,
+        transaction_app_owner=app,
     )
 
     # when
@@ -82,7 +86,11 @@ def test_trigger_transaction_request(
 @freeze_time("2022-06-11 12:50")
 @mock.patch("saleor.plugins.webhook.tasks.handle_transaction_request_task.delay")
 def test_trigger_transaction_request_with_webhook_subscription(
-    mocked_task, transaction_item_created_by_app, staff_user, permission_manage_payments
+    mocked_task,
+    transaction_item_created_by_app,
+    staff_user,
+    permission_manage_payments,
+    app,
 ):
     # given
     subscription = """
@@ -104,7 +112,6 @@ def test_trigger_transaction_request_with_webhook_subscription(
     event = transaction_item_created_by_app.events.create(
         type=TransactionEventType.REFUND_REQUEST
     )
-    app = transaction_item_created_by_app.app
     app.permissions.set([permission_manage_payments])
 
     webhook = app.webhooks.create(
@@ -120,6 +127,7 @@ def test_trigger_transaction_request_with_webhook_subscription(
         action_type="refund",
         action_value=Decimal("10.00"),
         event=event,
+        transaction_app_owner=app,
     )
 
     # when
@@ -159,6 +167,7 @@ def test_handle_transaction_request_task_with_only_psp_reference(
     permission_manage_payments,
     staff_user,
     mocked_webhook_response,
+    app,
 ):
     # given
     expected_psp_reference = "psp:ref:123"
@@ -173,7 +182,6 @@ def test_handle_transaction_request_task_with_only_psp_reference(
     event = transaction_item_created_by_app.events.create(
         type=TransactionEventType.REFUND_REQUEST
     )
-    app = transaction_item_created_by_app.app
     app.permissions.set([permission_manage_payments])
 
     webhook = app.webhooks.create(
@@ -188,6 +196,7 @@ def test_handle_transaction_request_task_with_only_psp_reference(
         action_type="refund",
         action_value=Decimal("10.00"),
         event=event,
+        transaction_app_owner=app,
     )
 
     payload = generate_transaction_action_request_payload(transaction_data, staff_user)
@@ -223,6 +232,7 @@ def test_handle_transaction_request_task_with_server_error(
     permission_manage_payments,
     staff_user,
     mocked_webhook_response,
+    app,
 ):
     # given
     mocked_webhook_response.status_code = status_code
@@ -235,7 +245,6 @@ def test_handle_transaction_request_task_with_server_error(
     event = transaction_item_created_by_app.events.create(
         type=TransactionEventType.CHARGE_REQUEST
     )
-    app = transaction_item_created_by_app.app
     app.permissions.set([permission_manage_payments])
 
     webhook = app.webhooks.create(
@@ -250,6 +259,7 @@ def test_handle_transaction_request_task_with_server_error(
         action_type="refund",
         action_value=Decimal("10.00"),
         event=event,
+        transaction_app_owner=app,
     )
 
     payload = generate_transaction_action_request_payload(transaction_data, staff_user)
@@ -276,6 +286,7 @@ def test_handle_transaction_request_task_with_missing_psp_reference(
     permission_manage_payments,
     staff_user,
     mocked_webhook_response,
+    app,
 ):
     # given
     mocked_webhook_response.text = "{}"
@@ -287,7 +298,6 @@ def test_handle_transaction_request_task_with_missing_psp_reference(
     event = transaction_item_created_by_app.events.create(
         type=TransactionEventType.REFUND_REQUEST
     )
-    app = transaction_item_created_by_app.app
     app.permissions.set([permission_manage_payments])
 
     webhook = app.webhooks.create(
@@ -302,6 +312,7 @@ def test_handle_transaction_request_task_with_missing_psp_reference(
         action_type="refund",
         action_value=Decimal("10.00"),
         event=event,
+        transaction_app_owner=app,
     )
 
     payload = generate_transaction_action_request_payload(transaction_data, staff_user)
@@ -349,6 +360,7 @@ def test_handle_transaction_request_task_with_missing_required_event_field(
     permission_manage_payments,
     staff_user,
     mocked_webhook_response,
+    app,
 ):
     # given
     expected_psp_reference = "psp:123:111"
@@ -365,7 +377,6 @@ def test_handle_transaction_request_task_with_missing_required_event_field(
     event = transaction_item_created_by_app.events.create(
         type=TransactionEventType.REFUND_REQUEST
     )
-    app = transaction_item_created_by_app.app
     app.permissions.set([permission_manage_payments])
 
     webhook = app.webhooks.create(
@@ -380,6 +391,7 @@ def test_handle_transaction_request_task_with_missing_required_event_field(
         action_type="refund",
         action_value=Decimal("10.00"),
         event=event,
+        transaction_app_owner=app,
     )
 
     payload = generate_transaction_action_request_payload(transaction_data, staff_user)
@@ -427,6 +439,7 @@ def test_handle_transaction_request_task_with_result_event(
     permission_manage_payments,
     staff_user,
     mocked_webhook_response,
+    app,
 ):
     # given
     request_psp_reference = "psp:123:111"
@@ -455,7 +468,6 @@ def test_handle_transaction_request_task_with_result_event(
     request_event = transaction_item_created_by_app.events.create(
         type=TransactionEventType.CHARGE_REQUEST
     )
-    app = transaction_item_created_by_app.app
     app.permissions.set([permission_manage_payments])
 
     webhook = app.webhooks.create(
@@ -470,6 +482,7 @@ def test_handle_transaction_request_task_with_result_event(
         action_type="refund",
         action_value=Decimal("10.00"),
         event=request_event,
+        transaction_app_owner=app,
     )
 
     payload = generate_transaction_action_request_payload(transaction_data, staff_user)
@@ -522,6 +535,7 @@ def test_handle_transaction_request_task_with_only_required_fields_for_result_ev
     permission_manage_payments,
     staff_user,
     mocked_webhook_response,
+    app,
 ):
     # given
     request_psp_reference = "psp:123:111"
@@ -539,7 +553,6 @@ def test_handle_transaction_request_task_with_only_required_fields_for_result_ev
     request_event = transaction_item_created_by_app.events.create(
         type=TransactionEventType.REFUND_REQUEST
     )
-    app = transaction_item_created_by_app.app
     app.permissions.set([permission_manage_payments])
 
     webhook = app.webhooks.create(
@@ -554,6 +567,7 @@ def test_handle_transaction_request_task_with_only_required_fields_for_result_ev
         action_type="refund",
         action_value=Decimal("10.00"),
         event=request_event,
+        transaction_app_owner=app,
     )
 
     payload = generate_transaction_action_request_payload(transaction_data, staff_user)
@@ -612,6 +626,7 @@ def test_handle_transaction_request_task_calls_recalculation_of_amounts(
     permission_manage_payments,
     staff_user,
     mocked_webhook_response,
+    app,
 ):
     # given
     request_psp_reference = "psp:123:111"
@@ -640,7 +655,6 @@ def test_handle_transaction_request_task_calls_recalculation_of_amounts(
     request_event = transaction_item_created_by_app.events.create(
         type=TransactionEventType.CHARGE_REQUEST
     )
-    app = transaction_item_created_by_app.app
     app.permissions.set([permission_manage_payments])
 
     webhook = app.webhooks.create(
@@ -655,6 +669,7 @@ def test_handle_transaction_request_task_calls_recalculation_of_amounts(
         action_type="charge",
         action_value=Decimal("12.00"),
         event=request_event,
+        transaction_app_owner=app,
     )
 
     payload = generate_transaction_action_request_payload(transaction_data, staff_user)

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1244,6 +1244,8 @@ def test_create_event_payload_reference_with_error(
     send_webhook_request_async(delivery.id)
     attempt = EventDeliveryAttempt.objects.first()
 
+    assert delivery
+    assert attempt
     assert delivery.webhook == webhook
     assert delivery.event_type == WebhookEventAsyncType.ORDER_CREATED
     assert attempt.response == "Unknown webhook scheme: ''"
@@ -1387,6 +1389,9 @@ def test_send_webhook_request_async(
     mocked_clear_delivery.assert_called_once_with(event_delivery)
     attempt = EventDeliveryAttempt.objects.filter(delivery=event_delivery).first()
     delivery = EventDelivery.objects.get(id=event_delivery.pk)
+
+    assert attempt
+    assert delivery
     assert attempt.status == EventDeliveryStatus.SUCCESS
     assert attempt.response == webhook_response.content
     assert attempt.response_headers == json.dumps(webhook_response.response_headers)
@@ -1454,6 +1459,7 @@ def test_transaction_action_request(
         action_type=TransactionAction.CHARGE,
         action_value=action_value,
         event=request_event,
+        transaction_app_owner=None,
     )
 
     # when
@@ -1501,7 +1507,7 @@ def test_transaction_charge_requested(
         currency="USD",
         order_id=order.pk,
         authorized_value=Decimal("10"),
-        app=app,
+        app_identifier=app.identifier,
     )
     event = transaction.events.create(type=TransactionEventType.CHARGE_REQUEST)
     action_value = Decimal("5.00")
@@ -1510,6 +1516,7 @@ def test_transaction_charge_requested(
         action_type=TransactionAction.CHARGE,
         action_value=action_value,
         event=event,
+        transaction_app_owner=app,
     )
 
     # when
@@ -1554,7 +1561,7 @@ def test_transaction_refund_requested(
         currency="USD",
         order_id=order.pk,
         authorized_value=Decimal("10"),
-        app=app,
+        app_identifier=app.identifier,
     )
     event = transaction.events.create(type=TransactionEventType.REFUND_REQUEST)
     action_value = Decimal("5.00")
@@ -1563,6 +1570,7 @@ def test_transaction_refund_requested(
         action_type=TransactionAction.REFUND,
         action_value=action_value,
         event=event,
+        transaction_app_owner=app,
     )
 
     # when
@@ -1607,7 +1615,7 @@ def test_transaction_cancelation_requested(
         currency="USD",
         order_id=order.pk,
         authorized_value=Decimal("10"),
-        app=app,
+        app_identifier=app.identifier,
     )
     event = transaction.events.create(type=TransactionEventType.CANCEL_REQUEST)
     action_value = Decimal("5.00")
@@ -1616,6 +1624,7 @@ def test_transaction_cancelation_requested(
         action_type=TransactionAction.CANCEL,
         action_value=action_value,
         event=event,
+        transaction_app_owner=app,
     )
 
     # when

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -5482,7 +5482,7 @@ def transaction_item_created_by_app(order, app):
         currency="USD",
         order_id=order.pk,
         charged_value=Decimal("10"),
-        app=app,
+        app_identifier=app.identifier,
     )
 
 

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -2050,6 +2050,7 @@ def test_generate_transaction_action_request_payload_for_order(
                 action_type=action_type,
                 action_value=action_value,
                 event=requested_event,
+                transaction_app_owner=None,
             ),
             requestor=requestor,
         )
@@ -2141,6 +2142,7 @@ def test_generate_transaction_action_request_payload_for_checkout(
                 action_type=action_type,
                 action_value=action_value,
                 event=requested_event,
+                transaction_app_owner=None,
             ),
             requestor=requestor,
         )


### PR DESCRIPTION
I want to merge this change because it change the way how we store relations between App - TransactionItem, and App-TransactionEvent. We use app.identifier, to find a proper app that should process the request. With this approach, reinstalled app should still be able to process own transactions.

----
Note, the failing CI is related to issue that exists on main.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
