### PR TITLE
Make custom header name case-insensitive.

### DIFF
--- a/saleor/app/manifest_validations.py
+++ b/saleor/app/manifest_validations.py
@@ -247,7 +247,7 @@ def clean_webhooks(manifest_data, errors):
 
         if custom_headers := webhook.get("customHeaders"):
             try:
-                custom_headers_validator(custom_headers)
+                webhook["customHeaders"] = custom_headers_validator(custom_headers)
             except ValidationError as err:
                 errors["webhooks"].append(
                     ValidationError(

--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -355,7 +355,7 @@ def test_install_app_with_webhook(
     assert webhook.subscription_query == app_manifest_webhook["query"]
     assert webhook.target_url == app_manifest_webhook["targetUrl"]
     assert webhook.is_active is True
-    assert webhook.custom_headers == custom_headers
+    assert webhook.custom_headers == {"x-key": "Value"}
 
 
 def test_install_app_webhook_incorrect_url(
@@ -431,7 +431,7 @@ def test_install_app_webhook_incorrect_custom_headers(
     error_dict = excinfo.value.error_dict
     assert "webhooks" in error_dict
     assert error_dict["webhooks"][0].message == (
-        'Invalid custom headers: "InvalidKey" '
+        'Invalid custom headers: "invalidkey" '
         'does not match allowed key pattern: "X-*" or "Authorization*".'
     )
 

--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -431,7 +431,7 @@ def test_install_app_webhook_incorrect_custom_headers(
     error_dict = excinfo.value.error_dict
     assert "webhooks" in error_dict
     assert error_dict["webhooks"][0].message == (
-        'Invalid custom headers: "invalidkey" '
+        'Invalid custom headers: "InvalidKey" '
         'does not match allowed key pattern: "X-*" or "Authorization*".'
     )
 

--- a/saleor/graphql/webhook/mutations/webhook_create.py
+++ b/saleor/graphql/webhook/mutations/webhook_create.py
@@ -130,7 +130,7 @@ class WebhookCreate(ModelMutation):
 
         if headers := cleaned_data.get("custom_headers"):
             try:
-                custom_headers_validator(headers)
+                cleaned_data["custom_headers"] = custom_headers_validator(headers)
             except ValidationError as err:
                 raise_validation_error(
                     field="customHeaders",

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_create.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_create.py
@@ -318,7 +318,7 @@ def test_webhook_create_invalid_custom_headers(app_api_client):
     error = data["errors"][0]
     assert error["field"] == "customHeaders"
     assert (
-        error["message"] == '"disallowedkey" does not match allowed key pattern: '
+        error["message"] == '"DisallowedKey" does not match allowed key pattern: '
         '"X-*" or "Authorization*".'
     )
     assert error["code"] == WebhookErrorCode.INVALID_CUSTOM_HEADERS.name

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_create.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_create.py
@@ -58,7 +58,10 @@ def test_webhook_create_by_app(app_api_client, permission_manage_orders):
     new_webhook = Webhook.objects.get()
     assert new_webhook.name == "New integration"
     assert new_webhook.target_url == "https://www.example.com"
-    assert new_webhook.custom_headers == custom_headers
+    assert new_webhook.custom_headers == {
+        "x-key": "Value",
+        "authorization-key": "Value",
+    }
     events = new_webhook.events.all()
     assert len(events) == 1
     assert events[0].event_type == WebhookEventTypeAsyncEnum.ORDER_CREATED.value
@@ -315,7 +318,7 @@ def test_webhook_create_invalid_custom_headers(app_api_client):
     error = data["errors"][0]
     assert error["field"] == "customHeaders"
     assert (
-        error["message"] == '"DisallowedKey" does not match allowed key pattern: '
+        error["message"] == '"disallowedkey" does not match allowed key pattern: '
         '"X-*" or "Authorization*".'
     )
     assert error["code"] == WebhookErrorCode.INVALID_CUSTOM_HEADERS.name

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_update.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_update.py
@@ -51,7 +51,7 @@ def test_webhook_update_by_staff(staff_api_client, webhook, permission_manage_ap
     # given
     query = WEBHOOK_UPDATE
     webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
-    custom_headers = {"X-Key": "Value", "Authorization-Key": "Value"}
+    custom_headers = {"x-key": "Value", "authorization-key": "Value"}
     variables = {
         "id": webhook_id,
         "input": {
@@ -72,7 +72,7 @@ def test_webhook_update_by_staff(staff_api_client, webhook, permission_manage_ap
 
     # then
     assert webhook.is_active is False
-    assert webhook.custom_headers == custom_headers
+    assert webhook.custom_headers == {"x-key": "Value", "authorization-key": "Value"}
     events = webhook.events.all()
     assert len(events) == 1
     assert events[0].event_type == WebhookEventTypeAsyncEnum.CUSTOMER_CREATED.value
@@ -169,7 +169,7 @@ def test_webhook_update_invalid_custom_headers(
     error = data["errors"][0]
     assert error["field"] == "customHeaders"
     assert (
-        error["message"] == '"DisallowedKey" does not match allowed key pattern: '
+        error["message"] == '"disallowedkey" does not match allowed key pattern: '
         '"X-*" or "Authorization*".'
     )
     assert error["code"] == WebhookErrorCode.INVALID_CUSTOM_HEADERS.name

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_update.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_update.py
@@ -169,7 +169,7 @@ def test_webhook_update_invalid_custom_headers(
     error = data["errors"][0]
     assert error["field"] == "customHeaders"
     assert (
-        error["message"] == '"disallowedkey" does not match allowed key pattern: '
+        error["message"] == '"DisallowedKey" does not match allowed key pattern: '
         '"X-*" or "Authorization*".'
     )
     assert error["code"] == WebhookErrorCode.INVALID_CUSTOM_HEADERS.name

--- a/saleor/webhook/tests/test_webhook_validators.py
+++ b/saleor/webhook/tests/test_webhook_validators.py
@@ -24,10 +24,14 @@ from ..validators import (
         ),
         (
             {"Key": "Value"},
-            '"key" does not match allowed key pattern: "X-*" or "Authorization*".',
+            '"Key" does not match allowed key pattern: "X-*" or "Authorization*".',
         ),
         (
             {"X-Key": 123},
+            "Header must consist of strings.",
+        ),
+        (
+            {123: "value"},
             "Header must consist of strings.",
         ),
         (
@@ -40,16 +44,16 @@ from ..validators import (
         ),
         (
             {"Key": "X" * HEADERS_LENGTH_LIMIT},
-            f'Header with key: "key" exceeds the limit of characters: '
+            f'Header with key: "Key" exceeds the limit of characters: '
             f"{HEADERS_LENGTH_LIMIT}.",
         ),
         (
             {"ABCX-Key": "Value"},
-            '"abcx-key" does not match allowed key pattern: "X-*" or "Authorization*".',
+            '"ABCX-Key" does not match allowed key pattern: "X-*" or "Authorization*".',
         ),
         (
             {"ABCAuthorization-Key": "Value"},
-            '"abcauthorization-key" does not match allowed key pattern:'
+            '"ABCAuthorization-Key" does not match allowed key pattern:'
             ' "X-*" or "Authorization*".',
         ),
     ],

--- a/saleor/webhook/tests/test_webhook_validators.py
+++ b/saleor/webhook/tests/test_webhook_validators.py
@@ -24,15 +24,15 @@ from ..validators import (
         ),
         (
             {"Key": "Value"},
-            '"Key" does not match allowed key pattern: "X-*" or "Authorization*".',
+            '"key" does not match allowed key pattern: "X-*" or "Authorization*".',
         ),
         (
             {"X-Key": 123},
             "Header must consist of strings.",
         ),
         (
-            {"Ke:y": "Value"},
-            'Key "Ke:y" contains invalid character.',
+            {"ke:y": "Value"},
+            'Key "ke:y" contains invalid character.',
         ),
         (
             {"Key": "Val:ue"},
@@ -40,16 +40,16 @@ from ..validators import (
         ),
         (
             {"Key": "X" * HEADERS_LENGTH_LIMIT},
-            f'Header with key: "Key" exceeds the limit of characters: '
+            f'Header with key: "key" exceeds the limit of characters: '
             f"{HEADERS_LENGTH_LIMIT}.",
         ),
         (
             {"ABCX-Key": "Value"},
-            '"ABCX-Key" does not match allowed key pattern: "X-*" or "Authorization*".',
+            '"abcx-key" does not match allowed key pattern: "X-*" or "Authorization*".',
         ),
         (
             {"ABCAuthorization-Key": "Value"},
-            '"ABCAuthorization-Key" does not match allowed key pattern:'
+            '"abcauthorization-key" does not match allowed key pattern:'
             ' "X-*" or "Authorization*".',
         ),
     ],
@@ -58,3 +58,10 @@ def test_webhook_validator(headers, err_msg):
     with pytest.raises(ValidationError) as err:
         custom_headers_validator(headers)
     assert err.value.message == err_msg
+
+
+@pytest.mark.parametrize(
+    "header", ["X-Key", "x-keY", "AuthoriZAtionKey", "authorization"]
+)
+def test_webhook_header_name_case_insensitive(header):
+    assert {header.lower(): "Value"} == custom_headers_validator({header: "Value"})

--- a/saleor/webhook/validators.py
+++ b/saleor/webhook/validators.py
@@ -5,7 +5,8 @@ from django.core.exceptions import ValidationError
 HEADERS_NUMBER_LIMIT = 5
 HEADERS_LENGTH_LIMIT = 998
 KEY_CHARS_ALLOWED = (
-    "!\"#$%&'()*+,-./0123456789;<=>?@[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+    "!\"#$%&'()*+,-./0123456789;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 )
 VALUE_CHARS_ALLOWED = (
     "!\"#$%&'()*+,-./0123456789;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -23,7 +24,6 @@ def custom_headers_validator(headers: Dict[str, str]) -> Dict[str, str]:
             f"Number of headers exceeds the limit: {HEADERS_NUMBER_LIMIT}."
         )
 
-    headers = {k.lower(): v for k, v in headers.items()}
     for key, value in headers.items():
         if not isinstance(key, str) or not isinstance(value, str):
             raise ValidationError("Header must consist of strings.")
@@ -40,10 +40,12 @@ def custom_headers_validator(headers: Dict[str, str]) -> Dict[str, str]:
         if not set(value).issubset(set(VALUE_CHARS_ALLOWED)):
             raise ValidationError(f'Value "{value}" contains invalid character.')
 
-        if not (key.startswith("x-") or key.startswith("authorization")):
+        if not (
+            key.lower().startswith("x-") or key.lower().startswith("authorization")
+        ):
             raise ValidationError(
                 f'"{key}" does not match allowed key pattern: '
                 f'"X-*" or "Authorization*".'
             )
 
-    return headers
+    return {k.lower(): v for k, v in headers.items()}

--- a/saleor/webhook/validators.py
+++ b/saleor/webhook/validators.py
@@ -5,8 +5,7 @@ from django.core.exceptions import ValidationError
 HEADERS_NUMBER_LIMIT = 5
 HEADERS_LENGTH_LIMIT = 998
 KEY_CHARS_ALLOWED = (
-    "!\"#$%&'()*+,-./0123456789;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    "[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+    "!\"#$%&'()*+,-./0123456789;<=>?@[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 )
 VALUE_CHARS_ALLOWED = (
     "!\"#$%&'()*+,-./0123456789;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -24,6 +23,7 @@ def custom_headers_validator(headers: Dict[str, str]) -> Dict[str, str]:
             f"Number of headers exceeds the limit: {HEADERS_NUMBER_LIMIT}."
         )
 
+    headers = {k.lower(): v for k, v in headers.items()}
     for key, value in headers.items():
         if not isinstance(key, str) or not isinstance(value, str):
             raise ValidationError("Header must consist of strings.")
@@ -40,7 +40,7 @@ def custom_headers_validator(headers: Dict[str, str]) -> Dict[str, str]:
         if not set(value).issubset(set(VALUE_CHARS_ALLOWED)):
             raise ValidationError(f'Value "{value}" contains invalid character.')
 
-        if not (key.startswith("X-") or key.startswith("Authorization")):
+        if not (key.startswith("x-") or key.startswith("authorization")):
             raise ValidationError(
                 f'"{key}" does not match allowed key pattern: '
                 f'"X-*" or "Authorization*".'


### PR DESCRIPTION
I want to merge this change, because currently custom header names are case-sensitive. This PR also ensure the header names are stored in database as lower-case strings.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
