### PR TITLE
Add integration tests for channel permissions

### DIFF
--- a/saleor/graphql/account/mutations/permission_group.py
+++ b/saleor/graphql/account/mutations/permission_group.py
@@ -270,13 +270,12 @@ class PermissionGroupUpdate(PermissionGroupCreate):
     def _save_m2m(cls, info: ResolveInfo, instance, cleaned_data):
         with traced_atomic_transaction():
             super()._save_m2m(info, instance, cleaned_data)
-            with traced_atomic_transaction():
-                if remove_users := cleaned_data.get("remove_users"):
-                    instance.user_set.remove(*remove_users)
-                if remove_permissions := cleaned_data.get("remove_permissions"):
-                    instance.permissions.remove(*remove_permissions)
-                if remove_channels := cleaned_data.get("remove_channels"):
-                    instance.channels.remove(*remove_channels)
+            if remove_users := cleaned_data.get("remove_users"):
+                instance.user_set.remove(*remove_users)
+            if remove_permissions := cleaned_data.get("remove_permissions"):
+                instance.permissions.remove(*remove_permissions)
+            if remove_channels := cleaned_data.get("remove_channels"):
+                instance.channels.remove(*remove_channels)
 
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):

--- a/saleor/graphql/order/tests/integration/test_draft_order.py
+++ b/saleor/graphql/order/tests/integration/test_draft_order.py
@@ -1,11 +1,15 @@
 import graphene
 
 from .....order import OrderStatus
-from ....tests.utils import get_graphql_content
+from ....account.tests.test_account_permission_group import (
+    PERMISSION_GROUP_UPDATE_MUTATION,
+)
+from ....tests.utils import assert_no_permission, get_graphql_content
 from ..mutations.test_draft_order_complete import DRAFT_ORDER_COMPLETE_MUTATION
 from ..mutations.test_draft_order_create import DRAFT_ORDER_CREATE_MUTATION
 from ..mutations.test_draft_order_update import DRAFT_ORDER_UPDATE_MUTATION
 from ..mutations.test_order_lines_create import ORDER_LINES_CREATE_MUTATION
+from ..mutations.test_order_mark_as_paid import MARK_ORDER_AS_PAID_MUTATION
 from ..queries.test_order import QUERY_ORDER_BY_ID
 
 
@@ -79,3 +83,77 @@ def test_create_order_by_staff_in_accessible_channel(
     content = get_graphql_content(response)
     order_data = content["data"]["order"]
     assert order_data["status"] == OrderStatus.UNFULFILLED.upper()
+
+
+def test_user_cannot_manage_draft_order_after_loosing_the_channel_access(
+    staff_api_client,
+    permission_group_manage_orders,
+    channel_USD,
+    graphql_address_data,
+    product,
+    shipping_method,
+    superuser_api_client,
+):
+    """Ensure that staff user cannot mark order as paid after loosing the access
+    to order channel."""
+    # given
+    permission_group_manage_orders.restricted_access_to_channels = True
+    permission_group_manage_orders.save(update_fields=["restricted_access_to_channels"])
+    permission_group_manage_orders.channels.add(channel_USD)
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    variant = product.variants.first()
+
+    # when
+
+    # create draft order
+    draft_order_create_variables = {
+        "input": {
+            "userEmail": "test@example.com",
+            "billingAddress": graphql_address_data,
+            "shippingAddress": graphql_address_data,
+            "channelId": graphene.Node.to_global_id("Channel", channel_USD.id),
+            "lines": [
+                {
+                    "quantity": 1,
+                    "variantId": graphene.Node.to_global_id(
+                        "ProductVariant", variant.id
+                    ),
+                }
+            ],
+            "shippingMethod": graphene.Node.to_global_id(
+                "ShippingMethod", shipping_method.id
+            ),
+        }
+    }
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_CREATE_MUTATION, draft_order_create_variables
+    )
+
+    draft_order_id = get_graphql_content(response)["data"]["draftOrderCreate"]["order"][
+        "id"
+    ]
+
+    # complete order
+    staff_api_client.post_graphql(DRAFT_ORDER_COMPLETE_MUTATION, {"id": draft_order_id})
+
+    # update permission group - remove access to order channel
+    permission_group_update_variables = {
+        "id": graphene.Node.to_global_id("Group", permission_group_manage_orders.id),
+        "input": {
+            "restrictedAccessToChannels": True,
+            "removeChannels": [graphene.Node.to_global_id("Channel", channel_USD.id)],
+        },
+    }
+    superuser_api_client.post_graphql(
+        PERMISSION_GROUP_UPDATE_MUTATION, permission_group_update_variables
+    )
+
+    # try to mark order as paid
+    response = staff_api_client.post_graphql(
+        MARK_ORDER_AS_PAID_MUTATION, {"id": draft_order_id}
+    )
+
+    # then
+    assert_no_permission(response)

