### PR TITLE
Update Security Policy Links

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,12 +11,11 @@ The following releases of Saleor are currently supported.
 
 ## Reporting a Vulnerability
 
-Please DO NOT report security vulnerabilities using a public GitHub issue. If you believe you've found a security issue, please contact our security mailing list.
-
-security@saleor.io
+Please DO NOT report security vulnerabilities using a public GitHub issue. If you believe you've found a security issue, please contact us through one of the following methods:
+- https://github.com/saleor/saleor/security/advisories
+- https://huntr.dev/repos/saleor/saleor
+- Alternavely, through our mailing list: security@saleor.io
 
 At this time we do not have a bounty program in place so we are not able to offer monetary rewards for any problems reported.
-
-You can also claim bounty rewards by reporting vulnerabilities using Huntr: https://huntr.dev
-
+You can claim bounty rewards by reporting vulnerabilities using Huntr: https://huntr.dev.
 Whichever method you choose, you will be credited as the reporter once the announcement is published.


### PR DESCRIPTION
This updates the security policy as we have enabled vulnerability reporting through GitHub (https://github.com/saleor/saleor/security/advisories)
