### PR TITLE
Drop event fields against events from query validation.

### DIFF
--- a/saleor/app/manifest_validations.py
+++ b/saleor/app/manifest_validations.py
@@ -234,14 +234,6 @@ def clean_webhooks(manifest_data, errors):
 
         if not webhook["events"]:
             webhook["events"] = subscription_query.events
-        elif sorted(webhook["events"]) != sorted(subscription_query.events):
-            errors["webhooks"].append(
-                ValidationError(
-                    "Events provided in `syncEvents` and `asyncEvents` does not "
-                    "match events from `query`",
-                    code=AppErrorCode.INVALID.value,
-                )
-            )
 
         try:
             target_url_validator(webhook["targetUrl"])

--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -436,36 +436,6 @@ def test_install_app_webhook_incorrect_custom_headers(
     )
 
 
-def test_install_app_with_webhook_mismatch_between_query_and_event_fields(
-    app_manifest,
-    app_manifest_webhook,
-    app_installation,
-    monkeypatch,
-    subscription_order_created_webhook,
-):
-    # given
-    app_manifest_webhook[
-        "query"
-    ] = subscription_order_created_webhook.subscription_query
-    app_manifest["webhooks"] = [app_manifest_webhook]
-
-    mocked_get_response = Mock()
-    mocked_get_response.json.return_value = app_manifest
-    monkeypatch.setattr(requests, "get", Mock(return_value=mocked_get_response))
-
-    # when & then
-    with pytest.raises(ValidationError) as excinfo:
-        install_app(app_installation, activate=True)
-
-    error_dict = excinfo.value.error_dict
-    assert "webhooks" in error_dict
-    assert (
-        error_dict["webhooks"][0].message
-        == "Events provided in `syncEvents` and `asyncEvents` "
-        "does not match events from `query`"
-    )
-
-
 def test_install_app_lack_of_token_target_url_in_manifest_data(
     app_manifest, app_installation, monkeypatch, permission_manage_products
 ):


### PR DESCRIPTION
I want to merge this change because at this stage, it seems to be redundant and causes more problems than gains. In example, does not work in case of shared subscription types like `CalculateTaxes`. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
