### PR TITLE
Update permission checking for order queries

### DIFF
--- a/saleor/graphql/account/tests/test_account_utils.py
+++ b/saleor/graphql/account/tests/test_account_utils.py
@@ -905,26 +905,30 @@ def test_requestor_has_access_no_access_by_staff(
 
 
 def test_get_user_accessible_channels_all_channels(
-    staff_user, permission_group_all_perms_all_channels, channel_PLN, channel_USD
+    staff_user, permission_group_all_perms_all_channels, info, channel_PLN, channel_USD
 ):
     # given
     permission_group_all_perms_all_channels.user_set.add(staff_user)
 
     # when
-    channels = get_user_accessible_channels(staff_user)
+    channels = get_user_accessible_channels(info, staff_user)
 
     # then
     assert len(channels) == Channel.objects.count()
 
 
 def test_get_user_accessible_channels_some_channels(
-    staff_user, permission_group_all_perms_channel_USD_only, channel_PLN, channel_USD
+    staff_user,
+    permission_group_all_perms_channel_USD_only,
+    info,
+    channel_PLN,
+    channel_USD,
 ):
     # given
     permission_group_all_perms_channel_USD_only.user_set.add(staff_user)
 
     # when
-    channels = get_user_accessible_channels(staff_user)
+    channels = get_user_accessible_channels(info, staff_user)
 
     # then
     assert len(channels) == 1
@@ -932,13 +936,17 @@ def test_get_user_accessible_channels_some_channels(
 
 
 def test_get_user_accessible_channels_restricted_access_no_channels(
-    staff_user, permission_group_all_perms_without_any_channel, channel_PLN, channel_USD
+    staff_user,
+    permission_group_all_perms_without_any_channel,
+    info,
+    channel_PLN,
+    channel_USD,
 ):
     # given
     permission_group_all_perms_without_any_channel.user_set.add(staff_user)
 
     # when
-    channels = get_user_accessible_channels(staff_user)
+    channels = get_user_accessible_channels(info, staff_user)
 
     # then
     assert len(channels) == 0

--- a/saleor/graphql/account/tests/test_account_utils.py
+++ b/saleor/graphql/account/tests/test_account_utils.py
@@ -1,5 +1,6 @@
 from ....account.models import Group, User
 from ....app.models import App
+from ....channel.models import Channel
 from ....permission.enums import (
     AccountPermissions,
     OrderPermissions,
@@ -17,6 +18,7 @@ from ..utils import (
     get_not_manageable_permissions_when_deactivate_or_remove_users,
     get_out_of_scope_permissions,
     get_out_of_scope_users,
+    get_user_accessible_channels,
     get_user_permissions,
     get_users_and_look_for_permissions_in_groups_with_manage_staff,
     is_owner_or_has_one_of_perms,
@@ -900,3 +902,43 @@ def test_requestor_has_access_no_access_by_staff(
 
     # then
     assert result is False
+
+
+def test_get_user_accessible_channels_all_channels(
+    staff_user, permission_group_all_perms_all_channels, channel_PLN, channel_USD
+):
+    # given
+    permission_group_all_perms_all_channels.user_set.add(staff_user)
+
+    # when
+    channels = get_user_accessible_channels(staff_user)
+
+    # then
+    assert len(channels) == Channel.objects.count()
+
+
+def test_get_user_accessible_channels_some_channels(
+    staff_user, permission_group_all_perms_channel_USD_only, channel_PLN, channel_USD
+):
+    # given
+    permission_group_all_perms_channel_USD_only.user_set.add(staff_user)
+
+    # when
+    channels = get_user_accessible_channels(staff_user)
+
+    # then
+    assert len(channels) == 1
+    assert channels[0] == channel_USD
+
+
+def test_get_user_accessible_channels_restricted_access_no_channels(
+    staff_user, permission_group_all_perms_without_any_channel, channel_PLN, channel_USD
+):
+    # given
+    permission_group_all_perms_without_any_channel.user_set.add(staff_user)
+
+    # when
+    channels = get_user_accessible_channels(staff_user)
+
+    # then
+    assert len(channels) == 0

--- a/saleor/graphql/account/tests/test_permission_group_queries.py
+++ b/saleor/graphql/account/tests/test_permission_group_queries.py
@@ -114,11 +114,11 @@ query ($sort_by: PermissionGroupSortingInput!) {
     (
         (
             {"field": "NAME", "direction": "ASC"},
-            ["Add", "Manage user groups.", "Remove"],
+            ["Add", "Manage user group.", "Remove"],
         ),
         (
             {"field": "NAME", "direction": "DESC"},
-            ["Remove", "Manage user groups.", "Add"],
+            ["Remove", "Manage user group.", "Add"],
         ),
     ),
 )

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -5,6 +5,7 @@ from typing import List, Optional, cast
 import graphene
 from django.contrib.auth import get_user_model
 from graphene import relay
+from promise import Promise
 
 from ...account import models
 from ...checkout.utils import get_user_checkout
@@ -504,18 +505,34 @@ class User(ModelObjectType[models.User]):
             )
         requester = user_or_app
 
-        def _resolve_orders(orders):
+        def _resolve_orders(data):
+            orders = data[0]
+            accessible_channels = data[1] if len(data) == 2 else None
             if not requester.has_perm(OrderPermissions.MANAGE_ORDERS):
                 # allow fetch requestor orders (except drafts)
                 orders = [
                     order for order in orders if order.status != OrderStatus.DRAFT
                 ]
 
+            # Return only orders from channels that the user has access to.
+            # The app has access to all channels.
+            if root != user_or_app and accessible_channels is not None:
+                accessible_channels = [channel.id for channel in accessible_channels]
+                orders = [
+                    order for order in orders if order.channel_id in accessible_channels
+                ]
+
             return create_connection_slice(
                 orders, info, kwargs, OrderCountableConnection
             )
 
-        return OrdersByUserLoader(info.context).load(root.id).then(_resolve_orders)
+        to_fetch = [OrdersByUserLoader(info.context).load(root.id)]
+        if isinstance(requester, models.User):
+            to_fetch.append(
+                AccessibleChannelsByUserIdLoader(info.context).load(requester.id)
+            )
+
+        return Promise.all(to_fetch).then(_resolve_orders)
 
     @staticmethod
     def resolve_avatar(

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -513,7 +513,10 @@ def check_is_owner_or_has_one_of_perms(
         raise PermissionDenied(permissions=list(perms) + [AuthorizationFilters.OWNER])
 
 
-def get_user_accessible_channels(user: User):
+def get_user_accessible_channels(user: Optional[User]):
+    if not user:
+        return Channel.objects.none()
+
     UserGroup = User.groups.through
     user_groups = UserGroup.objects.filter(user_id=user.id)
 

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -11,6 +11,7 @@ from graphene.utils.str_converters import to_camel_case
 from ...account import events as account_events
 from ...account.error_codes import AccountErrorCode
 from ...account.models import Group, User
+from ...channel.models import Channel
 from ...core.exceptions import PermissionDenied
 from ...permission.auth_filters import AuthorizationFilters
 from ...permission.enums import AccountPermissions
@@ -510,3 +511,18 @@ def check_is_owner_or_has_one_of_perms(
     """
     if not is_owner_or_has_one_of_perms(requestor, owner, *perms):
         raise PermissionDenied(permissions=list(perms) + [AuthorizationFilters.OWNER])
+
+
+def get_user_accessible_channels(user: User):
+    UserGroup = User.groups.through
+    user_groups = UserGroup.objects.filter(user_id=user.id)
+
+    groups = Group.objects.filter(id__in=user_groups.values("group_id"))
+
+    if groups.filter(restricted_access_to_channels=False).exists():
+        return Channel.objects.all()
+
+    GroupChannels = Group.channels.through
+    group_channels = GroupChannels.objects.filter(group_id__in=groups.values("id"))
+
+    return Channel.objects.filter(id__in=group_channels.values("channel_id"))

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -29,9 +29,13 @@ def resolve_orders(info, channel_slug):
     return qs.filter(channel_id__in=accessible_channels.values("id"))
 
 
-def resolve_draft_orders(_info):
+def resolve_draft_orders(info):
     qs = models.Order.objects.drafts()
-    return qs
+    requestor = get_user_or_app_from_context(info.context)
+    if isinstance(requestor, App):
+        return qs
+    accessible_channels = get_user_accessible_channels(requestor)
+    return qs.filter(channel_id__in=accessible_channels.values("id"))
 
 
 @traced_resolver

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -5,6 +5,7 @@ from django.db.models import Q
 from ...account.models import User
 from ...app.models import App
 from ...channel.models import Channel
+from ...core.exceptions import PermissionDenied
 from ...order import OrderStatus, models
 from ...order.events import OrderEvents
 from ...order.utils import sum_order_totals
@@ -26,6 +27,12 @@ def resolve_orders(info, channel_slug):
     if isinstance(requestor, App):
         return qs
     accessible_channels = get_user_accessible_channels(requestor)
+    if channel_slug and channel_slug not in [
+        channel.slug for channel in accessible_channels
+    ]:
+        raise PermissionDenied(
+            message=f"You do not have access to the {channel_slug} channel."
+        )
     return qs.filter(channel_id__in=accessible_channels.values("id"))
 
 

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -135,7 +135,7 @@ class OrderQueries(graphene.ObjectType):
 
     @staticmethod
     def resolve_homepage_events(_root, info: ResolveInfo, **kwargs):
-        qs = resolve_homepage_events()
+        qs = resolve_homepage_events(info)
         return create_connection_slice(qs, info, kwargs, OrderEventCountableConnection)
 
     @staticmethod
@@ -150,6 +150,8 @@ class OrderQueries(graphene.ObjectType):
 
     @staticmethod
     def resolve_orders(_root, info: ResolveInfo, *, channel=None, **kwargs):
+        # TODO: check if requestor has access to specify channel,
+        # if not raise validaiton error
         if sort_field_from_kwargs(kwargs) == OrderSortField.RANK:
             # sort by RANK can be used only with search filter
             if not search_string_in_kwargs(kwargs):
@@ -188,6 +190,8 @@ class OrderQueries(graphene.ObjectType):
 
     @staticmethod
     def resolve_orders_total(_root, info: ResolveInfo, *, period, channel=None):
+        # TODO: check if requestor has access to specify channel,
+        # if not raise validaiton error
         return resolve_orders_total(info, period, channel)
 
     @staticmethod

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -150,8 +150,6 @@ class OrderQueries(graphene.ObjectType):
 
     @staticmethod
     def resolve_orders(_root, info: ResolveInfo, *, channel=None, **kwargs):
-        # TODO: check if requestor has access to specify channel,
-        # if not raise validaiton error
         if sort_field_from_kwargs(kwargs) == OrderSortField.RANK:
             # sort by RANK can be used only with search filter
             if not search_string_in_kwargs(kwargs):

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -188,8 +188,6 @@ class OrderQueries(graphene.ObjectType):
 
     @staticmethod
     def resolve_orders_total(_root, info: ResolveInfo, *, period, channel=None):
-        # TODO: check if requestor has access to specify channel,
-        # if not raise validaiton error
         return resolve_orders_total(info, period, channel)
 
     @staticmethod

--- a/saleor/graphql/order/tests/deprecated/test_order.py
+++ b/saleor/graphql/order/tests/deprecated/test_order.py
@@ -47,16 +47,17 @@ query Orders($period: ReportingPeriod, $channel: String) {
 """
 
 
-def test_orders_total(staff_api_client, permission_manage_orders, order_with_lines):
+def test_orders_total(
+    staff_api_client, permission_group_manage_orders, order_with_lines
+):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     order = order_with_lines
     variables = {"period": ReportingPeriod.TODAY.name}
 
     # when
     with warnings.catch_warnings(record=True) as warns:
-        response = staff_api_client.post_graphql(
-            QUERY_ORDER_TOTAL, variables, permissions=[permission_manage_orders]
-        )
+        response = staff_api_client.post_graphql(QUERY_ORDER_TOTAL, variables)
         content = get_graphql_content(response)
 
     # then

--- a/saleor/graphql/order/tests/queries/test_draft_order.py
+++ b/saleor/graphql/order/tests/queries/test_draft_order.py
@@ -1,22 +1,121 @@
+import pytest
+
 from .....order.models import Order
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_no_permission, get_graphql_content
 
-
-def test_draft_order_query(staff_api_client, permission_manage_orders, orders):
-    query = """
+DRAFT_ORDER_QUERY = """
     query DraftOrdersQuery {
         draftOrders(first: 10) {
             edges {
                 node {
                     id
+                    number
                 }
             }
         }
     }
-    """
+"""
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    response = staff_api_client.post_graphql(query)
+
+@pytest.fixture
+def draft_orders_in_different_channels(
+    draft_order_list, channel_USD, channel_JPY, channel_PLN
+):
+    draft_order_list[0].channel = channel_USD
+    draft_order_list[1].channel = channel_JPY
+    draft_order_list[2].channel = channel_PLN
+
+    Order.objects.bulk_update(draft_order_list, ["channel"])
+    return draft_order_list
+
+
+def test_draft_order_query(
+    staff_api_client, permission_group_manage_orders, order, draft_order_list
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
+
+    # then
     edges = get_graphql_content(response)["data"]["draftOrders"]["edges"]
 
     assert len(edges) == Order.objects.drafts().count()
+
+
+def test_query_draft_orders_by_user_with_access_to_all_channels(
+    staff_api_client,
+    permission_group_all_perms_all_channels,
+    draft_orders_in_different_channels,
+):
+    # given
+    permission_group_all_perms_all_channels.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
+
+    # then
+    edges = get_graphql_content(response)["data"]["draftOrders"]["edges"]
+
+    assert len(edges) == len(draft_orders_in_different_channels)
+
+
+def test_query_draft_orders_by_user_with_restricted_access_to_channels(
+    staff_api_client,
+    permission_group_all_perms_channel_USD_only,
+    draft_orders_in_different_channels,
+):
+    # given
+    permission_group_all_perms_channel_USD_only.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+
+    assert len(content["data"]["draftOrders"]["edges"]) == 1
+    assert content["data"]["draftOrders"]["edges"][0]["node"]["number"] == str(
+        draft_orders_in_different_channels[0].number
+    )
+
+
+def test_query_draft_orders_by_user_with_restricted_access_to_channels_no_acc_channels(
+    staff_api_client,
+    permission_group_all_perms_without_any_channel,
+    draft_orders_in_different_channels,
+):
+    # given
+    permission_group_all_perms_without_any_channel.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(DRAFT_ORDER_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["draftOrders"]["edges"]) == 0
+
+
+def test_query_draft_orders_by_app(
+    app_api_client, permission_manage_orders, draft_orders_in_different_channels
+):
+    # when
+    response = app_api_client.post_graphql(
+        DRAFT_ORDER_QUERY, permissions=(permission_manage_orders,)
+    )
+
+    # then
+    edges = get_graphql_content(response)["data"]["draftOrders"]["edges"]
+
+    assert len(edges) == len(draft_orders_in_different_channels)
+
+
+def test_query_draft_orders_by_customer(
+    user_api_client, draft_orders_in_different_channels
+):
+    # when
+    response = user_api_client.post_graphql(DRAFT_ORDER_QUERY)
+
+    # then
+    assert_no_permission(response)

--- a/saleor/graphql/order/tests/queries/test_draft_order_with_filter.py
+++ b/saleor/graphql/order/tests/queries/test_draft_order_with_filter.py
@@ -37,11 +37,11 @@ def test_draft_orders_query_with_filter_search_by_number(
     draft_orders_query_with_filter,
     draft_order,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
 ):
     update_order_search_vector(draft_order)
     variables = {"filter": {"search": draft_order.number}}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(draft_orders_query_with_filter, variables)
     content = get_graphql_content(response)
     assert content["data"]["draftOrders"]["totalCount"] == 1
@@ -51,11 +51,11 @@ def test_draft_orders_query_with_filter_search_by_number_with_hash(
     draft_orders_query_with_filter,
     draft_order,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
 ):
     update_order_search_vector(draft_order)
     variables = {"filter": {"search": f"#{draft_order.number}"}}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(draft_orders_query_with_filter, variables)
     content = get_graphql_content(response)
     assert content["data"]["draftOrders"]["totalCount"] == 1
@@ -75,7 +75,7 @@ def test_draft_order_query_with_filter_customer_fields(
     user_value,
     draft_orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     customer_user,
     channel_USD,
 ):
@@ -96,7 +96,7 @@ def test_draft_order_query_with_filter_customer_fields(
     )
 
     variables = {"filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(draft_orders_query_with_filter, variables)
     content = get_graphql_content(response)
     orders = content["data"]["draftOrders"]["edges"]
@@ -126,19 +126,19 @@ def test_draft_order_query_with_filter_customer_fields(
         ({"created": {"lte": None}}, 2),
     ],
 )
-def test_draft_order_query_with_filter_created_(
+def test_draft_order_query_with_filter_created(
     orders_filter,
     count,
     draft_orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     channel_USD,
 ):
     Order.objects.create(status=OrderStatus.DRAFT, channel=channel_USD)
     with freeze_time("2012-01-14"):
         Order.objects.create(status=OrderStatus.DRAFT, channel=channel_USD)
     variables = {"filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(draft_orders_query_with_filter, variables)
     content = get_graphql_content(response)
     orders = content["data"]["draftOrders"]["edges"]
@@ -164,7 +164,7 @@ def test_draft_orders_query_with_filter_search(
     count,
     draft_orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     customer_user,
     channel_USD,
 ):
@@ -214,7 +214,7 @@ def test_draft_orders_query_with_filter_search(
 
     variables = {"filter": draft_orders_filter}
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(draft_orders_query_with_filter, variables)
     content = get_graphql_content(response)
     assert content["data"]["draftOrders"]["totalCount"] == count

--- a/saleor/graphql/order/tests/queries/test_draft_order_with_sort.py
+++ b/saleor/graphql/order/tests/queries/test_draft_order_with_sort.py
@@ -34,7 +34,7 @@ def test_query_draft_orders_with_sort(
     draft_order_sort,
     result_order,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     address,
     channel_USD,
 ):
@@ -72,7 +72,7 @@ def test_query_draft_orders_with_sort(
         )
     )
     variables = {"sort_by": draft_order_sort}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(QUERY_DRAFT_ORDER_WITH_SORT, variables)
     content = get_graphql_content(response)
     draft_orders = content["data"]["draftOrders"]["edges"]

--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -1512,6 +1512,8 @@ def test_query_orders_by_app(
     response = app_api_client.post_graphql(
         QUERY_ORDERS, permissions=(permission_manage_orders,)
     )
+
+    # then
     content = get_graphql_content(response)
     assert len(content["data"]["orders"]["edges"]) == len(order_list)
 
@@ -1519,7 +1521,6 @@ def test_query_orders_by_app(
 def test_query_orders_by_customer(
     order_list,
     user_api_client,
-    permission_manage_orders,
     channel_PLN,
     channel_JPY,
     channel_USD,

--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -28,7 +28,7 @@ from ....tests.utils import (
     get_graphql_content_from_response,
 )
 
-ORDERS_QUERY = """
+ORDERS_FULL_QUERY = """
 query OrdersQuery {
     orders(first: 1) {
         edges {
@@ -259,11 +259,11 @@ query OrdersQuery {
 
 def test_order_query(
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
     fulfilled_order,
     checkout,
     shipping_zone,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
 ):
     # given
     order = fulfilled_order
@@ -281,11 +281,11 @@ def test_order_query(
     order.shipping_method.save()
     order.save()
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -372,20 +372,20 @@ def test_order_query(
 
 def test_order_query_denormalized_shipping_tax_class_data(
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
     fulfilled_order,
 ):
     # given
     order = fulfilled_order
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
     shipping_tax_class = order.shipping_method.tax_class
     assert shipping_tax_class
 
     # when
     shipping_tax_class.delete()
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -412,8 +412,8 @@ def test_order_query_denormalized_shipping_tax_class_data(
 
 def test_order_query_total_price_is_0(
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
     fulfilled_order,
     shipping_zone,
 ):
@@ -433,11 +433,11 @@ def test_order_query_total_price_is_0(
     order.shipping_method.save()
     order.save()
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -456,7 +456,7 @@ def test_order_query_total_price_is_0(
 
 
 def test_order_query_shows_non_draft_orders(
-    staff_api_client, permission_manage_orders, orders
+    staff_api_client, permission_group_manage_orders, orders
 ):
     query = """
     query OrdersQuery {
@@ -470,7 +470,7 @@ def test_order_query_shows_non_draft_orders(
     }
     """
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(query)
     edges = get_graphql_content(response)["data"]["orders"]["edges"]
 
@@ -478,7 +478,7 @@ def test_order_query_shows_non_draft_orders(
 
 
 def test_orders_with_channel(
-    staff_api_client, permission_manage_orders, orders, channel_USD
+    staff_api_client, permission_group_manage_orders, orders, channel_USD
 ):
     query = """
     query OrdersQuery($channel: String) {
@@ -492,7 +492,7 @@ def test_orders_with_channel(
     }
     """
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {"channel": channel_USD.slug}
     response = staff_api_client.post_graphql(query, variables)
     edges = get_graphql_content(response)["data"]["orders"]["edges"]
@@ -500,7 +500,9 @@ def test_orders_with_channel(
     assert len(edges) == 3
 
 
-def test_orders_without_channel(staff_api_client, permission_manage_orders, orders):
+def test_orders_without_channel(
+    staff_api_client, permission_group_manage_orders, orders
+):
     query = """
     query OrdersQuery {
         orders(first: 10) {
@@ -513,7 +515,7 @@ def test_orders_without_channel(staff_api_client, permission_manage_orders, orde
     }
     """
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(query)
     edges = get_graphql_content(response)["data"]["orders"]["edges"]
 
@@ -554,8 +556,8 @@ def test_order_query_authorize_status(
     total_charged,
     expected_status,
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
     fulfilled_order,
 ):
     # given
@@ -564,11 +566,11 @@ def test_order_query_authorize_status(
     fulfilled_order.total_charged_amount = total_charged
     fulfilled_order.save()
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -592,8 +594,8 @@ def test_order_query_charge_status(
     total_charged,
     expected_status,
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
     fulfilled_order,
 ):
     # given
@@ -602,11 +604,11 @@ def test_order_query_charge_status(
     fulfilled_order.total_charged_amount = total_charged
     fulfilled_order.save()
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -616,8 +618,8 @@ def test_order_query_charge_status(
 
 def test_order_query_payment_status_with_total_fulfillment_refund_equal_to_order_total(
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
     fulfilled_order,
 ):
     # given
@@ -625,11 +627,11 @@ def test_order_query_payment_status_with_total_fulfillment_refund_equal_to_order
         tracking_number="123", total_refund_amount=fulfilled_order.total.gross.amount
     )
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -639,8 +641,8 @@ def test_order_query_payment_status_with_total_fulfillment_refund_equal_to_order
 
 def test_order_query_with_transactions_details(
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
     fulfilled_order,
     shipping_zone,
 ):
@@ -706,11 +708,11 @@ def test_order_query_with_transactions_details(
         ]
     )
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -740,8 +742,8 @@ def test_order_query_with_transactions_details(
 
 def test_order_query_shipping_method_channel_listing_does_not_exist(
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
     order_with_lines,
 ):
     # given
@@ -754,11 +756,11 @@ def test_order_query_shipping_method_channel_listing_does_not_exist(
         shipping_method=shipping_method, channel=order.channel
     ).delete()
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -768,8 +770,8 @@ def test_order_query_shipping_method_channel_listing_does_not_exist(
 
 def test_order_query_external_shipping_method(
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
     order_with_lines,
 ):
     external_shipping_method_id = graphene.Node.to_global_id("app", "1:external123")
@@ -780,11 +782,11 @@ def test_order_query_external_shipping_method(
     order.private_metadata = {PRIVATE_META_APP_SHIPPING_ID: external_shipping_method_id}
     order.save()
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -798,8 +800,8 @@ def test_order_query_external_shipping_method(
 
 def test_order_discounts_query(
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
     draft_order_with_fixed_discount_order,
 ):
     # given
@@ -809,11 +811,11 @@ def test_order_discounts_query(
 
     discount = order.discounts.get()
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -831,8 +833,8 @@ def test_order_discounts_query(
 
 def test_order_line_discount_query(
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
     draft_order_with_fixed_discount_order,
 ):
     # given
@@ -848,11 +850,11 @@ def test_order_line_discount_query(
 
     line_with_discount_id = graphene.Node.to_global_id("OrderLine", line.pk)
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -891,8 +893,8 @@ def test_order_line_discount_query(
 
 def test_order_query_in_pln_channel(
     staff_api_client,
-    permission_manage_orders,
-    permission_manage_shipping,
+    permission_group_manage_orders,
+    permission_group_manage_shipping,
     order_with_lines_channel_PLN,
     shipping_zone,
     channel_PLN,
@@ -900,11 +902,11 @@ def test_order_query_in_pln_channel(
     # given
     shipping_zone.channels.add(channel_PLN)
     order = order_with_lines_channel_PLN
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_manage_shipping.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(ORDERS_QUERY)
+    response = staff_api_client.post_graphql(ORDERS_FULL_QUERY)
     content = get_graphql_content(response)
 
     # then
@@ -988,7 +990,7 @@ def test_query_order_as_app(app_api_client, order):
     assert order_data["id"] == graphene.Node.to_global_id("Order", order.id)
 
 
-def test_staff_query_order_by_old_id(staff_api_client, order, permission_manage_orders):
+def test_staff_query_order_by_old_id(staff_api_client, order):
     # given
     order.use_old_id = True
     order.save(update_fields=["use_old_id"])
@@ -1321,7 +1323,7 @@ def test_query_order_fields_by_old_id_app_no_perm(order, app_api_client):
 
 
 def test_order_query_gift_cards(
-    staff_api_client, permission_manage_orders, order_with_lines, gift_card
+    staff_api_client, permission_group_manage_orders, order_with_lines, gift_card
 ):
     query = """
     query OrderQuery($id: ID!) {
@@ -1340,7 +1342,7 @@ def test_order_query_gift_cards(
 
     order_id = graphene.Node.to_global_id("Order", order_with_lines.id)
     variables = {"id": order_id}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     gift_card_data = content["data"]["order"]["giftCards"][0]
@@ -1394,3 +1396,143 @@ def test_order_display_gross_prices_use_country_exception(
 
     # then
     assert data["displayGrossPrices"] == tax_country_config.display_gross_prices
+
+
+QUERY_ORDERS = """
+    query OrdersQuery {
+        orders(first: 10) {
+            edges {
+                node {
+                    number
+                }
+            }
+        }
+    }
+"""
+
+
+def test_query_orders_by_user_with_access_to_all_channels(
+    order_list,
+    staff_api_client,
+    permission_group_all_perms_all_channels,
+    channel_PLN,
+    channel_JPY,
+    channel_USD,
+):
+    # given
+    user = staff_api_client.user
+    permission_group_all_perms_all_channels.user_set.add(user)
+
+    order_list[0].channel = channel_PLN
+    order_list[1].channel = channel_JPY
+    order_list[2].channel = channel_USD
+
+    Order.objects.bulk_update(order_list, ["channel"])
+
+    # when
+    response = staff_api_client.post_graphql(QUERY_ORDERS)
+    content = get_graphql_content(response)
+
+    # then
+    assert len(content["data"]["orders"]["edges"]) == len(order_list)
+
+
+def test_query_orders_by_user_with_restricted_access_to_channels(
+    order_list,
+    staff_api_client,
+    permission_group_all_perms_channel_USD_only,
+    channel_PLN,
+    channel_JPY,
+    channel_USD,
+):
+    # given
+    user = staff_api_client.user
+    permission_group_all_perms_channel_USD_only.user_set.add(user)
+
+    order_list[0].channel = channel_PLN
+    order_list[1].channel = channel_JPY
+    order_list[2].channel = channel_USD
+
+    Order.objects.bulk_update(order_list, ["channel"])
+
+    # when
+    response = staff_api_client.post_graphql(QUERY_ORDERS)
+    content = get_graphql_content(response)
+
+    # then
+    assert len(content["data"]["orders"]["edges"]) == 1
+    assert content["data"]["orders"]["edges"][0]["node"]["number"] == str(
+        order_list[2].number
+    )
+
+
+def test_query_orders_by_user_with_restricted_access_to_channels_no_acc_channels(
+    order_list,
+    staff_api_client,
+    permission_group_all_perms_without_any_channel,
+    channel_PLN,
+    channel_JPY,
+    channel_USD,
+):
+    """Ensure that query returns no orders when user has no accessible channels."""
+    # given
+    user = staff_api_client.user
+    permission_group_all_perms_without_any_channel.user_set.add(user)
+
+    order_list[0].channel = channel_PLN
+    order_list[1].channel = channel_JPY
+    order_list[2].channel = channel_USD
+
+    Order.objects.bulk_update(order_list, ["channel"])
+
+    # when
+    response = staff_api_client.post_graphql(QUERY_ORDERS)
+    content = get_graphql_content(response)
+
+    # then
+    assert len(content["data"]["orders"]["edges"]) == 0
+
+
+def test_query_orders_by_app(
+    order_list,
+    app_api_client,
+    permission_manage_orders,
+    channel_PLN,
+    channel_JPY,
+    channel_USD,
+):
+    # given
+    order_list[0].channel = channel_PLN
+    order_list[1].channel = channel_JPY
+    order_list[2].channel = channel_USD
+
+    Order.objects.bulk_update(order_list, ["channel"])
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_ORDERS, permissions=(permission_manage_orders,)
+    )
+    content = get_graphql_content(response)
+    assert len(content["data"]["orders"]["edges"]) == len(order_list)
+
+
+def test_query_orders_by_customer(
+    order_list,
+    user_api_client,
+    permission_manage_orders,
+    channel_PLN,
+    channel_JPY,
+    channel_USD,
+):
+    # given
+    order_list[0].channel = channel_PLN
+    order_list[1].channel = channel_JPY
+    order_list[2].channel = channel_USD
+
+    Order.objects.bulk_update(order_list, ["channel"])
+
+    # when
+    response = user_api_client.post_graphql(QUERY_ORDERS)
+
+    # then
+    assert_no_permission(response)

--- a/saleor/graphql/order/tests/queries/test_order_events.py
+++ b/saleor/graphql/order/tests/queries/test_order_events.py
@@ -51,7 +51,7 @@ ORDERS_FULFILLED_EVENTS = """
 
 def test_nested_order_events_query(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     permission_manage_apps,
     fulfilled_order,
     fulfillment,
@@ -78,9 +78,8 @@ def test_nested_order_events_query(
     )
     event.save()
 
-    staff_api_client.user.user_permissions.add(
-        permission_manage_orders, permission_manage_apps
-    )
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
     response = staff_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content["data"]["orders"]["edges"][0]["node"]["events"][0]
@@ -110,7 +109,7 @@ def test_nested_order_events_query(
 
 def test_nested_order_events_query_for_app(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     permission_manage_apps,
     fulfilled_order,
     fulfillment,
@@ -137,9 +136,8 @@ def test_nested_order_events_query_for_app(
     )
     event.save()
 
-    staff_api_client.user.user_permissions.add(
-        permission_manage_orders, permission_manage_apps
-    )
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
     response = staff_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content["data"]["orders"]["edges"][0]["node"]["events"][0]
@@ -190,7 +188,7 @@ ORDERS_WITH_EVENTS = """
 
 
 def test_related_order_events_query(
-    staff_api_client, permission_manage_orders, order, payment_dummy, staff_user
+    staff_api_client, permission_group_manage_orders, order, payment_dummy, staff_user
 ):
     new_order = deepcopy(order)
     new_order.id = None
@@ -203,7 +201,7 @@ def test_related_order_events_query(
         original_order=order, replace_order=new_order, user=staff_user, app=None
     )
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(ORDERS_WITH_EVENTS)
     content = get_graphql_content(response)
 
@@ -215,7 +213,7 @@ def test_related_order_events_query(
 
 
 def test_related_order_events_query_for_app(
-    staff_api_client, permission_manage_orders, order, payment_dummy, app
+    staff_api_client, permission_group_manage_orders, order, payment_dummy, app
 ):
     new_order = deepcopy(order)
     new_order.id = None
@@ -228,7 +226,7 @@ def test_related_order_events_query_for_app(
         original_order=order, replace_order=new_order, user=None, app=app
     )
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(ORDERS_WITH_EVENTS)
     content = get_graphql_content(response)
 
@@ -240,7 +238,7 @@ def test_related_order_events_query_for_app(
 
 
 def test_related_order_eventes_old_order_id(
-    staff_api_client, permission_manage_orders, order, payment_dummy, app
+    staff_api_client, permission_group_manage_orders, order, payment_dummy, app
 ):
     # given
     new_order = deepcopy(order)
@@ -259,7 +257,7 @@ def test_related_order_eventes_old_order_id(
         parameters=parameters,
     )
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(ORDERS_WITH_EVENTS)
@@ -276,7 +274,7 @@ def test_related_order_eventes_old_order_id(
 
 def test_order_events_without_permission(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines_and_events,
     customer_user,
 ):
@@ -284,7 +282,7 @@ def test_order_events_without_permission(
     last_event.user = customer_user
     last_event.save()
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(ORDERS_WITH_EVENTS)
     content = get_graphql_content(response)
 
@@ -316,7 +314,7 @@ QUERY_GET_FIRST_EVENT = """
 
 
 def test_retrieving_event_lines_with_deleted_line(
-    staff_api_client, order_with_lines, staff_user, permission_manage_orders
+    staff_api_client, order_with_lines, staff_user, permission_group_manage_orders
 ):
     order = order_with_lines
     lines = order_with_lines.lines.all()
@@ -331,7 +329,7 @@ def test_retrieving_event_lines_with_deleted_line(
     deleted_line.delete()
 
     # Prepare the query
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # Send the query and retrieve the data
     content = get_graphql_content(staff_api_client.post_graphql(QUERY_GET_FIRST_EVENT))
@@ -355,7 +353,7 @@ def test_retrieving_event_lines_with_deleted_line(
 
 
 def test_retrieving_event_lines_with_missing_line_pk_in_data(
-    staff_api_client, order_with_lines, staff_user, permission_manage_orders
+    staff_api_client, order_with_lines, staff_user, permission_group_manage_orders
 ):
     order = order_with_lines
     line = order_with_lines.lines.first()
@@ -368,7 +366,7 @@ def test_retrieving_event_lines_with_missing_line_pk_in_data(
     event.save(update_fields=["parameters"])
 
     # Prepare the query
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # Send the query and retrieve the data
     content = get_graphql_content(staff_api_client.post_graphql(QUERY_GET_FIRST_EVENT))

--- a/saleor/graphql/order/tests/queries/test_order_invoices.py
+++ b/saleor/graphql/order/tests/queries/test_order_invoices.py
@@ -19,9 +19,9 @@ ORDERS_WITH_INVOICES_QUERY = """
 
 
 def test_order_query_invoices(
-    user_api_client, permission_manage_orders, fulfilled_order
+    user_api_client, permission_group_manage_orders, fulfilled_order
 ):
-    user_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(user_api_client.user)
     response = user_api_client.post_graphql(ORDERS_WITH_INVOICES_QUERY)
     content = get_graphql_content(response)
     edges = content["data"]["orders"]["edges"]

--- a/saleor/graphql/order/tests/queries/test_order_line.py
+++ b/saleor/graphql/order/tests/queries/test_order_line.py
@@ -10,7 +10,9 @@ from ....core.enums import ThumbnailFormatEnum
 from ....tests.utils import get_graphql_content
 
 
-def test_order_line_query(staff_api_client, permission_manage_orders, fulfilled_order):
+def test_order_line_query(
+    staff_api_client, permission_group_manage_orders, fulfilled_order
+):
     order = fulfilled_order
     query = """
         query OrdersQuery {
@@ -80,7 +82,7 @@ def test_order_line_query(staff_api_client, permission_manage_orders, fulfilled_
     line.store_value_in_metadata({metadata_key: metadata_value})
     line.save()
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(query)
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
@@ -145,7 +147,7 @@ def test_order_line_query(staff_api_client, permission_manage_orders, fulfilled_
 
 
 def test_denormalized_tax_class_in_orderline_query(
-    staff_api_client, permission_manage_orders, fulfilled_order
+    staff_api_client, permission_group_manage_orders, fulfilled_order
 ):
     # given
     order = fulfilled_order
@@ -209,7 +211,7 @@ def test_denormalized_tax_class_in_orderline_query(
             }
         """
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     line_tax_class = order.lines.first().tax_class
     assert line_tax_class
 
@@ -242,7 +244,7 @@ def test_denormalized_tax_class_in_orderline_query(
 
 def test_order_line_with_allocations(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines,
 ):
     # given
@@ -267,7 +269,7 @@ def test_order_line_with_allocations(
             }
         }
     """
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(query)
@@ -315,7 +317,7 @@ query OrderQuery($id: ID!) {
 
 def test_query_order_line_stocks(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines_for_cc,
     warehouse,
     warehouse_for_cc,
@@ -325,14 +327,13 @@ def test_query_order_line_stocks(
     order = order_with_lines_for_cc
     variant = order.lines.first().variant
     variables = {"id": graphene.Node.to_global_id("Order", order.id)}
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # create the variant stock for not click and collect warehouse
     Stock.objects.create(warehouse=warehouse, product_variant=variant, quantity=10)
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_ORDER_LINE_STOCKS, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDER_LINE_STOCKS, variables)
 
     # then
     content = get_graphql_content(response)
@@ -365,11 +366,11 @@ ORDERS_QUERY_LINE_THUMBNAIL = """
 
 def test_order_query_no_thumbnail(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_line,
 ):
     # given
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(ORDERS_QUERY_LINE_THUMBNAIL)
@@ -383,7 +384,7 @@ def test_order_query_no_thumbnail(
 
 def test_order_query_product_image_size_and_format_given_proxy_url_returned(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_line,
     product_with_image,
     site_settings,
@@ -397,7 +398,7 @@ def test_order_query_product_image_size_and_format_given_proxy_url_returned(
         "format": format,
     }
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(ORDERS_QUERY_LINE_THUMBNAIL, variables)
@@ -416,7 +417,7 @@ def test_order_query_product_image_size_and_format_given_proxy_url_returned(
 
 def test_order_query_product_image_size_given_proxy_url_returned(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_line,
     product_with_image,
     site_settings,
@@ -428,7 +429,7 @@ def test_order_query_product_image_size_given_proxy_url_returned(
         "size": 120,
     }
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(ORDERS_QUERY_LINE_THUMBNAIL, variables)
@@ -446,7 +447,7 @@ def test_order_query_product_image_size_given_proxy_url_returned(
 
 def test_order_query_product_image_size_given_thumbnail_url_returned(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_line,
     product_with_image,
     site_settings,
@@ -463,7 +464,7 @@ def test_order_query_product_image_size_given_thumbnail_url_returned(
         "size": 120,
     }
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(ORDERS_QUERY_LINE_THUMBNAIL, variables)
@@ -480,7 +481,7 @@ def test_order_query_product_image_size_given_thumbnail_url_returned(
 
 def test_order_query_variant_image_size_and_format_given_proxy_url_returned(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_line,
     variant_with_image,
     site_settings,
@@ -494,7 +495,7 @@ def test_order_query_variant_image_size_and_format_given_proxy_url_returned(
         "format": format,
     }
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(ORDERS_QUERY_LINE_THUMBNAIL, variables)
@@ -513,7 +514,7 @@ def test_order_query_variant_image_size_and_format_given_proxy_url_returned(
 
 def test_order_query_variant_image_size_given_proxy_url_returned(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_line,
     variant_with_image,
     site_settings,
@@ -525,7 +526,7 @@ def test_order_query_variant_image_size_given_proxy_url_returned(
         "size": 120,
     }
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(ORDERS_QUERY_LINE_THUMBNAIL, variables)
@@ -543,7 +544,7 @@ def test_order_query_variant_image_size_given_proxy_url_returned(
 
 def test_order_query_variant_image_size_given_thumbnail_url_returned(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_line,
     variant_with_image,
     site_settings,
@@ -560,7 +561,7 @@ def test_order_query_variant_image_size_given_thumbnail_url_returned(
         "size": 120,
     }
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(ORDERS_QUERY_LINE_THUMBNAIL, variables)

--- a/saleor/graphql/order/tests/queries/test_order_payment_event.py
+++ b/saleor/graphql/order/tests/queries/test_order_payment_event.py
@@ -38,7 +38,7 @@ ORDERS_PAYMENTS_EVENTS_QUERY = """
 
 def test_payment_information_order_events_query(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     permission_manage_apps,
     order,
     payment_dummy,
@@ -52,9 +52,8 @@ def test_payment_information_order_events_query(
         order=order, user=staff_user, app=None, amount=amount, payment=payment_dummy
     )
 
-    staff_api_client.user.user_permissions.add(
-        permission_manage_orders, permission_manage_apps
-    )
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
     response = staff_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content["data"]["orders"]["edges"][0]["node"]["events"][0]
@@ -75,7 +74,7 @@ def test_payment_information_order_events_query(
 
 def test_payment_information_order_events_query_for_app(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     permission_manage_apps,
     order,
     payment_dummy,
@@ -89,9 +88,8 @@ def test_payment_information_order_events_query_for_app(
         order=order, user=None, app=app, amount=amount, payment=payment_dummy
     )
 
-    staff_api_client.user.user_permissions.add(
-        permission_manage_orders, permission_manage_apps
-    )
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
     response = staff_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content["data"]["orders"]["edges"][0]["node"]["events"][0]

--- a/saleor/graphql/order/tests/queries/test_order_shipping_method.py
+++ b/saleor/graphql/order/tests/queries/test_order_shipping_method.py
@@ -23,7 +23,7 @@ ORDERS_QUERY_SHIPPING_METHODS = """
 
 def test_order_query_without_available_shipping_methods(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order,
     shipping_method_channel_PLN,
     channel_USD,
@@ -32,7 +32,7 @@ def test_order_query_without_available_shipping_methods(
     order.shipping_method = shipping_method_channel_PLN
     order.save()
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(ORDERS_QUERY_SHIPPING_METHODS)
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
@@ -44,7 +44,7 @@ def test_order_available_shipping_methods_with_weight_based_shipping_method(
     staff_api_client,
     order_line,
     shipping_method_weight_based,
-    permission_manage_orders,
+    permission_group_manage_orders,
     minimum_order_weight_value,
 ):
     shipping_method = shipping_method_weight_based
@@ -59,7 +59,7 @@ def test_order_available_shipping_methods_with_weight_based_shipping_method(
 
     shipping_method.save(update_fields=["minimum_order_weight"])
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(ORDERS_QUERY_SHIPPING_METHODS)
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
@@ -71,7 +71,10 @@ def test_order_available_shipping_methods_with_weight_based_shipping_method(
 
 
 def test_order_available_shipping_methods_weight_method_with_higher_minimal_weigh(
-    staff_api_client, order_line, shipping_method_weight_based, permission_manage_orders
+    staff_api_client,
+    order_line,
+    shipping_method_weight_based,
+    permission_group_manage_orders,
 ):
     order = order_line.order
 
@@ -83,7 +86,7 @@ def test_order_available_shipping_methods_weight_method_with_higher_minimal_weig
     order.weight = Weight(kg=1)
     order.save(update_fields=["weight"])
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(ORDERS_QUERY_SHIPPING_METHODS)
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
@@ -96,11 +99,11 @@ def test_order_available_shipping_methods_weight_method_with_higher_minimal_weig
 
 def test_order_query_shipping_zones_with_available_shipping_methods(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     fulfilled_order,
     shipping_zone,
 ):
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(ORDERS_QUERY_SHIPPING_METHODS)
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
@@ -109,13 +112,13 @@ def test_order_query_shipping_zones_with_available_shipping_methods(
 
 def test_order_query_shipping_zones_without_channel(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     fulfilled_order,
     shipping_zone,
     channel_USD,
 ):
     channel_USD.shipping_zones.clear()
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(ORDERS_QUERY_SHIPPING_METHODS)
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
@@ -125,7 +128,7 @@ def test_order_query_shipping_zones_without_channel(
 
 def test_order_query_shipping_methods_excluded_postal_codes(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines_channel_PLN,
     channel_PLN,
 ):
@@ -134,7 +137,7 @@ def test_order_query_shipping_methods_excluded_postal_codes(
     order.shipping_address.postal_code = "HB5"
     order.shipping_address.save(update_fields=["postal_code"])
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(ORDERS_QUERY_SHIPPING_METHODS)
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
@@ -143,7 +146,7 @@ def test_order_query_shipping_methods_excluded_postal_codes(
 
 def test_order_available_shipping_methods_query(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     fulfilled_order,
     shipping_zone,
 ):
@@ -152,7 +155,7 @@ def test_order_available_shipping_methods_query(
         channel_id=fulfilled_order.channel_id
     ).price
 
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(ORDERS_QUERY_SHIPPING_METHODS)
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]

--- a/saleor/graphql/order/tests/queries/test_order_with_filter.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_filter.py
@@ -62,18 +62,17 @@ def order_list_with_cc_orders(orders, warehouse_for_cc):
 def test_order_query_with_filter_channels_with_one_channel(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     orders,
     channel_USD,
 ):
     # given
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.pk)
     variables = {"filter": {"channels": [channel_id]}}
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -84,16 +83,16 @@ def test_order_query_with_filter_channels_with_one_channel(
 def test_order_query_with_filter_channels_without_channel(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     orders,
 ):
     # given
     variables = {"filter": {"channels": []}}
 
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -104,7 +103,7 @@ def test_order_query_with_filter_channels_without_channel(
 def test_order_query_with_filter_channels_with_many_channel(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     orders,
     channel_USD,
     channel_PLN,
@@ -116,10 +115,10 @@ def test_order_query_with_filter_channels_with_many_channel(
     channel_pln_id = graphene.Node.to_global_id("Channel", channel_PLN.pk)
     variables = {"filter": {"channels": [channel_pln_id, channel_usd_id]}}
 
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -131,18 +130,17 @@ def test_order_query_with_filter_channels_with_many_channel(
 def test_order_query_with_filter_channels_with_empty_channel(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     orders,
     other_channel_USD,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     channel_id = graphene.Node.to_global_id("Channel", other_channel_USD.pk)
     variables = {"filter": {"channels": [channel_id]}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -153,11 +151,12 @@ def test_order_query_with_filter_channels_with_empty_channel(
 def test_order_query_with_filter_gift_card_used_true(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     gift_card,
     orders,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     gift_card_order = orders[0]
     gift_cards_used_in_order_event(
         [(gift_card, 20.0)], gift_card_order, staff_api_client.user, None
@@ -165,9 +164,7 @@ def test_order_query_with_filter_gift_card_used_true(
     variables = {"filter": {"giftCardUsed": True}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -181,11 +178,12 @@ def test_order_query_with_filter_gift_card_used_true(
 def test_order_query_with_filter_gift_card_used_false(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     gift_card,
     orders,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     gift_card_order = orders[0]
     gift_card_order_id = graphene.Node.to_global_id("Order", gift_card_order.id)
     gift_cards_used_in_order_event(
@@ -194,9 +192,7 @@ def test_order_query_with_filter_gift_card_used_false(
     variables = {"filter": {"giftCardUsed": False}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -209,19 +205,18 @@ def test_order_query_with_filter_gift_card_used_false(
 def test_order_query_with_filter_gift_card_bough_true(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     gift_card,
     orders,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     gift_card_order = orders[-1]
     gift_cards_bought_event([gift_card], gift_card_order, staff_api_client.user, None)
     variables = {"filter": {"giftCardBought": True}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -235,20 +230,19 @@ def test_order_query_with_filter_gift_card_bough_true(
 def test_order_query_with_filter_gift_card_bought_false(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     gift_card,
     orders,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     gift_card_order = orders[-1]
     gift_card_order_id = graphene.Node.to_global_id("Order", gift_card_order.id)
     gift_cards_bought_event([gift_card], gift_card_order, staff_api_client.user, None)
     variables = {"filter": {"giftCardBought": False}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -281,14 +275,14 @@ def test_order_query_with_filter_created(
     count,
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     channel_USD,
 ):
     Order.objects.create(channel=channel_USD)
     with freeze_time("2012-01-14"):
         Order.objects.create(channel=channel_USD)
     variables = {"filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     orders = content["data"]["orders"]["edges"]
@@ -321,7 +315,7 @@ def test_order_query_with_filter_updated_at(
     count,
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     channel_USD,
 ):
     with freeze_time("2012-01-14 11:00:00"):
@@ -331,7 +325,7 @@ def test_order_query_with_filter_updated_at(
         Order.objects.create(channel=channel_USD)
 
     variables = {"filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     orders = content["data"]["orders"]["edges"]
@@ -358,7 +352,7 @@ def test_order_query_with_filter_payment_status(
     orders_query_with_filter,
     staff_api_client,
     payment_dummy,
-    permission_manage_orders,
+    permission_group_manage_orders,
     channel_PLN,
 ):
     payment_dummy.charge_status = payment_status
@@ -370,7 +364,7 @@ def test_order_query_with_filter_payment_status(
     payment_dummy.save()
 
     variables = {"filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     orders = content["data"]["orders"]["edges"]
@@ -382,7 +376,7 @@ def test_order_query_with_filter_payment_fully_refunded_not_active(
     orders_query_with_filter,
     staff_api_client,
     payment_dummy,
-    permission_manage_orders,
+    permission_group_manage_orders,
     channel_PLN,
 ):
     # given
@@ -391,7 +385,7 @@ def test_order_query_with_filter_payment_fully_refunded_not_active(
     payment_dummy.order = Order.objects.create(channel=channel_PLN)
     payment_dummy.save()
     variables = {"filter": {"paymentStatus": "FULLY_REFUNDED"}}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
@@ -419,7 +413,7 @@ def test_order_query_with_filter_status(
     orders_query_with_filter,
     staff_api_client,
     payment_dummy,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order,
     channel_USD,
 ):
@@ -429,7 +423,7 @@ def test_order_query_with_filter_status(
     Order.objects.create(channel=channel_USD)
 
     variables = {"filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     orders = content["data"]["orders"]["edges"]
@@ -454,7 +448,7 @@ def test_order_query_with_filter_customer_fields(
     user_value,
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     customer_user,
     channel_USD,
 ):
@@ -466,7 +460,7 @@ def test_order_query_with_filter_customer_fields(
     Order.objects.bulk_create([order, Order(channel=channel_USD)])
 
     variables = {"filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     orders = content["data"]["orders"]["edges"]
@@ -479,17 +473,16 @@ def test_order_query_with_filter_customer_fields(
 def test_order_query_with_filter_is_click_and_collect_true(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_list_with_cc_orders,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     orders = order_list_with_cc_orders
     variables = {"filter": {"isClickAndCollect": True}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -508,17 +501,16 @@ def test_order_query_with_filter_is_click_and_collect_true(
 def test_order_query_with_filter_is_click_and_collect_false(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_list_with_cc_orders,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     orders = order_list_with_cc_orders
     variables = {"filter": {"isClickAndCollect": False}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -584,16 +576,15 @@ def preorders(orders, product):
 def test_order_query_with_filter_is_preorder_true(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     preorders,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {"filter": {"isPreorder": True}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -608,16 +599,15 @@ def test_order_query_with_filter_is_preorder_true(
 def test_order_query_with_filter_is_preorder_false(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     preorders,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {"filter": {"isPreorder": False}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -649,7 +639,7 @@ def test_orders_query_with_filter_search(
     count,
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     customer_user,
     channel_USD,
     product,
@@ -726,7 +716,7 @@ def test_orders_query_with_filter_search(
     Order.objects.bulk_update(orders, ["search_vector"])
 
     variables = {"filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     assert content["data"]["orders"]["totalCount"] == count
@@ -735,7 +725,7 @@ def test_orders_query_with_filter_search(
 def test_orders_query_with_filter_search_by_global_payment_id(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     customer_user,
     channel_USD,
 ):
@@ -770,7 +760,7 @@ def test_orders_query_with_filter_search_by_global_payment_id(
     Order.objects.bulk_update(orders, ["search_vector"])
 
     variables = {"filter": {"search": global_id}}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     assert content["data"]["orders"]["totalCount"] == 1
@@ -780,11 +770,11 @@ def test_orders_query_with_filter_search_by_number(
     orders_query_with_filter,
     order_with_search_vector_value,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
 ):
     order = order_with_search_vector_value
     variables = {"filter": {"search": order.number}}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     assert content["data"]["orders"]["totalCount"] == 1
@@ -794,29 +784,34 @@ def test_orders_query_with_filter_search_by_number_with_hash(
     orders_query_with_filter,
     order_with_search_vector_value,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
 ):
     order = order_with_search_vector_value
     variables = {"filter": {"search": f"#{order.number}"}}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     assert content["data"]["orders"]["totalCount"] == 1
 
 
 def test_orders_query_with_filter_search_by_product_sku_with_multiple_identic_sku(
-    orders_query_with_filter, staff_api_client, permission_manage_orders, allocations
+    orders_query_with_filter,
+    staff_api_client,
+    permission_group_manage_orders,
+    allocations,
 ):
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {"filter": {"search": allocations[0].order_line.product_sku}}
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     assert content["data"]["orders"]["totalCount"] == 3
 
 
 def test_order_query_with_filter_search_by_product_sku_order_line(
-    orders_query_with_filter, staff_api_client, permission_manage_orders, order_line
+    orders_query_with_filter,
+    staff_api_client,
+    permission_group_manage_orders,
+    order_line,
 ):
     query = """
       query ($filter: OrderFilterInput!, ) {
@@ -833,14 +828,13 @@ def test_order_query_with_filter_search_by_product_sku_order_line(
         }
       }
     """
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     order = order_line.order
     order.refresh_from_db()
     update_order_search_vector(order)
 
     variables = {"filter": {"search": order_line.product_sku}}
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     orders = content["data"]["orders"]["edges"][0]
     lines = orders["node"]["lines"][0]["productSku"]
@@ -852,10 +846,11 @@ def test_orders_query_with_filter_by_orders_id(
     orders_query_with_filter,
     staff_api_client,
     order,
-    permission_manage_orders,
+    permission_group_manage_orders,
     channel_USD,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     orders = Order.objects.bulk_create(
         [
             Order(
@@ -874,9 +869,7 @@ def test_orders_query_with_filter_by_orders_id(
     variables = {"filter": {"ids": orders_ids}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     edges = content["data"]["orders"]["edges"]
     response_ids = [edge["node"]["id"] for edge in edges]
@@ -890,10 +883,11 @@ def test_orders_query_with_filter_by_old_orders_id(
     orders_query_with_filter,
     staff_api_client,
     order,
-    permission_manage_orders,
+    permission_group_manage_orders,
     channel_USD,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     orders = Order.objects.bulk_create(
         [
             Order(
@@ -914,9 +908,7 @@ def test_orders_query_with_filter_by_old_orders_id(
     variables = {"filter": {"ids": orders_ids}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     edges = content["data"]["orders"]["edges"]
     response_ids = [edge["node"]["id"] for edge in edges]
@@ -930,10 +922,11 @@ def test_orders_query_with_filter_by_old_and_new_orders_id(
     orders_query_with_filter,
     staff_api_client,
     order,
-    permission_manage_orders,
+    permission_group_manage_orders,
     channel_USD,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     orders = Order.objects.bulk_create(
         [
             Order(
@@ -956,9 +949,7 @@ def test_orders_query_with_filter_by_old_and_new_orders_id(
     variables = {"filter": {"ids": orders_ids}}
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     edges = content["data"]["orders"]["edges"]
     response_ids = [edge["node"]["id"] for edge in edges]
@@ -973,7 +964,7 @@ def test_orders_query_with_filter_by_old_and_new_orders_id(
 def test_order_query_with_filter_search_by_product_sku_multi_order_lines(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     product,
     channel_USD,
     order,
@@ -1049,11 +1040,10 @@ def test_order_query_with_filter_search_by_product_sku_multi_order_lines(
     )
     order.refresh_from_db()
     update_order_search_vector(order)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     variables = {"filter": {"search": lines[0].product_sku}}
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     assert content["data"]["orders"]["totalCount"] == 1
 
@@ -1101,7 +1091,7 @@ def test_orders_query_with_filter_authorize_status(
     order_with_lines,
     order,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     customer_user,
     channel_USD,
 ):
@@ -1129,7 +1119,7 @@ def test_orders_query_with_filter_authorize_status(
     update_order_authorize_data(order_with_lines)
 
     variables = {"filter": {"authorizeStatus": statuses}}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
@@ -1182,7 +1172,7 @@ def test_orders_query_with_filter_charge_status(
     order_with_lines,
     order,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     customer_user,
     channel_USD,
 ):
@@ -1208,7 +1198,7 @@ def test_orders_query_with_filter_charge_status(
     update_order_charge_data(order_with_lines)
 
     variables = {"filter": {"chargeStatus": statuses}}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
@@ -1221,7 +1211,7 @@ def test_orders_query_with_filter_charge_status(
 def test_order_query_with_filter_numbers(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     orders,
     channel_USD,
 ):
@@ -1231,11 +1221,10 @@ def test_order_query_with_filter_numbers(
             "numbers": [str(orders[0].number), str(orders[2].number)],
         },
     }
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -1251,7 +1240,7 @@ def test_order_query_with_filter_numbers(
 def test_order_query_with_filter_not_allow_numbers_and_ids_together(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     orders,
     channel_USD,
 ):
@@ -1263,11 +1252,10 @@ def test_order_query_with_filter_not_allow_numbers_and_ids_together(
         },
     }
     error_message = "'ids' and 'numbers` are not allowed to use together in filter."
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content_from_response(response)
 
     # then
@@ -1278,12 +1266,13 @@ def test_order_query_with_filter_not_allow_numbers_and_ids_together(
 def test_order_query_with_filter_by_checkout_token(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     orders_from_checkout,
     orders,
     checkout,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {
         "filter": {
             "checkoutIds": [
@@ -1293,9 +1282,7 @@ def test_order_query_with_filter_by_checkout_token(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -1314,7 +1301,7 @@ def test_order_query_with_filter_by_checkout_token(
 def test_order_query_with_filter_by_multiple_checkout_tokens(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     orders_from_checkout,
     order_from_checkout_JPY,
     orders,
@@ -1322,6 +1309,7 @@ def test_order_query_with_filter_by_multiple_checkout_tokens(
     checkout_JPY,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {
         "filter": {
             "checkoutIds": [
@@ -1332,9 +1320,7 @@ def test_order_query_with_filter_by_multiple_checkout_tokens(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)
@@ -1353,10 +1339,11 @@ def test_order_query_with_filter_by_multiple_checkout_tokens(
 def test_order_query_with_filter_by_empty_list(
     orders_query_with_filter,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     orders_from_checkout,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {
         "filter": {
             "checkoutIds": [],
@@ -1364,9 +1351,7 @@ def test_order_query_with_filter_by_empty_list(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
-    )
+    response = staff_api_client.post_graphql(orders_query_with_filter, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/queries/test_order_with_sort.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_sort.py
@@ -36,7 +36,7 @@ def test_query_orders_with_sort(
     order_sort,
     result_order,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     address,
     channel_USD,
 ):
@@ -82,7 +82,7 @@ def test_query_orders_with_sort(
         )
     )
     variables = {"sort_by": order_sort}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(QUERY_ORDER_WITH_SORT, variables)
     content = get_graphql_content(response)
     orders = content["data"]["orders"]["edges"]
@@ -116,8 +116,10 @@ SEARCH_ORDERS_QUERY = """
 """
 
 
-def test_sort_order_by_rank_without_search(staff_api_client, permission_manage_orders):
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+def test_sort_order_by_rank_without_search(
+    staff_api_client, permission_group_manage_orders
+):
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     variables = {
         "sortBy": {"field": "RANK", "direction": "DESC"},

--- a/saleor/graphql/order/tests/queries/test_pagination.py
+++ b/saleor/graphql/order/tests/queries/test_pagination.py
@@ -160,7 +160,7 @@ def test_order_query_pagination_with_filter_created(
     orders_order,
     expected_total_count,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     orders_for_pagination,
     channel_USD,
 ):
@@ -168,7 +168,7 @@ def test_order_query_pagination_with_filter_created(
         Order.objects.create(channel=channel_USD)
     page_size = 2
     variables = {"first": page_size, "after": None, "filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_PAGINATION, variables)
     content = get_graphql_content(response)
 
@@ -210,9 +210,10 @@ def test_order_query_pagination_with_filter_payment_status(
     orders_order,
     staff_api_client,
     payment_dummy,
-    permission_manage_orders,
+    permission_group_manage_orders,
     orders_for_pagination,
 ):
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     payment_dummy.charge_status = payment_status
     payment_dummy.save()
 
@@ -224,7 +225,6 @@ def test_order_query_pagination_with_filter_payment_status(
 
     page_size = 2
     variables = {"first": page_size, "after": None, "filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
     response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_PAGINATION, variables)
     content = get_graphql_content(response)
 
@@ -251,7 +251,7 @@ def test_order_query_pagination_with_filter_status(
     status,
     orders_order,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order,
     orders_for_pagination,
 ):
@@ -260,7 +260,8 @@ def test_order_query_pagination_with_filter_status(
 
     page_size = 2
     variables = {"first": page_size, "after": None, "filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
     response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_PAGINATION, variables)
     content = get_graphql_content(response)
 
@@ -285,7 +286,7 @@ def test_order_query_pagination_with_filter_customer_fields(
     user_field,
     user_value,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     customer_user,
     orders_for_pagination,
     channel_USD,
@@ -298,7 +299,8 @@ def test_order_query_pagination_with_filter_customer_fields(
 
     page_size = 2
     variables = {"first": page_size, "after": None, "filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
     response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_PAGINATION, variables)
     content = get_graphql_content(response)
     orders = content["data"]["orders"]["edges"]
@@ -321,7 +323,7 @@ def test_draft_order_query_pagination_with_filter_customer_fields(
     user_field,
     user_value,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     customer_user,
     draft_orders_for_pagination,
     channel_USD,
@@ -338,7 +340,8 @@ def test_draft_order_query_pagination_with_filter_customer_fields(
 
     page_size = 2
     variables = {"first": page_size, "after": None, "filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
     response = staff_api_client.post_graphql(
         QUERY_DRAFT_ORDERS_WITH_PAGINATION, variables
     )
@@ -374,7 +377,7 @@ def test_draft_order_query_pagination_with_filter_created(
     expected_total_count,
     orders_order,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     draft_orders_for_pagination,
     channel_USD,
 ):
@@ -386,7 +389,8 @@ def test_draft_order_query_pagination_with_filter_created(
         )
     page_size = 2
     variables = {"first": page_size, "after": None, "filter": orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
     response = staff_api_client.post_graphql(
         QUERY_DRAFT_ORDERS_WITH_PAGINATION, variables
     )
@@ -416,7 +420,7 @@ def test_orders_query_pagination_with_filter_search(
     orders_filter,
     expected_total_count,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     customer_user,
     orders_for_pagination,
     channel_USD,
@@ -467,7 +471,8 @@ def test_orders_query_pagination_with_filter_search(
     orders_seen = 0
     while True:
         variables = {"first": 1, "after": after, "filter": orders_filter}
-        staff_api_client.user.user_permissions.add(permission_manage_orders)
+        permission_group_manage_orders.user_set.add(staff_api_client.user)
+
         response = staff_api_client.post_graphql(
             QUERY_ORDERS_WITH_PAGINATION, variables
         )
@@ -497,7 +502,7 @@ def test_draft_orders_query_pagination_with_filter_search(
     draft_orders_filter,
     expected_total_count,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     customer_user,
     draft_orders_for_pagination,
     channel_USD,
@@ -552,7 +557,8 @@ def test_draft_orders_query_pagination_with_filter_search(
 
     page_size = 2
     variables = {"first": page_size, "after": None, "filter": draft_orders_filter}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
     response = staff_api_client.post_graphql(
         QUERY_DRAFT_ORDERS_WITH_PAGINATION, variables
     )
@@ -564,12 +570,13 @@ def test_draft_orders_query_pagination_with_filter_search(
 
 
 def test_orders_query_pagination_with_filter_search_by_number(
-    order_with_search_vector_value, staff_api_client, permission_manage_orders
+    order_with_search_vector_value, staff_api_client, permission_group_manage_orders
 ):
     order = order_with_search_vector_value
     page_size = 2
     variables = {"first": page_size, "after": None, "filter": {"search": order.number}}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
     response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_PAGINATION, variables)
     content = get_graphql_content(response)
     assert content["data"]["orders"]["totalCount"] == 1
@@ -578,7 +585,7 @@ def test_orders_query_pagination_with_filter_search_by_number(
 def test_draft_orders_query_pagination_with_filter_search_by_number(
     draft_order,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
 ):
     update_order_search_vector(draft_order)
     page_size = 2
@@ -587,7 +594,8 @@ def test_draft_orders_query_pagination_with_filter_search_by_number(
         "after": None,
         "filter": {"search": draft_order.number},
     }
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
     response = staff_api_client.post_graphql(
         QUERY_DRAFT_ORDERS_WITH_PAGINATION, variables
     )
@@ -616,7 +624,7 @@ def test_query_orders_pagination_with_sort(
     order_sort,
     result_order,
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     address,
     channel_USD,
 ):
@@ -660,7 +668,8 @@ def test_query_orders_pagination_with_sort(
 
     page_size = 2
     variables = {"first": page_size, "after": None, "sortBy": order_sort}
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
     response = staff_api_client.post_graphql(QUERY_ORDERS_WITH_PAGINATION, variables)
     content = get_graphql_content(response)
     orders = content["data"]["orders"]["edges"]

--- a/saleor/graphql/order/tests/test_homepage.py
+++ b/saleor/graphql/order/tests/test_homepage.py
@@ -8,7 +8,9 @@ from ...core.enums import ReportingPeriod
 from ...tests.utils import assert_no_permission, get_graphql_content
 
 
-def test_homepage_events(order_events, staff_api_client, permission_manage_orders):
+def test_homepage_events(
+    order_events, staff_api_client, permission_group_manage_orders
+):
     query = """
     {
         homepageEvents(first: 20) {
@@ -22,9 +24,8 @@ def test_homepage_events(order_events, staff_api_client, permission_manage_order
         }
     }
     """
-    response = staff_api_client.post_graphql(
-        query, permissions=[permission_manage_orders]
-    )
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    response = staff_api_client.post_graphql(query)
     content = get_graphql_content(response)
     edges = content["data"]["homepageEvents"]["edges"]
     only_types = {"PLACED", "PLACED_FROM_DRAFT", "ORDER_FULLY_PAID"}
@@ -59,19 +60,18 @@ query Orders($period: ReportingPeriod, $channel: String) {
 
 def test_orders_total(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines,
     order_with_lines_channel_PLN,
     channel_USD,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     order = order_with_lines
     variables = {"period": ReportingPeriod.TODAY.name, "channel": channel_USD.slug}
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_ORDER_TOTAL, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDER_TOTAL, variables)
 
     # then
     content = get_graphql_content(response)
@@ -81,19 +81,18 @@ def test_orders_total(
 
 def test_orders_total_channel_pln(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines,
     order_with_lines_channel_PLN,
     channel_PLN,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     order = order_with_lines_channel_PLN
     variables = {"period": ReportingPeriod.TODAY.name, "channel": channel_PLN.slug}
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_ORDER_TOTAL, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDER_TOTAL, variables)
 
     # then
     content = get_graphql_content(response)
@@ -103,17 +102,16 @@ def test_orders_total_channel_pln(
 
 def test_orders_total_not_existing_channel(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines,
     order_with_lines_channel_PLN,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {"period": ReportingPeriod.TODAY.name, "channel": "not-existing"}
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_ORDER_TOTAL, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDER_TOTAL, variables)
 
     # then
     content = get_graphql_content(response)
@@ -122,19 +120,18 @@ def test_orders_total_not_existing_channel(
 
 def test_orders_total_as_staff(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines,
     order_with_lines_channel_PLN,
     channel_USD,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     order = order_with_lines
     variables = {"period": ReportingPeriod.TODAY.name, "channel": channel_USD.slug}
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_ORDER_TOTAL, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDER_TOTAL, variables)
 
     # then
     content = get_graphql_content(response)
@@ -207,12 +204,13 @@ QUERY_ORDER_TODAY_COUNT = """
 
 def test_orders_total_count_without_channel(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines,
     order_with_lines_channel_PLN,
     channel_USD,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {
         "created": {
             "gte": str(date.today() - timedelta(days=3)),
@@ -221,9 +219,7 @@ def test_orders_total_count_without_channel(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_ORDER_TODAY_COUNT, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDER_TODAY_COUNT, variables)
 
     # then
     content = get_graphql_content(response)
@@ -232,12 +228,13 @@ def test_orders_total_count_without_channel(
 
 def test_orders_total_count_channel_USD(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines,
     order_with_lines_channel_PLN,
     channel_USD,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {
         "created": {
             "gte": str(date.today() - timedelta(days=3)),
@@ -247,9 +244,7 @@ def test_orders_total_count_channel_USD(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_ORDER_TODAY_COUNT, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDER_TODAY_COUNT, variables)
 
     # then
     content = get_graphql_content(response)
@@ -258,12 +253,13 @@ def test_orders_total_count_channel_USD(
 
 def test_orders_total_count_channel_PLN(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines,
     order_with_lines_channel_PLN,
     channel_PLN,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {
         "created": {
             "gte": str(date.today() - timedelta(days=3)),
@@ -273,9 +269,7 @@ def test_orders_total_count_channel_PLN(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_ORDER_TODAY_COUNT, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDER_TODAY_COUNT, variables)
 
     # then
     content = get_graphql_content(response)
@@ -284,12 +278,13 @@ def test_orders_total_count_channel_PLN(
 
 def test_orders_total_count_as_staff(
     staff_api_client,
-    permission_manage_orders,
+    permission_group_manage_orders,
     order_with_lines,
     order_with_lines_channel_PLN,
     channel_USD,
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {
         "created": {
             "gte": str(date.today() - timedelta(days=3)),
@@ -299,9 +294,7 @@ def test_orders_total_count_as_staff(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        QUERY_ORDER_TODAY_COUNT, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(QUERY_ORDER_TODAY_COUNT, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/order/tests/test_homepage.py
+++ b/saleor/graphql/order/tests/test_homepage.py
@@ -261,6 +261,22 @@ def test_orders_total_as_staff(
     assert Money(amount, "USD") == order.total.gross
 
 
+def test_orders_total_no_access_to_channel(
+    staff_api_client, permission_group_all_perms_channel_USD_only, orders, channel_JPY
+):
+    # given
+    query = QUERY_ORDER_TOTAL
+
+    permission_group_all_perms_channel_USD_only.user_set.add(staff_api_client.user)
+    variables = {"period": ReportingPeriod.TODAY.name, "channel": channel_JPY.slug}
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    assert_no_permission(response)
+
+
 def test_orders_total_as_app(
     app_api_client,
     permission_manage_orders,

--- a/saleor/graphql/payment/resolvers.py
+++ b/saleor/graphql/payment/resolvers.py
@@ -14,10 +14,9 @@ def resolve_payments(info):
     payments = models.Payment.objects.all()
     if isinstance(requestor, app_models.App):
         return payments
-    accessible_channels = get_user_accessible_channels(requestor)
-    orders = order_models.Order.objects.filter(
-        channel_id__in=accessible_channels.values("id")
-    )
+    accessible_channels = get_user_accessible_channels(info, requestor)
+    channel_ids = [channel.id for channel in accessible_channels]
+    orders = order_models.Order.objects.filter(channel_id__in=channel_ids)
     return payments.filter(order_id__in=orders.values("id"))
 
 

--- a/saleor/graphql/payment/resolvers.py
+++ b/saleor/graphql/payment/resolvers.py
@@ -1,4 +1,8 @@
+from ...app import models as app_models
+from ...order import models as order_models
 from ...payment import models
+from ..account.utils import get_user_accessible_channels
+from ..utils import get_user_or_app_from_context
 
 
 def resolve_payment_by_id(id):
@@ -6,7 +10,15 @@ def resolve_payment_by_id(id):
 
 
 def resolve_payments(info):
-    return models.Payment.objects.all()
+    requestor = get_user_or_app_from_context(info.context)
+    payments = models.Payment.objects.all()
+    if isinstance(requestor, app_models.App):
+        return payments
+    accessible_channels = get_user_accessible_channels(requestor)
+    orders = order_models.Order.objects.filter(
+        channel_id__in=accessible_channels.values("id")
+    )
+    return payments.filter(order_id__in=orders.values("id"))
 
 
 def resolve_transaction(id):

--- a/saleor/graphql/payment/tests/benchmark/test_payment_transactions.py
+++ b/saleor/graphql/payment/tests/benchmark/test_payment_transactions.py
@@ -52,13 +52,16 @@ query {
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
 def test_payment_transactions(
-    staff_api_client, orders_for_benchmarks, permission_manage_orders, count_queries
+    staff_api_client,
+    orders_for_benchmarks,
+    permission_group_manage_orders,
+    count_queries,
 ):
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     transactions_count = 0
     content = get_graphql_content(
         staff_api_client.post_graphql(
             PAYMENT_TRANSACTIONS_QUERY,
-            permissions=[permission_manage_orders],
             check_no_permissions=False,
         )
     )

--- a/saleor/graphql/payment/tests/queries/test_payments_filter.py
+++ b/saleor/graphql/payment/tests/queries/test_payments_filter.py
@@ -35,9 +35,10 @@ PAYMENT_QUERY = """ query Payments($filter: PaymentFilterInput){
 
 
 def test_query_payments_filter_by_checkout(
-    payment_dummy, checkouts_list, permission_manage_orders, staff_api_client
+    payment_dummy, checkouts_list, permission_group_manage_orders, staff_api_client
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     payment1 = payment_dummy
     payment1.checkout = checkouts_list[0]
     payment1.save()
@@ -62,9 +63,7 @@ def test_query_payments_filter_by_checkout(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        PAYMENT_QUERY, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(PAYMENT_QUERY, variables)
 
     # then
     content = get_graphql_content(response)
@@ -77,9 +76,10 @@ def test_query_payments_filter_by_checkout(
 
 
 def test_query_payments_filter_by_one_id(
-    payments_dummy, permission_manage_orders, staff_api_client
+    payments_dummy, permission_group_manage_orders, staff_api_client
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     search_payment = payments_dummy[0]
 
     variables = {
@@ -89,9 +89,7 @@ def test_query_payments_filter_by_one_id(
     }
 
     # when
-    response = staff_api_client.post_graphql(
-        PAYMENT_QUERY, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(PAYMENT_QUERY, variables)
 
     # then
     content = get_graphql_content(response)
@@ -103,9 +101,10 @@ def test_query_payments_filter_by_one_id(
 
 
 def test_query_payments_filter_by_multiple_ids(
-    payments_dummy, permission_manage_orders, staff_api_client
+    payments_dummy, permission_group_manage_orders, staff_api_client
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     search_payments = payments_dummy[:2]
     search_payments_ids = [
         graphene.Node.to_global_id("Payment", payment.pk) for payment in search_payments
@@ -114,9 +113,7 @@ def test_query_payments_filter_by_multiple_ids(
     variables = {"filter": {"ids": search_payments_ids}}
 
     # when
-    response = staff_api_client.post_graphql(
-        PAYMENT_QUERY, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(PAYMENT_QUERY, variables)
 
     # then
     content = get_graphql_content(response)
@@ -131,15 +128,14 @@ def test_query_payments_filter_by_multiple_ids(
 
 
 def test_query_payments_filter_by_empty_id_list(
-    payments_dummy, permission_manage_orders, staff_api_client
+    payments_dummy, permission_group_manage_orders, staff_api_client
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {"filter": {"ids": []}}
 
     # when
-    response = staff_api_client.post_graphql(
-        PAYMENT_QUERY, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(PAYMENT_QUERY, variables)
 
     # then
     content = get_graphql_content(response)
@@ -154,17 +150,16 @@ def test_query_payments_filter_by_empty_id_list(
 
 
 def test_query_payments_filter_by_not_existing_id(
-    payments_dummy, permission_manage_orders, staff_api_client
+    payments_dummy, permission_group_manage_orders, staff_api_client
 ):
     # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     search_pk = max([payment.pk for payment in payments_dummy]) + 1
     search_id = graphene.Node.to_global_id("Payment", search_pk)
     variables = {"filter": {"ids": [search_id]}}
 
     # when
-    response = staff_api_client.post_graphql(
-        PAYMENT_QUERY, variables, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(PAYMENT_QUERY, variables)
 
     # then
     content = get_graphql_content(response)

--- a/saleor/graphql/payment/tests/queries/test_payments_query.py
+++ b/saleor/graphql/payment/tests/queries/test_payments_query.py
@@ -2,9 +2,34 @@ import json
 from decimal import Decimal
 
 import graphene
+import pytest
 
-from ....tests.utils import get_graphql_content, get_graphql_content_from_response
+from .....order.models import Order
+from .....payment.models import Payment
+from ....tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 from ...enums import PaymentChargeStatusEnum, TransactionActionEnum
+
+
+@pytest.fixture
+def payments_in_different_channels(
+    order_list, payments_dummy, channel_USD, channel_JPY, channel_PLN
+):
+    order_list[0].channel = channel_PLN
+    order_list[1].channel = channel_JPY
+    order_list[2].channel = channel_USD
+    Order.objects.bulk_update(order_list, ["channel"])
+
+    payments_dummy[0].order = order_list[0]
+    payments_dummy[1].order = order_list[1]
+    payments_dummy[2].order = order_list[2]
+    Payment.objects.bulk_update(payments_dummy, ["order"])
+
+    return payments_dummy
+
 
 PAYMENT_QUERY = """ query Payments($filter: PaymentFilterInput){
     payments(first: 20, filter: $filter) {
@@ -38,11 +63,10 @@ PAYMENT_QUERY = """ query Payments($filter: PaymentFilterInput){
 
 
 def test_payments_query(
-    payment_txn_captured, permission_manage_orders, staff_api_client
+    payment_txn_captured, permission_group_manage_orders, staff_api_client
 ):
-    response = staff_api_client.post_graphql(
-        PAYMENT_QUERY, permissions=[permission_manage_orders]
-    )
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    response = staff_api_client.post_graphql(PAYMENT_QUERY)
     content = get_graphql_content(response)
     data = content["data"]["payments"]["edges"][0]["node"]
     pay = payment_txn_captured
@@ -65,12 +89,13 @@ def test_payments_query(
     ]
 
 
-def test_query_payments(payment_dummy, permission_manage_orders, staff_api_client):
+def test_query_payments(
+    payment_dummy, permission_group_manage_orders, staff_api_client
+):
     payment = payment_dummy
     payment_id = graphene.Node.to_global_id("Payment", payment.pk)
-    response = staff_api_client.post_graphql(
-        PAYMENT_QUERY, {}, permissions=[permission_manage_orders]
-    )
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    response = staff_api_client.post_graphql(PAYMENT_QUERY, {})
     content = get_graphql_content(response)
     edges = content["data"]["payments"]["edges"]
     payment_ids = [edge["node"]["id"] for edge in edges]
@@ -78,15 +103,14 @@ def test_query_payments(payment_dummy, permission_manage_orders, staff_api_clien
 
 
 def test_query_payments_failed_payment(
-    payment_txn_capture_failed, permission_manage_orders, staff_api_client
+    payment_txn_capture_failed, permission_group_manage_orders, staff_api_client
 ):
     # given
     payment = payment_txn_capture_failed
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
 
     # when
-    response = staff_api_client.post_graphql(
-        PAYMENT_QUERY, permissions=[permission_manage_orders]
-    )
+    response = staff_api_client.post_graphql(PAYMENT_QUERY)
 
     # then
     content = get_graphql_content(response)
@@ -109,6 +133,83 @@ def test_query_payments_failed_payment(
             "gatewayResponse": json.dumps(txn.gateway_response),
         }
     ]
+
+
+def test_query_payments_by_user_with_access_to_all_channels(
+    payments_in_different_channels,
+    permission_group_all_perms_all_channels,
+    staff_api_client,
+):
+    # given
+    permission_group_all_perms_all_channels.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(PAYMENT_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    edges = content["data"]["payments"]["edges"]
+    assert len(edges) == len(payments_in_different_channels)
+
+
+def test_query_payments_by_user_with_restricted_access_to_channels(
+    payments_in_different_channels,
+    permission_group_all_perms_channel_USD_only,
+    staff_api_client,
+    channel_USD,
+):
+    # given
+    permission_group_all_perms_channel_USD_only.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(PAYMENT_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    edges = content["data"]["payments"]["edges"]
+    assert len(edges) == 1
+    assert edges[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Payment", Payment.objects.get(order__channel=channel_USD).pk
+    )
+
+
+def test_query_payments_by_user_with_restricted_access_to_channels_no_acc_channels(
+    payments_in_different_channels,
+    permission_group_all_perms_without_any_channel,
+    staff_api_client,
+):
+    # given
+    permission_group_all_perms_without_any_channel.user_set.add(staff_api_client.user)
+
+    # when
+    response = staff_api_client.post_graphql(PAYMENT_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    edges = content["data"]["payments"]["edges"]
+    assert len(edges) == 0
+
+
+def test_query_payments_by_app(
+    payments_in_different_channels, app_api_client, permission_manage_orders
+):
+    # when
+    response = app_api_client.post_graphql(
+        PAYMENT_QUERY, permissions=(permission_manage_orders,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    edges = content["data"]["payments"]["edges"]
+    assert len(edges) == len(payments_in_different_channels)
+
+
+def test_query_payments_by_customer(payments_in_different_channels, user_api_client):
+    # when
+    response = user_api_client.post_graphql(PAYMENT_QUERY)
+
+    # then
+    assert_no_permission(response)
 
 
 QUERY_PAYMENT_BY_ID = """

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -364,7 +364,7 @@ def test_order_shipping_methods(
     mocked_webhook,
     staff_api_client,
     order_with_lines,
-    permission_manage_orders,
+    permission_group_manage_orders,
     settings,
 ):
     # given
@@ -374,7 +374,7 @@ def test_order_shipping_methods(
     mocked_webhook.return_value = [
         ExcludedShippingMethod(excluded_shipping_method_id, webhook_reason)
     ]
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     # when
     response = staff_api_client.post_graphql(ORDER_QUERY_SHIPPING_METHOD)
     content = get_graphql_content(response)
@@ -398,7 +398,7 @@ def test_order_available_shipping_methods(
     mocked_webhook,
     staff_api_client,
     order_with_lines,
-    permission_manage_orders,
+    permission_group_manage_orders,
     settings,
     webhook_response,
     expected_count,
@@ -410,7 +410,7 @@ def test_order_available_shipping_methods(
         return webhook_response(order_with_lines.shipping_method)
 
     mocked_webhook.side_effect = respond
-    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
     # when
     response = staff_api_client.post_graphql(ORDER_QUERY_SHIPPING_METHOD)
     content = get_graphql_content(response)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4978,9 +4978,31 @@ def permission_manage_payments():
 
 
 @pytest.fixture
+def permission_group_manage_orders(permission_manage_orders, staff_users):
+    group = Group.objects.create(
+        name="Manage user group.", restricted_access_to_channels=False
+    )
+    group.permissions.add(permission_manage_orders)
+
+    group.user_set.add(staff_users[1])
+    return group
+
+
+@pytest.fixture
+def permission_group_manage_shipping(permission_manage_shipping, staff_users):
+    group = Group.objects.create(
+        name="Manage shipping group.", restricted_access_to_channels=False
+    )
+    group.permissions.add(permission_manage_shipping)
+
+    group.user_set.add(staff_users[1])
+    return group
+
+
+@pytest.fixture
 def permission_group_manage_users(permission_manage_users, staff_users):
     group = Group.objects.create(
-        name="Manage user groups.", restricted_access_to_channels=False
+        name="Manage user group.", restricted_access_to_channels=False
     )
     group.permissions.add(permission_manage_users)
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3291,6 +3291,16 @@ def order_list(customer_user, channel_USD):
 
 
 @pytest.fixture
+def draft_order_list(order_list):
+    for order in order_list:
+        order.status = OrderStatus.DRAFT
+        order.origin = OrderOrigin.DRAFT
+
+    Order.objects.bulk_update(order_list, ["status", "origin"])
+    return order_list
+
+
+@pytest.fixture
 def product_with_image(product, image, media_root):
     ProductMedia.objects.create(product=product, image=image)
     return product

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -5036,6 +5036,16 @@ def permission_group_all_perms_all_channels(
 
 
 @pytest.fixture
+def permission_group_no_perms_all_channels(staff_users, channel_USD, channel_PLN):
+    group = Group.objects.create(
+        name="All permissions for all channels.",
+        restricted_access_to_channels=False,
+    )
+    group.user_set.add(staff_users[1])
+    return group
+
+
+@pytest.fixture
 def permission_group_all_perms_channel_USD_only(
     permission_manage_users, staff_users, channel_USD, channel_PLN
 ):


### PR DESCRIPTION
Update orders query - the staff user will be able to see only orders channels that he has access to; apps has access to all channels.

⚠️ 
The order mutations will be updated in separate PR

**Affected queries:**
- `orders`
- `draftOrders`
- `homepageEvents`
- `ordersTotal`
- `payments`

**Affected fields**
- `user.orders`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