--- a/saleor/graphql/order/tests/integration/test_draft_order.py
+++ b/saleor/graphql/order/tests/integration/test_draft_order.py
@@ -1,0 +1,81 @@
+import graphene
+
+from .....order import OrderStatus
+from ....tests.utils import get_graphql_content
+from ..mutations.test_draft_order_complete import DRAFT_ORDER_COMPLETE_MUTATION
+from ..mutations.test_draft_order_create import DRAFT_ORDER_CREATE_MUTATION
+from ..mutations.test_draft_order_update import DRAFT_ORDER_UPDATE_MUTATION
+from ..mutations.test_order_lines_create import ORDER_LINES_CREATE_MUTATION
+from ..queries.test_order import QUERY_ORDER_BY_ID
+
+
+def test_create_order_by_staff_in_accessible_channel(
+    staff_api_client,
+    permission_group_manage_orders,
+    channel_PLN,
+    channel_USD,
+    product,
+    shipping_method,
+    graphql_address_data,
+):
+    """Ensure that staff user is able to create and complete the draft order
+    in the channel he has access to."""
+    # given
+    permission_group_manage_orders.restricted_access_to_channels = True
+    permission_group_manage_orders.save(update_fields=["restricted_access_to_channels"])
+    permission_group_manage_orders.channels.add(channel_USD)
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    # when
+
+    # create order
+    draft_order_create_variables = {
+        "input": {
+            "userEmail": "test@example.com",
+            "billingAddress": graphql_address_data,
+            "shippingAddress": graphql_address_data,
+            "channelId": graphene.Node.to_global_id("Channel", channel_USD.id),
+        }
+    }
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_CREATE_MUTATION, draft_order_create_variables
+    )
+
+    draft_order_id = get_graphql_content(response)["data"]["draftOrderCreate"]["order"][
+        "id"
+    ]
+
+    # add lines to order
+    variant = product.variants.first()
+    order_lines_create_variables = {
+        "orderId": draft_order_id,
+        "variantId": graphene.Node.to_global_id("ProductVariant", variant.id),
+        "quantity": 2,
+    }
+    staff_api_client.post_graphql(
+        ORDER_LINES_CREATE_MUTATION, order_lines_create_variables
+    )
+
+    # update order with available product and shipping method
+    draft_order_update_variables = {
+        "id": draft_order_id,
+        "input": {
+            "shippingMethod": graphene.Node.to_global_id(
+                "ShippingMethod", shipping_method.id
+            ),
+        },
+    }
+    staff_api_client.post_graphql(
+        DRAFT_ORDER_UPDATE_MUTATION, draft_order_update_variables
+    )
+
+    # complete order
+    staff_api_client.post_graphql(DRAFT_ORDER_COMPLETE_MUTATION, {"id": draft_order_id})
+
+    # then
+    # query created order
+    response = staff_api_client.post_graphql(QUERY_ORDER_BY_ID, {"id": draft_order_id})
+    content = get_graphql_content(response)
+    order_data = content["data"]["order"]
+    assert order_data["status"] == OrderStatus.UNFULFILLED.upper()

--- a/saleor/graphql/order/tests/integration/test_draft_order.py
+++ b/saleor/graphql/order/tests/integration/test_draft_order.py
@@ -1,4 +1,5 @@
 import graphene
