### PR TITLE
Change batch size to leave margin for payload

### DIFF
--- a/saleor/order/migrations/0139_fix_undiscounted_total_on_lines.py
+++ b/saleor/order/migrations/0139_fix_undiscounted_total_on_lines.py
@@ -6,8 +6,9 @@ from django.db.models.signals import post_migrate
 
 from saleor.order.tasks import send_order_updated
 
-# 5000 results in 246701 bytes (base64(json(list of ids))) which is the limit for SQS
-SEND_ORDER_UPDATED_BATCH_SIZE = 5000
+# 3500 results in 187344 bytes (base64(json(list of ids)))
+# leave safe margin for rest of the payload
+SEND_ORDER_UPDATED_BATCH_SIZE = 3500
 
 
 RAW_SQL = """


### PR DESCRIPTION
I want to merge this change because previous value did not leave margin for payload data.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
