### PR TITLE
Fix handling generating payload for shipping methods with removed channel listings

### DIFF
--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -241,12 +241,15 @@ def _generate_shipping_method_payload(shipping_method, channel):
     if not shipping_method:
         return None
 
-    serializer = PayloadSerializer()
-    shipping_method_fields = ("name", "type")
-
     shipping_method_channel_listing = shipping_method.channel_listings.filter(
         channel=channel,
     ).first()
+
+    if not shipping_method_channel_listing:
+        return None
+
+    serializer = PayloadSerializer()
+    shipping_method_fields = ("name", "type")
 
     payload = serializer.serialize(
         [shipping_method],

--- a/saleor/webhook/tests/test_webhook_sample_payloads.py
+++ b/saleor/webhook/tests/test_webhook_sample_payloads.py
@@ -105,6 +105,27 @@ def test_generate_sample_payload_fulfillment_created(fulfillment):
     assert sample_fulfillment_payload == fulfillment_payload
 
 
+def test_generate_sample_payload_order_removed_channel_listing_from_shipping(
+    fulfilled_order, payment_txn_captured
+):
+    # given
+    event_name = WebhookEventAsyncType.ORDER_UPDATED
+    order_status = OrderStatus.CANCELED
+    order = fulfilled_order
+    order.status = order_status
+    order.shipping_method.channel_listings.all().delete()
+    order.save()
+    order_id = graphene.Node.to_global_id("Order", order.id)
+
+    # when
+    payload = generate_sample_payload(event_name)
+    order_payload = json.loads(generate_order_payload(order))
+    # then
+    assert order_id == payload[0]["id"]
+    assert order.user_email != payload[0]["user_email"]
+    assert order_payload[0]["shipping_method"] is None
+
+
 @pytest.mark.parametrize(
     "event_name",
     [


### PR DESCRIPTION
I want to merge this change because it fixes #12154
The webhook will be triggered. The payload will return `None` for shipping method without a proper channel listing.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
