### PR TITLE
Fix incorrect tax calculation in Order and Checkout total calculations

### DIFF
--- a/saleor/tax/calculations/checkout.py
+++ b/saleor/tax/calculations/checkout.py
@@ -80,6 +80,7 @@ def update_checkout_prices_with_flat_rates(
     subtotal = sum(
         [line_info.line.total_price for line_info in lines], zero_taxed_money(currency)
     )
+    subtotal = quantize_price(subtotal, currency)
     checkout.subtotal = subtotal
     checkout.total = subtotal + shipping_price
 
@@ -117,7 +118,7 @@ def calculate_checkout_line_total(
         prices_entered_with_tax,
     )
     quantity = checkout_line_info.line.quantity
-    return quantize_price(unit_taxed_price * quantity, unit_taxed_price.currency)
+    return unit_taxed_price * quantity
 
 
 def _calculate_checkout_line_unit_price(

--- a/saleor/tax/calculations/order.py
+++ b/saleor/tax/calculations/order.py
@@ -65,7 +65,9 @@ def update_order_prices_with_flat_rates(
     order.shipping_tax_rate = normalize_tax_rate_for_db(shipping_tax_rate)
 
     # Calculate order total.
-    order.undiscounted_total = undiscounted_subtotal + order.base_shipping_price
+    order.undiscounted_total = quantize_price(
+        undiscounted_subtotal + order.base_shipping_price, order.currency
+    )
     order.total = _calculate_order_total(order, lines)
 
 
@@ -179,10 +181,9 @@ def update_taxes_for_order_lines(
         line.unit_price = quantize_price(unit_price, currency)
         line.undiscounted_unit_price = quantize_price(undiscounted_unit_price, currency)
 
-        line.total_price = quantize_price(unit_price * line.quantity, currency)
-        line.undiscounted_total_price = quantize_price(
-            undiscounted_unit_price * line.quantity, currency
-        )
+        line.total_price = unit_price * line.quantity
+        line.undiscounted_total_price = undiscounted_unit_price * line.quantity
+
         line.tax_rate = normalize_tax_rate_for_db(tax_rate)
 
     return lines, undiscounted_subtotal

--- a/saleor/tax/tests/test_order_calculations.py
+++ b/saleor/tax/tests/test_order_calculations.py
@@ -459,9 +459,7 @@ def test_update_taxes_for_order_lines(order_with_lines):
         )
         assert line.undiscounted_unit_price == line.unit_price
         assert line.total_price == TaxedMoney(
-            net=quantize_price(
-                line.base_unit_price / Decimal("1.23") * line.quantity, currency
-            ),
+            net=line.base_unit_price / Decimal("1.23") * line.quantity,
             gross=line.base_unit_price * line.quantity,
         )
         assert line.undiscounted_total_price == line.total_price
@@ -526,14 +524,12 @@ def test_update_taxes_for_order_lines_voucher_on_entire_order(
             gross=line.base_unit_price,
         )
         assert line.total_price == TaxedMoney(
-            net=quantize_price(unit_gross / Decimal("1.23") * line.quantity, currency),
-            gross=quantize_price(unit_gross * line.quantity, currency),
+            net=unit_gross / Decimal("1.23") * line.quantity,
+            gross=unit_gross * line.quantity,
         )
         assert line.undiscounted_total_price == TaxedMoney(
-            net=quantize_price(
-                line.base_unit_price / Decimal("1.23") * line.quantity, currency
-            ),
-            gross=quantize_price(line.base_unit_price * line.quantity, currency),
+            net=line.base_unit_price / Decimal("1.23") * line.quantity,
+            gross=line.base_unit_price * line.quantity,
         )
         assert line.tax_rate == (line.unit_price.tax / line.unit_price.net).quantize(
             Decimal(".001")
@@ -587,9 +583,7 @@ def test_update_taxes_for_order_lines_voucher_on_shipping(
         )
         assert line.undiscounted_unit_price == line.unit_price
         assert line.total_price == TaxedMoney(
-            net=quantize_price(
-                line.base_unit_price / Decimal("1.23") * line.quantity, currency
-            ),
+            net=line.base_unit_price / Decimal("1.23") * line.quantity,
             gross=line.base_unit_price * line.quantity,
         )
         assert line.undiscounted_total_price == line.total_price


### PR DESCRIPTION
I want to merge this change because it fixes an issue with lines price rounding when applying taxes.

See the following issue https://github.com/saleor/saleor/issues/12348 for a more detailed description

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
