### PR TITLE
Fix migrations failing when missing site settings

### DIFF
--- a/saleor/channel/migrations/0007_order_settings_per_channel.py
+++ b/saleor/channel/migrations/0007_order_settings_per_channel.py
@@ -7,20 +7,19 @@ def set_order_settings(apps, schema_editor):
 
     site_settings = SiteSettings.objects.first()
 
+    automatically_confirm_all_new_orders = True
+    automatically_fulfill_non_shippable_gift_card = True
     if site_settings:
-        Channel.objects.update(
-            automatically_confirm_all_new_orders=(
-                site_settings.automatically_confirm_all_new_orders
-            ),
-            automatically_fulfill_non_shippable_gift_card=(
-                site_settings.automatically_fulfill_non_shippable_gift_card
-            ),
+        automatically_confirm_all_new_orders = (
+            site_settings.automatically_confirm_all_new_orders
         )
-    else:
-        Channel.objects.update(
-            automatically_confirm_all_new_orders=True,
-            automatically_fulfill_non_shippable_gift_card=True,
+        automatically_fulfill_non_shippable_gift_card = (
+            site_settings.automatically_fulfill_non_shippable_gift_card
         )
+    Channel.objects.update(
+        automatically_confirm_all_new_orders=automatically_confirm_all_new_orders,
+        automatically_fulfill_non_shippable_gift_card=automatically_fulfill_non_shippable_gift_card,
+    )
 
 
 class Migration(migrations.Migration):

--- a/saleor/channel/migrations/0007_order_settings_per_channel.py
+++ b/saleor/channel/migrations/0007_order_settings_per_channel.py
@@ -7,14 +7,20 @@ def set_order_settings(apps, schema_editor):
 
     site_settings = SiteSettings.objects.first()
 
-    Channel.objects.update(
-        automatically_confirm_all_new_orders=(
-            site_settings.automatically_confirm_all_new_orders
-        ),
-        automatically_fulfill_non_shippable_gift_card=(
-            site_settings.automatically_fulfill_non_shippable_gift_card
-        ),
-    )
+    if site_settings:
+        Channel.objects.update(
+            automatically_confirm_all_new_orders=(
+                site_settings.automatically_confirm_all_new_orders
+            ),
+            automatically_fulfill_non_shippable_gift_card=(
+                site_settings.automatically_fulfill_non_shippable_gift_card
+            ),
+        )
+    else:
+        Channel.objects.update(
+            automatically_confirm_all_new_orders=True,
+            automatically_fulfill_non_shippable_gift_card=True,
+        )
 
 
 class Migration(migrations.Migration):

--- a/saleor/channel/migrations/0008_update_null_order_settings.py
+++ b/saleor/channel/migrations/0008_update_null_order_settings.py
@@ -13,25 +13,22 @@ def set_order_settings(apps, schema_editor):
 
     site_settings = SiteSettings.objects.first()
 
-    qs = Channel.objects.filter(
+    automatically_confirm_all_new_orders = True
+    automatically_fulfill_non_shippable_gift_card = True
+    if site_settings:
+        automatically_confirm_all_new_orders = (
+            site_settings.automatically_confirm_all_new_orders
+        )
+        automatically_fulfill_non_shippable_gift_card = (
+            site_settings.automatically_fulfill_non_shippable_gift_card
+        )
+    Channel.objects.filter(
         Q(automatically_confirm_all_new_orders__isnull=True)
         | Q(automatically_fulfill_non_shippable_gift_card__isnull=True)
+    ).update(
+        automatically_confirm_all_new_orders=automatically_confirm_all_new_orders,
+        automatically_fulfill_non_shippable_gift_card=automatically_fulfill_non_shippable_gift_card,
     )
-
-    if site_settings:
-        qs.update(
-            automatically_confirm_all_new_orders=(
-                site_settings.automatically_confirm_all_new_orders
-            ),
-            automatically_fulfill_non_shippable_gift_card=(
-                site_settings.automatically_fulfill_non_shippable_gift_card
-            ),
-        )
-    else:
-        qs.update(
-            automatically_confirm_all_new_orders=True,
-            automatically_fulfill_non_shippable_gift_card=True,
-        )
 
 
 class Migration(migrations.Migration):

--- a/saleor/channel/migrations/0008_update_null_order_settings.py
+++ b/saleor/channel/migrations/0008_update_null_order_settings.py
@@ -13,17 +13,25 @@ def set_order_settings(apps, schema_editor):
 
     site_settings = SiteSettings.objects.first()
 
-    Channel.objects.filter(
+    qs = Channel.objects.filter(
         Q(automatically_confirm_all_new_orders__isnull=True)
         | Q(automatically_fulfill_non_shippable_gift_card__isnull=True)
-    ).update(
-        automatically_confirm_all_new_orders=(
-            site_settings.automatically_confirm_all_new_orders
-        ),
-        automatically_fulfill_non_shippable_gift_card=(
-            site_settings.automatically_fulfill_non_shippable_gift_card
-        ),
     )
+
+    if site_settings:
+        qs.update(
+            automatically_confirm_all_new_orders=(
+                site_settings.automatically_confirm_all_new_orders
+            ),
+            automatically_fulfill_non_shippable_gift_card=(
+                site_settings.automatically_fulfill_non_shippable_gift_card
+            ),
+        )
+    else:
+        qs.update(
+            automatically_confirm_all_new_orders=True,
+            automatically_fulfill_non_shippable_gift_card=True,
+        )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
I want to merge this change because...
When running tests with `--reuse-db` there is no guarantee that `SiteSetting` object will exists in db.
This pr fixes it.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
