### PR TITLE
Use default db for synchronous tax webhooks

### DIFF
--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -24,7 +24,7 @@ from ...account.i18n import I18nMixin
 from ...account.types import Address, AddressInput, User
 from ...app.dataloaders import get_app_promise
 from ...channel.utils import clean_channel, validate_channel
-from ...core.context import set_mutation_flag_in_context
+from ...core.context import disallow_replica_in_context
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import (
     BaseMutation,
@@ -80,7 +80,7 @@ class SetPassword(CreateToken):
 
     @classmethod
     def mutate(cls, root, info, **data):
-        set_mutation_flag_in_context(info.context)
+        disallow_replica_in_context(info.context)
         manager = get_plugin_manager_promise(info.context).get()
         result = manager.perform_mutation(
             mutation_cls=cls, root=root, info=info, data=data

--- a/saleor/graphql/context.py
+++ b/saleor/graphql/context.py
@@ -16,7 +16,7 @@ from .core import SaleorContext
 def get_context_value(request: HttpRequest) -> SaleorContext:
     request = cast(SaleorContext, request)
     request.dataloaders = {}
-    request.is_mutation = False
+    request.allow_replica = getattr(request, "allow_replica", True)
     set_app_on_context(request)
     set_auth_on_context(request)
     set_decoded_auth_token(request)

--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -47,7 +47,7 @@ def get_database_connection_name(context: SaleorContext) -> str:
     Queryset to main database: `User.objects.all()`.
     Queryset to read replica: `User.objects.using(connection_name).all()`.
     """
-    allow_replica = getattr(context, "allow_replica", False)
+    allow_replica = getattr(context, "allow_replica", True)
     if allow_replica:
         return settings.DATABASE_CONNECTION_REPLICA_NAME
     return settings.DATABASE_CONNECTION_DEFAULT_NAME

--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -17,25 +17,24 @@ UserType = Optional[User]
 class SaleorContext(HttpRequest):
     _cached_user: UserType
     decoded_auth_token: Optional[Dict[str, Any]]
-    is_mutation: bool
+    allow_replica: bool = True
     dataloaders: Dict[str, "DataLoader"]
     app: Optional["App"]
     user: UserType  # type: ignore
 
 
-def set_mutation_flag_in_context(context: SaleorContext) -> None:
-    """Set information in context to don't use database replicas.
+def disallow_replica_in_context(context: SaleorContext) -> None:
+    """Set information in context to use database replicas or not.
 
     Part of the database read replicas in Saleor.
     When Saleor builds a response for mutation `context` stores information
-    `is_mutation=True`. That means that all data should be provided from
+    `allow_replica=False`. That means that all data should be provided from
     the master database.
-    When Saleor build a response for query `context` doesn't have the
-    `is_mutation` field.
+    When Saleor builds a response for query, set `allow_replica`=True in `context`.
     That means that all data should be provided from reading replica of the database.
     Database read replica couldn't be used to save any data.
     """
-    context.is_mutation = True
+    context.allow_replica = False
 
 
 def get_database_connection_name(context: SaleorContext) -> str:
@@ -43,13 +42,13 @@ def get_database_connection_name(context: SaleorContext) -> str:
 
     Part of the database read replicas in Saleor.
     Return proper connection name based on `context`.
-    For more info check `set_mutation_flag_in_context`
+    For more info check `disallow_replica_in_context`
     Add `.using(connection_name)` to use connection name in QuerySet.
     Queryset to main database: `User.objects.all()`.
     Queryset to read replica: `User.objects.using(connection_name).all()`.
     """
-    is_mutation = getattr(context, "is_mutation", False)
-    if not is_mutation:
+    allow_replica = getattr(context, "allow_replica", False)
+    if allow_replica:
         return settings.DATABASE_CONNECTION_REPLICA_NAME
     return settings.DATABASE_CONNECTION_DEFAULT_NAME
 

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -30,7 +30,7 @@ from ..meta.permissions import PRIVATE_META_PERMISSION_MAP, PUBLIC_META_PERMISSI
 from ..payment.utils import metadata_contains_empty_key
 from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import get_nodes, resolve_global_ids_to_primary_keys
-from .context import set_mutation_flag_in_context, setup_context_user
+from .context import disallow_replica_in_context, setup_context_user
 from .descriptions import DEPRECATED_IN_3X_FIELD
 from .types import (
     TYPES_WITH_DOUBLE_ID_AVAILABLE,
@@ -376,7 +376,7 @@ class BaseMutation(graphene.Mutation):
 
     @classmethod
     def mutate(cls, root, info, **data):
-        set_mutation_flag_in_context(info.context)
+        disallow_replica_in_context(info.context)
         setup_context_user(info.context)
 
         if not cls.check_permissions(info.context):
@@ -776,7 +776,7 @@ class BaseBulkMutation(BaseMutation):
 
     @classmethod
     def mutate(cls, root, info, **data):
-        set_mutation_flag_in_context(info.context)
+        disallow_replica_in_context(info.context)
         setup_context_user(info.context)
 
         if not cls.check_permissions(info.context):

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -1,4 +1,5 @@
 from functools import partial
+from unittest import mock
 from unittest.mock import Mock
 
 import graphene
@@ -363,3 +364,27 @@ def test_from_global_id_or_error_wth_type(product):
 
     assert product_id == str(product.id)
     assert product_type == expected_product_type
+
+
+@mock.patch("saleor.graphql.order.schema.create_connection_slice")
+def test_query_allow_replica(
+    mocked_resolver, staff_api_client, order, permission_manage_orders
+):
+    # given
+    query = """
+        query {
+          orders(first: 5){
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+    """
+
+    # when
+    staff_api_client.post_graphql(query, permissions=[permission_manage_orders])
+
+    # then
+    assert mocked_resolver.call_args[0][1].context.allow_replica

--- a/saleor/graphql/plugins/dataloaders.py
+++ b/saleor/graphql/plugins/dataloaders.py
@@ -28,14 +28,16 @@ class PluginManagerByRequestorDataloader(DataLoader):
     context_key = "plugin_manager_by_requestor"
 
     def batch_load(self, keys):
-        return [get_plugins_manager(lambda: key) for key in keys]
+        allow_replica = getattr(self.context, "allow_replica", True)
+        return [get_plugins_manager(lambda: key, allow_replica) for key in keys]
 
 
 class AnonymousPluginManagerLoader(DataLoader):
     context_key = "anonymous_plugin_manager"
 
     def batch_load(self, keys):
-        return [get_plugins_manager() for key in keys]
+        allow_replica = getattr(self.context, "allow_replica", True)
+        return [get_plugins_manager(None, allow_replica) for key in keys]
 
 
 def plugin_manager_promise(request, app):

--- a/saleor/graphql/product/mutations/digital_contents.py
+++ b/saleor/graphql/product/mutations/digital_contents.py
@@ -6,7 +6,7 @@ from ....core.permissions import ProductPermissions
 from ....product import models
 from ....product.error_codes import ProductErrorCode
 from ...channel import ChannelContext
-from ...core.context import set_mutation_flag_in_context
+from ...core.context import disallow_replica_in_context
 from ...core.descriptions import ADDED_IN_38
 from ...core.mutations import BaseMutation, ModelMutation
 from ...core.types import NonNullList, ProductError, Upload
@@ -161,7 +161,7 @@ class DigitalContentDelete(BaseMutation):
 
     @classmethod
     def mutate(cls, root, info, **data):
-        set_mutation_flag_in_context(info.context)
+        disallow_replica_in_context(info.context)
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -71,7 +71,9 @@ def check_document_is_single_subscription(document: GraphQLDocument) -> bool:
     return len(subscriptions) == 1
 
 
-def initialize_request(requestor=None, sync_event=False) -> HttpRequest:
+def initialize_request(
+    requestor=None, sync_event=False, allow_replica=True
+) -> HttpRequest:
     """Prepare a request object for webhook subscription.
 
     It creates a dummy request object.
@@ -96,6 +98,7 @@ def initialize_request(requestor=None, sync_event=False) -> HttpRequest:
     request.sync_event = sync_event  # type: ignore
     request.requestor = requestor  # type: ignore
     request.request_time = request_time  # type: ignore
+    request.allow_replica = allow_replica  # type: ignore
 
     return request
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -131,7 +131,8 @@ class BasePlugin:
         active: bool,
         channel: Optional["Channel"] = None,
         requestor_getter: Optional[Callable[[], "Requestor"]] = None,
-        db_config: Optional["PluginConfiguration"] = None
+        db_config: Optional["PluginConfiguration"] = None,
+        allow_replica: bool = True,
     ):
         self.configuration = self.get_plugin_configuration(configuration)
         self.active = active
@@ -140,6 +141,7 @@ class BasePlugin:
             SimpleLazyObject(requestor_getter) if requestor_getter else requestor_getter
         )
         self.db_config = db_config
+        self.allow_replica = allow_replica
 
     def __str__(self):
         return self.PLUGIN_NAME

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -89,6 +89,7 @@ class PluginsManager(PaymentInterface):
         db_configs_map: dict,
         channel: Optional["Channel"] = None,
         requestor_getter=None,
+        allow_replica=True,
     ) -> "BasePlugin":
         db_config = None
         if PluginClass.PLUGIN_ID in db_configs_map:
@@ -106,9 +107,10 @@ class PluginsManager(PaymentInterface):
             channel=channel,
             requestor_getter=requestor_getter,
             db_config=db_config,
+            allow_replica=allow_replica,
         )
 
