### PR TITLE
[Support for payment transaction actions] Bump branch after releasing 312

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
-# 3.12.0 [Unreleased]
+# 3.13.0 [Unreleased]
 ### Highlights
 - Improve support for handling transactions - #10350 by @korycins
   - API changes:
@@ -70,34 +70,33 @@ All notable, unreleased changes to this project will be documented in this file.
       - `TRANSACTION_ACTION_REQUEST` - Use `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead.
     - Deprecate object fields:
       - `TransactionItem`:
-        - `voidedAmount` - Use `canceledAmount`. This field will be removed in Saleor 3.13 (Preview feature).
-        - `status` - Not needed anymore. The transaction amounts will be used to determine a current status of transactions. This field will be removed in Saleor 3.13 (Preview feature).
-        - `reference` - Use `pspReference` instead. This field will be removed in Saleor 3.13 (Preview feature).
+        - `voidedAmount` - Use `canceledAmount`. This field will be removed in Saleor 3.14 (Preview feature).
+        - `status` - Not needed anymore. The transaction amounts will be used to determine a current status of transactions. This field will be removed in Saleor 3.14 (Preview feature).
+        - `reference` - Use `pspReference` instead. This field will be removed in Saleor 3.14 (Preview feature).
       - `TransactionEvent`:
-        - `status` - Use `type` instead. This field will be removed in Saleor 3.13 (Preview feature).
-        - `reference` - Use `pspReference` instead. This field will be removed in Saleor 3.13 (Preview feature).
-        - `name` - Use `message` instead. This field will be removed in Saleor 3.13 (Preview feature).
+        - `status` - Use `type` instead. This field will be removed in Saleor 3.14 (Preview feature).
+        - `reference` - Use `pspReference` instead. This field will be removed in Saleor 3.14 (Preview feature).
+        - `name` - Use `message` instead. This field will be removed in Saleor 3.14 (Preview feature).
       - `TransactionActionEnum`
-        - `VOID` - Use `CANCEL` instead. This field will be removed in Saleor 3.13 (Preview feature).
+        - `VOID` - Use `CANCEL` instead. This field will be removed in Saleor 3.14 (Preview feature).
       - `Order`:
         - `totalCaptured` - Use `totalCharged` instead. Will be removed in Saleor 4.0
       - `OrderEvent`:
-        - `status` - Use `TransactionEvent` to track the status of `TransactionItem`. This field will be removed in Saleor 3.13 (Preview feature).
+        - `status` - Use `TransactionEvent` to track the status of `TransactionItem`. This field will be removed in Saleor 3.14 (Preview feature).
       - `OrderEventsEnum`:
-        - `TRANSACTION_CAPTURE_REQUESTED` - Use `TRANSACTION_CHARGE_REQUESTED` instead. This field will be removed in Saleor 3.13 (Preview feature).
-        - `TRANSACTION_VOID_REQUESTED` - Use `TRANSACTION_CANCEL_REQUESTED` instead. This field will be removed in Saleor 3.13 (Preview feature).
+        - `TRANSACTION_CAPTURE_REQUESTED` - Use `TRANSACTION_CHARGE_REQUESTED` instead. This field will be removed in Saleor 3.14 (Preview feature).
+        - `TRANSACTION_VOID_REQUESTED` - Use `TRANSACTION_CANCEL_REQUESTED` instead. This field will be removed in Saleor 3.14 (Preview feature).
 
     - Deprecate input fields:
       - `TransactionCreateInput` & `TransactionUpdateInput`:
-        - `status` - Not needed anymore. The transaction amounts will be used to determine a current status of transactions. This input field will be removed in Saleor 3.13 (Preview feature).
-        - `type` - Use `name` and `message` instead. This input field will be removed in Saleor 3.13 (Preview feature).
-        - `reference` - Use `pspReference` instead. This input field will be removed in Saleor 3.13 (Preview feature).
-        - `amountVoided` - Use `amountCanceled` instead. This input field will be removed in Saleor 3.13 (Preview feature).
+        - `status` - Not needed anymore. The transaction amounts will be used to determine a current status of transactions. This input field will be removed in Saleor 3.14 (Preview feature).
+        - `type` - Use `name` and `message` instead. This input field will be removed in Saleor 3.14 (Preview feature).
+        - `reference` - Use `pspReference` instead. This input field will be removed in Saleor 3.14 (Preview feature).
+        - `amountVoided` - Use `amountCanceled` instead. This input field will be removed in Saleor 3.14 (Preview feature).
       - `TransactionEventInput`:
-        - `status` - Status will be calculated by Saleor. This input field will be removed in Saleor 3.13 (Preview feature).
-        - `reference` - Use `pspReference` instead. This input field will be removed in Saleor 3.13 (Preview feature).
-        - `name` - Use `message` instead. This field will be removed in Saleor 3.13 (Preview feature).
-
+        - `status` - Status will be calculated by Saleor. This input field will be removed in Saleor 3.14 (Preview feature).
+        - `reference` - Use `pspReference` instead. This input field will be removed in Saleor 3.14 (Preview feature).
+        - `name` - Use `message` instead. This field will be removed in Saleor 3.14 (Preview feature).
 
 ### Breaking changes
 - **Feature preview breaking change**:
@@ -106,45 +105,6 @@ All notable, unreleased changes to this project will be documented in this file.
     - `transactionRequestAction` mutation can't be executed with `MANAGE_ORDERS` permission. Permission `HANDLE_PAYMENTS` is required.
     - Drop calling `TRANSACTION_ACTION_REQUEST` webhook inside a mutation related to `Payment` types. The related mutations: `orderVoid`, `orderCapture`, `orderRefund`, `orderFulfillmentRefundProducts`, `orderFulfillmentReturnProducts`. Use dedicated mutation for triggering an action: `transactionRequestAction`.
     - When calling `transactionUpdate` mutation, the amounts from the previous state should not be reduced.
-  - `stocks` and `channelListings` inputs for preview `ProductVariantBulkUpdate` mutation has been changed. Both inputs have been extended by:
-      - `create` input - list of items that should be created
-      - `update` input - list of items that should be updated
-      - `remove` input - list of objects ID's that should be removed
-
-    If your platform relies on this [Preview] feature, make sure you update your mutations stocks and channel listings inputs from:
-      ```
-         {
-          "stocks/channelListings": [
-            {
-              ...
-            }
-          ]
-         }
-      ```
-      to:
-      ```
-         {
-          "stocks/channelListings": {
-            "create": [
-              {
-               ...
-              }
-            ]
-          }
-         }
-      ```
-        }
-       }
-    ```
-- Change the discount rounding mode - #12041 by @IKarbowiak
-  - Change the rounding mode from `ROUND_DOWN` to `ROUND_HALF_UP` - it affects the discount amount and total price of future checkouts and orders with a percentage discount applied.
-  The discount amount might be 0.01 greater, and the total price might be 0.01 lower.
-  E.g. if you had an order for $13 and applied a 12.5% discount, you would get $11.38 with a $1.62 discount, but now it will be calculated as $11.37 with $1.63 discount.
-
-- Media and image fields now default to returning 4K thumbnails instead of original uploads - #11996 by @patrys
-# 3.13.0 [Unreleased]
-
-### Breaking changes
 
 ### GraphQL API
 

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -1,15 +1,15 @@
 # Deprecation message for queries, object fields and mutations. Use it, when
 # `deprecation_reason` argument is supported.
 DEPRECATED_IN_3X_FIELD = "This field will be removed in Saleor 4.0."
-PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD = (
-    "This field will be removed in Saleor 3.13 (Preview Feature)."
+PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD = (
+    "This field will be removed in Saleor 3.14 (Preview Feature)."
 )
 
 # Deprecation message for input fields and query arguments. Use it, when
 # deprecation message needs to be included in the field description.
 DEPRECATED_IN_3X_INPUT = "\n\nDEPRECATED: this field will be removed in Saleor 4.0."
-PREVIEW_FEATURE_DEPRECATED_IN_312_INPUT = (
-    "\n\nDEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature)."
+PREVIEW_FEATURE_DEPRECATED_IN_313_INPUT = (
+    "\n\nDEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature)."
 )
 
 DEPRECATED_IN_3X_MUTATION = (
@@ -28,6 +28,7 @@ ADDED_IN_39 = "\n\nAdded in Saleor 3.9."
 ADDED_IN_310 = "\n\nAdded in Saleor 3.10."
 ADDED_IN_311 = "\n\nAdded in Saleor 3.11."
 ADDED_IN_312 = "\n\nAdded in Saleor 3.12."
+ADDED_IN_313 = "\n\nAdded in Saleor 3.13."
 
 
 PREVIEW_FEATURE = (

--- a/saleor/graphql/order/enums.py
+++ b/saleor/graphql/order/enums.py
@@ -11,7 +11,7 @@ from ...order import (
     OrderStatus,
     error_codes,
 )
-from ..core.descriptions import PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD
+from ..core.descriptions import PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD
 
 
 def order_event_enum_description(enum):
@@ -19,12 +19,12 @@ def order_event_enum_description(enum):
         return "The different order event types. "
     if enum == OrderEventsEnum.TRANSACTION_VOID_REQUESTED:
         return (
-            f"{PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD} "
+            f"{PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD} "
             "Use `TRANSACTION_CANCEL_REQUESTED` instead."
         )
     if enum == OrderEventsEnum.TRANSACTION_CAPTURE_REQUESTED:
         return (
-            f"{PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD} "
+            f"{PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD} "
             "Use `TRANSACTION_CHARGE_REQUESTED` instead."
         )
     return None

--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -2,7 +2,7 @@ import graphene
 
 from ....permission.enums import OrderPermissions
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_312, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_313, PREVIEW_FEATURE
 from ...core.mutations import BaseMutation
 from ...core.scalars import Decimal
 from ...core.types.common import Error
@@ -36,7 +36,7 @@ class OrderGrantRefundCreate(BaseMutation):
 
     class Meta:
         description = (
-            "Adds granted refund to the order." + ADDED_IN_312 + PREVIEW_FEATURE
+            "Adds granted refund to the order." + ADDED_IN_313 + PREVIEW_FEATURE
         )
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderGrantRefundCreateError

--- a/saleor/graphql/order/mutations/order_grant_refund_update.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_update.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 
 from ....order import models
 from ....permission.enums import OrderPermissions
-from ...core.descriptions import ADDED_IN_312, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_313, PREVIEW_FEATURE
 from ...core.mutations import ModelMutation
 from ...core.scalars import Decimal
 from ...core.types.common import Error
@@ -36,7 +36,7 @@ class OrderGrantRefundUpdate(ModelMutation):
         )
 
     class Meta:
-        description = "Updates granted refund." + ADDED_IN_312 + PREVIEW_FEATURE
+        description = "Updates granted refund." + ADDED_IN_313 + PREVIEW_FEATURE
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderGrantRefundUpdateError
         model = models.OrderGrantedRefund

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -70,10 +70,10 @@ from ..core.descriptions import (
     ADDED_IN_39,
     ADDED_IN_310,
     ADDED_IN_311,
-    ADDED_IN_312,
+    ADDED_IN_313,
     DEPRECATED_IN_3X_FIELD,
     PREVIEW_FEATURE,
-    PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD,
+    PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD,
 )
 from ..core.enums import LanguageCodeEnum
 from ..core.fields import PermissionsField
@@ -223,7 +223,7 @@ class OrderGrantedRefund(ModelObjectType):
     app = graphene.Field(App, description=("App that performed the action."))
 
     class Meta:
-        description = "The details of granted refund." + ADDED_IN_312 + PREVIEW_FEATURE
+        description = "The details of granted refund." + ADDED_IN_313 + PREVIEW_FEATURE
         model = models.OrderGrantedRefund
 
     @staticmethod
@@ -349,7 +349,7 @@ class OrderEvent(ModelObjectType[models.OrderEvent]):
         TransactionEventStatusEnum,
         description="The status of payment's transaction.",
         deprecation_reason=(
-            PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD
+            PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD
             + "Use `TransactionEvent` to track the status of `TransactionItem`."
         ),
     )
@@ -1153,12 +1153,12 @@ class Order(ModelObjectType[models.Order]):
         required=True,
     )
     total_charged = graphene.Field(
-        Money, description="Amount charged for the order." + ADDED_IN_312, required=True
+        Money, description="Amount charged for the order." + ADDED_IN_313, required=True
     )
 
     total_canceled = graphene.Field(
         Money,
-        description="Amount canceled for the order." + ADDED_IN_312,
+        description="Amount canceled for the order." + ADDED_IN_313,
         required=True,
     )
 
@@ -1253,20 +1253,20 @@ class Order(ModelObjectType[models.Order]):
     granted_refunds = PermissionsField(
         NonNullList(OrderGrantedRefund),
         required=True,
-        description="List of granted refunds." + ADDED_IN_312 + PREVIEW_FEATURE,
+        description="List of granted refunds." + ADDED_IN_313 + PREVIEW_FEATURE,
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )
     total_granted_refund = PermissionsField(
         Money,
         required=True,
-        description="Total amount of granted refund." + ADDED_IN_312 + PREVIEW_FEATURE,
+        description="Total amount of granted refund." + ADDED_IN_313 + PREVIEW_FEATURE,
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )
     total_refunded = graphene.Field(
         Money,
         required=True,
         description="Total refund amount for the order."
-        + ADDED_IN_312
+        + ADDED_IN_313
         + PREVIEW_FEATURE,
     )
     total_refund_pending = PermissionsField(
@@ -1274,7 +1274,7 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "Total amount of ongoing refund requests for the order's transactions."
-            + ADDED_IN_312
+            + ADDED_IN_313
             + PREVIEW_FEATURE
         ),
         permissions=[OrderPermissions.MANAGE_ORDERS],
@@ -1284,7 +1284,7 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "Total amount of ongoing authorize requests for the order's transactions."
-            + ADDED_IN_312
+            + ADDED_IN_313
             + PREVIEW_FEATURE
         ),
         permissions=[OrderPermissions.MANAGE_ORDERS],
