### PR TITLE
Upgrade GraphiQL to `2.4` for playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### GraphQL API
 - [Preview] Add `StockBulkUpdate` mutation - #12139 by @SzymJ
+- Upgrade GraphiQL to `2.4.0` for playground - #12271 by @zaiste
 
 ### Other changes
 

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -8,19 +8,19 @@
 
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-10/dist/umd/index.css"
-    integrity="sha256-ZJCckg9tCLN/1GDFgJUsuVH9o8NGGcFD4kELL6KFAyc="
+    href="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-11/dist/umd/index.css"
+    integrity="sha256-E72GyD1jj9aVaRpcpp10kI1KxHgxpH+YFFxYGoFn4X8="
     crossorigin="anonymous"
   />
   <!-- sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc= is inline css added by the playground when opening settings -->
   <!-- sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c= is the inline code below -->
-  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-10/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-10/dist/umd/index.css 'sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc='; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }} {{ plugins_url }}; script-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-11/dist/umd/index.js 'sha256-hM8ziVmFsNZhvY3EjvTholqPBoYTMv/3+1nOBhZrL+c='; style-src https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-11/dist/umd/index.css 'sha256-Y/huXlwoYkVyQlxwSVcCi1RCDGDCSVBzDt0hYP9qlTc='; font-src 'self' data:; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
 </head>
 <body>
   <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}></div>
   <script
-    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-10/dist/umd/index.js"
-    integrity="sha256-7NMm/mvIdkuYIRo237M74Lk5JSB9y85AaI+23EfsYtA="
+    src="https://cdn.jsdelivr.net/npm/@saleor/graphql-playground@2.0.0-11/dist/umd/index.js"
+    integrity="sha256-rA1RZxC+CNMLNYlDdMRTfMx9jVmG32H9iv6ekgl9hGI="
     crossorigin="anonymous">
   </script>
 


### PR DESCRIPTION
I want to merge this change because it updates GraphiQL to `2.4` for playground

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
