### PR TITLE
Fix slug validation and generation for Attribute create

### DIFF
--- a/saleor/graphql/attribute/mutations/mixins.py
+++ b/saleor/graphql/attribute/mutations/mixins.py
@@ -121,7 +121,8 @@ class AttributeMixin:
     @classmethod
     def check_values_are_unique(cls, values_input: dict, attribute: models.Attribute):
         # Check values uniqueness in case of creating new attribute.
-        existing_names = attribute.values.values_list("slug", flat=True)
+        existing_names = attribute.values.values_list("name", flat=True)
+        existing_names = [name.lower().strip() for name in existing_names]
         for value_data in values_input:
             name = unidecode(value_data["name"]).lower().strip()
             if name in existing_names:

--- a/saleor/graphql/attribute/mutations/mixins.py
+++ b/saleor/graphql/attribute/mutations/mixins.py
@@ -43,10 +43,11 @@ class AttributeMixin:
             )
 
         is_swatch_attr = attribute_input_type == AttributeInputType.SWATCH
-        values_list = list(attribute.values.values_list("slug", flat=True))
+
+        slug_list = list(attribute.values.values_list("slug", flat=True))
 
         for value_data in values_input:
-            cls._validate_value(attribute, value_data, is_swatch_attr, values_list)
+            cls._validate_value(attribute, value_data, is_swatch_attr, slug_list)
 
         cls.check_values_are_unique(values_input, attribute)
 
@@ -56,7 +57,7 @@ class AttributeMixin:
         attribute: models.Attribute,
         value_data: dict,
         is_swatch_attr: bool,
-        values_list: list,
+        slug_list: list,
     ):
         """Validate the new attribute value."""
         value = value_data.get("name")
@@ -75,9 +76,9 @@ class AttributeMixin:
         else:
             cls.validate_non_swatch_attr_value(value_data)
 
-        slug_value = prepare_unique_slug(slugify(unidecode(value)), values_list)
+        slug_value = prepare_unique_slug(slugify(unidecode(value)), slug_list)
         value_data["slug"] = slug_value
-        values_list.append(slug_value)
+        slug_list.append(slug_value)
 
         attribute_value = models.AttributeValue(**value_data, attribute=attribute)
         try:
@@ -120,10 +121,10 @@ class AttributeMixin:
     @classmethod
     def check_values_are_unique(cls, values_input: dict, attribute: models.Attribute):
         # Check values uniqueness in case of creating new attribute.
-        existing_values = attribute.values.values_list("slug", flat=True)
+        existing_names = attribute.values.values_list("slug", flat=True)
         for value_data in values_input:
-            slug = slugify(unidecode(value_data["name"]))
-            if slug in existing_values:
+            name = unidecode(value_data["name"]).lower().strip()
+            if name in existing_names:
                 msg = (
                     f'Value {value_data["name"]} already exists within this attribute.'
                 )

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
@@ -597,6 +597,12 @@ def test_update_attribute_slug_and_name(
             "Provided values are not unique.",
             AttributeErrorCode.UNIQUE,
         ),
+        (
+            "Red color ",
+            "Red color",
+            "Provided values are not unique.",
+            AttributeErrorCode.UNIQUE,
+        ),
     ),
 )
 def test_update_attribute_and_add_attribute_values_errors(

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
@@ -672,7 +672,9 @@ def test_update_attribute_and_remove_others_attribute_value(
 
 
 def test_update_attribute_name_similar_value(
-    staff_api_client, attribute_without_values, permission_manage_product_types_and_attributes
+    staff_api_client,
+    attribute_without_values,
+    permission_manage_product_types_and_attributes,
 ):
     # given
     query = UPDATE_ATTRIBUTE_MUTATION
@@ -681,9 +683,7 @@ def test_update_attribute_name_similar_value(
     name = "1.5"
     node_id = graphene.Node.to_global_id("Attribute", attribute.id)
     variables = {
-        "input": {
-            "addValues": [{"name": name}],
-            "removeValues": []},
+        "input": {"addValues": [{"name": name}], "removeValues": []},
         "id": node_id,
     }
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
@@ -7,7 +7,7 @@ from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
 from .....attribute.error_codes import AttributeErrorCode
-from .....attribute.models import Attribute
+from .....attribute.models import Attribute, AttributeValue
 from .....core.utils.json_serializer import CustomJsonEncoder
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
@@ -669,3 +669,35 @@ def test_update_attribute_and_remove_others_attribute_value(
     assert errors
     assert errors[0]["field"] == "removeValues"
     assert errors[0]["code"] == AttributeErrorCode.INVALID.name
+
+
+def test_update_attribute_name_similar_value(
+    staff_api_client, attribute_without_values, permission_manage_product_types_and_attributes
+):
+    # given
+    query = UPDATE_ATTRIBUTE_MUTATION
+    attribute = attribute_without_values
+    AttributeValue.objects.create(attribute=attribute, name="15", slug="15")
+    name = "1.5"
+    node_id = graphene.Node.to_global_id("Attribute", attribute.id)
+    variables = {
+        "input": {
+            "addValues": [{"name": name}],
+            "removeValues": []},
+        "id": node_id,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    attribute.refresh_from_db()
+    data = content["data"]["attributeUpdate"]
+    assert len(data["errors"]) == 0
+    values_edges = data["attribute"]["choices"]["edges"]
+    assert len(values_edges) == 2
+    slugs = [node["node"]["slug"] for node in values_edges]
+    assert set(slugs) == {"15", "15-2"}

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -2144,7 +2144,7 @@ def test_query_product_media_sorting_asc(
     media = content["data"]["product"]["media"]
     _, media1 = graphene.Node.from_global_id(media[0]["id"])
     _, media2 = graphene.Node.from_global_id(media[1]["id"])
-    assert media1 < media2
+    assert int(media1) < int(media2)
 
 
 def test_query_product_media_sorting_desc(
@@ -2169,7 +2169,7 @@ def test_query_product_media_sorting_desc(
     media = content["data"]["product"]["media"]
     _, media1 = graphene.Node.from_global_id(media[0]["id"])
     _, media2 = graphene.Node.from_global_id(media[1]["id"])
-    assert media1 > media2
+    assert int(media1) > int(media2)
 
 
 def test_query_product_media_sorting_default(


### PR DESCRIPTION
I want to merge this change because it fixes a problem where creating Attribute with two similar values returned ValidationError when it shouldn't. 

Example valid input that was raising error: 
```{
  "input": {
    "availableInGrid": true,
    "entityType": null,
    "filterableInDashboard": true,
    "filterableInStorefront": true,
    "inputType": "DROPDOWN",
    "name": "test",
    "slug": "test",
    "storefrontSearchPosition": null,
    "type": "PRODUCT_TYPE",
    "valueRequired": true,
    "visibleInStorefront": true,
    "values": [
      {
        "name": "1.5"
      },
      {
        "name": "15"
      }
    ]
  }
}
```

Acceptance criteria: 
- Mutation with given input works properly and creates Attribute with given values.
- Adding values with similar names (the ones that would have the same result when they are slugified) would result in generating a unique slug for all the values. 
- Names that are different only by upper/lower case or spaces are not allowed.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
