### PR TITLE
Fix error in case of not provided orderSetting

### DIFF
--- a/saleor/graphql/channel/mutations/channel_create.py
+++ b/saleor/graphql/channel/mutations/channel_create.py
@@ -130,6 +130,7 @@ class ChannelCreate(ModelMutation):
                 cleaned_input[
                     "automatically_fulfill_non_shippable_gift_card"
                 ] = automatically_fulfill_non_shippable_gift_card
+
         return cleaned_input
 
     @classmethod

--- a/saleor/graphql/channel/mutations/channel_update.py
+++ b/saleor/graphql/channel/mutations/channel_update.py
@@ -91,12 +91,20 @@ class ChannelUpdate(ModelMutation):
         if stock_settings := cleaned_input.get("stock_settings"):
             cleaned_input["allocation_strategy"] = stock_settings["allocation_strategy"]
         if order_settings := cleaned_input.get("order_settings"):
-            cleaned_input["automatically_confirm_all_new_orders"] = order_settings[
+            automatically_confirm_all_new_orders = order_settings.get(
                 "automatically_confirm_all_new_orders"
-            ]
-            cleaned_input[
+            )
+            if automatically_confirm_all_new_orders is not None:
+                cleaned_input[
+                    "automatically_confirm_all_new_orders"
+                ] = automatically_confirm_all_new_orders
+            automatically_fulfill_non_shippable_gift_card = order_settings.get(
                 "automatically_fulfill_non_shippable_gift_card"
-            ] = order_settings["automatically_fulfill_non_shippable_gift_card"]
+            )
+            if automatically_fulfill_non_shippable_gift_card is not None:
+                cleaned_input[
+                    "automatically_fulfill_non_shippable_gift_card"
+                ] = automatically_fulfill_non_shippable_gift_card
 
         return cleaned_input
 

--- a/saleor/graphql/channel/tests/mutations/test_channel_update.py
+++ b/saleor/graphql/channel/tests/mutations/test_channel_update.py
@@ -752,6 +752,39 @@ def test_channel_update_order_settings_manage_orders(
     )
 
 
+def test_channel_update_order_settings_empty_order_settings(
+    permission_manage_orders,
+    staff_api_client,
+    channel_USD,
+):
+    # given
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+    variables = {
+        "id": channel_id,
+        "input": {
+            "orderSettings": {},
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHANNEL_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_orders,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["channelUpdate"]
+    assert not data["errors"]
+    channel_data = data["channel"]
+    assert channel_data["orderSettings"]["automaticallyConfirmAllNewOrders"] is True
+    assert (
+        channel_data["orderSettings"]["automaticallyFulfillNonShippableGiftCard"]
+        is True
+    )
+
+
 def test_channel_update_order_settings_manage_orders_as_app(
     permission_manage_orders,
     app_api_client,


### PR DESCRIPTION
Fix to PR: https://github.com/saleor/saleor/pull/11417

Impacted mutation: `ChannelUpdate`.
Error cause:  not providing one of `orderSettings` fields

Example:
`
mutation {
  channelUpdate(
    id: "test"
    input: {orderSettings: {automaticallyConfirmAllNewOrders: true}}
  )
}
`

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
