### PR TITLE
Add order as Apollo Federation entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - Add `requiredSaleorVersion` validation to `appInstall` and `appFetchManifest` mutations
 - Add new field `author` to `Manifest` and `App` object types - #12166 by @przlada
 - Add backwards compatibility for `taxCode` field - #12325 by @maarcingebala
+- Support resolving `Order` as an entity in Apollo Federation - #12328 by @binary-koan
 
 ### Other changes
 - Create order discounts for all voucher types - #12272 by @IKarbowiak

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -16,7 +16,7 @@ from ..utils.filters import filter_by_period
 ORDER_SEARCH_FIELDS = ("id", "discount_name", "token", "user_email", "user__email")
 
 
-def resolve_orders(info, requesting_user=None, requestor_has_access_to_all=True, ids=None, channel_slug=None):
+def resolve_orders(info, channel_slug=None, requesting_user=None, requestor_has_access_to_all=True, ids=None):
     database_connection_name = get_database_connection_name(info.context)
     qs = models.Order.objects.using(database_connection_name).non_draft()
     if channel_slug:

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -10,22 +10,18 @@ from ...order.utils import sum_order_totals
 from ..channel.utils import get_default_channel_slug_or_graphql_error
 from ..core.context import get_database_connection_name
 from ..core.tracing import traced_resolver
-from ..core.utils import from_global_id_or_error
 from ..utils.filters import filter_by_period
 
 ORDER_SEARCH_FIELDS = ("id", "discount_name", "token", "user_email", "user__email")
 
 
-def resolve_orders(info, channel_slug=None, requesting_user=None, requestor_has_access_to_all=True, ids=None):
+def resolve_orders(
+    info, channel_slug=None, requesting_user=None, requestor_has_access_to_all=False
+):
     database_connection_name = get_database_connection_name(info.context)
     qs = models.Order.objects.using(database_connection_name).non_draft()
     if channel_slug:
         qs = qs.filter(channel__slug=str(channel_slug))
