### PR TITLE
[Support for payment apps] Fix incorrect payload returned by mutations for  field `data`

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1694,7 +1694,7 @@ class PaymentGatewayInitialize(TransactionSessionBase):
             app_identifier = identifier
             payment_gateway_response = payment_gateways_response_dict.get(identifier)
             if payment_gateway_response:
-                data = payment_gateway_response.data
+                response_data = payment_gateway_response.data
                 errors = []
                 if payment_gateway_response.error:
                     code = common_types.PaymentGatewayConfigErrorCode.INVALID.value
@@ -1707,7 +1707,7 @@ class PaymentGatewayInitialize(TransactionSessionBase):
                     ]
 
             else:
-                data = None
+                response_data = None
                 code = common_types.PaymentGatewayConfigErrorCode.NOT_FOUND.value
                 msg = (
                     "Active app with `HANDLE_PAYMENT` permissions or "
@@ -1720,8 +1720,11 @@ class PaymentGatewayInitialize(TransactionSessionBase):
                         "code": code,
                     }
                 ]
+            data_to_return = response_data.get("data") if response_data else None
             response.append(
-                PaymentGatewayConfig(id=app_identifier, data=data, errors=errors)
+                PaymentGatewayConfig(
+                    id=app_identifier, data=data_to_return, errors=errors
+                )
             )
         return response
 

