### PR TITLE
Fix integrity error with returning products with old ids

### DIFF
--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -1148,6 +1148,7 @@ def create_replace_order(
             order_line.order = replace_order
             order_line.quantity = line_data.quantity
             order_line.quantity_fulfilled = 0
+            order_line.old_id = None
             # we set order_line_id as a key to use it for iterating over fulfillment
             # items
             order_line_to_create[order_line_id] = order_line
@@ -1172,6 +1173,7 @@ def create_replace_order(
             order_line = order_line_from_fulfillment
             order_line_id = order_line.pk
             order_line.pk = None
+            order_line.old_id = None
             order_line.order = replace_order
             order_line.quantity = fulfillment_line_data.quantity
             order_line.quantity_fulfilled = 0


### PR DESCRIPTION
I want to merge this change because it is a port of https://github.com/saleor/saleor/pull/12194

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
