### PR TITLE
Fix invalid draft order prices when using staff discount

### DIFF
--- a/saleor/order/base_calculations.py
+++ b/saleor/order/base_calculations.py
@@ -17,7 +17,7 @@ def base_order_shipping(order: "Order") -> Money:
     return order.base_shipping_price
 
 
-def _base_order_subtotal(order: "Order", lines: Iterable["OrderLine"]) -> Money:
+def base_order_subtotal(order: "Order", lines: Iterable["OrderLine"]) -> Money:
     currency = order.currency
     subtotal = zero_money(currency)
     for line in lines:
@@ -39,7 +39,7 @@ def base_order_total(order: "Order", lines: Iterable["OrderLine"]) -> Money:
     (OrderDiscounts with type `order_discount.type == OrderDiscountType.MANUAL`).
     """
     currency = order.currency
-    subtotal = _base_order_subtotal(order, lines)
+    subtotal = base_order_subtotal(order, lines)
     shipping_price = order.base_shipping_price
     order_discounts = order.discounts.all()
     order_discounts_to_update = []

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4113,6 +4113,8 @@ def order_with_lines(
     order.shipping_price = TaxedMoney(net=net, gross=gross)
     order.base_shipping_price = net
     order.shipping_tax_rate = calculate_tax_rate(order.shipping_price)
+    order.total += order.shipping_price
+    order.undiscounted_total += order.shipping_price
     order.save()
 
     recalculate_order(order)
@@ -4625,11 +4627,10 @@ def fulfillment_awaiting_approval(fulfilled_order):
 
 
 @pytest.fixture
-def draft_order(order_with_lines, shipping_method):
+def draft_order(order_with_lines):
     Allocation.objects.filter(order_line__order=order_with_lines).delete()
     order_with_lines.status = OrderStatus.DRAFT
     order_with_lines.origin = OrderOrigin.DRAFT
-    order_with_lines.shipping_method = shipping_method
     order_with_lines.save(update_fields=["status", "origin"])
     return order_with_lines
 


### PR DESCRIPTION
Fix invalid shipping price and line unit price calculations when applying the staff discount on draft orders.

Port of https://github.com/saleor/saleor/pull/12256

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
