### PR TITLE
Include access-control-allow-credentials in the simple CORS flow

### DIFF
--- a/saleor/asgi/cors_handler.py
+++ b/saleor/asgi/cors_handler.py
@@ -74,8 +74,16 @@ def cors_handler(application: ASGI3Application) -> ASGI3Application:
                     response_headers = [
                         (key, value)
                         for key, value in message["headers"]
-                        if key.lower() not in {b"access-control-allow-origin", b"vary"}
+                        if key.lower()
+                        not in {
+                            b"access-control-allow-credentials",
+                            b"access-control-allow-origin",
+                            b"vary",
+                        }
                     ]
+                    response_headers.append(
+                        (b"access-control-allow-credentials", b"true")
+                    )
                     vary_header = next(
                         (
                             value

--- a/saleor/asgi/tests/test_cors.py
+++ b/saleor/asgi/tests/test_cors.py
@@ -86,6 +86,7 @@ async def test_access_control_header_simple(asgi_app: ASGI3Application, settings
             type="http.response.start",
             status=200,
             headers=[
+                (b"access-control-allow-credentials", b"true"),
                 (b"access-control-allow-origin", b"http://localhost:3000"),
                 (b"content-type", b"text/plain"),
                 (b"vary", b"Origin"),


### PR DESCRIPTION
This adds one additional header to the simple CORS flow.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