@@ -1294,7 +1294,7 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "Total amount of ongoing charge requests for the order's transactions."
-            + ADDED_IN_312
+            + ADDED_IN_313
             + PREVIEW_FEATURE
         ),
         permissions=[OrderPermissions.MANAGE_ORDERS],
@@ -1304,7 +1304,7 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "Total amount of ongoing cancel requests for the order's transactions."
-            + ADDED_IN_312
+            + ADDED_IN_313
             + PREVIEW_FEATURE
         ),
         permissions=[OrderPermissions.MANAGE_ORDERS],
@@ -1315,7 +1315,7 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "The difference amount between granted refund and the "
-            "amounts that are pending and refunded." + ADDED_IN_312 + PREVIEW_FEATURE
+            "amounts that are pending and refunded." + ADDED_IN_313 + PREVIEW_FEATURE
         ),
         permissions=[OrderPermissions.MANAGE_ORDERS],
     )

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -62,10 +62,10 @@ from ..core import ResolveInfo
 from ..core.descriptions import (
     ADDED_IN_31,
     ADDED_IN_34,
-    ADDED_IN_312,
+    ADDED_IN_313,
     DEPRECATED_IN_3X_INPUT,
     PREVIEW_FEATURE,
-    PREVIEW_FEATURE_DEPRECATED_IN_312_INPUT,
+    PREVIEW_FEATURE_DEPRECATED_IN_313_INPUT,
 )
 from ..core.enums import TransactionEventReportErrorCode
 from ..core.fields import JSONString
