### PR TITLE
Fix default db setup to replica.

### DIFF
--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -47,7 +47,7 @@ def get_database_connection_name(context: SaleorContext) -> str:
     Queryset to main database: `User.objects.all()`.
     Queryset to read replica: `User.objects.using(connection_name).all()`.
     """
-    allow_replica = getattr(context, "allow_replica", False)
+    allow_replica = getattr(context, "allow_replica", True)
     if allow_replica:
         return settings.DATABASE_CONNECTION_REPLICA_NAME
     return settings.DATABASE_CONNECTION_DEFAULT_NAME


### PR DESCRIPTION
I want to merge this change, to setup default database to replica in `get_database_connection_name` function.

Please note, that previous default value `False` was never read, as `SaleorContext` has default value for `allow_replica` flag. However, a lot of tests do not cast `WSGIRequest` into `SaleorContext`, therefor I kept `getattr` function with `True` default value.

It relates to: https://github.com/saleor/saleor/pull/11920

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