-    def __init__(self, plugins: List[str], requestor_getter=None):
+    def __init__(self, plugins: List[str], requestor_getter=None, allow_replica=True):
         with opentracing.global_tracer().start_active_span("PluginsManager.__init__"):
             self.all_plugins = []
             self.global_plugins = []
@@ -125,6 +127,7 @@ class PluginsManager(PaymentInterface):
                             PluginClass,
                             global_db_configs,
                             requestor_getter=requestor_getter,
+                            allow_replica=allow_replica,
                         )
                         self.global_plugins.append(plugin)
                         self.all_plugins.append(plugin)
@@ -132,7 +135,11 @@ class PluginsManager(PaymentInterface):
                         for channel in channels:
                             channel_configs = channel_db_configs.get(channel, {})
                             plugin = self._load_plugin(
-                                PluginClass, channel_configs, channel, requestor_getter
+                                PluginClass,
+                                channel_configs,
+                                channel,
+                                requestor_getter,
+                                allow_replica,
                             )
                             self.plugins_per_channel[channel.slug].append(plugin)
                             self.all_plugins.append(plugin)
@@ -1643,7 +1650,8 @@ class PluginsManager(PaymentInterface):
 
 
 def get_plugins_manager(
-    requestor_getter: Optional[Callable[[], "Requestor"]] = None
+    requestor_getter: Optional[Callable[[], "Requestor"]] = None,
+    allow_replica=True,
 ) -> PluginsManager:
     with opentracing.global_tracer().start_active_span("get_plugins_manager"):
