### PR TITLE
Use default db for synchronous tax webhooks

### DIFF
--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -28,7 +28,7 @@ from ...account.types import Address, AddressInput, User
 from ...app.dataloaders import get_app_promise
 from ...channel.utils import clean_channel, validate_channel
 from ...core import ResolveInfo
-from ...core.context import set_mutation_flag_in_context
+from ...core.context import disallow_replica_in_context
 from ...core.descriptions import ADDED_IN_310
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import (
@@ -87,7 +87,7 @@ class SetPassword(CreateToken):
     def mutate(  # type: ignore[override]
         cls, root, info: ResolveInfo, /, *, email, password, token
     ):
-        set_mutation_flag_in_context(info.context)
+        disallow_replica_in_context(info.context)
         manager = get_plugin_manager_promise(info.context).get()
         result = manager.perform_mutation(
             mutation_cls=cls,

--- a/saleor/graphql/context.py
+++ b/saleor/graphql/context.py
@@ -17,7 +17,7 @@ from .core import SaleorContext
 def get_context_value(request: HttpRequest) -> SaleorContext:
     request = cast(SaleorContext, request)
     request.dataloaders = {}
-    request.is_mutation = False
+    request.allow_replica = getattr(request, "allow_replica", True)
     request.request_time = timezone.now()
     set_app_on_context(request)
     set_auth_on_context(request)

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -48,7 +48,7 @@ from ..meta.permissions import PRIVATE_META_PERMISSION_MAP, PUBLIC_META_PERMISSI
 from ..payment.utils import metadata_contains_empty_key
 from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import get_nodes, resolve_global_ids_to_primary_keys
-from .context import set_mutation_flag_in_context, setup_context_user
+from .context import disallow_replica_in_context, setup_context_user
 from .descriptions import DEPRECATED_IN_3X_FIELD
 from .types import (
     TYPES_WITH_DOUBLE_ID_AVAILABLE,
@@ -501,7 +501,7 @@ class BaseMutation(graphene.Mutation):
 
     @classmethod
     def mutate(cls, root, info: ResolveInfo, **data):
-        set_mutation_flag_in_context(info.context)
+        disallow_replica_in_context(info.context)
         setup_context_user(info.context)
 
         if not cls.check_permissions(info.context):
@@ -937,7 +937,7 @@ class BaseBulkMutation(BaseMutation):
 
     @classmethod
     def mutate(cls, root, info: ResolveInfo, **data):
-        set_mutation_flag_in_context(info.context)
+        disallow_replica_in_context(info.context)
         setup_context_user(info.context)
 
         if not cls.check_permissions(info.context):

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -1,4 +1,5 @@
 from functools import partial
+from unittest import mock
 from unittest.mock import Mock
 
 import graphene
@@ -363,3 +364,27 @@ def test_from_global_id_or_error_wth_type(product):
 
     assert product_id == str(product.id)
     assert product_type == expected_product_type
+
+
+@mock.patch("saleor.graphql.order.schema.create_connection_slice")
+def test_query_allow_replica(
+    mocked_resolver, staff_api_client, order, permission_manage_orders
+):
+    # given
+    query = """
+        query {
+          orders(first: 5){
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+    """
+
+    # when
+    staff_api_client.post_graphql(query, permissions=[permission_manage_orders])
+
+    # then
+    assert mocked_resolver.call_args[0][1].context.allow_replica

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -143,7 +143,6 @@ class OrderQueries(graphene.ObjectType):
         validate_one_of_args_is_in_query(
             "id", id, "external_reference", external_reference
         )
-
         if not id:
             id = ext_ref_to_global_id_or_error(models.Order, external_reference)
         _, id = from_global_id_or_error(id, Order)

--- a/saleor/graphql/plugins/dataloaders.py
+++ b/saleor/graphql/plugins/dataloaders.py
@@ -31,14 +31,16 @@ class PluginManagerByRequestorDataloader(DataLoader):
     context_key = "plugin_manager_by_requestor"
 
     def batch_load(self, keys):
-        return [get_plugins_manager(lambda: key) for key in keys]
+        allow_replica = getattr(self.context, "allow_replica", True)
+        return [get_plugins_manager(lambda: key, allow_replica) for key in keys]
 
 
 class AnonymousPluginManagerLoader(DataLoader):
     context_key = "anonymous_plugin_manager"
 
     def batch_load(self, keys):
-        return [get_plugins_manager() for key in keys]
+        allow_replica = getattr(self.context, "allow_replica", True)
+        return [get_plugins_manager(None, allow_replica) for key in keys]
 
 
 def plugin_manager_promise(context: SaleorContext, app) -> Promise[PluginsManager]:

--- a/saleor/graphql/product/mutations/digital_contents.py
+++ b/saleor/graphql/product/mutations/digital_contents.py
@@ -7,7 +7,7 @@ from ....product import models
 from ....product.error_codes import ProductErrorCode
 from ...channel import ChannelContext
 from ...core import ResolveInfo
-from ...core.context import set_mutation_flag_in_context
+from ...core.context import disallow_replica_in_context
 from ...core.descriptions import ADDED_IN_38
 from ...core.mutations import BaseMutation, ModelMutation
 from ...core.types import NonNullList, ProductError, Upload
@@ -166,7 +166,7 @@ class DigitalContentDelete(BaseMutation):
     def mutate(  # type: ignore[override]
         cls, root, info: ResolveInfo, /, *, variant_id: str
     ):
-        set_mutation_flag_in_context(info.context)
+        disallow_replica_in_context(info.context)
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -71,7 +71,9 @@ def check_document_is_single_subscription(document: GraphQLDocument) -> bool:
     return len(subscriptions) == 1
 
 
-def initialize_request(requestor=None, sync_event=False) -> SaleorContext:
+def initialize_request(
+    requestor=None, sync_event=False, allow_replica=True
+) -> SaleorContext:
     """Prepare a request object for webhook subscription.
 
     It creates a dummy request object.
@@ -83,7 +85,6 @@ def initialize_request(requestor=None, sync_event=False) -> SaleorContext:
         return PluginsManager(settings.PLUGINS, requestor_getter)
 
     request_time = timezone.now()
-
     request = SaleorContext()
     request.path = "/graphql/"
     request.path_info = "/graphql/"
@@ -96,6 +97,7 @@ def initialize_request(requestor=None, sync_event=False) -> SaleorContext:
     setattr(request, "sync_event", sync_event)
     request.requestor = requestor
     request.request_time = request_time
+    request.allow_replica = allow_replica
 
     return request
 
@@ -141,7 +143,6 @@ def generate_payload_from_subscription(
         ast,
     )
     app_id = app.pk if app else None
-
     request.app = app
 
     results = document.execute(

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -132,7 +132,8 @@ class BasePlugin:
         active: bool,
         channel: Optional["Channel"] = None,
         requestor_getter: Optional[Callable[[], "Requestor"]] = None,
-        db_config: Optional["PluginConfiguration"] = None
+        db_config: Optional["PluginConfiguration"] = None,
+        allow_replica: bool = True,
     ):
         self.configuration = self.get_plugin_configuration(configuration)
         self.active = active
@@ -141,6 +142,7 @@ class BasePlugin:
             SimpleLazyObject(requestor_getter) if requestor_getter else requestor_getter
         )
         self.db_config = db_config
+        self.allow_replica = allow_replica
 
     def __str__(self):
         return self.PLUGIN_NAME

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -90,6 +90,7 @@ class PluginsManager(PaymentInterface):
         db_configs_map: dict,
         channel: Optional["Channel"] = None,
         requestor_getter=None,
+        allow_replica=True,
     ) -> "BasePlugin":
         db_config = None
         if PluginClass.PLUGIN_ID in db_configs_map:
@@ -107,9 +108,10 @@ class PluginsManager(PaymentInterface):
             channel=channel,
             requestor_getter=requestor_getter,
             db_config=db_config,
+            allow_replica=allow_replica,
         )
 
-    def __init__(self, plugins: List[str], requestor_getter=None):
+    def __init__(self, plugins: List[str], requestor_getter=None, allow_replica=True):
         with opentracing.global_tracer().start_active_span("PluginsManager.__init__"):
             self.all_plugins = []
             self.global_plugins = []
@@ -126,6 +128,7 @@ class PluginsManager(PaymentInterface):
                             PluginClass,
                             global_db_configs,
                             requestor_getter=requestor_getter,
+                            allow_replica=allow_replica,
                         )
                         self.global_plugins.append(plugin)
                         self.all_plugins.append(plugin)
@@ -133,7 +136,11 @@ class PluginsManager(PaymentInterface):
                         for channel in channels:
                             channel_configs = channel_db_configs.get(channel, {})
                             plugin = self._load_plugin(
-                                PluginClass, channel_configs, channel, requestor_getter
+                                PluginClass,
+                                channel_configs,
+                                channel,
+                                requestor_getter,
+                                allow_replica,
                             )
                             self.plugins_per_channel[channel.slug].append(plugin)
                             self.all_plugins.append(plugin)
@@ -1654,7 +1661,8 @@ class PluginsManager(PaymentInterface):
 
 
 def get_plugins_manager(
-    requestor_getter: Optional[Callable[[], "Requestor"]] = None
+    requestor_getter: Optional[Callable[[], "Requestor"]] = None,
+    allow_replica=True,
 ) -> PluginsManager:
     with opentracing.global_tracer().start_active_span("get_plugins_manager"):
-        return PluginsManager(settings.PLUGINS, requestor_getter)
+        return PluginsManager(settings.PLUGINS, requestor_getter, allow_replica)

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1303,7 +1303,6 @@ class WebhookPlugin(BasePlugin):
         transaction_kind: str,
         payment_information: "PaymentData",
         previous_value,
-        **kwargs
     ) -> "GatewayResponse":
         """Trigger payment webhook event.
 
@@ -1479,6 +1478,7 @@ class WebhookPlugin(BasePlugin):
             parse_tax_data,
             checkout_info.checkout,
             self.requestor,
+            self.allow_replica,
         )
 
     def get_taxes_for_order(
@@ -1490,6 +1490,7 @@ class WebhookPlugin(BasePlugin):
             parse_tax_data,
             order,
             self.requestor,
+            self.allow_replica,
         )
 
     def get_shipping_methods_for_checkout(

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -254,6 +254,7 @@ def trigger_all_webhooks_sync(
     parse_response: Callable[[Any], Optional[R]],
     subscribable_object=None,
     requestor=None,
+    allow_replica=True,
 ) -> Optional[R]:
     """Send all synchronous webhook request for given event type.
 
@@ -270,8 +271,9 @@ def trigger_all_webhooks_sync(
         if webhook.subscription_query:
             if request_context is None:
                 request_context = initialize_request(
-                    requestor, event_type in WebhookEventSyncType.ALL
+                    requestor, event_type in WebhookEventSyncType.ALL, allow_replica
                 )
+
             delivery = create_delivery_for_subscription_sync_event(
                 event_type=event_type,
                 subscribable_object=subscribable_object,

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -924,3 +924,13 @@ def subscription_order_filter_shipping_methods_webhook_with_available_ship_metho
         queries.ORDER_FILTER_SHIPPING_METHODS_AVAILABLE_SHIPPING_METHODS,
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
     )
+
+
+@pytest.fixture
+def subscription_calculate_taxes_for_order(
+    subscription_webhook,
+):
+    return subscription_webhook(
+        queries.ORDER_CALCULATE_TAXES,
+        WebhookEventSyncType.ORDER_CALCULATE_TAXES,
+    )

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -2074,3 +2074,24 @@ QUERY_WITH_MULTIPLE_FRAGMENTS = (
     }
     """
 )
+
+
+ORDER_CALCULATE_TAXES = """
+    subscription {
+      event {
+        ... on CalculateTaxes {
+          taxBase {
+            sourceObject {
+              ...on Order{
+                discounts {
+                  amount {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+"""

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
@@ -1,8 +1,16 @@
 import dataclasses
 import json
+from decimal import Decimal
 from unittest import mock
 
+import graphene
+
 from .....core.models import EventDelivery
+from .....graphql.discount.enums import DiscountValueTypeEnum
+from .....graphql.order.tests.mutations.test_order_discount import ORDER_DISCOUNT_ADD
+from .....graphql.product.tests.mutations.test_product_create import (
+    CREATE_PRODUCT_MUTATION,
+)
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .....webhook.models import Webhook
 from ...tasks import trigger_webhook_sync, trigger_webhooks_async
@@ -71,3 +79,80 @@ def test_trigger_webhook_sync_with_subscription(
     # then
     assert json.loads(event_delivery.payload.payload) == expected_payment_payload
     mock_request.assert_called_once_with(payment_app.name, event_delivery)
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+@mock.patch("saleor.plugins.webhook.tasks.get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.tasks.generate_payload_from_subscription")
+def test_trigger_webhook_sync_with_subscription_within_mutation_use_default_db(
+    mocked_generate_payload,
+    mocked_get_webhooks_for_event,
+    mocked_request,
+    draft_order,
+    app_api_client,
+    permission_manage_orders,
+    settings,
+    subscription_calculate_taxes_for_order,
+):
+    # given
+    webhook = subscription_calculate_taxes_for_order
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    mocked_get_webhooks_for_event.return_value = [webhook]
+    variables = {
+        "orderId": graphene.Node.to_global_id("Order", draft_order.pk),
+        "input": {
+            "valueType": DiscountValueTypeEnum.PERCENTAGE.name,
+            "value": Decimal("50"),
+        },
+    }
+    app_api_client.app.permissions.add(permission_manage_orders)
+
+    # when
+    app_api_client.post_graphql(ORDER_DISCOUNT_ADD, variables)
+
+    # then
+    mocked_generate_payload.assert_called_once()
+    assert not mocked_generate_payload.call_args[1]["request"].allow_replica
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_async")
+@mock.patch("saleor.plugins.webhook.tasks.get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.tasks.generate_payload_from_subscription")
+def test_trigger_webhook_async_with_subscription_use_replica_db(
+    mocked_generate_payload,
+    mocked_get_webhooks_for_event,
+    mocked_request,
+    staff_api_client,
+    product_type,
+    category,
+    permission_manage_products,
+    subscription_product_created_webhook,
+    settings,
+):
+    # given
+    webhook = subscription_product_created_webhook
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    mocked_get_webhooks_for_event.return_value = [webhook]
+
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    category_id = graphene.Node.to_global_id("Category", category.pk)
+    product_name = "test name"
+    product_slug = "product-test-slug"
+
+    variables = {
+        "input": {
+            "productType": product_type_id,
+            "category": category_id,
+            "name": product_name,
+            "slug": product_slug,
+        }
+    }
+
+    # when
+    staff_api_client.post_graphql(
+        CREATE_PRODUCT_MUTATION, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    mocked_generate_payload.assert_called_once()
+    assert mocked_generate_payload.call_args[1]["request"].allow_replica


### PR DESCRIPTION
https://github.com/saleor/saleor/issues/11906
I want to merge this change because when tax webhooks are triggered during mutation, subscription payload is generated based on replica db, so changes done by the mutation are not visible in the payload.

This is port to: https://github.com/saleor/saleor/pull/11920

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
