### PR TITLE
Fix column name typo in SQL

### DIFF
--- a/saleor/order/migrations/0139_fix_undiscounted_total_on_lines.py
+++ b/saleor/order/migrations/0139_fix_undiscounted_total_on_lines.py
@@ -34,7 +34,7 @@ RAW_SQL = """
         NOT ("order_orderline"."undiscounted_total_price_net_amount" =
                 ("order_orderline"."undiscounted_unit_price_net_amount" *
                 "order_orderline"."quantity")))
-    RETURNING "order_orderline"."id";
+    RETURNING "order_orderline"."order_id";
 """  # noqa: E501
 
 


### PR DESCRIPTION
I want to merge this change because SQL was incorrect about column name that needs to be returned after update.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
