### PR TITLE
Add support for all attributes types in variant bulk mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Media and image fields now default to returning 4K thumbnails instead of original uploads - #11996 by @patrys
 
 ### GraphQL API
+- Added support for all attributes types in `BulkAttributeValueInput` - #12095 by @SzymJ
 - Add possibility  to remove `stocks` and `channel listings` in `ProductVariantBulkUpdate` mutation.
 - Move `orderSettings` query to `Channel` type - #11417 by @kadewu:
   - Mutation `Channel.channelCreate` and `Channel.channelUpdate` have new `orderSettings` input.

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -119,6 +119,7 @@ class BulkAttributeValueInput(InputObjectType):
         description=(
             "The value or slug of an attribute to resolve. "
             "If the passed value is non-existent, it will be created."
+            + DEPRECATED_IN_3X_FIELD
         ),
     )
     dropdown = AttributeValueSelectableTypeInput(

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -16,15 +16,26 @@ from ....product.error_codes import ProductVariantBulkErrorCode
 from ....product.search import update_product_search_vector
 from ....product.tasks import update_product_discounted_price_task
 from ....warehouse import models as warehouse_models
+from ...attribute.types import (
+    AttributeValueDescriptions,
+    AttributeValueSelectableTypeInput,
+)
 from ...attribute.utils import AttributeAssignmentMixin
 from ...channel import ChannelContext
-from ...core.descriptions import ADDED_IN_311, DEPRECATED_IN_3X_FIELD, PREVIEW_FEATURE
+from ...core.descriptions import (
+    ADDED_IN_311,
+    ADDED_IN_312,
+    DEPRECATED_IN_3X_FIELD,
+    PREVIEW_FEATURE,
+)
 from ...core.enums import ErrorPolicyEnum
+from ...core.fields import JSONString
 from ...core.mutations import (
     BaseMutation,
     ModelMutation,
     validation_error_to_error_type,
 )
+from ...core.scalars import Date
 from ...core.types import BulkProductError, NonNullList, ProductVariantBulkError
 from ...core.utils import get_duplicated_values
 from ...core.validators import validate_price_precision
@@ -110,12 +121,61 @@ class BulkAttributeValueInput(InputObjectType):
             "If the passed value is non-existent, it will be created."
         ),
     )
+    dropdown = AttributeValueSelectableTypeInput(
+        required=False,
+        description="Attribute value ID." + ADDED_IN_312,
+    )
+    swatch = AttributeValueSelectableTypeInput(
+        required=False,
+        description="Attribute value ID." + ADDED_IN_312,
+    )
+    multiselect = NonNullList(
+        AttributeValueSelectableTypeInput,
+        required=False,
+        description="List of attribute value IDs." + ADDED_IN_312,
+    )
+    numeric = graphene.String(
+        required=False,
+        description="Numeric value of an attribute." + ADDED_IN_312,
+    )
+    file = graphene.String(
+        required=False,
+        description=(
+            "URL of the file attribute. Every time, a new value is created."
+            + ADDED_IN_312
+        ),
+    )
+    content_type = graphene.String(
+        required=False,
+        description="File content type." + ADDED_IN_312,
+    )
+    references = NonNullList(
+        graphene.ID,
+        description=(
+            "List of entity IDs that will be used as references." + ADDED_IN_312
+        ),
+        required=False,
+    )
+    rich_text = JSONString(
+        required=False,
+        description="Text content in JSON format." + ADDED_IN_312,
+    )
+    plain_text = graphene.String(
+        required=False,
+        description="Plain text content." + ADDED_IN_312,
+    )
     boolean = graphene.Boolean(
         required=False,
         description=(
             "The boolean value of an attribute to resolve. "
             "If the passed value is non-existent, it will be created."
         ),
+    )
+    date = Date(
+        required=False, description=AttributeValueDescriptions.DATE + ADDED_IN_312
+    )
+    date_time = graphene.DateTime(
+        required=False, description=AttributeValueDescriptions.DATE_TIME + ADDED_IN_312
     )
 
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
@@ -3,6 +3,9 @@ from unittest.mock import ANY, patch
 from uuid import uuid4
 
 import graphene
+import pytz
+from django.conf import settings
+from freezegun import freeze_time
 
 from .....attribute import AttributeInputType
 from .....product.error_codes import ProductVariantBulkErrorCode
