### PR TITLE
Add possibility to finalize the checkout with paid transactions

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from decimal import Decimal
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -24,7 +25,7 @@ from ..account.error_codes import AccountErrorCode
 from ..account.models import User
 from ..account.utils import store_user_address
 from ..channel import MarkAsPaidStrategy
-from ..checkout import calculations
+from ..checkout import CheckoutAuthorizeStatus, calculations
 from ..checkout.error_codes import CheckoutErrorCode
 from ..core.exceptions import GiftCardNotApplicable, InsufficientStock
 from ..core.postgres import FlatConcatSearchVector
@@ -44,11 +45,7 @@ from ..graphql.checkout.utils import (
     prepare_insufficient_stock_checkout_validation_error,
 )
 from ..order import OrderOrigin, OrderStatus
-from ..order.actions import (
-    mark_order_as_paid_with_payment,
-    mark_order_as_paid_with_transaction,
-    order_created,
-)
+from ..order.actions import mark_order_as_paid_with_payment, order_created
 from ..order.fetch import OrderInfo, OrderLineInfo
 from ..order.models import Order, OrderLine
 from ..order.notifications import send_order_confirmation
@@ -80,6 +77,7 @@ from .base_calculations import (
 from .calculations import fetch_checkout_data
 from .checkout_cleaner import (
     _validate_gift_cards,
+    clean_billing_address,
     clean_checkout_payment,
     clean_checkout_shipping,
 )
@@ -667,19 +665,9 @@ def _prepare_checkout(
     discounts,
     tracking_code,
     redirect_url,
-    payment,
 ):
-    """Prepare checkout object to complete the checkout process."""
     checkout = checkout_info.checkout
     clean_checkout_shipping(checkout_info, lines, CheckoutErrorCode)
-    clean_checkout_payment(
-        manager,
-        checkout_info,
-        lines,
-        discounts,
-        CheckoutErrorCode,
-        last_payment=payment,
-    )
     if not checkout_info.channel.is_active:
         raise ValidationError(
             {
@@ -709,6 +697,64 @@ def _prepare_checkout(
     if to_update:
         to_update.append("last_change")
         checkout.save(update_fields=to_update)
+
+
+def _prepare_checkout_with_transactions(
+    manager: "PluginsManager",
+    checkout_info: "CheckoutInfo",
+    lines: Iterable["CheckoutLineInfo"],
+    discounts,
+    tracking_code,
+    redirect_url,
+):
+    """Prepare checkout object with transactions to complete the checkout process."""
+    clean_billing_address(checkout_info, CheckoutErrorCode)
+    if checkout_info.checkout.authorize_status != CheckoutAuthorizeStatus.FULL:
+        raise ValidationError(
+            {
+                "id": ValidationError(
+                    "The authorized amount doesn't cover the checkout's total amount",
+                    code=CheckoutErrorCode.CHECKOUT_NOT_FULLY_PAID.value,
+                )
+            }
+        )
+
+    _prepare_checkout(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        discounts=discounts,
+        tracking_code=tracking_code,
+        redirect_url=redirect_url,
+    )
+
+
+def _prepare_checkout_with_payment(
+    manager: "PluginsManager",
+    checkout_info: "CheckoutInfo",
+    lines: Iterable["CheckoutLineInfo"],
+    discounts,
+    tracking_code,
+    redirect_url,
+    payment,
+):
+    """Prepare checkout object with payment to complete the checkout process."""
+    clean_checkout_payment(
+        manager,
+        checkout_info,
+        lines,
+        discounts,
+        CheckoutErrorCode,
+        last_payment=payment,
+    )
+    _prepare_checkout(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        discounts=discounts,
+        tracking_code=tracking_code,
+        redirect_url=redirect_url,
+    )
 
 
 def _get_order_data(
@@ -810,7 +856,7 @@ def complete_checkout_pre_payment_part(
     channel_slug = checkout_info.channel.slug
     payment = checkout.get_last_active_payment()
     try:
-        _prepare_checkout(
+        _prepare_checkout_with_payment(
             manager=manager,
             checkout_info=checkout_info,
             lines=lines,
@@ -906,8 +952,6 @@ def complete_checkout_post_payment_part(
                 == MarkAsPaidStrategy.PAYMENT_FLOW
             ):
                 mark_order_as_paid_with_payment(order, user, app, manager)
-            else:
-                mark_order_as_paid_with_transaction(order, user, app, manager)
 
     return order, action_required, action_data
 
@@ -940,7 +984,7 @@ def _increase_voucher_usage(checkout_info: "CheckoutInfo"):
 def _create_order_lines_from_checkout_lines(
     checkout_info: CheckoutInfo,
     lines: List[CheckoutLineInfo],
-    discounts: List["DiscountInfo"],
+    discounts: Iterable["DiscountInfo"],
     manager: "PluginsManager",
     order_pk: Union[str, UUID],
     prices_entered_with_tax: bool,
@@ -1022,7 +1066,7 @@ def _post_create_order_actions(
     checkout_info: "CheckoutInfo",
     order_lines_info: List["OrderLineInfo"],
     manager: "PluginsManager",
-    user: User,
+    user: Optional[User],
     app: Optional["App"],
     site_settings: "SiteSettings",
 ):
@@ -1055,9 +1099,9 @@ def _post_create_order_actions(
 def _create_order_from_checkout(
     checkout_info: CheckoutInfo,
     checkout_lines_info: List[CheckoutLineInfo],
-    discounts: List["DiscountInfo"],
+    discounts: Iterable["DiscountInfo"],
     manager: "PluginsManager",
-    user: User,
+    user: Optional[User],
     app: Optional["App"],
     tracking_code: Optional[str] = None,
     metadata_list: Optional[List] = None,
@@ -1081,7 +1125,6 @@ def _create_order_from_checkout(
         address=address,
         discounts=discounts,
     )
-    undiscounted_total = taxed_total + checkout_info.checkout.discount
 
     # voucher
     voucher = checkout_info.voucher
@@ -1129,7 +1172,6 @@ def _create_order_from_checkout(
         language_code=checkout_info.checkout.language_code,
         tracking_client_id=tracking_code or "",
         total=taxed_total,  # money field not supported by mypy_django_plugin
-        undiscounted_total=undiscounted_total,  # money field not supported by mypy_django_plugin # noqa: E501
         shipping_tax_rate=shipping_tax_rate,
         voucher=voucher,
         checkout_token=str(checkout_info.checkout.token),
@@ -1161,6 +1203,22 @@ def _create_order_from_checkout(
         manager=manager,
         order_pk=order.pk,
         prices_entered_with_tax=prices_entered_with_tax,
+    )
+
+    # update undiscounted order total
+    undiscounted_total = (
+        sum(
+            [line.line.undiscounted_total_price for line in order_lines_info],
+            start=zero_taxed_money(taxed_total.currency),
+        )
+        + shipping_total
+    )
+    order.undiscounted_total = undiscounted_total
+    order.save(
+        update_fields=[
+            "undiscounted_total_net_amount",
+            "undiscounted_total_gross_amount",
+        ]
     )
 
     # allocations
@@ -1212,11 +1270,11 @@ def _create_order_from_checkout(
 def create_order_from_checkout(
     checkout_info: CheckoutInfo,
     checkout_lines: Iterable["CheckoutLineInfo"],
-    discounts: List["DiscountInfo"],
+    discounts: Iterable["DiscountInfo"],
     manager: "PluginsManager",
-    user: User,
+    user: Optional["User"],
     app: Optional["App"],
-    tracking_code: str,
+    tracking_code: Optional[str],
     delete_checkout: bool = True,
     metadata_list: Optional[List] = None,
     private_metadata_list: Optional[List] = None,
@@ -1272,6 +1330,95 @@ def create_order_from_checkout(
 
 
 def complete_checkout(
+    manager: "PluginsManager",
+    checkout_info: "CheckoutInfo",
+    lines: Iterable["CheckoutLineInfo"],
+    payment_data,
+    store_source,
+    discounts,
+    user,
+    app,
+    site_settings=None,
+    tracking_code=None,
+    redirect_url=None,
+    metadata_list: Optional[List] = None,
+    private_metadata_list: Optional[List] = None,
+) -> Tuple[Optional[Order], bool, dict]:
+    transactions = checkout_info.checkout.payment_transactions.all()
+    fetch_checkout_data(checkout_info, manager, lines, discounts=discounts)
+    checkout_is_zero = checkout_info.checkout.total.gross.amount == Decimal(0)
+    if transactions or (
+        checkout_is_zero
+        and checkout_info.channel.order_mark_as_paid_strategy
+        == MarkAsPaidStrategy.TRANSACTION_FLOW
+    ):
+        order = complete_checkout_with_transaction(
+            manager=manager,
+            checkout_info=checkout_info,
+            lines=lines,
+            discounts=discounts,
+            user=user,
+            app=app,
+            tracking_code=tracking_code,
+            redirect_url=redirect_url,
+            metadata_list=metadata_list,
+            private_metadata_list=private_metadata_list,
+        )
+        return order, False, {}
+
+    return complete_checkout_with_payment(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        payment_data=payment_data,
+        store_source=store_source,
+        discounts=discounts,
+        user=user,
+        app=app,
+        site_settings=site_settings,
+        tracking_code=tracking_code,
+        redirect_url=redirect_url,
+        metadata_list=metadata_list,
+        private_metadata_list=private_metadata_list,
+    )
+
+
+def complete_checkout_with_transaction(
+    manager: "PluginsManager",
+    checkout_info: "CheckoutInfo",
+    lines: Iterable["CheckoutLineInfo"],
+    discounts: Iterable["DiscountInfo"],
+    user: Optional["User"],
+    app: Optional["App"],
+    tracking_code: Optional[str] = None,
+    redirect_url: Optional[str] = None,
+    metadata_list: Optional[List] = None,
+    private_metadata_list: Optional[List] = None,
+) -> Optional[Order]:
+    _prepare_checkout_with_transactions(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        discounts=discounts,
+        tracking_code=tracking_code,
+        redirect_url=redirect_url,
+    )
+
+    return create_order_from_checkout(
+        checkout_info=checkout_info,
+        checkout_lines=lines,
+        discounts=discounts,
+        manager=manager,
+        user=user,
+        app=app,
+        tracking_code=tracking_code,
+        delete_checkout=True,
+        metadata_list=metadata_list,
+        private_metadata_list=private_metadata_list,
+    )
+
+
+def complete_checkout_with_payment(
     manager: "PluginsManager",
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1346,6 +1346,11 @@ def complete_checkout(
 ) -> Tuple[Optional[Order], bool, dict]:
     transactions = checkout_info.checkout.payment_transactions.all()
     fetch_checkout_data(checkout_info, manager, lines, discounts=discounts)
+
+    # When checkout is zero, we don't need any transaction to cover the checkout total.
+    # We check if checkout is zero, and we also check what flow for marking an order as
+    # paid is used. In case when we have TRANSACTION_FLOW we use transaction flow to
+    # finalize the checkout.
     checkout_is_zero = checkout_info.checkout.total.gross.amount == Decimal(0)
     if transactions or (
         checkout_is_zero

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -703,9 +703,9 @@ def _prepare_checkout_with_transactions(
     manager: "PluginsManager",
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
-    discounts,
-    tracking_code,
-    redirect_url,
+    discounts: Iterable["DiscountInfo"],
+    tracking_code: Optional[str],
+    redirect_url: Optional[str],
 ):
     """Prepare checkout object with transactions to complete the checkout process."""
     clean_billing_address(checkout_info, CheckoutErrorCode)
@@ -713,7 +713,7 @@ def _prepare_checkout_with_transactions(
         raise ValidationError(
             {
                 "id": ValidationError(
-                    "The authorized amount doesn't cover the checkout's total amount",
+                    "The authorized amount doesn't cover the checkout's total amount.",
                     code=CheckoutErrorCode.CHECKOUT_NOT_FULLY_PAID.value,
                 )
             }
@@ -733,10 +733,10 @@ def _prepare_checkout_with_payment(
     manager: "PluginsManager",
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
-    discounts,
-    tracking_code,
-    redirect_url,
-    payment,
+    discounts: Iterable["DiscountInfo"],
+    tracking_code: Optional[str],
+    redirect_url: Optional[str],
+    payment: Optional[Payment],
 ):
     """Prepare checkout object with payment to complete the checkout process."""
     clean_checkout_payment(
@@ -1333,14 +1333,14 @@ def complete_checkout(
     manager: "PluginsManager",
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
-    payment_data,
-    store_source,
-    discounts,
-    user,
-    app,
-    site_settings=None,
-    tracking_code=None,
-    redirect_url=None,
+    payment_data: Dict[Any, Any],
+    store_source: bool,
+    discounts: Iterable["DiscountInfo"],
+    user: Optional["User"],
+    app: Optional["App"],
+    site_settings: Optional["SiteSettings"] = None,
+    tracking_code: Optional[str] = None,
+    redirect_url: Optional[str] = None,
     metadata_list: Optional[List] = None,
     private_metadata_list: Optional[List] = None,
 ) -> Tuple[Optional[Order], bool, dict]:

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -32,6 +32,7 @@ from ..complete_checkout import (
     complete_checkout,
 )
 from ..fetch import fetch_checkout_info, fetch_checkout_lines
+from ..payment_utils import update_checkout_payment_statuses
 from ..utils import add_variant_to_checkout
 
 
@@ -1205,6 +1206,8 @@ def test_complete_checkout_0_total_with_transaction_for_mark_as_paid(
     checkout.billing_address = customer_user.default_billing_address
     checkout.save()
 
+    update_checkout_payment_statuses(checkout, zero_money(checkout.currency))
+
     manager = get_plugins_manager()
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
@@ -1225,21 +1228,13 @@ def test_complete_checkout_0_total_with_transaction_for_mark_as_paid(
     flush_post_commit_hooks()
 
     assert order
-    assert order.events.get(type=OrderEvents.ORDER_MARKED_AS_PAID)
-    transaction = order.payment_transactions.get()
-    assert transaction.charged_value == order.total.gross.amount
     assert order.authorize_status == OrderAuthorizeStatus.FULL
     assert order.charge_status == OrderChargeStatus.FULL
 
 
-@pytest.mark.parametrize(
-    "mark_as_paid_strategy",
-    [MarkAsPaidStrategy.TRANSACTION_FLOW, MarkAsPaidStrategy.PAYMENT_FLOW],
-)
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
 def test_complete_checkout_0_total_captured_payment_creates_expected_events(
     mock_notify,
-    mark_as_paid_strategy,
     checkout_with_item_total_0,
     customer_user,
     channel_USD,
@@ -1250,7 +1245,7 @@ def test_complete_checkout_0_total_captured_payment_creates_expected_events(
     checkout_user = customer_user
 
     channel = checkout.channel
-    channel.order_mark_as_paid_strategy = mark_as_paid_strategy
+    channel.order_mark_as_paid_strategy = MarkAsPaidStrategy.PAYMENT_FLOW
     channel.save(update_fields=["order_mark_as_paid_strategy"])
 
     # Ensure not events are existing prior
@@ -1671,7 +1666,7 @@ def test_complete_checkout_invalid_shipping_method(
     app,
     payment_txn_to_confirm,
 ):
-    """Ensure that when an error in _prepare_checkout method is raised
+    """Ensure that when an error in _prepare_checkout_with_payment method is raised
     the method for refund or void is called."""
     # given
     checkout = checkout_ready_to_complete
@@ -1724,3 +1719,127 @@ def test_complete_checkout_invalid_shipping_method(
     mocked_payment_refund_or_void.called_once_with(
         payment, manager, channel_slug=checkout.channel.slug
     )
+
+
+# @pytest.mark.parametrize(
+#     "mark_as_paid_strategy",
+#     [MarkAsPaidStrategy.TRANSACTION_FLOW, MarkAsPaidStrategy.PAYMENT_FLOW],
+# )
+@mock.patch("saleor.checkout.complete_checkout.complete_checkout_with_transaction")
+def test_checkout_complete_pick_transaction_flow(
+    mocked_flow,
+    order,
+    checkout_ready_to_complete,
+    customer_user,
+    transaction_item_generator,
+):
+    # given
+    checkout = checkout_ready_to_complete
+    checkout.user = customer_user
+    checkout.billing_address = customer_user.default_billing_address
+    checkout.shipping_address = customer_user.default_billing_address
+    checkout.tracking_code = ""
+    checkout.redirect_url = "https://www.example.com"
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    transaction_item_generator(checkout_id=checkout.pk)
+    mocked_flow.return_value = order, False, {}
+
+    # when
+    order, action_required, _ = complete_checkout(
+        checkout_info=checkout_info,
+        manager=manager,
+        lines=lines,
+        payment_data={},
+        store_source=False,
+        discounts=None,
+        user=customer_user,
+        app=None,
+    )
+
+    # then
+    assert mocked_flow.called
+
+
+@mock.patch("saleor.checkout.complete_checkout.complete_checkout_with_transaction")
+def test_checkout_complete_pick_transaction_flow_when_checkout_total_zero(
+    mocked_flow, order, checkout_with_item_total_0, customer_user, channel_USD
+):
+    # given
+    checkout = checkout_with_item_total_0
+    checkout.user = customer_user
+    checkout.billing_address = customer_user.default_billing_address
+    checkout.shipping_address = customer_user.default_billing_address
+    checkout.tracking_code = ""
+    checkout.redirect_url = "https://www.example.com"
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+
+    checkout.total = zero_taxed_money(checkout.currency)
+    update_checkout_payment_statuses(
+        checkout=checkout,
+        checkout_total_gross=checkout.total,
+    )
+
+    mocked_flow.return_value = order, False, {}
+    channel_USD.order_mark_as_paid_strategy = MarkAsPaidStrategy.TRANSACTION_FLOW
+    channel_USD.save()
+
+    # when
+    order, action_required, _ = complete_checkout(
+        checkout_info=checkout_info,
+        manager=manager,
+        lines=lines,
+        payment_data={},
+        store_source=False,
+        discounts=None,
+        user=customer_user,
+        app=None,
+    )
+
+    # then
+    assert mocked_flow.called
+
+
+@mock.patch("saleor.checkout.complete_checkout.complete_checkout_with_payment")
+def test_checkout_complete_pick_payment_flow(
+    mocked_flow, order, checkout_ready_to_complete, customer_user
+):
+    # given
+    checkout = checkout_ready_to_complete
+    checkout.user = customer_user
+    checkout.billing_address = customer_user.default_billing_address
+    checkout.shipping_address = customer_user.default_billing_address
+    checkout.tracking_code = ""
+    checkout.redirect_url = "https://www.example.com"
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+
+    mocked_flow.return_value = order, False, {}
+
+    payment = Payment.objects.create(
+        gateway="mirumee.payments.dummy", is_active=True, checkout=checkout
+    )
+    payment.to_confirm = True
+    payment.save()
+
+    # when
+    order, action_required, _ = complete_checkout(
+        checkout_info=checkout_info,
+        manager=manager,
+        lines=lines,
+        payment_data={},
+        store_source=False,
+        discounts=None,
+        user=customer_user,
+        app=None,
+    )
+
+    # then
+    assert mocked_flow.called

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -1721,10 +1721,6 @@ def test_complete_checkout_invalid_shipping_method(
     )
 
 
-# @pytest.mark.parametrize(
-#     "mark_as_paid_strategy",
-#     [MarkAsPaidStrategy.TRANSACTION_FLOW, MarkAsPaidStrategy.PAYMENT_FLOW],
-# )
 @mock.patch("saleor.checkout.complete_checkout.complete_checkout_with_transaction")
 def test_checkout_complete_pick_transaction_flow(
     mocked_flow,
@@ -1760,7 +1756,18 @@ def test_checkout_complete_pick_transaction_flow(
     )
 
     # then
-    assert mocked_flow.called
+    mocked_flow.assert_called_once_with(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        discounts=None,
+        user=customer_user,
+        app=None,
+        tracking_code=None,
+        redirect_url=None,
+        metadata_list=None,
+        private_metadata_list=None,
+    )
 
 
 @mock.patch("saleor.checkout.complete_checkout.complete_checkout_with_transaction")
@@ -1802,7 +1809,18 @@ def test_checkout_complete_pick_transaction_flow_when_checkout_total_zero(
     )
 
     # then
-    assert mocked_flow.called
+    mocked_flow.assert_called_once_with(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        discounts=None,
+        user=customer_user,
+        app=None,
+        tracking_code=None,
+        redirect_url=None,
+        metadata_list=None,
+        private_metadata_list=None,
+    )
 
 
 @mock.patch("saleor.checkout.complete_checkout.complete_checkout_with_payment")
@@ -1842,4 +1860,18 @@ def test_checkout_complete_pick_payment_flow(
     )
 
     # then
-    assert mocked_flow.called
+    mocked_flow.assert_called_once_with(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        payment_data={},
+        store_source=False,
+        discounts=None,
+        user=customer_user,
+        app=None,
+        site_settings=None,
+        tracking_code=None,
+        redirect_url=None,
+        metadata_list=None,
+        private_metadata_list=None,
+    )

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -1,9 +1,6 @@
-from typing import cast
-
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....account.models import User
 from ....checkout.checkout_cleaner import validate_checkout
 from ....checkout.complete_checkout import create_order_from_checkout
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
@@ -107,7 +104,6 @@ class OrderCreateFromCheckout(BaseMutation):
         remove_checkout
     ):
         user = info.context.user
-        user = cast(User, user)
         checkout = cls.get_node_or_error(
             info,
             id,
@@ -148,7 +144,7 @@ class OrderCreateFromCheckout(BaseMutation):
                 manager=manager,
                 user=user,
                 app=app,
-                tracking_code=str(tracking_code),
+                tracking_code=tracking_code,
                 delete_checkout=remove_checkout,
                 metadata_list=metadata,
                 private_metadata_list=private_metadata,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -1,0 +1,649 @@
+from decimal import Decimal
+
+from .....channel import MarkAsPaidStrategy
+from .....checkout import calculations
+from .....checkout.error_codes import CheckoutErrorCode
+from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from .....checkout.models import Checkout
+from .....checkout.payment_utils import update_checkout_payment_statuses
+from .....core.taxes import zero_money
+from .....order import OrderAuthorizeStatus, OrderChargeStatus, OrderOrigin, OrderStatus
+from .....order.models import Order
+from .....payment import TransactionEventType
+from .....payment.transaction_item_calculations import recalculate_transaction_amounts
+from .....plugins.manager import get_plugins_manager
+from .....warehouse.models import Reservation
+from ....core.utils import to_global_id_or_none
+from ....tests.utils import get_graphql_content
+
+MUTATION_CHECKOUT_COMPLETE = """
+    mutation checkoutComplete(
+            $id: ID,
+            $redirectUrl: String,
+            $metadata: [MetadataInput!],
+        ) {
+        checkoutComplete(
+                id: $id,
+                redirectUrl: $redirectUrl,
+                metadata: $metadata,
+            ) {
+            order {
+                id
+                token
+                original
+                origin
+                authorizeStatus
+                chargeStatus
+                deliveryMethod {
+                    ... on Warehouse {
+                        id
+                    }
+                    ... on ShippingMethod {
+                        id
+                    }
+                }
+                total {
+                    currency
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+                undiscountedTotal {
+                    currency
+                    net {
+                        amount
+                    }
+                    gross {
+                        amount
+                    }
+                }
+            }
+            errors {
+                field,
+                message,
+                variants,
+                code
+            }
+            confirmationNeeded
+            confirmationData
+        }
+    }
+    """
+
+
+def test_checkout_without_any_transaction(
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    transaction_item_generator,
+    address,
+    shipping_method,
+):
+    # given
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.tax_exemption = True
+    checkout.save()
+
+    channel = checkout.channel
+    channel.automatically_confirm_all_new_orders = True
+    channel.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+
+    update_checkout_payment_statuses(
+        checkout=checkout_info.checkout,
+        checkout_total_gross=total.gross,
+    )
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert data["errors"]
+
+
+def test_checkout_with_total_0(
+    checkout_with_item_total_0,
+    user_api_client,
+    gift_card,
+    transaction_item_generator,
+    address,
+    shipping_method,
+    channel_USD,
+):
+    # given
+    shipping_method.channel_listings.update(price_amount=Decimal(0))
+
+    checkout = checkout_with_item_total_0
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+    channel = checkout.channel
+    channel.automatically_confirm_all_new_orders = True
+    channel.order_mark_as_paid_strategy = MarkAsPaidStrategy.TRANSACTION_FLOW
+    channel.save()
+
+    update_checkout_payment_statuses(
+        checkout=checkout_info.checkout,
+        checkout_total_gross=total.gross,
+    )
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+
+    order = Order.objects.get()
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+    assert to_global_id_or_none(order) == data["order"]["id"]
+
+    assert order.total_charged == zero_money(order.currency)
+    assert order.total_authorized == zero_money(order.currency)
+    assert order.charge_status == OrderChargeStatus.FULL
+    assert order.authorize_status == OrderAuthorizeStatus.FULL
+
+
+def test_checkout_with_authorized(
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    transaction_item_generator,
+    address,
+    shipping_method,
+):
+    # given
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.metadata_storage.store_value_in_metadata(items={"accepted": "true"})
+    checkout.metadata_storage.store_value_in_private_metadata(
+        items={"accepted": "false"}
+    )
+    checkout.tax_exemption = True
+    checkout.save()
+    checkout.metadata_storage.save()
+
+    checkout_line = checkout.lines.first()
+    checkout_line_quantity = checkout_line.quantity
+    checkout_line_variant = checkout_line.variant
+
+    channel = checkout.channel
+    channel.automatically_confirm_all_new_orders = True
+    channel.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+
+    transaction = transaction_item_generator(
+        checkout_id=checkout.pk, authorized_value=total.gross.amount
+    )
+
+    update_checkout_payment_statuses(
+        checkout=checkout_info.checkout,
+        checkout_total_gross=total.gross,
+    )
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    order = Order.objects.get()
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+    assert to_global_id_or_none(order) == data["order"]["id"]
+
+    assert order.total_charged == zero_money(order.currency)
+    assert order.total_authorized_amount == transaction.authorized_value
+    assert order.charge_status == OrderChargeStatus.NONE
+    assert order.authorize_status == OrderAuthorizeStatus.FULL
+
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.origin == OrderOrigin.CHECKOUT
+
+    assert order.redirect_url == redirect_url
+    assert order.total.gross == total.gross
+    assert order.metadata == checkout.metadata_storage.metadata
+    assert order.private_metadata == checkout.metadata_storage.private_metadata
+
+    order_line = order.lines.first()
+    line_tax_class = order_line.tax_class
+    shipping_tax_class = shipping_method.tax_class
+
+    assert checkout_line_quantity == order_line.quantity
+    assert checkout_line_variant == order_line.variant
+
+    assert order_line.tax_class == line_tax_class
+    assert order_line.tax_class_name == line_tax_class.name
+    assert order_line.tax_class_metadata == line_tax_class.metadata
+    assert order_line.tax_class_private_metadata == line_tax_class.private_metadata
+
+    assert order.shipping_address == address
+    assert order.shipping_method == checkout.shipping_method
+    assert order.shipping_tax_rate is not None
+    assert order.shipping_tax_class_name == shipping_tax_class.name
+    assert order.shipping_tax_class_metadata == shipping_tax_class.metadata
+    assert (
+        order.shipping_tax_class_private_metadata == shipping_tax_class.private_metadata
+    )
+
+    assert not Checkout.objects.filter()
+    assert not len(Reservation.objects.all())
+
+
+def test_checkout_with_charged(
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    transaction_item_generator,
+    address,
+    shipping_method,
+):
+    # given
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.metadata_storage.store_value_in_metadata(items={"accepted": "true"})
+    checkout.metadata_storage.store_value_in_private_metadata(
+        items={"accepted": "false"}
+    )
+    checkout.tax_exemption = True
+    checkout.save()
+    checkout.metadata_storage.save()
+
+    checkout_line = checkout.lines.first()
+    checkout_line_quantity = checkout_line.quantity
+    checkout_line_variant = checkout_line.variant
+
+    channel = checkout.channel
+    channel.automatically_confirm_all_new_orders = True
+    channel.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+
+    transaction = transaction_item_generator(
+        checkout_id=checkout.pk, charged_value=total.gross.amount
+    )
+
+    update_checkout_payment_statuses(
+        checkout=checkout_info.checkout,
+        checkout_total_gross=total.gross,
+    )
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    order = Order.objects.get()
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+    assert to_global_id_or_none(order) == data["order"]["id"]
+
+    assert order.total_charged_amount == transaction.charged_value
+    assert order.total_authorized == zero_money(order.currency)
+    assert order.charge_status == OrderChargeStatus.FULL
+    assert order.authorize_status == OrderAuthorizeStatus.FULL
+
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.origin == OrderOrigin.CHECKOUT
+
+    assert order.redirect_url == redirect_url
+    assert order.total.gross == total.gross
+    assert order.metadata == checkout.metadata_storage.metadata
+    assert order.private_metadata == checkout.metadata_storage.private_metadata
+
+    order_line = order.lines.first()
+    line_tax_class = order_line.tax_class
+    shipping_tax_class = shipping_method.tax_class
+
+    assert checkout_line_quantity == order_line.quantity
+    assert checkout_line_variant == order_line.variant
+
+    assert order_line.tax_class == line_tax_class
+    assert order_line.tax_class_name == line_tax_class.name
+    assert order_line.tax_class_metadata == line_tax_class.metadata
+    assert order_line.tax_class_private_metadata == line_tax_class.private_metadata
+
+    assert order.shipping_address == address
+    assert order.shipping_method == checkout.shipping_method
+    assert order.shipping_tax_rate is not None
+    assert order.shipping_tax_class_name == shipping_tax_class.name
+    assert order.shipping_tax_class_metadata == shipping_tax_class.metadata
+    assert (
+        order.shipping_tax_class_private_metadata == shipping_tax_class.private_metadata
+    )
+
+    assert not Checkout.objects.filter()
+    assert not len(Reservation.objects.all())
+
+
+def test_checkout_paid_with_multiple_transactions(
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    transaction_item_generator,
+    address,
+    shipping_method,
+):
+    # given
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    channel = checkout.channel
+    channel.automatically_confirm_all_new_orders = True
+    channel.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+
+    transaction = transaction_item_generator(
+        checkout_id=checkout.pk, charged_value=total.gross.amount - Decimal("10")
+    )
+    second_transaction = transaction_item_generator(
+        checkout_id=checkout.pk, charged_value=Decimal("10")
+    )
+
+    update_checkout_payment_statuses(
+        checkout=checkout_info.checkout,
+        checkout_total_gross=total.gross,
+    )
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    order = Order.objects.get()
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+    assert to_global_id_or_none(order) == data["order"]["id"]
+
+    assert (
+        order.total_charged_amount
+        == transaction.charged_value + second_transaction.charged_value
+    )
+    assert order.total_authorized == zero_money(order.currency)
+    assert order.charge_status == OrderChargeStatus.FULL
+    assert order.authorize_status == OrderAuthorizeStatus.FULL
+
+
+def test_checkout_partially_paid(
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    transaction_item_generator,
+    address,
+    shipping_method,
+):
+    # given
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.tax_exemption = True
+    checkout.save()
+
+    channel = checkout.channel
+    channel.automatically_confirm_all_new_orders = True
+    channel.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+
+    transaction_item_generator(
+        checkout_id=checkout.pk, charged_value=total.gross.amount - Decimal("10")
+    )
+
+    update_checkout_payment_statuses(
+        checkout=checkout_info.checkout,
+        checkout_total_gross=total.gross,
+    )
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert len(data["errors"]) == 1
+    error = data["errors"][0]
+    assert error["field"] == "id"
+    assert error["code"] == CheckoutErrorCode.CHECKOUT_NOT_FULLY_PAID.name
+
+
+def test_checkout_with_pending_charged(
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    transaction_item_generator,
+    address,
+    shipping_method,
+    transaction_events_generator,
+):
+    # given
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    channel = checkout.channel
+    channel.automatically_confirm_all_new_orders = True
+    channel.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+
+    transaction = transaction_item_generator(checkout_id=checkout.pk)
+    transaction_events_generator(
+        transaction=transaction,
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.CHARGE_REQUEST,
+        ],
+        amounts=[
+            total.gross.amount,
+        ],
+    )
+    recalculate_transaction_amounts(transaction)
+
+    update_checkout_payment_statuses(
+        checkout=checkout_info.checkout,
+        checkout_total_gross=total.gross,
+    )
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    order = Order.objects.get()
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+    assert to_global_id_or_none(order) == data["order"]["id"]
+
+    assert order.total_charged == zero_money(order.currency)
+    assert order.total_authorized == zero_money(order.currency)
+    assert order.charge_status == OrderChargeStatus.NONE
+    assert order.authorize_status == OrderAuthorizeStatus.NONE
+
+
+def test_checkout_with_pending_authorized(
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    transaction_item_generator,
+    address,
+    shipping_method,
+    transaction_events_generator,
+):
+    # given
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.metadata_storage.store_value_in_metadata(items={"accepted": "true"})
+    checkout.metadata_storage.store_value_in_private_metadata(
+        items={"accepted": "false"}
+    )
+    checkout.tax_exemption = True
+    checkout.save()
+    checkout.metadata_storage.save()
+
+    checkout_line = checkout.lines.first()
+    checkout_line_quantity = checkout_line.quantity
+    checkout_line_variant = checkout_line.variant
+
+    channel = checkout.channel
+    channel.automatically_confirm_all_new_orders = True
+    channel.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+
+    transaction = transaction_item_generator(checkout_id=checkout.pk)
+    transaction_events_generator(
+        transaction=transaction,
+        psp_references=[
+            "1",
+        ],
+        types=[
+            TransactionEventType.AUTHORIZATION_REQUEST,
+        ],
+        amounts=[
+            total.gross.amount,
+        ],
+    )
+    recalculate_transaction_amounts(transaction)
+
+    update_checkout_payment_statuses(
+        checkout=checkout_info.checkout,
+        checkout_total_gross=total.gross,
+    )
+
+    redirect_url = "https://www.example.com"
+    variables = {"id": to_global_id_or_none(checkout), "redirectUrl": redirect_url}
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    order = Order.objects.get()
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+    assert to_global_id_or_none(order) == data["order"]["id"]
+
+    assert order.total_charged == zero_money(order.currency)
+    assert order.total_authorized == zero_money(order.currency)
+    assert order.charge_status == OrderChargeStatus.NONE
+    assert order.authorize_status == OrderAuthorizeStatus.NONE
+
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.origin == OrderOrigin.CHECKOUT
+
+    assert order.redirect_url == redirect_url
+    assert order.total.gross == total.gross
+    assert order.metadata == checkout.metadata_storage.metadata
+    assert order.private_metadata == checkout.metadata_storage.private_metadata
+
+    order_line = order.lines.first()
+    line_tax_class = order_line.tax_class
+    shipping_tax_class = shipping_method.tax_class
+
+    assert checkout_line_quantity == order_line.quantity
+    assert checkout_line_variant == order_line.variant
+
+    assert order_line.tax_class == line_tax_class
+    assert order_line.tax_class_name == line_tax_class.name
+    assert order_line.tax_class_metadata == line_tax_class.metadata
+    assert order_line.tax_class_private_metadata == line_tax_class.private_metadata
+
+    assert order.shipping_address == address
+    assert order.shipping_method == checkout.shipping_method
+    assert order.shipping_tax_rate is not None
+    assert order.shipping_tax_class_name == shipping_tax_class.name
+    assert order.shipping_tax_class_metadata == shipping_tax_class.metadata
+    assert (
+        order.shipping_tax_class_private_metadata == shipping_tax_class.private_metadata
+    )
+
+    assert not Checkout.objects.filter()
+    assert not len(Reservation.objects.all())

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -116,6 +116,8 @@ def test_checkout_without_any_transaction(
     content = get_graphql_content(response)
     data = content["data"]["checkoutComplete"]
     assert data["errors"]
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["code"] == CheckoutErrorCode.CHECKOUT_NOT_FULLY_PAID.name
 
 
 def test_checkout_with_total_0(

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -86,7 +86,7 @@ class OrderFulfillmentLineInfo(TypedDict):
 
 def order_created(
     order_info: "OrderInfo",
-    user: User,
+    user: Optional[User],
     app: Optional["App"],
     manager: "PluginsManager",
     from_draft: bool = False,
@@ -123,7 +123,7 @@ def order_created(
 
 def order_confirmed(
     order: "Order",
-    user: User,
+    user: Optional[User],
     app: Optional["App"],
     manager: "PluginsManager",
     send_confirmation_email: bool = False,

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -895,9 +895,9 @@ def _update_order_total_charged(
     order_payments: QuerySet["Payment"],
     order_transactions: QuerySet["TransactionItem"],
 ):
-    order.total_charged_amount = (
-        sum(order_payments.values_list("captured_amount", flat=True)) or 0
-    )
+    order.total_charged_amount = sum(
+        order_payments.values_list("captured_amount", flat=True)
+    ) or Decimal(0)
     order.total_charged_amount += sum(
         order_transactions.values_list("charged_value", flat=True)
     )
@@ -932,9 +932,9 @@ def _update_order_total_authorized(
     order.total_authorized_amount = get_total_authorized(
         order_payments, order.currency
     ).amount
-    order.total_authorized_amount += (
-        sum(order_transactions.values_list("authorized_value", flat=True)) or 0
-    )
+    order.total_authorized_amount += sum(
+        order_transactions.values_list("authorized_value", flat=True)
+    ) or Decimal(0)
 
 
 def update_order_authorize_status(order: Order):

--- a/saleor/payment/tests/test_transaction_item_calculations.py
+++ b/saleor/payment/tests/test_transaction_item_calculations.py
@@ -1,39 +1,11 @@
 from datetime import timedelta
 from decimal import Decimal
-from typing import Callable, List
 
-import pytest
 from django.utils import timezone
 
 from .. import TransactionEventType
-from ..models import TransactionEvent, TransactionItem
+from ..models import TransactionItem
 from ..transaction_item_calculations import recalculate_transaction_amounts
-
-
-@pytest.fixture
-def transaction_events_generator() -> (
-    Callable[
-        [List[str], List[str], List[Decimal], TransactionItem], List[TransactionEvent]
-    ]
-):
-    def factory(
-        psp_references: List[str],
-        types: List[str],
-        amounts: List[Decimal],
-        transaction: TransactionItem,
-    ):
-        return TransactionEvent.objects.bulk_create(
-            TransactionEvent(
-                transaction=transaction,
-                psp_reference=reference,
-                type=event_type,
-                amount_value=amount,
-                include_in_calculations=True,
-            )
-            for reference, event_type, amount in zip(psp_references, types, amounts)
-        )
-
-    return factory
 
 
 def _assert_amounts(


### PR DESCRIPTION
I want to merge this change because it covers https://github.com/saleor/saleor/issues/12303

With this PR we allow using checkoutComplete mutation when the checkout is paid with transactions.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
