### PR TITLE
Add acceptance criteria to feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,62 @@
----
-name: Feature request
-about: Suggest an idea for this project
-title: ''
-labels: Feature request
-assignees: ''
 
----
+## Problem
+<!-- Describe what you are trying to achive. You can include proposed solution.  -->
 
-### What I'm trying to achieve
-…
 
-### Describe a proposed solution
-...
+___
 
-### Other solutions I've tried and won't work
-…
+## 1. General Assumptions
+<!--   -->
 
-### Screenshots or mockups
-<!-- Please provide any illustrations that could help others understand the problem or the proposed solution. -->
+### Acceptance Criteria 
+<!-- Conditions that a feature must satisfy to be approved by QA
+Examples:  
+- Functional use case:
+  - Permissions: Object/Field must be fetched by authenticated app and staff user (with `MANAGE_ORDERS') 
+  - All `Checkout`, `Order` mutations should work with both new and old field (id, token) 
+  - Error should be handled according to new policy 'policy_name' 
+- Non-functional use case 
+  - X objects can be updated in one mutation
+-->
+
+- [ ] 
+- [ ] 
+
+ 
+## 2. API changes
+### Mutations
+```
+```
+### Types
+```
+```
+
+## 3. Database changes
+<!-- New models or changes in existing models  -->
+
+
+## 4. UML diagrams
+<!-- You can render UML diagrams using [Mermaid](https://mermaidjs.github.io/). For example, this will produce a sequence diagram: -->
+```mermaid
+```
+
+## 5. To Do list
+<!-- 
+Everything from developer perspective
+e.g.: 
+- add models
+- migrations
+ -->
+- [ ] 
+- [ ] 
+- [ ] 
+
+## 6. To Test
+<!-- 
+Put here additional info of what it would be good to check along with new changes.
+e.g.: 
+- Check feature with all tax systems 
+- Test with overrode prices
+ -->
+- [ ] 
+- [ ] 


### PR DESCRIPTION
I want to merge this change because I want to introduce acceptance criteria in Saleor task

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
