### PR TITLE
Fix tax class permissions

### DIFF
--- a/saleor/graphql/order/tests/queries/test_order_line.py
+++ b/saleor/graphql/order/tests/queries/test_order_line.py
@@ -573,3 +573,55 @@ def test_order_query_variant_image_size_given_thumbnail_url_returned(
         order_data["lines"][0]["thumbnail"]["url"]
         == f"http://{site_settings.site.domain}/media/thumbnails/{thumbnail_mock.name}"
     )
+
+
+QUERY_LINE_TAX_CLASS_QUERY = """
+    query OrdersQuery {
+        orders(first: 1) {
+            edges {
+                node {
+                    lines {
+                        id
+                        taxClass {
+                            id
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+def test_order_line_tax_class_query_by_staff(
+    staff_api_client,
+    permission_manage_orders,
+    order_line,
+):
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    # when
+    response = staff_api_client.post_graphql(QUERY_LINE_TAX_CLASS_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+    assert order_data["lines"][0]["taxClass"]["id"]
+
+
+def test_order_line_tax_class_query_by_app(
+    app_api_client,
+    permission_manage_orders,
+    order_line,
+):
+    # given
+    app_api_client.app.permissions.add(permission_manage_orders)
+
+    # when
+    response = app_api_client.post_graphql(QUERY_LINE_TAX_CLASS_QUERY)
+
+    # then
+    content = get_graphql_content(response)
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+    assert order_data["lines"][0]["taxClass"]["id"]

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -619,7 +619,10 @@ class OrderLine(ModelObjectType[models.OrderLine]):
         + ADDED_IN_39
         + PREVIEW_FEATURE,
         required=False,
-        permissions=[AuthorizationFilters.AUTHENTICATED_STAFF_USER],
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        ],
     )
     tax_class_name = graphene.Field(
         graphene.String,
@@ -1014,7 +1017,10 @@ class Order(ModelObjectType[models.Order]):
         + ADDED_IN_39
         + PREVIEW_FEATURE,
         required=False,
-        permissions=[AuthorizationFilters.AUTHENTICATED_STAFF_USER],
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        ],
     )
     shipping_tax_class_name = graphene.Field(
         graphene.String,

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -2480,3 +2480,49 @@ def test_product_query_by_external_reference(
     assert product_data is not None
     assert product_data["name"] == product.name
     assert product_data["externalReference"] == product.external_reference
+
+
+PRODUCT_TAX_CLASS_QUERY = """
+    query getProduct($id: ID!) {
+        product(id: $id) {
+            id
+            taxClass {
+                id
+            }
+        }
+    }
+"""
+
+
+def test_product_tax_class_query_by_app(app_api_client, product):
+    # given
+    variables = {
+        "id": graphene.Node.to_global_id("Product", product.id),
+    }
+
+    # when
+    response = app_api_client.post_graphql(PRODUCT_TAX_CLASS_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]
+    assert data["product"]
+    assert data["product"]["id"]
+    assert data["product"]["taxClass"]["id"]
+
+
+def test_product_tax_class_query_by_staff(staff_api_client, product):
+    # given
+    variables = {
+        "id": graphene.Node.to_global_id("Product", product.id),
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PRODUCT_TAX_CLASS_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]
+    assert data["product"]
+    assert data["product"]["id"]
+    assert data["product"]["taxClass"]["id"]

--- a/saleor/graphql/product/tests/queries/test_product_type_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_type_query.py
@@ -543,3 +543,52 @@ def test_query_product_type_for_federation(api_client, product, channel_USD):
             "name": product_type.name,
         }
     ]
+
+
+PRODUCT_TYPE_TAX_CLASS_QUERY = """
+    query getProductType($id: ID!) {
+        productType(id: $id) {
+            id
+            taxClass {
+                id
+            }
+        }
+    }
+"""
+
+
+def test_product_type_tax_class_query_by_app(
+    app_api_client,
+    product_type,
+):
+    # given
+    variables = {
+        "id": graphene.Node.to_global_id("ProductType", product_type.id),
+    }
+
+    # when
+    response = app_api_client.post_graphql(PRODUCT_TYPE_TAX_CLASS_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]
+    assert data["productType"]
+    assert data["productType"]["id"]
+    assert data["productType"]["taxClass"]["id"]
+
+
+def test_product_type_tax_class_query_by_staff(staff_api_client, product_type):
+    # given
+    variables = {
+        "id": graphene.Node.to_global_id("ProductType", product_type.id),
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PRODUCT_TYPE_TAX_CLASS_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]
+    assert data["productType"]
+    assert data["productType"]["id"]
+    assert data["productType"]["taxClass"]["id"]

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -956,7 +956,10 @@ class Product(ChannelContextTypeWithMetadata[models.Product]):
             "type use this tax class, unless it's overridden in the `Product` type."
         ),
         required=False,
-        permissions=[AuthorizationFilters.AUTHENTICATED_STAFF_USER],
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        ],
     )
     external_reference = graphene.String(
         description=f"External ID of this product. {ADDED_IN_310}",
@@ -1592,7 +1595,10 @@ class ProductType(ModelObjectType[models.ProductType]):
             "type use this tax class, unless it's overridden in the `Product` type."
         ),
         required=False,
-        permissions=[AuthorizationFilters.AUTHENTICATED_STAFF_USER],
+        permissions=[
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        ],
     )
     variant_attributes = NonNullList(
         Attribute,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3517,7 +3517,7 @@ type ShippingMethodType implements Node & ObjectWithMetadata {
   """
   Tax class assigned to this shipping method.
   
