### PR TITLE
Fix order shipping Avatax tax calculations for JPY currency

### DIFF
--- a/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_order_total_for_JPY.yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_avatax/test_calculate_order_total_for_JPY.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesInvoice",
+      "lines": [{"quantity": 3, "amount": "3600.000", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "123", "discounted": false, "description": "Test product"},
+      {"quantity": 1, "amount": "700.000", "taxCode": "FR000000", "taxIncluded": true,
+      "itemCode": "Shipping", "discounted": false, "description": null}], "code":
+      "acd43357-0b7e-4f75-8e50-4847acce9dfd", "date": "2023-03-06", "customerCode":
+      0, "discount": null, "addresses": {"shipFrom": {"line1": "Teczowa 7", "line2":
+      "", "city": "Wroclaw", "region": "", "country": "PL", "postalCode": "53-601"},
+      "shipTo": {"line1": "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW", "region":
+      "", "country": "PL", "postalCode": "53-601"}}, "commit": false, "currencyCode":
+      "JPY", "email": "test@example.com"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '836'
+      User-Agent:
+      - python-requests/2.28.2
+    method: POST
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: '{"id":85020701818896,"code":"acd43357-0b7e-4f75-8e50-4847acce9dfd","companyId":7799660,"date":"2023-03-06","status":"Saved","type":"SalesInvoice","batchCode":"","currencyCode":"JPY","exchangeRateCurrencyCode":"JPY","customerUsageType":"","entityUseCode":"","customerVendorCode":"0","customerCode":"0","exemptNo":"","reconciled":false,"locationCode":"","reportingLocationCode":"","purchaseOrderNo":"","referenceCode":"","salespersonCode":"","taxOverrideType":"None","taxOverrideAmount":0.0,"taxOverrideReason":"","totalAmount":3496.11,"totalExempt":0.17,"totalDiscount":0.0,"totalTax":803.0,"totalTaxable":3495.94,"totalTaxCalculated":803.0,"adjustmentReason":"NotAdjusted","adjustmentDescription":"","locked":false,"region":"","country":"PL","version":1,"softwareVersion":"23.2.3.0","originAddressId":85020701818898,"destinationAddressId":85020701818897,"exchangeRateEffectiveDate":"2023-03-06","exchangeRate":1.0,"description":"","email":"test@example.com","businessIdentificationNo":"","modifiedDate":"2023-03-06T10:49:16.1930736Z","modifiedUserId":6479978,"taxDate":"2023-03-06","lines":[{"id":85020701818902,"transactionId":85020701818896,"lineNumber":"1","boundaryOverrideId":0,"customerUsageType":"","entityUseCode":"","description":"Test
+        product","destinationAddressId":85020701818897,"originAddressId":85020701818898,"discountAmount":0.0,"discountTypeId":0,"exemptAmount":0.17,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"isSSTP":false,"itemCode":"123","lineAmount":2927.0000,"quantity":3.0,"ref1":"","ref2":"","reportingDate":"2023-03-06","revAccount":"","sourcing":"Destination","tax":673.0,"taxableAmount":2926.83,"taxCalculated":673.0,"taxCode":"O9999999","taxCodeId":9111,"taxDate":"2023-03-06","taxEngine":"","taxOverrideType":"None","businessIdentificationNo":"","taxOverrideAmount":0.0,"taxOverrideReason":"","taxIncluded":true,"details":[{"id":85020701818923,"transactionLineId":85020701818902,"transactionId":85020701818896,"addressId":85020701818897,"country":"PL","region":"PL","countyFIPS":"","stateFIPS":"","exemptAmount":0.0000,"exemptReasonId":4,"inState":true,"jurisCode":"PL","jurisName":"POLAND","jurisdictionId":200102,"signatureCode":"","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0000,"nonTaxableRuleId":0,"nonTaxableType":"RateRule","rate":0.230000,"rateRuleId":411502,"rateSourceId":0,"serCode":"","sourcing":"Destination","tax":673.1700,"taxableAmount":2926.8300,"taxType":"Output","taxSubTypeId":"O","taxTypeGroupId":"InputAndOutput","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxRegionId":205102,"taxCalculated":673.1700,"taxOverride":0.0000,"rateType":"Standard","rateTypeCode":"S","taxableUnits":2926.8300,"nonTaxableUnits":0.0000,"exemptUnits":0.0000,"unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":2926.83,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":673.17,"reportingTaxCalculated":673.17,"liabilityType":"Seller"}],"nonPassthroughDetails":[],"lineLocationTypes":[{"documentLineLocationTypeId":85020701818905,"documentLineId":85020701818902,"documentAddressId":85020701818898,"locationTypeCode":"ShipFrom"},{"documentLineLocationTypeId":85020701818906,"documentLineId":85020701818902,"documentAddressId":85020701818897,"locationTypeCode":"ShipTo"}],"parameters":[{"name":"Transport","value":"None"},{"name":"IsMarketplace","value":"False"},{"name":"IsTriangulation","value":"false"},{"name":"IsGoodsSecondHand","value":"false"}],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLS-230C","vatNumberTypeId":0},{"id":85020701818903,"transactionId":85020701818896,"lineNumber":"2","boundaryOverrideId":0,"customerUsageType":"","entityUseCode":"","description":"","destinationAddressId":85020701818897,"originAddressId":85020701818898,"discountAmount":0.0,"discountTypeId":0,"exemptAmount":0.0,"exemptCertId":0,"exemptNo":"","isItemTaxable":true,"isSSTP":false,"itemCode":"Shipping","lineAmount":569.1100,"quantity":1.0,"ref1":"","ref2":"","reportingDate":"2023-03-06","revAccount":"","sourcing":"Destination","tax":130.0,"taxableAmount":569.11,"taxCalculated":130.0,"taxCode":"FR000000","taxCodeId":8550,"taxDate":"2023-03-06","taxEngine":"","taxOverrideType":"None","businessIdentificationNo":"","taxOverrideAmount":0.0,"taxOverrideReason":"","taxIncluded":true,"details":[{"id":85020701818943,"transactionLineId":85020701818903,"transactionId":85020701818896,"addressId":85020701818897,"country":"PL","region":"PL","countyFIPS":"","stateFIPS":"","exemptAmount":0.0000,"exemptReasonId":4,"inState":true,"jurisCode":"PL","jurisName":"POLAND","jurisdictionId":200102,"signatureCode":"","stateAssignedNo":"","jurisType":"CNT","jurisdictionType":"Country","nonTaxableAmount":0.0000,"nonTaxableRuleId":0,"nonTaxableType":"RateRule","rate":0.230000,"rateRuleId":411502,"rateSourceId":0,"serCode":"","sourcing":"Destination","tax":130.8900,"taxableAmount":569.1100,"taxType":"Output","taxSubTypeId":"O","taxTypeGroupId":"InputAndOutput","taxName":"Standard
+        Rate","taxAuthorityTypeId":45,"taxRegionId":205102,"taxCalculated":130.8900,"taxOverride":0.0000,"rateType":"Standard","rateTypeCode":"S","taxableUnits":569.1100,"nonTaxableUnits":0.0000,"exemptUnits":0.0000,"unitOfBasis":"PerCurrencyUnit","isNonPassThru":false,"isFee":false,"reportingTaxableUnits":569.11,"reportingNonTaxableUnits":0.0,"reportingExemptUnits":0.0,"reportingTax":130.89,"reportingTaxCalculated":130.89,"liabilityType":"Seller"}],"nonPassthroughDetails":[],"lineLocationTypes":[{"documentLineLocationTypeId":85020701818925,"documentLineId":85020701818903,"documentAddressId":85020701818898,"locationTypeCode":"ShipFrom"},{"documentLineLocationTypeId":85020701818926,"documentLineId":85020701818903,"documentAddressId":85020701818897,"locationTypeCode":"ShipTo"}],"parameters":[{"name":"Transport","value":"None"},{"name":"IsMarketplace","value":"False"},{"name":"IsTriangulation","value":"false"},{"name":"IsGoodsSecondHand","value":"false"}],"hsCode":"","costInsuranceFreight":0.0,"vatCode":"PLS-230D","vatNumberTypeId":0}],"addresses":[{"id":85020701818897,"transactionId":85020701818896,"boundaryLevel":"Zip5","line1":"Teczowa
+        7","line2":"","line3":"","city":"WROCLAW","region":"","postalCode":"53-601","country":"PL","taxRegionId":205102},{"id":85020701818898,"transactionId":85020701818896,"boundaryLevel":"Zip5","line1":"Teczowa
+        7","line2":"","line3":"","city":"Wroclaw","region":"","postalCode":"53-601","country":"PL","taxRegionId":205102}],"locationTypes":[{"documentLocationTypeId":85020701818900,"documentId":85020701818896,"documentAddressId":85020701818898,"locationTypeCode":"ShipFrom"},{"documentLocationTypeId":85020701818901,"documentId":85020701818896,"documentAddressId":85020701818897,"locationTypeCode":"ShipTo"}],"summary":[{"country":"PL","region":"PL","jurisType":"Country","jurisCode":"PL","jurisName":"POLAND","taxAuthorityType":45,"stateAssignedNo":"","taxType":"Output","taxSubType":"O","taxName":"Standard
+        Rate","rateType":"Standard","taxable":3495.94,"rate":0.230000,"tax":804.06,"taxCalculated":804.06,"nonTaxable":0.00,"exemption":0.00}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 06 Mar 2023 10:49:16 GMT
+      Location:
+      - /api/v2/companies/7799660/transactions/85020701818896
+      ServerDuration:
+      - '00:00:00.0447832'
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      api-supported-versions:
+      - '2.0'
+      cache-control:
+      - private, no-cache, no-store
+      referrer-policy:
+      - same-origin
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-avalara-uid:
+      - 6edeb815-87c2-4530-bda8-fee6389b8812
+      x-correlation-id:
+      - 6edeb815-87c2-4530-bda8-fee6389b8812
+      x-frame-options:
+      - sameorigin
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1


### PR DESCRIPTION
Fix the problem with order shipping taxes calculation by Avalara plugin for `JPY` currency.

Port of https://github.com/saleor/saleor/pull/12231

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