@@ -643,32 +643,32 @@ class TransactionUpdateInput(graphene.InputObjectType):
     status = graphene.String(
         description=(
             "Status of the transaction."
-            + PREVIEW_FEATURE_DEPRECATED_IN_312_INPUT
+            + PREVIEW_FEATURE_DEPRECATED_IN_313_INPUT
             + " The `status` is not needed. The amounts can be used to define "
             "the current status of transactions."
         ),
     )
     type = graphene.String(
         description="Payment type used for this transaction."
-        + PREVIEW_FEATURE_DEPRECATED_IN_312_INPUT
+        + PREVIEW_FEATURE_DEPRECATED_IN_313_INPUT
         + " Use `name` and `message` instead.",
     )
     name = graphene.String(
-        description="Payment name of the transaction." + ADDED_IN_312
+        description="Payment name of the transaction." + ADDED_IN_313
     )
     message = graphene.String(
-        description="The message of the transaction." + ADDED_IN_312
+        description="The message of the transaction." + ADDED_IN_313
     )
 
     reference = graphene.String(
         description=(
             "Reference of the transaction. "
-            + PREVIEW_FEATURE_DEPRECATED_IN_312_INPUT
+            + PREVIEW_FEATURE_DEPRECATED_IN_313_INPUT
             + " Use `pspReference` instead."
         )
     )
     psp_reference = graphene.String(
-        description=("PSP Reference of the transaction. " + ADDED_IN_312)
+        description=("PSP Reference of the transaction. " + ADDED_IN_313)
     )
     available_actions = graphene.List(
         graphene.NonNull(TransactionActionEnum),
@@ -679,11 +679,11 @@ class TransactionUpdateInput(graphene.InputObjectType):
     amount_refunded = MoneyInput(description="Amount refunded by this transaction.")
     amount_voided = MoneyInput(
         description="Amount voided by this transaction."
-        + PREVIEW_FEATURE_DEPRECATED_IN_312_INPUT
+        + PREVIEW_FEATURE_DEPRECATED_IN_313_INPUT
         + " Use `amountCanceled` instead."
     )
     amount_canceled = MoneyInput(
-        description="Amount canceled by this transaction." + ADDED_IN_312
+        description="Amount canceled by this transaction." + ADDED_IN_313
     )
 
     metadata = graphene.List(
@@ -699,7 +699,7 @@ class TransactionUpdateInput(graphene.InputObjectType):
     external_url = graphene.String(
         description=(
             "The url that will allow to redirect user to "
-            "payment provider page with transaction event details." + ADDED_IN_312
+            "payment provider page with transaction event details." + ADDED_IN_313
         )
     )
 
@@ -713,27 +713,27 @@ class TransactionEventInput(graphene.InputObjectType):
         TransactionEventStatusEnum,
         required=False,
         description="Current status of the payment transaction."
-        + PREVIEW_FEATURE_DEPRECATED_IN_312_INPUT
+        + PREVIEW_FEATURE_DEPRECATED_IN_313_INPUT
         + " Status will be calculated by Saleor.",
     )
     reference = graphene.String(
         description=(
             "Reference of the transaction. "
-            + PREVIEW_FEATURE_DEPRECATED_IN_312_INPUT
+            + PREVIEW_FEATURE_DEPRECATED_IN_313_INPUT
             + " Use `pspReference` instead."
         )
     )
 
     psp_reference = graphene.String(
-        description=("PSP Reference related to this action." + ADDED_IN_312)
+        description=("PSP Reference related to this action." + ADDED_IN_313)
     )
     name = graphene.String(
         description="Name of the transaction."
-        + PREVIEW_FEATURE_DEPRECATED_IN_312_INPUT
+        + PREVIEW_FEATURE_DEPRECATED_IN_313_INPUT
         + " Use `message` instead. `name` field will be added to `message`."
     )
     message = graphene.String(
-        description="The message related to the event." + ADDED_IN_312
+        description="The message related to the event." + ADDED_IN_313
     )
 
 
@@ -1360,7 +1360,7 @@ class TransactionEventReport(ModelMutation):
     class Meta:
         description = (
             "Report the event for the transaction."
-            + ADDED_IN_312
+            + ADDED_IN_313
             + PREVIEW_FEATURE
             + "\n\nRequires the following permissions: "
             + f"{AuthorizationFilters.OWNER.name} "

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -12,9 +12,9 @@ from ..core.descriptions import (
     ADDED_IN_31,
     ADDED_IN_34,
     ADDED_IN_36,
-    ADDED_IN_312,
+    ADDED_IN_313,
     PREVIEW_FEATURE,
-    PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD,
+    PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD,
 )
 from ..core.fields import JSONString, PermissionsField
 from ..core.tracing import traced_resolver
@@ -262,49 +262,49 @@ class TransactionEvent(ModelObjectType[models.TransactionEvent]):
         description="Status of transaction's event.",
         required=True,
         deprecation_reason=(
-            f"{PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD} Use `type` instead."
+            f"{PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD} Use `type` instead."
         ),
     )
     reference = graphene.String(
         description="Reference of transaction's event.",
         required=True,
         deprecation_reason=(
-            f"{PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD}" "Use `pspReference` instead."
+            f"{PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD}" "Use `pspReference` instead."
         ),
     )
     psp_reference = graphene.String(
-        description="PSP reference of transaction." + ADDED_IN_312, required=True
+        description="PSP reference of transaction." + ADDED_IN_313, required=True
     )
     name = graphene.String(
         description="Name of the transaction's event.",
         deprecation_reason=(
-            f"{PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD} Use `message` instead."
+            f"{PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD} Use `message` instead."
         ),
     )
     message = graphene.String(
-        description="Message related to the transaction's event." + ADDED_IN_312,
+        description="Message related to the transaction's event." + ADDED_IN_313,
         required=True,
     )
     external_url = graphene.String(
         description=(
             "The url that will allow to redirect user to "
-            "payment provider page with transaction details." + ADDED_IN_312
+            "payment provider page with transaction details." + ADDED_IN_313
         ),
         required=True,
     )
     amount = graphene.Field(
         Money,
         required=True,
-        description="The amount related to this event." + ADDED_IN_312,
+        description="The amount related to this event." + ADDED_IN_313,
     )
     type = graphene.Field(
         TransactionEventTypeEnum,
-        description="The type of action related to this event." + ADDED_IN_312,
+        description="The type of action related to this event." + ADDED_IN_313,
     )
 
     created_by = graphene.Field(
         "saleor.graphql.core.types.user_or_app.UserOrApp",
-        description=("User or App that created the transaction event." + ADDED_IN_312),
+        description=("User or App that created the transaction event." + ADDED_IN_313),
     )
 
     class Meta:
@@ -379,7 +379,7 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
         required=True,
         description=(
             "Total amount of ongoing authorization requests for the transaction."
-            + ADDED_IN_312
+            + ADDED_IN_313
         ),
     )
     refunded_amount = graphene.Field(
@@ -390,7 +390,7 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
         required=True,
         description=(
             "Total amount of ongoing refund requests for the transaction."
-            + ADDED_IN_312
+            + ADDED_IN_313
         ),
     )
     voided_amount = graphene.Field(
@@ -398,21 +398,21 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
         required=True,
         description=("Total amount voided for this payment."),
         deprecation_reason=(
-            PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD + "Use `canceledAmount` instead."
+            PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD + "Use `canceledAmount` instead."
         ),
     )
 
     canceled_amount = graphene.Field(
         Money,
         required=True,
-        description="Total amount canceled for this payment." + ADDED_IN_312,
+        description="Total amount canceled for this payment." + ADDED_IN_313,
     )
     cancel_pending_amount = graphene.Field(
         Money,
         required=True,
         description=(
             "Total amount of ongoing cancel requests for the transaction."
-            + ADDED_IN_312
+            + ADDED_IN_313
         ),
     )
     charged_amount = graphene.Field(
@@ -423,13 +423,13 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
         required=True,
         description=(
             "Total amount of ongoing charge requests for the transaction."
-            + ADDED_IN_312
+            + ADDED_IN_313
         ),
     )
     status = graphene.String(
         description="Status of transaction.",
         deprecation_reason=(
-            PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD
+            PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD
             + " The `status` is not needed. The amounts can be used to define "
             "the current status of transactions."
         ),
@@ -439,27 +439,27 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     type = graphene.String(
         description="Type of transaction.",
         deprecation_reason=(
-            PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD
+            PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD
             + " Use `name` or `message` instead."
         ),
         required=True,
     )
     name = graphene.String(
-        description="Name of the transaction." + ADDED_IN_312, required=True
+        description="Name of the transaction." + ADDED_IN_313, required=True
     )
     message = graphene.String(
-        description="Message related to the transaction." + ADDED_IN_312, required=True
+        description="Message related to the transaction." + ADDED_IN_313, required=True
     )
 
     reference = graphene.String(
         description="Reference of transaction.",
         required=True,
         deprecation_reason=(
-            PREVIEW_FEATURE_DEPRECATED_IN_312_FIELD + "Use `pspReference` instead."
+            PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD + "Use `pspReference` instead."
         ),
     )
     psp_reference = graphene.String(
-        description="PSP reference of transaction." + ADDED_IN_312, required=True
+        description="PSP reference of transaction." + ADDED_IN_313, required=True
     )
     order = graphene.Field(
         "saleor.graphql.order.types.Order",
@@ -470,12 +470,12 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     )
     created_by = graphene.Field(
         "saleor.graphql.core.types.user_or_app.UserOrApp",
-        description=("User or App that created the transaction." + ADDED_IN_312),
+        description=("User or App that created the transaction." + ADDED_IN_313),
     )
     external_url = graphene.String(
         description=(
             "The url that will allow to redirect user to "
-            "payment provider page with transaction details." + ADDED_IN_312
+            "payment provider page with transaction details." + ADDED_IN_313
         ),
         required=True,
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1881,7 +1881,7 @@ enum WebhookEventTypeEnum {
   """
   An action requested for transaction.
   
-  DEPRECATED: this subscription will be removed in Saleor 3.13 (Preview Feature). Use `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead.
+  DEPRECATED: this subscription will be removed in Saleor 3.14 (Preview Feature). Use `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead.
   """
   TRANSACTION_ACTION_REQUEST
 
@@ -1970,7 +1970,7 @@ enum WebhookEventTypeEnum {
   """
   Event called when charge has been requested for transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -1979,7 +1979,7 @@ enum WebhookEventTypeEnum {
   """
   Event called when refund has been requested for transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -1988,7 +1988,7 @@ enum WebhookEventTypeEnum {
   """
   Event called when cancel has been requested for transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -2057,7 +2057,7 @@ enum WebhookEventTypeSyncEnum {
   """
   Event called when charge has been requested for transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -2066,7 +2066,7 @@ enum WebhookEventTypeSyncEnum {
   """
   Event called when refund has been requested for transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -2075,7 +2075,7 @@ enum WebhookEventTypeSyncEnum {
   """
   Event called when cancel has been requested for transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -2489,7 +2489,7 @@ enum WebhookEventTypeAsyncEnum {
   """
   An action requested for transaction.
   
-  DEPRECATED: this subscription will be removed in Saleor 3.13 (Preview Feature). Use `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead.
+  DEPRECATED: this subscription will be removed in Saleor 3.14 (Preview Feature). Use `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead.
   """
   TRANSACTION_ACTION_REQUEST
 
@@ -9577,7 +9577,7 @@ type TransactionItem implements Node & ObjectWithMetadata {
   """
   Total amount of ongoing authorization requests for the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   authorizePendingAmount: Money!
 
@@ -9587,24 +9587,24 @@ type TransactionItem implements Node & ObjectWithMetadata {
   """
   Total amount of ongoing refund requests for the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   refundPendingAmount: Money!
 
   """Total amount voided for this payment."""
-  voidedAmount: Money! @deprecated(reason: "This field will be removed in Saleor 3.13 (Preview Feature).Use `canceledAmount` instead.")
+  voidedAmount: Money! @deprecated(reason: "This field will be removed in Saleor 3.14 (Preview Feature).Use `canceledAmount` instead.")
 
   """
   Total amount canceled for this payment.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   canceledAmount: Money!
 
   """
   Total amount of ongoing cancel requests for the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   cancelPendingAmount: Money!
 
@@ -9614,37 +9614,37 @@ type TransactionItem implements Node & ObjectWithMetadata {
   """
   Total amount of ongoing charge requests for the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   chargePendingAmount: Money!
 
   """Status of transaction."""
-  status: String! @deprecated(reason: "This field will be removed in Saleor 3.13 (Preview Feature). The `status` is not needed. The amounts can be used to define the current status of transactions.")
+  status: String! @deprecated(reason: "This field will be removed in Saleor 3.14 (Preview Feature). The `status` is not needed. The amounts can be used to define the current status of transactions.")
 
   """Type of transaction."""
-  type: String! @deprecated(reason: "This field will be removed in Saleor 3.13 (Preview Feature). Use `name` or `message` instead.")
+  type: String! @deprecated(reason: "This field will be removed in Saleor 3.14 (Preview Feature). Use `name` or `message` instead.")
 
   """
   Name of the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   name: String!
 
   """
   Message related to the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   message: String!
 
   """Reference of transaction."""
-  reference: String! @deprecated(reason: "This field will be removed in Saleor 3.13 (Preview Feature).Use `pspReference` instead.")
+  reference: String! @deprecated(reason: "This field will be removed in Saleor 3.14 (Preview Feature).Use `pspReference` instead.")
 
   """
   PSP reference of transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   pspReference: String!
 
@@ -9661,14 +9661,14 @@ type TransactionItem implements Node & ObjectWithMetadata {
   """
   User or App that created the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   createdBy: UserOrApp
 
   """
   The url that will allow to redirect user to payment provider page with transaction details.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   externalUrl: String!
 }
@@ -9680,7 +9680,7 @@ Represents possible actions on payment transaction.
     CHARGE - Represents the charge action.
     REFUND - Represents a refund action.
     VOID - Represents a void action. This field will be removed
-    in Saleor 3.13 (Preview Feature). Use `CANCEL` instead.
+    in Saleor 3.14 (Preview Feature). Use `CANCEL` instead.
     CANCEL - Represents a cancel action. Added in Saleor 3.12.
 """
 enum TransactionActionEnum {
@@ -9931,14 +9931,14 @@ type Order implements Node & ObjectWithMetadata {
   """
   Amount charged for the order.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   totalCharged: Money!
 
   """
   Amount canceled for the order.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   totalCanceled: Money!
 
@@ -10014,7 +10014,7 @@ type Order implements Node & ObjectWithMetadata {
   """
   List of granted refunds.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
@@ -10025,7 +10025,7 @@ type Order implements Node & ObjectWithMetadata {
   """
   Total amount of granted refund.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
@@ -10036,7 +10036,7 @@ type Order implements Node & ObjectWithMetadata {
   """
   Total refund amount for the order.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
@@ -10045,7 +10045,7 @@ type Order implements Node & ObjectWithMetadata {
   """
   Total amount of ongoing refund requests for the order's transactions.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
@@ -10056,7 +10056,7 @@ type Order implements Node & ObjectWithMetadata {
   """
   Total amount of ongoing authorize requests for the order's transactions.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
@@ -10067,7 +10067,7 @@ type Order implements Node & ObjectWithMetadata {
   """
   Total amount of ongoing charge requests for the order's transactions.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
@@ -10078,7 +10078,7 @@ type Order implements Node & ObjectWithMetadata {
   """
   Total amount of ongoing cancel requests for the order's transactions.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
@@ -10089,7 +10089,7 @@ type Order implements Node & ObjectWithMetadata {
   """
   The difference amount between granted refund and the amounts that are pending and refunded.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
@@ -10780,7 +10780,7 @@ type OrderEvent implements Node {
   discount: OrderEventDiscountObject
 
   """The status of payment's transaction."""
-  status: TransactionStatus @deprecated(reason: "This field will be removed in Saleor 3.13 (Preview Feature).Use `TransactionEvent` to track the status of `TransactionItem`.")
+  status: TransactionStatus @deprecated(reason: "This field will be removed in Saleor 3.14 (Preview Feature).Use `TransactionEvent` to track the status of `TransactionItem`.")
 
   """The reference of payment's transaction."""
   reference: String
@@ -10820,13 +10820,13 @@ enum OrderEventsEnum {
   TRANSACTION_CHARGE_REQUESTED
 
   """
-  This field will be removed in Saleor 3.13 (Preview Feature). Use `TRANSACTION_CHARGE_REQUESTED` instead.
+  This field will be removed in Saleor 3.14 (Preview Feature). Use `TRANSACTION_CHARGE_REQUESTED` instead.
   """
   TRANSACTION_CAPTURE_REQUESTED
   TRANSACTION_REFUND_REQUESTED
 
   """
-  This field will be removed in Saleor 3.13 (Preview Feature). Use `TRANSACTION_CANCEL_REQUESTED` instead.
+  This field will be removed in Saleor 3.14 (Preview Feature). Use `TRANSACTION_CANCEL_REQUESTED` instead.
   """
   TRANSACTION_VOID_REQUESTED
   TRANSACTION_CANCEL_REQUESTED
@@ -11011,7 +11011,7 @@ enum AddressTypeEnum {
 """
 The details of granted refund.
 
-Added in Saleor 3.12.
+Added in Saleor 3.13.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -11046,53 +11046,53 @@ type TransactionEvent implements Node {
   createdAt: DateTime!
 
   """Status of transaction's event."""
-  status: TransactionStatus! @deprecated(reason: "This field will be removed in Saleor 3.13 (Preview Feature). Use `type` instead.")
+  status: TransactionStatus! @deprecated(reason: "This field will be removed in Saleor 3.14 (Preview Feature). Use `type` instead.")
 
   """Reference of transaction's event."""
-  reference: String! @deprecated(reason: "This field will be removed in Saleor 3.13 (Preview Feature).Use `pspReference` instead.")
+  reference: String! @deprecated(reason: "This field will be removed in Saleor 3.14 (Preview Feature).Use `pspReference` instead.")
 
   """
   PSP reference of transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   pspReference: String!
 
   """Name of the transaction's event."""
-  name: String @deprecated(reason: "This field will be removed in Saleor 3.13 (Preview Feature). Use `message` instead.")
+  name: String @deprecated(reason: "This field will be removed in Saleor 3.14 (Preview Feature). Use `message` instead.")
 
   """
   Message related to the transaction's event.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   message: String!
 
   """
   The url that will allow to redirect user to payment provider page with transaction details.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   externalUrl: String!
 
   """
   The amount related to this event.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   amount: Money!
 
   """
   The type of action related to this event.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   type: TransactionEventTypeEnum
 
   """
   User or App that created the transaction event.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   createdBy: UserOrApp
 }
@@ -13915,7 +13915,7 @@ type Mutation {
   """
   Report the event for the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
@@ -14328,7 +14328,7 @@ type Mutation {
   """
   Adds granted refund to the order.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point. 
   
@@ -14345,7 +14345,7 @@ type Mutation {
   """
   Updates granted refund.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point. 
   
@@ -20162,42 +20162,42 @@ input TransactionCreateInput {
   """
   Status of the transaction.
   
-  DEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature). The `status` is not needed. The amounts can be used to define the current status of transactions.
+  DEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature). The `status` is not needed. The amounts can be used to define the current status of transactions.
   """
   status: String
 
   """
   Payment type used for this transaction.
   
-  DEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature). Use `name` and `message` instead.
+  DEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature). Use `name` and `message` instead.
   """
   type: String
 
   """
   Payment name of the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   name: String
 
   """
   The message of the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   message: String
 
   """
   Reference of the transaction. 
   
-  DEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature). Use `pspReference` instead.
+  DEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature). Use `pspReference` instead.
   """
   reference: String
 
   """
   PSP Reference of the transaction. 
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   pspReference: String
 
@@ -20216,14 +20216,14 @@ input TransactionCreateInput {
   """
   Amount voided by this transaction.
   
-  DEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature). Use `amountCanceled` instead.
+  DEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature). Use `amountCanceled` instead.
   """
   amountVoided: MoneyInput
 
   """
   Amount canceled by this transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   amountCanceled: MoneyInput
 
@@ -20236,7 +20236,7 @@ input TransactionCreateInput {
   """
   The url that will allow to redirect user to payment provider page with transaction event details.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   externalUrl: String
 }
@@ -20245,35 +20245,35 @@ input TransactionEventInput {
   """
   Current status of the payment transaction.
   
-  DEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature). Status will be calculated by Saleor.
+  DEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature). Status will be calculated by Saleor.
   """
   status: TransactionStatus
 
   """
   Reference of the transaction. 
   
-  DEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature). Use `pspReference` instead.
+  DEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature). Use `pspReference` instead.
   """
   reference: String
 
   """
   PSP Reference related to this action.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   pspReference: String
 
   """
   Name of the transaction.
   
-  DEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature). Use `message` instead. `name` field will be added to `message`.
+  DEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature). Use `message` instead. `name` field will be added to `message`.
   """
   name: String
 
   """
   The message related to the event.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   message: String
 }
@@ -20319,42 +20319,42 @@ input TransactionUpdateInput {
   """
   Status of the transaction.
   
-  DEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature). The `status` is not needed. The amounts can be used to define the current status of transactions.
+  DEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature). The `status` is not needed. The amounts can be used to define the current status of transactions.
   """
   status: String
 
   """
   Payment type used for this transaction.
   
-  DEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature). Use `name` and `message` instead.
+  DEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature). Use `name` and `message` instead.
   """
   type: String
 
   """
   Payment name of the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   name: String
 
   """
   The message of the transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   message: String
 
   """
   Reference of the transaction. 
   
-  DEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature). Use `pspReference` instead.
+  DEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature). Use `pspReference` instead.
   """
   reference: String
 
   """
   PSP Reference of the transaction. 
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   pspReference: String
 
@@ -20373,14 +20373,14 @@ input TransactionUpdateInput {
   """
   Amount voided by this transaction.
   
-  DEPRECATED: this field will be removed in Saleor 3.13 (Preview Feature). Use `amountCanceled` instead.
+  DEPRECATED: this field will be removed in Saleor 3.14 (Preview Feature). Use `amountCanceled` instead.
   """
   amountVoided: MoneyInput
 
   """
   Amount canceled by this transaction.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   amountCanceled: MoneyInput
 
@@ -20393,7 +20393,7 @@ input TransactionUpdateInput {
   """
   The url that will allow to redirect user to payment provider page with transaction event details.
   
-  Added in Saleor 3.12.
+  Added in Saleor 3.13.
   """
   externalUrl: String
 }
@@ -20436,7 +20436,7 @@ enum TransactionRequestActionErrorCode {
 """
 Report the event for the transaction.
 
-Added in Saleor 3.12.
+Added in Saleor 3.13.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
@@ -21235,7 +21235,7 @@ input OrderReturnFulfillmentLineInput {
 """
 Adds granted refund to the order.
 
-Added in Saleor 3.12.
+Added in Saleor 3.13.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point. 
 
@@ -21288,7 +21288,7 @@ scalar Decimal
 """
 Updates granted refund.
 
-Added in Saleor 3.12.
+Added in Saleor 3.13.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point. 
 
@@ -27541,7 +27541,7 @@ Event sent when transaction action is requested.
 
 Added in Saleor 3.4.
 
-DEPRECATED: this subscription will be removed in Saleor 3.13 (Preview Feature). Use `TransactionChargeRequested`, `TransactionRefundRequested`, `TransactionCancelationRequested` instead.
+DEPRECATED: this subscription will be removed in Saleor 3.14 (Preview Feature). Use `TransactionChargeRequested`, `TransactionRefundRequested`, `TransactionCancelationRequested` instead.
 """
 type TransactionActionRequest implements Event {
   """Time of the event."""
@@ -28071,7 +28071,7 @@ type PaymentListGateways implements Event {
 """
 Event sent when transaction cancelation is requested.
 
-Added in Saleor 3.12.
+Added in Saleor 3.13.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -28098,7 +28098,7 @@ type TransactionCancelationRequested implements Event {
 """
 Event sent when transaction charge is requested.
 
-Added in Saleor 3.12.
+Added in Saleor 3.13.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -28125,7 +28125,7 @@ type TransactionChargeRequested implements Event {
 """
 Event sent when transaction refund is requested.
 
-Added in Saleor 3.12.
+Added in Saleor 3.13.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -1,7 +1,13 @@
 import graphene
 
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
-from ..core.descriptions import ADDED_IN_36, ADDED_IN_38, ADDED_IN_312, PREVIEW_FEATURE
+from ..core.descriptions import (
+    ADDED_IN_36,
+    ADDED_IN_38,
+    ADDED_IN_312,
+    ADDED_IN_313,
+    PREVIEW_FEATURE,
+)
 from ..core.utils import str_to_enum
 
 checkout_updated_event_enum_description = (
@@ -152,7 +158,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.STAFF_DELETED: "A staff user is deleted.",
     WebhookEventAsyncType.TRANSACTION_ACTION_REQUEST: (
         "An action requested for transaction."
-        + "\n\nDEPRECATED: this subscription will be removed in Saleor 3.13 "
+        + "\n\nDEPRECATED: this subscription will be removed in Saleor 3.14 "
         + "(Preview Feature). Use `TRANSACTION_CHARGE_REQUESTED`, "
         + "`TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead."
     ),
@@ -200,17 +206,17 @@ WEBHOOK_EVENT_DESCRIPTION = {
     ),
     WebhookEventSyncType.TRANSACTION_CHARGE_REQUESTED: (
         "Event called when charge has been requested for transaction."
-        + ADDED_IN_312
+        + ADDED_IN_313
         + PREVIEW_FEATURE
     ),
     WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED: (
         "Event called when refund has been requested for transaction."
-        + ADDED_IN_312
+        + ADDED_IN_313
         + PREVIEW_FEATURE
     ),
     WebhookEventSyncType.TRANSACTION_CANCELATION_REQUESTED: (
         "Event called when cancel has been requested for transaction."
-        + ADDED_IN_312
+        + ADDED_IN_313
         + PREVIEW_FEATURE
     ),
 }

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -36,6 +36,7 @@ from ..core.descriptions import (
     ADDED_IN_310,
     ADDED_IN_311,
     ADDED_IN_312,
+    ADDED_IN_313,
     PREVIEW_FEATURE,
 )
 from ..core.scalars import PositiveDecimal
@@ -1560,7 +1561,7 @@ class TransactionActionRequest(TransactionActionBase, SubscriptionObjectType):
         description = (
             "Event sent when transaction action is requested."
             + ADDED_IN_34
-            + "\n\nDEPRECATED: this subscription will be removed in Saleor 3.13 "
+            + "\n\nDEPRECATED: this subscription will be removed in Saleor 3.14 "
             + "(Preview Feature). Use `TransactionChargeRequested`, "
             + "`TransactionRefundRequested`, `TransactionCancelationRequested` instead."
         )
@@ -1573,7 +1574,7 @@ class TransactionChargeRequested(TransactionActionBase, SubscriptionObjectType):
         enable_dry_run = False
         description = (
             "Event sent when transaction charge is requested."
-            + ADDED_IN_312
+            + ADDED_IN_313
             + PREVIEW_FEATURE
         )
 
@@ -1585,7 +1586,7 @@ class TransactionRefundRequested(TransactionActionBase, SubscriptionObjectType):
         enable_dry_run = False
         description = (
             "Event sent when transaction refund is requested."
-            + ADDED_IN_312
+            + ADDED_IN_313
             + PREVIEW_FEATURE
         )
 
@@ -1597,7 +1598,7 @@ class TransactionCancelationRequested(TransactionActionBase, SubscriptionObjectT
         enable_dry_run = False
         description = (
             "Event sent when transaction cancelation is requested."
-            + ADDED_IN_312
+            + ADDED_IN_313
             + PREVIEW_FEATURE
         )
 

--- a/saleor/payment/__init__.py
+++ b/saleor/payment/__init__.py
@@ -150,7 +150,7 @@ class TransactionAction:
     CHARGE - Represents the charge action.
     REFUND - Represents a refund action.
     VOID - Represents a void action. This field will be removed
-    in Saleor 3.13 (Preview Feature). Use `CANCEL` instead.
+    in Saleor 3.14 (Preview Feature). Use `CANCEL` instead.
     CANCEL - Represents a cancel action. Added in Saleor 3.12.
     """
 


### PR DESCRIPTION
I want to merge this change because it bumps the api labels after releasing 3.12

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
