### PR TITLE
Add sending order ids in batches in post migration signal

### DIFF
--- a/saleor/order/migrations/0139_fix_undiscounted_total_on_lines.py
+++ b/saleor/order/migrations/0139_fix_undiscounted_total_on_lines.py
@@ -6,6 +6,9 @@ from django.db.models.signals import post_migrate
 
 from saleor.order.tasks import send_order_updated
 
+# 5000 results in 246701 bytes (base64(json(list of ids))) which is the limit for SQS
+SEND_ORDER_UPDATED_BATCH_SIZE = 5000
+
 
 RAW_SQL = """
     UPDATE "order_orderline"
@@ -35,20 +38,27 @@ RAW_SQL = """
 """  # noqa: E501
 
 
-def set_order_line_base_prices(apps, schema_editor):
-    def on_migrations_complete(sender=None, **kwargs):
-        order_ids = list(kwargs.get("updated_orders_pks"))
-        send_order_updated.delay(order_ids)
+def on_migrations_complete(sender=None, **kwargs):
+    order_ids = list(kwargs.get("updated_orders_pks"))
 
+    for index in range(0, len(order_ids), SEND_ORDER_UPDATED_BATCH_SIZE):
+        send_order_updated.delay(
+            order_ids[index : index + SEND_ORDER_UPDATED_BATCH_SIZE]
+        )
+
+
+def set_order_line_base_prices(apps, schema_editor):
     with connection.cursor() as cursor:
         cursor.execute(RAW_SQL)
         records = cursor.fetchall()
 
-    updated_orders_pks = {record[0] for record in records}
-    if updated_orders_pks:
+    if records:
         sender = registry.get_app_config("order")
         post_migrate.connect(
-            partial(on_migrations_complete, updated_orders_pks=updated_orders_pks),
+            partial(
+                on_migrations_complete,
+                updated_orders_pks=[record[0] for record in records],
+            ),
             weak=False,
             dispatch_uid="send_order_updated",
             sender=sender,


### PR DESCRIPTION
I want to merge this change because those changes will make that order that needs to be updated in post migration signal will be send in batches.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
