### PR TITLE
Fix sort-input object types `direction` field descriptions

### DIFF
--- a/saleor/graphql/core/types/sort_input.py
+++ b/saleor/graphql/core/types/sort_input.py
@@ -1,3 +1,5 @@
+import copy
+
 import graphene
 from graphene.types.inputobjecttype import InputObjectTypeOptions
 
@@ -14,7 +16,7 @@ class SortInputObjectType(BaseInputObjectType):
     direction = graphene.Argument(
         OrderDirection,
         required=True,
-        description="Specifies the direction in which to sort products.",
+        description="Specifies the direction in which to sort.",
     )
 
     class Meta:
@@ -30,13 +32,17 @@ class SortInputObjectType(BaseInputObjectType):
             _meta.sort_enum = sort_enum
 
         super().__init_subclass_with_meta__(container, _meta, **options)
-        if sort_enum and type_name:
-            field = graphene.Argument(
-                sort_enum,
-                required=True,
-                description=f"Sort {type_name} by the selected field.",
-            )
-            cls._meta.fields.update({"field": field})
+        if type_name:
+            field = copy.copy(cls._meta.fields["direction"])
+            field.description = f"Specifies the direction in which to sort {type_name}."
+            cls._meta.fields["direction"] = field
+            if sort_enum and "field" not in cls._meta.fields:
+                field = graphene.Argument(
+                    sort_enum,
+                    required=True,
+                    description=f"Sort {type_name} by the selected field.",
+                )
+                cls._meta.fields.update({"field": field})
 
 
 class ChannelSortInputObjectType(SortInputObjectType):

--- a/saleor/graphql/product/sorters.py
+++ b/saleor/graphql/product/sorters.py
@@ -271,6 +271,7 @@ class ProductOrder(ChannelSortInputObjectType):
     class Meta:
         doc_category = DOC_CATEGORY_PRODUCTS
         sort_enum = ProductOrderField
+        type_name = "products"
 
 
 class ProductVariantSortField(BaseEnum):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2995,7 +2995,7 @@ type EventDeliveryAttempt implements Node @doc(category: "Webhooks") {
 }
 
 input EventDeliveryAttemptSortingInput @doc(category: "Webhooks") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort attempts."""
   direction: OrderDirection!
 
   """Sort attempts by the selected field."""
@@ -3016,7 +3016,7 @@ enum EventDeliveryAttemptSortField @doc(category: "Webhooks") {
 }
 
 input EventDeliverySortingInput @doc(category: "Webhooks") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort deliveries."""
   direction: OrderDirection!
 
   """Sort deliveries by the selected field."""
@@ -5787,7 +5787,7 @@ value as specified by
 scalar Date
 
 input AttributeChoicesSortingInput @doc(category: "Attributes") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort attribute choices."""
   direction: OrderDirection!
 
   """Sort attribute choices by the selected field."""
@@ -7069,7 +7069,7 @@ type Margin @doc(category: "Products") {
 }
 
 input MediaSortingInput @doc(category: "Products") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort media."""
   direction: OrderDirection!
 
   """Sort media by the selected field."""
@@ -7294,7 +7294,7 @@ input WarehouseFilterInput @doc(category: "Products") {
 }
 
 input WarehouseSortingInput @doc(category: "Products") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort warehouses."""
   direction: OrderDirection!
 
   """Sort warehouses by the selected field."""
@@ -8503,7 +8503,7 @@ type TaxClassCountableEdge {
 }
 
 input TaxClassSortingInput @doc(category: "Taxes") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort tax classes."""
   direction: OrderDirection!
 
   """Sort tax classes by the selected field."""
@@ -11513,7 +11513,7 @@ input CategoryFilterInput @doc(category: "Products") {
 }
 
 input CategorySortingInput @doc(category: "Products") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort categories."""
   direction: OrderDirection!
 
   """
@@ -11559,7 +11559,7 @@ enum CollectionPublished @doc(category: "Products") {
 }
 
 input CollectionSortingInput @doc(category: "Products") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort collections."""
   direction: OrderDirection!
 
   """
