### PR TITLE
Address validation country area additional mapping

### DIFF
--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -40,7 +40,9 @@ AREA_TYPE = {
 
 CountryAreaValues = namedtuple("CountryAreaValues", ["value", "choices"])
 
-COUNTRY_AREA_MAP = {"CH": CountryAreaValues("Graubünden", ["Graubünden"])}
+COUNTRY_AREA_MAP = {"CH": [
+    CountryAreaValues("Graubünden", ["Graubünden"]),
+]}
 
 
 class PossiblePhoneNumberFormField(forms.CharField):
@@ -188,14 +190,15 @@ class CountryAwareAddressForm(AddressForm):
             normalized_data = i18naddress.normalize_address(data)
 
             if data.get("country_area") and not normalized_data.get("country_area"):
-                country_area = COUNTRY_AREA_MAP.get(data["country_code"])
-                if data["country_area"] in country_area.choices:
-                    normalized_data["country_area"] = country_area.value
-                else:
-                    raise i18naddress.InvalidAddress(
-                        "This value is not valid for the address.",
-                        {"country_area": "invalid"},
-                    )
+                country_areas = COUNTRY_AREA_MAP.get(data["country_code"])
+                for country_area in country_areas:
+                    if data["country_area"] in country_area.choices:
+                        normalized_data["country_area"] = country_area.value
+                    else:
+                        raise i18naddress.InvalidAddress(
+                            "This value is not valid for the address.",
+                            {"country_area": "invalid"},
+                        )
 
             if getattr(self, "enable_normalization", True):
                 data = normalized_data

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -40,9 +40,11 @@ AREA_TYPE = {
 
 CountryAreaValues = namedtuple("CountryAreaValues", ["value", "choices"])
 
-COUNTRY_AREA_MAP = {"CH": [
-    CountryAreaValues("Graubünden", ["Graubünden"]),
-]}
+COUNTRY_AREA_MAP = {
+    "CH": [
+        CountryAreaValues("Graubünden", ["Graubünden"]),
+    ]
+}
 
 
 class PossiblePhoneNumberFormField(forms.CharField):

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -4627,7 +4627,6 @@ def test_create_address_mutation_validate_country_area_from_map_success(
     data = content["data"]["addressCreate"]
     assert data["address"]["city"] == "Dummy"
     assert data["address"]["country"]["code"] == "CH"
-    # assert data["address"]["country_area"] == "Graubünden"
 
     address_obj = Address.objects.get(city="Dummy")
     assert address_obj.country_area == "Graubünden"

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -801,6 +801,22 @@ def graphql_address_data():
 
 
 @pytest.fixture
+def graphql_address_data_country_area_from_map():
+    return {
+        "firstName": "John Saleor",
+        "lastName": "Doe Mirumee",
+        "companyName": "Mirumee Software",
+        "streetAddress1": "Resgia 99",
+        "streetAddress2": "",
+        "postalCode": "7432",
+        "country": "CH",
+        "city": "Zillis",
+        "countryArea": "Graubünden",
+        "phone": "+41613324386",
+    }
+
+
+@pytest.fixture
 def customer_user(address):  # pylint: disable=W0613
     default_address = address.get_copy()
     user = User.objects.create_user(


### PR DESCRIPTION
I want to merge this change because it resolves issue #12093

The full map is not yet provided. There is only one example for `CH` country area `Graubünden`.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
