### PR TITLE
Fix loading related_order when related id is the old order_id

### DIFF
--- a/saleor/graphql/order/dataloaders.py
+++ b/saleor/graphql/order/dataloaders.py
@@ -43,6 +43,18 @@ class OrderByIdLoader(DataLoader):
         return [orders.get(order_id) for order_id in keys]
 
 
+class OrderByNumberLoader(DataLoader):
+    context_key = "order_by_number"
+
+    def batch_load(self, keys):
+        orders = (
+            Order.objects.using(self.database_connection_name)
+            .filter(number__in=keys)
+            .in_bulk(field_name="number")
+        )
+        return [orders.get(number) for number in keys]
+
+
 class OrdersByUserLoader(DataLoader):
     context_key = "order_by_user"
 

--- a/saleor/graphql/order/tests/queries/test_order_events.py
+++ b/saleor/graphql/order/tests/queries/test_order_events.py
@@ -2,9 +2,10 @@ from copy import deepcopy
 
 import graphene
 
+from .....order import OrderEvents
 from .....order import events as order_events
 from .....order.events import order_replacement_created
-from .....order.models import get_order_number
+from .....order.models import OrderEvent, get_order_number
 from ....tests.utils import get_graphql_content
 
 ORDERS_FULFILLED_EVENTS = """
@@ -229,6 +230,41 @@ def test_related_order_events_query_for_app(
 
     staff_api_client.user.user_permissions.add(permission_manage_orders)
     response = staff_api_client.post_graphql(ORDERS_WITH_EVENTS)
+    content = get_graphql_content(response)
+
+    data = content["data"]["orders"]["edges"]
+    for order_data in data:
+        events_data = order_data["node"]["events"]
+        if order_data["node"]["id"] != related_order_id:
+            assert events_data[0]["relatedOrder"]["id"] == related_order_id
+
+
+def test_related_order_eventes_old_order_id(
+    staff_api_client, permission_manage_orders, order, payment_dummy, app
+):
+    # given
+    new_order = deepcopy(order)
+    new_order.id = None
+    new_order.number = get_order_number()
+    new_order.save()
+
+    related_order_id = graphene.Node.to_global_id("Order", new_order.id)
+
+    parameters = {"related_order_pk": new_order.number}
+    OrderEvent.objects.create(
+        order=order,
+        type=OrderEvents.ORDER_REPLACEMENT_CREATED,
+        user=None,
+        app=app,
+        parameters=parameters,
+    )
+
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    # when
+    response = staff_api_client.post_graphql(ORDERS_WITH_EVENTS)
+
+    # then
     content = get_graphql_content(response)
 
     data = content["data"]["orders"]["edges"]


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/12161

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
