### PR TITLE
Publish schema.graphql on release

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -2,8 +2,10 @@
   "github": {
     "release": true,
     "draft": true,
-    "releaseName": "${version}"
+    "releaseName": "${version}",
+    "assets": ["saleor/graphql/schema.graphql"]
   },
+
   "npm": {
     "publish": false
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Create order discounts for all voucher types - #12272 by @IKarbowiak
 - Core now supports Dev Containers for local development - #12391 by @patrys
 - Use mailhog smtp server on Dev Container - #12402 by @carlosa54
+- Publish schema.graphql on releases - #12431 by @maarcingebala
 
 ### Saleor Apps
 


### PR DESCRIPTION
With this change, whenever a new release comes out, the `schema.graphql` file will be automatically uploaded to the release assets. This will make the latest schema available for other tools, such as API reference generator. Example from my tests in another repo:
<img width="745" alt="image" src="https://user-images.githubusercontent.com/5421321/228226862-97397f5c-48f4-4344-b973-e45cca94902e.png">


# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
