### PR TITLE
Validate positive value of weight fields directly in `WeightScalar` object.

### DIFF
--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -90,6 +90,8 @@ class WeightScalar(graphene.Scalar):
             weight = WeightScalar.parse_decimal(node.value)
         if weight is None:
             raise GraphQLError(f"Unsupported value: {node.value}")
+        if weight.value < 0:
+            raise GraphQLError(f"Negative weight value: {weight}")
         return weight
 
     @staticmethod

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -58,20 +58,21 @@ class JSON(GenericScalar):
     @staticmethod
     def parse_literal(node):
         if not isinstance(node, ast.ObjectValue):
-            raise GraphQLError("JSON scalar needs to recieve a correct JSON structure.")
+            raise GraphQLError("JSON scalar needs to receive a correct JSON structure.")
         return node
 
 
 class WeightScalar(graphene.Scalar):
     @staticmethod
     def parse_value(value):
-        weight = None
         if isinstance(value, dict):
             weight = Weight(**{value["unit"]: value["value"]})
         else:
             weight = WeightScalar.parse_decimal(value)
         if weight is None:
             raise GraphQLError(f"Unsupported value: {value}")
+        if weight.value < 0:
+            raise GraphQLError(f"Negative weight value: {weight}")
         return weight
 
     @staticmethod
@@ -83,7 +84,6 @@ class WeightScalar(graphene.Scalar):
 
     @staticmethod
     def parse_literal(node):
-        weight = None
         if isinstance(node, ast.ObjectValue):
             weight = WeightScalar.parse_literal_object(node)
         else:

--- a/saleor/graphql/product/mutations/product/product_create.py
+++ b/saleor/graphql/product/mutations/product/product_create.py
@@ -158,17 +158,6 @@ class ProductCreate(ModelMutation):
             clean_editor_js(description, to_string=True) if description else ""
         )
 
-        weight = cleaned_input.get("weight")
-        if weight and weight.value < 0:
-            raise ValidationError(
-                {
-                    "weight": ValidationError(
-                        "Product can't have negative weight.",
-                        code=ProductErrorCode.INVALID.value,
-                    )
-                }
-            )
-
         # Attributes are provided as list of `AttributeValueInput` objects.
         # We need to transform them into the format they're stored in the
         # `Product` model, which is HStore field that maps attribute's PK to

--- a/saleor/graphql/product/mutations/product_type/product_type_create.py
+++ b/saleor/graphql/product/mutations/product_type/product_type_create.py
@@ -98,17 +98,6 @@ class ProductTypeCreate(ModelMutation):
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
         cleaned_input["kind"] = cls.clean_product_kind(instance, cleaned_input)
 