-        return PluginsManager(settings.PLUGINS, requestor_getter)
+        return PluginsManager(settings.PLUGINS, requestor_getter, allow_replica)

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1291,6 +1291,7 @@ class WebhookPlugin(BasePlugin):
         transaction_kind: str,
         payment_information: "PaymentData",
         previous_value,
+        **kwargs,
     ) -> "GatewayResponse":
         """Trigger payment webhook event.
 

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1291,7 +1291,6 @@ class WebhookPlugin(BasePlugin):
         transaction_kind: str,
         payment_information: "PaymentData",
         previous_value,
-        **kwargs
     ) -> "GatewayResponse":
         """Trigger payment webhook event.
 
@@ -1467,6 +1466,7 @@ class WebhookPlugin(BasePlugin):
             parse_tax_data,
             checkout_info.checkout,
             self.requestor,
+            self.allow_replica,
         )
 
     def get_taxes_for_order(
@@ -1478,6 +1478,7 @@ class WebhookPlugin(BasePlugin):
             parse_tax_data,
             order,
             self.requestor,
+            self.allow_replica,
         )
 
     def get_shipping_methods_for_checkout(

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -253,6 +253,7 @@ def trigger_all_webhooks_sync(
     parse_response: Callable[[Any], Optional[R]],
     subscribable_object=None,
     requestor=None,
+    allow_replica=True,
 ) -> Optional[R]:
     """Send all synchronous webhook request for given event type.
 
@@ -269,8 +270,9 @@ def trigger_all_webhooks_sync(
         if webhook.subscription_query:
             if request_context is None:
                 request_context = initialize_request(
-                    requestor, event_type in WebhookEventSyncType.ALL
+                    requestor, event_type in WebhookEventSyncType.ALL, allow_replica
                 )
+
             delivery = create_delivery_for_subscription_sync_event(
                 event_type=event_type,
                 subscribable_object=subscribable_object,

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -916,3 +916,13 @@ def subscription_order_filter_shipping_methods_webhook_with_available_ship_metho
         queries.ORDER_FILTER_SHIPPING_METHODS_AVAILABLE_SHIPPING_METHODS,
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
     )
+
+
+@pytest.fixture
+def subscription_calculate_taxes_for_order(
+    subscription_webhook,
+):
+    return subscription_webhook(
+        queries.ORDER_CALCULATE_TAXES,
+        WebhookEventSyncType.ORDER_CALCULATE_TAXES,
+    )

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -2047,3 +2047,24 @@ QUERY_WITH_MULTIPLE_FRAGMENTS = (
     }
     """
 )