-    if ids:
-        db_ids = [
-            from_global_id_or_error(node_id, "Order")[1] for node_id in ids
-        ]
-        qs = qs.filter(pk__in=db_ids)
     if requesting_user and not requestor_has_access_to_all:
         qs = qs.filter(user_id=requesting_user.id)
     return qs

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -28,8 +28,6 @@ def resolve_orders(info, requesting_user=None, requestor_has_access_to_all=True,
         qs = qs.filter(pk__in=db_ids)
     if requesting_user and not requestor_has_access_to_all:
         qs = qs.filter(user_id=requesting_user.id)
-    if not requestor_has_access_to_all:
-        qs = qs.exclude(status=OrderStatus.DRAFT)
     return qs
 
 

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -10,16 +10,26 @@ from ...order.utils import sum_order_totals
 from ..channel.utils import get_default_channel_slug_or_graphql_error
 from ..core.context import get_database_connection_name
 from ..core.tracing import traced_resolver
+from ..core.utils import from_global_id_or_error
 from ..utils.filters import filter_by_period
 
 ORDER_SEARCH_FIELDS = ("id", "discount_name", "token", "user_email", "user__email")
 
 
-def resolve_orders(info, channel_slug):
+def resolve_orders(info, requesting_user=None, requestor_has_access_to_all=True, ids=None, channel_slug=None):
     database_connection_name = get_database_connection_name(info.context)
     qs = models.Order.objects.using(database_connection_name).non_draft()
     if channel_slug:
         qs = qs.filter(channel__slug=str(channel_slug))
+    if ids:
+        db_ids = [
+            from_global_id_or_error(node_id, "Order")[1] for node_id in ids
+        ]
+        qs = qs.filter(pk__in=db_ids)
+    if requesting_user and not requestor_has_access_to_all:
+        qs = qs.filter(user_id=requesting_user.id)
+    if not requestor_has_access_to_all:
+        qs = qs.exclude(status=OrderStatus.DRAFT)
     return qs
 
 

--- a/saleor/graphql/order/tests/queries/test_order_entity.py
+++ b/saleor/graphql/order/tests/queries/test_order_entity.py
@@ -4,7 +4,6 @@ from .....order import OrderStatus
 from .....order.models import Order
 from ....tests.utils import get_graphql_content
 
-
 ORDER_FEDERATION_QUERY = """
   query GetOrderInFederation($representations: [_Any]) {
     _entities(representations: $representations) {
@@ -65,7 +64,9 @@ def test_staff_query_order_by_id_without_permission_for_federation(
     assert content["data"]["_entities"] == [None]
 
 
-def test_customer_query_own_orders_for_federation(user_api_client, customer_user, order_list):
+def test_customer_query_own_orders_for_federation(
+    user_api_client, customer_user, order_list
+):
     order_unfulfilled = order_list[0]
     order_unfulfilled.user = customer_user
 
@@ -141,9 +142,7 @@ def test_customer_query_order_without_permission_for_federation(
     assert content["data"]["_entities"] == [None]
 
 
-def test_unauthenticated_query_order_for_federation(
-    api_client, fulfilled_order
-):
+def test_unauthenticated_query_order_for_federation(api_client, fulfilled_order):
     fulfilled_order_id = graphene.Node.to_global_id("Order", fulfilled_order.id)
     variables = {
         "representations": [

--- a/saleor/graphql/order/tests/queries/test_order_entity.py
+++ b/saleor/graphql/order/tests/queries/test_order_entity.py
@@ -1,0 +1,159 @@
+import graphene
+
+from .....order import OrderStatus
+from .....order.models import Order
+from ....tests.utils import get_graphql_content
+
+
+ORDER_FEDERATION_QUERY = """
+  query GetOrderInFederation($representations: [_Any]) {
+    _entities(representations: $representations) {
+      __typename
+      ... on Order {
+        id
+        number
+      }
+    }
+  }
+"""
+
+
+def test_staff_query_order_by_id_for_federation(
+    staff_api_client, fulfilled_order, permission_manage_orders
+):
+    order_id = graphene.Node.to_global_id("Order", fulfilled_order.id)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Order",
+                "id": order_id,
+            },
+        ],
+    }
+
+    response = staff_api_client.post_graphql(
+        ORDER_FEDERATION_QUERY,
+        variables,
+        permissions=[permission_manage_orders],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [
+        {
+            "__typename": "Order",
+            "id": order_id,
+            "number": str(fulfilled_order.number),
+        },
+    ]
+
+
+def test_staff_query_order_by_id_without_permission_for_federation(
+    staff_api_client, fulfilled_order
+):
+    fulfilled_order_id = graphene.Node.to_global_id("Order", fulfilled_order.id)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Order",
+                "id": fulfilled_order_id,
+            },
+        ],
+    }
+
+    response = staff_api_client.post_graphql(ORDER_FEDERATION_QUERY, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
+
+
+def test_customer_query_own_orders_for_federation(user_api_client, customer_user, order_list):
+    order_unfulfilled = order_list[0]
+    order_unfulfilled.user = customer_user
+
+    order_unconfirmed = order_list[1]
+    order_unconfirmed.status = OrderStatus.UNCONFIRMED
+    order_unconfirmed.user = customer_user
+
+    order_draft = order_list[2]
+    order_draft.status = OrderStatus.DRAFT
+    order_draft.user = customer_user
+
+    Order.objects.bulk_update(
+        [order_unconfirmed, order_draft, order_unfulfilled], ["user", "status"]
+    )
+
+    order_unfulfilled_id = graphene.Node.to_global_id("Order", order_unfulfilled.id)
+    order_unconfirmed_id = graphene.Node.to_global_id("Order", order_unconfirmed.id)
+    order_draft_id = graphene.Node.to_global_id("Order", order_draft.id)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Order",
+                "id": order_unfulfilled_id,
+            },
+            {
+                "__typename": "Order",
+                "id": order_unconfirmed_id,
+            },
+            {
+                "__typename": "Order",
+                "id": order_draft_id,
+            },
+        ],
+    }
+
+    response = user_api_client.post_graphql(
+        ORDER_FEDERATION_QUERY,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["_entities"] == [
+        {
+            "__typename": "Order",
+            "id": order_unfulfilled_id,
+            "number": str(order_unfulfilled.number),
+        },
+        {
+            "__typename": "Order",
+            "id": order_unconfirmed_id,
+            "number": str(order_unconfirmed.number),
+        },
+        # Users without permission cannot see draft orders
+        None,
+    ]
+
+
+def test_customer_query_order_without_permission_for_federation(
+    user2_api_client, fulfilled_order
+):
+    fulfilled_order_id = graphene.Node.to_global_id("Order", fulfilled_order.id)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Order",
+                "id": fulfilled_order_id,
+            },
+        ],
+    }
+
+    response = user2_api_client.post_graphql(ORDER_FEDERATION_QUERY, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]
+
+
+def test_unauthenticated_query_order_for_federation(
+    api_client, fulfilled_order
+):
+    fulfilled_order_id = graphene.Node.to_global_id("Order", fulfilled_order.id)
+    variables = {
+        "representations": [
+            {
+                "__typename": "Order",
+                "id": fulfilled_order_id,
+            },
+        ],
+    }
+
+    response = api_client.post_graphql(ORDER_FEDERATION_QUERY, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["_entities"] == [None]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -27641,7 +27641,7 @@ union TaxSourceLine = CheckoutLine | OrderLine
 scalar _Any
 
 """_Entity union as defined by Federation spec."""
-union _Entity = App | Address | User | Group | ProductVariant | Product | ProductType | ProductMedia | Category | Collection | PageType
+union _Entity = App | Address | User | Group | ProductVariant | Product | ProductType | ProductMedia | Category | Collection | PageType | Order
 
 """_Service manifest as defined by Federation spec."""
 type _Service {


### PR DESCRIPTION
I want to merge this change because I want to build custom APIs that return orders with Apollo Federation. Currently it is possible to extend the Order type in a federated API, but it is not possible to return an Order from a custom type because it's not a federated entity.

I tried to be somewhat consistent with how Product entities work, and hopefully figured out strict enough permission handling. Wasn't sure exactly what to test, but I tried to cover a reasonable number of cases.

I wasn't sure whether to make `channel` a key; since it works differently in orders compared to products etc I figured it wasn't worth the effort, but I could probably figure out how to make a key of `id channel.id` if that's a better solution.

Happy to make any changes to get this mergeable - we'd really like to improve our federated API with this change!

Partially addresses #11986

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [x] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
