### PR TITLE
Add app field to transaction models 

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -895,10 +895,14 @@ class TransactionCreate(BaseMutation):
         transaction_input["psp_reference"] = transaction_input.get(
             "psp_reference", reference
         )
+        app_identifier = None
+        if app and app.identifier:
+            app_identifier = app.identifier
         return payment_models.TransactionItem.objects.create(
             **transaction_input,
             user=user if user and user.is_authenticated else None,
-            app_identifier=app.identifier if app else None,
+            app_identifier=app_identifier,
+            app=app,
         )
 
     @classmethod
@@ -911,13 +915,17 @@ class TransactionCreate(BaseMutation):
     ) -> payment_models.TransactionEvent:
         reference = transaction_event_input.pop("reference", None)
         psp_reference = transaction_event_input.get("psp_reference", reference)
+        app_identifier = None
+        if app and app.identifier:
+            app_identifier = app.identifier
         return transaction.events.create(
             status=transaction_event_input["status"],
             psp_reference=psp_reference,
             message=cls.create_event_message(transaction_event_input),
             transaction=transaction,
             user=user if user and user.is_authenticated else None,
-            app_identifier=app.identifier if app else None,
+            app_identifier=app_identifier,
+            app=app,
         )
 
     @classmethod
@@ -1397,6 +1405,10 @@ class TransactionEventReport(ModelMutation):
                 ]
             )
 
+        app_identifier = None
+        if app and app.identifier:
+            app_identifier = app.identifier
+
         transaction_event_data = {
             "psp_reference": psp_reference,
             "type": type,
@@ -1406,7 +1418,8 @@ class TransactionEventReport(ModelMutation):
             "external_url": external_url or "",
             "message": message or "",
             "transaction": transaction,
-            "app_identifier": app.identifier if app else None,
+            "app_identifier": app_identifier,
+            "app": app,
             "user": user,
             "include_in_calculations": True,
         }

--- a/saleor/graphql/payment/tests/mutations/test_transaction_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_create.py
@@ -198,6 +198,7 @@ def test_transaction_create_for_order_by_app(
         private_metadata["key"]: private_metadata["value"]
     }
     assert transaction.app_identifier == app_api_client.app.identifier
+    assert transaction.app == app_api_client.app
     assert transaction.user is None
     assert transaction.external_url == external_url
 
@@ -354,6 +355,7 @@ def test_transaction_create_for_checkout_by_app(
     }
     assert transaction.external_url == external_url
     assert transaction.app_identifier == app_api_client.app.identifier
+    assert transaction.app == app_api_client.app
     assert transaction.user is None
 
 
