### PR TITLE
Fix taxClass update zero rate

### DIFF
--- a/saleor/graphql/tax/mutations/tax_class_update.py
+++ b/saleor/graphql/tax/mutations/tax_class_update.py
@@ -109,7 +109,7 @@ class TaxClassUpdate(ModelMutation):
         for obj in to_update:
             data = input_data_by_country[obj.country]
             rate = data.get("rate")
-            if rate:
+            if rate is not None:
                 obj.rate = rate
                 updated_countries.append(obj.country.code)
         models.TaxClassCountryRate.objects.bulk_update(to_update, fields=("rate",))


### PR DESCRIPTION
I want to merge this change because it fixes the bug that occurs when TaxClass country rate is updated with 0.0 value

Port of #12505
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
