### PR TITLE
Use `GITHUB_OUTPUT` instead of deprecated `::set-output`

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           # The name of the owner and of the repository: owner/repository
           IMAGE_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
-          echo ::set-output name=image_name::${IMAGE_NAME}
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_OUTPUT
 
       # Outputs container tags for tagged pushes starting by 'v'
       # Pushes only to GitHub Container Repository (ghcr.io)

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           # The name of the owner and of the repository: owner/repository
           IMAGE_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
-          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          echo "image_name=$IMAGE_NAME" >> $GITHUB_OUTPUT
 
       # Outputs container tags for tagged pushes starting by 'v'
       # Pushes only to GitHub Container Repository (ghcr.io)

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -19,7 +19,7 @@ jobs:
         id: set-domain
         # Set test instance domain based on branch name slug
         run: |
-          echo "::set-output name=domain::${{ env.GITHUB_HEAD_REF_SLUG_URL }}.api.saleor.rocks"
+          echo "domain=${{ env.GITHUB_HEAD_REF_SLUG_URL }}.api.saleor.rocks" >> $GITHUB_OUTPUT
 
       - name: Start deployment
         uses: bobheadxi/deployments@v0.4.2


### PR DESCRIPTION
CI/CD workflow tech debt mitigation for old set-output
More about deprecation: [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
