### PR TITLE
Make sure to return correct transaction event, for transactionEventReport

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1492,6 +1492,6 @@ class TransactionEventReport(ModelMutation):
         return cls(
             already_processed=already_processed,
             transaction=transaction,
-            transaction_event=payment_models.TransactionEvent.objects.first(),
+            transaction_event=transaction_event,
             errors=[],
         )


### PR DESCRIPTION
I want to merge this change because previously we were returning the .first(). I left this by mistake and proper transactionEvent object should be returned

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
