### PR TITLE
Update Avatax tests to always use env variables for configuration

### DIFF
--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -7,6 +7,7 @@ from ....checkout.fetch import CheckoutInfo, get_delivery_method_info
 from ....shipping.models import ShippingMethodChannelListing
 from ....shipping.utils import convert_to_shipping_method_data
 from ...models import PluginConfiguration
+from .. import AvataxConfiguration
 from ..plugin import AvataxPlugin
 
 
@@ -60,6 +61,20 @@ def plugin_configuration(db, channel_USD):
         return configuration
 
     return set_configuration
+
+
+@pytest.fixture
+def avatax_config():
+    return AvataxConfiguration(
+        username_or_account=os.environ.get("AVALARA_USERNAME", "test"),
+        password_or_license=os.environ.get("AVALARA_PASSWORD", "test"),
+        use_sandbox=True,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
Update `Avatax` tests to always use env variables for configuration

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