@@ -11623,7 +11623,7 @@ enum ProductTypeEnum @doc(category: "Products") {
 }
 
 input ProductTypeSortingInput @doc(category: "Products") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort product types."""
   direction: OrderDirection!
 
   """Sort product types by the selected field."""
@@ -11650,7 +11650,7 @@ input ProductVariantFilterInput @doc(category: "Products") {
 }
 
 input ProductVariantSortingInput @doc(category: "Products") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort productVariants."""
   direction: OrderDirection!
 
   """Sort productVariants by the selected field."""
@@ -11707,7 +11707,7 @@ type PageCountableEdge {
 }
 
 input PageSortingInput @doc(category: "Pages") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort pages."""
   direction: OrderDirection!
 
   """Sort pages by the selected field."""
@@ -11779,7 +11779,7 @@ type PageTypeCountableEdge {
 }
 
 input PageTypeSortingInput @doc(category: "Pages") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort page types."""
   direction: OrderDirection!
 
   """Sort page types by the selected field."""
@@ -11817,7 +11817,7 @@ type OrderEventCountableEdge {
 }
 
 input OrderSortingInput @doc(category: "Orders") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort orders."""
   direction: OrderDirection!
 
   """Sort orders by the selected field."""
@@ -11916,7 +11916,7 @@ type MenuCountableEdge {
 }
 
 input MenuSortingInput {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort menus."""
   direction: OrderDirection!
 
   """Sort menus by the selected field."""
@@ -11956,7 +11956,7 @@ type MenuItemCountableEdge {
 }
 
 input MenuItemSortingInput {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort menu items."""
   direction: OrderDirection!
 
   """Sort menu items by the selected field."""
@@ -11974,7 +11974,7 @@ input MenuItemFilterInput {
 }
 
 input GiftCardSortingInput @doc(category: "Gift cards") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort gift cards."""
   direction: OrderDirection!
 
   """Sort gift cards by the selected field."""
@@ -12126,7 +12126,7 @@ enum PluginConfigurationType {
 }
 
 input PluginSortingInput {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort plugins."""
   direction: OrderDirection!
 
   """Sort plugins by the selected field."""
@@ -12171,7 +12171,7 @@ enum DiscountStatusEnum @doc(category: "Discounts") {
 }
 
 input SaleSortingInput @doc(category: "Discounts") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort sales."""
   direction: OrderDirection!
 
   """
@@ -12246,7 +12246,7 @@ enum VoucherDiscountType @doc(category: "Discounts") {
 }
 
 input VoucherSortingInput @doc(category: "Discounts") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort vouchers."""
   direction: OrderDirection!
 
   """
@@ -12377,7 +12377,7 @@ input ExportFileFilterInput {
 }
 
 input ExportFileSortingInput {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort export file."""
   direction: OrderDirection!
 
   """Sort export file by the selected field."""
@@ -12392,7 +12392,7 @@ enum ExportFileSortField {
 }
 
 input CheckoutSortingInput @doc(category: "Checkout") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort checkouts."""
   direction: OrderDirection!
 
   """Sort checkouts by the selected field."""
@@ -12439,7 +12439,7 @@ type CheckoutLineCountableEdge {
 }
 
 input AttributeSortingInput @doc(category: "Attributes") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort attributes."""
   direction: OrderDirection!
 
   """Sort attributes by the selected field."""
@@ -12520,7 +12520,7 @@ input AppFilterInput @doc(category: "Apps") {
 }
 
 input AppSortingInput @doc(category: "Apps") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort apps."""
   direction: OrderDirection!
 
   """Sort apps by the selected field."""
@@ -12617,7 +12617,7 @@ input CustomerFilterInput @doc(category: "Users") {
 }
 
 input UserSortingInput @doc(category: "Users") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort users."""
   direction: OrderDirection!
 
   """Sort users by the selected field."""
@@ -12667,7 +12667,7 @@ input PermissionGroupFilterInput @doc(category: "Users") {
 }
 
 input PermissionGroupSortingInput @doc(category: "Users") {
-  """Specifies the direction in which to sort products."""
+  """Specifies the direction in which to sort permission group."""
   direction: OrderDirection!
 
   """Sort permission group by the selected field."""


### PR DESCRIPTION
I want to merge this change because it fixes descriptions of the `direction` field for all sort-input object types based on `SortInputObjectType`. Previously all had the same description: "Specifies the direction in which to sort **products.**"

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
