### PR TITLE
Fix Avalara tax calculation for JPY currency

### DIFF
--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -376,11 +376,9 @@ class AvataxPlugin(BasePlugin):
         discounts: Iterable["DiscountInfo"],
         previous_value: TaxedMoney,
     ) -> TaxedMoney:
-        base_total = previous_value
-
         charge_taxes = get_charge_taxes_for_checkout(checkout_info, lines)
         if not charge_taxes:
-            return base_total
+            return previous_value
 
         prices_entered_with_tax = partial(
             _get_prices_entered_with_tax_for_checkout, checkout_info
@@ -391,11 +389,18 @@ class AvataxPlugin(BasePlugin):
         )
         variant = checkout_line_info.variant
 
+        if not taxes_data or "error" in taxes_data:
+            return previous_value
+
         return self._calculate_checkout_line_total_price(
             taxes_data,
             variant.sku or variant.get_global_id(),
             prices_entered_with_tax,
-            previous_value,
+            base_value=SimpleLazyObject(
+                lambda: base_calculations.calculate_base_line_total_price(
+                    checkout_line_info, checkout_info.channel, discounts
+                )
+            ),
         )
 
     @staticmethod
@@ -403,11 +408,9 @@ class AvataxPlugin(BasePlugin):
         taxes_data: Dict[str, Any],
         item_code: str,
         prices_entered_with_tax: Callable[[], bool],
-        base_value: TaxedMoney,
+        # base_value should be provided as SimpleLazyObject
+        base_value: Money,
     ) -> TaxedMoney:
-        if not taxes_data or "error" in taxes_data:
-            return base_value
-
         currency = taxes_data.get("currencyCode")
 
         for line in taxes_data.get("lines", []):
@@ -421,7 +424,12 @@ class AvataxPlugin(BasePlugin):
             net = Decimal(line["lineAmount"])
 
             if currency == "JPY" and prices_entered_with_tax():
-                line_gross = base_value.gross
+                if isinstance(base_value, SimpleLazyObject):
+                    base_value = base_value._setupfunc()  # type: ignore
+
+                line_gross = Money(
+                    base_value.amount - discount_amount, currency=currency
+                )
                 line_net = Money(amount=line_gross.amount - tax, currency=currency)
             else:
                 net -= discount_amount
@@ -429,7 +437,9 @@ class AvataxPlugin(BasePlugin):
                 line_net = Money(amount=net, currency=currency)
 
             return TaxedMoney(net=line_net, gross=line_gross)
