### PR TITLE
Move invoices to Orders API reference category

### DIFF
--- a/saleor/graphql/core/doc_category.py
+++ b/saleor/graphql/core/doc_category.py
@@ -35,6 +35,8 @@ DOC_CATEGORY_MAP = {
     "discount.VoucherChannelListing": DOC_CATEGORY_DISCOUNTS,
     "discount.Voucher": DOC_CATEGORY_DISCOUNTS,
     "discount.OrderDiscount": DOC_CATEGORY_DISCOUNTS,
+    "invoice.Invoice": DOC_CATEGORY_ORDERS,
+    "invoice.InvoiceEvent": DOC_CATEGORY_ORDERS,
     "giftcard.GiftCard": DOC_CATEGORY_GIFT_CARDS,
     "giftcard.GiftCardTag": DOC_CATEGORY_GIFT_CARDS,
     "giftcard.GiftEvent": DOC_CATEGORY_GIFT_CARDS,

--- a/saleor/graphql/core/enums.py
+++ b/saleor/graphql/core/enums.py
@@ -198,6 +198,7 @@ OrderErrorCode = graphene.Enum.from_enum(order_error_codes.OrderErrorCode)
 OrderErrorCode.doc_category = DOC_CATEGORY_ORDERS
 
 InvoiceErrorCode = graphene.Enum.from_enum(invoice_error_codes.InvoiceErrorCode)
+InvoiceErrorCode.doc_category = DOC_CATEGORY_ORDERS
 
 PageErrorCode = graphene.Enum.from_enum(page_error_codes.PageErrorCode)
 PageErrorCode.doc_category = DOC_CATEGORY_PAGES

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -331,6 +331,9 @@ class OrderError(Error):
 class InvoiceError(Error):
     code = InvoiceErrorCode(description="The error code.", required=True)
 
+    class Meta:
+        doc_category = DOC_CATEGORY_ORDERS
+
 
 class PermissionGroupError(Error):
     code = PermissionGroupErrorCode(description="The error code.", required=True)

--- a/saleor/graphql/invoice/mutations.py
+++ b/saleor/graphql/invoice/mutations.py
@@ -12,8 +12,9 @@ from ...order import events as order_events
 from ...permission.enums import OrderPermissions
 from ..app.dataloaders import get_app_promise
 from ..core import ResolveInfo
+from ..core.doc_category import DOC_CATEGORY_ORDERS
 from ..core.mutations import ModelDeleteMutation, ModelMutation
-from ..core.types import InvoiceError
+from ..core.types import BaseInputObjectType, InvoiceError
 from ..order.types import Order
 from ..plugins.dataloaders import get_plugin_manager_promise
 from .types import Invoice
@@ -109,9 +110,12 @@ class InvoiceRequest(ModelMutation):
         return InvoiceRequest(invoice=invoice, order=order)
 
 
-class InvoiceCreateInput(graphene.InputObjectType):
+class InvoiceCreateInput(BaseInputObjectType):
     number = graphene.String(required=True, description="Invoice number.")
     url = graphene.String(required=True, description="URL of an invoice to download.")
+
+    class Meta:
+        doc_category = DOC_CATEGORY_ORDERS
 
 
 class InvoiceCreate(ModelMutation):
@@ -247,9 +251,12 @@ class InvoiceDelete(ModelDeleteMutation):
         return response
 
 
-class UpdateInvoiceInput(graphene.InputObjectType):
+class UpdateInvoiceInput(BaseInputObjectType):
     number = graphene.String(description="Invoice number")
     url = graphene.String(description="URL of an invoice to download.")
+
+    class Meta:
+        doc_category = DOC_CATEGORY_ORDERS
 
 
 class InvoiceUpdate(ModelMutation):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10484,7 +10484,7 @@ enum OrderAction @doc(category: "Payments") {
 }
 
 """Represents an Invoice."""
-type Invoice implements ObjectWithMetadata & Job & Node {
+type Invoice implements ObjectWithMetadata & Job & Node @doc(category: "Orders") {
   """List of private metadata items. Requires staff permissions to access."""
   privateMetadata: [MetadataItem!]!
 
@@ -14958,7 +14958,7 @@ type Mutation {
 
     """ID of the order related to invoice."""
     orderId: ID!
-  ): InvoiceRequest
+  ): InvoiceRequest @doc(category: "Orders")
 
   """
   Requests deletion of an invoice. 
@@ -14968,7 +14968,7 @@ type Mutation {
   invoiceRequestDelete(
     """ID of an invoice to request the deletion."""
     id: ID!
-  ): InvoiceRequestDelete
+  ): InvoiceRequestDelete @doc(category: "Orders")
 
   """
   Creates a ready to send invoice. 
@@ -14981,7 +14981,7 @@ type Mutation {
 
     """ID of the order related to invoice."""
     orderId: ID!
-  ): InvoiceCreate
+  ): InvoiceCreate @doc(category: "Orders")
 
   """
   Deletes an invoice. 
@@ -14991,7 +14991,7 @@ type Mutation {
   invoiceDelete(
     """ID of an invoice to delete."""
     id: ID!
-  ): InvoiceDelete
+  ): InvoiceDelete @doc(category: "Orders")
 
   """
   Updates an invoice. 
@@ -15004,7 +15004,7 @@ type Mutation {
 
     """Fields to use when updating an invoice."""
     input: UpdateInvoiceInput!
-  ): InvoiceUpdate
+  ): InvoiceUpdate @doc(category: "Orders")
 
   """
   Send an invoice notification to the customer. 
@@ -15014,7 +15014,7 @@ type Mutation {
   invoiceSendNotification(
     """ID of an invoice to be sent."""
     id: ID!
-  ): InvoiceSendNotification
+  ): InvoiceSendNotification @doc(category: "Orders")
 
   """
   Activate a gift card. 