@@ -25,6 +28,22 @@ PRODUCT_VARIANT_BULK_CREATE_MUTATION = """
                         id
                         name
                         sku
+                        attributes{
+                            values {
+                                name
+                                slug
+                                reference
+                                richText
+                                plainText
+                                boolean
+                                date
+                                dateTime
+                                file {
+                                    url
+                                    contentType
+                                }
+                            }
+                        }
                         stocks {
                             warehouse {
                                 slug
@@ -214,6 +233,126 @@ def test_product_variant_bulk_create_with_swatch_attribute(
     product_variant = ProductVariant.objects.get(sku=sku)
     product.refresh_from_db()
     assert product.default_variant == product_variant
+
+
+def test_product_variant_bulk_create_with_plain_text_attribute(
+    staff_api_client, product, plain_text_attribute, permission_manage_products
+):
+    # given
+    product_variant_count = ProductVariant.objects.count()
+    product.product_type.variant_attributes.add(plain_text_attribute)
+
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    attribute_id = graphene.Node.to_global_id("Attribute", plain_text_attribute.pk)
+    plain_text = "Test Text"
+    sku = str(uuid4())[:12]
+    variants = [
+        {
+            "sku": sku,
+            "weight": 2.5,
+            "trackInventory": True,
+            "attributes": [{"id": attribute_id, "plainText": plain_text}],
+        }
+    ]
+
+    variables = {"productId": product_id, "variants": variants}
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkCreate"]
+
+    # then
+    assert not data["results"][0]["errors"]
+    assert data["count"] == 1
+    attributes = data["results"][0]["productVariant"]["attributes"]
+    assert attributes[-1]["values"][0]["plainText"] == plain_text
+    assert product_variant_count + 1 == ProductVariant.objects.count()
+
+
+@freeze_time(datetime(2020, 5, 5, 5, 5, 5, tzinfo=pytz.utc))
+def test_product_variant_bulk_create_with_date_attribute(
+    staff_api_client, product, date_attribute, permission_manage_products
+):
+    # given
+    product_variant_count = ProductVariant.objects.count()
+    product.product_type.variant_attributes.add(date_attribute)
+
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    attribute_id = graphene.Node.to_global_id("Attribute", date_attribute.pk)
+    date_time_value = datetime.now(tz=pytz.utc)
+    date_value = date_time_value.date()
+
+    sku = str(uuid4())[:12]
+    variants = [
+        {
+            "sku": sku,
+            "weight": 2.5,
+            "trackInventory": True,
+            "attributes": [{"id": attribute_id, "date": date_value}],
+        }
+    ]
+
+    variables = {"productId": product_id, "variants": variants}
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkCreate"]
+
+    # then
+    assert not data["results"][0]["errors"]
+    assert data["count"] == 1
+    attributes = data["results"][0]["productVariant"]["attributes"]
+    assert attributes[-1]["values"][0]["date"] == str(date_value)
+    assert product_variant_count + 1 == ProductVariant.objects.count()
+
+
+def test_product_variant_bulk_create_with_file_attribute(
+    staff_api_client, product, file_attribute, permission_manage_products, site_settings
+):
+    # given
+    product_variant_count = ProductVariant.objects.count()
+    product.product_type.variant_attributes.add(file_attribute)
+
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    attribute_id = graphene.Node.to_global_id("Attribute", file_attribute.pk)
+    existing_value = file_attribute.values.first()
+    domain = site_settings.site.domain
+    file_url = f"http://{domain}{settings.MEDIA_URL}{existing_value.file_url}"
+
+    sku = str(uuid4())[:12]
+    variants = [
+        {
+            "sku": sku,
+            "weight": 2.5,
+            "trackInventory": True,
+            "attributes": [{"id": attribute_id, "file": file_url}],
+        }
+    ]
+
+    variables = {"productId": product_id, "variants": variants}
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkCreate"]
+
+    # then
+    assert not data["results"][0]["errors"]
+    assert data["count"] == 1
+    attributes = data["results"][0]["productVariant"]["attributes"]
+    assert attributes[-1]["values"][0]["file"]["url"] == file_url
+    assert product_variant_count + 1 == ProductVariant.objects.count()
 
 
 def test_product_variant_bulk_create_only_not_variant_selection_attributes(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -19017,9 +19017,86 @@ input BulkAttributeValueInput {
   values: [String!]
 
   """
+  Attribute value ID.
+  
+  Added in Saleor 3.12.
+  """
+  dropdown: AttributeValueSelectableTypeInput
+
+  """
+  Attribute value ID.
+  
+  Added in Saleor 3.12.
+  """
+  swatch: AttributeValueSelectableTypeInput
+
+  """
+  List of attribute value IDs.
+  
+  Added in Saleor 3.12.
+  """
+  multiselect: [AttributeValueSelectableTypeInput!]
+
+  """
+  Numeric value of an attribute.
+  
+  Added in Saleor 3.12.
+  """
+  numeric: String
+
+  """
+  URL of the file attribute. Every time, a new value is created.
+  
+  Added in Saleor 3.12.
+  """
+  file: String
+
+  """
+  File content type.
+  
+  Added in Saleor 3.12.
+  """
+  contentType: String
+
+  """
+  List of entity IDs that will be used as references.
+  
+  Added in Saleor 3.12.
+  """
+  references: [ID!]
+
+  """
+  Text content in JSON format.
+  
+  Added in Saleor 3.12.
+  """
+  richText: JSONString
+
+  """
+  Plain text content.
+  
+  Added in Saleor 3.12.
+  """
+  plainText: String
+
+  """
   The boolean value of an attribute to resolve. If the passed value is non-existent, it will be created.
   """
   boolean: Boolean
+
+  """
+  Represents the date value of the attribute value.
+  
+  Added in Saleor 3.12.
+  """
+  date: Date
+
+  """
+  Represents the date/time value of the attribute value.
+  
+  Added in Saleor 3.12.
+  """
+  dateTime: DateTime
 }
 
 input ProductVariantChannelListingAddInput {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -19012,7 +19012,7 @@ input BulkAttributeValueInput {
   id: ID
 
   """
-  The value or slug of an attribute to resolve. If the passed value is non-existent, it will be created.
+  The value or slug of an attribute to resolve. If the passed value is non-existent, it will be created.This field will be removed in Saleor 4.0.
   """
   values: [String!]
 


### PR DESCRIPTION
I want to merge this change because it adds support for all attributes types in `ProductVariantBulkCreate`/`ProductVariantBulkUpdate` mutations.

resolves #12094 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