-  Requires one of the following permissions: MANAGE_TAXES, MANAGE_SHIPPING.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass: TaxClass
 }
@@ -5089,7 +5089,7 @@ type Product implements Node & ObjectWithMetadata {
   """
   Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
   
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass: TaxClass
 
@@ -5186,7 +5186,7 @@ type ProductType implements Node & ObjectWithMetadata {
   """
   Tax class assigned to this product type. All products of this product type use this tax class, unless it's overridden in the `Product` type.
   
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass: TaxClass
 
@@ -9723,7 +9723,7 @@ type Order implements Node & ObjectWithMetadata {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   shippingTaxClass: TaxClass
 
@@ -10082,7 +10082,7 @@ type OrderLine implements Node & ObjectWithMetadata {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass: TaxClass
 

--- a/saleor/graphql/shipping/tests/test_shipping_zones_query.py
+++ b/saleor/graphql/shipping/tests/test_shipping_zones_query.py
@@ -339,3 +339,54 @@ def test_query_shipping_zone_search_by_channels_no_matter_of_input(
     assert len(data) == 1
     assert data[0]["node"]["name"] == shipping_zone_pln.name
     assert data[0]["node"]["id"] == shipping_zone_pln_id
+
+
+SHIPPING_METHOD_TAX_CLASS_QUERY = """
+    query ShippingQuery($id: ID!) {
+        shippingZone(id: $id) {
+            name
+            shippingMethods {
+                id
+                taxClass {
+                    id
+                }
+            }
+        }
+    }
+"""
+
+
+def test_shipping_method_tax_class_query_by_app(
+    app_api_client, shipping_zone, permission_manage_shipping
+):
+    # given
+    variables = {
+        "id": graphene.Node.to_global_id("ShippingZone", shipping_zone.id),
+    }
+
+    # when
+    app_api_client.app.permissions.add(permission_manage_shipping)
+    response = app_api_client.post_graphql(SHIPPING_METHOD_TAX_CLASS_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]
+    assert data["shippingZone"]["shippingMethods"][0]["taxClass"]["id"]
+
+
+def test_shipping_method_tax_class_query_by_staff(
+    staff_api_client, shipping_zone, permission_manage_shipping
+):
+    # given
+    variables = {
+        "id": graphene.Node.to_global_id("ShippingZone", shipping_zone.id),
+    }
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    response = staff_api_client.post_graphql(SHIPPING_METHOD_TAX_CLASS_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]
+    assert data["shippingZone"]["shippingMethods"][0]["taxClass"]["id"]

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -5,7 +5,8 @@ from django.db.models import QuerySet
 from graphene import relay
 
 from ...core.weight import convert_weight_to_default_weight_unit
-from ...permission.enums import CheckoutPermissions, ShippingPermissions
+from ...permission.auth_filters import AuthorizationFilters
+from ...permission.enums import ShippingPermissions
 from ...product import models as product_models
 from ...shipping import models
 from ...shipping.interface import ShippingMethodData
@@ -152,8 +153,8 @@ class ShippingMethodType(ChannelContextTypeWithMetadataForObjectType):
         description="Tax class assigned to this shipping method.",
         required=False,
         permissions=[
-            CheckoutPermissions.MANAGE_TAXES,
-            ShippingPermissions.MANAGE_SHIPPING,
+            AuthorizationFilters.AUTHENTICATED_STAFF_USER,
+            AuthorizationFilters.AUTHENTICATED_APP,
         ],
     )
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3528,6 +3528,7 @@ def order_line(order, variant):
         base_unit_price=unit_price.gross,
         undiscounted_base_unit_price=unit_price.gross,
         tax_rate=Decimal("0.23"),
+        tax_class=variant.product.tax_class,
     )
 
 


### PR DESCRIPTION
Fix tax class permissions to allow to be fetched both by staff users and apps. Before, only staff users could fetch it.

Acceptance criteria:
- [ ] `Product.taxClass` can be fetched by authenticated app and staff user (no special permissions required)
- [ ] `ProductType.taxClass`  - as above
- [ ] `ShippingMethod.taxClass` - as above
- [ ] `OrderLine.taxClass` - as above.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
