### PR TITLE
Use up-to-date link to Pillow docs

### DIFF
--- a/saleor/thumbnail/__init__.py
+++ b/saleor/thumbnail/__init__.py
@@ -19,8 +19,8 @@ class ThumbnailFormat:
 
 
 # PIL-supported file formats as found here:
-# https://infohost.nmt.edu/tcc/help/pubs/pil/formats.html
-# {mime type: PIL Identifier}
+# https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
+# Dict structure: {<mime-type>: <PIL-identifier>}
 MIME_TYPE_TO_PIL_IDENTIFIER = {
     "image/avif": "AVIF",
     "image/bmp": "BMP",


### PR DESCRIPTION
This changes a link that was pointing to PIL docs instead of Pillow docs. The previous link is or was not working (host unreachable), PIL is no longer maintained since 2011 we should thus refer to Pillow docs.

Original link: https://web.archive.org/web/20190331063244/https://infohost.nmt.edu/tcc/help/pubs/pil/formats.html