@@ -762,6 +764,7 @@ def test_creates_transaction_event_for_order_by_app(
     assert event.status == event_status
     assert event.psp_reference == event_psp_reference
     assert event.app_identifier == app_api_client.app.identifier
+    assert event.app == app_api_client.app
     assert event.user is None
 
 
@@ -830,6 +833,7 @@ def test_creates_transaction_event_for_checkout_by_app(
     assert event.status == event_status
     assert event.psp_reference == event_psp_reference
     assert event.app_identifier == app_api_client.app.identifier
+    assert event.app == app_api_client.app
     assert event.user is None
 
 
@@ -889,6 +893,7 @@ def test_transaction_create_for_order_by_staff(
     }
     assert transaction.user == staff_api_client.user
     assert not transaction.app_identifier
+    assert not transaction.app
 
 
 def test_transaction_create_for_order_updates_order_total_authorized_by_staff(
@@ -1039,6 +1044,7 @@ def test_transaction_create_for_checkout_by_staff(
         private_metadata["key"]: private_metadata["value"]
     }
     assert transaction.app_identifier is None
+    assert transaction.app is None
     assert transaction.user == staff_api_client.user
 
 
@@ -1447,6 +1453,7 @@ def test_creates_transaction_event_for_order_by_staff(
     assert event.psp_reference == event_psp_reference
     assert event.user == staff_api_client.user
     assert event.app_identifier is None
+    assert event.app is None
 
 
 def test_creates_transaction_event_for_checkout_by_staff(
@@ -1519,6 +1526,7 @@ def test_creates_transaction_event_for_checkout_by_staff(
     assert event.psp_reference == event_psp_reference
     assert event.user == staff_api_client.user
     assert event.app_identifier is None
+    assert event.app is None
 
 
 def test_transaction_create_external_url_incorrect_url_format_by_app(

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -121,6 +121,7 @@ def test_transaction_event_report_by_app(
     assert event.external_url == external_url
     assert event.transaction == transaction
     assert event.app_identifier == app_api_client.app.identifier
+    assert event.app == app_api_client.app
     assert event.user is None
 
 
@@ -190,6 +191,7 @@ def test_transaction_event_report_by_user(
     assert event.external_url == external_url
     assert event.transaction == transaction
     assert event.app_identifier is None
+    assert event.app is None
     assert event.user == staff_api_client.user
 
     transaction.refresh_from_db()
@@ -247,7 +249,8 @@ def test_transaction_event_report_called_by_non_app_owner(
     second_app.identifier = "different-identifier"
     second_app.save()
     transaction_item_created_by_app.app_identifier = second_app.identifier
-    transaction_item_created_by_app.save(update_fields=["app_identifier"])
+    transaction_item_created_by_app.app = None
+    transaction_item_created_by_app.save(update_fields=["app_identifier", "app"])
 
     transaction_id = to_global_id_or_none(transaction_item_created_by_app)
     variables = {

--- a/saleor/graphql/payment/utils.py
+++ b/saleor/graphql/payment/utils.py
@@ -19,13 +19,20 @@ def check_if_requestor_has_access(
     # Previously we didn't require app/user attached to transaction. We can't
     # determine which app/user is an owner of the transaction. So for transaction
     # without attached owner we require only HANDLE_PAYMENTS.
-    if not transaction.user_id and not transaction.app_identifier:
+    if (
+        not transaction.user_id
+        and not transaction.app_identifier
+        and not transaction.app_id
+    ):
         return True
 
     if user and transaction.user_id == user.id:
         return True
 
-    if app and transaction.app_identifier == app.identifier:
-        return True
+    if app:
+        if transaction.app_id == app.id:
+            return True
 
+        if transaction.app_identifier and transaction.app_identifier == app.identifier:
+            return True
     return False

--- a/saleor/payment/migrations/0040_auto_20220922_1146.py
+++ b/saleor/payment/migrations/0040_auto_20220922_1146.py
@@ -37,6 +37,17 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name="transactionitem",
+            name="app",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="app.app",
+            ),
+        ),
+        migrations.AddField(
+            model_name="transactionitem",
             name="user",
             field=models.ForeignKey(
                 blank=True,
@@ -140,6 +151,17 @@ class Migration(migrations.Migration):
             model_name="transactionevent",
             name="app_identifier",
             field=models.CharField(blank=True, max_length=256, null=True),
+        ),
+        migrations.AddField(
+            model_name="transactionevent",
+            name="app",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="app.app",
+            ),
         ),
         migrations.AddField(
             model_name="transactionevent",

--- a/saleor/payment/models.py
+++ b/saleor/payment/models.py
@@ -128,6 +128,19 @@ class TransactionItem(ModelWithMetadata):
         on_delete=models.SET_NULL,
         related_name="+",
     )
+
+    # We store app and app_identifier, as the app field stores apps of
+    # all types (local, third-party), and the app_identifier field stores
+    # only third-party apps.
+    # In the case of re-installing the third-party app, we are able to match
+    # existing transactions with the re-installed app by using `app_identifier`.
+    app = models.ForeignKey(
+        "app.App",
+        related_name="+",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+    )
     app_identifier = models.CharField(blank=True, null=True, max_length=256)
 
     class Meta:
@@ -173,6 +186,15 @@ class TransactionEvent(models.Model):
         null=True,
         on_delete=models.SET_NULL,
         related_name="+",
+    )
+
+    # We store app and app_identifier, as the app field stores apps of
+    # all types (local, third-party), and the app_identifier field stores
+    # only third-party apps.
+    # In the case of re-installing the third-party app, we are able to match
+    # existing transactions with the re-installed app by using `app_identifier`.
+    app = models.ForeignKey(
+        "app.App", related_name="+", null=True, blank=True, on_delete=models.SET_NULL
     )
     app_identifier = models.CharField(blank=True, null=True, max_length=256)
 

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -971,6 +971,10 @@ def create_transaction_event_from_request_and_webhook_response(
     request_event.save()
     event = None
     if response_event := transaction_request_response.event:
+        app_identifier = None
+        if app and app.identifier:
+            app_identifier = app.identifier
+
         event = TransactionEvent(
             psp_reference=response_event.psp_reference,
             created_at=response_event.time or timezone.now(),
@@ -980,7 +984,8 @@ def create_transaction_event_from_request_and_webhook_response(
             currency=request_event.currency,
             transaction_id=request_event.transaction_id,
             message=response_event.message,
-            app_identifier=app.identifier,
+            app_identifier=app_identifier,
+            app=app,
             include_in_calculations=True,
         )
         with transaction.atomic():
@@ -1024,6 +1029,7 @@ def _prepare_manual_event(
         transaction_id=transaction.pk,
         include_in_calculations=True,
         app_identifier=app.identifier if app else None,
+        app=app,
         user=user,
         created_at=timezone.now(),
         message="Manual adjustment of the transaction.",
@@ -1133,6 +1139,7 @@ def create_transaction_for_order(
         order_id=order.pk,
         user=user,
         app_identifier=app.identifier if app else None,
+        app=app,
         psp_reference=psp_reference,
         currency=order.currency,
     )

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1508,6 +1508,7 @@ def test_transaction_charge_requested(
         order_id=order.pk,
         authorized_value=Decimal("10"),
         app_identifier=app.identifier,
+        app=app,
     )
     event = transaction.events.create(type=TransactionEventType.CHARGE_REQUEST)
     action_value = Decimal("5.00")
@@ -1562,6 +1563,7 @@ def test_transaction_refund_requested(
         order_id=order.pk,
         authorized_value=Decimal("10"),
         app_identifier=app.identifier,
+        app=app,
     )
     event = transaction.events.create(type=TransactionEventType.REFUND_REQUEST)
     action_value = Decimal("5.00")
@@ -1616,6 +1618,7 @@ def test_transaction_cancelation_requested(
         order_id=order.pk,
         authorized_value=Decimal("10"),
         app_identifier=app.identifier,
+        app=app,
     )
     event = transaction.events.create(type=TransactionEventType.CANCEL_REQUEST)
     action_value = Decimal("5.00")

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -5501,6 +5501,7 @@ def transaction_item_generator():
             order_id=order_id,
             checkout_id=checkout_id,
             app_identifier=app.identifier if app else None,
+            app=app,
             user=user,
         )
         create_manual_adjustment_events(


### PR DESCRIPTION
I want to merge this change because it adds an `app` field to `TransactionItem` and `TransactionEvent`. 
We use it to determine the owner of the transaction and transaction event. If the `app` field is set to null, and the used app is third-party app, that has identifier, we use it to match a proper app. This is usefull in case of re-installing the third-party app. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
