### PR TITLE
Fix loading related_order when related id is the old order_id

### DIFF
--- a/saleor/graphql/order/dataloaders.py
+++ b/saleor/graphql/order/dataloaders.py
@@ -35,6 +35,19 @@ class OrderByIdLoader(DataLoader):
         return [orders.get(order_id) for order_id in keys]
 
 
+class OrderByNumberLoader(DataLoader):
+    context_key = "order_by_number"
+
+    def batch_load(self, keys):
+        orders = Order.objects.using(self.database_connection_name).filter(
+            number__in=keys
+        )
+        orders_by_number = defaultdict(Order)
+        for order in orders:
+            orders_by_number[order.number] = order
+        return [orders_by_number.get(number) for number in keys]
+
+
 class OrdersByUserLoader(DataLoader):
     context_key = "order_by_user"
 

--- a/saleor/graphql/order/dataloaders.py
+++ b/saleor/graphql/order/dataloaders.py
@@ -39,13 +39,12 @@ class OrderByNumberLoader(DataLoader):
     context_key = "order_by_number"
 
     def batch_load(self, keys):
-        orders = Order.objects.using(self.database_connection_name).filter(
-            number__in=keys
+        orders = (
+            Order.objects.using(self.database_connection_name)
+            .filter(number__in=keys)
+            .in_bulk(field_name="number")
         )
-        orders_by_number = defaultdict(Order)
-        for order in orders:
-            orders_by_number[order.number] = order
-        return [orders_by_number.get(number) for number in keys]
+        return [orders.get(number) for number in keys]
 
 
 class OrdersByUserLoader(DataLoader):

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -124,6 +124,7 @@ from .dataloaders import (
     FulfillmentLinesByIdLoader,
     FulfillmentsByOrderIdLoader,
     OrderByIdLoader,
+    OrderByNumberLoader,
     OrderEventsByOrderIdLoader,
     OrderLineByIdLoader,
     OrderLinesByOrderIdLoader,
@@ -422,10 +423,19 @@ class OrderEvent(ModelObjectType):
 
     @staticmethod
     def resolve_related_order(root: models.OrderEvent, info):
-        order_pk = root.parameters.get("related_order_pk")
-        if not order_pk:
+        order_pk_or_number = root.parameters.get("related_order_pk")
+        if not order_pk_or_number:
             return None
-        return OrderByIdLoader(info.context).load(UUID(order_pk))
+
+        try:
+            # Orders that primary_key are not uuid are old int `id's`.
+            # In migration `order_0128`, before migrating old `id's` to uuid,
+            # old `id's` were saved to field `number`.
+            order_pk = UUID(order_pk_or_number)
+        except (AttributeError, ValueError):
+            return OrderByNumberLoader(info.context).load(order_pk_or_number)
+
+        return OrderByIdLoader(info.context).load(order_pk)
 
     @staticmethod
     def resolve_discount(root: models.OrderEvent, info):


### PR DESCRIPTION
Fix https://github.com/saleor/saleor/issues/12148

If provided `related_order_pk` is not parsable by UUID, then we can assume that's old integer id.
In migration `order_0128` all old integer id's were copied to the `number` field, so we can use `number` to search for order.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
