### PR TITLE
Default to serving 4K images instead of originals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable, unreleased changes to this project will be documented in this file.
        }
     ```
 
-
+- Media and image fields now default to returning 4K thumbnails instead of original uploads - #11996 by @patrys
 
 ### GraphQL API
 - Add possibility  to remove `stocks` and `channel listings` in `ProductVariantBulkUpdate` mutation.

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -900,7 +900,7 @@ def test_query_user_avatar_with_size_thumbnail_url_returned(
     )
 
 
-def test_query_user_avatar_only_format_provided_original_image_returned(
+def test_query_user_avatar_original_size_custom_format_provided_original_image_returned(
     staff_api_client, media_root, permission_manage_staff, site_settings
 ):
     # given
@@ -913,7 +913,7 @@ def test_query_user_avatar_only_format_provided_original_image_returned(
     format = ThumbnailFormatEnum.WEBP.name
 
     id = graphene.Node.to_global_id("User", user.pk)
-    variables = {"id": id, "format": format}
+    variables = {"id": id, "format": format, "size": 0}
 
     # when
     response = staff_api_client.post_graphql(
@@ -942,6 +942,8 @@ def test_query_user_avatar_no_size_value(
     id = graphene.Node.to_global_id("User", user.pk)
     variables = {"id": id}
 
+    user_uuid = graphene.Node.to_global_id("User", user.uuid)
+
     # when
     response = staff_api_client.post_graphql(
         USER_AVATAR_QUERY, variables, permissions=[permission_manage_staff]
@@ -952,7 +954,7 @@ def test_query_user_avatar_no_size_value(
     data = content["data"]["user"]
     assert (
         data["avatar"]["url"]
-        == f"http://{site_settings.site.domain}/media/user-avatars/{avatar_mock.name}"
+        == f"http://{site_settings.site.domain}/thumbnail/{user_uuid}/4096/"
     )
 
 
@@ -5897,7 +5899,7 @@ USER_AVATAR_UPDATE_MUTATION = """
     mutation userAvatarUpdate($image: Upload!) {
         userAvatarUpdate(image: $image) {
             user {
-                avatar {
+                avatar(size: 0) {
                     url
                 }
             }

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -488,7 +488,7 @@ class User(ModelObjectType[models.User]):
         if not root.avatar:
             return
 
-        if not size:
+        if size == 0:
             return Image(url=root.avatar.url, alt=None)
 
         format = get_thumbnail_format(format)

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -570,16 +570,16 @@ class TimePeriod(graphene.ObjectType):
 class ThumbnailField(graphene.Field):
     size = graphene.Int(
         description=(
-            "Size of the image. If not provided, the original image "
-            "will be returned."
-        )
+            "Desired longest side the image in pixels. Defaults to 4096. "
+            "Images are never cropped. "
+            "Pass 0 to retrieve the original size (not recommended)."
+        ),
     )
     format = ThumbnailFormatEnum(
         default_value="ORIGINAL",
         description=(
             "The format of the image. When not provided, format of the original "
-            "image will be used. Must be provided together with the size value, "
-            "otherwise original image will be returned." + ADDED_IN_36 + PREVIEW_FEATURE
+            "image will be used." + ADDED_IN_36 + PREVIEW_FEATURE
         ),
     )
 

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -771,7 +771,7 @@ def test_products_media_for_federation_query_count(
           __typename
           ... on ProductMedia {
             id
-            url
+            url(size: 0)
           }
         }
       }

--- a/saleor/graphql/product/tests/mutations/test_product_media_delete.py
+++ b/saleor/graphql/product/tests/mutations/test_product_media_delete.py
@@ -24,7 +24,7 @@ def test_product_media_delete(
                 productMediaDelete(id: $id) {
                     media {
                         id
-                        url
+                        url(size: 0)
                     }
                 }
             }

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -1854,7 +1854,7 @@ def test_query_product_media_by_id_with_size_thumbnail_url_returned(
     )
 
 
-def test_query_product_media_by_id_only_format_provided_original_image_returned(
+def test_query_product_media_by_id_zero_size_custom_format_provided(
     user_api_client, product_with_image, channel_USD, site_settings
 ):
     query = QUERY_PRODUCT_MEDIA_BY_ID
@@ -1868,6 +1868,7 @@ def test_query_product_media_by_id_only_format_provided_original_image_returned(
         "mediaId": media_id,
         "channel": channel_USD.slug,
         "format": format,
+        "size": 0,
     }
 
     response = user_api_client.post_graphql(query, variables)
@@ -1934,7 +1935,7 @@ def test_query_product_media_by_id_avif_format(
     )
 
 
-def test_query_product_media_by_id_no_size_value_original_image_returned(
+def test_query_product_media_by_id_zero_size_value_original_image_returned(
     user_api_client, product_with_image, channel_USD, site_settings
 ):
     query = QUERY_PRODUCT_MEDIA_BY_ID
@@ -1946,6 +1947,7 @@ def test_query_product_media_by_id_no_size_value_original_image_returned(
         "productId": graphene.Node.to_global_id("Product", product_with_image.pk),
         "mediaId": media_id,
         "channel": channel_USD.slug,
+        "size": 0,
     }
 
     response = user_api_client.post_graphql(query, variables)
@@ -2011,7 +2013,7 @@ def test_query_product_media_for_federation(
           __typename
           ... on ProductMedia {
             id
-            url
+            url(size: 0)
           }
         }
       }

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -613,7 +613,7 @@ MUTATION_CATEGORY_UPDATE_MUTATION = """
                 parent {
                     id
                 }
-                backgroundImage{
+                backgroundImage(size: 0) {
                     alt
                     url
                 }
@@ -1479,7 +1479,7 @@ def test_category_image_query_with_size_thumbnail_url_returned(
     )
 
 
-def test_category_image_query_only_format_provided_original_image_returned(
+def test_category_image_query_zero_size_custom_format_provided_original_image_returned(
     user_api_client, non_default_category, media_root, site_settings
 ):
     # given
@@ -1497,6 +1497,7 @@ def test_category_image_query_only_format_provided_original_image_returned(
     variables = {
         "id": category_id,
         "format": format,
+        "size": 0,
     }
 
     # when
@@ -1512,7 +1513,7 @@ def test_category_image_query_only_format_provided_original_image_returned(
     assert data["backgroundImage"]["url"] == expected_url
 
 
-def test_category_image_query_no_size_value_original_image_returned(
+def test_category_image_query_zero_size_value_original_image_returned(
     user_api_client, non_default_category, media_root, site_settings
 ):
     # given
@@ -1527,6 +1528,7 @@ def test_category_image_query_no_size_value_original_image_returned(
     category_id = graphene.Node.to_global_id("Category", category.pk)
     variables = {
         "id": category_id,
+        "size": 0,
     }
 
     # when

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -718,7 +718,7 @@ MUTATION_UPDATE_COLLECTION_WITH_BACKGROUND_IMAGE = """
         ) {
             collection {
                 slug
-                backgroundImage{
+                backgroundImage(size: 0) {
                     alt
                     url
                 }
@@ -1459,7 +1459,7 @@ def test_collection_image_query_with_size_thumbnail_url_returned(
     )
 
 
-def test_collection_image_query_only_format_provided_original_image_returned(
+def test_collection_image_query_zero_size_custom_format_provided(
     user_api_client, published_collection, media_root, channel_USD, site_settings
 ):
     # given
@@ -1478,6 +1478,7 @@ def test_collection_image_query_only_format_provided_original_image_returned(
         "id": collection_id,
         "channel": channel_USD.slug,
         "format": format,
+        "size": 0,
     }
 
     # when
@@ -1495,7 +1496,7 @@ def test_collection_image_query_only_format_provided_original_image_returned(
     assert data["backgroundImage"]["url"] == expected_url
 
 
-def test_collection_image_query_no_size_value_original_image_returned(
+def test_collection_image_query_zero_size_value_original_image_returned(
     user_api_client, published_collection, media_root, channel_USD, site_settings
 ):
     # given
@@ -1511,6 +1512,7 @@ def test_collection_image_query_no_size_value_original_image_returned(
     variables = {
         "id": collection_id,
         "channel": channel_USD.slug,
+        "size": 0,
     }
 
     # when

--- a/saleor/graphql/product/types/categories.py
+++ b/saleor/graphql/product/types/categories.py
@@ -109,7 +109,7 @@ class Category(ModelObjectType[models.Category]):
             return
 
         alt = root.background_image_alt
-        if not size:
+        if size == 0:
             return Image(url=root.background_image.url, alt=alt)
 
         format = get_thumbnail_format(format)

--- a/saleor/graphql/product/types/collections.py
+++ b/saleor/graphql/product/types/collections.py
@@ -102,7 +102,7 @@ class Collection(ChannelContextTypeWithMetadata[models.Collection]):
             return
 
         alt = node.background_image_alt
-        if not size:
+        if size == 0:
             return Image(url=node.background_image.url, alt=alt)
 
         format = get_thumbnail_format(format)

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -1791,7 +1791,7 @@ class ProductMedia(ModelObjectType[models.ProductMedia]):
         if not root.image:
             return
 
-        if not size:
+        if size == 0:
             return build_absolute_uri(root.image.url)
 
         format = get_thumbnail_format(format)
@@ -1851,7 +1851,7 @@ class ProductImage(graphene.ObjectType):
         if not root.image:
             return
 
-        if not size:
+        if size == 0:
             return build_absolute_uri(root.image.url)
 
         format = get_thumbnail_format(format)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4950,12 +4950,12 @@ type Product implements Node & ObjectWithMetadata {
   descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
   thumbnail(
     """
-    Size of the image. If not provided, the original image will be returned.
+    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
+    The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
     
@@ -5975,12 +5975,12 @@ type Category implements Node & ObjectWithMetadata {
   ): CategoryCountableConnection
   backgroundImage(
     """
-    Size of the image. If not provided, the original image will be returned.
+    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
+    The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
     
@@ -6586,12 +6586,12 @@ type ProductImage {
   sortOrder: Int
   url(
     """
-    Size of the image. If not provided, the original image will be returned.
+    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
+    The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
     
@@ -6668,12 +6668,12 @@ type ProductMedia implements Node & ObjectWithMetadata {
   oembedData: JSONString!
   url(
     """
-    Size of the image. If not provided, the original image will be returned.
+    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
+    The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
     
@@ -7036,12 +7036,12 @@ type Collection implements Node & ObjectWithMetadata {
   ): ProductCountableConnection
   backgroundImage(
     """
-    Size of the image. If not provided, the original image will be returned.
+    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
+    The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
     
@@ -8849,12 +8849,12 @@ type User implements Node & ObjectWithMetadata {
   editableGroups: [Group!]
   avatar(
     """
-    Size of the image. If not provided, the original image will be returned.
+    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
+    The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
     
@@ -9998,12 +9998,12 @@ type OrderLine implements Node & ObjectWithMetadata {
   digitalContentUrl: DigitalContentUrl
   thumbnail(
     """
-    Size of the image. If not provided, the original image will be returned.
+    Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
     """
     size: Int
 
     """
-    The format of the image. When not provided, format of the original image will be used. Must be provided together with the size value, otherwise original image will be returned.
+    The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
     

--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -142,7 +142,7 @@ def format_datetime(this, date, date_format=None):
     return date.strftime(date_format)
 
 
-def get_product_image_thumbnail(this, size, image_data):
+def get_product_image_thumbnail(this, size: int, image_data):
     """Use provided size to get a correct image."""
     expected_size = get_thumbnail_size(size)
     return image_data["original"][str(expected_size)]

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -694,7 +694,7 @@ PRODUCT_MEDIA_CREATED = """
         ...on ProductMediaCreated{
           productMedia{
             id
-            url
+            url(size: 0)
             productId
           }
         }
@@ -708,7 +708,7 @@ PRODUCT_MEDIA_UPDATED = """
         ...on ProductMediaUpdated{
           productMedia{
             id
-            url
+            url(size: 0)
             productId
           }
         }
@@ -722,7 +722,7 @@ PRODUCT_MEDIA_DELETED = """
         ...on ProductMediaDeleted{
           productMedia{
             id
-            url
+            url(size: 0)
             productId
           }
         }

--- a/saleor/thumbnail/__init__.py
+++ b/saleor/thumbnail/__init__.py
@@ -3,6 +3,8 @@ default_app_config = "saleor.thumbnail.app.ThumbnailAppConfig"
 # defines the available thumbnail resolutions
 THUMBNAIL_SIZES = [32, 64, 128, 256, 512, 1024, 2048, 4096]
 
+DEFAULT_THUMBNAIL_SIZE = 4096
+
 
 class ThumbnailFormat:
     ORIGINAL = "original"

--- a/saleor/thumbnail/utils.py
+++ b/saleor/thumbnail/utils.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 import graphene
 import magic
@@ -7,7 +7,12 @@ from django.core.files.storage import default_storage
 from django.urls import reverse
 from PIL import Image
 
-from . import MIME_TYPE_TO_PIL_IDENTIFIER, THUMBNAIL_SIZES, ThumbnailFormat
+from . import (
+    DEFAULT_THUMBNAIL_SIZE,
+    MIME_TYPE_TO_PIL_IDENTIFIER,
+    THUMBNAIL_SIZES,
+    ThumbnailFormat,
+)
 
 if TYPE_CHECKING:
     from .models import Thumbnail
@@ -38,13 +43,16 @@ def prepare_image_proxy_url(
     return reverse("thumbnail", kwargs=kwargs)
 
 
-def get_thumbnail_size(size: Union[str, int]) -> int:
+def get_thumbnail_size(size: Optional[int]) -> int:
     """Return the closest size to the given one of the available sizes."""
-    size = int(size)
-    if size in THUMBNAIL_SIZES:
-        return size
+    if size is None:
+        requested_size = DEFAULT_THUMBNAIL_SIZE
+    else:
+        requested_size = size
+    if requested_size in THUMBNAIL_SIZES:
+        return requested_size
 
-    return min(THUMBNAIL_SIZES, key=lambda x: abs(x - size))
+    return min(THUMBNAIL_SIZES, key=lambda x: abs(x - requested_size))
 
 
 def get_thumbnail_format(format: Optional[str]) -> Optional[str]:

--- a/saleor/thumbnail/views.py
+++ b/saleor/thumbnail/views.py
@@ -46,7 +46,10 @@ def handle_thumbnail(
     if object_type not in TYPE_TO_MODEL_DATA_MAPPING.keys():
         return HttpResponseNotFound("Invalid instance type.")
 
-    size_px: int = get_thumbnail_size(size)
+    try:
+        size_px = get_thumbnail_size(int(size))
+    except ValueError:
+        return HttpResponseNotFound("Invalid size.")
 
     # return the thumbnail if it's already exist
     model_data = TYPE_TO_MODEL_DATA_MAPPING[object_type]


### PR DESCRIPTION
This changes the default behavior to return a 4K thumbnail instead of the original which could be tens of MiB. Not requesting an appropriate thumbnail is among API users' most common mistakes.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