+
+
+ORDER_CALCULATE_TAXES = """
+    subscription {
+      event {
+        ... on CalculateTaxes {
+          taxBase {
+            sourceObject {
+              ...on Order{
+                discounts {
+                  amount {
+                    amount
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+"""

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
@@ -1,8 +1,16 @@
 import dataclasses
 import json
+from decimal import Decimal
 from unittest import mock
 
+import graphene
+
 from .....core.models import EventDelivery
+from .....graphql.discount.enums import DiscountValueTypeEnum
+from .....graphql.order.tests.mutations.test_order_discount import ORDER_DISCOUNT_ADD
+from .....graphql.product.tests.mutations.test_product_create import (
+    CREATE_PRODUCT_MUTATION,
+)
 from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .....webhook.models import Webhook
 from ...tasks import trigger_webhook_sync, trigger_webhooks_async
@@ -51,3 +59,80 @@ def test_trigger_webhook_sync_with_subscription(
     # then
     assert json.loads(event_delivery.payload.payload) == expected_payment_payload
     mock_request.assert_called_once_with(payment_app.name, event_delivery)
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+@mock.patch("saleor.plugins.webhook.tasks.get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.tasks.generate_payload_from_subscription")
+def test_trigger_webhook_sync_with_subscription_within_mutation_use_default_db(
+    mocked_generate_payload,
+    mocked_get_webhooks_for_event,
+    mocked_request,
+    draft_order,
+    app_api_client,
+    permission_manage_orders,
+    settings,
+    subscription_calculate_taxes_for_order,
+):
+    # given
+    webhook = subscription_calculate_taxes_for_order
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    mocked_get_webhooks_for_event.return_value = [webhook]
+    variables = {
+        "orderId": graphene.Node.to_global_id("Order", draft_order.pk),
+        "input": {
+            "valueType": DiscountValueTypeEnum.PERCENTAGE.name,
+            "value": Decimal("50"),
+        },
+    }
+    app_api_client.app.permissions.add(permission_manage_orders)
+
+    # when
+    app_api_client.post_graphql(ORDER_DISCOUNT_ADD, variables)
+
+    # then
+    mocked_generate_payload.assert_called_once()
+    assert not mocked_generate_payload.call_args[1]["request"].allow_replica
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_async")
+@mock.patch("saleor.plugins.webhook.tasks.get_webhooks_for_event")
+@mock.patch("saleor.plugins.webhook.tasks.generate_payload_from_subscription")
+def test_trigger_webhook_async_with_subscription_use_replica_db(
+    mocked_generate_payload,
+    mocked_get_webhooks_for_event,
+    mocked_request,
+    staff_api_client,
+    product_type,
+    category,
+    permission_manage_products,
+    subscription_product_created_webhook,
+    settings,
+):
+    # given
+    webhook = subscription_product_created_webhook
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    mocked_get_webhooks_for_event.return_value = [webhook]
+
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    category_id = graphene.Node.to_global_id("Category", category.pk)
+    product_name = "test name"
+    product_slug = "product-test-slug"
+
+    variables = {
+        "input": {
+            "productType": product_type_id,
+            "category": category_id,
+            "name": product_name,
+            "slug": product_slug,
+        }
+    }
+
+    # when
+    staff_api_client.post_graphql(
+        CREATE_PRODUCT_MUTATION, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    mocked_generate_payload.assert_called_once()
+    assert mocked_generate_payload.call_args[1]["request"].allow_replica


### PR DESCRIPTION
https://github.com/saleor/saleor/issues/11906
I want to merge this change because when tax webhooks are triggered during mutation, subscription payload is generated based on replica db, so changes done by the mutation are not visible in the payload.

This is port to: https://github.com/saleor/saleor/pull/11920

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
