### PR TITLE
Revert JWT expiration error code

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -6,7 +6,6 @@ from typing import Iterable, Tuple, Union
 from uuid import UUID
 
 import graphene
-import jwt
 from django.core.exceptions import (
     NON_FIELD_ERRORS,
     ImproperlyConfigured,
@@ -19,7 +18,6 @@ from graphene import ObjectType
 from graphene.types.mutation import MutationOptions
 from graphql.error import GraphQLError
 
-from ...account.error_codes import AccountErrorCode
 from ...core.db.utils import set_mutation_flag_in_context, setup_context_user
 from ...core.exceptions import PermissionDenied
 from ...core.permissions import (
@@ -366,14 +364,7 @@ class BaseMutation(graphene.Mutation):
     @classmethod
     def mutate(cls, root, info, **data):
         set_mutation_flag_in_context(info.context)
-        try:
-            setup_context_user(info.context)
-        except jwt.InvalidTokenError:
-            return cls.handle_errors(
-                ValidationError(
-                    "Invalid token", code=AccountErrorCode.JWT_INVALID_TOKEN.value
-                )
-            )
+        setup_context_user(info.context)
 
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)
@@ -717,14 +708,7 @@ class BaseBulkMutation(BaseMutation):
     @classmethod
     def mutate(cls, root, info, **data):
         set_mutation_flag_in_context(info.context)
-        try:
-            setup_context_user(info.context)
-        except jwt.InvalidTokenError:
-            return cls.handle_errors(
-                ValidationError(
-                    "Invalid token", code=AccountErrorCode.JWT_INVALID_TOKEN.value
-                )
-            )
+        setup_context_user(info.context)
 
         if not cls.check_permissions(info.context):
             raise PermissionDenied(permissions=cls._meta.permissions)

--- a/saleor/graphql/core/tests/test_base_mutation.py
+++ b/saleor/graphql/core/tests/test_base_mutation.py
@@ -4,12 +4,15 @@ import graphene
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import SimpleLazyObject
+from freezegun import freeze_time
 from graphql import GraphQLError
 from graphql.execution import ExecutionResult
 
 from saleor.core.permissions import ProductPermissions
 from saleor.plugins.tests.sample_plugins import PluginSample
 
+from ....core.jwt import create_access_token
+from ....graphql.tests.utils import get_graphql_content
 from ....order.models import Order
 from ....product.models import Product
 from ...order import types as order_types
@@ -430,3 +433,36 @@ def test_base_mutation_get_node_by_pk_with_qs_for_product(staff_user, product):
 
     # then
     assert node.id == product.id
+
+
+def test_expired_token_error(user_api_client, channel_USD):
+    # given
+    user = user_api_client.user
+    with freeze_time("2023-01-01 12:00:00"):
+        expired_access_token = create_access_token(user)
+        user_api_client.token = expired_access_token
+
+    mutation = """
+      mutation createCheckout($checkoutInput: CheckoutCreateInput!) {
+        checkoutCreate(input: $checkoutInput) {
+          checkout {
+            id
+          }
+          errors {
+            field
+            message
+            code
+          }
+        }
+      }
+    """
+
+    # when
+    variables = {"checkoutInput": {"channel": channel_USD.slug, "lines": []}}
+    response = user_api_client.post_graphql(mutation, variables)
+    content = get_graphql_content(response, ignore_errors=True)
+
+    # then
+    error = content["errors"][0]
+    assert error["message"] == "Signature has expired"
+    assert error["extensions"]["exception"]["code"] == "ExpiredSignatureError"

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -12,6 +12,7 @@ from django.db.models.functions import Concat
 from graphql import GraphQLDocument
 from graphql.error import GraphQLError
 from graphql.error import format_error as format_graphql_error
+from jwt import InvalidTokenError
 
 from ...core.exceptions import (
     CircularSubscriptionSyncEvent,
@@ -39,6 +40,7 @@ REVERSED_DIRECTION = {
 ALLOWED_ERRORS = [
     CircularSubscriptionSyncEvent,
     GraphQLError,
+    InvalidTokenError,
     PermissionDenied,
     ReadOnlyException,
     ValidationError,
@@ -284,7 +286,10 @@ def format_error(error, handled_exceptions):
     # If DEBUG mode is disabled we allow only certain error messages to be returned in
     # the API. This prevents from leaking internals that might be included in Python
     # exceptions' error messages.
-    if type(exc) not in ALLOWED_ERRORS and not settings.DEBUG:
+    is_allowed_err = type(exc) in ALLOWED_ERRORS or any(
+        [isinstance(exc, allowed_err) for allowed_err in ALLOWED_ERRORS]
+    )
+    if not is_allowed_err and not settings.DEBUG:
         result["message"] = INTERNAL_ERROR_MESSAGE
 
     result["extensions"]["exception"] = {"code": type(exc).__name__}


### PR DESCRIPTION
Recent [security fixes](https://github.com/saleor/saleor/releases/tag/3.7.59) unintentionally introduced a breaking change in error returned from API when the JWT token is expired. Before, the API was returning the `ExpiredSignatureError` code, but it was changed to the `invalid_token` code. This PR reverts the behavior for JWT errors, while all other internal errors are still hidden in API responses.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
