### PR TITLE
Update Avatax tests to alwyas use env variables for configuration

### DIFF
--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -7,6 +7,7 @@ from ....checkout.fetch import CheckoutInfo, get_delivery_method_info
 from ....shipping.models import ShippingMethodChannelListing
 from ....shipping.utils import convert_to_shipping_method_data
 from ...models import PluginConfiguration
+from .. import AvataxConfiguration
 from ..plugin import AvataxPlugin
 
 
@@ -60,6 +61,20 @@ def plugin_configuration(db, channel_USD):
         return configuration
 
     return set_configuration
+
+
+@pytest.fixture
+def avatax_config():
+    return AvataxConfiguration(
+        username_or_account=os.environ.get("AVALARA_USERNAME", "test"),
+        password_or_license=os.environ.get("AVALARA_PASSWORD", "test"),
+        use_sandbox=True,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
+    )
 
 
 @pytest.fixture

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -67,20 +67,6 @@ def order_set_shipping_method(order, shipping_method):
     )
 
 
-@pytest.fixture
-def avatax_config():
-    return AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=True,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
-
 @pytest.mark.vcr()
 @pytest.mark.parametrize(
     "with_discount, expected_net, expected_gross, prices_entered_with_tax",
@@ -2882,6 +2868,7 @@ def test_generate_request_data_from_checkout_for_cc_and_single_location(
     address,
     address_other_country,
     warehouse,
+    avatax_config,
 ):
     # given
     warehouse.address = address_other_country
@@ -2893,22 +2880,20 @@ def test_generate_request_data_from_checkout_for_cc_and_single_location(
     checkout_with_item.save()
 
     address_data = address_other_country.as_data()
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address=address_data.get("street_address_1"),
-        from_city=address_data.get("city"),
-        from_postal_code=address_data.get("postal_code"),
-        from_country=address_data.get("country"),
-    )
+
+    avatax_config.from_street_address = address_data.get("street_address_1")
+    avatax_config.from_city = address_data.get("city")
+    avatax_config.from_postal_code = address_data.get("postal_code")
+    avatax_config.from_country = address_data.get("country")
 
     manager = get_plugins_manager()
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     # when
-    request_data = generate_request_data_from_checkout(checkout_info, lines, config)
+    request_data = generate_request_data_from_checkout(
+        checkout_info, lines, avatax_config
+    )
 
     # then
     addresses = request_data["createTransactionModel"]["addresses"]
@@ -2930,6 +2915,7 @@ def test_get_checkout_tax_data_with_single_point(
     mock_cache_set,
     checkout_with_item,
     warehouse,
+    avatax_config,
 ):
     # given
     address = Address.objects.create(
@@ -2945,24 +2931,14 @@ def test_get_checkout_tax_data_with_single_point(
     checkout_with_item.collection_point = warehouse
     checkout_with_item.save()
 
-    address_data = warehouse.address.as_data()
-
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=True,
-        from_street_address=address_data.get("street_address_1"),
-        from_city=address_data.get("city"),
-        from_postal_code=address_data.get("postal_code"),
-        from_country=address_data.get("country"),
-    )
-
     manager = get_plugins_manager()
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     # when
-    response = get_checkout_tax_data(checkout_info, lines, discounts=[], config=config)
+    response = get_checkout_tax_data(
+        checkout_info, lines, discounts=[], config=avatax_config
+    )
 
     # then
     assert len(response.get("addresses", [])) == 1
@@ -3975,8 +3951,9 @@ def test_api_post_request_handles_json_errors(product, monkeypatch, avatax_confi
 
 
 def test_get_order_request_data_checks_when_taxes_are_included_to_price(
-    order_with_lines, shipping_zone
+    order_with_lines, shipping_zone, avatax_config
 ):
+    # given
     tax_configuration = order_with_lines.channel.tax_configuration
     tax_configuration.prices_entered_with_tax = True
     tax_configuration.save(update_fields=["prices_entered_with_tax"])
@@ -3992,19 +3969,11 @@ def test_get_order_request_data_checks_when_taxes_are_included_to_price(
     order_with_lines.shipping_method = method
     order_with_lines.save()
 
-    config = AvataxConfiguration(
-        username_or_account="test",
-        password_or_license="test",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-    request_data = get_order_request_data(order_with_lines, config)
+    # when
+    request_data = get_order_request_data(order_with_lines, avatax_config)
     lines_data = request_data["createTransactionModel"]["lines"]
 
+    # then
     assert all([line for line in lines_data if line["taxIncluded"] is True])
 
 
@@ -4014,6 +3983,7 @@ def test_get_order_request_data_uses_correct_address_for_cc(
     address,
     address_other_country,
     warehouse,
+    avatax_config,
 ):
     # given
     site_settings.include_taxes_in_prices = True
@@ -4030,19 +4000,8 @@ def test_get_order_request_data_uses_correct_address_for_cc(
     order_with_lines.shipping_method = None
     order_with_lines.save()
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     expected_address_data = address_other_country.as_data()
@@ -4065,6 +4024,7 @@ def test_get_order_request_data_uses_correct_address_for_cc_with_single_location
     address,
     address_other_country,
     warehouse,
+    avatax_config,
 ):
     # given
     site_settings.include_taxes_in_prices = True
@@ -4083,17 +4043,13 @@ def test_get_order_request_data_uses_correct_address_for_cc_with_single_location
 
     address_data = address_other_country.as_data()
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address=address_data.get("street_address_1"),
-        from_city=address_data.get("city"),
-        from_postal_code=address_data.get("postal_code"),
-        from_country=address_data.get("country"),
-    )
+    avatax_config.from_street_address = address_data.get("street_address_1")
+    avatax_config.from_city = address_data.get("city")
+    avatax_config.from_postal_code = address_data.get("postal_code")
+    avatax_config.from_country = address_data.get("country")
+
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     addresses = request_data["createTransactionModel"]["addresses"]
@@ -4111,7 +4067,7 @@ def test_get_order_request_data_uses_correct_address_for_cc_with_single_location
 
 
 def test_get_order_request_data_for_line_with_already_included_taxes_in_price(
-    order_with_lines, shipping_zone
+    order_with_lines, shipping_zone, avatax_config
 ):
     """Ensure that when line already has calculated taxes, the `taxIncluded` flag
     is set based on site settings, and we are sending the base price of line."""
@@ -4134,19 +4090,8 @@ def test_get_order_request_data_for_line_with_already_included_taxes_in_price(
     order_with_lines.shipping_method = method
     order_with_lines.save()
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -4166,7 +4111,7 @@ def test_get_order_request_data_for_line_with_already_included_taxes_in_price(
 
 
 def test_get_order_request_data_confirmed_order_with_voucher(
-    order_with_lines, shipping_zone, voucher
+    order_with_lines, shipping_zone, voucher, avatax_config
 ):
     tax_configuration = order_with_lines.channel.tax_configuration
     tax_configuration.prices_entered_with_tax = True
@@ -4203,17 +4148,7 @@ def test_get_order_request_data_confirmed_order_with_voucher(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
     lines_data = request_data["createTransactionModel"]["lines"]
 
     # extra one from shipping data
@@ -4225,8 +4160,9 @@ def test_get_order_request_data_confirmed_order_with_voucher(
 
 
 def test_get_order_request_data_confirmed_order_with_sale(
-    order_with_lines, shipping_zone, sale
+    order_with_lines, shipping_zone, sale, avatax_config
 ):
+    # given
     tax_configuration = order_with_lines.channel.tax_configuration
     tax_configuration.prices_entered_with_tax = True
     tax_configuration.save(update_fields=["prices_entered_with_tax"])
@@ -4255,17 +4191,10 @@ def test_get_order_request_data_confirmed_order_with_sale(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-    request_data = get_order_request_data(order_with_lines, config)
+    # when
+    request_data = get_order_request_data(order_with_lines, avatax_config)
+
+    # then
     lines_data = request_data["createTransactionModel"]["lines"]
 
     # extra one from shipping data
@@ -4273,7 +4202,7 @@ def test_get_order_request_data_confirmed_order_with_sale(
 
 
 def test_get_order_request_data_draft_order_with_voucher(
-    order_with_lines, shipping_zone, voucher
+    order_with_lines, shipping_zone, voucher, avatax_config
 ):
     # given
     tax_configuration = order_with_lines.channel.tax_configuration
@@ -4312,19 +4241,8 @@ def test_get_order_request_data_draft_order_with_voucher(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -4339,7 +4257,7 @@ def test_get_order_request_data_draft_order_with_voucher(
 
 
 def test_get_order_request_data_draft_order_with_shipping_voucher(
-    order_with_lines, shipping_zone, voucher_free_shipping
+    order_with_lines, shipping_zone, voucher_free_shipping, avatax_config
 ):
     # given
     tax_configuration = order_with_lines.channel.tax_configuration
@@ -4383,19 +4301,8 @@ def test_get_order_request_data_draft_order_with_shipping_voucher(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -4407,7 +4314,7 @@ def test_get_order_request_data_draft_order_with_shipping_voucher(
 
 
 def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
-    order_with_lines, shipping_zone, voucher_free_shipping
+    order_with_lines, shipping_zone, voucher_free_shipping, avatax_config
 ):
     """Ensure that when order has shipping voucher with price bigger than shipping
     price, the shipping price will not be negative."""
@@ -4453,19 +4360,8 @@ def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -4477,7 +4373,7 @@ def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
 
 
 def test_get_order_request_data_draft_order_with_sale(
-    order_with_lines, shipping_zone, sale
+    order_with_lines, shipping_zone, sale, avatax_config
 ):
     # given
     tax_configuration = order_with_lines.channel.tax_configuration
@@ -4509,19 +4405,8 @@ def test_get_order_request_data_draft_order_with_sale(
         ]
     )
 
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, avatax_config)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -4558,6 +4443,7 @@ def test_get_order_tax_data_with_single_location(
     mock_cache_set,
     order_line,
     warehouse,
+    avatax_config,
 ):
     # given
     address = Address.objects.create(
@@ -4575,19 +4461,13 @@ def test_get_order_tax_data_with_single_location(
     order.save()
 
     address_data = warehouse.address.as_data()
-
-    config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
-        use_sandbox=True,
-        from_street_address=address_data.get("street_address_1"),
-        from_city=address_data.get("city"),
-        from_postal_code=address_data.get("postal_code"),
-        from_country=address_data.get("country"),
-    )
+    avatax_config.from_street_address = address_data.get("street_address_1")
+    avatax_config.from_city = address_data.get("city")
+    avatax_config.from_postal_code = address_data.get("postal_code")
+    avatax_config.from_country = address_data.get("country")
 
     # when
-    response = get_order_tax_data(order, config)
+    response = get_order_tax_data(order, avatax_config)
 
     # then
     assert len(response.get("addresses", [])) == 1
@@ -4952,7 +4832,7 @@ def test_generate_request_data_from_checkout_lines_with_shipping_method(
 
 
 def test_get_order_lines_data_gets_tax_code_from_product_tax_class(
-    settings, channel_USD, plugin_configuration, order_with_lines
+    settings, channel_USD, plugin_configuration, order_with_lines, avatax_config
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
@@ -4966,26 +4846,15 @@ def test_get_order_lines_data_gets_tax_code_from_product_tax_class(
     )
     tax_class.save()
 
-    config = AvataxConfiguration(
-        username_or_account="test",
-        password_or_license="test",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    lines_data = get_order_lines_data(order_with_lines, config, discounted=False)
+    lines_data = get_order_lines_data(order_with_lines, avatax_config, discounted=False)
 
     # then
     assert lines_data[0]["taxCode"] == tax_code
 
 
 def test_get_order_lines_data_gets_tax_code_from_product_type_tax_class(
-    settings, channel_USD, plugin_configuration, order_with_lines
+    settings, channel_USD, plugin_configuration, order_with_lines, avatax_config
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
@@ -5003,26 +4872,15 @@ def test_get_order_lines_data_gets_tax_code_from_product_type_tax_class(
     )
     tax_class.save()
 
-    config = AvataxConfiguration(
-        username_or_account="test",
-        password_or_license="test",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    lines_data = get_order_lines_data(order_with_lines, config, discounted=False)
+    lines_data = get_order_lines_data(order_with_lines, avatax_config, discounted=False)
 
     # then
     assert lines_data[0]["taxCode"] == tax_code
 
 
 def test_get_order_lines_data_sets_different_tax_code_for_zero_amount(
-    settings, channel_USD, plugin_configuration, order_with_lines
+    settings, channel_USD, plugin_configuration, order_with_lines, avatax_config
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
@@ -5043,19 +4901,8 @@ def test_get_order_lines_data_sets_different_tax_code_for_zero_amount(
     )
     variant.product.tax_class.save()
 
-    config = AvataxConfiguration(
-        username_or_account="test",
-        password_or_license="test",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    lines_data = get_order_lines_data(order_with_lines, config, discounted=False)
+    lines_data = get_order_lines_data(order_with_lines, avatax_config, discounted=False)
 
     # then
     assert lines_data[0]["amount"] == "0.000"
@@ -5063,7 +4910,7 @@ def test_get_order_lines_data_sets_different_tax_code_for_zero_amount(
 
 
 def test_get_order_lines_data_with_discounted(
-    settings, channel_USD, plugin_configuration, order, order_line
+    settings, channel_USD, plugin_configuration, order, order_line, avatax_config
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
@@ -5085,19 +4932,8 @@ def test_get_order_lines_data_with_discounted(
     )
     variant.product.tax_class.save()
 
-    config = AvataxConfiguration(
-        username_or_account="test",
-        password_or_license="test",
-        use_sandbox=False,
-        from_street_address="Tęczowa 7",
-        from_city="WROCŁAW",
-        from_country_area="",
-        from_postal_code="53-601",
-        from_country="PL",
-    )
-
     # when
-    lines_data = get_order_lines_data(order, config, discounted=True)
+    lines_data = get_order_lines_data(order, avatax_config, discounted=True)
 
     # then
     assert len(lines_data) == 1


### PR DESCRIPTION
Update `Avatax` tests to always use env variables for configuration

Port of https://github.com/saleor/saleor/pull/12207
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
