### PR TITLE
Update Avatax tests to alwyas use env variables for configuration

### DIFF
--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -7,6 +7,7 @@ from ....checkout.fetch import CheckoutInfo, get_delivery_method_info
 from ....shipping.models import ShippingMethodChannelListing
 from ....shipping.utils import convert_to_shipping_method_data
 from ...models import PluginConfiguration
+from .. import AvataxConfiguration
 from ..plugin import AvataxPlugin
 
 
@@ -60,6 +61,20 @@ def plugin_configuration(db, channel_USD):
         return configuration
 
     return set_configuration
+
+
+@pytest.fixture
+def avatax_config():
+    return AvataxConfiguration(
+        username_or_account=os.environ.get("AVALARA_USERNAME", "test"),
+        password_or_license=os.environ.get("AVALARA_PASSWORD", "test"),
+        use_sandbox=True,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
+    )
 
 
 @pytest.fixture

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -66,20 +66,6 @@ def order_set_shipping_method(order, shipping_method):
     )
 
 
-@pytest.fixture
-def avatax_config():
-    return AvataxConfiguration(
-        username_or_account="test",
-        password_or_license="test",
-        use_sandbox=True,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
-
 @pytest.mark.vcr()
 @pytest.mark.parametrize(
     "with_discount, expected_net, expected_gross, prices_entered_with_tax",
@@ -2879,6 +2865,7 @@ def test_generate_request_data_from_checkout_for_cc_and_single_location(
     address,
     address_other_country,
     warehouse,
+    avatax_config,
 ):
     # given
     warehouse.address = address_other_country
@@ -2890,22 +2877,20 @@ def test_generate_request_data_from_checkout_for_cc_and_single_location(
     checkout_with_item.save()
 
     address_data = address_other_country.as_data()
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address=address_data.get("street_address_1"),
-        from_city=address_data.get("city"),
-        from_postal_code=address_data.get("postal_code"),
-        from_country=address_data.get("country"),
-    )
+
+    avatax_config.from_street_address = address_data.get("street_address_1")
+    avatax_config.from_city = address_data.get("city")
+    avatax_config.from_postal_code = address_data.get("postal_code")
+    avatax_config.from_country = address_data.get("country")
 
     manager = get_plugins_manager()
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     # when
-    request_data = generate_request_data_from_checkout(checkout_info, lines, config)
+    request_data = generate_request_data_from_checkout(
+        checkout_info, lines, avatax_config
+    )
 
     # then
     addresses = request_data["createTransactionModel"]["addresses"]
@@ -2927,6 +2912,7 @@ def test_get_checkout_tax_data_with_single_point(
     mock_cache_set,
     checkout_with_item,
     warehouse,
+    avatax_config,
 ):
     # given
     address = Address.objects.create(
@@ -2942,24 +2928,14 @@ def test_get_checkout_tax_data_with_single_point(
     checkout_with_item.collection_point = warehouse
     checkout_with_item.save()
 
-    address_data = warehouse.address.as_data()
-
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=True,
-        from_street_address=address_data.get("street_address_1"),
-        from_city=address_data.get("city"),
-        from_postal_code=address_data.get("postal_code"),
-        from_country=address_data.get("country"),
-    )
-
     manager = get_plugins_manager()
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     # when
-    response = get_checkout_tax_data(checkout_info, lines, discounts=[], config=config)
+    response = get_checkout_tax_data(
+        checkout_info, lines, discounts=[], config=avatax_config
+    )
 
     # then
     assert len(response.get("addresses", [])) == 1
@@ -3971,8 +3947,9 @@ def test_api_post_request_handles_json_errors(product, monkeypatch, avatax_confi
 
 
 def test_get_order_request_data_checks_when_taxes_are_included_to_price(
-    order_with_lines, shipping_zone
+    order_with_lines, shipping_zone, avatax_config
 ):
+    # given
     tax_configuration = order_with_lines.channel.tax_configuration
     tax_configuration.prices_entered_with_tax = True
     tax_configuration.save(update_fields=["prices_entered_with_tax"])
@@ -3988,19 +3965,11 @@ def test_get_order_request_data_checks_when_taxes_are_included_to_price(
     order_with_lines.shipping_method = method
     order_with_lines.save()
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-    request_data = get_order_request_data(order_with_lines, config)
+    # when
+    request_data = get_order_request_data(order_with_lines, avatax_config)
     lines_data = request_data["createTransactionModel"]["lines"]
 
+    # then
     assert all([line for line in lines_data if line["taxIncluded"] is True])
 
 
@@ -4010,6 +3979,7 @@ def test_get_order_request_data_uses_correct_address_for_cc(
     address,
     address_other_country,
     warehouse,
+    avatax_config,
 ):
     # given
     site_settings.include_taxes_in_prices = True
@@ -4026,19 +3996,8 @@ def test_get_order_request_data_uses_correct_address_for_cc(
     order_with_lines.shipping_method = None
     order_with_lines.save()
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     expected_address_data = address_other_country.as_data()
@@ -4061,6 +4020,7 @@ def test_get_order_request_data_uses_correct_address_for_cc_with_single_location
     address,
     address_other_country,
     warehouse,
+    avatax_config,
 ):
     # given
     site_settings.include_taxes_in_prices = True
@@ -4079,17 +4039,13 @@ def test_get_order_request_data_uses_correct_address_for_cc_with_single_location
 
     address_data = address_other_country.as_data()
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address=address_data.get("street_address_1"),
-        from_city=address_data.get("city"),
-        from_postal_code=address_data.get("postal_code"),
-        from_country=address_data.get("country"),
-    )
+    avatax_config.from_street_address = address_data.get("street_address_1")
+    avatax_config.from_city = address_data.get("city")
+    avatax_config.from_postal_code = address_data.get("postal_code")
+    avatax_config.from_country = address_data.get("country")
+
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     addresses = request_data["createTransactionModel"]["addresses"]
@@ -4107,7 +4063,7 @@ def test_get_order_request_data_uses_correct_address_for_cc_with_single_location
 
 
 def test_get_order_request_data_for_line_with_already_included_taxes_in_price(
-    order_with_lines, shipping_zone
+    order_with_lines, shipping_zone, avatax_config
 ):
     """Ensure that when line already has calculated taxes, the `taxIncluded` flag
     is set based on site settings, and we are sending the base price of line."""
@@ -4130,19 +4086,8 @@ def test_get_order_request_data_for_line_with_already_included_taxes_in_price(
     order_with_lines.shipping_method = method
     order_with_lines.save()
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -4162,7 +4107,7 @@ def test_get_order_request_data_for_line_with_already_included_taxes_in_price(
 
 
 def test_get_order_request_data_confirmed_order_with_voucher(
-    order_with_lines, shipping_zone, voucher
+    order_with_lines, shipping_zone, voucher, avatax_config
 ):
     tax_configuration = order_with_lines.channel.tax_configuration
     tax_configuration.prices_entered_with_tax = True
@@ -4199,17 +4144,7 @@ def test_get_order_request_data_confirmed_order_with_voucher(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
     lines_data = request_data["createTransactionModel"]["lines"]
 
     # extra one from shipping data
@@ -4221,8 +4156,9 @@ def test_get_order_request_data_confirmed_order_with_voucher(
 
 
 def test_get_order_request_data_confirmed_order_with_sale(
-    order_with_lines, shipping_zone, sale
+    order_with_lines, shipping_zone, sale, avatax_config
 ):
+    # given
     tax_configuration = order_with_lines.channel.tax_configuration
     tax_configuration.prices_entered_with_tax = True
     tax_configuration.save(update_fields=["prices_entered_with_tax"])
@@ -4251,17 +4187,10 @@ def test_get_order_request_data_confirmed_order_with_sale(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-    request_data = get_order_request_data(order_with_lines, config)
+    # when
+    request_data = get_order_request_data(order_with_lines, avatax_config)
+
+    # then
     lines_data = request_data["createTransactionModel"]["lines"]
 
     # extra one from shipping data
@@ -4269,7 +4198,7 @@ def test_get_order_request_data_confirmed_order_with_sale(
 
 
 def test_get_order_request_data_draft_order_with_voucher(
-    order_with_lines, shipping_zone, voucher
+    order_with_lines, shipping_zone, voucher, avatax_config
 ):
     # given
     tax_configuration = order_with_lines.channel.tax_configuration
@@ -4308,19 +4237,8 @@ def test_get_order_request_data_draft_order_with_voucher(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -4335,7 +4253,7 @@ def test_get_order_request_data_draft_order_with_voucher(
 
 
 def test_get_order_request_data_draft_order_with_shipping_voucher(
-    order_with_lines, shipping_zone, voucher_free_shipping
+    order_with_lines, shipping_zone, voucher_free_shipping, avatax_config
 ):
     # given
     tax_configuration = order_with_lines.channel.tax_configuration
@@ -4379,19 +4297,8 @@ def test_get_order_request_data_draft_order_with_shipping_voucher(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -4403,7 +4310,7 @@ def test_get_order_request_data_draft_order_with_shipping_voucher(
 
 
 def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
-    order_with_lines, shipping_zone, voucher_free_shipping
+    order_with_lines, shipping_zone, voucher_free_shipping, avatax_config
 ):
     """Ensure that when order has shipping voucher with price bigger than shipping
     price, the shipping price will not be negative."""
@@ -4449,19 +4356,8 @@ def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -4473,7 +4369,7 @@ def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
 
 
 def test_get_order_request_data_draft_order_with_sale(
-    order_with_lines, shipping_zone, sale
+    order_with_lines, shipping_zone, sale, avatax_config
 ):
     # given
     tax_configuration = order_with_lines.channel.tax_configuration
@@ -4505,19 +4401,8 @@ def test_get_order_request_data_draft_order_with_sale(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -4554,6 +4439,7 @@ def test_get_order_tax_data_with_single_location(
     mock_cache_set,
     order_line,
     warehouse,
+    avatax_config,
 ):
     # given
     address = Address.objects.create(
@@ -4571,19 +4457,13 @@ def test_get_order_tax_data_with_single_location(
     order.save()
 
     address_data = warehouse.address.as_data()
-
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=True,
-        from_street_address=address_data.get("street_address_1"),
-        from_city=address_data.get("city"),
-        from_postal_code=address_data.get("postal_code"),
-        from_country=address_data.get("country"),
-    )
+    avatax_config.from_street_address = address_data.get("street_address_1")
+    avatax_config.from_city = address_data.get("city")
+    avatax_config.from_postal_code = address_data.get("postal_code")
+    avatax_config.from_country = address_data.get("country")
 
     # when
-    response = get_order_tax_data(order, config)
+    response = get_order_tax_data(order, avatax_config)
 
     # then
     assert len(response.get("addresses", [])) == 1
@@ -4948,7 +4828,7 @@ def test_generate_request_data_from_checkout_lines_with_shipping_method(
 
 
 def test_get_order_lines_data_gets_tax_code_from_product_tax_class(
-    settings, channel_USD, plugin_configuration, order_with_lines
+    settings, channel_USD, plugin_configuration, order_with_lines, avatax_config
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
@@ -4962,26 +4842,15 @@ def test_get_order_lines_data_gets_tax_code_from_product_tax_class(
     )
     tax_class.save()
 
-    config = AvataxConfiguration(
-        username_or_account="test",
-        password_or_license="test",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    lines_data = get_order_lines_data(order_with_lines, config, discounted=False)
+    lines_data = get_order_lines_data(order_with_lines, avatax_config, discounted=False)
 
     # then
     assert lines_data[0]["taxCode"] == tax_code
 
 
 def test_get_order_lines_data_gets_tax_code_from_product_type_tax_class(
-    settings, channel_USD, plugin_configuration, order_with_lines
+    settings, channel_USD, plugin_configuration, order_with_lines, avatax_config
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
@@ -4999,26 +4868,15 @@ def test_get_order_lines_data_gets_tax_code_from_product_type_tax_class(
     )
     tax_class.save()
 
-    config = AvataxConfiguration(
-        username_or_account="test",
-        password_or_license="test",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    lines_data = get_order_lines_data(order_with_lines, config, discounted=False)
+    lines_data = get_order_lines_data(order_with_lines, avatax_config, discounted=False)
 
     # then
     assert lines_data[0]["taxCode"] == tax_code
 
 
 def test_get_order_lines_data_sets_different_tax_code_for_zero_amount(
-    settings, channel_USD, plugin_configuration, order_with_lines
+    settings, channel_USD, plugin_configuration, order_with_lines, avatax_config
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
@@ -5039,19 +4897,8 @@ def test_get_order_lines_data_sets_different_tax_code_for_zero_amount(
     )
     variant.product.tax_class.save()
 
-    config = AvataxConfiguration(
-        username_or_account="test",
-        password_or_license="test",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    lines_data = get_order_lines_data(order_with_lines, config, discounted=False)
+    lines_data = get_order_lines_data(order_with_lines, avatax_config, discounted=False)
 
     # then
     assert lines_data[0]["amount"] == "0.000"
@@ -5059,7 +4906,7 @@ def test_get_order_lines_data_sets_different_tax_code_for_zero_amount(
 
 
 def test_get_order_lines_data_with_discounted(
-    settings, channel_USD, plugin_configuration, order, order_line
+    settings, channel_USD, plugin_configuration, order, order_line, avatax_config
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
@@ -5081,19 +4928,8 @@ def test_get_order_lines_data_with_discounted(
     )
     variant.product.tax_class.save()
 
-    config = AvataxConfiguration(
-        username_or_account="test",
-        password_or_license="test",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    lines_data = get_order_lines_data(order, config, discounted=True)
+    lines_data = get_order_lines_data(order, avatax_config, discounted=True)
 
     # then
     assert len(lines_data) == 1


### PR DESCRIPTION
Update `Avatax` tests to always use env variables for configuration

Port of https://github.com/saleor/saleor/pull/12207

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
