### PR TITLE
Use replicas on order queries

### DIFF
--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -9,32 +9,36 @@ from ...order.events import OrderEvents
 from ...order.models import OrderEvent
 from ...order.utils import sum_order_totals
 from ..channel.utils import get_default_channel_slug_or_graphql_error
+from ..core.context import get_database_connection_name
 from ..utils.filters import filter_by_period
 
 ORDER_SEARCH_FIELDS = ("id", "discount_name", "token", "user_email", "user__email")
 
 
-def resolve_orders(_info, channel_slug):
-    qs = models.Order.objects.non_draft()
+def resolve_orders(info, channel_slug):
+    database_connection_name = get_database_connection_name(info.context)
+    qs = models.Order.objects.using(database_connection_name).non_draft()
     if channel_slug:
         qs = qs.filter(channel__slug=str(channel_slug))
     return qs
 
 
-def resolve_draft_orders(_info):
-    qs = models.Order.objects.drafts()
-    return qs
+def resolve_draft_orders(info):
+    database_connection_name = get_database_connection_name(info.context)
+    return models.Order.objects.using(database_connection_name).drafts()
 
 
 @traced_resolver
-def resolve_orders_total(_info, period, channel_slug):
+def resolve_orders_total(info, period, channel_slug):
     if channel_slug is None:
         channel_slug = get_default_channel_slug_or_graphql_error()
     channel = Channel.objects.filter(slug=str(channel_slug)).first()
     if not channel:
         return None
+    database_connection_name = get_database_connection_name(info.context)
     qs = (
-        models.Order.objects.non_draft()
+        models.Order.objects.using(database_connection_name)
+        .non_draft()
         .exclude(status=OrderStatus.CANCELED)
         .filter(channel__slug=str(channel_slug))
     )
@@ -42,7 +46,7 @@ def resolve_orders_total(_info, period, channel_slug):
     return sum_order_totals(qs, channel.currency_code)
 
 
-def resolve_order(id):
+def resolve_order(info, id):
     if id is None:
         return None
     try:
@@ -50,20 +54,26 @@ def resolve_order(id):
         lookup = Q(id=id)
     except ValueError:
         lookup = Q(number=id) & Q(use_old_id=True)
-    return models.Order.objects.filter(lookup).first()
+    database_connection_name = get_database_connection_name(info.context)
+    return models.Order.objects.using(database_connection_name).filter(lookup).first()
 
 
-def resolve_homepage_events():
+def resolve_homepage_events(info):
     # Filter only selected events to be displayed on homepage.
     types = [
         OrderEvents.PLACED,
         OrderEvents.PLACED_FROM_DRAFT,
         OrderEvents.ORDER_FULLY_PAID,
     ]
-    return OrderEvent.objects.filter(type__in=types)
+    database_connection_name = get_database_connection_name(info.context)
+    return OrderEvent.objects.using(database_connection_name).filter(type__in=types)
 
 
-def resolve_order_by_token(token):
+def resolve_order_by_token(info, token):
+    database_connection_name = get_database_connection_name(info.context)
     return (
-        models.Order.objects.exclude(status=OrderStatus.DRAFT).filter(id=token).first()
+        models.Order.objects.using(database_connection_name)
+        .exclude(status=OrderStatus.DRAFT)
+        .filter(id=token)
+        .first()
     )

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -129,13 +129,13 @@ class OrderQueries(graphene.ObjectType):
 
     @staticmethod
     def resolve_homepage_events(_root, info, **kwargs):
-        qs = resolve_homepage_events()
+        qs = resolve_homepage_events(info)
         return create_connection_slice(qs, info, kwargs, OrderEventCountableConnection)
 
     @staticmethod
-    def resolve_order(_root, _info, **data):
+    def resolve_order(_root, info, **data):
         _, id = from_global_id_or_error(data.get("id"), Order)
-        return resolve_order(id)
+        return resolve_order(info, id)
 
     @staticmethod
     def resolve_orders(_root, info, *, channel=None, **kwargs):
@@ -180,8 +180,8 @@ class OrderQueries(graphene.ObjectType):
         return resolve_orders_total(info, period, channel)
 
     @staticmethod
-    def resolve_order_by_token(_root, _info, *, token):
-        return resolve_order_by_token(token)
+    def resolve_order_by_token(_root, info, *, token):
+        return resolve_order_by_token(info, token)
 
 
 class OrderMutations(graphene.ObjectType):


### PR DESCRIPTION
I want to merge this change because order queries used to be executed on the writer which shouldn't be the case.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
