### PR TITLE
Add payment-gateway-initialize-session webhook

### DIFF
--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -1,6 +1,7 @@
 import decimal
 
 import graphene
+from graphene.types.generic import GenericScalar
 from graphql.error import GraphQLError
 from graphql.language import ast
 from measurement.measures import Weight
@@ -51,6 +52,14 @@ class PositiveDecimal(Decimal):
                 f"Value cannot be lower than 0. Unsupported value: {value}"
             )
         return value
+
+
+class JSON(GenericScalar):
+    @staticmethod
+    def parse_literal(node):
+        if not isinstance(node, ast.ObjectValue):
+            raise GraphQLError("JSON scalar needs to recieve a correct JSON structure.")
+        return node
 
 
 class WeightScalar(graphene.Scalar):

--- a/saleor/graphql/core/types/order_or_checkout.py
+++ b/saleor/graphql/core/types/order_or_checkout.py
@@ -1,0 +1,32 @@
+import graphene
+
+from ....checkout.models import Checkout
+from ....order.models import Order
+from ...checkout import types as checkout_types
+from ...order import types as order_types
+
+# The file hasn't been attached to the __init__ file as it generates the circular
+# graphql import. Graphene for Union types requires already initialized types so
+# we need to provide a fully initialized type.
+
+
+class OrderOrCheckoutBase(graphene.Union):
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def get_types(cls):
+        return (checkout_types.Checkout, order_types.Order)
+
+    @classmethod
+    def resolve_type(cls, instance, info: graphene.ResolveInfo):
+        if isinstance(instance, Checkout):
+            return checkout_types.Checkout
+        if isinstance(instance, Order):
+            return order_types.Order
+        return super(OrderOrCheckoutBase, cls).resolve_type(instance, info)
+
+
+class OrderOrCheckout(OrderOrCheckoutBase):
+    class Meta:
+        types = OrderOrCheckoutBase.get_types()

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -38,19 +38,12 @@ from ...tax.dataloaders import (
 from .. import ResolveInfo
 from .common import NonNullList
 from .money import Money
+from .order_or_checkout import OrderOrCheckoutBase
 
 
-class TaxSourceObject(graphene.Union):
+class TaxSourceObject(OrderOrCheckoutBase):
     class Meta:
-        types = (checkout_types.Checkout, order_types.Order)
-
-    @classmethod
-    def resolve_type(cls, instance, info: ResolveInfo):
-        if isinstance(instance, Checkout):
-            return checkout_types.Checkout
-        if isinstance(instance, Order):
-            return order_types.Order
-        return super(TaxSourceObject, cls).resolve_type(instance, info)
+        types = OrderOrCheckoutBase.get_types()
 
 
 class TaxSourceLine(graphene.Union):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1955,6 +1955,7 @@ enum WebhookEventTypeEnum {
 
   """Filter shipping methods for checkout."""
   CHECKOUT_FILTER_SHIPPING_METHODS
+  PAYMENT_GATEWAY_INITIALIZE_SESSION
 }
 
 """Synchronous webhook event."""
@@ -2018,6 +2019,7 @@ enum WebhookEventTypeSyncEnum {
 
   """Filter shipping methods for checkout."""
   CHECKOUT_FILTER_SHIPPING_METHODS
+  PAYMENT_GATEWAY_INITIALIZE_SESSION
 }
 
 """Asynchronous webhook event."""
@@ -27787,6 +27789,37 @@ type TaxableObjectLine {
 }
 
 union TaxSourceLine = CheckoutLine | OrderLine
+
+"""
+Event sent when user wants to initialize the payment gateway.
+
+Added in Saleor 3.12.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type PaymentGatewayInitializeSession implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """Checkout or order"""
+  sourceObject: OrderOrCheckout
+
+  """Payment gateway data in JSON format, recieved from storefront."""
+  data: JSON
+}
+
+union OrderOrCheckout = Checkout | Order
+
+scalar JSON
 
 """_Any value scalar as defined by Federation spec."""
 scalar _Any

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -27811,10 +27811,13 @@ type PaymentGatewayInitializeSession implements Event {
   recipient: App
 
   """Checkout or order"""
-  sourceObject: OrderOrCheckout
+  sourceObject: OrderOrCheckout!
 
   """Payment gateway data in JSON format, recieved from storefront."""
   data: JSON
+
+  """Amount requested for initializing the payment gateway."""
+  amount: PositiveDecimal
 }
 
 union OrderOrCheckout = Checkout | Order

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -10,7 +10,6 @@ from promise import Promise
 
 from ...app.models import App
 from ...core.exceptions import PermissionDenied
-from ...plugins.manager import PluginsManager
 from ...settings import get_host
 from ..core import SaleorContext
 from ..utils import format_error
@@ -25,9 +24,6 @@ def initialize_request(requestor=None, sync_event=False) -> SaleorContext:
 
     return: HttpRequest
     """
-
-    def _get_plugins(requestor_getter):
-        return PluginsManager(settings.PLUGINS, requestor_getter)
 
     request_time = timezone.now()
 

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1566,10 +1566,16 @@ class TransactionCancelationRequested(TransactionActionBase, SubscriptionObjectT
 
 
 class PaymentGatewayInitializeSession(SubscriptionObjectType):
-    source_object = graphene.Field(OrderOrCheckout, description="Checkout or order")
+    source_object = graphene.Field(
+        OrderOrCheckout, description="Checkout or order", required=True
+    )
     data = graphene.Field(
         JSON,
         description="Payment gateway data in JSON format, recieved from storefront.",
+    )
+    amount = graphene.Field(
+        PositiveDecimal,
+        description="Amount requested for initializing the payment gateway.",
     )
 
     class Meta:
@@ -1585,14 +1591,20 @@ class PaymentGatewayInitializeSession(SubscriptionObjectType):
     @staticmethod
     def resolve_source_object(root, _info: ResolveInfo):
         _, objects = root
-        source_object, _ = objects
+        source_object, _, _ = objects
         return source_object
 
     @staticmethod
     def resolve_data(root, _info: ResolveInfo):
         _, objects = root
-        _, data = objects
+        _, data, _ = objects
         return data
+
+    @staticmethod
+    def resolve_amount(root, _info: ResolveInfo):
+        _, objects = root
+        _, _, amount = objects
+        return amount
 
 
 class TransactionItemMetadataUpdated(SubscriptionObjectType):

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -35,10 +35,12 @@ from ..core.descriptions import (
     ADDED_IN_39,
     ADDED_IN_310,
     ADDED_IN_311,
+    ADDED_IN_312,
     PREVIEW_FEATURE,
 )
-from ..core.scalars import PositiveDecimal
+from ..core.scalars import JSON, PositiveDecimal
 from ..core.types import NonNullList, SubscriptionObjectType
+from ..core.types.order_or_checkout import OrderOrCheckout
 from ..order.dataloaders import OrderByIdLoader
 from ..payment.enums import TransactionActionEnum
 from ..payment.types import TransactionItem
@@ -1563,6 +1565,36 @@ class TransactionCancelationRequested(TransactionActionBase, SubscriptionObjectT
         )
 
 
+class PaymentGatewayInitializeSession(SubscriptionObjectType):
+    source_object = graphene.Field(OrderOrCheckout, description="Checkout or order")
+    data = graphene.Field(
+        JSON,
+        description="Payment gateway data in JSON format, recieved from storefront.",
+    )
+
+    class Meta:
+        interfaces = (Event,)
+        root_type = None
+        enable_dry_run = False
+        description = (
+            "Event sent when user wants to initialize the payment gateway."
+            + ADDED_IN_312
+            + PREVIEW_FEATURE
+        )
+
+    @staticmethod
+    def resolve_source_object(root, _info: ResolveInfo):
+        _, objects = root
+        source_object, _ = objects
+        return source_object
+
+    @staticmethod
+    def resolve_data(root, _info: ResolveInfo):
+        _, objects = root
+        _, data = objects
+        return data
+
+
 class TransactionItemMetadataUpdated(SubscriptionObjectType):
     transaction = graphene.Field(
         TransactionItem,
@@ -2051,4 +2083,7 @@ WEBHOOK_TYPES_MAP = {
     ),
     WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES: CalculateTaxes,
     WebhookEventSyncType.ORDER_CALCULATE_TAXES: CalculateTaxes,
+    WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION: (
+        PaymentGatewayInitializeSession
+    ),
 }

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -51,6 +51,13 @@ class TransactionData:
 
 
 @dataclass
+class PaymentGatewayData:
+    app_identifier: str
+    data: Optional[Dict[Any, Any]] = None
+    error: Optional[str] = None
+
+
+@dataclass
 class PaymentMethodInfo:
     """Uniform way to represent payment method information."""
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -774,7 +774,12 @@ class BasePlugin:
     transaction_refund_requested: Callable[["TransactionActionData", None], None]
 
     payment_gateway_initialize_session: Callable[
-        [Optional[list["PaymentGatewayData"]], Union["Checkout", "Order"], None],
+        [
+            Decimal,
+            Optional[list["PaymentGatewayData"]],
+            Union["Checkout", "Order"],
+            None,
+        ],
         list["PaymentGatewayData"],
     ]
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from ..menu.models import Menu, MenuItem
     from ..order.models import Fulfillment, Order, OrderLine
     from ..page.models import Page, PageType
+    from ..payment.interface import PaymentGatewayData
     from ..payment.models import TransactionItem
     from ..product.models import (
         Category,
@@ -772,6 +773,11 @@ class BasePlugin:
 
     transaction_refund_requested: Callable[["TransactionActionData", None], None]
 
+    payment_gateway_initialize_session: Callable[
+        [Optional[list["PaymentGatewayData"]], Union["Checkout", "Order"], None],
+        list["PaymentGatewayData"],
+    ]
+
     # Trigger when transaction item metadata is updated.
     #
     # Overwrite this method if you need to trigger specific logic when a transaction
@@ -1127,7 +1133,6 @@ class BasePlugin:
         config_structure = getattr(cls, "CONFIG_STRUCTURE") or {}
         fields_without_structure = []
         for configuration_field in configuration:
-
             structure_to_add = config_structure.get(configuration_field.get("name"))
             if structure_to_add:
                 configuration_field.update(structure_to_add)

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
         InitializedPaymentResponse,
         PaymentData,
         PaymentGateway,
+        PaymentGatewayData,
         TokenConfig,
         TransactionActionData,
     )
@@ -940,6 +941,21 @@ class PluginsManager(PaymentInterface):
             "transaction_cancelation_requested",
             default_value,
             payment_data,
+            channel_slug=channel_slug,
+        )
+
+    def payment_gateway_initialize_session(
+        self,
+        payment_gateways: Optional[list["PaymentGatewayData"]],
+        transaction_object: Union["Order", "Checkout"],
+        channel_slug: str,
+    ) -> list["PaymentGatewayData"]:
+        default_value = None
+        return self.__run_method_on_plugins(
+            "payment_gateway_initialize_session",
+            default_value,
+            payment_gateways,
+            transaction_object,
             channel_slug=channel_slug,
         )
 

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -946,6 +946,7 @@ class PluginsManager(PaymentInterface):
 
     def payment_gateway_initialize_session(
         self,
+        amount: Decimal,
         payment_gateways: Optional[list["PaymentGatewayData"]],
         transaction_object: Union["Order", "Checkout"],
         channel_slug: str,
@@ -953,6 +954,7 @@ class PluginsManager(PaymentInterface):
         default_value = None
         return self.__run_method_on_plugins(
             "payment_gateway_initialize_session",
+            amount,
             default_value,
             payment_gateways,
             transaction_object,

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -312,6 +312,7 @@ class PluginSample(BasePlugin):
 
     def payment_gateway_initialize_session(
         self,
+        amount: Decimal,
         payment_gateways: Optional[list["PaymentGatewayData"]],
         transaction_object: Union["Order", "Checkout"],
         previous_value: Any,

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -20,6 +20,7 @@ from prices import Money, TaxedMoney
 from ...account.models import User
 from ...core.taxes import TaxData, TaxLineData, TaxType
 from ...order.interface import OrderTaxedPricesData
+from ...payment.interface import PaymentGatewayData
 from ..base_plugin import BasePlugin, ConfigurationTypeField, ExternalAccessTokens
 
 if TYPE_CHECKING:
@@ -34,7 +35,6 @@ if TYPE_CHECKING:
 
 
 def sample_tax_data(obj_with_lines: Union["Order", "Checkout"]) -> TaxData:
-
     unit = Decimal("10.00")
     unit_gross = Decimal("12.30")
     lines = [
@@ -309,6 +309,14 @@ class PluginSample(BasePlugin):
         previous_value: Optional[Union[ExecutionResult, GraphQLError]],
     ) -> Optional[Union[ExecutionResult, GraphQLError]]:
         return None
+
+    def payment_gateway_initialize_session(
+        self,
+        payment_gateways: Optional[list["PaymentGatewayData"]],
+        transaction_object: Union["Order", "Checkout"],
+        previous_value: Any,
+    ):
+        return [PaymentGatewayData(app_identifier="123", data={"some": "json-data"})]
 
 
 class ChannelPluginSample(PluginSample):

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1186,6 +1186,7 @@ def test_manager_payment_gateway_initialize_session(channel_USD, checkout):
 
     # when
     response = manager.payment_gateway_initialize_session(
+        amount=Decimal("10.00"),
         payment_gateways=None,
         transaction_object=checkout,
         channel_slug=channel_USD.slug,

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -653,7 +653,6 @@ def test_plugin_updates_configuration_shape(
     plugin_configuration,
     monkeypatch,
 ):
-
     config_structure = PluginSample.CONFIG_STRUCTURE.copy()
     config_structure["Foo"] = new_config_structure
     monkeypatch.setattr(PluginSample, "CONFIG_STRUCTURE", config_structure)
@@ -1174,3 +1173,24 @@ def test_manager_is_event_active_for_any_plugin(channel_USD):
     assert manager.is_event_active_for_any_plugin(
         "calculate_checkout_total", channel_USD.slug
     )
+
+
+def test_manager_payment_gateway_initialize_session(channel_USD, checkout):
+    # given
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+        "saleor.plugins.tests.sample_plugins.PluginInactive",
+    ]
+
+    manager = PluginsManager(plugins=plugins)
+
+    # when
+    response = manager.payment_gateway_initialize_session(
+        payment_gateways=None,
+        transaction_object=checkout,
+        channel_slug=channel_USD.slug,
+    )
+
+    # then
+    assert isinstance(response, list)
+    assert len(response) == 1

--- a/saleor/plugins/webhook/shipping.py
+++ b/saleor/plugins/webhook/shipping.py
@@ -110,6 +110,8 @@ def get_excluded_shipping_methods_or_fetch(
     excluded_methods = []
     # Gather responses from webhooks
     for webhook in webhooks:
+        if not webhook:
+            continue
         response_data = trigger_webhook_sync(
             event_type,
             payload,

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -225,18 +225,18 @@ def group_webhooks_by_subscription(webhooks):
 def trigger_webhook_sync(
     event_type: str,
     data: str,
-    webhook: Optional["Webhook"],
+    webhook: "Webhook",
     subscribable_object=None,
     timeout=None,
+    request=None,
 ) -> Optional[Dict[Any, Any]]:
     """Send a synchronous webhook request."""
-    if not webhook:
-        raise PaymentError(f"No payment webhook found for event: {event_type}.")
     if webhook.subscription_query:
         delivery = create_delivery_for_subscription_sync_event(
             event_type=event_type,
             subscribable_object=subscribable_object,
             webhook=webhook,
+            request=request,
         )
         if not delivery:
             return None
@@ -633,7 +633,6 @@ def _send_webhook_request_sync(
 def send_webhook_request_sync(
     app_name, delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT
 ) -> Optional[Dict[Any, Any]]:
-
     response, response_data = _send_webhook_request_sync(app_name, delivery, timeout)
     return response_data if response.status == EventDeliveryStatus.SUCCESS else None
 

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_gateway_initialize_session.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_gateway_initialize_session.py
@@ -1,4 +1,5 @@
 import json
+from decimal import Decimal
 
 import graphene
 
@@ -39,10 +40,11 @@ def test_payment_gateway_initialize_session_checkout_with_data(
     event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
     webhook.events.create(event_type=event_type)
     payload_data = {"some": "json data"}
+    amount = Decimal("10")
 
     # when
     delivery = create_deliveries_for_subscriptions(
-        event_type, (checkout, payload_data), [webhook]
+        event_type, (checkout, payload_data, amount), [webhook]
     )[0]
 
     # then
@@ -69,10 +71,10 @@ def test_payment_gateway_initialize_session_checkout_without_data(
     event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
     webhook.events.create(event_type=event_type)
     payload_data = None
-
+    amount = Decimal("10")
     # when
     delivery = create_deliveries_for_subscriptions(
-        event_type, (checkout, payload_data), [webhook]
+        event_type, (checkout, payload_data, amount), [webhook]
     )[0]
 
     # then
@@ -98,10 +100,11 @@ def test_payment_gateway_initialize_session_order_with_data(
     event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
     webhook.events.create(event_type=event_type)
     payload_data = {"some": "json data"}
+    amount = Decimal("10")
 
     # when
     delivery = create_deliveries_for_subscriptions(
-        event_type, (order, payload_data), [webhook]
+        event_type, (order, payload_data, amount), [webhook]
     )[0]
 
     # then
@@ -128,10 +131,11 @@ def test_payment_gateway_initialize_session_order_without_data(
     event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
     webhook.events.create(event_type=event_type)
     payload_data = None
+    amount = Decimal("10")
 
     # when
     delivery = create_deliveries_for_subscriptions(
-        event_type, (order, payload_data), [webhook]
+        event_type, (order, payload_data, amount), [webhook]
     )[0]
 
     # then

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_gateway_initialize_session.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_gateway_initialize_session.py
@@ -1,0 +1,144 @@
+import json
+
+import graphene
+
+from .....webhook.event_types import WebhookEventSyncType
+from .....webhook.models import Webhook
+from ...tasks import create_deliveries_for_subscriptions
+
+PAYMENT_GATEWAY_INITIALIZE_SESSION = """
+subscription {
+  event{
+    ...on PaymentGatewayInitializeSession{
+      data
+      sourceObject{
+        __typename
+        ... on Checkout{
+          id
+        }
+        ... on Order{
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_payment_gateway_initialize_session_checkout_with_data(
+    checkout, webhook_app, permission_manage_payments
+):
+    # given
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        subscription_query=PAYMENT_GATEWAY_INITIALIZE_SESSION,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+    payload_data = {"some": "json data"}
+
+    # when
+    delivery = create_deliveries_for_subscriptions(
+        event_type, (checkout, payload_data), [webhook]
+    )[0]
+
+    # then
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    assert delivery.payload
+    assert delivery.payload.payload
+    assert json.loads(delivery.payload.payload) == {
+        "data": payload_data,
+        "sourceObject": {"__typename": "Checkout", "id": checkout_id},
+    }
+
+
+def test_payment_gateway_initialize_session_checkout_without_data(
+    checkout, webhook_app, permission_manage_payments
+):
+    # given
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        subscription_query=PAYMENT_GATEWAY_INITIALIZE_SESSION,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+    payload_data = None
+
+    # when
+    delivery = create_deliveries_for_subscriptions(
+        event_type, (checkout, payload_data), [webhook]
+    )[0]
+
+    # then
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    assert delivery.payload
+    assert delivery.payload.payload
+    assert json.loads(delivery.payload.payload) == {
+        "data": None,
+        "sourceObject": {"__typename": "Checkout", "id": checkout_id},
+    }
+
+
+def test_payment_gateway_initialize_session_order_with_data(
+    order, webhook_app, permission_manage_payments
+):
+    # given
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        subscription_query=PAYMENT_GATEWAY_INITIALIZE_SESSION,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+    payload_data = {"some": "json data"}
+
+    # when
+    delivery = create_deliveries_for_subscriptions(
+        event_type, (order, payload_data), [webhook]
+    )[0]
+
+    # then
+
+    order_id = graphene.Node.to_global_id("Order", order.pk)
+    assert delivery.payload
+    assert delivery.payload.payload
+    assert json.loads(delivery.payload.payload) == {
+        "data": payload_data,
+        "sourceObject": {"__typename": "Order", "id": order_id},
+    }
+
+
+def test_payment_gateway_initialize_session_order_without_data(
+    order, webhook_app, permission_manage_payments
+):
+    # given
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        subscription_query=PAYMENT_GATEWAY_INITIALIZE_SESSION,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+    payload_data = None
+
+    # when
+    delivery = create_deliveries_for_subscriptions(
+        event_type, (order, payload_data), [webhook]
+    )[0]
+
+    # then
+    order_id = graphene.Node.to_global_id("Order", order.pk)
+    assert delivery.payload
+    assert delivery.payload.payload
+    assert json.loads(delivery.payload.payload) == {
+        "data": None,
+        "sourceObject": {"__typename": "Order", "id": order_id},
+    }

--- a/saleor/plugins/webhook/tests/test_payment_gateway_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_gateway_initialize_session_webhook.py
@@ -1,0 +1,386 @@
+import json
+from unittest import mock
+
+import graphene
+from freezegun import freeze_time
+
+from ....core import EventDeliveryStatus
+from ....core.models import EventDelivery, EventPayload
+from ....payment.interface import PaymentGatewayData
+from ....webhook.event_types import WebhookEventSyncType
+from ....webhook.models import Webhook
+from ....webhook.payloads import generate_checkout_payload, generate_order_payload
+
+PAYMENT_GATEWAY_INITIALIZE_SESSION = """
+subscription {
+  event{
+    ...on PaymentGatewayInitializeSession{
+      data
+      sourceObject{
+        __typename
+        ... on Checkout{
+          id
+        }
+        ... on Order{
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _assert_for_checkout_with_subscription(
+    checkout, request_data, webhook, expected_data, response, mock_request
+):
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    payload = {
+        "data": request_data,
+        "sourceObject": {"__typename": "Checkout", "id": checkout_id},
+    }
+    _assert_fields(payload, webhook, expected_data, response, mock_request)
+
+
+def _assert_for_order_with_subscription(
+    order, request_data, webhook, expected_data, response, mock_request
+):
+    order_id = graphene.Node.to_global_id("Order", order.pk)
+    payload = {
+        "data": request_data,
+        "sourceObject": {"__typename": "Order", "id": order_id},
+    }
+    _assert_fields(payload, webhook, expected_data, response, mock_request)
+
+
+def _assert_for_checkout_with_static_payload(
+    checkout, request_data, webhook, expected_data, response, mock_request
+):
+    payload = json.loads(generate_checkout_payload(checkout, None))
+    payload[0]["data"] = request_data
+    _assert_fields(payload, webhook, expected_data, response, mock_request)
+
+
+def _assert_for_order_with_static_payload(
+    order, request_data, webhook, expected_data, response, mock_request
+):
+    payload = json.loads(generate_order_payload(order, None))
+    payload[0]["data"] = request_data
+    _assert_fields(payload, webhook, expected_data, response, mock_request)
+
+
+def _assert_fields(payload, webhook, expected_data, response, mock_request):
+    webhook_app = webhook.app
+    event_payload = EventPayload.objects.get()
+    assert json.loads(event_payload.payload) == payload
+    delivery = EventDelivery.objects.get()
+    assert delivery.status == EventDeliveryStatus.PENDING
+    assert (
+        delivery.event_type == WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    )
+    assert delivery.payload == event_payload
+    assert delivery.webhook == webhook
+    mock_request.assert_called_once_with(webhook.app.name, delivery)
+    assert response == [
+        PaymentGatewayData(app_identifier=webhook_app.identifier, data=expected_data)
+    ]
+
+
+@freeze_time()
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_gateway_initialize_checkout_without_request_data_and_static_payload(
+    mock_request, webhook_plugin, webhook_app, checkout, permission_manage_payments
+):
+    # given
+    expected_data = {"some": "json data"}
+    mock_request.return_value = expected_data
+    plugin = webhook_plugin()
+
+    webhook_app.identifier = "app.identifier"
+    webhook_app.save()
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+
+    # when
+    response = plugin.payment_gateway_initialize_session(
+        payment_gateways=None, transaction_object=checkout, previous_value=None
+    )
+
+    # then
+    _assert_for_checkout_with_static_payload(
+        checkout, None, webhook, expected_data, response, mock_request
+    )
+
+
+@freeze_time()
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_gateway_initialize_checkout_with_request_data_and_static_payload(
+    mock_request, webhook_plugin, webhook_app, checkout, permission_manage_payments
+):
+    # given
+    data = {"some": "request-data"}
+    expected_data = {"some": "json data"}
+    mock_request.return_value = expected_data
+    plugin = webhook_plugin()
+
+    webhook_app.identifier = "app.identifier"
+    webhook_app.save()
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+
+    # when
+    response = plugin.payment_gateway_initialize_session(
+        payment_gateways=[
+            PaymentGatewayData(app_identifier=webhook_app.identifier, data=data)
+        ],
+        transaction_object=checkout,
+        previous_value=None,
+    )
+
+    # then
+    _assert_for_checkout_with_static_payload(
+        checkout, data, webhook, expected_data, response, mock_request
+    )
+
+
+@freeze_time()
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_gateway_initialize_checkout_without_request_data(
+    mock_request, webhook_plugin, webhook_app, checkout, permission_manage_payments
+):
+    # given
+    expected_data = {"some": "json data"}
+    mock_request.return_value = expected_data
+    plugin = webhook_plugin()
+
+    webhook_app.identifier = "app.identifier"
+    webhook_app.save()
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        subscription_query=PAYMENT_GATEWAY_INITIALIZE_SESSION,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+
+    # when
+    response = plugin.payment_gateway_initialize_session(
+        payment_gateways=None, transaction_object=checkout, previous_value=None
+    )
+
+    # then
+    _assert_for_checkout_with_subscription(
+        checkout, None, webhook, expected_data, response, mock_request
+    )
+
+
+@freeze_time()
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_gateway_initialize_checkout_with_request_data(
+    mock_request, webhook_plugin, webhook_app, checkout, permission_manage_payments
+):
+    # given
+    data = {"some": "request-data"}
+    expected_data = {"some": "json data"}
+    mock_request.return_value = expected_data
+    plugin = webhook_plugin()
+
+    webhook_app.identifier = "app.identifier"
+    webhook_app.save()
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        subscription_query=PAYMENT_GATEWAY_INITIALIZE_SESSION,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+
+    # when
+    response = plugin.payment_gateway_initialize_session(
+        payment_gateways=[
+            PaymentGatewayData(app_identifier=webhook_app.identifier, data=data)
+        ],
+        transaction_object=checkout,
+        previous_value=None,
+    )
+
+    # then
+    _assert_for_checkout_with_subscription(
+        checkout, data, webhook, expected_data, response, mock_request
+    )
+
+
+@freeze_time()
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_gateway_initialize_session_skips_app_without_identifier(
+    mock_request, webhook_plugin, webhook_app, checkout, permission_manage_payments
+):
+    # given
+    plugin = webhook_plugin()
+
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+
+    # when
+    response = plugin.payment_gateway_initialize_session(
+        payment_gateways=None, transaction_object=checkout, previous_value=None
+    )
+
+    # then
+    assert not EventPayload.objects.first()
+    assert not EventDelivery.objects.first()
+    assert not mock_request.called
+    assert response == []
+
+
+@freeze_time()
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_gateway_initialize_order_without_request_data_static_payload(
+    mock_request, webhook_plugin, webhook_app, order, permission_manage_payments
+):
+    # given
+    expected_data = {"some": "json data"}
+    mock_request.return_value = expected_data
+    plugin = webhook_plugin()
+
+    webhook_app.identifier = "app.identifier"
+    webhook_app.save()
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+
+    # when
+    response = plugin.payment_gateway_initialize_session(
+        payment_gateways=None, transaction_object=order, previous_value=None
+    )
+
+    # then
+    _assert_for_order_with_static_payload(
+        order, None, webhook, expected_data, response, mock_request
+    )
+
+
+@freeze_time()
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_gateway_initialize_order_with_request_data_static_payload(
+    mock_request, webhook_plugin, webhook_app, order, permission_manage_payments
+):
+    # given
+    data = {"some": "request-data"}
+    expected_data = {"some": "json data"}
+    mock_request.return_value = expected_data
+    plugin = webhook_plugin()
+
+    webhook_app.identifier = "app.identifier"
+    webhook_app.save()
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+
+    # when
+    response = plugin.payment_gateway_initialize_session(
+        payment_gateways=[
+            PaymentGatewayData(app_identifier=webhook_app.identifier, data=data)
+        ],
+        transaction_object=order,
+        previous_value=None,
+    )
+
+    # then
+    _assert_for_order_with_static_payload(
+        order, data, webhook, expected_data, response, mock_request
+    )
+
+
+@freeze_time()
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_gateway_initialize_session_for_order_without_request_data(
+    mock_request, webhook_plugin, webhook_app, order, permission_manage_payments
+):
+    # given
+    expected_data = {"some": "json data"}
+    mock_request.return_value = expected_data
+    plugin = webhook_plugin()
+
+    webhook_app.identifier = "app.identifier"
+    webhook_app.save()
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        subscription_query=PAYMENT_GATEWAY_INITIALIZE_SESSION,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+
+    # when
+    response = plugin.payment_gateway_initialize_session(
+        payment_gateways=None, transaction_object=order, previous_value=None
+    )
+
+    # then
+    _assert_for_order_with_subscription(
+        order, None, webhook, expected_data, response, mock_request
+    )
+
+
+@freeze_time()
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_gateway_initialize_session_for_order_with_request_data(
+    mock_request, webhook_plugin, webhook_app, order, permission_manage_payments
+):
+    # given
+    data = {"some": "request-data"}
+    expected_data = {"some": "json data"}
+    mock_request.return_value = expected_data
+    plugin = webhook_plugin()
+
+    webhook_app.identifier = "app.identifier"
+    webhook_app.save()
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        subscription_query=PAYMENT_GATEWAY_INITIALIZE_SESSION,
+    )
+    event_type = WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+
+    # when
+    response = plugin.payment_gateway_initialize_session(
+        payment_gateways=[
+            PaymentGatewayData(app_identifier=webhook_app.identifier, data=data)
+        ],
+        transaction_object=order,
+        previous_value=None,
+    )
+
+    # then
+    _assert_for_order_with_subscription(
+        order, data, webhook, expected_data, response, mock_request
+    )

--- a/saleor/plugins/webhook/tests/test_payment_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook.py
@@ -78,15 +78,6 @@ def test_trigger_webhook_sync_with_subscription(
     mock_request.assert_called_once_with(payment_app.name, fake_delivery)
 
 
-def test_trigger_webhook_sync_no_webhook_available():
-    app = App.objects.create(name="Dummy app", is_active=True)
-    # should raise an error for app with no payment webhooks
-    with pytest.raises(PaymentError):
-        trigger_webhook_sync(
-            WebhookEventSyncType.PAYMENT_REFUND, {}, app.webhooks.first()
-        )
-
-
 @mock.patch("saleor.plugins.webhook.tasks.observability.report_event_delivery_attempt")
 @mock.patch("saleor.plugins.webhook.tasks.requests.post")
 def test_send_webhook_request_sync_failed_attempt(

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -521,6 +521,8 @@ class WebhookEventSyncType:
     CHECKOUT_FILTER_SHIPPING_METHODS = "checkout_filter_shipping_methods"
     ORDER_FILTER_SHIPPING_METHODS = "order_filter_shipping_methods"
 
+    PAYMENT_GATEWAY_INITIALIZE_SESSION = "payment_gateway_initialize_session"
+
     DISPLAY_LABELS = {
         PAYMENT_AUTHORIZE: "Authorize payment",
         PAYMENT_CAPTURE: "Capture payment",
@@ -537,6 +539,7 @@ class WebhookEventSyncType:
         SHIPPING_LIST_METHODS_FOR_CHECKOUT: "Shipping list methods for checkout",
         ORDER_FILTER_SHIPPING_METHODS: "Filter order shipping methods",
         CHECKOUT_FILTER_SHIPPING_METHODS: "Filter checkout shipping methods",
+        PAYMENT_GATEWAY_INITIALIZE_SESSION: "Initialize payment gateway session",
     }
 
     CHOICES = [
@@ -563,6 +566,10 @@ class WebhookEventSyncType:
         (
             CHECKOUT_FILTER_SHIPPING_METHODS,
             DISPLAY_LABELS[CHECKOUT_FILTER_SHIPPING_METHODS],
+        ),
+        (
+            PAYMENT_GATEWAY_INITIALIZE_SESSION,
+            DISPLAY_LABELS[PAYMENT_GATEWAY_INITIALIZE_SESSION],
         ),
     ]
 
@@ -594,4 +601,5 @@ class WebhookEventSyncType:
         SHIPPING_LIST_METHODS_FOR_CHECKOUT: ShippingPermissions.MANAGE_SHIPPING,
         ORDER_FILTER_SHIPPING_METHODS: OrderPermissions.MANAGE_ORDERS,
         CHECKOUT_FILTER_SHIPPING_METHODS: CheckoutPermissions.MANAGE_CHECKOUTS,
+        PAYMENT_GATEWAY_INITIALIZE_SESSION: PaymentPermissions.HANDLE_PAYMENTS,
     }

--- a/saleor/webhook/utils.py
+++ b/saleor/webhook/utils.py
@@ -15,6 +15,7 @@ def get_webhooks_for_event(
     event_type: str,
     webhooks: Optional["QuerySet[Webhook]"] = None,
     apps_ids: Optional["list[int]"] = None,
+    apps_identifier: Optional[list[str]] = None,
 ) -> "QuerySet[Webhook]":
     """Get active webhooks from the database for an event."""
     permissions = {}
@@ -31,6 +32,9 @@ def get_webhooks_for_event(
     app_kwargs: dict = {"is_active": True, **permissions}
     if apps_ids:
         app_kwargs["id__in"] = apps_ids
+    if apps_identifier:
+        app_kwargs["identifier__in"] = apps_identifier
+
     apps = App.objects.filter(**app_kwargs)
     event_types = [event_type]
     if event_type in WebhookEventAsyncType.ALL:


### PR DESCRIPTION
I want to merge this change because it adds new webhook, as explained here: https://github.com/saleor/saleor/issues/12016

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
