### PR TITLE
Fix saving metadata in variant bulk mutations

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -135,6 +135,8 @@ class ProductVariantBulkCreate(BaseMutation):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
         error_type_class = BulkProductError
         error_type_field = "bulk_product_errors"
+        support_meta_field = True
+        support_private_meta_field = True
 
     @classmethod
     def clean_attributes(
@@ -466,9 +468,15 @@ class ProductVariantBulkCreate(BaseMutation):
                 )
                 continue
             try:
+                metadata_list = cleaned_input.pop("metadata", None)
+                private_metadata_list = cleaned_input.pop("private_metadata", None)
+
                 instance = models.ProductVariant()
                 cleaned_input["product"] = product
                 instance = cls.construct_instance(instance, cleaned_input)
+                cls.validate_and_update_metadata(
+                    instance, metadata_list, private_metadata_list
+                )
                 cls.clean_instance(info, instance)
                 instances_data_and_errors_list.append(
                     {

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -80,6 +80,8 @@ class ProductVariantBulkUpdate(BaseMutation):
         )
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
         error_type_class = ProductVariantBulkError
+        support_meta_field = True
+        support_private_meta_field = True
 
     @classmethod
     def save(cls, info, instance, cleaned_input):

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
@@ -22,6 +22,10 @@ PRODUCT_VARIANT_BULK_CREATE_MUTATION = """
             ) {
                 results{
                     productVariant{
+                        metadata {
+                            key
+                            value
+                        }
                         id
                         name
                         sku
@@ -81,7 +85,10 @@ def test_product_variant_bulk_create_by_name(
     attribut_id = graphene.Node.to_global_id("Attribute", size_attribute.pk)
     attribute_value = size_attribute.values.last()
     sku = str(uuid4())[:12]
-    name = "new-variant-anem"
+    name = "new-variant-name"
+    metadata_key = "md key"
+    metadata_value = "md value"
+
     variants = [
         {
             "sku": sku,
@@ -89,6 +96,7 @@ def test_product_variant_bulk_create_by_name(
             "trackInventory": True,
             "name": name,
             "attributes": [{"id": attribut_id, "values": [attribute_value.name]}],
+            "metadata": [{"key": metadata_key, "value": metadata_value}],
         }
     ]
 
@@ -106,7 +114,10 @@ def test_product_variant_bulk_create_by_name(
     # then
     assert not data["results"][0]["errors"]
     assert data["count"] == 1
-    assert data["results"][0]["productVariant"]["name"] == name
+    variant_data = data["results"][0]["productVariant"]
+    assert variant_data["name"] == name
+    assert variant_data["metadata"][0]["key"] == metadata_key
+    assert variant_data["metadata"][0]["value"] == metadata_value
     assert product_variant_count + 1 == ProductVariant.objects.count()
     assert attribute_value_count == size_attribute.values.count()
     product_variant = ProductVariant.objects.get(sku=sku)

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -25,6 +25,10 @@ PRODUCT_VARIANT_BULK_UPDATE_MUTATION = """
                         channels
                     }
                     productVariant{
+                        metadata {
+                            key
+                            value
+                        }
                         id
                         name
                         sku
@@ -77,7 +81,16 @@ def test_product_variant_bulk_update(
     old_name = variant.name
     new_name = "new-random-name"
 
-    variants = [{"id": variant_id, "name": new_name}]
+    metadata_key = "md key"
+    metadata_value = "md value"
+
+    variants = [
+        {
+            "id": variant_id,
+            "name": new_name,
+            "metadata": [{"key": metadata_key, "value": metadata_value}],
+        }
+    ]
 
     variables = {"productId": product_id, "variants": variants}
 
@@ -93,7 +106,10 @@ def test_product_variant_bulk_update(
     # then
     assert not data["results"][0]["errors"]
     assert data["count"] == 1
-    assert data["results"][0]["productVariant"]["name"] == new_name
+    variant_data = data["results"][0]["productVariant"]
+    assert variant_data["name"] == new_name
+    assert variant_data["metadata"][0]["key"] == metadata_key
+    assert variant_data["metadata"][0]["value"] == metadata_value
     assert product_with_single_variant.variants.count() == 1
     assert old_name != new_name
     assert product_variant_created_webhook_mock.call_count == data["count"]


### PR DESCRIPTION
I want to merge this change because it fixes saving metadata and private metadata in variant bulk mutations.

port of #12097
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
