### PR TITLE
Use mailpit in Dev Container

### DIFF
--- a/.devcontainer/backend.env
+++ b/.devcontainer/backend.env
@@ -3,5 +3,5 @@ DASHBOARD_URL=http://localhost:9000/
 DEFAULT_FROM_EMAIL=noreply@example.com
 CELERY_BROKER_URL=redis://redis:6379/1
 SECRET_KEY=changeme
-# Mailhog
-EMAIL_URL=smtp://mailhog:1025
+# Mailpit
+EMAIL_URL=smtp://mailpit:1025

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "forwardPorts": [
     8000,
     "dashboard:9000",
-    "mailhog:8025"
+    "mailpit:8025"
   ],
   "portsAttributes": {
     "8000": {
@@ -15,8 +15,8 @@
     "dashboard:9000": {
         "label": "Saleor Dashboard"
     },
-    "mailhog:8025": {
-      "label": "Mailhog UI"
+    "mailpit:8025": {
+      "label": "Mailpit UI"
     }
   },
   "postCreateCommand": "python manage.py migrate",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -50,11 +50,11 @@ services:
     volumes:
       - ..:/app
 
-  mailhog:
-    image: mailhog/mailhog
+  mailpit:
+    image: axllent/mailpit
     ports:
       - "1025" # SMTP Server
-      - "8025" # Mailhog UI
+      - "8025" # Mailpit UI
     restart: unless-stopped
 
 volumes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Use mailhog smtp server on Dev Container - #12402 by @carlosa54
 - Publish schema.graphql on releases - #12431 by @maarcingebala
 - Fix missing webhook triggers for `order_updated` and `order_fully_paid` when an order is paid with a `transactionItem` - #12508 by @korycins
+- Remove mailhog in favor of mailpit - #12447 by @carlosa54
 
 ### Saleor Apps
 


### PR DESCRIPTION
I want to merge this change because it replaces mailhog with mailpit.

I recently pushed https://github.com/saleor/saleor/pull/12402 for Mailhog support in the Dev Container setup with a workaround for `arm64` users since the mailhog docker image don't have support for it. I was going to add a new issue in the Mailhog repo but realized that the project seem unmaintained.

Found a well maintained alternative [Mailpit](https://github.com/axllent/mailpit) that was inspired by `Mailhog` and started using it and it works pretty nice. It also has a docker image that supports multiple archs so no need to emulate

### Screenshots
<img width="1728" alt="mailpit" src="https://user-images.githubusercontent.com/4250593/229318555-e87f3424-3d00-4aa2-a5de-d808d0186050.png">



<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
