### PR TITLE
Change `requiredSaleorVersion` prerelease policy

### DIFF
--- a/saleor/app/manifest_validations.py
+++ b/saleor/app/manifest_validations.py
@@ -32,6 +32,7 @@ class RequiredSaleorVersionSpec(NpmSpec):
     class Parser(NpmSpec.Parser):
         @classmethod
         def range(cls, operator, target):
+            # change prerelease policy from `same-patch` to `natural`
             return Range(operator, target, prerelease_policy=Range.PRERELEASE_NATURAL)
 
 

--- a/saleor/app/manifest_validations.py
+++ b/saleor/app/manifest_validations.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Value
 from django.db.models.functions import Concat
 from semantic_version import NpmSpec, Version
+from semantic_version.base import Range
 
 from .. import __version__
 from ..graphql.core.utils import str_to_enum
@@ -25,6 +26,13 @@ from .validators import AppURLValidator
 logger = logging.getLogger(__name__)
 
 T_ERRORS = Dict[str, List[ValidationError]]
+
+
+class RequiredSaleorVersionSpec(NpmSpec):
+    class Parser(NpmSpec.Parser):
+        @classmethod
+        def range(cls, operator, target):
+            return Range(operator, target, prerelease_policy=Range.PRERELEASE_NATURAL)
 
 
 def _clean_app_url(url):
@@ -319,7 +327,7 @@ def clean_required_saleor_version(
     if not required_version:
         return None
     try:
-        spec = NpmSpec(required_version)
+        spec = RequiredSaleorVersionSpec(required_version)
     except Exception:
         msg = "Incorrect value for required Saleor version."
         raise ValidationError(msg, code=AppErrorCode.INVALID.value)

--- a/saleor/app/tests/test_validators.py
+++ b/saleor/app/tests/test_validators.py
@@ -36,6 +36,7 @@ def test_parse_version():
         ("^3.12.0-0 <=3.14", "3.12.0-a", True),
         ("^3.12", "4.0.0", False),
         ("^3.12", "3.12.0-a", False),
+        ("^3.12", "3.13.0-a", True),
     ],
 )
 def test_clean_required_saleor_version(required_version, version, satisfied):


### PR DESCRIPTION
I want to merge this change because it changes how Saleor's prerelease versions are treated if an app in the manifest provides the `requiredSaleorVersion` range. 
For example, if the required Saleor version is: `^3.11`, it will be met by Saleor versions greater or equal to `3.11.0` but also prereleases of the subsequent minor versions like `3.12.0-a`. This wasn't a case previously and would require explicitly adding a prerelease version to App's manifest, for example: `^3.11 || ~3.12.0-0`. Therefore, the required version validator prerelease policy is changed from "same-patch" to "natural", which better fits Saleor and apps development and release cycle.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
