### PR TITLE
Drop site order-settings from database

### DIFF
--- a/saleor/site/migrations/0036_remove_order_settings.py
+++ b/saleor/site/migrations/0036_remove_order_settings.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [("site", "0035_sitesettings_separate_state_remove_order_settings")]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    ALTER TABLE site_sitesettings
+                    DROP COLUMN
+                    automatically_fulfill_non_shippable_gift_card,
+                    DROP COLUMN
+                    automatically_confirm_all_new_orders;
+                    """,
+                    reverse_sql="""
+                    ALTER TABLE site_sitesettings
+                    ADD COLUMN
+                    automatically_fulfill_non_shippable_gift_card
+                    BOOLEAN,
+                    ADD COLUMN
+                    automatically_confirm_all_new_orders
+                    BOOLEAN;
+                    """,
+                )
+            ]
+        )
+    ]


### PR DESCRIPTION
Drop fields from database cause of: https://github.com/saleor/saleor/pull/11417

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