@@ -22498,7 +22498,7 @@ Request an invoice for the order using plugin.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
-type InvoiceRequest {
+type InvoiceRequest @doc(category: "Orders") {
   """Order related to an invoice."""
   order: Order
   invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
@@ -22506,7 +22506,7 @@ type InvoiceRequest {
   invoice: Invoice
 }
 
-type InvoiceError {
+type InvoiceError @doc(category: "Orders") {
   """
   Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
   """
@@ -22520,7 +22520,7 @@ type InvoiceError {
 }
 
 """An enumeration."""
-enum InvoiceErrorCode {
+enum InvoiceErrorCode @doc(category: "Orders") {
   REQUIRED
   NOT_READY
   URL_NOT_SET
@@ -22536,7 +22536,7 @@ Requests deletion of an invoice.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
-type InvoiceRequestDelete {
+type InvoiceRequestDelete @doc(category: "Orders") {
   invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
@@ -22547,13 +22547,13 @@ Creates a ready to send invoice.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
-type InvoiceCreate {
+type InvoiceCreate @doc(category: "Orders") {
   invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
 
-input InvoiceCreateInput {
+input InvoiceCreateInput @doc(category: "Orders") {
   """Invoice number."""
   number: String!
 
@@ -22566,7 +22566,7 @@ Deletes an invoice.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
-type InvoiceDelete {
+type InvoiceDelete @doc(category: "Orders") {
   invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
@@ -22577,13 +22577,13 @@ Updates an invoice.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
-type InvoiceUpdate {
+type InvoiceUpdate @doc(category: "Orders") {
   invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
 
-input UpdateInvoiceInput {
+input UpdateInvoiceInput @doc(category: "Orders") {
   """Invoice number"""
   number: String
 
@@ -22596,7 +22596,7 @@ Send an invoice notification to the customer.
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
-type InvoiceSendNotification {
+type InvoiceSendNotification @doc(category: "Orders") {
   invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
@@ -27364,7 +27364,7 @@ Added in Saleor 3.2.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
-type InvoiceRequested implements Event {
+type InvoiceRequested implements Event @doc(category: "Orders") {
   """Time of the event."""
   issuedAt: DateTime
 
@@ -27395,7 +27395,7 @@ Added in Saleor 3.2.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
-type InvoiceDeleted implements Event {
+type InvoiceDeleted implements Event @doc(category: "Orders") {
   """Time of the event."""
   issuedAt: DateTime
 
@@ -27426,7 +27426,7 @@ Added in Saleor 3.2.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
-type InvoiceSent implements Event {
+type InvoiceSent implements Event @doc(category: "Orders") {
   """Time of the event."""
   issuedAt: DateTime
 


### PR DESCRIPTION
Change doc_category for invoice-related types to "Orders".

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
