### PR TITLE
Use default db for synchronous tax webhooks

### DIFF
--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -90,11 +90,14 @@ def generate_payload_from_subscription(
     app_id = app.pk if app else None
 
     request.app = app
+    is_mutation = request.is_mutation if request.is_mutation else False
+    context = get_context_value(request)
+    context.is_mutation = is_mutation
 
     results = document.execute(
         allow_subscriptions=True,
         root=(event_type, subscribable_object),
-        context=get_context_value(request),
+        context=context,
     )
     if hasattr(results, "errors"):
         logger.warning(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1479,6 +1479,7 @@ class WebhookPlugin(BasePlugin):
             parse_tax_data,
             checkout_info.checkout,
             self.requestor,
+            is_mutation=True,
         )
 
     def get_taxes_for_order(
@@ -1490,6 +1491,7 @@ class WebhookPlugin(BasePlugin):
             parse_tax_data,
             order,
             self.requestor,
+            is_mutation=True,
         )
 
     def get_shipping_methods_for_checkout(

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -254,6 +254,7 @@ def trigger_all_webhooks_sync(
     parse_response: Callable[[Any], Optional[R]],
     subscribable_object=None,
     requestor=None,
+    is_mutation=False,
 ) -> Optional[R]:
     """Send all synchronous webhook request for given event type.
 
@@ -272,6 +273,8 @@ def trigger_all_webhooks_sync(
                 request_context = initialize_request(
                     requestor, event_type in WebhookEventSyncType.ALL
                 )
+                request_context.is_mutation = is_mutation
+
             delivery = create_delivery_for_subscription_sync_event(
                 event_type=event_type,
                 subscribable_object=subscribable_object,


### PR DESCRIPTION
https://github.com/saleor/saleor/issues/11906
I want to merge this change because when tax webhooks are triggered during mutation, subscription payload is generated based on replica db, so changes done by the mutation are not visible in the payload.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
