### PR TITLE
Fix orderSettingsUpdate mutation with markAsPaidStrategy

### DIFF
--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -436,6 +436,7 @@ class OrderSettingsUpdate(BaseMutation):
             automatically_fulfill_non_shippable_gift_card=(
                 channel.automatically_fulfill_non_shippable_gift_card
             ),
+            mark_as_paid_strategy=channel.order_mark_as_paid_strategy,
         )
         return OrderSettingsUpdate(order_settings=order_settings)
 

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -1332,6 +1332,7 @@ ORDER_SETTINGS_UPDATE_MUTATION = """
             orderSettings {
                 automaticallyConfirmAllNewOrders
                 automaticallyFulfillNonShippableGiftCard
+                markAsPaidStrategy
             }
         }
     }


### PR DESCRIPTION
I want to merge this change because the returned object from orderSettingsUpdate, didn't return markAsPaidStrategy field. 
Then input of the mutation doesn't change as the mutation is deprecated.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