--- a/saleor/graphql/payment/tests/mutations/test_payment_gateway_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_payment_gateway_initialize.py
@@ -53,9 +53,12 @@ def test_for_checkout_without_payment_gateways(
     checkout = checkout_info.checkout
     expected_app_identifier = "app.id"
     expected_data = {"json": "data"}
+    expected_response = {"data": expected_data}
 
     mocked_initialize.return_value = [
-        PaymentGatewayData(app_identifier=expected_app_identifier, data=expected_data)
+        PaymentGatewayData(
+            app_identifier=expected_app_identifier, data=expected_response
+        )
     ]
 
     variables = {"id": to_global_id_or_none(checkout), "paymentGateways": None}
@@ -87,9 +90,12 @@ def test_for_order_without_payment_gateways(
     order = order_with_lines
     expected_app_identifier = "app.id"
     expected_data = {"json": "data"}
+    expected_response = {"data": expected_data}
 
     mocked_initialize.return_value = [
-        PaymentGatewayData(app_identifier=expected_app_identifier, data=expected_data)
+        PaymentGatewayData(
+            app_identifier=expected_app_identifier, data=expected_response
+        )
     ]
 
     variables = {"id": to_global_id_or_none(order), "paymentGateways": None}
@@ -128,9 +134,12 @@ def test_for_checkout_with_payment_gateways(
     expected_app_identifier = "app.id"
     expected_data = {"json": "data"}
     expected_input_data = {"input": "json"}
+    expected_response = {"data": expected_data}
 
     mocked_initialize.return_value = [
-        PaymentGatewayData(app_identifier=expected_app_identifier, data=expected_data)
+        PaymentGatewayData(
+            app_identifier=expected_app_identifier, data=expected_response
+        )
     ]
 
     variables = {
@@ -177,9 +186,12 @@ def test_for_order_with_payment_gateways(
     expected_app_identifier = "app.id"
     expected_data = {"json": "data"}
     expected_input_data = {"input": "json"}
+    expected_response = {"data": expected_data}
 
     mocked_initialize.return_value = [
-        PaymentGatewayData(app_identifier=expected_app_identifier, data=expected_data)
+        PaymentGatewayData(
+            app_identifier=expected_app_identifier, data=expected_response
+        )
     ]
 
     variables = {
@@ -225,11 +237,14 @@ def test_for_checkout_with_payment_gateways_and_amount(
     checkout = checkout_with_prices
     expected_app_identifier = "app.id"
     expected_data = {"json": "data"}
+    expected_response = {"data": expected_data}
     expected_input_data = {"input": "json"}
     excpected_amount = Decimal(30)
 
     mocked_initialize.return_value = [
-        PaymentGatewayData(app_identifier=expected_app_identifier, data=expected_data)
+        PaymentGatewayData(
+            app_identifier=expected_app_identifier, data=expected_response
+        )
     ]
 
     variables = {
@@ -276,10 +291,13 @@ def test_for_order_with_payment_gateways_and_amount(
     order = order_with_lines
     expected_app_identifier = "app.id"
     expected_data = {"json": "data"}
+    expected_response = {"data": expected_data}
     expected_input_data = {"input": "json"}
     excpected_amount = Decimal(30)
     mocked_initialize.return_value = [
-        PaymentGatewayData(app_identifier=expected_app_identifier, data=expected_data)
+        PaymentGatewayData(
+            app_identifier=expected_app_identifier, data=expected_response
+        )
     ]
     variables = {
         "id": to_global_id_or_none(order),
@@ -556,6 +574,7 @@ def test_for_checkout_with_multiple_payment_gateways(
     excpected_amount = Decimal(30)
     first_expected_app_identifier = "app.id"
     first_expected_data = {"json": "data"}
+    first_expected_response = {"data": first_expected_data}
     first_expected_input_data = {"input": "json"}
 
     second_expected_input_data = {"input": "json2"}
@@ -571,7 +590,7 @@ def test_for_checkout_with_multiple_payment_gateways(
 
     mocked_initialize.return_value = [
         PaymentGatewayData(
-            app_identifier=first_expected_app_identifier, data=first_expected_data
+            app_identifier=first_expected_app_identifier, data=first_expected_response
         ),
         PaymentGatewayData(
             app_identifier=second_expected_app_identifier, error=second_error_msg
@@ -662,6 +681,7 @@ def test_for_order_with_multiple_payment_gateways(
     excpected_amount = Decimal(30)
     first_expected_app_identifier = "app.id"
     first_expected_data = {"json": "data"}
+    first_expected_response = {"data": first_expected_data}
     first_expected_input_data = {"input": "json"}
 
     second_expected_input_data = {"input": "json2"}
@@ -677,7 +697,7 @@ def test_for_order_with_multiple_payment_gateways(
 
     mocked_initialize.return_value = [
         PaymentGatewayData(
-            app_identifier=first_expected_app_identifier, data=first_expected_data
+            app_identifier=first_expected_app_identifier, data=first_expected_response
         ),
         PaymentGatewayData(
             app_identifier=second_expected_app_identifier, error=second_error_msg

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -28,6 +28,7 @@ mutation TransactionProcess(
     id: $id
     data: $data
   ) {
+    data
     transaction {
       id
       authorizedAmount {
@@ -89,9 +90,11 @@ def _assert_fields(
     charged_value=Decimal(0),
     charge_pending_value=Decimal(0),
     authorize_pending_value=Decimal(0),
+    returned_data=None,
 ):
     assert not content["data"]["transactionProcess"]["errors"]
     response_data = content["data"]["transactionProcess"]
+    assert response_data["data"] == returned_data
     transaction_data = response_data["transaction"]
     transaction = source_object.payment_transactions.last()
     assert transaction
@@ -200,6 +203,7 @@ def test_for_checkout_without_data(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
+    del expected_response["data"]
     mocked_process.return_value = PaymentGatewayData(
         app_identifier=expected_app_identifier, data=expected_response
     )
@@ -221,6 +225,7 @@ def test_for_checkout_without_data(
         app_identifier=webhook_app.identifier,
         mocked_process=mocked_process,
         charged_value=expected_amount,
+        returned_data=None,
     )
     assert checkout.charge_status == CheckoutChargeStatus.PARTIAL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.PARTIAL
@@ -256,6 +261,7 @@ def test_for_order_without_data(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
+    del expected_response["data"]
     mocked_process.return_value = PaymentGatewayData(
         app_identifier=expected_app_identifier, data=expected_response
     )
@@ -276,6 +282,7 @@ def test_for_order_without_data(
         app_identifier=webhook_app.identifier,
         mocked_process=mocked_process,
         charged_value=expected_amount,
+        returned_data=None,
     )
 
 
@@ -333,6 +340,7 @@ def test_for_checkout_with_data(
         mocked_process=mocked_process,
         charged_value=expected_amount,
         data=expected_data,
+        returned_data=expected_response["data"],
     )
     assert checkout.charge_status == CheckoutChargeStatus.PARTIAL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.PARTIAL
@@ -390,6 +398,7 @@ def test_for_order_with_data(
         mocked_process=mocked_process,
         charged_value=expected_amount,
         data=expected_data,
+        returned_data=expected_response["data"],
     )
 
 
@@ -447,6 +456,7 @@ def test_checkout_with_pending_amount(
         mocked_process=mocked_process,
         charge_pending_value=expected_amount,
         request_event_include_in_calculations=True,
+        returned_data=expected_response["data"],
     )
     assert checkout.charge_status == CheckoutChargeStatus.PARTIAL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.PARTIAL
@@ -503,6 +513,7 @@ def test_order_with_pending_amount(
         mocked_process=mocked_process,
         charge_pending_value=expected_amount,
         request_event_include_in_calculations=True,
+        returned_data=expected_response["data"],
     )
 
 
@@ -558,6 +569,7 @@ def test_checkout_with_action_required_response(
         response_event_type=TransactionEventType.CHARGE_ACTION_REQUIRED,
         app_identifier=webhook_app.identifier,
         mocked_process=mocked_process,
+        returned_data=expected_response["data"],
     )
     assert checkout.charge_status == CheckoutChargeStatus.NONE
     assert checkout.authorize_status == CheckoutAuthorizeStatus.NONE
@@ -612,6 +624,7 @@ def test_order_with_action_required_response(
         response_event_type=TransactionEventType.CHARGE_ACTION_REQUIRED,
         app_identifier=webhook_app.identifier,
         mocked_process=mocked_process,
+        returned_data=expected_response["data"],
     )
 
 

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1371,16 +1371,17 @@ def handle_transaction_initialize_session(
     )
     response = manager.transaction_initialize_session(session_data)
 
-    data = response.data if response else None
+    response_data = response.data if response else None
 
     created_event = create_transaction_event_for_transaction_session(
         request_event,
         app,
-        transaction_webhook_response=data,
+        transaction_webhook_response=response_data,
         manager=manager,
         discounts=discounts,
     )
-    return created_event.transaction, created_event, data
+    data_to_return = response_data.get("data") if response_data else None
+    return created_event.transaction, created_event, data_to_return
 
 
 def handle_transaction_process_session(
@@ -1406,13 +1407,14 @@ def handle_transaction_process_session(
 
     response = manager.transaction_process_session(session_data)
 
-    data = response.data if response else None
+    response_data = response.data if response else None
 
     created_event = create_transaction_event_for_transaction_session(
         request_event,
         app,
-        transaction_webhook_response=data,
+        transaction_webhook_response=response_data,
         manager=manager,
         discounts=discounts,
     )
-    return created_event, data
+    data_to_return = response_data.get("data") if response_data else None
+    return created_event, data_to_return


### PR DESCRIPTION
I want to merge this change because it fixes the incorrect response that mutations were returning for `data` field.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
