### PR TITLE
Optimize queries in migration 0139_fix_undiscounted_total_on_lines

### DIFF
--- a/saleor/order/migrations/0139_fix_undiscounted_total_on_lines.py
+++ b/saleor/order/migrations/0139_fix_undiscounted_total_on_lines.py
@@ -1,32 +1,38 @@
 from functools import partial
 
 from django.apps import apps as registry
-from django.db import migrations
-from django.db.models import F, Q
+from django.db import connection, migrations
 from django.db.models.signals import post_migrate
 
 from saleor.order.tasks import send_order_updated
 
-BATCH_SIZE = 500
 
+RAW_SQL = """
+    UPDATE "order_orderline"
+    SET
+        "undiscounted_total_price_gross_amount" = CASE
+            WHEN NOT (
+                ("order_orderline"."undiscounted_unit_price_gross_amount" * "order_orderline"."quantity") =
+                                                    "order_orderline"."undiscounted_total_price_gross_amount")
+            THEN ("order_orderline"."undiscounted_unit_price_gross_amount" * "order_orderline"."quantity")
+            ELSE "order_orderline"."undiscounted_total_price_gross_amount" END,
 
-def queryset_in_batches(queryset):
-    """Slice a queryset into batches.
+        "undiscounted_total_price_net_amount"   = CASE
+            WHEN NOT (
+                ("order_orderline"."undiscounted_unit_price_net_amount" * "order_orderline"."quantity") =
+                                                    "order_orderline"."undiscounted_total_price_net_amount")
+            THEN ("order_orderline"."undiscounted_unit_price_net_amount" * "order_orderline"."quantity")
+            ELSE "order_orderline"."undiscounted_total_price_net_amount" END
 
-    Input queryset should be sorted be pk.
-    """
-    start_pk = 0
-
-    while True:
-        qs = queryset.filter(pk__gt=start_pk)[:BATCH_SIZE]
-        pks = list(qs.values_list("pk", flat=True))
-
-        if not pks:
-            break
-
-        yield pks
-
-        start_pk = pks[-1]
+    WHERE (
+        NOT ("order_orderline"."undiscounted_total_price_gross_amount" =
+                ("order_orderline"."undiscounted_unit_price_gross_amount" *
+                "order_orderline"."quantity")) OR
+        NOT ("order_orderline"."undiscounted_total_price_net_amount" =
+                ("order_orderline"."undiscounted_unit_price_net_amount" *
+                "order_orderline"."quantity")))
+    RETURNING "order_orderline"."id";
+"""  # noqa: E501
 
 
 def set_order_line_base_prices(apps, schema_editor):
@@ -34,53 +40,12 @@ def set_order_line_base_prices(apps, schema_editor):
         order_ids = list(kwargs.get("updated_orders_pks"))
         send_order_updated.delay(order_ids)
 
-    OrderLine = apps.get_model("order", "OrderLine")
-    order_lines_to_update = OrderLine.objects.filter(
-        ~Q(
-            undiscounted_total_price_gross_amount=F(
-                "undiscounted_unit_price_gross_amount"
-            )
-            * F("quantity")
-        )
-        | ~Q(
-            undiscounted_total_price_net_amount=F("undiscounted_unit_price_net_amount")
-            * F("quantity")
-        )
-    ).order_by("pk")
-    updated_orders_pks = []
-    for batch_pks in queryset_in_batches(order_lines_to_update):
-        order_lines = OrderLine.objects.filter(pk__in=batch_pks)
-        for order_line in order_lines:
-            old_undiscounted_total_price_gross_amount = (
-                order_line.undiscounted_total_price_gross_amount
-            )
-            old_undiscounted_total_price_net_amount = (
-                order_line.undiscounted_total_price_net_amount
-            )
-            order_line.undiscounted_total_price_gross_amount = (
-                order_line.undiscounted_unit_price_gross_amount * order_line.quantity
-            )
-            order_line.undiscounted_total_price_net_amount = (
-                order_line.undiscounted_unit_price_net_amount * order_line.quantity
-            )
-            if (
-                order_line.undiscounted_total_price_gross_amount
-                != old_undiscounted_total_price_gross_amount
-                or order_line.undiscounted_total_price_net_amount
-                != old_undiscounted_total_price_net_amount
-            ):
-                updated_orders_pks.append(order_line.order_id)
-        OrderLine.objects.bulk_update(
-            order_lines,
-            [
-                "undiscounted_total_price_gross_amount",
-                "undiscounted_total_price_net_amount",
-            ],
-        )
+    with connection.cursor() as cursor:
+        cursor.execute(RAW_SQL)
+        records = cursor.fetchall()
 
-    # If we updated any order we should trigger `order_updated` after migrations
+    updated_orders_pks = {record[0] for record in records}
     if updated_orders_pks:
-        updated_orders_pks = set(updated_orders_pks)
         sender = registry.get_app_config("order")
         post_migrate.connect(
             partial(on_migrations_complete, updated_orders_pks=updated_orders_pks),
@@ -91,7 +56,6 @@ def set_order_line_base_prices(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("order", "0138_orderline_base_price"),
     ]


### PR DESCRIPTION
I want to merge this change because it optimizes the order's `0139_fix_undiscounted_total_on_lines` migration.
Before (depending on dataset) we could have 3502 separate SQL update queries, now that's a single update query.

Local dataset (1249529 order line records):
Before: 4 min 22 sec
After: 2 min 18 sec

### Original SQL - 4:22
Total number of queries 3502.
#### 1 - 0.050
```postgres
SELECT "order_orderline"."id"  
FROM "order_orderline"  
WHERE ((NOT ("order_orderline"."undiscounted_total_price_gross_amount" =  
             ("order_orderline"."undiscounted_unit_price_gross_amount" *  
              "order_orderline"."quantity")) OR  
        NOT ("order_orderline"."undiscounted_total_price_net_amount" =  
             ("order_orderline"."undiscounted_unit_price_net_amount" *  
              "order_orderline"."quantity"))) AND "order_orderline"."id" > 0)  
ORDER BY "order_orderline"."id" ASC  
LIMIT 500
```
#### 2 - 0.012
```postgresql
SELECT "order_orderline"."id",  
       "order_orderline"."product_name",  
       "order_orderline"."product_sku",  
       "order_orderline"."quantity",  
       "order_orderline"."is_shipping_required",  
       "order_orderline"."quantity_fulfilled",  
       "order_orderline"."variant_id",  
       "order_orderline"."tax_rate",  
       "order_orderline"."translated_product_name",  
       "order_orderline"."unit_price_gross_amount",  
       "order_orderline"."unit_price_net_amount",  
       "order_orderline"."currency",  
       "order_orderline"."translated_variant_name",  
       "order_orderline"."variant_name",  
       "order_orderline"."total_price_gross_amount",  
       "order_orderline"."total_price_net_amount",  
       "order_orderline"."unit_discount_amount",  
       "order_orderline"."unit_discount_value",  
       "order_orderline"."unit_discount_reason",  
       "order_orderline"."unit_discount_type",  
       "order_orderline"."undiscounted_total_price_gross_amount",  
       "order_orderline"."undiscounted_total_price_net_amount",  
       "order_orderline"."undiscounted_unit_price_gross_amount",  
       "order_orderline"."undiscounted_unit_price_net_amount",  
       "order_orderline"."is_gift_card",  
       "order_orderline"."product_variant_id",  
       "order_orderline"."sale_id",  
       "order_orderline"."voucher_code",  
       "order_orderline"."order_id",  
       "order_orderline"."base_unit_price_amount",  
       "order_orderline"."undiscounted_base_unit_price_amount"  
FROM "order_orderline"  
WHERE "order_orderline"."id" IN (<list of ids>);
```
#### 3 - 0.279
This SQL is quite long, this is only fragment of it.
```postgresql
UPDATE "order_orderline"  
SET "undiscounted_total_price_gross_amount" = CAST(CASE  
                                                       WHEN ("order_orderline"."id" = 3)  
                                                           THEN 10.000  
                                                       WHEN ("order_orderline"."id" = 5)  
                                                           THEN 20.000  
                                                       WHEN ("order_orderline"."id" = 6)  
                                                           THEN 24.000  
                                                       WHEN ("order_orderline"."id" = 9)  
                                                           THEN 36.000
                                                        ELSE NULL END AS numeric(12, 3)),
                                                        "undiscounted_total_price_net_amount"   = CAST(CASE  
                                                   WHEN ("order_orderline"."id" = 3)  
                                                       THEN 10.000  
                                                   WHEN ("order_orderline"."id" = 5)  
                                                       THEN 20.000  
                                                   WHEN ("order_orderline"."id" = 6)  
                                                       THEN 24.000  
                                                   WHEN ("order_orderline"."id" = 9)  
                                                       THEN 36.000  
                                                   ELSE NULL END AS numeric(12, 3))  
WHERE "order_orderline"."id" IN (<list of ids>);
```
#### 4 to 3502
It is a sequence of queries from 1 to 3 as it is doing with all in 500 batches.

### Refactored SQL - 2:18
#### 1 - 137.758s
```postgresql
UPDATE "order_orderline"
SET "undiscounted_total_price_gross_amount" = CASE
                                                  WHEN NOT (
                                                          ("order_orderline"."undiscounted_unit_price_gross_amount" *
                                                           "order_orderline"."quantity") =
                                                          "order_orderline"."undiscounted_total_price_gross_amount")
                                                      THEN (
                                                          "order_orderline"."undiscounted_unit_price_gross_amount" *
                                                          "order_orderline"."quantity")
                                                  ELSE "order_orderline"."undiscounted_total_price_gross_amount" END,

    "undiscounted_total_price_net_amount"   = CASE
                                                  WHEN NOT (
                                                          ("order_orderline"."undiscounted_unit_price_net_amount" *
                                                           "order_orderline"."quantity") =
                                                          "order_orderline"."undiscounted_total_price_net_amount")
                                                      THEN (
                                                          "order_orderline"."undiscounted_unit_price_net_amount" *
                                                          "order_orderline"."quantity")
                                                  ELSE "order_orderline"."undiscounted_total_price_net_amount" END

WHERE (
              NOT ("order_orderline"."undiscounted_total_price_gross_amount" =
                   ("order_orderline"."undiscounted_unit_price_gross_amount" *
                    "order_orderline"."quantity")) OR
              NOT ("order_orderline"."undiscounted_total_price_net_amount" =
                   ("order_orderline"."undiscounted_unit_price_net_amount" *
                    "order_orderline"."quantity")))
RETURNING "order_orderline"."id";
```
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