-        weight = cleaned_input.get("weight")
-        if weight and weight.value < 0:
-            raise ValidationError(
-                {
-                    "weight": ValidationError(
-                        "Product type can't have negative weight.",
-                        code=ProductErrorCode.INVALID.value,
-                    )
-                }
-            )
-
         try:
             cleaned_input = validate_slug_and_generate_if_needed(
                 instance, "name", cleaned_input

--- a/saleor/graphql/product/mutations/product_variant/product_variant_create.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_create.py
@@ -183,18 +183,6 @@ class ProductVariantCreate(ModelMutation):
         **kwargs,
     ):
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
-
-        weight = cleaned_input.get("weight")
-        if weight and weight.value < 0:
-            raise ValidationError(
-                {
-                    "weight": ValidationError(
-                        "Product variant can't have negative weight.",
-                        code=ProductErrorCode.INVALID.value,
-                    )
-                }
-            )
-
         quantity_limit_per_customer = cleaned_input.get("quantity_limit_per_customer")
         if quantity_limit_per_customer is not None and quantity_limit_per_customer < 1:
             raise ValidationError(

--- a/saleor/graphql/product/tests/mutations/test_product_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_create.py
@@ -19,6 +19,7 @@ from .....plugins.manager import PluginsManager
 from .....product.error_codes import ProductErrorCode
 from .....product.models import Product
 from .....tests.utils import dummy_editorjs
+from ....tests.utils import assert_graphql_error_with_message
 
 CREATE_PRODUCT_MUTATION = """
        mutation createProduct(
@@ -883,13 +884,12 @@ def test_create_product_with_negative_weight(
     }
 
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
     )
-    content = get_graphql_content(response)
-    data = content["data"]["productCreate"]
-    error = data["errors"][0]
-    assert error["field"] == "weight"
-    assert error["code"] == ProductErrorCode.INVALID.name
+    assert_graphql_error_with_message(response, "Negative weight value: -1")
 
 
 def test_create_product_with_unicode_in_slug_and_name(

--- a/saleor/graphql/product/tests/mutations/test_product_type_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_type_create.py
@@ -6,7 +6,7 @@ import pytest
 from .....attribute import AttributeType
 from .....product.error_codes import ProductErrorCode
 from .....product.models import ProductType
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_graphql_error_with_message, get_graphql_content
 from ...enums import ProductTypeKindEnum
 
 PRODUCT_TYPE_CREATE_MUTATION = """
@@ -474,13 +474,12 @@ def test_create_product_type_create_with_negative_weight(
         "type": ProductTypeKindEnum.NORMAL.name,
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[permission_manage_product_types_and_attributes],
+        check_no_permissions=False,
     )
-    content = get_graphql_content(response)
-    data = content["data"]["productTypeCreate"]
-    error = data["errors"][0]
-    assert error["field"] == "weight"
-    assert error["code"] == ProductErrorCode.INVALID.name
+    assert_graphql_error_with_message(response, "Negative weight value: -1.1")
 
 
 def test_product_type_create_mutation_not_valid_attributes(

--- a/saleor/graphql/product/tests/mutations/test_product_type_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_type_update.py
@@ -5,7 +5,7 @@ import pytest
 
 from .....product.error_codes import ProductErrorCode
 from .....product.models import ProductType
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_graphql_error_with_message, get_graphql_content
 from ...enums import ProductTypeKindEnum
 
 PRODUCT_TYPE_UPDATE_MUTATION = """
@@ -327,14 +327,12 @@ def test_update_product_type_with_negative_weight(
     node_id = graphene.Node.to_global_id("ProductType", product_type.id)
     variables = {"id": node_id, "weight": "-1"}
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[permission_manage_product_types_and_attributes],
+        check_no_permissions=False,
     )
-    content = get_graphql_content(response)
-    product_type.refresh_from_db()
-    data = content["data"]["productTypeUpdate"]
-    error = data["errors"][0]
-    assert error["field"] == "weight"
-    assert error["code"] == ProductErrorCode.INVALID.name
+    assert_graphql_error_with_message(response, "Negative weight value: -1")
 
 
 def test_update_product_type_kind(

--- a/saleor/graphql/product/tests/mutations/test_product_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_update.py
@@ -18,6 +18,7 @@ from .....plugins.manager import PluginsManager
 from .....product.error_codes import ProductErrorCode
 from .....product.models import Product
 from ....attribute.utils import AttributeInputErrors
+from ....tests.utils import assert_graphql_error_with_message
 
 MUTATION_UPDATE_PRODUCT = """
     mutation updateProduct($productId: ID!, $input: ProductInput!) {
@@ -1876,13 +1877,12 @@ def test_update_product_with_negative_weight(
     variables = {"productId": product_id, "weight": -1}
 
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
     )
-    content = get_graphql_content(response)
-    data = content["data"]["productUpdate"]
-    error = data["errors"][0]
-    assert error["field"] == "weight"
-    assert error["code"] == ProductErrorCode.INVALID.name
+    assert_graphql_error_with_message(response, "Negative weight value: -1")
 
 
 UPDATE_PRODUCT = """

--- a/saleor/graphql/product/tests/mutations/test_product_variant_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_create.py
@@ -12,7 +12,7 @@ from freezegun import freeze_time
 from .....product.error_codes import ProductErrorCode
 from .....tests.utils import dummy_editorjs, flush_post_commit_hooks
 from ....core.enums import WeightUnitsEnum
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_graphql_error_with_message, get_graphql_content
 
 CREATE_VARIANT_MUTATION = """
       mutation createVariant ($input: ProductVariantCreateInput!) {
@@ -1208,13 +1208,12 @@ def test_create_product_variant_with_negative_weight(
         }
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_products]
+        query,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
     )
-    content = get_graphql_content(response)
-    data = content["data"]["productVariantCreate"]
-    error = data["errors"][0]
-    assert error["field"] == "weight"
-    assert error["code"] == ProductErrorCode.INVALID.name
+    assert_graphql_error_with_message(response, "Negative weight value: -1")
 
 
 def test_create_product_variant_required_without_attributes(

--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -513,20 +513,6 @@ class ShippingPriceMixin:
         min_weight = cleaned_input.get("minimum_order_weight")
         max_weight = cleaned_input.get("maximum_order_weight")
 
-        if min_weight and min_weight.value < 0:
-            errors["minimum_order_weight"] = ValidationError(
-                "Shipping can't have negative weight.",
-                code=ShippingErrorCode.INVALID.value,
-            )
-        if max_weight and max_weight.value < 0:
-            errors["maximum_order_weight"] = ValidationError(
-                "Shipping can't have negative weight.",
-                code=ShippingErrorCode.INVALID.value,
-            )
-
-        if errors:
-            return
-
         if (
             min_weight is not None
             and max_weight is not None

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_create.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_create.py
@@ -13,7 +13,7 @@ from .....tests.utils import dummy_editorjs
 from .....webhook.event_types import WebhookEventAsyncType
 from .....webhook.payloads import generate_meta, generate_requestor
 from ....core.enums import WeightUnitsEnum
-from ....tests.utils import get_graphql_content
+from ....tests.utils import assert_graphql_error_with_message, get_graphql_content
 from ...types import PostalCodeRuleInclusionTypeEnum, ShippingMethodTypeEnum
 
 PRICE_BASED_SHIPPING_MUTATION = """
@@ -471,12 +471,9 @@ def test_create_shipping_method_with_negative_min_weight(
         WEIGHT_BASED_SHIPPING_MUTATION,
         variables,
         permissions=[permission_manage_shipping],
+        check_no_permissions=False,
     )
-    content = get_graphql_content(response)
-    data = content["data"]["shippingPriceCreate"]
-    error = data["errors"][0]
-    assert error["field"] == "minimumOrderWeight"
-    assert error["code"] == ShippingErrorCode.INVALID.name
+    assert_graphql_error_with_message(response, "Negative weight value: -20")
 
 
 def test_create_shipping_method_with_negative_max_weight(
@@ -493,9 +490,6 @@ def test_create_shipping_method_with_negative_max_weight(
         WEIGHT_BASED_SHIPPING_MUTATION,
         variables,
         permissions=[permission_manage_shipping],
+        check_no_permissions=False,
     )
-    content = get_graphql_content(response)
-    data = content["data"]["shippingPriceCreate"]
-    error = data["errors"][0]
-    assert error["field"] == "maximumOrderWeight"
-    assert error["code"] == ShippingErrorCode.INVALID.name
+    assert_graphql_error_with_message(response, "Negative weight value: -15")


### PR DESCRIPTION
I want to merge this change because I want to move validation of positive weight value, directly to `WeightScalar` object, instead of every single mutation, containing weight field.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
