### PR TITLE
Support setting password on account without one with `changePassword`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - Deprecate `Shop.orderSettings` query. Use `Channel.orderSettings` query instead.
   - Deprecate `Shop.orderSettingsUpdate` mutation. Use `Channel.channelUpdate` instead.
 - Add meta fields to `ProductMedia` model - #11894 by @zedzior
+- Make `oldPassword` argument on `passwordChange` mutation optional; support accounts without usable passwords - @11999 by @rafalp
 
 
 ### Other changes

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -2,6 +2,7 @@ from typing import cast
 
 import graphene
 from django.contrib.auth import password_validation
+from django.contrib.auth.hashers import make_password
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 
@@ -272,7 +273,7 @@ class PasswordChange(BaseMutation):
 
     class Arguments:
         old_password = graphene.String(
-            required=True, description="Current user password."
+            required=False, description="Current user password."
         )
         new_password = graphene.String(required=True, description="New user password.")
 
@@ -282,22 +283,34 @@ class PasswordChange(BaseMutation):
         error_type_field = "account_errors"
         permissions = (AuthorizationFilters.AUTHENTICATED_USER,)
 
+    @staticmethod
+    def raise_invalid_credentials():
+        raise ValidationError(
+            {
+                "old_password": ValidationError(
+                    "Old password isn't valid.",
+                    code=AccountErrorCode.INVALID_CREDENTIALS.value,
+                )
+            }
+        )
+
     @classmethod
     def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
         user = info.context.user
         user = cast(models.User, user)
-        old_password = data["old_password"]
+        old_password = data.get("old_password")
         new_password = data["new_password"]
 
-        if not user.check_password(old_password):
-            raise ValidationError(
-                {
-                    "old_password": ValidationError(
-                        "Old password isn't valid.",
-                        code=AccountErrorCode.INVALID_CREDENTIALS.value,
-                    )
-                }
-            )
+        if old_password is None:
+            # Spend time hashing useless password
+            # This prevents outside actors telling if user has unusable
+            # password set or not by measuring API's response time
+            make_password("waste-time")
+
+            if user.has_usable_password():
+                cls.raise_invalid_credentials()
+        elif not user.check_password(old_password):
+            cls.raise_invalid_credentials()
         try:
             password_validation.validate_password(new_password, user)
         except ValidationError as error:

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -303,8 +303,8 @@ class PasswordChange(BaseMutation):
 
         if old_password is None:
             # Spend time hashing useless password
-            # This prevents outside actors telling if user has unusable
-            # password set or not by measuring API's response time
+            # This prevents the outside actors from telling if user has
+            # unusable password set or not by measuring API's response time
             make_password("waste-time")
 
             if user.has_usable_password():

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -4377,7 +4377,7 @@ def test_set_password_invalid_password(user_api_client, customer_user, settings)
 
 
 CHANGE_PASSWORD_MUTATION = """
-    mutation PasswordChange($oldPassword: String!, $newPassword: String!) {
+    mutation PasswordChange($oldPassword: String, $newPassword: String!) {
         passwordChange(oldPassword: $oldPassword, newPassword: $newPassword) {
             errors {
                 field
@@ -4446,6 +4446,50 @@ def test_password_change_invalid_new_password(user_api_client, settings):
     )
     assert errors[1]["field"] == "newPassword"
     assert errors[1]["message"] == "This password is entirely numeric."
+
+
+def test_password_change_user_unusable_password_fails_if_old_password_is_given(
+    user_api_client
+):
+    customer_user = user_api_client.user
+    customer_user.set_unusable_password()
+    customer_user.save()
+
+    new_password = "spanish-inquisition"
+
+    variables = {"oldPassword": "password", "newPassword": new_password}
+    response = user_api_client.post_graphql(CHANGE_PASSWORD_MUTATION, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["passwordChange"]
+    assert data["errors"]
+    assert data["errors"][0]["field"] == "oldPassword"
+
+    customer_user.refresh_from_db()
+    assert not customer_user.has_usable_password()
+
+
+def test_password_change_user_unusable_password_if_old_password_is_omitted(
+    user_api_client
+):
+    customer_user = user_api_client.user
+    customer_user.set_unusable_password()
+    customer_user.save()
+
+    new_password = "spanish-inquisition"
+
+    variables = {"oldPassword": None, "newPassword": new_password}
+    response = user_api_client.post_graphql(CHANGE_PASSWORD_MUTATION, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["passwordChange"]
+    assert not data["errors"]
+    assert data["user"]["email"] == customer_user.email
+
+    customer_user.refresh_from_db()
+    assert customer_user.check_password(new_password)
+
+    password_change_event = account_events.CustomerEvent.objects.get()
+    assert password_change_event.type == account_events.CustomerEvents.PASSWORD_CHANGED
+    assert password_change_event.user == customer_user
 
 
 ADDRESS_CREATE_MUTATION = """

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -4449,7 +4449,7 @@ def test_password_change_invalid_new_password(user_api_client, settings):
 
 
 def test_password_change_user_unusable_password_fails_if_old_password_is_set(
-    user_api_client
+    user_api_client,
 ):
     customer_user = user_api_client.user
     customer_user.set_unusable_password()
@@ -4469,7 +4469,7 @@ def test_password_change_user_unusable_password_fails_if_old_password_is_set(
 
 
 def test_password_change_user_unusable_password_if_old_password_is_omitted(
-    user_api_client
+    user_api_client,
 ):
     customer_user = user_api_client.user
     customer_user.set_unusable_password()
@@ -4493,7 +4493,7 @@ def test_password_change_user_unusable_password_if_old_password_is_omitted(
 
 
 def test_password_change_user_usable_password_fails_if_old_password_is_omitted(
-    user_api_client
+    user_api_client,
 ):
     customer_user = user_api_client.user
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15698,7 +15698,7 @@ type Mutation {
     newPassword: String!
 
     """Current user password."""
-    oldPassword: String!
+    oldPassword: String
   ): PasswordChange
 
   """


### PR DESCRIPTION
Context for this change can be found in [this discussion](https://github.com/saleor/saleor/discussions/11800#discussioncomment-4922974), but TL;DR is this change will enable users and integrations to set password on user accounts that don't have one with `passwordChange` mutation

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
