### PR TITLE
Remove __str__ methods returning data

### DIFF
--- a/saleor/account/models.py
+++ b/saleor/account/models.py
@@ -93,15 +93,6 @@ class Address(ModelWithMetadata):
             ),
         ]
 
-    @property
-    def full_name(self):
-        return f"{self.first_name} {self.last_name}"
-
-    def __str__(self):
-        if self.company_name:
-            return f"{self.company_name} - {self.full_name}"
-        return self.full_name
-
     def __eq__(self, other):
         if not isinstance(other, Address):
             return False
@@ -231,6 +222,11 @@ class User(
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._effective_permissions = None
+
+    def __str__(self):
+        # Override the default __str__ of AbstractUser that returns username, which may
+        # lead to leaking sensitive data in logs.
+        return str(self.uuid)
 
     @property
     def effective_permissions(self) -> models.QuerySet[Permission]:

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -44,21 +44,10 @@ def _save_instance(instance, metadata_field: str):
 
     try:
         instance.save(update_fields=fields)
-    except DatabaseError as e:
-        msg = (
-            "Cannot update metadata for instance: %(instance)s. "
-            "Updating not existing object. Details: %(details)s."
-        )
-        params = {
-            "instance": str(instance),
-            "details": str(e),
-        }
+    except DatabaseError:
+        msg = "Cannot update metadata for instance. Updating not existing object."
         raise ValidationError(
-            {
-                "metadata": ValidationError(
-                    msg, code=MetadataErrorCode.NOT_FOUND.value, params=params
-                )
-            }
+            {"metadata": ValidationError(msg, code=MetadataErrorCode.NOT_FOUND.value)}
         )
 
 

--- a/saleor/site/models.py
+++ b/saleor/site/models.py
@@ -105,9 +105,6 @@ class SiteSettings(models.Model):
             (SitePermissions.MANAGE_TRANSLATIONS.codename, "Manage translations."),
         )
 
-    def __str__(self):
-        return self.site.name
-
     @property
     def default_from_email(self) -> str:
         sender_name: str = self.default_mail_sender_name
@@ -147,9 +144,6 @@ class SiteSettingsTranslation(Translation):
             self.pk,
             self.site_settings_id,
         )
-
-    def __str__(self):
-        return self.site_settings.site.name
 
     def get_translated_object_id(self):
         return "Shop", self.site_settings_id

--- a/saleor/site/tests/test_site_settings.py
+++ b/saleor/site/tests/test_site_settings.py
@@ -8,4 +8,3 @@ def test_new_get_current():
     assert result.name == "mirumee.com"
     assert result.domain == "mirumee.com"
     assert type(result.settings) == SiteSettings
-    assert str(result.settings) == "mirumee.com"


### PR DESCRIPTION
This PR improves a bunch of `__str__` functions:
- Remove custom `__str__` method for Address model, so that the string representation doesn't include personal data.
- Override the `__str__` for User model to return UUID instead of user's email
- Remove some `__str__` methods that were using DB relations
- Remove error message that could potentially serialize the model instance along and return it in API response, along with the database error details.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
