### PR TITLE
Fix order filtering by charge status

### DIFF
--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -10,6 +10,7 @@ from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCardEvent
 from ...order.models import Order, OrderLine
 from ...order.search import search_orders
+from ...payment import ChargeStatus
 from ...product.models import ProductVariant
 from ..core.filters import (
     GlobalIDMultipleChoiceFilter,
@@ -27,7 +28,10 @@ from .enums import OrderAuthorizeStatusEnum, OrderChargeStatusEnum, OrderStatusF
 
 def filter_payment_status(qs, _, value):
     if value:
-        qs = qs.filter(payments__is_active=True, payments__charge_status__in=value)
+        lookup = Q(payments__is_active=True, payments__charge_status__in=value)
+        if ChargeStatus.FULLY_REFUNDED in value:
+            lookup |= Q(payments__charge_status=ChargeStatus.FULLY_REFUNDED)
+        qs = qs.filter(lookup)
     return qs
 
 

--- a/saleor/graphql/order/tests/queries/test_order_with_filter.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_filter.py
@@ -378,6 +378,30 @@ def test_order_query_with_filter_payment_status(
     assert len(orders) == count
 
 
+def test_order_query_with_filter_payment_fully_refunded_not_active(
+    orders_query_with_filter,
+    staff_api_client,
+    payment_dummy,
+    permission_manage_orders,
+    channel_PLN,
+):
+    # given
+    payment_dummy.charge_status = ChargeStatus.FULLY_REFUNDED
+    payment_dummy.is_active = False
+    payment_dummy.order = Order.objects.create(channel=channel_PLN)
+    payment_dummy.save()
+    variables = {"filter": {"paymentStatus": "FULLY_REFUNDED"}}
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    # when
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+
+    # then
+    assert len(orders) == 1
+
+
 @pytest.mark.parametrize(
     "orders_filter, count, status",
     [


### PR DESCRIPTION
It is a port of #12045

I want to merge this change because filter by payment status was filtering only active payments so it skipped FULLY_REFUNDED orders since they are deactivated when they are fully refunded.

It fixes #12012