### PR TITLE
Fix deadlock in order events celery migrations task

### DIFF
--- a/saleor/order/migrations/tasks/saleor3_13.py
+++ b/saleor/order/migrations/tasks/saleor3_13.py
@@ -4,7 +4,7 @@ from ...models import OrderEvent
 from django.db import transaction
 from django.db.models import QuerySet
 
-# Batch size of size 5000 is about 1MB memory usage in task
+# Batch size of size 5000 is about 3MB memory usage in task
 BATCH_SIZE = 5000
 
 

--- a/saleor/order/migrations/tasks/saleor3_13.py
+++ b/saleor/order/migrations/tasks/saleor3_13.py
@@ -17,9 +17,11 @@ def update_type_to_transaction_cancel_requested(qs: QuerySet[OrderEvent]):
 
 @app.task
 def order_events_rename_transaction_void_events_task():
-    qs = OrderEvent.objects.filter(type="transaction_void_requested").order_by("-pk")
-    ids = qs.values_list("pk", flat=True)[:BATCH_SIZE]
-    qs = qs.filter(pk__in=ids)
+    events = OrderEvent.objects.filter(type="transaction_void_requested").order_by(
+        "-pk"
+    )
+    ids = events.values_list("pk", flat=True)[:BATCH_SIZE]
+    qs = OrderEvent.objects.filter(pk__in=ids)
 
     if ids:
         update_type_to_transaction_cancel_requested(qs)
@@ -35,9 +37,11 @@ def update_type_to_transaction_charge_requested(qs: QuerySet[OrderEvent]):
 
 @app.task
 def order_events_rename_transaction_capture_events_task():
-    qs = OrderEvent.objects.filter(type="transaction_capture_requested").order_by("-pk")
-    ids = qs.values_list("pk", flat=True)[:BATCH_SIZE]
-    qs = qs.filter(pk__in=ids)
+    events = OrderEvent.objects.filter(type="transaction_capture_requested").order_by(
+        "-pk"
+    )
+    ids = events.values_list("pk", flat=True)[:BATCH_SIZE]
+    qs = OrderEvent.objects.filter(pk__in=ids)
 
     if ids:
         update_type_to_transaction_charge_requested(qs)


### PR DESCRIPTION
I want to merge this change because it fixes the issue when the migration triggered the data migration as celery tasks and there is more than one celery worker that can process the tasks. Previously there was a possibility of having a deadlock during the update, currently, we lock the batch of products.

Additionaly increase the batch size and improve query performance to decrease overall migration time.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