-        return base_value
+        if isinstance(base_value, SimpleLazyObject):
+            base_value = base_value._setupfunc()  # type: ignore
+        return TaxedMoney(net=base_value, gross=base_value)
 
     def calculate_order_line_total(
         self,
@@ -523,12 +533,18 @@ class AvataxPlugin(BasePlugin):
         taxes_data = self._get_checkout_tax_data(
             checkout_info, lines, discounts, previous_value
         )
-        default_total = previous_value * quantity
+        if not taxes_data or "error" in taxes_data:
+            return previous_value
+
         taxed_total_price = self._calculate_checkout_line_total_price(
             taxes_data,
             variant.sku or variant.get_global_id(),
             prices_entered_with_tax,
-            default_total,
+            base_value=SimpleLazyObject(
+                lambda: base_calculations.calculate_base_line_total_price(
+                    checkout_line_info, checkout_info.channel, discounts
+                )
+            ),
         )
         return taxed_total_price / quantity
 

--- a/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_checkout_total_for_JPY[False-3493-4297-3.0-True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_checkout_total_for_JPY[False-3493-4297-3.0-True].yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
+      "lines": [{"quantity": 3, "amount": "3600", "taxCode": "PS081282", "taxIncluded":
+      true, "itemCode": "123", "discounted": true, "description": "Test product",
+      "ref1": "123"}, {"quantity": 1, "amount": "700.000", "taxCode": "FR000000",
+      "taxIncluded": true, "itemCode": "Shipping", "discounted": false, "description":
+      null}], "code": "46c5c966-7f2d-46c6-af09-95691a4ab415", "date": "2023-02-28",
+      "customerCode": 0, "discount": "3.0", "addresses": {"shipFrom": {"line1": "Teczowa
+      7", "line2": "", "city": "Wroclaw", "region": "", "country": "PL", "postalCode":
+      "53-601"}, "shipTo": {"line1": "O\u0142awska 10", "line2": "", "city": "WROC\u0141AW",
+      "region": "", "country": "PL", "postalCode": "53-105"}}, "commit": false, "currencyCode":
+      "JPY", "email": null}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '832'
+      User-Agent:
+      - python-requests/2.28.1
+    method: POST
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: '{"id":0,"code":"46c5c966-7f2d-46c6-af09-95691a4ab415","companyId":7799660,"date":"2023-02-28","paymentDate":"2023-02-28","status":"Temporary","type":"SalesOrder","batchCode":"","currencyCode":"JPY","exchangeRateCurrencyCode":"JPY","customerUsageType":"","entityUseCode":"","customerVendorCode":"0","customerCode":"0","exemptNo":"","reconciled":false,"locationCode":"","reportingLocationCode":"","purchaseOrderNo":"","referenceCode":"","salespersonCode":"","totalAmount":3495.61,"totalExempt":-0.39,"totalDiscount":3.0,"totalTax":804.0,"totalTaxable":3493.0,"totalTaxCalculated":804.0,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2023-02-28","exchangeRate":1.0,"modifiedDate":"2023-02-28T14:21:36.7475482Z","modifiedUserId":6479978,"taxDate":"2023-02-28","lines":[{"id":0,"transactionId":0,"lineNumber":"1","customerUsageType":"","entityUseCode":"","description":"Test
+        product","discountAmount":3.0,"exemptAmount":-0.39,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"itemCode":"123","lineAmount":2927.0,"quantity":3.0,"ref1":"123","ref2":"","reportingDate":"2023-02-28","tax":673.0,"taxableAmount":2924.0,"taxCalculated":673.0,"taxCode":"PS081282","taxCodeId":38007,"taxDate":"2023-02-28","taxIncluded":true,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"PL","region":"PL","exemptAmount":0.0,"jurisCode":"PL","jurisName":"POLAND","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0,"rate":0.230000,"tax":672.61,"taxableAmount":2924.39,"taxType":"Output","taxSubTypeId":"O","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxCalculated":672.61,"rateType":"Standard","rateTypeCode":"S","unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":2924.39,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":672.61,"reportingTaxCalculated":672.61,"avtUserBIN":"","liabilityType":"Seller"}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLSL230C","vatNumberTypeId":0},{"id":0,"transactionId":0,"lineNumber":"2","customerUsageType":"","entityUseCode":"","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"itemCode":"Shipping","lineAmount":569.0,"quantity":1.0,"ref1":"","ref2":"","reportingDate":"2023-02-28","tax":131.0,"taxableAmount":569.0,"taxCalculated":131.0,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2023-02-28","taxIncluded":true,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"PL","region":"PL","exemptAmount":0.0,"jurisCode":"PL","jurisName":"POLAND","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0,"rate":0.230000,"tax":130.89,"taxableAmount":569.11,"taxType":"Output","taxSubTypeId":"O","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxCalculated":130.89,"rateType":"Standard","rateTypeCode":"S","unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":569.11,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":130.89,"reportingTaxCalculated":130.89,"liabilityType":"Seller"}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLS-230D","vatNumberTypeId":0}],"addresses":[{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Olawska
+        10","line2":"","line3":"","city":"WROCLAW","region":"","postalCode":"53-105","country":"PL","taxRegionId":205102,"latitude":"","longitude":""},{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Teczowa
+        7","line2":"","line3":"","city":"Wroclaw","region":"","postalCode":"53-601","country":"PL","taxRegionId":205102,"latitude":"","longitude":""}],"summary":[{"country":"PL","region":"PL","jurisType":"Country","jurisCode":"PL","jurisName":"POLAND","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Output","taxSubType":"O","taxName":"Standard
+        Rate","rateType":"Standard","taxable":3493.50,"rate":0.230000,"tax":803.50,"taxCalculated":803.50,"nonTaxable":0.0,"exemption":0.0}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 28 Feb 2023 14:21:36 GMT
+      Location:
+      - /api/v2/companies/7799660/transactions/0
+      ServerDuration:
+      - '00:00:00.0214852'
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      api-supported-versions:
+      - '2.0'
+      cache-control:
+      - private, no-cache, no-store
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - 3e77ca9d-45d3-462e-b785-92008ccd7be9
+      x-correlation-id:
+      - 3e77ca9d-45d3-462e-b785-92008ccd7be9
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_checkout_total_for_JPY[False-4300-5289-0.0-False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_checkout_total_for_JPY[False-4300-5289-0.0-False].yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
+      "lines": [{"quantity": 3, "amount": "3600", "taxCode": "PS081282", "taxIncluded":
+      false, "itemCode": "123", "discounted": true, "description": "Test product",
+      "ref1": "123"}, {"quantity": 1, "amount": "700.000", "taxCode": "FR000000",
+      "taxIncluded": false, "itemCode": "Shipping", "discounted": false, "description":
+      null}], "code": "a6a85cf3-b846-48a0-b38c-de4f42b74efd", "date": "2023-02-28",
+      "customerCode": 0, "discount": null, "addresses": {"shipFrom": {"line1": "Teczowa
+      7", "line2": "", "city": "Wroclaw", "region": "", "country": "PL", "postalCode":
+      "53-601"}, "shipTo": {"line1": "O\u0142awska 10", "line2": "", "city": "WROC\u0141AW",
+      "region": "", "country": "PL", "postalCode": "53-105"}}, "commit": false, "currencyCode":
+      "JPY", "email": null}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '833'
+      User-Agent:
+      - python-requests/2.28.1
+    method: POST
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: '{"id":0,"code":"a6a85cf3-b846-48a0-b38c-de4f42b74efd","companyId":7799660,"date":"2023-02-28","paymentDate":"2023-02-28","status":"Temporary","type":"SalesOrder","batchCode":"","currencyCode":"JPY","exchangeRateCurrencyCode":"JPY","customerUsageType":"","entityUseCode":"","customerVendorCode":"0","customerCode":"0","exemptNo":"","reconciled":false,"locationCode":"","reportingLocationCode":"","purchaseOrderNo":"","referenceCode":"","salespersonCode":"","totalAmount":4300.0,"totalExempt":0.0,"totalDiscount":0.0,"totalTax":989.0,"totalTaxable":4300.0,"totalTaxCalculated":989.0,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2023-02-28","exchangeRate":1.0,"modifiedDate":"2023-02-28T14:21:35.3606313Z","modifiedUserId":6479978,"taxDate":"2023-02-28","lines":[{"id":0,"transactionId":0,"lineNumber":"1","customerUsageType":"","entityUseCode":"","description":"Test
+        product","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"itemCode":"123","lineAmount":3600.0,"quantity":3.0,"ref1":"123","ref2":"","reportingDate":"2023-02-28","tax":828.0,"taxableAmount":3600.0,"taxCalculated":828.0,"taxCode":"PS081282","taxCodeId":38007,"taxDate":"2023-02-28","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"PL","region":"PL","exemptAmount":0.0,"jurisCode":"PL","jurisName":"POLAND","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0,"rate":0.230000,"tax":828.0,"taxableAmount":3600.0,"taxType":"Output","taxSubTypeId":"O","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxCalculated":828.0,"rateType":"Standard","rateTypeCode":"S","unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":3600.0,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":828.0,"reportingTaxCalculated":828.0,"avtUserBIN":"","liabilityType":"Seller"}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLSL230C","vatNumberTypeId":0},{"id":0,"transactionId":0,"lineNumber":"2","customerUsageType":"","entityUseCode":"","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"itemCode":"Shipping","lineAmount":700.0,"quantity":1.0,"ref1":"","ref2":"","reportingDate":"2023-02-28","tax":161.0,"taxableAmount":700.0,"taxCalculated":161.0,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2023-02-28","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"PL","region":"PL","exemptAmount":0.0,"jurisCode":"PL","jurisName":"POLAND","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0,"rate":0.230000,"tax":161.0,"taxableAmount":700.0,"taxType":"Output","taxSubTypeId":"O","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxCalculated":161.0,"rateType":"Standard","rateTypeCode":"S","unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":700.0,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":161.0,"reportingTaxCalculated":161.0,"liabilityType":"Seller"}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLS-230D","vatNumberTypeId":0}],"addresses":[{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Olawska
+        10","line2":"","line3":"","city":"WROCLAW","region":"","postalCode":"53-105","country":"PL","taxRegionId":205102,"latitude":"","longitude":""},{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Teczowa
+        7","line2":"","line3":"","city":"Wroclaw","region":"","postalCode":"53-601","country":"PL","taxRegionId":205102,"latitude":"","longitude":""}],"summary":[{"country":"PL","region":"PL","jurisType":"Country","jurisCode":"PL","jurisName":"POLAND","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Output","taxSubType":"O","taxName":"Standard
+        Rate","rateType":"Standard","taxable":4300.0,"rate":0.230000,"tax":989.0,"taxCalculated":989.0,"nonTaxable":0.0,"exemption":0.0}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 28 Feb 2023 14:21:35 GMT
+      Location:
+      - /api/v2/companies/7799660/transactions/0
+      ServerDuration:
+      - '00:00:00.0232804'
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      api-supported-versions:
+      - '2.0'
+      cache-control:
+      - private, no-cache, no-store
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - d380393b-8cf3-4f63-9029-a338567295bd
+      x-correlation-id:
+      - d380393b-8cf3-4f63-9029-a338567295bd
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_checkout_total_for_JPY[True-3484-4285-0.0-True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_checkout_total_for_JPY[True-3484-4285-0.0-True].yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
+      "lines": [{"quantity": 3, "amount": "3585", "taxCode": "PS081282", "taxIncluded":
+      true, "itemCode": "123", "discounted": true, "description": "Test product",
+      "ref1": "123"}, {"quantity": 1, "amount": "700.000", "taxCode": "FR000000",
+      "taxIncluded": true, "itemCode": "Shipping", "discounted": false, "description":
+      null}], "code": "fb6e705c-80bc-4e00-83db-1914a7e94933", "date": "2023-02-28",
+      "customerCode": 0, "discount": null, "addresses": {"shipFrom": {"line1": "Teczowa
+      7", "line2": "", "city": "Wroclaw", "region": "", "country": "PL", "postalCode":
+      "53-601"}, "shipTo": {"line1": "O\u0142awska 10", "line2": "", "city": "WROC\u0141AW",
+      "region": "", "country": "PL", "postalCode": "53-105"}}, "commit": false, "currencyCode":
+      "JPY", "email": null}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '831'
+      User-Agent:
+      - python-requests/2.28.1
+    method: POST
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: '{"id":0,"code":"fb6e705c-80bc-4e00-83db-1914a7e94933","companyId":7799660,"date":"2023-02-28","paymentDate":"2023-02-28","status":"Temporary","type":"SalesOrder","batchCode":"","currencyCode":"JPY","exchangeRateCurrencyCode":"JPY","customerUsageType":"","entityUseCode":"","customerVendorCode":"0","customerCode":"0","exemptNo":"","reconciled":false,"locationCode":"","reportingLocationCode":"","purchaseOrderNo":"","referenceCode":"","salespersonCode":"","totalAmount":3484.37,"totalExempt":0.37,"totalDiscount":0.0,"totalTax":801.0,"totalTaxable":3484.0,"totalTaxCalculated":801.0,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2023-02-28","exchangeRate":1.0,"modifiedDate":"2023-02-28T14:21:32.5552891Z","modifiedUserId":6479978,"taxDate":"2023-02-28","lines":[{"id":0,"transactionId":0,"lineNumber":"1","customerUsageType":"","entityUseCode":"","description":"Test
+        product","discountAmount":0.0,"exemptAmount":0.37,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"itemCode":"123","lineAmount":2915.0,"quantity":3.0,"ref1":"123","ref2":"","reportingDate":"2023-02-28","tax":670.0,"taxableAmount":2915.0,"taxCalculated":670.0,"taxCode":"PS081282","taxCodeId":38007,"taxDate":"2023-02-28","taxIncluded":true,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"PL","region":"PL","exemptAmount":0.0,"jurisCode":"PL","jurisName":"POLAND","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0,"rate":0.230000,"tax":670.37,"taxableAmount":2914.63,"taxType":"Output","taxSubTypeId":"O","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxCalculated":670.37,"rateType":"Standard","rateTypeCode":"S","unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":2914.63,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":670.37,"reportingTaxCalculated":670.37,"avtUserBIN":"","liabilityType":"Seller"}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLSL230C","vatNumberTypeId":0},{"id":0,"transactionId":0,"lineNumber":"2","customerUsageType":"","entityUseCode":"","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"itemCode":"Shipping","lineAmount":569.0,"quantity":1.0,"ref1":"","ref2":"","reportingDate":"2023-02-28","tax":131.0,"taxableAmount":569.0,"taxCalculated":131.0,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2023-02-28","taxIncluded":true,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"PL","region":"PL","exemptAmount":0.0,"jurisCode":"PL","jurisName":"POLAND","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0,"rate":0.230000,"tax":130.89,"taxableAmount":569.11,"taxType":"Output","taxSubTypeId":"O","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxCalculated":130.89,"rateType":"Standard","rateTypeCode":"S","unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":569.11,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":130.89,"reportingTaxCalculated":130.89,"liabilityType":"Seller"}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLS-230D","vatNumberTypeId":0}],"addresses":[{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Olawska
+        10","line2":"","line3":"","city":"WROCLAW","region":"","postalCode":"53-105","country":"PL","taxRegionId":205102,"latitude":"","longitude":""},{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Teczowa
+        7","line2":"","line3":"","city":"Wroclaw","region":"","postalCode":"53-601","country":"PL","taxRegionId":205102,"latitude":"","longitude":""}],"summary":[{"country":"PL","region":"PL","jurisType":"Country","jurisCode":"PL","jurisName":"POLAND","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Output","taxSubType":"O","taxName":"Standard
+        Rate","rateType":"Standard","taxable":3483.74,"rate":0.230000,"tax":801.26,"taxCalculated":801.26,"nonTaxable":0.0,"exemption":0.0}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 28 Feb 2023 14:21:32 GMT
+      Location:
+      - /api/v2/companies/7799660/transactions/0
+      ServerDuration:
+      - '00:00:00.0206591'
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      api-supported-versions:
+      - '2.0'
+      cache-control:
+      - private, no-cache, no-store
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - 08e3dff6-4465-42ca-95c1-7b0e3ea1e1b8
+      x-correlation-id:
+      - 08e3dff6-4465-42ca-95c1-7b0e3ea1e1b8
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_checkout_total_for_JPY[True-4280-5264-5.0-False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_checkout_total_for_JPY[True-4280-5264-5.0-False].yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
+      "lines": [{"quantity": 3, "amount": "3585", "taxCode": "PS081282", "taxIncluded":
+      false, "itemCode": "123", "discounted": true, "description": "Test product",
+      "ref1": "123"}, {"quantity": 1, "amount": "700.000", "taxCode": "FR000000",
+      "taxIncluded": false, "itemCode": "Shipping", "discounted": false, "description":
+      null}], "code": "7927798f-9104-411c-8739-a9628e2e86e8", "date": "2023-02-28",
+      "customerCode": 0, "discount": "5.0", "addresses": {"shipFrom": {"line1": "Teczowa
+      7", "line2": "", "city": "Wroclaw", "region": "", "country": "PL", "postalCode":
+      "53-601"}, "shipTo": {"line1": "O\u0142awska 10", "line2": "", "city": "WROC\u0141AW",
+      "region": "", "country": "PL", "postalCode": "53-105"}}, "commit": false, "currencyCode":
+      "JPY", "email": null}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '834'
+      User-Agent:
+      - python-requests/2.28.1
+    method: POST
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: '{"id":0,"code":"7927798f-9104-411c-8739-a9628e2e86e8","companyId":7799660,"date":"2023-02-28","paymentDate":"2023-02-28","status":"Temporary","type":"SalesOrder","batchCode":"","currencyCode":"JPY","exchangeRateCurrencyCode":"JPY","customerUsageType":"","entityUseCode":"","customerVendorCode":"0","customerCode":"0","exemptNo":"","reconciled":false,"locationCode":"","reportingLocationCode":"","purchaseOrderNo":"","referenceCode":"","salespersonCode":"","totalAmount":4285.0,"totalExempt":0.0,"totalDiscount":5.0,"totalTax":984.0,"totalTaxable":4280.0,"totalTaxCalculated":984.0,"adjustmentReason":"NotAdjusted","locked":false,"version":1,"exchangeRateEffectiveDate":"2023-02-28","exchangeRate":1.0,"modifiedDate":"2023-02-28T14:21:34.008221Z","modifiedUserId":6479978,"taxDate":"2023-02-28","lines":[{"id":0,"transactionId":0,"lineNumber":"1","customerUsageType":"","entityUseCode":"","description":"Test
+        product","discountAmount":5.0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"itemCode":"123","lineAmount":3585.0,"quantity":3.0,"ref1":"123","ref2":"","reportingDate":"2023-02-28","tax":823.0,"taxableAmount":3580.0,"taxCalculated":823.0,"taxCode":"PS081282","taxCodeId":38007,"taxDate":"2023-02-28","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"PL","region":"PL","exemptAmount":0.0,"jurisCode":"PL","jurisName":"POLAND","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0,"rate":0.230000,"tax":823.4,"taxableAmount":3580.0,"taxType":"Output","taxSubTypeId":"O","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxCalculated":823.4,"rateType":"Standard","rateTypeCode":"S","unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":3580.0,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":823.4,"reportingTaxCalculated":823.4,"avtUserBIN":"","liabilityType":"Seller"}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLSL230C","vatNumberTypeId":0},{"id":0,"transactionId":0,"lineNumber":"2","customerUsageType":"","entityUseCode":"","discountAmount":0.0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"itemCode":"Shipping","lineAmount":700.0,"quantity":1.0,"ref1":"","ref2":"","reportingDate":"2023-02-28","tax":161.0,"taxableAmount":700.0,"taxCalculated":161.0,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2023-02-28","taxIncluded":false,"details":[{"id":0,"transactionLineId":0,"transactionId":0,"country":"PL","region":"PL","exemptAmount":0.0,"jurisCode":"PL","jurisName":"POLAND","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0,"rate":0.230000,"tax":161.0,"taxableAmount":700.0,"taxType":"Output","taxSubTypeId":"O","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxCalculated":161.0,"rateType":"Standard","rateTypeCode":"S","unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":700.0,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":161.0,"reportingTaxCalculated":161.0,"liabilityType":"Seller"}],"nonPassthroughDetails":[],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLS-230D","vatNumberTypeId":0}],"addresses":[{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Olawska
+        10","line2":"","line3":"","city":"WROCLAW","region":"","postalCode":"53-105","country":"PL","taxRegionId":205102,"latitude":"","longitude":""},{"id":0,"transactionId":0,"boundaryLevel":"Zip5","line1":"Teczowa
+        7","line2":"","line3":"","city":"Wroclaw","region":"","postalCode":"53-601","country":"PL","taxRegionId":205102,"latitude":"","longitude":""}],"summary":[{"country":"PL","region":"PL","jurisType":"Country","jurisCode":"PL","jurisName":"POLAND","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Output","taxSubType":"O","taxName":"Standard
+        Rate","rateType":"Standard","taxable":4280.0,"rate":0.230000,"tax":984.4,"taxCalculated":984.4,"nonTaxable":0.0,"exemption":0.0}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 28 Feb 2023 14:21:34 GMT
+      Location:
+      - /api/v2/companies/7799660/transactions/0
+      ServerDuration:
+      - '00:00:00.0200013'
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      api-supported-versions:
+      - '2.0'
+      cache-control:
+      - private, no-cache, no-store
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - 224d80bc-8881-4adc-9da3-903a210dc903
+      x-correlation-id:
+      - 224d80bc-8881-4adc-9da3-903a210dc903
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4876,6 +4876,24 @@ def discount_info(category, collection, sale, channel_USD):
 
 
 @pytest.fixture
+def discount_info_JPY(sale, product_in_channel_JPY, channel_JPY):
+    sale_channel_listing = sale.channel_listings.create(
+        channel=channel_JPY,
+        discount_value=5,
+        currency=channel_JPY.currency_code,
+    )
+
+    return DiscountInfo(
+        sale=sale,
+        channel_listings={channel_JPY.slug: sale_channel_listing},
+        product_ids={product_in_channel_JPY.id},
+        category_ids=set(),
+        collection_ids=set(),
+        variants_ids=set(),
+    )
+
+
+@pytest.fixture
 def permission_manage_staff():
     return Permission.objects.get(codename="manage_staff")
 


### PR DESCRIPTION
Fix problem with calculating taxes by Avalara plugin for `JPY` currency.

Port of #12158

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
