### PR TITLE
Fix deadlock between adyen webhook and checkoutComplete

### DIFF
--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_api_response.py
@@ -28,7 +28,12 @@ def test_handle_api_response_auto_capture_order_created_can_refund(
         }
     )
 
-    handle_api_response(payment_adyen_for_checkout, adyen_response, plugin.channel.slug)
+    handle_api_response(
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        adyen_response,
+        plugin.channel.slug,
+    )
 
     payment_adyen_for_checkout.refresh_from_db()
 
@@ -60,7 +65,12 @@ def test_handle_api_response_auto_capture_false_order_created_can_void(
         }
     )
 
-    handle_api_response(payment_adyen_for_checkout, adyen_response, plugin.channel.slug)
+    handle_api_response(
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        adyen_response,
+        plugin.channel.slug,
+    )
 
     payment_adyen_for_checkout.refresh_from_db()
 
@@ -94,7 +104,12 @@ def test_handle_api_response_auto_capture_false_cannot_create_order_void_payment
         }
     )
 
-    handle_api_response(payment_adyen_for_checkout, adyen_response, plugin.channel.slug)
+    handle_api_response(
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        adyen_response,
+        plugin.channel.slug,
+    )
 
     payment_adyen_for_checkout.refresh_from_db()
 
@@ -130,7 +145,12 @@ def test_handle_api_response_auto_capture_cannot_create_order_refund_payment(
         }
     )
 
-    handle_api_response(payment_adyen_for_checkout, adyen_response, plugin.channel.slug)
+    handle_api_response(
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        adyen_response,
+        plugin.channel.slug,
+    )
 
     payment_adyen_for_checkout.refresh_from_db()
 
@@ -169,7 +189,12 @@ def test_handle_api_response_auto_capture_cannot_create_order_variant_deleted(
         }
     )
 