+import pytest
 
 from .....order import OrderStatus
 from ....account.tests.test_account_permission_group import (
@@ -13,6 +14,7 @@ from ..mutations.test_order_mark_as_paid import MARK_ORDER_AS_PAID_MUTATION
 from ..queries.test_order import QUERY_ORDER_BY_ID
 
 
+@pytest.mark.integration
 def test_create_order_by_staff_in_accessible_channel(
     staff_api_client,
     permission_group_manage_orders,
@@ -85,6 +87,7 @@ def test_create_order_by_staff_in_accessible_channel(
     assert order_data["status"] == OrderStatus.UNFULFILLED.upper()
 
 
+@pytest.mark.integration
 def test_user_cannot_manage_draft_order_after_loosing_the_channel_access(
     staff_api_client,
     permission_group_manage_orders,

--- a/saleor/graphql/order/tests/integration/test_order.py
+++ b/saleor/graphql/order/tests/integration/test_order.py
@@ -1,0 +1,78 @@
+import graphene
+
+from ....account.tests.test_account_permission_group import (
+    PERMISSION_GROUP_UPDATE_MUTATION,
+)
+from ....tests.utils import assert_no_permission, get_graphql_content
+from ..mutations.test_fulfillment_cancel import CANCEL_FULFILLMENT_MUTATION
+from ..mutations.test_order_fulfill import ORDER_FULFILL_MUTATION
+
+
+def test_user_cannot_manage_order_after_loosing_the_channel_access(
+    staff_api_client,
+    # superuser,
+    superuser_api_client,
+    permission_group_manage_orders,
+    permission_group_all_perms_all_channels,
+    order_with_lines,
+    warehouse,
+    channel_PLN,
+):
+    """Ensure that staff user cannot cancel fulfillment after loosing the access
+    to order channel."""
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    permission_group_all_perms_all_channels.user_set.add(superuser_api_client.user)
+    order = order_with_lines
+    order_line_1, order_line_2 = order.lines.all()
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
+
+    # when
+    # fulfill order
+    fulfill_order_variables = {
+        "order": order_id,
+        "input": {
+            "lines": [
+                {
+                    "orderLineId": graphene.Node.to_global_id(
+                        "OrderLine", order_line_1.id
+                    ),
+                    "stocks": [{"quantity": 3, "warehouse": warehouse_id}],
+                },
+                {
+                    "orderLineId": graphene.Node.to_global_id(
+                        "OrderLine", order_line_2.id
+                    ),
+                    "stocks": [{"quantity": 2, "warehouse": warehouse_id}],
+                },
+            ],
+        },
+    }
+    response = staff_api_client.post_graphql(
+        ORDER_FULFILL_MUTATION, fulfill_order_variables
+    )
+    fulfillment_id = get_graphql_content(response)["data"]["orderFulfill"][
+        "fulfillments"
+    ][0]["id"]
+
+    # update permission group - remove access to order channel
+    permission_group_update_variables = {
+        "id": graphene.Node.to_global_id("Group", permission_group_manage_orders.id),
+        "input": {
+            "restrictedAccessToChannels": True,
+            "addChannels": [graphene.Node.to_global_id("Channel", channel_PLN.id)],
+        },
+    }
+    superuser_api_client.post_graphql(
+        PERMISSION_GROUP_UPDATE_MUTATION, permission_group_update_variables
+    )
+
+    # try to cancel fulfillment
+    cancel_fulfillment_variables = {"id": fulfillment_id, "warehouseId": warehouse_id}
+    response = staff_api_client.post_graphql(
+        CANCEL_FULFILLMENT_MUTATION, cancel_fulfillment_variables
+    )
+
+    # then
+    assert_no_permission(response)

--- a/saleor/graphql/order/tests/integration/test_order.py
+++ b/saleor/graphql/order/tests/integration/test_order.py
@@ -10,7 +10,6 @@ from ..mutations.test_order_fulfill import ORDER_FULFILL_MUTATION
 
 def test_user_cannot_manage_order_after_loosing_the_channel_access(
     staff_api_client,
-    # superuser,
     superuser_api_client,
     permission_group_manage_orders,
     permission_group_all_perms_all_channels,
@@ -49,6 +48,7 @@ def test_user_cannot_manage_order_after_loosing_the_channel_access(
             ],
         },
     }
+
     response = staff_api_client.post_graphql(
         ORDER_FULFILL_MUTATION, fulfill_order_variables
     )

--- a/saleor/graphql/order/tests/integration/test_order.py
+++ b/saleor/graphql/order/tests/integration/test_order.py
@@ -1,4 +1,5 @@
 import graphene
+import pytest
 
 from ....account.tests.test_account_permission_group import (
     PERMISSION_GROUP_UPDATE_MUTATION,
@@ -8,6 +9,7 @@ from ..mutations.test_fulfillment_cancel import CANCEL_FULFILLMENT_MUTATION
 from ..mutations.test_order_fulfill import ORDER_FULFILL_MUTATION
 
 
+@pytest.mark.integration
 def test_user_cannot_manage_order_after_loosing_the_channel_access(
     staff_api_client,
     superuser_api_client,

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -17,22 +17,10 @@ from ....tests.utils import assert_no_permission, get_graphql_content
 
 DRAFT_ORDER_CREATE_MUTATION = """
     mutation draftCreate(
-        $user: ID, $discount: PositiveDecimal, $lines: [OrderLineCreateInput!],
-        $shippingAddress: AddressInput, $billingAddress: AddressInput,
-        $shippingMethod: ID, $voucher: ID, $customerNote: String, $channel: ID,
-        $redirectUrl: String, $externalReference: String
+            $input: DraftOrderCreateInput!
         ) {
             draftOrderCreate(
-                input: {
-                    user: $user, discount: $discount,
-                    lines: $lines, shippingAddress: $shippingAddress,
-                    billingAddress: $billingAddress,
-                    shippingMethod: $shippingMethod, voucher: $voucher,
-                    channelId: $channel,
-                    redirectUrl: $redirectUrl,
-                    customerNote: $customerNote,
-                    externalReference: $externalReference
-                }
+                input: $input
             ) {
                 errors {
                     field
@@ -120,17 +108,19 @@ def test_draft_order_create(
     external_reference = "test-ext-ref"
 
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "lines": variant_list,
-        "billingAddress": shipping_address,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
-        "channel": channel_id,
-        "redirectUrl": redirect_url,
-        "externalReference": external_reference,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "lines": variant_list,
+            "billingAddress": shipping_address,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+            "externalReference": external_reference,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -218,13 +208,15 @@ def test_draft_order_create_by_user_no_channel_access(
     redirect_url = "https://www.example.com"
 
     variables = {
-        "user": user_id,
-        "lines": variant_list,
-        "billingAddress": shipping_address,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "channel": channel_id,
-        "redirectUrl": redirect_url,
+        "input": {
+            "user": user_id,
+            "lines": variant_list,
+            "billingAddress": shipping_address,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+        }
     }
 
     # when
@@ -264,13 +256,15 @@ def test_draft_order_create_by_app(
     redirect_url = "https://www.example.com"
 
     variables = {
-        "user": user_id,
-        "lines": variant_list,
-        "billingAddress": shipping_address,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "channel": channel_id,
-        "redirectUrl": redirect_url,
+        "input": {
+            "user": user_id,
+            "lines": variant_list,
+            "billingAddress": shipping_address,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+        }
     }
 
     # when
@@ -319,16 +313,18 @@ def test_draft_order_create_with_same_variant_and_force_new_line(
     redirect_url = "https://www.example.com"
 
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "lines": variant_list,
-        "billingAddress": shipping_address,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
-        "channel": channel_id,
-        "redirectUrl": redirect_url,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "lines": variant_list,
+            "billingAddress": shipping_address,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -421,14 +417,16 @@ def test_draft_order_create_with_inactive_channel(
     voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "lines": variant_list,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
-        "channel": channel_id,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "lines": variant_list,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+            "channelId": channel_id,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -497,16 +495,18 @@ def test_draft_order_create_without_sku(
     redirect_url = "https://www.example.com"
 
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "lines": variant_list,
-        "billingAddress": shipping_address,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
-        "channel": channel_id,
-        "redirectUrl": redirect_url,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "lines": variant_list,
+            "billingAddress": shipping_address,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -580,11 +580,13 @@ def test_draft_order_create_variant_with_0_price(
     shipping_address = graphql_address_data
     shipping_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
     variables = {
-        "user": user_id,
-        "lines": variant_list,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "channel": channel_id,
+        "input": {
+            "user": user_id,
+            "lines": variant_list,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "channelId": channel_id,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -651,14 +653,16 @@ def test_draft_order_create_tax_error(
     shipping_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
     voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "lines": variant_list,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
-        "channel": channel_id,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "lines": variant_list,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+            "channelId": channel_id,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -701,14 +705,16 @@ def test_draft_order_create_with_voucher_not_assigned_to_order_channel(
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     voucher.channel_listings.all().delete()
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "lines": variant_list,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
-        "channel": channel_id,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "lines": variant_list,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+            "channelId": channel_id,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -741,13 +747,15 @@ def test_draft_order_create_with_product_and_variant_not_assigned_to_order_chann
     variant.product.channel_listings.all().delete()
     variant.channel_listings.all().delete()
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "lines": variant_list,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "customerNote": customer_note,
-        "channel": channel_id,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "lines": variant_list,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "customerNote": customer_note,
+            "channelId": channel_id,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -781,13 +789,15 @@ def test_draft_order_create_with_variant_not_assigned_to_order_channel(
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     variant.channel_listings.all().delete()
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "lines": variant_list,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "customerNote": customer_note,
-        "channel": channel_id,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "lines": variant_list,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "customerNote": customer_note,
+            "channelId": channel_id,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -823,8 +833,10 @@ def test_draft_order_create_without_channel(
         {"variantId": variant_1_id, "quantity": 1},
     ]
     variables = {
-        "user": user_id,
-        "lines": variant_list,
+        "input": {
+            "user": user_id,
+            "lines": variant_list,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -862,9 +874,11 @@ def test_draft_order_create_with_negative_quantity_line(
         {"variantId": variant_1_id, "quantity": 1},
     ]
     variables = {
-        "user": user_id,
-        "lines": variant_list,
-        "channel": channel_id,
+        "input": {
+            "user": user_id,
+            "lines": variant_list,
+            "channelId": channel_id,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -913,14 +927,16 @@ def test_draft_order_create_with_channel_with_unpublished_product(
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "channel": channel_id,
-        "lines": variant_list,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "channelId": channel_id,
+            "lines": variant_list,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+        }
     }
 
     response = staff_api_client.post_graphql(query, variables)
@@ -972,14 +988,16 @@ def test_draft_order_create_with_channel_with_unpublished_product_by_date(
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "channel": channel_id,
-        "lines": variant_list,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "channelId": channel_id,
+            "lines": variant_list,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+        }
     }
 
     response = staff_api_client.post_graphql(query, variables)
@@ -1028,14 +1046,16 @@ def test_draft_order_create_with_channel(
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "channel": channel_id,
-        "lines": variant_list,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "channelId": channel_id,
+            "lines": variant_list,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -1099,14 +1119,16 @@ def test_draft_order_create_product_without_shipping(
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "channel": channel_id,
-        "lines": variant_list,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "channelId": channel_id,
+            "lines": variant_list,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+        }
     }
 
     # when
@@ -1176,16 +1198,18 @@ def test_draft_order_create_invalid_billing_address(
     redirect_url = "https://www.example.com"
 
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "lines": variant_list,
-        "billingAddress": billing_address,
-        "shippingAddress": graphql_address_data,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
-        "channel": channel_id,
-        "redirectUrl": redirect_url,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "lines": variant_list,
+            "billingAddress": billing_address,
+            "shippingAddress": graphql_address_data,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -1235,16 +1259,18 @@ def test_draft_order_create_invalid_shipping_address(
     redirect_url = "https://www.example.com"
 
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "lines": variant_list,
-        "billingAddress": graphql_address_data,
-        "shippingAddress": shipping_address,
-        "shippingMethod": shipping_id,
-        "voucher": voucher_id,
-        "customerNote": customer_note,
-        "channel": channel_id,
-        "redirectUrl": redirect_url,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "lines": variant_list,
+            "billingAddress": graphql_address_data,
+            "shippingAddress": shipping_address,
+            "shippingMethod": shipping_id,
+            "voucher": voucher_id,
+            "customerNote": customer_note,
+            "channelId": channel_id,
+            "redirectUrl": redirect_url,
+        }
     }
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -1296,13 +1322,15 @@ def test_draft_order_create_price_recalculation(
     voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
     channel_id = graphene.Node.to_global_id("Channel", channel_PLN.id)
     variables = {
-        "user": user_id,
-        "discount": discount,
-        "lines": lines,
-        "billingAddress": address,
-        "shippingAddress": address,
-        "voucher": voucher_id,
-        "channel": channel_id,
+        "input": {
+            "user": user_id,
+            "discount": discount,
+            "lines": lines,
+            "billingAddress": address,
+            "shippingAddress": address,
+            "voucher": voucher_id,
+            "channelId": channel_id,
+        }
     }
 
     # when
@@ -1342,10 +1370,12 @@ def test_draft_order_create_update_display_gross_prices(
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
 
     variables = {
-        "lines": variant_list,
-        "billingAddress": graphql_address_data,
-        "shippingAddress": graphql_address_data,
-        "channel": channel_id,
+        "input": {
+            "lines": variant_list,
+            "billingAddress": graphql_address_data,
+            "shippingAddress": graphql_address_data,
+            "channelId": channel_id,
+        }
     }
 
     # when
@@ -1376,7 +1406,7 @@ def test_draft_order_create_with_non_unique_external_reference(
     order.external_reference = ext_ref
     order.save(update_fields=["external_reference"])
 
-    variables = {"channel": channel_id, "externalReference": ext_ref}
+    variables = {"input": {"channelId": channel_id, "externalReference": ext_ref}}
 
     # when
     response = staff_api_client.post_graphql(query, variables)

--- a/saleor/graphql/order/tests/mutations/test_order_mark_as_paid.py
+++ b/saleor/graphql/order/tests/mutations/test_order_mark_as_paid.py
@@ -9,7 +9,7 @@ from .....order.error_codes import OrderErrorCode
 from .....payment import TransactionEventType
 from ....tests.utils import assert_no_permission, get_graphql_content
 
-MUTATION_MARK_ORDER_AS_PAID = """
+MARK_ORDER_AS_PAID_MUTATION = """
     mutation markPaid($id: ID!, $transaction: String) {
         orderMarkAsPaid(id: $id, transactionReference: $transaction) {
             errors {
@@ -37,7 +37,7 @@ def test_paid_order_mark_as_paid_with_payment(
 ):
     permission_group_manage_orders.user_set.add(staff_api_client.user)
     order = payment_txn_preauth.order
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id}
     response = staff_api_client.post_graphql(query, variables)
@@ -57,7 +57,7 @@ def test_order_mark_as_paid_with_external_reference_with_payment(
     permission_group_manage_orders.user_set.add(staff_api_client.user)
     transaction_reference = "searchable-id"
     order = order_with_lines
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
     assert not order.is_fully_paid()
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id, "transaction": transaction_reference}
@@ -98,7 +98,7 @@ def test_order_mark_as_paid_with_payment(
     channel.order_mark_as_paid_strategy = order_mark_as_paid_strategy
     channel.save(update_fields=["order_mark_as_paid_strategy"])
 
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
     assert not order.is_fully_paid()
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id}
@@ -129,14 +129,14 @@ def test_paid_order_mark_as_paid_by_user_no_channel_access(
     order.channel = channel_PLN
     order.save(update_fields=["channel"])
 
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
 
     assert not order.is_fully_paid()
 
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id}
 
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id}
 
@@ -152,7 +152,7 @@ def test_order_mark_as_paid_by_app(
 ):
     # given
     order = order_with_lines
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
     assert not order.is_fully_paid()
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id}
@@ -195,7 +195,7 @@ def test_order_mark_as_paid_no_billing_address_with_payment(
     channel.order_mark_as_paid_strategy = order_mark_as_paid_strategy
     channel.save(update_fields=["order_mark_as_paid_strategy"])
 
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id}
 
@@ -223,7 +223,7 @@ def test_draft_order_mark_as_paid_check_price_recalculation_with_payment(
     order.should_refresh_prices = True
     order.status = OrderStatus.DRAFT
     order.save()
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id}
 
@@ -255,7 +255,7 @@ def test_paid_order_mark_as_paid_with_transaction(
 
     order.payment_transactions.create(charged_value=order.total.gross.amount)
 
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id}
 
@@ -284,7 +284,7 @@ def test_order_mark_as_paid_with_external_reference_with_transaction(
     channel.save(update_fields=["order_mark_as_paid_strategy"])
 
     transaction_reference = "searchable-id"
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
     assert not order.is_fully_paid()
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id, "transaction": transaction_reference}
@@ -322,7 +322,7 @@ def test_order_mark_as_paid_with_transaction_creates_transaction_event(
     channel.order_mark_as_paid_strategy = MarkAsPaidStrategy.TRANSACTION_FLOW
     channel.save(update_fields=["order_mark_as_paid_strategy"])
 
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id}
 
@@ -361,7 +361,7 @@ def test_draft_order_mark_as_paid_check_price_recalculation_transaction(
     channel.order_mark_as_paid_strategy = MarkAsPaidStrategy.TRANSACTION_FLOW
     channel.save(update_fields=["order_mark_as_paid_strategy"])
 
-    query = MUTATION_MARK_ORDER_AS_PAID
+    query = MARK_ORDER_AS_PAID_MUTATION
     order_id = graphene.Node.to_global_id("Order", order.id)
     variables = {"id": order_id}
 

--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -1009,8 +1009,9 @@ def test_order_query_in_pln_channel(
 QUERY_ORDER_BY_ID = """
     query OrderQuery($id: ID) {
         order(id: $id) {
-            number
             id
+            number
+            status
         }
     }
 """

--- a/saleor/graphql/tests/fixtures.py
+++ b/saleor/graphql/tests/fixtures.py
@@ -192,7 +192,7 @@ def graphql_log_handler():
 
 
 @pytest.fixture
-def superuser():
+def superuser(db):
     superuser = User.objects.create_user(
         "superuser@example.com",
         "pass",

--- a/saleor/tests/utils.py
+++ b/saleor/tests/utils.py
@@ -11,9 +11,11 @@ def flush_post_commit_hooks():
     for alias in connections:
         connection = transaction.get_connection(alias)
         was_atomic = connection.in_atomic_block
+        was_commit_on_exit = connection.commit_on_exit
         connection.in_atomic_block = False
         connection.run_and_clear_commit_hooks()
         connection.in_atomic_block = was_atomic
+        connection.commit_on_exit = was_commit_on_exit
 
 
 def dummy_editorjs(text, json_format=False):


### PR DESCRIPTION
Add integration tests for channel permissions


Should not be able to mark as paid order in channel that staff user loose access to | GIVEN restricted permission group exist in the channel  (permissionGroupCreate) "group": {        "id": "R3JvdXA6MjY=",        "name": "order manager USD",        "permissions": [          {            "name": "Manage orders."          }        ],        "restrictedAccessToChannels": true,        "accessibleChannels": [          {            "slug": "default-channel"          }        ]      }AND new staff user has been assigned to this group (staffUpdate / permissionGroupUpdate)WHEN staff user run draftOrderCreate for accessibleChannelAND staff user run draftOrderCompleteAND admin change accessibleChannels for "order manager USD" group (remove "default-channel") AND staff user tries to run orderMarkAsPaidTHEN error should be raised
-- | --
Should not be able to cancel fulfilment for order in channel that staff user loose access to | GIVEN permission group exist "restrictedAccessToChannels": false,AND staff user is assigned to this group (staffUpdate / permissionGroupUpdate)AND order in "default-chanel" exist in saleor in status UNFULFILLEDWHEN sfatt user run orderFulfillAND admin change "restrictedAccessToChannels": true, addChannels: chanel-pln for groupAND staff user tries to run orderFulfillmentCancelTHEN error should be raised
Should be able to create order in the accessibleChannels | GIVEN restricted permission group exist in the channel  (permissionGroupCreate) "group": {        "id": "R3JvdXA6MjY=",        "name": "order manager USD",        "permissions": [          {            "name": "Manage orders."          }        ],        "restrictedAccessToChannels": true,        "accessibleChannels": [          {            "slug": "default-channel"          }        ]      }And new staff user has been assigned to this group (staffUpdate / permissionGroupUpdate)WHEN user run draftOrderCreate for accessibleChannelAND run draftOrderUpdate with available products and shipping methodAND run draftOrderCompleteTHEN order should be created in status UNFULFILLED



<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
