### PR TITLE
Configure send_webhook_request_sync json decoder

### DIFF
--- a/saleor/plugins/webhook/conftest.py
+++ b/saleor/plugins/webhook/conftest.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 
 from ...webhook.event_types import WebhookEventSyncType
@@ -10,10 +12,10 @@ def tax_line_data_response():
     return {
         "id": "1234",
         "currency": "PLN",
-        "unit_net_amount": 12.34,
-        "unit_gross_amount": 12.34,
-        "total_gross_amount": 12.34,
-        "total_net_amount": 12.34,
+        "unit_net_amount": Decimal("12.34"),
+        "unit_gross_amount": Decimal("12.34"),
+        "total_gross_amount": Decimal("12.34"),
+        "total_net_amount": Decimal("12.34"),
         "tax_rate": 23,
     }
 
@@ -22,12 +24,12 @@ def tax_line_data_response():
 def tax_data_response(tax_line_data_response):
     return {
         "currency": "PLN",
-        "total_net_amount": 12.34,
-        "total_gross_amount": 12.34,
-        "subtotal_net_amount": 12.34,
-        "subtotal_gross_amount": 12.34,
-        "shipping_price_gross_amount": 12.34,
-        "shipping_price_net_amount": 12.34,
+        "total_net_amount": Decimal("12.34"),
+        "total_gross_amount": Decimal("12.34"),
+        "subtotal_net_amount": Decimal("12.34"),
+        "subtotal_gross_amount": Decimal("12.34"),
+        "shipping_price_gross_amount": Decimal("12.34"),
+        "shipping_price_net_amount": Decimal("12.34"),
         "shipping_tax_rate": 23,
         "lines": [tax_line_data_response] * 5,
     }

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any, DefaultDict, List, Optional, Set, Union
 
 import graphene
@@ -1432,7 +1433,7 @@ class WebhookPlugin(BasePlugin):
         currency: Optional[str],
         checkout: Optional["Checkout"],
         previous_value,
-        **kwargs
+        **kwargs,
     ) -> List["PaymentGateway"]:
         gateways = []
         event_type = WebhookEventSyncType.PAYMENT_LIST_GATEWAYS
@@ -1543,6 +1544,7 @@ class WebhookPlugin(BasePlugin):
             checkout_info.checkout,
             self.requestor,
             self.allow_replica,
+            decoder_kwargs={"parse_float": Decimal},
         )
 
     def get_taxes_for_order(
@@ -1555,6 +1557,7 @@ class WebhookPlugin(BasePlugin):
             order,
             self.requestor,
             self.allow_replica,
+            decoder_kwargs={"parse_float": Decimal},
         )
 
     def get_shipping_methods_for_checkout(

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -255,6 +255,7 @@ def trigger_all_webhooks_sync(
     subscribable_object=None,
     requestor=None,
     allow_replica=True,
+    decoder_kwargs={},
 ) -> Optional[R]:
     """Send all synchronous webhook request for given event type.
 
@@ -293,7 +294,9 @@ def trigger_all_webhooks_sync(
                 webhook=webhook,
             )
 
-        response_data = send_webhook_request_sync(webhook.app.name, delivery)
+        response_data = send_webhook_request_sync(
+            webhook.app.name, delivery, decoder_kwargs=decoder_kwargs
+        )
         if parsed_response := parse_response(response_data):
             return parsed_response
     return None
@@ -568,7 +571,7 @@ def send_webhook_request_async(self, event_delivery_id):
 
 
 def send_webhook_request_sync(
-    app_name, delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT
+    app_name, delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT, decoder_kwargs={}
 ) -> Optional[Dict[Any, Any]]:
     event_payload = delivery.payload
     data = event_payload.payload
@@ -604,7 +607,7 @@ def send_webhook_request_sync(
                 timeout=timeout,
                 custom_headers=webhook.custom_headers,
             )
-            response_data = json.loads(response.content)
+            response_data = json.loads(response.content, **decoder_kwargs)
 
     except JSONDecodeError as e:
         logger.info(

--- a/saleor/plugins/webhook/tests/test_tax_webhook.py
+++ b/saleor/plugins/webhook/tests/test_tax_webhook.py
@@ -63,7 +63,9 @@ def test_get_taxes_for_order(
     assert delivery.event_type == WebhookEventSyncType.ORDER_CALCULATE_TAXES
     assert delivery.payload == payload
     assert delivery.webhook == tax_order_webhook
-    mock_request.assert_called_once_with(tax_order_webhook.app.name, delivery)
+    mock_request.assert_called_once_with(
+        tax_order_webhook.app.name, delivery, decoder_kwargs={}
+    )
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)
 
@@ -181,7 +183,7 @@ def test_get_taxes_for_order_with_sync_subscription(
     assert delivery.event_type == WebhookEventSyncType.ORDER_CALCULATE_TAXES
     assert delivery.payload == payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook.app.name, delivery)
+    mock_request.assert_called_once_with(webhook.app.name, delivery, decoder_kwargs={})
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)
 
@@ -222,6 +224,6 @@ def test_get_taxes_for_checkout_with_sync_subscription(
     assert delivery.event_type == WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
     assert delivery.payload == payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook.app.name, delivery)
+    mock_request.assert_called_once_with(webhook.app.name, delivery, decoder_kwargs={})
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)


### PR DESCRIPTION
I want to merge this change because it fixes: #12280

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