-    handle_api_response(payment_adyen_for_checkout, adyen_response, plugin.channel.slug)
+    handle_api_response(
+        payment_adyen_for_checkout,
+        payment_adyen_for_checkout.checkout,
+        adyen_response,
+        plugin.channel.slug,
+    )
 
     payment_adyen_for_checkout.refresh_from_db()
 

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -64,12 +64,10 @@ from .utils.common import (
 logger = logging.getLogger(__name__)
 
 
-def get_payment(
+def get_payment_id(
     payment_id: Optional[str],
     transaction_id: Optional[str] = None,
-    check_if_active=True,
-) -> Optional[Payment]:
-    transaction_id = transaction_id or ""
+):
     if payment_id is None or not payment_id.strip():
         logger.warning("Missing payment ID. Reference %s", transaction_id)
         return None
@@ -83,6 +81,18 @@ def get_payment(
             payment_id,
             transaction_id,
         )
+        return None
+    return db_payment_id
+
+
+def get_payment(
+    payment_id: Optional[str],
+    transaction_id: Optional[str] = None,
+    check_if_active=True,
+) -> Optional[Payment]:
+    transaction_id = transaction_id or ""
+    db_payment_id = get_payment_id(payment_id)
+    if not db_payment_id:
         return None
     payments = (
         Payment.objects.prefetch_related("order", "checkout")
@@ -102,9 +112,7 @@ def get_payment(
     return payment
 
 
-def get_checkout(payment: Payment) -> Optional[Checkout]:
-    if not payment.checkout:
-        return None
+def get_checkout(payment_id: int) -> Optional[Checkout]:
     # Lock checkout in the same way as in checkoutComplete
     return (
         Checkout.objects.select_for_update(of=("self",))
@@ -113,7 +121,7 @@ def get_checkout(payment: Payment) -> Optional[Checkout]:
             "lines__variant__product",
         )
         .select_related("shipping_method__shipping_zone")
-        .filter(pk=payment.checkout.pk)
+        .filter(payments__id=payment_id)
         .first()
     )
 
@@ -259,13 +267,21 @@ def handle_authorization(notification: Dict[str, Any], gateway_config: GatewayCo
     """
 
     transaction_id = notification.get("pspReference")
+    graphql_payment_id = notification.get("merchantReference")
+    payment_id = get_payment_id(graphql_payment_id, transaction_id)
+    if not payment_id:
+        # We can't decode the merchantReference which should be a payment id in
+        # graphql format
+        return
+
+    checkout = get_checkout(payment_id)
+
     payment = get_payment(
         notification.get("merchantReference"), transaction_id, check_if_active=False
     )
     if not payment:
         # We don't know anything about that payment
         return
-    checkout = get_checkout(payment)
 
     manager = get_plugins_manager()
     adyen_auto_capture = gateway_config.connection_params["adyen_auto_capture"]
@@ -388,12 +404,16 @@ def handle_cancel_or_refund(
 def handle_capture(notification: Dict[str, Any], _gateway_config: GatewayConfig):
     # https://docs.adyen.com/checkout/capture#capture-notification
     transaction_id = notification.get("pspReference")
-    payment = get_payment(
-        notification.get("merchantReference"), transaction_id, check_if_active=False
-    )
+    graphql_payment_id = notification.get("merchantReference")
+
+    payment_id = get_payment_id(graphql_payment_id, transaction_id)
+    if not payment_id:
+        return
+    checkout = get_checkout(payment_id)
+
+    payment = get_payment(graphql_payment_id, transaction_id, check_if_active=False)
     if not payment:
         return
-    checkout = get_checkout(payment)
 
     manager = get_plugins_manager()
 
@@ -1007,7 +1027,8 @@ def handle_additional_actions(
             extra={"payment_id": payment_id, "checkout_id": checkout_pk},
         )
         return HttpResponseNotFound()
-
+    db_payment_id = get_payment_id(payment_id)
+    checkout = get_checkout(db_payment_id)
     payment = get_payment(payment_id, transaction_id=None)
     if not payment:
         logger.warning(
@@ -1020,7 +1041,7 @@ def handle_additional_actions(
     # Adyen for some payment methods can call success notification before we will
     # call an additional_action.
     if not payment.order_id:
-        if not payment.checkout or str(payment.checkout.token) != checkout_pk:
+        if not checkout or str(checkout.token) != checkout_pk:
             logger.warning(
                 "There is no checkout with this payment.",
                 extra={"checkout_pk": checkout_pk, "payment_id": payment_id},
@@ -1051,7 +1072,7 @@ def handle_additional_actions(
         result = api_call(request_data, payment_details)
     except PaymentError as e:
         return HttpResponseBadRequest(str(e))
-    handle_api_response(payment, result, channel_slug)
+    handle_api_response(payment, checkout, result, channel_slug)
     redirect_url = prepare_redirect_url(payment_id, checkout_pk, result, return_url)
     parsed = urlparse(return_url)
     redirect_class = HttpResponseRedirect
@@ -1103,8 +1124,12 @@ def prepare_redirect_url(
     return prepare_url(urlencode(params), return_url)
 
 
-def handle_api_response(payment: Payment, response: Adyen.Adyen, channel_slug: str):
-    checkout = get_checkout(payment)
+def handle_api_response(
+    payment: Payment,
+    checkout: Optional[Checkout],
+    response: Adyen.Adyen,
+    channel_slug: str,
+):
     payment_data = create_payment_information(
         payment=payment,
         payment_token=payment.token,
@@ -1143,7 +1168,7 @@ def handle_api_response(payment: Payment, response: Adyen.Adyen, channel_slug: s
         payment_information=payment_data,
         gateway_response=gateway_response,
     )
-    if is_success and not action_required and not payment.order:
+    if is_success and not action_required and not payment.order and checkout:
         manager = get_plugins_manager()
 
         confirm_payment_and_set_back_to_confirm(payment, manager, channel_slug)


### PR DESCRIPTION
I want to merge this change because it is port of changes from https://github.com/saleor/saleor/pull/12195

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
