### PR TITLE
Fix email image payload

### DIFF
--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -8,7 +8,7 @@ from ..account.models import StaffNotificationRecipient
 from ..core.notification.utils import get_site_context
 from ..core.notify_events import NotifyEventType
 from ..core.prices import quantize_price, quantize_price_fields
-from ..core.utils.url import prepare_url
+from ..core.utils.url import build_absolute_uri, prepare_url
 from ..discount import OrderDiscountType
 from ..graphql.core.utils import to_global_id_or_none
 from ..product import ProductMediaTypes
@@ -27,8 +27,8 @@ def get_image_payload(instance: ProductMedia):
         # This is temporary solution, the get_product_image_thumbnail_url
         # should be optimize - we should fetch all thumbnails at once instead of
         # fetching thumbnails by one for each size
-        str(size): get_image_or_proxy_url(
-            None, str(instance.id), "ProductMedia", size, None
+        str(size): build_absolute_uri(
+            get_image_or_proxy_url(None, str(instance.id), "ProductMedia", size, None)
         )
         for size in THUMBNAIL_SIZES
     }

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -677,4 +677,7 @@ def test_get_default_images_payload(product_with_image):
     # then
     images_payload = payload["first_image"]["original"]
     for th_size in THUMBNAIL_SIZES:
-        assert images_payload[str(th_size)] == f"/thumbnail/{media_id}/{th_size}/"
+        assert (
+            images_payload[str(th_size)]
+            == f"http://mirumee.com/thumbnail/{media_id}/{th_size}/"
+        )


### PR DESCRIPTION
Fix the problem with using `get_product_image_thumbnail` method in templates.

Port of https://github.com/saleor/saleor/pull/11997

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
