### PR TITLE
[Support for payment apps] Add optional psp reference, when app returns action-required

### DIFF
--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -29,7 +29,7 @@ class TransactionActionData:
 
 @dataclass
 class TransactionRequestEventResponse:
-    psp_reference: str
+    psp_reference: Optional[str]
     type: str
     amount: Decimal
     time: Optional[datetime] = None
@@ -39,7 +39,7 @@ class TransactionRequestEventResponse:
 
 @dataclass
 class TransactionRequestResponse:
-    psp_reference: str
+    psp_reference: Optional[str]
     event: Optional["TransactionRequestEventResponse"] = None
 
 


### PR DESCRIPTION
I want to merge this change because it covers https://github.com/saleor/saleor/issues/12143

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
