### PR TITLE
Drop preview label for stable changes

### DIFF
--- a/saleor/graphql/account/mutations/authentication.py
+++ b/saleor/graphql/account/mutations/authentication.py
@@ -27,7 +27,7 @@ from ....core.jwt import (
 from ....permission.auth_filters import AuthorizationFilters
 from ....permission.enums import get_permissions_from_names
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_38, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_38
 from ...core.doc_category import DOC_CATEGORY_AUTH
 from ...core.fields import JSONString
 from ...core.mutations import BaseMutation
@@ -90,7 +90,7 @@ class CreateToken(BaseMutation):
             required=False,
             description=(
                 "The audience that will be included to JWT tokens with "
-                "prefix `custom:`." + ADDED_IN_38 + PREVIEW_FEATURE
+                "prefix `custom:`." + ADDED_IN_38
             ),
         )
 

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -5,7 +5,7 @@ from ...permission.auth_filters import AuthorizationFilters
 from ...permission.enums import AppPermission
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
-from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_31
 from ..core.doc_category import DOC_CATEGORY_APPS
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.types import FilterInputObjectType, NonNullList
@@ -98,7 +98,7 @@ class AppQueries(graphene.ObjectType):
         filter=AppExtensionFilterInput(
             description="Filtering options for apps extensions."
         ),
-        description="List of all extensions." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="List of all extensions." + ADDED_IN_31,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_STAFF_USER,
             AuthorizationFilters.AUTHENTICATED_APP,
@@ -110,7 +110,7 @@ class AppQueries(graphene.ObjectType):
         id=graphene.Argument(
             graphene.ID, description="ID of the app extension.", required=True
         ),
-        description="Look up an app extension by ID." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="Look up an app extension by ID." + ADDED_IN_31,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_STAFF_USER,
             AuthorizationFilters.AUTHENTICATED_APP,

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -243,14 +243,13 @@ class Manifest(BaseObjectType):
     extensions = NonNullList(AppManifestExtension, required=True)
     webhooks = NonNullList(
         AppManifestWebhook,
-        description="List of the app's webhooks." + ADDED_IN_35 + PREVIEW_FEATURE,
+        description="List of the app's webhooks." + ADDED_IN_35,
         required=True,
     )
     audience = graphene.String(
         description=(
             "The audience that will be included in all JWT tokens for the app."
             + ADDED_IN_38
-            + PREVIEW_FEATURE
         )
     )
     required_saleor_version = graphene.Field(
@@ -358,7 +357,7 @@ class App(ModelObjectType[models.App]):
     )
     extensions = NonNullList(
         AppExtension,
-        description="App's dashboard extensions." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="App's dashboard extensions." + ADDED_IN_31,
         required=True,
     )
 

--- a/saleor/graphql/attribute/schema.py
+++ b/saleor/graphql/attribute/schema.py
@@ -30,9 +30,7 @@ class AttributeQueries(graphene.ObjectType):
         description="List of the shop's attributes.",
         filter=AttributeFilterInput(description="Filtering options for attributes."),
         where=AttributeWhereInput(
-            description="Filtering options for attributes."
-            + ADDED_IN_311
-            + PREVIEW_FEATURE
+            description="Filtering options for attributes." + ADDED_IN_311
         ),
         search=graphene.String(
             description="Search attributes." + ADDED_IN_311 + PREVIEW_FEATURE

--- a/saleor/graphql/channel/mutations/channel_create.py
+++ b/saleor/graphql/channel/mutations/channel_create.py
@@ -96,7 +96,7 @@ class ChannelInput(BaseInputObjectType):
     is_active = graphene.Boolean(description="isActive flag.")
     stock_settings = graphene.Field(
         StockSettingsInput,
-        description=("The channel stock settings." + ADDED_IN_37 + PREVIEW_FEATURE),
+        description=("The channel stock settings." + ADDED_IN_37),
         required=False,
     )
     add_shipping_zones = NonNullList(
@@ -106,9 +106,7 @@ class ChannelInput(BaseInputObjectType):
     )
     add_warehouses = NonNullList(
         graphene.ID,
-        description="List of warehouses to assign to the channel."
-        + ADDED_IN_35
-        + PREVIEW_FEATURE,
+        description="List of warehouses to assign to the channel." + ADDED_IN_35,
         required=False,
     )
     order_settings = graphene.Field(
@@ -131,9 +129,7 @@ class ChannelCreateInput(ChannelInput):
         description=(
             "Default country for the channel. Default country can be "
             "used in checkout to determine the stock quantities or calculate taxes "
-            "when the country was not explicitly provided."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
+            "when the country was not explicitly provided." + ADDED_IN_31
         ),
         required=True,
     )

--- a/saleor/graphql/channel/mutations/channel_reorder_warehouses.py
+++ b/saleor/graphql/channel/mutations/channel_reorder_warehouses.py
@@ -8,7 +8,7 @@ from ....channel.error_codes import ChannelErrorCode
 from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import ChannelPermissions
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_37, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_37
 from ...core.doc_category import DOC_CATEGORY_CHANNELS
 from ...core.inputs import ReorderInput
 from ...core.mutations import BaseMutation
@@ -37,9 +37,7 @@ class ChannelReorderWarehouses(BaseMutation):
         )
 
     class Meta:
-        description = (
-            "Reorder the warehouses of a channel." + ADDED_IN_37 + PREVIEW_FEATURE
-        )
+        description = "Reorder the warehouses of a channel." + ADDED_IN_37
         doc_category = DOC_CATEGORY_CHANNELS
         permissions = (ChannelPermissions.MANAGE_CHANNELS,)
         error_type_class = ChannelError

--- a/saleor/graphql/channel/mutations/channel_update.py
+++ b/saleor/graphql/channel/mutations/channel_update.py
@@ -11,7 +11,7 @@ from ....shipping.tasks import (
 )
 from ...account.enums import CountryCodeEnum
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_31, ADDED_IN_35, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_31, ADDED_IN_35
 from ...core.doc_category import DOC_CATEGORY_CHANNELS
 from ...core.mutations import ModelMutation
 from ...core.types import ChannelError, NonNullList
@@ -39,9 +39,7 @@ class ChannelUpdateInput(ChannelInput):
     )
     remove_warehouses = NonNullList(
         graphene.ID,
-        description="List of warehouses to unassign from the channel."
-        + ADDED_IN_35
-        + PREVIEW_FEATURE,
+        description="List of warehouses to unassign from the channel." + ADDED_IN_35,
         required=False,
     )
 

--- a/saleor/graphql/channel/schema.py
+++ b/saleor/graphql/channel/schema.py
@@ -2,7 +2,7 @@ import graphene
 
 from ...permission.auth_filters import AuthorizationFilters
 from ..core import ResolveInfo
-from ..core.descriptions import ADDED_IN_36, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_36
 from ..core.doc_category import DOC_CATEGORY_CHANNELS
 from ..core.fields import BaseField, PermissionsField
 from ..core.types import NonNullList
@@ -26,7 +26,7 @@ class ChannelQueries(graphene.ObjectType):
         ),
         slug=graphene.Argument(
             graphene.String,
-            description="Slug of the channel." + ADDED_IN_36 + PREVIEW_FEATURE,
+            description="Slug of the channel." + ADDED_IN_36,
             required=False,
         ),
         description="Look up a channel by ID or slug.",

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -162,9 +162,7 @@ class StockSettings(ObjectType):
     )
 
     class Meta:
-        description = (
-            "Represents the channel stock settings." + ADDED_IN_37 + PREVIEW_FEATURE
-        )
+        description = "Represents the channel stock settings." + ADDED_IN_37
 
 
 class OrderSettings(ObjectType):
@@ -274,9 +272,7 @@ class Channel(ModelObjectType):
     )
     warehouses = PermissionsField(
         NonNullList(Warehouse),
-        description="List of warehouses assigned to this channel."
-        + ADDED_IN_35
-        + PREVIEW_FEATURE,
+        description="List of warehouses assigned to this channel." + ADDED_IN_35,
         required=True,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_APP,
@@ -285,23 +281,18 @@ class Channel(ModelObjectType):
     )
     countries = NonNullList(
         CountryDisplay,
-        description="List of shippable countries for the channel."
-        + ADDED_IN_36
-        + PREVIEW_FEATURE,
+        description="List of shippable countries for the channel." + ADDED_IN_36,
     )
 
     available_shipping_methods_per_country = graphene.Field(
         NonNullList("saleor.graphql.shipping.types.ShippingMethodsPerCountry"),
         countries=graphene.Argument(NonNullList(CountryCodeEnum)),
         description="Shipping methods that are available for the channel."
-        + ADDED_IN_36
-        + PREVIEW_FEATURE,
+        + ADDED_IN_36,
     )
     stock_settings = PermissionsField(
         StockSettings,
-        description=(
-            "Define the stock setting for this channel." + ADDED_IN_37 + PREVIEW_FEATURE
-        ),
+        description=("Define the stock setting for this channel." + ADDED_IN_37),
         required=True,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_APP,

--- a/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_billing_address_update.py
@@ -9,12 +9,7 @@ from ....checkout.utils import (
 from ....core.tracing import traced_atomic_transaction
 from ...account.types import AddressInput
 from ...core import ResolveInfo
-from ...core.descriptions import (
-    ADDED_IN_34,
-    ADDED_IN_35,
-    DEPRECATED_IN_3X_INPUT,
-    PREVIEW_FEATURE,
-)
+from ...core.descriptions import ADDED_IN_34, ADDED_IN_35, DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.scalars import UUID
 from ...core.types import CheckoutError
@@ -52,7 +47,6 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
             description=(
                 "The rules for changing validation for received billing address data."
                 + ADDED_IN_35
-                + PREVIEW_FEATURE
             ),
         )
 

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -20,7 +20,6 @@ from ...core.descriptions import (
     ADDED_IN_36,
     ADDED_IN_38,
     DEPRECATED_IN_3X_FIELD,
-    PREVIEW_FEATURE,
 )
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.enums import LanguageCodeEnum
@@ -107,7 +106,6 @@ class CheckoutLineInput(BaseInputObjectType):
             "with `HANDLE_CHECKOUTS` permission. When the line with the same variant "
             "will be provided multiple times, the last price will be used."
             + ADDED_IN_31
-            + PREVIEW_FEATURE
         ),
     )
     force_new_line = graphene.Boolean(
@@ -115,7 +113,7 @@ class CheckoutLineInput(BaseInputObjectType):
         default_value=False,
         description=(
             "Flag that allow force splitting the same variant into multiple lines "
-            "by skipping the matching logic. " + ADDED_IN_36 + PREVIEW_FEATURE
+            "by skipping the matching logic. " + ADDED_IN_36
         ),
     )
     metadata = NonNullList(
@@ -155,9 +153,7 @@ class CheckoutCreateInput(BaseInputObjectType):
     validation_rules = CheckoutValidationRules(
         required=False,
         description=(
-            "The checkout validation rules that can be changed."
-            + ADDED_IN_35
-            + PREVIEW_FEATURE
+            "The checkout validation rules that can be changed." + ADDED_IN_35
         ),
     )
 

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -24,12 +24,7 @@ from ....shipping import models as shipping_models
 from ....shipping.utils import convert_to_shipping_method_data
 from ....warehouse import models as warehouse_models
 from ...core import ResolveInfo
-from ...core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_34,
-    DEPRECATED_IN_3X_INPUT,
-    PREVIEW_FEATURE,
-)
+from ...core.descriptions import ADDED_IN_31, ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -64,7 +59,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
     class Meta:
         description = (
             "Updates the delivery method (shipping method or pick up point) "
-            "of the checkout." + ADDED_IN_31 + PREVIEW_FEATURE
+            "of the checkout." + ADDED_IN_31
         )
         doc_category = DOC_CATEGORY_CHECKOUT
         error_type_class = CheckoutError

--- a/saleor/graphql/checkout/mutations/checkout_lines_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_update.py
@@ -13,7 +13,6 @@ from ...core.descriptions import (
     ADDED_IN_34,
     ADDED_IN_36,
     DEPRECATED_IN_3X_INPUT,
-    PREVIEW_FEATURE,
 )
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.scalars import UUID, PositiveDecimal
@@ -51,7 +50,6 @@ class CheckoutLineUpdateInput(BaseInputObjectType):
             "with `HANDLE_CHECKOUTS` permission. When the line with the same variant "
             "will be provided multiple times, the last price will be used."
             + ADDED_IN_31
-            + PREVIEW_FEATURE
         ),
     )
     line_id = graphene.ID(

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -19,12 +19,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....warehouse.reservations import is_reservation_enabled
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
-from ...core.descriptions import (
-    ADDED_IN_34,
-    ADDED_IN_35,
-    DEPRECATED_IN_3X_INPUT,
-    PREVIEW_FEATURE,
-)
+from ...core.descriptions import ADDED_IN_34, ADDED_IN_35, DEPRECATED_IN_3X_INPUT
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -72,7 +67,6 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
             description=(
                 "The rules for changing validation for received shipping address data."
                 + ADDED_IN_35
-                + PREVIEW_FEATURE
             ),
         )
 

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -10,7 +10,7 @@ from ....discount.models import NotApplicable
 from ....permission.enums import CheckoutPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_32, ADDED_IN_38, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_32, ADDED_IN_38
 from ...core.doc_category import DOC_CATEGORY_CHECKOUT
 from ...core.mutations import BaseMutation
 from ...core.types import Error, NonNullList
@@ -78,7 +78,6 @@ class OrderCreateFromCheckout(BaseMutation):
             "Create new order from existing checkout. Requires the "
             "following permissions: AUTHENTICATED_APP and HANDLE_CHECKOUTS."
             + ADDED_IN_32
-            + PREVIEW_FEATURE
         )
         doc_category = DOC_CATEGORY_CHECKOUT
         object_type = Order

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -493,7 +493,9 @@ class Checkout(ModelObjectType[models.Checkout]):
         TransactionItem,
         description=(
             "List of transactions for the checkout. Requires one of the "
-            "following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS." + ADDED_IN_34
+            "following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS."
+            + ADDED_IN_34
+            + PREVIEW_FEATURE
         ),
     )
     display_gross_prices = graphene.Boolean(

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -360,7 +360,7 @@ class DeliveryMethod(graphene.Union):
         description = (
             "Represents a delivery method chosen for the checkout. "
             '`Warehouse` type is used when checkout is marked as "click and collect" '
-            "and `ShippingMethod` otherwise." + ADDED_IN_31 + PREVIEW_FEATURE
+            "and `ShippingMethod` otherwise." + ADDED_IN_31
         )
         types = (Warehouse, ShippingMethod)
 
@@ -409,9 +409,7 @@ class Checkout(ModelObjectType[models.Checkout]):
         Warehouse,
         required=True,
         description=(
-            "Collection points that can be used for this order."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
+            "Collection points that can be used for this order." + ADDED_IN_31
         ),
     )
     available_payment_gateways = NonNullList(
@@ -455,11 +453,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     )
     delivery_method = graphene.Field(
         DeliveryMethod,
-        description=(
-            "The delivery method selected for this checkout."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
-        ),
+        description=("The delivery method selected for this checkout." + ADDED_IN_31),
     )
     subtotal_price = graphene.Field(
         TaxedMoney,
@@ -468,9 +462,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     )
     tax_exemption = graphene.Boolean(
         description=(
-            "Returns True if checkout has to be exempt from taxes."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
+            "Returns True if checkout has to be exempt from taxes." + ADDED_IN_38
         ),
         required=True,
     )
@@ -501,15 +493,13 @@ class Checkout(ModelObjectType[models.Checkout]):
         TransactionItem,
         description=(
             "List of transactions for the checkout. Requires one of the "
-            "following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS."
-            + ADDED_IN_34
-            + PREVIEW_FEATURE
+            "following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS." + ADDED_IN_34
         ),
     )
     display_gross_prices = graphene.Boolean(
         description=(
             "Determines whether checkout prices should include taxes when displayed "
-            "in a storefront." + ADDED_IN_39 + PREVIEW_FEATURE
+            "in a storefront." + ADDED_IN_39
         ),
         required=True,
     )

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -22,12 +22,7 @@ from ...core.doc_category import (
     DOC_CATEGORY_USERS,
     DOC_CATEGORY_WEBHOOKS,
 )
-from ..descriptions import (
-    ADDED_IN_36,
-    ADDED_IN_312,
-    DEPRECATED_IN_3X_FIELD,
-    PREVIEW_FEATURE,
-)
+from ..descriptions import ADDED_IN_36, ADDED_IN_312, DEPRECATED_IN_3X_FIELD
 from ..enums import (
     AccountErrorCode,
     AppErrorCode,
@@ -775,7 +770,7 @@ class ThumbnailField(graphene.Field):
         default_value="ORIGINAL",
         description=(
             "The format of the image. When not provided, format of the original "
-            "image will be used." + ADDED_IN_36 + PREVIEW_FEATURE
+            "image will be used." + ADDED_IN_36
         ),
     )
 

--- a/saleor/graphql/csv/mutations/export_gift_cards.py
+++ b/saleor/graphql/csv/mutations/export_gift_cards.py
@@ -6,7 +6,7 @@ from ....csv.tasks import export_gift_cards_task
 from ....permission.enums import GiftcardPermissions
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_31
 from ...core.doc_category import DOC_CATEGORY_GIFT_CARDS
 from ...core.types import BaseInputObjectType, ExportError, NonNullList
 from ...giftcard.filters import GiftCardFilterInput
@@ -40,7 +40,7 @@ class ExportGiftCards(BaseExportMutation):
         )
 
     class Meta:
-        description = "Export gift cards to csv file." + ADDED_IN_31 + PREVIEW_FEATURE
+        description = "Export gift cards to csv file." + ADDED_IN_31
         doc_category = DOC_CATEGORY_GIFT_CARDS
         permissions = (GiftcardPermissions.MANAGE_GIFT_CARD,)
         error_type_class = ExportError

--- a/saleor/graphql/giftcard/bulk_mutations.py
+++ b/saleor/graphql/giftcard/bulk_mutations.py
@@ -13,7 +13,7 @@ from ...giftcard.utils import is_gift_card_expired
 from ...permission.enums import GiftcardPermissions
 from ..app.dataloaders import get_app_promise
 from ..core import ResolveInfo
-from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_31
 from ..core.doc_category import DOC_CATEGORY_GIFT_CARDS
 from ..core.mutations import BaseBulkMutation, BaseMutation, ModelBulkDeleteMutation
 from ..core.scalars import Date
@@ -61,7 +61,7 @@ class GiftCardBulkCreate(BaseMutation):
         )
 
     class Meta:
-        description = "Create gift cards." + ADDED_IN_31 + PREVIEW_FEATURE
+        description = "Create gift cards." + ADDED_IN_31
         doc_category = DOC_CATEGORY_GIFT_CARDS
         model = models.GiftCard
         permissions = (GiftcardPermissions.MANAGE_GIFT_CARD,)
@@ -174,7 +174,7 @@ class GiftCardBulkDelete(ModelBulkDeleteMutation):
         )
 
     class Meta:
-        description = "Delete gift cards." + ADDED_IN_31 + PREVIEW_FEATURE
+        description = "Delete gift cards." + ADDED_IN_31
         model = models.GiftCard
         object_type = GiftCard
         permissions = (GiftcardPermissions.MANAGE_GIFT_CARD,)
@@ -196,7 +196,7 @@ class GiftCardBulkActivate(BaseBulkMutation):
         )
 
     class Meta:
-        description = "Activate gift cards." + ADDED_IN_31 + PREVIEW_FEATURE
+        description = "Activate gift cards." + ADDED_IN_31
         model = models.GiftCard
         object_type = GiftCard
         permissions = (GiftcardPermissions.MANAGE_GIFT_CARD,)
@@ -234,7 +234,7 @@ class GiftCardBulkDeactivate(BaseBulkMutation):
         )
 
     class Meta:
-        description = "Deactivate gift cards." + ADDED_IN_31 + PREVIEW_FEATURE
+        description = "Deactivate gift cards." + ADDED_IN_31
         model = models.GiftCard
         object_type = GiftCard
         permissions = (GiftcardPermissions.MANAGE_GIFT_CARD,)

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -20,7 +20,7 @@ from ...giftcard.utils import (
 from ...permission.enums import GiftcardPermissions
 from ..app.dataloaders import get_app_promise
 from ..core import ResolveInfo
-from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_INPUT, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_INPUT
 from ..core.doc_category import DOC_CATEGORY_GIFT_CARDS
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.scalars import Date, PositiveDecimal
@@ -47,11 +47,9 @@ def clean_gift_card(gift_card: models.GiftCard) -> models.GiftCard:
 class GiftCardInput(BaseInputObjectType):
     add_tags = NonNullList(
         graphene.String,
-        description="The gift card tags to add." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="The gift card tags to add." + ADDED_IN_31,
     )
-    expiry_date = Date(
-        description="The gift card expiry date." + ADDED_IN_31 + PREVIEW_FEATURE
-    )
+    expiry_date = Date(description="The gift card expiry date." + ADDED_IN_31)
 
     # DEPRECATED
     start_date = Date(
@@ -80,16 +78,12 @@ class GiftCardCreateInput(GiftCardInput):
     )
     channel = graphene.String(
         description=(
-            "Slug of a channel from which the email should be sent."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
+            "Slug of a channel from which the email should be sent." + ADDED_IN_31
         )
     )
     is_active = graphene.Boolean(
         required=True,
-        description=(
-            "Determine if gift card is active." + ADDED_IN_31 + PREVIEW_FEATURE
-        ),
+        description=("Determine if gift card is active." + ADDED_IN_31),
     )
     code = graphene.String(
         required=False,
@@ -99,9 +93,7 @@ class GiftCardCreateInput(GiftCardInput):
         ),
     )
     note = graphene.String(
-        description=(
-            "The gift card note from the staff member." + ADDED_IN_31 + PREVIEW_FEATURE
-        )
+        description=("The gift card note from the staff member." + ADDED_IN_31)
     )
 
     class Meta:
@@ -111,10 +103,10 @@ class GiftCardCreateInput(GiftCardInput):
 class GiftCardUpdateInput(GiftCardInput):
     remove_tags = NonNullList(
         graphene.String,
-        description="The gift card tags to remove." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="The gift card tags to remove." + ADDED_IN_31,
     )
     balance_amount = PositiveDecimal(
-        description="The gift card balance amount." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="The gift card balance amount." + ADDED_IN_31,
         required=False,
     )
 
@@ -393,7 +385,7 @@ class GiftCardDelete(ModelDeleteMutation):
         id = graphene.ID(description="ID of the gift card to delete.", required=True)
 
     class Meta:
-        description = "Delete gift card." + ADDED_IN_31 + PREVIEW_FEATURE
+        description = "Delete gift card." + ADDED_IN_31
         model = models.GiftCard
         object_type = GiftCard
         permissions = (GiftcardPermissions.MANAGE_GIFT_CARD,)
@@ -500,7 +492,7 @@ class GiftCardResend(BaseMutation):
         )
 
     class Meta:
-        description = "Resend a gift card." + ADDED_IN_31 + PREVIEW_FEATURE
+        description = "Resend a gift card." + ADDED_IN_31
         doc_category = DOC_CATEGORY_GIFT_CARDS
         permissions = (GiftcardPermissions.MANAGE_GIFT_CARD,)
         error_type_class = GiftCardError
@@ -582,7 +574,7 @@ class GiftCardAddNote(BaseMutation):
         )
 
     class Meta:
-        description = "Adds note to the gift card." + ADDED_IN_31 + PREVIEW_FEATURE
+        description = "Adds note to the gift card." + ADDED_IN_31
         doc_category = DOC_CATEGORY_GIFT_CARDS
         permissions = (GiftcardPermissions.MANAGE_GIFT_CARD,)
         error_type_class = GiftCardError

--- a/saleor/graphql/giftcard/schema.py
+++ b/saleor/graphql/giftcard/schema.py
@@ -5,7 +5,7 @@ from ...giftcard import models
 from ...permission.enums import GiftcardPermissions
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
-from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_31
 from ..core.doc_category import DOC_CATEGORY_GIFT_CARDS
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.types import NonNullList
@@ -45,13 +45,9 @@ class GiftCardQueries(graphene.ObjectType):
     )
     gift_cards = FilterConnectionField(
         GiftCardCountableConnection,
-        sort_by=GiftCardSortingInput(
-            description="Sort gift cards." + ADDED_IN_31 + PREVIEW_FEATURE
-        ),
+        sort_by=GiftCardSortingInput(description="Sort gift cards." + ADDED_IN_31),
         filter=GiftCardFilterInput(
-            description=(
-                "Filtering options for gift cards." + ADDED_IN_31 + PREVIEW_FEATURE
-            )
+            description=("Filtering options for gift cards." + ADDED_IN_31)
         ),
         description="List of gift cards.",
         permissions=[
@@ -61,7 +57,7 @@ class GiftCardQueries(graphene.ObjectType):
     )
     gift_card_currencies = PermissionsField(
         NonNullList(graphene.String),
-        description="List of gift card currencies." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="List of gift card currencies." + ADDED_IN_31,
         required=True,
         permissions=[
             GiftcardPermissions.MANAGE_GIFT_CARD,
@@ -73,7 +69,7 @@ class GiftCardQueries(graphene.ObjectType):
         filter=GiftCardTagFilterInput(
             description="Filtering options for gift card tags."
         ),
-        description="List of gift card tags." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="List of gift card tags." + ADDED_IN_31,
         permissions=[
             GiftcardPermissions.MANAGE_GIFT_CARD,
         ],

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -19,7 +19,7 @@ from ..app.types import App
 from ..channel import ChannelContext
 from ..channel.dataloaders import ChannelByIdLoader
 from ..core.connection import CountableConnection
-from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_FIELD, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_FIELD
 from ..core.doc_category import DOC_CATEGORY_GIFT_CARDS
 from ..core.fields import PermissionsField
 from ..core.scalars import Date
@@ -109,7 +109,7 @@ class GiftCardEvent(ModelObjectType[models.GiftCardEvent]):
     old_expiry_date = Date(description="Previous gift card expiry date.")
 
     class Meta:
-        description = "History log of the gift card." + ADDED_IN_31 + PREVIEW_FEATURE
+        description = "History log of the gift card." + ADDED_IN_31
         model = models.GiftCardEvent
         interfaces = [graphene.relay.Node]
 
@@ -219,7 +219,7 @@ class GiftCardTag(ModelObjectType[models.GiftCardTag]):
     name = graphene.String(required=True)
 
     class Meta:
-        description = "The gift card tag." + ADDED_IN_31 + PREVIEW_FEATURE
+        description = "The gift card tag." + ADDED_IN_31
         model = models.GiftCardTag
         interfaces = [graphene.relay.Node]
 
@@ -245,22 +245,17 @@ class GiftCard(ModelObjectType[models.GiftCard]):
     created = graphene.DateTime(required=True)
     created_by = graphene.Field(
         "saleor.graphql.account.types.User",
-        description=(
-            "The user who bought or issued a gift card." + ADDED_IN_31 + PREVIEW_FEATURE
-        ),
+        description=("The user who bought or issued a gift card." + ADDED_IN_31),
     )
     used_by = graphene.Field(
         "saleor.graphql.account.types.User",
-        description=(
-            "The customer who used a gift card." + ADDED_IN_31 + PREVIEW_FEATURE
-        ),
+        description=("The customer who used a gift card." + ADDED_IN_31),
     )
     created_by_email = graphene.String(
         required=False,
         description=(
             "Email address of the user who bought or issued gift card."
             + ADDED_IN_31
-            + PREVIEW_FEATURE
             + "\n\nRequires one of the following permissions: "
             f"{AccountPermissions.MANAGE_USERS.name}, "
             f"{AuthorizationFilters.OWNER.name}."
@@ -269,9 +264,7 @@ class GiftCard(ModelObjectType[models.GiftCard]):
     used_by_email = graphene.String(
         required=False,
         description=(
-            "Email address of the customer who used a gift card."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
+            "Email address of the customer who used a gift card." + ADDED_IN_31
         ),
     )
     last_used_on = graphene.DateTime()
@@ -281,25 +274,20 @@ class GiftCard(ModelObjectType[models.GiftCard]):
         description=(
             "App which created the gift card."
             + ADDED_IN_31
-            + PREVIEW_FEATURE
             + "\n\nRequires one of the following permissions: "
             f"{AppPermission.MANAGE_APPS.name}, {AuthorizationFilters.OWNER.name}."
         ),
     )
     product = graphene.Field(
         "saleor.graphql.product.types.products.Product",
-        description="Related gift card product." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="Related gift card product." + ADDED_IN_31,
     )
     events = PermissionsField(
         NonNullList(GiftCardEvent),
         filter=GiftCardEventFilterInput(
             description="Filtering options for gift card events."
         ),
-        description=(
-            "List of events associated with the gift card."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
-        ),
+        description=("List of events associated with the gift card." + ADDED_IN_31),
         required=True,
         permissions=[
             GiftcardPermissions.MANAGE_GIFT_CARD,
@@ -307,7 +295,7 @@ class GiftCard(ModelObjectType[models.GiftCard]):
     )
     tags = PermissionsField(
         NonNullList(GiftCardTag),
-        description="The gift card tag." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="The gift card tag." + ADDED_IN_31,
         required=True,
         permissions=[
             GiftcardPermissions.MANAGE_GIFT_CARD,
@@ -315,9 +303,7 @@ class GiftCard(ModelObjectType[models.GiftCard]):
     )
     bought_in_channel = graphene.String(
         description=(
-            "Slug of the channel where the gift card was bought."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
+            "Slug of the channel where the gift card was bought." + ADDED_IN_31
         ),
         required=False,
     )

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -26,7 +26,7 @@ from ...account.types import AddressInput
 from ...app.dataloaders import get_app_promise
 from ...channel.types import Channel
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_36, ADDED_IN_310, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_36, ADDED_IN_310
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import ModelMutation
 from ...core.scalars import PositiveDecimal
@@ -61,7 +61,7 @@ class OrderLineCreateInput(OrderLineInput):
         default_value=False,
         description=(
             "Flag that allow force splitting the same variant into multiple lines "
-            "by skipping the matching logic. " + ADDED_IN_36 + PREVIEW_FEATURE
+            "by skipping the matching logic. " + ADDED_IN_36
         ),
     )
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -684,9 +684,9 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     )
     tax_class = PermissionsField(
         TaxClass,
-        description="Denormalized tax class of the product in this order line."
-        + ADDED_IN_39
-        + PREVIEW_FEATURE,
+        description=(
+            "Denormalized tax class of the product in this order line." + ADDED_IN_39
+        ),
         required=False,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_STAFF_USER,
@@ -695,24 +695,20 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     )
     tax_class_name = graphene.Field(
         graphene.String,
-        description="Denormalized name of the tax class."
-        + ADDED_IN_39
-        + PREVIEW_FEATURE,
+        description="Denormalized name of the tax class." + ADDED_IN_39,
         required=False,
     )
     tax_class_metadata = NonNullList(
         MetadataItem,
         required=True,
-        description="Denormalized public metadata of the tax class."
-        + ADDED_IN_39
-        + PREVIEW_FEATURE,
+        description="Denormalized public metadata of the tax class." + ADDED_IN_39,
     )
     tax_class_private_metadata = NonNullList(
         MetadataItem,
         required=True,
         description=(
             "Denormalized private metadata of the tax class. Requires staff "
-            "permissions to access." + ADDED_IN_39 + PREVIEW_FEATURE
+            "permissions to access." + ADDED_IN_39
         ),
     )
 
@@ -1002,9 +998,7 @@ class Order(ModelObjectType[models.Order]):
     available_collection_points = NonNullList(
         Warehouse,
         description=(
-            "Collection points that can be used for this order."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
+            "Collection points that can be used for this order." + ADDED_IN_31
         ),
         required=True,
     )
@@ -1034,20 +1028,16 @@ class Order(ModelObjectType[models.Order]):
         description="User-friendly payment status.", required=True
     )
     authorize_status = OrderAuthorizeStatusEnum(
-        description=(
-            "The authorize status of the order." + ADDED_IN_34 + PREVIEW_FEATURE
-        ),
+        description=("The authorize status of the order." + ADDED_IN_34),
         required=True,
     )
     charge_status = OrderChargeStatusEnum(
-        description=("The charge status of the order." + ADDED_IN_34 + PREVIEW_FEATURE),
+        description=("The charge status of the order." + ADDED_IN_34),
         required=True,
     )
     tax_exemption = graphene.Boolean(
         description=(
-            "Returns True if order has to be exempt from taxes."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
+            "Returns True if order has to be exempt from taxes." + ADDED_IN_38
         ),
         required=True,
     )
@@ -1055,9 +1045,7 @@ class Order(ModelObjectType[models.Order]):
         TransactionItem,
         description=(
             "List of transactions for the order. Requires one of the "
-            "following permissions: MANAGE_ORDERS, HANDLE_PAYMENTS."
-            + ADDED_IN_34
-            + PREVIEW_FEATURE
+            "following permissions: MANAGE_ORDERS, HANDLE_PAYMENTS." + ADDED_IN_34
         ),
         required=True,
     )
@@ -1084,8 +1072,7 @@ class Order(ModelObjectType[models.Order]):
     shipping_tax_class = PermissionsField(
         TaxClass,
         description="Denormalized tax class assigned to the shipping method."
-        + ADDED_IN_39
-        + PREVIEW_FEATURE,
+        + ADDED_IN_39,
         required=False,
         permissions=[
             AuthorizationFilters.AUTHENTICATED_STAFF_USER,
@@ -1097,7 +1084,6 @@ class Order(ModelObjectType[models.Order]):
         description=(
             "Denormalized name of the tax class assigned to the shipping method."
             + ADDED_IN_39
-            + PREVIEW_FEATURE
         ),
         required=False,
     )
@@ -1107,7 +1093,6 @@ class Order(ModelObjectType[models.Order]):
         description=(
             "Denormalized public metadata of the shipping method's tax class."
             + ADDED_IN_39
-            + PREVIEW_FEATURE
         ),
     )
     shipping_tax_class_private_metadata = NonNullList(
@@ -1115,7 +1100,7 @@ class Order(ModelObjectType[models.Order]):
         required=True,
         description=(
             "Denormalized private metadata of the shipping method's tax class. "
-            "Requires staff permissions to access." + ADDED_IN_39 + PREVIEW_FEATURE
+            "Requires staff permissions to access." + ADDED_IN_39
         ),
     )
     token = graphene.String(
@@ -1189,11 +1174,7 @@ class Order(ModelObjectType[models.Order]):
     )
     delivery_method = graphene.Field(
         DeliveryMethod,
-        description=(
-            "The delivery method selected for this order."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
-        ),
+        description=("The delivery method selected for this order." + ADDED_IN_31),
     )
     language_code = graphene.String(
         deprecation_reason=(
@@ -1238,7 +1219,7 @@ class Order(ModelObjectType[models.Order]):
     display_gross_prices = graphene.Boolean(
         description=(
             "Determines whether checkout prices should include taxes when displayed "
-            "in a storefront." + ADDED_IN_39 + PREVIEW_FEATURE
+            "in a storefront." + ADDED_IN_39
         ),
         required=True,
     )

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1126,6 +1126,7 @@ class TransactionUpdate(TransactionCreate):
         description = (
             "Create transaction for checkout or order."
             + ADDED_IN_34
+            + PREVIEW_FEATURE
             + "\n\nRequires the following permissions: "
             + f"{AuthorizationFilters.OWNER.name} "
             + f"and {PaymentPermissions.HANDLE_PAYMENTS.name}."
@@ -1320,7 +1321,9 @@ class TransactionRequestAction(BaseMutation):
         )
 
     class Meta:
-        description = "Request an action for payment transaction." + ADDED_IN_34
+        description = (
+            "Request an action for payment transaction." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
         doc_category = DOC_CATEGORY_PAYMENTS
         error_type_class = common_types.TransactionRequestActionError
         permissions = (PaymentPermissions.HANDLE_PAYMENTS,)

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -801,7 +801,9 @@ class TransactionCreate(BaseMutation):
         )
 
     class Meta:
-        description = "Create transaction for checkout or order." + ADDED_IN_34
+        description = (
+            "Create transaction for checkout or order." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
         doc_category = DOC_CATEGORY_PAYMENTS
         error_type_class = common_types.TransactionCreateError
         permissions = (PaymentPermissions.HANDLE_PAYMENTS,)

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -801,9 +801,7 @@ class TransactionCreate(BaseMutation):
         )
 
     class Meta:
-        description = (
-            "Create transaction for checkout or order." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Create transaction for checkout or order." + ADDED_IN_34
         doc_category = DOC_CATEGORY_PAYMENTS
         error_type_class = common_types.TransactionCreateError
         permissions = (PaymentPermissions.HANDLE_PAYMENTS,)
@@ -1126,7 +1124,6 @@ class TransactionUpdate(TransactionCreate):
         description = (
             "Create transaction for checkout or order."
             + ADDED_IN_34
-            + PREVIEW_FEATURE
             + "\n\nRequires the following permissions: "
             + f"{AuthorizationFilters.OWNER.name} "
             + f"and {PaymentPermissions.HANDLE_PAYMENTS.name}."
@@ -1321,9 +1318,7 @@ class TransactionRequestAction(BaseMutation):
         )
 
     class Meta:
-        description = (
-            "Request an action for payment transaction." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Request an action for payment transaction." + ADDED_IN_34
         doc_category = DOC_CATEGORY_PAYMENTS
         error_type_class = common_types.TransactionRequestActionError
         permissions = (PaymentPermissions.HANDLE_PAYMENTS,)

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -3,7 +3,7 @@ import graphene
 from ...permission.enums import OrderPermissions, PaymentPermissions
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
-from ..core.descriptions import ADDED_IN_36
+from ..core.descriptions import ADDED_IN_36, PREVIEW_FEATURE
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.utils import from_global_id_or_error
@@ -49,7 +49,7 @@ class PaymentQueries(graphene.ObjectType):
     )
     transaction = PermissionsField(
         TransactionItem,
-        description="Look up a transaction by ID." + ADDED_IN_36,
+        description="Look up a transaction by ID." + ADDED_IN_36 + PREVIEW_FEATURE,
         id=graphene.Argument(
             graphene.ID, description="ID of a transaction.", required=True
         ),

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -3,7 +3,7 @@ import graphene
 from ...permission.enums import OrderPermissions, PaymentPermissions
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
-from ..core.descriptions import ADDED_IN_36, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_36
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.utils import from_global_id_or_error
@@ -49,7 +49,7 @@ class PaymentQueries(graphene.ObjectType):
     )
     transaction = PermissionsField(
         TransactionItem,
-        description="Look up a transaction by ID." + ADDED_IN_36 + PREVIEW_FEATURE,
+        description="Look up a transaction by ID." + ADDED_IN_36,
         id=graphene.Argument(
             graphene.ID, description="ID of a transaction.", required=True
         ),

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -18,7 +18,6 @@ from ..core.descriptions import (
     ADDED_IN_34,
     ADDED_IN_36,
     ADDED_IN_313,
-    PREVIEW_FEATURE,
     PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD,
 )
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
@@ -492,9 +491,7 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     )
 
     class Meta:
-        description = (
-            "Represents a payment transaction." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Represents a payment transaction." + ADDED_IN_34
         interfaces = [relay.Node, ObjectWithMetadata]
         model = models.TransactionItem
 

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -18,6 +18,7 @@ from ..core.descriptions import (
     ADDED_IN_34,
     ADDED_IN_36,
     ADDED_IN_313,
+    PREVIEW_FEATURE,
     PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD,
 )
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
@@ -491,7 +492,9 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
     )
 
     class Meta:
-        description = "Represents a payment transaction." + ADDED_IN_34
+        description = (
+            "Represents a payment transaction." + ADDED_IN_34 + PREVIEW_FEATURE
+        )
         interfaces = [relay.Node, ObjectWithMetadata]
         model = models.TransactionItem
 

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -27,7 +27,6 @@ from ...core.descriptions import (
     ADDED_IN_33,
     ADDED_IN_38,
     DEPRECATED_IN_3X_INPUT,
-    PREVIEW_FEATURE,
 )
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.mutations import BaseMutation
@@ -391,11 +390,7 @@ class ProductVariantChannelListingAddInput(BaseInputObjectType):
     )
     cost_price = PositiveDecimal(description="Cost price of the variant in channel.")
     preorder_threshold = graphene.Int(
-        description=(
-            "The threshold for preorder variant in channel."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
-        )
+        description=("The threshold for preorder variant in channel." + ADDED_IN_31)
     )
 
     class Meta:

--- a/saleor/graphql/product/mutations/product_variant/product_variant_create.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_create.py
@@ -18,12 +18,7 @@ from ....attribute.types import AttributeValueInput
 from ....attribute.utils import AttributeAssignmentMixin, AttrValuesInput
 from ....channel import ChannelContext
 from ....core import ResolveInfo
-from ....core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_38,
-    ADDED_IN_310,
-    PREVIEW_FEATURE,
-)
+from ....core.descriptions import ADDED_IN_31, ADDED_IN_38, ADDED_IN_310
 from ....core.doc_category import DOC_CATEGORY_PRODUCTS
 from ....core.mutations import ModelMutation
 from ....core.scalars import WeightScalar
@@ -69,15 +64,13 @@ class ProductVariantInput(BaseInputObjectType):
     )
     weight = WeightScalar(description="Weight of the Product Variant.", required=False)
     preorder = PreorderSettingsInput(
-        description=(
-            "Determines if variant is in preorder." + ADDED_IN_31 + PREVIEW_FEATURE
-        )
+        description=("Determines if variant is in preorder." + ADDED_IN_31)
     )
     quantity_limit_per_customer = graphene.Int(
         required=False,
         description=(
             "Determines maximum quantity of `ProductVariant`,"
-            "that can be bought in a single checkout." + ADDED_IN_31 + PREVIEW_FEATURE
+            "that can be bought in a single checkout." + ADDED_IN_31
         ),
     )
     metadata = NonNullList(

--- a/saleor/graphql/product/mutations/product_variant/product_variant_preorder_deactivate.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_preorder_deactivate.py
@@ -9,7 +9,7 @@ from .....product.error_codes import ProductErrorCode
 from .....warehouse.management import deactivate_preorder_for_variant
 from ....channel import ChannelContext
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_31
 from ....core.doc_category import DOC_CATEGORY_PRODUCTS
 from ....core.mutations import BaseMutation
 from ....core.types import ProductError
@@ -31,9 +31,7 @@ class ProductVariantPreorderDeactivate(BaseMutation):
     class Meta:
         description = (
             "Deactivates product variant preorder. "
-            "It changes all preorder allocation into regular allocation."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
+            "It changes all preorder allocation into regular allocation." + ADDED_IN_31
         )
         doc_category = DOC_CATEGORY_PRODUCTS
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -22,12 +22,7 @@ from ....tax.utils import (
 from ...account import types as account_types
 from ...channel.dataloaders import ChannelByIdLoader
 from ...channel.types import Channel
-from ...core.descriptions import (
-    ADDED_IN_31,
-    ADDED_IN_33,
-    DEPRECATED_IN_3X_FIELD,
-    PREVIEW_FEATURE,
-)
+from ...core.descriptions import ADDED_IN_31, ADDED_IN_33, DEPRECATED_IN_3X_FIELD
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.fields import PermissionsField
 from ...core.scalars import Date
@@ -357,7 +352,7 @@ class ProductVariantChannelListing(
     preorder_threshold = graphene.Field(
         PreorderThreshold,
         required=False,
-        description="Preorder variant data." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="Preorder variant data." + ADDED_IN_31,
     )
 
     class Meta:

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -59,7 +59,6 @@ from ...core.descriptions import (
     ADDED_IN_312,
     DEPRECATED_IN_3X_FIELD,
     DEPRECATED_IN_3X_INPUT,
-    PREVIEW_FEATURE,
     RICH_CONTENT,
 )
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
@@ -210,7 +209,7 @@ class ProductPricingInfo(BasePricingInfo):
     display_gross_prices = graphene.Boolean(
         description=(
             "Determines whether this product's price displayed in a storefront "
-            "should include taxes." + ADDED_IN_39 + PREVIEW_FEATURE
+            "should include taxes." + ADDED_IN_39
         ),
         required=True,
     )
@@ -362,9 +361,7 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
     preorder = graphene.Field(
         PreorderData,
         required=False,
-        description=(
-            "Preorder data for product variant." + ADDED_IN_31 + PREVIEW_FEATURE
-        ),
+        description=("Preorder data for product variant." + ADDED_IN_31),
     )
     created = graphene.DateTime(required=True)
     updated_at = graphene.DateTime(required=True)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14103,7 +14103,9 @@ type Mutation {
   """
   Create transaction for checkout or order.
   
-  Added in Saleor 3.4. 
+  Added in Saleor 3.4.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
   
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
@@ -20615,7 +20617,9 @@ input MoneyInput {
 """
 Create transaction for checkout or order.
 
-Added in Saleor 3.4. 
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point. 
 
 Requires one of the following permissions: HANDLE_PAYMENTS.
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -626,6 +626,8 @@ type Query {
   
   Added in Saleor 3.6.
   
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
   transaction(
@@ -9339,6 +9341,8 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   List of transactions for the checkout. Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
   
   Added in Saleor 3.4.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   transactions: [TransactionItem!]
 
@@ -9709,6 +9713,8 @@ union DeliveryMethod = Warehouse | ShippingMethod
 Represents a payment transaction.
 
 Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Payments") {
   """The ID of the object."""
@@ -14125,6 +14131,8 @@ type Mutation {
   
   Added in Saleor 3.4.
   
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  
   Requires the following permissions: OWNER and HANDLE_PAYMENTS.
   """
   transactionUpdate(
@@ -14141,7 +14149,9 @@ type Mutation {
   """
   Request an action for payment transaction.
   
-  Added in Saleor 3.4. 
+  Added in Saleor 3.4.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
   
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
@@ -20776,6 +20786,8 @@ Create transaction for checkout or order.
 
 Added in Saleor 3.4.
 
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+
 Requires the following permissions: OWNER and HANDLE_PAYMENTS.
 """
 type TransactionUpdate @doc(category: "Payments") {
@@ -20892,7 +20904,9 @@ input TransactionUpdateInput @doc(category: "Payments") {
 """
 Request an action for payment transaction.
 
-Added in Saleor 3.4. 
+Added in Saleor 3.4.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point. 
 
 Requires one of the following permissions: HANDLE_PAYMENTS.
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -121,8 +121,6 @@ type Query {
   
   Added in Saleor 3.9.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxConfiguration(
@@ -134,8 +132,6 @@ type Query {
   List of tax configurations.
   
   Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
@@ -165,8 +161,6 @@ type Query {
   
   Added in Saleor 3.9.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass(
@@ -178,8 +172,6 @@ type Query {
   List of tax classes.
   
   Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
@@ -634,8 +626,6 @@ type Query {
   
   Added in Saleor 3.6.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
   transaction(
@@ -928,8 +918,6 @@ type Query {
     Sort gift cards.
     
     Added in Saleor 3.1.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     sortBy: GiftCardSortingInput
 
@@ -937,8 +925,6 @@ type Query {
     Filtering options for gift cards.
     
     Added in Saleor 3.1.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     filter: GiftCardFilterInput
 
@@ -964,8 +950,6 @@ type Query {
   
   Added in Saleor 3.1.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   giftCardCurrencies: [String!]! @doc(category: "Gift cards")
@@ -974,8 +958,6 @@ type Query {
   List of gift card tags.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -1274,8 +1256,6 @@ type Query {
     Slug of the channel.
     
     Added in Saleor 3.6.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     slug: String
   ): Channel @doc(category: "Channels")
@@ -1296,8 +1276,6 @@ type Query {
     Filtering options for attributes.
     
     Added in Saleor 3.11.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     where: AttributeWhereInput
 
@@ -1400,8 +1378,6 @@ type Query {
   
   Added in Saleor 3.1.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   appExtensions(
@@ -1429,8 +1405,6 @@ type Query {
   Look up an app extension by ID.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
@@ -1750,8 +1724,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A gift card metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   GIFT_CARD_METADATA_UPDATED
 
@@ -1802,8 +1774,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   An order metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_METADATA_UPDATED
 
@@ -1850,8 +1820,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A customer account metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   CUSTOMER_METADATA_UPDATED
 
@@ -1868,8 +1836,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A collection metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   COLLECTION_METADATA_UPDATED
 
@@ -1907,8 +1873,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A product metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   PRODUCT_METADATA_UPDATED
 
@@ -1934,8 +1898,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A product variant metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   PRODUCT_VARIANT_METADATA_UPDATED
 
@@ -1952,8 +1914,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A checkout metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   CHECKOUT_METADATA_UPDATED
 
@@ -1970,8 +1930,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A fulfillment metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   FULFILLMENT_METADATA_UPDATED
 
@@ -2027,8 +1985,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A shipping zone metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   SHIPPING_ZONE_METADATA_UPDATED
 
@@ -2052,8 +2008,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   Transaction item metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   TRANSACTION_ITEM_METADATA_UPDATED
 
@@ -2076,8 +2030,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A warehouse metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   WAREHOUSE_METADATA_UPDATED
 
@@ -2094,8 +2046,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   A voucher metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   VOUCHER_METADATA_UPDATED
 
@@ -2161,8 +2111,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   Event called for checkout tax calculation.
   
   Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   CHECKOUT_CALCULATE_TAXES
 
@@ -2170,8 +2118,6 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   Event called for order tax calculation.
   
   Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_CALCULATE_TAXES
 
@@ -2251,8 +2197,6 @@ enum WebhookEventTypeSyncEnum @doc(category: "Webhooks") {
   Event called for checkout tax calculation.
   
   Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   CHECKOUT_CALCULATE_TAXES
 
@@ -2260,8 +2204,6 @@ enum WebhookEventTypeSyncEnum @doc(category: "Webhooks") {
   Event called for order tax calculation.
   
   Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_CALCULATE_TAXES
 
@@ -2377,8 +2319,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A gift card metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   GIFT_CARD_METADATA_UPDATED
 
@@ -2429,8 +2369,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   An order metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   ORDER_METADATA_UPDATED
 
@@ -2477,8 +2415,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A customer account metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   CUSTOMER_METADATA_UPDATED
 
@@ -2495,8 +2431,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A collection metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   COLLECTION_METADATA_UPDATED
 
@@ -2534,8 +2468,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A product metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   PRODUCT_METADATA_UPDATED
 
@@ -2561,8 +2493,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A product variant metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   PRODUCT_VARIANT_METADATA_UPDATED
 
@@ -2579,8 +2509,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A checkout metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   CHECKOUT_METADATA_UPDATED
 
@@ -2597,8 +2525,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A fulfillment metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   FULFILLMENT_METADATA_UPDATED
 
@@ -2654,8 +2580,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A shipping zone metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   SHIPPING_ZONE_METADATA_UPDATED
 
@@ -2679,8 +2603,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   Transaction item metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   TRANSACTION_ITEM_METADATA_UPDATED
 
@@ -2703,8 +2625,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A warehouse metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   WAREHOUSE_METADATA_UPDATED
 
@@ -2721,8 +2641,6 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   A voucher metadata is updated.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   VOUCHER_METADATA_UPDATED
 
@@ -2863,8 +2781,6 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
   App's dashboard extensions.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   extensions: [AppExtension!]!
 }
@@ -3387,8 +3303,6 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
   Click and collect options: local, all or disabled.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   clickAndCollectOption: WarehouseClickAndCollectOptionEnum!
   shippingZones(
@@ -4651,8 +4565,6 @@ type Channel implements Node @doc(category: "Channels") {
   
   Added in Saleor 3.5.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
   warehouses: [Warehouse!]!
@@ -4661,8 +4573,6 @@ type Channel implements Node @doc(category: "Channels") {
   List of shippable countries for the channel.
   
   Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   countries: [CountryDisplay!]
 
@@ -4670,8 +4580,6 @@ type Channel implements Node @doc(category: "Channels") {
   Shipping methods that are available for the channel.
   
   Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   availableShippingMethodsPerCountry(countries: [CountryCode!]): [ShippingMethodsPerCountry!]
 
@@ -4679,8 +4587,6 @@ type Channel implements Node @doc(category: "Channels") {
   Define the stock setting for this channel.
   
   Added in Saleor 3.7.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: AUTHENTICATED_APP, AUTHENTICATED_STAFF_USER.
   """
@@ -4700,8 +4606,6 @@ type Channel implements Node @doc(category: "Channels") {
 List of shipping methods available for the country.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ShippingMethodsPerCountry @doc(category: "Shipping") {
   """The country code."""
@@ -5071,8 +4975,6 @@ enum WeightUnitsEnum {
 Represents the channel stock settings.
 
 Added in Saleor 3.7.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type StockSettings {
   """
@@ -5294,8 +5196,6 @@ type Product implements Node & ObjectWithMetadata @doc(category: "Products") {
     The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     format: ThumbnailFormatEnum = ORIGINAL
   ): Image
@@ -5577,8 +5477,6 @@ type TaxType @doc(category: "Taxes") {
 Tax class is a named object used to define tax rates per country. Tax class can be assigned to product types, products and shipping methods to define their tax rates.
 
 Added in Saleor 3.9.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type TaxClass implements Node & ObjectWithMetadata @doc(category: "Taxes") {
   """The ID of the object."""
@@ -5641,8 +5539,6 @@ type TaxClass implements Node & ObjectWithMetadata @doc(category: "Taxes") {
 Tax rate for a country. When tax class is null, it represents the default tax rate for that country; otherwise it's a country tax rate specific to the given tax class.
 
 Added in Saleor 3.9.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type TaxClassCountryRate @doc(category: "Taxes") {
   """Country in which this tax rate applies."""
@@ -6351,8 +6247,6 @@ type Category implements Node & ObjectWithMetadata @doc(category: "Products") {
     The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     format: ThumbnailFormatEnum = ORIGINAL
   ): Image
@@ -6803,8 +6697,6 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
   Preorder data for product variant.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   preorder: PreorderData
   created: DateTime!
@@ -6838,8 +6730,6 @@ type ProductVariantChannelListing implements Node @doc(category: "Products") {
   Preorder variant data.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   preorderThreshold: PreorderThreshold
 }
@@ -6962,8 +6852,6 @@ type ProductImage @doc(category: "Products") {
     The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     format: ThumbnailFormatEnum = ORIGINAL
   ): String!
@@ -7044,8 +6932,6 @@ type ProductMedia implements Node & ObjectWithMetadata @doc(category: "Products"
     The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     format: ThumbnailFormatEnum = ORIGINAL
   ): String!
@@ -7222,8 +7108,6 @@ type ProductPricingInfo @doc(category: "Products") {
   Determines whether this product's price displayed in a storefront should include taxes.
   
   Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   displayGrossPrices: Boolean!
 }
@@ -7416,8 +7300,6 @@ type Collection implements Node & ObjectWithMetadata @doc(category: "Products") 
     The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     format: ThumbnailFormatEnum = ORIGINAL
   ): Image
@@ -8625,8 +8507,6 @@ enum TranslatableKinds {
 Channel-specific tax configuration.
 
 Added in Saleor 3.9.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes") {
   """The ID of the object."""
@@ -8710,8 +8590,6 @@ enum TaxCalculationStrategy @doc(category: "Taxes") {
 Country-specific exceptions of a channel's tax configuration.
 
 Added in Saleor 3.9.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type TaxConfigurationPerCountry @doc(category: "Taxes") {
   """Country in which this configuration applies."""
@@ -8793,8 +8671,6 @@ input TaxClassFilterInput @doc(category: "Taxes") {
 Tax class rates grouped by country.
 
 Added in Saleor 3.9.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type TaxCountryConfiguration @doc(category: "Taxes") {
   """A country for which tax class rates are grouped."""
@@ -8970,8 +8846,6 @@ type Shop {
   Default number of maximum line quantity in single checkout (per single checkout line).
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
@@ -9277,8 +9151,6 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
     The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     format: ThumbnailFormatEnum = ORIGINAL
   ): Image
@@ -9390,8 +9262,6 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   Collection points that can be used for this order.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   availableCollectionPoints: [Warehouse!]!
 
@@ -9432,8 +9302,6 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   The delivery method selected for this checkout.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   deliveryMethod: DeliveryMethod
 
@@ -9444,8 +9312,6 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   Returns True if checkout has to be exempt from taxes.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   taxExemption: Boolean!
 
@@ -9473,8 +9339,6 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   List of transactions for the checkout. Requires one of the following permissions: MANAGE_CHECKOUTS, HANDLE_PAYMENTS.
   
   Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   transactions: [TransactionItem!]
 
@@ -9482,8 +9346,6 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   Determines whether checkout prices should include taxes when displayed in a storefront.
   
   Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   displayGrossPrices: Boolean!
 
@@ -9574,8 +9436,6 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   The user who bought or issued a gift card.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   createdBy: User
 
@@ -9583,8 +9443,6 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   The customer who used a gift card.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   usedBy: User
 
@@ -9592,8 +9450,6 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   Email address of the user who bought or issued gift card.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: MANAGE_USERS, OWNER.
   """
@@ -9603,8 +9459,6 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   Email address of the customer who used a gift card.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   usedByEmail: String
   lastUsedOn: DateTime
@@ -9615,8 +9469,6 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   
   Added in Saleor 3.1.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: MANAGE_APPS, OWNER.
   """
   app: App
@@ -9625,8 +9477,6 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   Related gift card product.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   product: Product
 
@@ -9634,8 +9484,6 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   List of events associated with the gift card.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -9649,8 +9497,6 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   
   Added in Saleor 3.1.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
   tags: [GiftCardTag!]!
@@ -9659,8 +9505,6 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
   Slug of the channel where the gift card was bought.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   boughtInChannel: String
   isActive: Boolean!
@@ -9681,8 +9525,6 @@ type GiftCard implements Node & ObjectWithMetadata @doc(category: "Gift cards") 
 History log of the gift card.
 
 Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type GiftCardEvent implements Node {
   id: ID!
@@ -9770,8 +9612,6 @@ input GiftCardEventFilterInput @doc(category: "Gift cards") {
 The gift card tag.
 
 Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type GiftCardTag implements Node @doc(category: "Gift cards") {
   id: ID!
@@ -9862,8 +9702,6 @@ type CheckoutLine implements Node & ObjectWithMetadata @doc(category: "Checkout"
 Represents a delivery method chosen for the checkout. `Warehouse` type is used when checkout is marked as "click and collect" and `ShippingMethod` otherwise.
 
 Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 union DeliveryMethod = Warehouse | ShippingMethod
 
@@ -9871,8 +9709,6 @@ union DeliveryMethod = Warehouse | ShippingMethod
 Represents a payment transaction.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type TransactionItem implements Node & ObjectWithMetadata @doc(category: "Payments") {
   """The ID of the object."""
@@ -10143,8 +9979,6 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   Collection points that can be used for this order.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   availableCollectionPoints: [Warehouse!]!
 
@@ -10175,8 +10009,6 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   The authorize status of the order.
   
   Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   authorizeStatus: OrderAuthorizeStatusEnum!
 
@@ -10184,8 +10016,6 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   The charge status of the order.
   
   Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   chargeStatus: OrderChargeStatusEnum!
 
@@ -10193,8 +10023,6 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   Returns True if order has to be exempt from taxes.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   taxExemption: Boolean!
 
@@ -10202,8 +10030,6 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   List of transactions for the order. Requires one of the following permissions: MANAGE_ORDERS, HANDLE_PAYMENTS.
   
   Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   transactions: [TransactionItem!]!
 
@@ -10230,8 +10056,6 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   
   Added in Saleor 3.9.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   shippingTaxClass: TaxClass
@@ -10240,8 +10064,6 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   Denormalized name of the tax class assigned to the shipping method.
   
   Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   shippingTaxClassName: String
 
@@ -10249,8 +10071,6 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   Denormalized public metadata of the shipping method's tax class.
   
   Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   shippingTaxClassMetadata: [MetadataItem!]!
 
@@ -10258,8 +10078,6 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   Denormalized private metadata of the shipping method's tax class. Requires staff permissions to access.
   
   Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   shippingTaxClassPrivateMetadata: [MetadataItem!]!
   token: String! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `id` instead.")
@@ -10324,8 +10142,6 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   The delivery method selected for this order.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   deliveryMethod: DeliveryMethod
   languageCode: String! @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `languageCodeEnum` field to fetch the language code. ")
@@ -10352,8 +10168,6 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   Determines whether checkout prices should include taxes when displayed in a storefront.
   
   Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   displayGrossPrices: Boolean!
 
@@ -10634,8 +10448,6 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
     The format of the image. When not provided, format of the original image will be used.
     
     Added in Saleor 3.6.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     format: ThumbnailFormatEnum = ORIGINAL
   ): Image
@@ -10690,8 +10502,6 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   
   Added in Saleor 3.9.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires one of the following permissions: AUTHENTICATED_STAFF_USER, AUTHENTICATED_APP.
   """
   taxClass: TaxClass
@@ -10700,8 +10510,6 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   Denormalized name of the tax class.
   
   Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   taxClassName: String
 
@@ -10709,8 +10517,6 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   Denormalized public metadata of the tax class.
   
   Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   taxClassMetadata: [MetadataItem!]!
 
@@ -10718,8 +10524,6 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   Denormalized private metadata of the tax class. Requires staff permissions to access.
   
   Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   taxClassPrivateMetadata: [MetadataItem!]!
 }
@@ -13117,9 +12921,7 @@ type Mutation {
   """
   Create a tax class.
   
-  Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.9. 
   
   Requires one of the following permissions: MANAGE_TAXES.
   """
@@ -13131,9 +12933,7 @@ type Mutation {
   """
   Delete a tax class. After deleting the tax class any products, product types or shipping methods using it are updated to use the default tax class.
   
-  Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.9. 
   
   Requires one of the following permissions: MANAGE_TAXES.
   """
@@ -13145,9 +12945,7 @@ type Mutation {
   """
   Update a tax class.
   
-  Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.9. 
   
   Requires one of the following permissions: MANAGE_TAXES.
   """
@@ -13162,9 +12960,7 @@ type Mutation {
   """
   Update tax configuration for a channel.
   
-  Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.9. 
   
   Requires one of the following permissions: MANAGE_TAXES.
   """
@@ -13179,9 +12975,7 @@ type Mutation {
   """
   Update tax class rates for a specific country.
   
-  Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.9. 
   
   Requires one of the following permissions: MANAGE_TAXES.
   """
@@ -13198,9 +12992,7 @@ type Mutation {
   """
   Remove all tax class rates for a specific country.
   
-  Added in Saleor 3.9.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.9. 
   
   Requires one of the following permissions: MANAGE_TAXES.
   """
@@ -13212,9 +13004,7 @@ type Mutation {
   """
   Exempt checkout or order from charging the taxes. When tax exemption is enabled, taxes won't be charged for the checkout or order. Taxes may still be calculated in cases when product prices are entered with the tax included and the net price needs to be known.
   
-  Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.8. 
   
   Requires one of the following permissions: MANAGE_TAXES.
   """
@@ -14221,9 +14011,7 @@ type Mutation {
   """
   Deactivates product variant preorder. It changes all preorder allocation into regular allocation.
   
-  Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.1. 
   
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
@@ -14315,9 +14103,7 @@ type Mutation {
   """
   Create transaction for checkout or order.
   
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.4. 
   
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
@@ -14337,8 +14123,6 @@ type Mutation {
   
   Added in Saleor 3.4.
   
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
   Requires the following permissions: OWNER and HANDLE_PAYMENTS.
   """
   transactionUpdate(
@@ -14355,9 +14139,7 @@ type Mutation {
   """
   Request an action for payment transaction.
   
-  Added in Saleor 3.4.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.4. 
   
   Requires one of the following permissions: HANDLE_PAYMENTS.
   """
@@ -15321,9 +15103,7 @@ type Mutation {
   """
   Delete gift card.
   
-  Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.1. 
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -15358,9 +15138,7 @@ type Mutation {
   """
   Resend a gift card.
   
-  Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.1. 
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -15372,9 +15150,7 @@ type Mutation {
   """
   Adds note to the gift card.
   
-  Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.1. 
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -15389,9 +15165,7 @@ type Mutation {
   """
   Create gift cards.
   
-  Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.1. 
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -15403,9 +15177,7 @@ type Mutation {
   """
   Delete gift cards.
   
-  Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.1. 
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -15417,9 +15189,7 @@ type Mutation {
   """
   Activate gift cards.
   
-  Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.1. 
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -15431,9 +15201,7 @@ type Mutation {
   """
   Deactivate gift cards.
   
-  Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.1. 
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -15681,9 +15449,7 @@ type Mutation {
   """
   Export gift cards to csv file.
   
-  Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.1. 
   
   Requires one of the following permissions: MANAGE_GIFT_CARD.
   """
@@ -15759,8 +15525,6 @@ type Mutation {
     The rules for changing validation for received billing address data.
     
     Added in Saleor 3.5.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     validationRules: CheckoutAddressValidationRules
   ): CheckoutBillingAddressUpdate @doc(category: "Checkout")
@@ -16101,8 +15865,6 @@ type Mutation {
     The rules for changing validation for received shipping address data.
     
     Added in Saleor 3.5.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     validationRules: CheckoutAddressValidationRules
   ): CheckoutShippingAddressUpdate @doc(category: "Checkout")
@@ -16138,8 +15900,6 @@ type Mutation {
   Updates the delivery method (shipping method or pick up point) of the checkout.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   checkoutDeliveryMethodUpdate(
     """Delivery Method ID (`Warehouse` ID or `ShippingMethod` ID)."""
@@ -16191,8 +15951,6 @@ type Mutation {
   Create new order from existing checkout. Requires the following permissions: AUTHENTICATED_APP and HANDLE_CHECKOUTS.
   
   Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   orderCreateFromCheckout(
     """ID of a checkout that will be converted to an order."""
@@ -16278,9 +16036,7 @@ type Mutation {
   """
   Reorder the warehouses of a channel.
   
-  Added in Saleor 3.7.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  Added in Saleor 3.7. 
   
   Requires one of the following permissions: MANAGE_CHANNELS.
   """
@@ -16567,8 +16323,6 @@ type Mutation {
     The audience that will be included to JWT tokens with prefix `custom:`.
     
     Added in Saleor 3.8.
-    
-    Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
     audience: String
 
@@ -17141,8 +16895,6 @@ input WebhookCreateInput @doc(category: "Webhooks") {
   Subscription query used to define a webhook payload.
   
   Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   query: String
 
@@ -17215,8 +16967,6 @@ input WebhookUpdateInput @doc(category: "Webhooks") {
   Subscription query used to define a webhook payload.
   
   Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   query: String
 
@@ -17423,8 +17173,6 @@ input WarehouseUpdateInput @doc(category: "Products") {
   Click and collect options: local, all or disabled.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   clickAndCollectOption: WarehouseClickAndCollectOptionEnum
 
@@ -17432,8 +17180,6 @@ input WarehouseUpdateInput @doc(category: "Products") {
   Visibility of warehouse stocks.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   isPrivate: Boolean
 }
@@ -17474,9 +17220,7 @@ type WarehouseShippingZoneUnassign @doc(category: "Products") {
 """
 Create a tax class.
 
-Added in Saleor 3.9.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.9. 
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -17529,9 +17273,7 @@ input CountryRateInput @doc(category: "Taxes") {
 """
 Delete a tax class. After deleting the tax class any products, product types or shipping methods using it are updated to use the default tax class.
 
-Added in Saleor 3.9.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.9. 
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -17563,9 +17305,7 @@ enum TaxClassDeleteErrorCode @doc(category: "Taxes") {
 """
 Update a tax class.
 
-Added in Saleor 3.9.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.9. 
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -17626,9 +17366,7 @@ input CountryRateUpdateInput @doc(category: "Taxes") {
 """
 Update tax configuration for a channel.
 
-Added in Saleor 3.9.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.9. 
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -17708,9 +17446,7 @@ input TaxConfigurationPerCountryInput @doc(category: "Taxes") {
 """
 Update tax class rates for a specific country.
 
-Added in Saleor 3.9.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.9. 
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -17756,9 +17492,7 @@ input TaxClassRateInput @doc(category: "Taxes") {
 """
 Remove all tax class rates for a specific country.
 
-Added in Saleor 3.9.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.9. 
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -17791,9 +17525,7 @@ enum TaxCountryConfigurationDeleteErrorCode @doc(category: "Taxes") {
 """
 Exempt checkout or order from charging the taxes. When tax exemption is enabled, taxes won't be charged for the checkout or order. Taxes may still be calculated in cases when product prices are entered with the tax included and the net price needs to be known.
 
-Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.8. 
 
 Requires one of the following permissions: MANAGE_TAXES.
 """
@@ -18065,8 +17797,6 @@ input ShopSettingsInput {
   Default number of maximum line quantity in single checkout. Minimum possible value is 1, default value is 50.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   limitQuantityPerCheckout: Int
 
@@ -19465,8 +19195,6 @@ input ProductVariantBulkCreateInput @doc(category: "Products") {
   Determines if variant is in preorder.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   preorder: PreorderSettingsInput
 
@@ -19474,8 +19202,6 @@ input ProductVariantBulkCreateInput @doc(category: "Products") {
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   quantityLimitPerCustomer: Int
 
@@ -19629,8 +19355,6 @@ input ProductVariantChannelListingAddInput @doc(category: "Products") {
   The threshold for preorder variant in channel.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   preorderThreshold: Int
 }
@@ -20202,8 +19926,6 @@ input ProductVariantCreateInput @doc(category: "Products") {
   Determines if variant is in preorder.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   preorder: PreorderSettingsInput
 
@@ -20211,8 +19933,6 @@ input ProductVariantCreateInput @doc(category: "Products") {
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   quantityLimitPerCustomer: Int
 
@@ -20413,8 +20133,6 @@ input ProductVariantBulkUpdateInput @doc(category: "Products") {
   Determines if variant is in preorder.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   preorder: PreorderSettingsInput
 
@@ -20422,8 +20140,6 @@ input ProductVariantBulkUpdateInput @doc(category: "Products") {
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   quantityLimitPerCustomer: Int
 
@@ -20640,8 +20356,6 @@ input ProductVariantInput @doc(category: "Products") {
   Determines if variant is in preorder.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   preorder: PreorderSettingsInput
 
@@ -20649,8 +20363,6 @@ input ProductVariantInput @doc(category: "Products") {
   Determines maximum quantity of `ProductVariant`,that can be bought in a single checkout.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   quantityLimitPerCustomer: Int
 
@@ -20729,9 +20441,7 @@ type ProductVariantReorderAttributeValues @doc(category: "Products") {
 """
 Deactivates product variant preorder. It changes all preorder allocation into regular allocation.
 
-Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.1. 
 
 Requires one of the following permissions: MANAGE_PRODUCTS.
 """
@@ -20905,9 +20615,7 @@ input MoneyInput {
 """
 Create transaction for checkout or order.
 
-Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.4. 
 
 Requires one of the following permissions: HANDLE_PAYMENTS.
 """
@@ -21064,8 +20772,6 @@ Create transaction for checkout or order.
 
 Added in Saleor 3.4.
 
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
-
 Requires the following permissions: OWNER and HANDLE_PAYMENTS.
 """
 type TransactionUpdate @doc(category: "Payments") {
@@ -21182,9 +20888,7 @@ input TransactionUpdateInput @doc(category: "Payments") {
 """
 Request an action for payment transaction.
 
-Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.4. 
 
 Requires one of the following permissions: HANDLE_PAYMENTS.
 """
@@ -21797,8 +21501,6 @@ input OrderLineCreateInput @doc(category: "Orders") {
   Flag that allow force splitting the same variant into multiple lines by skipping the matching logic. 
   
   Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   forceNewLine: Boolean = false
 }
@@ -22940,8 +22642,6 @@ input GiftCardCreateInput @doc(category: "Gift cards") {
   The gift card tags to add.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addTags: [String!]
 
@@ -22949,8 +22649,6 @@ input GiftCardCreateInput @doc(category: "Gift cards") {
   The gift card expiry date.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   expiryDate: Date
 
@@ -22978,8 +22676,6 @@ input GiftCardCreateInput @doc(category: "Gift cards") {
   Slug of a channel from which the email should be sent.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   channel: String
 
@@ -22987,8 +22683,6 @@ input GiftCardCreateInput @doc(category: "Gift cards") {
   Determine if gift card is active.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   isActive: Boolean!
 
@@ -23003,8 +22697,6 @@ input GiftCardCreateInput @doc(category: "Gift cards") {
   The gift card note from the staff member.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   note: String
 }
@@ -23020,9 +22712,7 @@ input PriceInput {
 """
 Delete gift card.
 
-Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.1. 
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
@@ -23060,8 +22750,6 @@ input GiftCardUpdateInput @doc(category: "Gift cards") {
   The gift card tags to add.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addTags: [String!]
 
@@ -23069,8 +22757,6 @@ input GiftCardUpdateInput @doc(category: "Gift cards") {
   The gift card expiry date.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   expiryDate: Date
 
@@ -23092,8 +22778,6 @@ input GiftCardUpdateInput @doc(category: "Gift cards") {
   The gift card tags to remove.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   removeTags: [String!]
 
@@ -23101,8 +22785,6 @@ input GiftCardUpdateInput @doc(category: "Gift cards") {
   The gift card balance amount.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   balanceAmount: PositiveDecimal
 }
@@ -23110,9 +22792,7 @@ input GiftCardUpdateInput @doc(category: "Gift cards") {
 """
 Resend a gift card.
 
-Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.1. 
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
@@ -23136,9 +22816,7 @@ input GiftCardResendInput @doc(category: "Gift cards") {
 """
 Adds note to the gift card.
 
-Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.1. 
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
@@ -23159,9 +22837,7 @@ input GiftCardAddNoteInput @doc(category: "Gift cards") {
 """
 Create gift cards.
 
-Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.1. 
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
@@ -23194,9 +22870,7 @@ input GiftCardBulkCreateInput @doc(category: "Gift cards") {
 """
 Delete gift cards.
 
-Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.1. 
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
@@ -23209,9 +22883,7 @@ type GiftCardBulkDelete @doc(category: "Gift cards") {
 """
 Activate gift cards.
 
-Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.1. 
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
@@ -23224,9 +22896,7 @@ type GiftCardBulkActivate @doc(category: "Gift cards") {
 """
 Deactivate gift cards.
 
-Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.1. 
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
@@ -23783,9 +23453,7 @@ enum FileTypesEnum {
 """
 Export gift cards to csv file.
 
-Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.1. 
 
 Requires one of the following permissions: MANAGE_GIFT_CARD.
 """
@@ -23983,8 +23651,6 @@ input CheckoutCreateInput @doc(category: "Checkout") {
   The checkout validation rules that can be changed.
   
   Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   validationRules: CheckoutValidationRules
 }
@@ -24000,8 +23666,6 @@ input CheckoutLineInput @doc(category: "Checkout") {
   Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   price: PositiveDecimal
 
@@ -24009,8 +23673,6 @@ input CheckoutLineInput @doc(category: "Checkout") {
   Flag that allow force splitting the same variant into multiple lines by skipping the matching logic. 
   
   Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   forceNewLine: Boolean = false
 
@@ -24116,8 +23778,6 @@ input CheckoutLineUpdateInput @doc(category: "Checkout") {
   Custom price of the item. Can be set only by apps with `HANDLE_CHECKOUTS` permission. When the line with the same variant will be provided multiple times, the last price will be used.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   price: PositiveDecimal
 
@@ -24218,8 +23878,6 @@ type CheckoutShippingMethodUpdate @doc(category: "Checkout") {
 Updates the delivery method (shipping method or pick up point) of the checkout.
 
 Added in Saleor 3.1.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CheckoutDeliveryMethodUpdate @doc(category: "Checkout") {
   """An updated checkout."""
@@ -24239,8 +23897,6 @@ type CheckoutLanguageCodeUpdate @doc(category: "Checkout") {
 Create new order from existing checkout. Requires the following permissions: AUTHENTICATED_APP and HANDLE_CHECKOUTS.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type OrderCreateFromCheckout @doc(category: "Checkout") {
   """Placed order."""
@@ -24336,8 +23992,6 @@ input ChannelCreateInput @doc(category: "Channels") {
   The channel stock settings.
   
   Added in Saleor 3.7.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   stockSettings: StockSettingsInput
 
@@ -24348,8 +24002,6 @@ input ChannelCreateInput @doc(category: "Channels") {
   List of warehouses to assign to the channel.
   
   Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addWarehouses: [ID!]
 
@@ -24373,8 +24025,6 @@ input ChannelCreateInput @doc(category: "Channels") {
   Default country for the channel. Default country can be used in checkout to determine the stock quantities or calculate taxes when the country was not explicitly provided.
   
   Added in Saleor 3.1.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   defaultCountry: CountryCode!
 }
@@ -24447,8 +24097,6 @@ input ChannelUpdateInput @doc(category: "Channels") {
   The channel stock settings.
   
   Added in Saleor 3.7.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   stockSettings: StockSettingsInput
 
@@ -24459,8 +24107,6 @@ input ChannelUpdateInput @doc(category: "Channels") {
   List of warehouses to assign to the channel.
   
   Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   addWarehouses: [ID!]
 
@@ -24491,8 +24137,6 @@ input ChannelUpdateInput @doc(category: "Channels") {
   List of warehouses to unassign from the channel.
   
   Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   removeWarehouses: [ID!]
 }
@@ -24540,9 +24184,7 @@ type ChannelDeactivate @doc(category: "Channels") {
 """
 Reorder the warehouses of a channel.
 
-Added in Saleor 3.7.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+Added in Saleor 3.7. 
 
 Requires one of the following permissions: MANAGE_CHANNELS.
 """
@@ -25109,8 +24751,6 @@ type Manifest @doc(category: "Apps") {
   List of the app's webhooks.
   
   Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   webhooks: [AppManifestWebhook!]!
 
@@ -25118,8 +24758,6 @@ type Manifest @doc(category: "Apps") {
   The audience that will be included in all JWT tokens for the app.
   
   Added in Saleor 3.8.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   audience: String
 
@@ -26089,8 +25727,6 @@ type Subscription {
   Look up subscription event.
   
   Added in Saleor 3.2.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   event: Event
 }
@@ -26152,8 +25788,6 @@ enum VolumeUnitsEnum {
 Event sent when new address is created.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AddressCreated implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -26176,8 +25810,6 @@ type AddressCreated implements Event @doc(category: "Users") {
 Event sent when address is updated.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AddressUpdated implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -26200,8 +25832,6 @@ type AddressUpdated implements Event @doc(category: "Users") {
 Event sent when address is deleted.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AddressDeleted implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -26224,8 +25854,6 @@ type AddressDeleted implements Event @doc(category: "Users") {
 Event sent when new app is installed.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AppInstalled implements Event @doc(category: "Apps") {
   """Time of the event."""
@@ -26248,8 +25876,6 @@ type AppInstalled implements Event @doc(category: "Apps") {
 Event sent when app is updated.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AppUpdated implements Event @doc(category: "Apps") {
   """Time of the event."""
@@ -26272,8 +25898,6 @@ type AppUpdated implements Event @doc(category: "Apps") {
 Event sent when app is deleted.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AppDeleted implements Event @doc(category: "Apps") {
   """Time of the event."""
@@ -26296,8 +25920,6 @@ type AppDeleted implements Event @doc(category: "Apps") {
 Event sent when app status has changed.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AppStatusChanged implements Event @doc(category: "Apps") {
   """Time of the event."""
@@ -26320,8 +25942,6 @@ type AppStatusChanged implements Event @doc(category: "Apps") {
 Event sent when new attribute is created.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AttributeCreated implements Event @doc(category: "Attributes") {
   """Time of the event."""
@@ -26344,8 +25964,6 @@ type AttributeCreated implements Event @doc(category: "Attributes") {
 Event sent when attribute is updated.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AttributeUpdated implements Event @doc(category: "Attributes") {
   """Time of the event."""
@@ -26368,8 +25986,6 @@ type AttributeUpdated implements Event @doc(category: "Attributes") {
 Event sent when attribute is deleted.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AttributeDeleted implements Event @doc(category: "Attributes") {
   """Time of the event."""
@@ -26392,8 +26008,6 @@ type AttributeDeleted implements Event @doc(category: "Attributes") {
 Event sent when new attribute value is created.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AttributeValueCreated implements Event @doc(category: "Attributes") {
   """Time of the event."""
@@ -26416,8 +26030,6 @@ type AttributeValueCreated implements Event @doc(category: "Attributes") {
 Event sent when attribute value is updated.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AttributeValueUpdated implements Event @doc(category: "Attributes") {
   """Time of the event."""
@@ -26440,8 +26052,6 @@ type AttributeValueUpdated implements Event @doc(category: "Attributes") {
 Event sent when attribute value is deleted.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type AttributeValueDeleted implements Event @doc(category: "Attributes") {
   """Time of the event."""
@@ -26464,8 +26074,6 @@ type AttributeValueDeleted implements Event @doc(category: "Attributes") {
 Event sent when new category is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CategoryCreated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -26488,8 +26096,6 @@ type CategoryCreated implements Event @doc(category: "Products") {
 Event sent when category is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CategoryUpdated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -26512,8 +26118,6 @@ type CategoryUpdated implements Event @doc(category: "Products") {
 Event sent when category is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CategoryDeleted implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -26536,8 +26140,6 @@ type CategoryDeleted implements Event @doc(category: "Products") {
 Event sent when new channel is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ChannelCreated implements Event @doc(category: "Channels") {
   """Time of the event."""
@@ -26560,8 +26162,6 @@ type ChannelCreated implements Event @doc(category: "Channels") {
 Event sent when channel is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ChannelUpdated implements Event @doc(category: "Channels") {
   """Time of the event."""
@@ -26584,8 +26184,6 @@ type ChannelUpdated implements Event @doc(category: "Channels") {
 Event sent when channel is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ChannelDeleted implements Event @doc(category: "Channels") {
   """Time of the event."""
@@ -26608,8 +26206,6 @@ type ChannelDeleted implements Event @doc(category: "Channels") {
 Event sent when channel status has changed.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ChannelStatusChanged implements Event @doc(category: "Channels") {
   """Time of the event."""
@@ -26632,8 +26228,6 @@ type ChannelStatusChanged implements Event @doc(category: "Channels") {
 Event sent when new gift card is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type GiftCardCreated implements Event @doc(category: "Gift cards") {
   """Time of the event."""
@@ -26656,8 +26250,6 @@ type GiftCardCreated implements Event @doc(category: "Gift cards") {
 Event sent when gift card is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type GiftCardUpdated implements Event @doc(category: "Gift cards") {
   """Time of the event."""
@@ -26680,8 +26272,6 @@ type GiftCardUpdated implements Event @doc(category: "Gift cards") {
 Event sent when gift card is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type GiftCardDeleted implements Event @doc(category: "Gift cards") {
   """Time of the event."""
@@ -26734,8 +26324,6 @@ type GiftCardSent implements Event @doc(category: "Gift cards") {
 Event sent when gift card status has changed.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type GiftCardStatusChanged implements Event @doc(category: "Gift cards") {
   """Time of the event."""
@@ -26758,8 +26346,6 @@ type GiftCardStatusChanged implements Event @doc(category: "Gift cards") {
 Event sent when gift card metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type GiftCardMetadataUpdated implements Event @doc(category: "Gift cards") {
   """Time of the event."""
@@ -26782,8 +26368,6 @@ type GiftCardMetadataUpdated implements Event @doc(category: "Gift cards") {
 Event sent when new menu is created.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type MenuCreated implements Event {
   """Time of the event."""
@@ -26809,8 +26393,6 @@ type MenuCreated implements Event {
 Event sent when menu is updated.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type MenuUpdated implements Event {
   """Time of the event."""
@@ -26836,8 +26418,6 @@ type MenuUpdated implements Event {
 Event sent when menu is deleted.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type MenuDeleted implements Event {
   """Time of the event."""
@@ -26863,8 +26443,6 @@ type MenuDeleted implements Event {
 Event sent when new menu item is created.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type MenuItemCreated implements Event {
   """Time of the event."""
@@ -26890,8 +26468,6 @@ type MenuItemCreated implements Event {
 Event sent when menu item is updated.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type MenuItemUpdated implements Event {
   """Time of the event."""
@@ -26917,8 +26493,6 @@ type MenuItemUpdated implements Event {
 Event sent when menu item is deleted.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type MenuItemDeleted implements Event {
   """Time of the event."""
@@ -26944,8 +26518,6 @@ type MenuItemDeleted implements Event {
 Event sent when new order is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type OrderCreated implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -26968,8 +26540,6 @@ type OrderCreated implements Event @doc(category: "Orders") {
 Event sent when order is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type OrderUpdated implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -26992,8 +26562,6 @@ type OrderUpdated implements Event @doc(category: "Orders") {
 Event sent when order is confirmed.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type OrderConfirmed implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27016,8 +26584,6 @@ type OrderConfirmed implements Event @doc(category: "Orders") {
 Event sent when order is fully paid.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type OrderFullyPaid implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27040,8 +26606,6 @@ type OrderFullyPaid implements Event @doc(category: "Orders") {
 Event sent when order is fulfilled.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type OrderFulfilled implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27064,8 +26628,6 @@ type OrderFulfilled implements Event @doc(category: "Orders") {
 Event sent when order is canceled.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type OrderCancelled implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27112,8 +26674,6 @@ type OrderExpired implements Event @doc(category: "Orders") {
 Event sent when order metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type OrderMetadataUpdated implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27136,8 +26696,6 @@ type OrderMetadataUpdated implements Event @doc(category: "Orders") {
 Event sent when new draft order is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type DraftOrderCreated implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27160,8 +26718,6 @@ type DraftOrderCreated implements Event @doc(category: "Orders") {
 Event sent when draft order is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type DraftOrderUpdated implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27184,8 +26740,6 @@ type DraftOrderUpdated implements Event @doc(category: "Orders") {
 Event sent when draft order is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type DraftOrderDeleted implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27208,8 +26762,6 @@ type DraftOrderDeleted implements Event @doc(category: "Orders") {
 Event sent when new product is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ProductCreated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -27238,8 +26790,6 @@ type ProductCreated implements Event @doc(category: "Products") {
 Event sent when product is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ProductUpdated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -27268,8 +26818,6 @@ type ProductUpdated implements Event @doc(category: "Products") {
 Event sent when product is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ProductDeleted implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -27298,8 +26846,6 @@ type ProductDeleted implements Event @doc(category: "Products") {
 Event sent when product metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ProductMetadataUpdated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -27394,8 +26940,6 @@ type ProductMediaDeleted implements Event @doc(category: "Products") {
 Event sent when new product variant is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ProductVariantCreated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -27421,8 +26965,6 @@ type ProductVariantCreated implements Event @doc(category: "Products") {
 Event sent when product variant is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ProductVariantUpdated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -27448,8 +26990,6 @@ type ProductVariantUpdated implements Event @doc(category: "Products") {
 Event sent when product variant is out of stock.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ProductVariantOutOfStock implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -27478,8 +27018,6 @@ type ProductVariantOutOfStock implements Event @doc(category: "Products") {
 Event sent when product variant is back in stock.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ProductVariantBackInStock implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -27538,8 +27076,6 @@ type ProductVariantStockUpdated implements Event {
 Event sent when product variant is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ProductVariantDeleted implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -27565,8 +27101,6 @@ type ProductVariantDeleted implements Event @doc(category: "Products") {
 Event sent when product variant metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ProductVariantMetadataUpdated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -27592,8 +27126,6 @@ type ProductVariantMetadataUpdated implements Event @doc(category: "Products") {
 Event sent when new sale is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type SaleCreated implements Event @doc(category: "Discounts") {
   """Time of the event."""
@@ -27619,8 +27151,6 @@ type SaleCreated implements Event @doc(category: "Discounts") {
 Event sent when sale is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type SaleUpdated implements Event @doc(category: "Discounts") {
   """Time of the event."""
@@ -27646,8 +27176,6 @@ type SaleUpdated implements Event @doc(category: "Discounts") {
 Event sent when sale is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type SaleDeleted implements Event @doc(category: "Discounts") {
   """Time of the event."""
@@ -27673,8 +27201,6 @@ type SaleDeleted implements Event @doc(category: "Discounts") {
 The event informs about the start or end of the sale.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type SaleToggle implements Event @doc(category: "Discounts") {
   """Time of the event."""
@@ -27693,8 +27219,6 @@ type SaleToggle implements Event @doc(category: "Discounts") {
   The sale the event relates to.
   
   Added in Saleor 3.5.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   sale(
     """Slug of a channel for which the data should be returned."""
@@ -27706,8 +27230,6 @@ type SaleToggle implements Event @doc(category: "Discounts") {
 Event sent when invoice is requested.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type InvoiceRequested implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27737,8 +27259,6 @@ type InvoiceRequested implements Event @doc(category: "Orders") {
 Event sent when invoice is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type InvoiceDeleted implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27768,8 +27288,6 @@ type InvoiceDeleted implements Event @doc(category: "Orders") {
 Event sent when invoice is sent.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type InvoiceSent implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27799,8 +27317,6 @@ type InvoiceSent implements Event @doc(category: "Orders") {
 Event sent when new fulfillment is created.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type FulfillmentCreated implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27826,8 +27342,6 @@ type FulfillmentCreated implements Event @doc(category: "Orders") {
 Event sent when fulfillment is canceled.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type FulfillmentCanceled implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27853,8 +27367,6 @@ type FulfillmentCanceled implements Event @doc(category: "Orders") {
 Event sent when fulfillment is approved.
 
 Added in Saleor 3.7.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type FulfillmentApproved implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27880,8 +27392,6 @@ type FulfillmentApproved implements Event @doc(category: "Orders") {
 Event sent when fulfillment metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type FulfillmentMetadataUpdated implements Event @doc(category: "Orders") {
   """Time of the event."""
@@ -27907,8 +27417,6 @@ type FulfillmentMetadataUpdated implements Event @doc(category: "Orders") {
 Event sent when new customer user is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CustomerCreated implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -27931,8 +27439,6 @@ type CustomerCreated implements Event @doc(category: "Users") {
 Event sent when customer user is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CustomerUpdated implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -27955,8 +27461,6 @@ type CustomerUpdated implements Event @doc(category: "Users") {
 Event sent when customer user metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CustomerMetadataUpdated implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -27979,8 +27483,6 @@ type CustomerMetadataUpdated implements Event @doc(category: "Users") {
 Event sent when new collection is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CollectionCreated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -28006,8 +27508,6 @@ type CollectionCreated implements Event @doc(category: "Products") {
 Event sent when collection is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CollectionUpdated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -28033,8 +27533,6 @@ type CollectionUpdated implements Event @doc(category: "Products") {
 Event sent when collection is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CollectionDeleted implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -28060,8 +27558,6 @@ type CollectionDeleted implements Event @doc(category: "Products") {
 Event sent when collection metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CollectionMetadataUpdated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -28087,8 +27583,6 @@ type CollectionMetadataUpdated implements Event @doc(category: "Products") {
 Event sent when new checkout is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CheckoutCreated implements Event @doc(category: "Checkout") {
   """Time of the event."""
@@ -28111,8 +27605,6 @@ type CheckoutCreated implements Event @doc(category: "Checkout") {
 Event sent when checkout is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CheckoutUpdated implements Event @doc(category: "Checkout") {
   """Time of the event."""
@@ -28159,8 +27651,6 @@ type CheckoutFullyPaid implements Event @doc(category: "Checkout") {
 Event sent when checkout metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CheckoutMetadataUpdated implements Event @doc(category: "Checkout") {
   """Time of the event."""
@@ -28183,8 +27673,6 @@ type CheckoutMetadataUpdated implements Event @doc(category: "Checkout") {
 Event sent when new page is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PageCreated implements Event @doc(category: "Pages") {
   """Time of the event."""
@@ -28207,8 +27695,6 @@ type PageCreated implements Event @doc(category: "Pages") {
 Event sent when page is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PageUpdated implements Event @doc(category: "Pages") {
   """Time of the event."""
@@ -28231,8 +27717,6 @@ type PageUpdated implements Event @doc(category: "Pages") {
 Event sent when page is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PageDeleted implements Event @doc(category: "Pages") {
   """Time of the event."""
@@ -28255,8 +27739,6 @@ type PageDeleted implements Event @doc(category: "Pages") {
 Event sent when new page type is created.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PageTypeCreated implements Event @doc(category: "Pages") {
   """Time of the event."""
@@ -28279,8 +27761,6 @@ type PageTypeCreated implements Event @doc(category: "Pages") {
 Event sent when page type is updated.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PageTypeUpdated implements Event @doc(category: "Pages") {
   """Time of the event."""
@@ -28303,8 +27783,6 @@ type PageTypeUpdated implements Event @doc(category: "Pages") {
 Event sent when page type is deleted.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PageTypeDeleted implements Event @doc(category: "Pages") {
   """Time of the event."""
@@ -28327,8 +27805,6 @@ type PageTypeDeleted implements Event @doc(category: "Pages") {
 Event sent when new permission group is created.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PermissionGroupCreated implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -28351,8 +27827,6 @@ type PermissionGroupCreated implements Event @doc(category: "Users") {
 Event sent when permission group is updated.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PermissionGroupUpdated implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -28375,8 +27849,6 @@ type PermissionGroupUpdated implements Event @doc(category: "Users") {
 Event sent when permission group is deleted.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PermissionGroupDeleted implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -28399,8 +27871,6 @@ type PermissionGroupDeleted implements Event @doc(category: "Users") {
 Event sent when new shipping price is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ShippingPriceCreated implements Event {
   """Time of the event."""
@@ -28432,8 +27902,6 @@ type ShippingPriceCreated implements Event {
 Event sent when shipping price is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ShippingPriceUpdated implements Event {
   """Time of the event."""
@@ -28465,8 +27933,6 @@ type ShippingPriceUpdated implements Event {
 Event sent when shipping price is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ShippingPriceDeleted implements Event {
   """Time of the event."""
@@ -28498,8 +27964,6 @@ type ShippingPriceDeleted implements Event {
 Event sent when new shipping zone is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ShippingZoneCreated implements Event @doc(category: "Shipping") {
   """Time of the event."""
@@ -28525,8 +27989,6 @@ type ShippingZoneCreated implements Event @doc(category: "Shipping") {
 Event sent when shipping zone is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ShippingZoneUpdated implements Event @doc(category: "Shipping") {
   """Time of the event."""
@@ -28552,8 +28014,6 @@ type ShippingZoneUpdated implements Event @doc(category: "Shipping") {
 Event sent when shipping zone is deleted.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ShippingZoneDeleted implements Event @doc(category: "Shipping") {
   """Time of the event."""
@@ -28579,8 +28039,6 @@ type ShippingZoneDeleted implements Event @doc(category: "Shipping") {
 Event sent when shipping zone metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ShippingZoneMetadataUpdated implements Event @doc(category: "Shipping") {
   """Time of the event."""
@@ -28606,8 +28064,6 @@ type ShippingZoneMetadataUpdated implements Event @doc(category: "Shipping") {
 Event sent when new staff user is created.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type StaffCreated implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -28630,8 +28086,6 @@ type StaffCreated implements Event @doc(category: "Users") {
 Event sent when staff user is updated.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type StaffUpdated implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -28654,8 +28108,6 @@ type StaffUpdated implements Event @doc(category: "Users") {
 Event sent when staff user is deleted.
 
 Added in Saleor 3.5.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type StaffDeleted implements Event @doc(category: "Users") {
   """Time of the event."""
@@ -28713,8 +28165,6 @@ type TransactionAction {
 Event sent when transaction item metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type TransactionItemMetadataUpdated implements Event @doc(category: "Payments") {
   """Time of the event."""
@@ -28729,11 +28179,7 @@ type TransactionItemMetadataUpdated implements Event @doc(category: "Payments") 
   """The application receiving the webhook."""
   recipient: App
 
-  """
-  Look up a transaction.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  """
+  """Look up a transaction."""
   transaction: TransactionItem
 }
 
@@ -28741,8 +28187,6 @@ type TransactionItemMetadataUpdated implements Event @doc(category: "Payments") 
 Event sent when new translation is created.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type TranslationCreated implements Event {
   """Time of the event."""
@@ -28767,8 +28211,6 @@ union TranslationTypes = ProductTranslation | CollectionTranslation | CategoryTr
 Event sent when translation is updated.
 
 Added in Saleor 3.2.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type TranslationUpdated implements Event {
   """Time of the event."""
@@ -28791,8 +28233,6 @@ type TranslationUpdated implements Event {
 Event sent when new voucher is created.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type VoucherCreated implements Event @doc(category: "Discounts") {
   """Time of the event."""
@@ -28818,8 +28258,6 @@ type VoucherCreated implements Event @doc(category: "Discounts") {
 Event sent when voucher is updated.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type VoucherUpdated implements Event @doc(category: "Discounts") {
   """Time of the event."""
@@ -28845,8 +28283,6 @@ type VoucherUpdated implements Event @doc(category: "Discounts") {
 Event sent when voucher is deleted.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type VoucherDeleted implements Event @doc(category: "Discounts") {
   """Time of the event."""
@@ -28872,8 +28308,6 @@ type VoucherDeleted implements Event @doc(category: "Discounts") {
 Event sent when voucher metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type VoucherMetadataUpdated implements Event @doc(category: "Discounts") {
   """Time of the event."""
@@ -28899,8 +28333,6 @@ type VoucherMetadataUpdated implements Event @doc(category: "Discounts") {
 Event sent when new warehouse is created.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type WarehouseCreated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -28923,8 +28355,6 @@ type WarehouseCreated implements Event @doc(category: "Products") {
 Event sent when warehouse is updated.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type WarehouseUpdated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -28947,8 +28377,6 @@ type WarehouseUpdated implements Event @doc(category: "Products") {
 Event sent when warehouse is deleted.
 
 Added in Saleor 3.4.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type WarehouseDeleted implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -28971,8 +28399,6 @@ type WarehouseDeleted implements Event @doc(category: "Products") {
 Event sent when warehouse metadata is updated.
 
 Added in Saleor 3.8.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type WarehouseMetadataUpdated implements Event @doc(category: "Products") {
   """Time of the event."""
@@ -29042,8 +28468,6 @@ type ThumbnailCreated implements Event {
 Authorize payment.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PaymentAuthorize implements Event {
   """Time of the event."""
@@ -29066,8 +28490,6 @@ type PaymentAuthorize implements Event {
 Capture payment.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PaymentCaptureEvent implements Event {
   """Time of the event."""
@@ -29090,8 +28512,6 @@ type PaymentCaptureEvent implements Event {
 Refund payment.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PaymentRefundEvent implements Event {
   """Time of the event."""
@@ -29114,8 +28534,6 @@ type PaymentRefundEvent implements Event {
 Void payment.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PaymentVoidEvent implements Event {
   """Time of the event."""
@@ -29138,8 +28556,6 @@ type PaymentVoidEvent implements Event {
 Confirm payment.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PaymentConfirmEvent implements Event {
   """Time of the event."""
@@ -29162,8 +28578,6 @@ type PaymentConfirmEvent implements Event {
 Process payment.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PaymentProcessEvent implements Event {
   """Time of the event."""
@@ -29186,8 +28600,6 @@ type PaymentProcessEvent implements Event {
 List payment gateways.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type PaymentListGateways implements Event {
   """Time of the event."""
@@ -29291,8 +28703,6 @@ type TransactionRefundRequested implements Event {
 Filter shipping methods for order.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type OrderFilterShippingMethods implements Event {
   """Time of the event."""
@@ -29314,8 +28724,6 @@ type OrderFilterShippingMethods implements Event {
   Shipping methods that can be used with this checkout.
   
   Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   shippingMethods: [ShippingMethod!]
 }
@@ -29324,8 +28732,6 @@ type OrderFilterShippingMethods implements Event {
 Filter shipping methods for checkout.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CheckoutFilterShippingMethods implements Event {
   """Time of the event."""
@@ -29347,8 +28753,6 @@ type CheckoutFilterShippingMethods implements Event {
   Shipping methods that can be used with this checkout.
   
   Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   shippingMethods: [ShippingMethod!]
 }
@@ -29357,8 +28761,6 @@ type CheckoutFilterShippingMethods implements Event {
 List shipping methods for checkout.
 
 Added in Saleor 3.6.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type ShippingListMethodsForCheckout implements Event {
   """Time of the event."""
@@ -29380,8 +28782,6 @@ type ShippingListMethodsForCheckout implements Event {
   Shipping methods that can be used with this checkout.
   
   Added in Saleor 3.6.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   shippingMethods: [ShippingMethod!]
 }
@@ -29390,8 +28790,6 @@ type ShippingListMethodsForCheckout implements Event {
 Synchronous webhook for calculating checkout/order taxes.
 
 Added in Saleor 3.7.
-
-Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
 type CalculateTaxes implements Event {
   """Time of the event."""

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -21,12 +21,7 @@ from ..channel.types import (
     ChannelContextTypeWithMetadataForObjectType,
 )
 from ..core.connection import CountableConnection, create_connection_slice
-from ..core.descriptions import (
-    ADDED_IN_36,
-    DEPRECATED_IN_3X_FIELD,
-    PREVIEW_FEATURE,
-    RICH_CONTENT,
-)
+from ..core.descriptions import ADDED_IN_36, DEPRECATED_IN_3X_FIELD, RICH_CONTENT
 from ..core.doc_category import DOC_CATEGORY_SHIPPING
 from ..core.fields import ConnectionField, JSONString, PermissionsField
 from ..core.tracing import traced_resolver
@@ -423,7 +418,5 @@ class ShippingMethodsPerCountry(BaseObjectType):
     class Meta:
         doc_category = DOC_CATEGORY_SHIPPING
         description = (
-            "List of shipping methods available for the country."
-            + ADDED_IN_36
-            + PREVIEW_FEATURE
+            "List of shipping methods available for the country." + ADDED_IN_36
         )

--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -13,7 +13,7 @@ from ..account.i18n import I18nMixin
 from ..account.types import AddressInput, StaffNotificationRecipient
 from ..channel.types import OrderSettings
 from ..core import ResolveInfo
-from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_INPUT, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_INPUT
 from ..core.doc_category import DOC_CATEGORY_GIFT_CARDS, DOC_CATEGORY_ORDERS
 from ..core.enums import WeightUnitsEnum
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
@@ -78,9 +78,7 @@ class ShopSettingsInput(graphene.InputObjectType):
         description=(
             "Default number of maximum line quantity "
             "in single checkout. Minimum possible value is 1, default "
-            f"value is {DEFAULT_LIMIT_QUANTITY_PER_CHECKOUT}."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
+            f"value is {DEFAULT_LIMIT_QUANTITY_PER_CHECKOUT}." + ADDED_IN_31
         )
     )
 

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -20,7 +20,6 @@ from ..core.descriptions import (
     ADDED_IN_35,
     DEPRECATED_IN_3X_FIELD,
     DEPRECATED_IN_3X_INPUT,
-    PREVIEW_FEATURE,
 )
 from ..core.enums import LanguageCodeEnum, WeightUnitsEnum
 from ..core.fields import PermissionsField
@@ -253,7 +252,7 @@ class Shop(graphene.ObjectType):
         graphene.Int,
         description=(
             "Default number of maximum line quantity in single checkout "
-            "(per single checkout line)." + ADDED_IN_31 + PREVIEW_FEATURE
+            "(per single checkout line)." + ADDED_IN_31
         ),
         permissions=[SitePermissions.MANAGE_SETTINGS],
     )

--- a/saleor/graphql/tax/mutations/tax_class_create.py
+++ b/saleor/graphql/tax/mutations/tax_class_create.py
@@ -3,7 +3,7 @@ import graphene
 from ....permission.enums import CheckoutPermissions
 from ....tax import error_codes, models
 from ...account.enums import CountryCodeEnum
-from ...core.descriptions import ADDED_IN_39, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_39
 from ...core.doc_category import DOC_CATEGORY_TAXES
 from ...core.mutations import ModelMutation
 from ...core.types import BaseInputObjectType, Error, NonNullList
@@ -59,7 +59,7 @@ class TaxClassCreate(ModelMutation):
         )
 
     class Meta:
-        description = "Create a tax class." + ADDED_IN_39 + PREVIEW_FEATURE
+        description = "Create a tax class." + ADDED_IN_39
         error_type_class = TaxClassCreateError
         model = models.TaxClass
         object_type = TaxClass

--- a/saleor/graphql/tax/mutations/tax_class_delete.py
+++ b/saleor/graphql/tax/mutations/tax_class_delete.py
@@ -2,7 +2,7 @@ import graphene
 
 from ....permission.enums import CheckoutPermissions
 from ....tax import error_codes, models
-from ...core.descriptions import ADDED_IN_39, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_39
 from ...core.doc_category import DOC_CATEGORY_TAXES
 from ...core.mutations import ModelDeleteMutation
 from ...core.types import Error
@@ -25,14 +25,10 @@ class TaxClassDelete(ModelDeleteMutation):
 
     class Meta:
         description = (
-            (
-                "Delete a tax class. After deleting the tax class any products, "
-                "product types or shipping methods using it are updated to use the "
-                "default tax class."
-            )
-            + ADDED_IN_39
-            + PREVIEW_FEATURE
-        )
+            "Delete a tax class. After deleting the tax class any products, "
+            "product types or shipping methods using it are updated to use the "
+            "default tax class."
+        ) + ADDED_IN_39
         error_type_class = TaxClassDeleteError
         model = models.TaxClass
         object_type = TaxClass

--- a/saleor/graphql/tax/mutations/tax_class_update.py
+++ b/saleor/graphql/tax/mutations/tax_class_update.py
@@ -5,7 +5,7 @@ from ....permission.enums import CheckoutPermissions
 from ....tax import error_codes, models
 from ...account.enums import CountryCodeEnum
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_39, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_39
 from ...core.doc_category import DOC_CATEGORY_TAXES
 from ...core.mutations import ModelMutation
 from ...core.types import BaseInputObjectType, Error, NonNullList
@@ -72,7 +72,7 @@ class TaxClassUpdate(ModelMutation):
         )
 
     class Meta:
-        description = "Update a tax class." + ADDED_IN_39 + PREVIEW_FEATURE
+        description = "Update a tax class." + ADDED_IN_39
         error_type_class = TaxClassUpdateError
         model = models.TaxClass
         object_type = TaxClass

--- a/saleor/graphql/tax/mutations/tax_configuration_update.py
+++ b/saleor/graphql/tax/mutations/tax_configuration_update.py
@@ -5,7 +5,7 @@ from ....permission.enums import CheckoutPermissions
 from ....tax import error_codes, models
 from ...account.enums import CountryCodeEnum
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_39, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_39
 from ...core.doc_category import DOC_CATEGORY_TAXES
 from ...core.mutations import ModelMutation
 from ...core.types import BaseInputObjectType, Error, NonNullList
@@ -107,9 +107,7 @@ class TaxConfigurationUpdate(ModelMutation):
         )
 
     class Meta:
-        description = (
-            "Update tax configuration for a channel." + ADDED_IN_39 + PREVIEW_FEATURE
-        )
+        description = "Update tax configuration for a channel." + ADDED_IN_39
         error_type_class = TaxConfigurationUpdateError
         model = models.TaxConfiguration
         object_type = TaxConfiguration

--- a/saleor/graphql/tax/mutations/tax_country_configuration_delete.py
+++ b/saleor/graphql/tax/mutations/tax_country_configuration_delete.py
@@ -5,7 +5,7 @@ from ....permission.enums import CheckoutPermissions
 from ....tax import error_codes, models
 from ...account.enums import CountryCodeEnum
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_39, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_39
 from ...core.doc_category import DOC_CATEGORY_TAXES
 from ...core.mutations import BaseMutation
 from ...core.types import Error
@@ -38,11 +38,7 @@ class TaxCountryConfigurationDelete(BaseMutation):
         )
 
     class Meta:
-        description = (
-            "Remove all tax class rates for a specific country."
-            + ADDED_IN_39
-            + PREVIEW_FEATURE
-        )
+        description = "Remove all tax class rates for a specific country." + ADDED_IN_39
         doc_category = DOC_CATEGORY_TAXES
         error_type_class = TaxCountryConfigurationDeleteError
         permissions = (CheckoutPermissions.MANAGE_TAXES,)

--- a/saleor/graphql/tax/mutations/tax_country_configuration_update.py
+++ b/saleor/graphql/tax/mutations/tax_country_configuration_update.py
@@ -10,7 +10,7 @@ from ....permission.enums import CheckoutPermissions
 from ....tax import error_codes, models
 from ...account.enums import CountryCodeEnum
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_39, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_39
 from ...core.doc_category import DOC_CATEGORY_TAXES
 from ...core.mutations import BaseMutation
 from ...core.types import BaseInputObjectType, Error, NonNullList
@@ -69,11 +69,7 @@ class TaxCountryConfigurationUpdate(BaseMutation):
         )
 
     class Meta:
-        description = (
-            "Update tax class rates for a specific country."
-            + ADDED_IN_39
-            + PREVIEW_FEATURE
-        )
+        description = "Update tax class rates for a specific country." + ADDED_IN_39
         doc_category = DOC_CATEGORY_TAXES
         error_type_class = TaxCountryConfigurationUpdateError
         permissions = (CheckoutPermissions.MANAGE_TAXES,)

--- a/saleor/graphql/tax/mutations/tax_exemption_manage.py
+++ b/saleor/graphql/tax/mutations/tax_exemption_manage.py
@@ -10,7 +10,7 @@ from ....order.models import Order
 from ....permission.enums import CheckoutPermissions
 from ....tax import error_codes
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_38, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_38
 from ...core.doc_category import DOC_CATEGORY_TAXES
 from ...core.types import Error
 from ...core.types.taxes import TaxSourceObject
@@ -46,9 +46,7 @@ class TaxExemptionManage(BaseMutation):
             "Exempt checkout or order from charging the taxes. When tax exemption is "
             "enabled, taxes won't be charged for the checkout or order. Taxes may "
             "still be calculated in cases when product prices are entered with the "
-            "tax included and the net price needs to be known."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
+            "tax included and the net price needs to be known." + ADDED_IN_38
         )
         doc_category = DOC_CATEGORY_TAXES
         error_type_class = TaxExemptionManageError

--- a/saleor/graphql/tax/schema.py
+++ b/saleor/graphql/tax/schema.py
@@ -8,7 +8,7 @@ from ...tax import models
 from ..account.enums import CountryCodeEnum
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
-from ..core.descriptions import ADDED_IN_39, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_39
 from ..core.doc_category import DOC_CATEGORY_TAXES
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.types import NonNullList
@@ -36,7 +36,7 @@ from .types import (
 class TaxQueries(graphene.ObjectType):
     tax_configuration = PermissionsField(
         TaxConfiguration,
-        description="Look up a tax configuration." + ADDED_IN_39 + PREVIEW_FEATURE,
+        description="Look up a tax configuration." + ADDED_IN_39,
         id=graphene.Argument(
             graphene.ID, description="ID of a tax configuration.", required=True
         ),
@@ -48,7 +48,7 @@ class TaxQueries(graphene.ObjectType):
     )
     tax_configurations = FilterConnectionField(
         TaxConfigurationCountableConnection,
-        description="List of tax configurations." + ADDED_IN_39 + PREVIEW_FEATURE,
+        description="List of tax configurations." + ADDED_IN_39,
         filter=TaxConfigurationFilterInput(
             description="Filtering options for tax configurations."
         ),
@@ -60,7 +60,7 @@ class TaxQueries(graphene.ObjectType):
     )
     tax_class = PermissionsField(
         TaxClass,
-        description="Look up a tax class." + ADDED_IN_39 + PREVIEW_FEATURE,
+        description="Look up a tax class." + ADDED_IN_39,
         id=graphene.Argument(
             graphene.ID, description="ID of a tax class.", required=True
         ),
@@ -72,7 +72,7 @@ class TaxQueries(graphene.ObjectType):
     )
     tax_classes = FilterConnectionField(
         TaxClassCountableConnection,
-        description="List of tax classes." + ADDED_IN_39 + PREVIEW_FEATURE,
+        description="List of tax classes." + ADDED_IN_39,
         sort_by=TaxClassSortingInput(description="Sort tax classes."),
         filter=TaxClassFilterInput(description="Filtering options for tax classes."),
         permissions=[

--- a/saleor/graphql/tax/types.py
+++ b/saleor/graphql/tax/types.py
@@ -5,7 +5,7 @@ from ..channel.dataloaders import ChannelByIdLoader
 from ..channel.types import Channel
 from ..core import ResolveInfo
 from ..core.connection import CountableConnection
-from ..core.descriptions import ADDED_IN_39, PREVIEW_FEATURE
+from ..core.descriptions import ADDED_IN_39
 from ..core.doc_category import DOC_CATEGORY_TAXES
 from ..core.types import BaseObjectType, CountryDisplay, ModelObjectType, NonNullList
 from ..meta.types import ObjectWithMetadata
@@ -54,9 +54,7 @@ class TaxConfiguration(ModelObjectType[models.TaxConfiguration]):
     )
 
     class Meta:
-        description = (
-            "Channel-specific tax configuration." + ADDED_IN_39 + PREVIEW_FEATURE
-        )
+        description = "Channel-specific tax configuration." + ADDED_IN_39
         interfaces = [graphene.relay.Node, ObjectWithMetadata]
         model = models.TaxConfiguration
 
@@ -108,7 +106,6 @@ class TaxConfigurationPerCountry(ModelObjectType[models.TaxConfigurationPerCount
         description = (
             "Country-specific exceptions of a channel's tax configuration."
             + ADDED_IN_39
-            + PREVIEW_FEATURE
         )
         interface = [graphene.relay.Node]
         model = models.TaxConfigurationPerCountry
@@ -130,7 +127,7 @@ class TaxClass(ModelObjectType[models.TaxClass]):
         description = (
             "Tax class is a named object used to define tax rates per country. Tax "
             "class can be assigned to product types, products and shipping methods to "
-            "define their tax rates." + ADDED_IN_39 + PREVIEW_FEATURE
+            "define their tax rates." + ADDED_IN_39
         )
         interfaces = [graphene.relay.Node, ObjectWithMetadata]
         model = models.TaxClass
@@ -161,7 +158,7 @@ class TaxClassCountryRate(ModelObjectType[models.TaxClassCountryRate]):
         description = (
             "Tax rate for a country. When tax class is null, it represents the default "
             "tax rate for that country; otherwise it's a country tax rate specific to "
-            "the given tax class." + ADDED_IN_39 + PREVIEW_FEATURE
+            "the given tax class." + ADDED_IN_39
         )
         model = models.TaxClassCountryRate
 
@@ -189,9 +186,7 @@ class TaxCountryConfiguration(BaseObjectType):
     )
 
     class Meta:
-        description = (
-            "Tax class rates grouped by country." + ADDED_IN_39 + PREVIEW_FEATURE
-        )
+        description = "Tax class rates grouped by country." + ADDED_IN_39
         doc_category = DOC_CATEGORY_TAXES
 
     @staticmethod

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -15,7 +15,6 @@ from ..core.descriptions import (
     ADDED_IN_310,
     DEPRECATED_IN_3X_FIELD,
     DEPRECATED_IN_3X_INPUT,
-    PREVIEW_FEATURE,
 )
 from ..core.doc_category import DOC_CATEGORY_PRODUCTS
 from ..core.fields import ConnectionField, PermissionsField
@@ -70,14 +69,12 @@ class WarehouseUpdateInput(WarehouseInput):
     )
     click_and_collect_option = WarehouseClickAndCollectOptionEnum(
         description=(
-            "Click and collect options: local, all or disabled."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
+            "Click and collect options: local, all or disabled." + ADDED_IN_31
         ),
         required=False,
     )
     is_private = graphene.Boolean(
-        description="Visibility of warehouse stocks." + ADDED_IN_31 + PREVIEW_FEATURE,
+        description="Visibility of warehouse stocks." + ADDED_IN_31,
         required=False,
     )
 
@@ -101,9 +98,7 @@ class Warehouse(ModelObjectType[models.Warehouse]):
     )
     click_and_collect_option = WarehouseClickAndCollectOptionEnum(
         description=(
-            "Click and collect options: local, all or disabled."
-            + ADDED_IN_31
-            + PREVIEW_FEATURE
+            "Click and collect options: local, all or disabled." + ADDED_IN_31
         ),
         required=True,
     )

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -55,19 +55,19 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.CHECKOUT_CREATED: "A new checkout is created.",
     WebhookEventAsyncType.CHECKOUT_UPDATED: checkout_updated_event_enum_description,
     WebhookEventAsyncType.CHECKOUT_METADATA_UPDATED: (
-        "A checkout metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "A checkout metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.COLLECTION_CREATED: "A new collection is created.",
     WebhookEventAsyncType.COLLECTION_UPDATED: "A collection is updated.",
     WebhookEventAsyncType.COLLECTION_DELETED: "A collection is deleted.",
     WebhookEventAsyncType.COLLECTION_METADATA_UPDATED: (
-        "A collection metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "A collection metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.CUSTOMER_CREATED: "A new customer account is created.",
     WebhookEventAsyncType.CUSTOMER_UPDATED: "A customer account is updated.",
     WebhookEventAsyncType.CUSTOMER_DELETED: "A customer account is deleted.",
     WebhookEventAsyncType.CUSTOMER_METADATA_UPDATED: (
-        "A customer account metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "A customer account metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.GIFT_CARD_CREATED: "A new gift card created.",
     WebhookEventAsyncType.GIFT_CARD_UPDATED: "A gift card is updated.",
@@ -77,7 +77,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
     ),
     WebhookEventAsyncType.GIFT_CARD_STATUS_CHANGED: "A gift card status is changed.",
     WebhookEventAsyncType.GIFT_CARD_METADATA_UPDATED: (
-        "A gift card metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "A gift card metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.INVOICE_REQUESTED: "An invoice for order requested.",
     WebhookEventAsyncType.INVOICE_DELETED: "An invoice is deleted.",
@@ -97,7 +97,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.ORDER_EXPIRED: "An order is expired.",
     WebhookEventAsyncType.ORDER_FULFILLED: "An order is fulfilled.",
     WebhookEventAsyncType.ORDER_METADATA_UPDATED: (
-        "An order metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "An order metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.DRAFT_ORDER_CREATED: "A draft order is created.",
     WebhookEventAsyncType.DRAFT_ORDER_UPDATED: "A draft order is updated.",
@@ -110,7 +110,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.FULFILLMENT_CANCELED: "A fulfillment is cancelled.",
     WebhookEventAsyncType.FULFILLMENT_APPROVED: "A fulfillment is approved.",
     WebhookEventAsyncType.FULFILLMENT_METADATA_UPDATED: (
-        "A fulfillment metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "A fulfillment metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.PAGE_CREATED: "A new page is created.",
     WebhookEventAsyncType.PAGE_UPDATED: "A page is updated.",
@@ -127,7 +127,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.PRODUCT_UPDATED: "A product is updated.",
     WebhookEventAsyncType.PRODUCT_DELETED: "A product is deleted.",
     WebhookEventAsyncType.PRODUCT_METADATA_UPDATED: (
-        "A product metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "A product metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.PRODUCT_MEDIA_CREATED: "A new product media is created."
     + ADDED_IN_312,
@@ -139,7 +139,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED: "A product variant is updated.",
     WebhookEventAsyncType.PRODUCT_VARIANT_DELETED: "A product variant is deleted.",
     WebhookEventAsyncType.PRODUCT_VARIANT_METADATA_UPDATED: (
-        "A product variant metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "A product variant metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK: (
         "A product variant is out of stock."
@@ -157,7 +157,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.SHIPPING_ZONE_UPDATED: "A shipping zone is updated.",
     WebhookEventAsyncType.SHIPPING_ZONE_DELETED: "A shipping zone is deleted.",
     WebhookEventAsyncType.SHIPPING_ZONE_METADATA_UPDATED: (
-        "A shipping zone metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "A shipping zone metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.STAFF_CREATED: "A new staff user is created.",
     WebhookEventAsyncType.STAFF_UPDATED: "A staff user is updated.",
@@ -169,7 +169,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
         + "`TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead."
     ),
     WebhookEventAsyncType.TRANSACTION_ITEM_METADATA_UPDATED: (
-        "Transaction item metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "Transaction item metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.TRANSLATION_CREATED: "A new translation is created.",
     WebhookEventAsyncType.TRANSLATION_UPDATED: "A translation is updated.",
@@ -177,13 +177,13 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.WAREHOUSE_UPDATED: "A warehouse is updated.",
     WebhookEventAsyncType.WAREHOUSE_DELETED: "A warehouse is deleted.",
     WebhookEventAsyncType.WAREHOUSE_METADATA_UPDATED: (
-        "A warehouse metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "A warehouse metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.VOUCHER_CREATED: "A new voucher created.",
     WebhookEventAsyncType.VOUCHER_UPDATED: "A voucher is updated.",
     WebhookEventAsyncType.VOUCHER_DELETED: "A voucher is deleted.",
     WebhookEventAsyncType.VOUCHER_METADATA_UPDATED: (
-        "A voucher metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
+        "A voucher metadata is updated." + ADDED_IN_38
     ),
     WebhookEventAsyncType.ANY: "All the events.",
     WebhookEventAsyncType.OBSERVABILITY: "An observability event is created.",
@@ -205,10 +205,10 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventSyncType.PAYMENT_CONFIRM: "Confirm payment.",
     WebhookEventSyncType.PAYMENT_PROCESS: "Process payment.",
     WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES: (
-        "Event called for checkout tax calculation." + ADDED_IN_36 + PREVIEW_FEATURE
+        "Event called for checkout tax calculation." + ADDED_IN_36
     ),
     WebhookEventSyncType.ORDER_CALCULATE_TAXES: (
-        "Event called for order tax calculation." + ADDED_IN_36 + PREVIEW_FEATURE
+        "Event called for order tax calculation." + ADDED_IN_36
     ),
     WebhookEventSyncType.TRANSACTION_CHARGE_REQUESTED: (
         "Event called when charge has been requested for transaction."

--- a/saleor/graphql/webhook/mutations/webhook_create.py
+++ b/saleor/graphql/webhook/mutations/webhook_create.py
@@ -63,7 +63,7 @@ class WebhookCreateInput(BaseInputObjectType):
     )
     query = graphene.String(
         description="Subscription query used to define a webhook payload."
-        f"{ADDED_IN_32}{PREVIEW_FEATURE}",
+        + ADDED_IN_32,
         required=False,
     )
     custom_headers = JSONString(
@@ -71,7 +71,8 @@ class WebhookCreateInput(BaseInputObjectType):
         f"There is a limitation of {HEADERS_NUMBER_LIMIT} headers per webhook "
         f"and {HEADERS_LENGTH_LIMIT} characters per header."
         f'Only "X-*" and "Authorization*" keys are allowed.'
-        f"{ADDED_IN_312}{PREVIEW_FEATURE}",
+        + ADDED_IN_312
+        + PREVIEW_FEATURE,
         required=False,
     )
 

--- a/saleor/graphql/webhook/mutations/webhook_update.py
+++ b/saleor/graphql/webhook/mutations/webhook_update.py
@@ -56,7 +56,7 @@ class WebhookUpdateInput(BaseInputObjectType):
     )
     query = graphene.String(
         description="Subscription query used to define a webhook payload."
-        f"{ADDED_IN_32}{PREVIEW_FEATURE}",
+        + ADDED_IN_32,
         required=False,
     )
     custom_headers = JSONString(
@@ -64,7 +64,8 @@ class WebhookUpdateInput(BaseInputObjectType):
         f"There is a limitation of {HEADERS_NUMBER_LIMIT} headers per webhook "
         f"and {HEADERS_LENGTH_LIMIT} characters per header."
         f'Only "X-*" and "Authorization*" keys are allowed.'
-        f"{ADDED_IN_312}{PREVIEW_FEATURE}",
+        + ADDED_IN_312
+        + PREVIEW_FEATURE,
         required=False,
     )
 

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -137,9 +137,7 @@ class AddressCreated(SubscriptionObjectType, AddressBase):
         root_type = "Address"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new address is created." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new address is created." + ADDED_IN_35
 
 
 class AddressUpdated(SubscriptionObjectType, AddressBase):
@@ -147,9 +145,7 @@ class AddressUpdated(SubscriptionObjectType, AddressBase):
         root_type = "Address"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when address is updated." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when address is updated." + ADDED_IN_35
 
 
 class AddressDeleted(SubscriptionObjectType, AddressBase):
@@ -157,9 +153,7 @@ class AddressDeleted(SubscriptionObjectType, AddressBase):
         root_type = "Address"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when address is deleted." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when address is deleted." + ADDED_IN_35
 
 
 class AppBase(AbstractType):
@@ -179,9 +173,7 @@ class AppInstalled(SubscriptionObjectType, AppBase):
         root_type = "App"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new app is installed." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new app is installed." + ADDED_IN_34
 
 
 class AppUpdated(SubscriptionObjectType, AppBase):
@@ -189,7 +181,7 @@ class AppUpdated(SubscriptionObjectType, AppBase):
         root_type = "App"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when app is updated." + ADDED_IN_34 + PREVIEW_FEATURE
+        description = "Event sent when app is updated." + ADDED_IN_34
 
 
 class AppDeleted(SubscriptionObjectType, AppBase):
@@ -197,7 +189,7 @@ class AppDeleted(SubscriptionObjectType, AppBase):
         root_type = "App"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when app is deleted." + ADDED_IN_34 + PREVIEW_FEATURE
+        description = "Event sent when app is deleted." + ADDED_IN_34
 
 
 class AppStatusChanged(SubscriptionObjectType, AppBase):
@@ -205,9 +197,7 @@ class AppStatusChanged(SubscriptionObjectType, AppBase):
         root_type = "App"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when app status has changed." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when app status has changed." + ADDED_IN_34
 
 
 class AttributeBase(AbstractType):
@@ -227,9 +217,7 @@ class AttributeCreated(SubscriptionObjectType, AttributeBase):
         root_type = "Attribute"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new attribute is created." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new attribute is created." + ADDED_IN_35
 
 
 class AttributeUpdated(SubscriptionObjectType, AttributeBase):
@@ -237,9 +225,7 @@ class AttributeUpdated(SubscriptionObjectType, AttributeBase):
         root_type = "Attribute"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when attribute is updated." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when attribute is updated." + ADDED_IN_35
 
 
 class AttributeDeleted(SubscriptionObjectType, AttributeBase):
@@ -247,9 +233,7 @@ class AttributeDeleted(SubscriptionObjectType, AttributeBase):
         root_type = "Attribute"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when attribute is deleted." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when attribute is deleted." + ADDED_IN_35
 
 
 class AttributeValueBase(AbstractType):
@@ -269,11 +253,7 @@ class AttributeValueCreated(SubscriptionObjectType, AttributeValueBase):
         root_type = "AttributeValue"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new attribute value is created."
-            + ADDED_IN_35
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when new attribute value is created." + ADDED_IN_35
 
 
 class AttributeValueUpdated(SubscriptionObjectType, AttributeValueBase):
@@ -281,11 +261,7 @@ class AttributeValueUpdated(SubscriptionObjectType, AttributeValueBase):
         root_type = "AttributeValue"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when attribute value is updated."
-            + ADDED_IN_35
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when attribute value is updated." + ADDED_IN_35
 
 
 class AttributeValueDeleted(SubscriptionObjectType, AttributeValueBase):
@@ -293,11 +269,7 @@ class AttributeValueDeleted(SubscriptionObjectType, AttributeValueBase):
         root_type = "AttributeValue"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when attribute value is deleted."
-            + ADDED_IN_35
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when attribute value is deleted." + ADDED_IN_35
 
 
 class CategoryBase(AbstractType):
@@ -317,9 +289,7 @@ class CategoryCreated(SubscriptionObjectType, CategoryBase):
         root_type = "Category"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new category is created." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new category is created." + ADDED_IN_32
 
 
 class CategoryUpdated(SubscriptionObjectType, CategoryBase):
@@ -327,9 +297,7 @@ class CategoryUpdated(SubscriptionObjectType, CategoryBase):
         root_type = "Category"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when category is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when category is updated." + ADDED_IN_32
 
 
 class CategoryDeleted(SubscriptionObjectType, CategoryBase):
@@ -337,9 +305,7 @@ class CategoryDeleted(SubscriptionObjectType, CategoryBase):
         root_type = "Category"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when category is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when category is deleted." + ADDED_IN_32
 
 
 class ChannelBase(AbstractType):
@@ -359,9 +325,7 @@ class ChannelCreated(SubscriptionObjectType, ChannelBase):
         root_type = "Channel"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new channel is created." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new channel is created." + ADDED_IN_32
 
 
 class ChannelUpdated(SubscriptionObjectType, ChannelBase):
@@ -369,9 +333,7 @@ class ChannelUpdated(SubscriptionObjectType, ChannelBase):
         root_type = "Channel"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when channel is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when channel is updated." + ADDED_IN_32
 
 
 class ChannelDeleted(SubscriptionObjectType, ChannelBase):
@@ -379,9 +341,7 @@ class ChannelDeleted(SubscriptionObjectType, ChannelBase):
         root_type = "Channel"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when channel is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when channel is deleted." + ADDED_IN_32
 
 
 class ChannelStatusChanged(SubscriptionObjectType, ChannelBase):
@@ -389,11 +349,7 @@ class ChannelStatusChanged(SubscriptionObjectType, ChannelBase):
         root_type = "Channel"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when channel status has changed."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when channel status has changed." + ADDED_IN_32
 
 
 class OrderBase(AbstractType):
@@ -413,9 +369,7 @@ class OrderCreated(SubscriptionObjectType, OrderBase):
         root_type = "Order"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new order is created." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new order is created." + ADDED_IN_32
 
 
 class OrderUpdated(SubscriptionObjectType, OrderBase):
@@ -423,9 +377,7 @@ class OrderUpdated(SubscriptionObjectType, OrderBase):
         root_type = "Order"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when order is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when order is updated." + ADDED_IN_32
 
 
 class OrderConfirmed(SubscriptionObjectType, OrderBase):
@@ -433,9 +385,7 @@ class OrderConfirmed(SubscriptionObjectType, OrderBase):
         root_type = "Order"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when order is confirmed." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when order is confirmed." + ADDED_IN_32
 
 
 class OrderFullyPaid(SubscriptionObjectType, OrderBase):
@@ -443,9 +393,7 @@ class OrderFullyPaid(SubscriptionObjectType, OrderBase):
         root_type = "Order"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when order is fully paid." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when order is fully paid." + ADDED_IN_32
 
 
 class OrderFulfilled(SubscriptionObjectType, OrderBase):
@@ -453,9 +401,7 @@ class OrderFulfilled(SubscriptionObjectType, OrderBase):
         root_type = "Order"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when order is fulfilled." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when order is fulfilled." + ADDED_IN_32
 
 
 class OrderCancelled(SubscriptionObjectType, OrderBase):
@@ -463,9 +409,7 @@ class OrderCancelled(SubscriptionObjectType, OrderBase):
         root_type = "Order"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when order is canceled." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when order is canceled." + ADDED_IN_32
 
 
 class OrderExpired(SubscriptionObjectType, OrderBase):
@@ -483,9 +427,7 @@ class OrderMetadataUpdated(SubscriptionObjectType, OrderBase):
         root_type = "Order"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when order metadata is updated." + ADDED_IN_38 + PREVIEW_FEATURE
-        )
+        description = "Event sent when order metadata is updated." + ADDED_IN_38
 
 
 class DraftOrderCreated(SubscriptionObjectType, OrderBase):
@@ -493,11 +435,7 @@ class DraftOrderCreated(SubscriptionObjectType, OrderBase):
         root_type = "Order"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new draft order is created."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when new draft order is created." + ADDED_IN_32
 
 
 class DraftOrderUpdated(SubscriptionObjectType, OrderBase):
@@ -505,9 +443,7 @@ class DraftOrderUpdated(SubscriptionObjectType, OrderBase):
         root_type = "Order"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when draft order is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when draft order is updated." + ADDED_IN_32
 
 
 class DraftOrderDeleted(SubscriptionObjectType, OrderBase):
@@ -515,9 +451,7 @@ class DraftOrderDeleted(SubscriptionObjectType, OrderBase):
         root_type = "Order"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when draft order is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when draft order is deleted." + ADDED_IN_32
 
 
 class GiftCardBase(AbstractType):
@@ -537,9 +471,7 @@ class GiftCardCreated(SubscriptionObjectType, GiftCardBase):
         root_type = "GiftCard"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new gift card is created." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new gift card is created." + ADDED_IN_32
 
 
 class GiftCardUpdated(SubscriptionObjectType, GiftCardBase):
@@ -547,9 +479,7 @@ class GiftCardUpdated(SubscriptionObjectType, GiftCardBase):
         root_type = "GiftCard"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when gift card is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when gift card is updated." + ADDED_IN_32
 
 
 class GiftCardDeleted(SubscriptionObjectType, GiftCardBase):
@@ -557,9 +487,7 @@ class GiftCardDeleted(SubscriptionObjectType, GiftCardBase):
         root_type = "GiftCard"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when gift card is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when gift card is deleted." + ADDED_IN_32
 
 
 class GiftCardSent(SubscriptionObjectType, GiftCardBase):
@@ -599,11 +527,7 @@ class GiftCardStatusChanged(SubscriptionObjectType, GiftCardBase):
         root_type = "GiftCard"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when gift card status has changed."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when gift card status has changed." + ADDED_IN_32
 
 
 class GiftCardMetadataUpdated(SubscriptionObjectType, GiftCardBase):
@@ -611,11 +535,7 @@ class GiftCardMetadataUpdated(SubscriptionObjectType, GiftCardBase):
         root_type = "GiftCard"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when gift card metadata is updated."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when gift card metadata is updated." + ADDED_IN_38
 
 
 class MenuBase(AbstractType):
@@ -638,9 +558,7 @@ class MenuCreated(SubscriptionObjectType, MenuBase):
         root_type = "Menu"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new menu is created." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new menu is created." + ADDED_IN_34
 
 
 class MenuUpdated(SubscriptionObjectType, MenuBase):
@@ -648,7 +566,7 @@ class MenuUpdated(SubscriptionObjectType, MenuBase):
         root_type = "Menu"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when menu is updated." + ADDED_IN_34 + PREVIEW_FEATURE
+        description = "Event sent when menu is updated." + ADDED_IN_34
 
 
 class MenuDeleted(SubscriptionObjectType, MenuBase):
@@ -656,7 +574,7 @@ class MenuDeleted(SubscriptionObjectType, MenuBase):
         root_type = "Menu"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when menu is deleted." + ADDED_IN_34 + PREVIEW_FEATURE
+        description = "Event sent when menu is deleted." + ADDED_IN_34
 
 
 class MenuItemBase(AbstractType):
@@ -679,9 +597,7 @@ class MenuItemCreated(SubscriptionObjectType, MenuItemBase):
         root_type = "MenuItem"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new menu item is created." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new menu item is created." + ADDED_IN_34
 
 
 class MenuItemUpdated(SubscriptionObjectType, MenuItemBase):
@@ -689,9 +605,7 @@ class MenuItemUpdated(SubscriptionObjectType, MenuItemBase):
         root_type = "MenuItem"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when menu item is updated." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when menu item is updated." + ADDED_IN_34
 
 
 class MenuItemDeleted(SubscriptionObjectType, MenuItemBase):
@@ -699,9 +613,7 @@ class MenuItemDeleted(SubscriptionObjectType, MenuItemBase):
         root_type = "MenuItem"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when menu item is deleted." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when menu item is deleted." + ADDED_IN_34
 
 
 class ProductBase(AbstractType):
@@ -733,9 +645,7 @@ class ProductCreated(SubscriptionObjectType, ProductBase):
         root_type = "Product"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new product is created." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new product is created." + ADDED_IN_32
 
 
 class ProductUpdated(SubscriptionObjectType, ProductBase):
@@ -743,9 +653,7 @@ class ProductUpdated(SubscriptionObjectType, ProductBase):
         root_type = "Product"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when product is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when product is updated." + ADDED_IN_32
 
 
 class ProductDeleted(SubscriptionObjectType, ProductBase):
@@ -753,9 +661,7 @@ class ProductDeleted(SubscriptionObjectType, ProductBase):
         root_type = "Product"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when product is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when product is deleted." + ADDED_IN_32
 
 
 class ProductMetadataUpdated(SubscriptionObjectType, ProductBase):
@@ -763,11 +669,7 @@ class ProductMetadataUpdated(SubscriptionObjectType, ProductBase):
         root_type = "Product"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when product metadata is updated."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when product metadata is updated." + ADDED_IN_38
 
 
 class ProductMediaBase(AbstractType):
@@ -826,11 +728,7 @@ class ProductVariantCreated(SubscriptionObjectType, ProductVariantBase):
         root_type = "Product"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new product variant is created."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when new product variant is created." + ADDED_IN_32
 
 
 class ProductVariantUpdated(SubscriptionObjectType, ProductVariantBase):
@@ -838,11 +736,7 @@ class ProductVariantUpdated(SubscriptionObjectType, ProductVariantBase):
         root_type = "Product"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when product variant is updated."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when product variant is updated." + ADDED_IN_32
 
 
 class ProductVariantDeleted(SubscriptionObjectType, ProductVariantBase):
@@ -850,11 +744,7 @@ class ProductVariantDeleted(SubscriptionObjectType, ProductVariantBase):
         root_type = "Product"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when product variant is deleted."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when product variant is deleted." + ADDED_IN_32
 
 
 class ProductVariantMetadataUpdated(SubscriptionObjectType, ProductVariantBase):
@@ -863,9 +753,7 @@ class ProductVariantMetadataUpdated(SubscriptionObjectType, ProductVariantBase):
         enable_dry_run = True
         interfaces = (Event,)
         description = (
-            "Event sent when product variant metadata is updated."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
+            "Event sent when product variant metadata is updated." + ADDED_IN_38
         )
 
 
@@ -878,11 +766,7 @@ class ProductVariantOutOfStock(SubscriptionObjectType, ProductVariantBase):
         root_type = "Stock"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when product variant is out of stock."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when product variant is out of stock." + ADDED_IN_32
 
     @staticmethod
     def resolve_product_variant(root, info: ResolveInfo, channel=None):
@@ -905,11 +789,7 @@ class ProductVariantBackInStock(SubscriptionObjectType, ProductVariantBase):
         root_type = "Stock"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when product variant is back in stock."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when product variant is back in stock." + ADDED_IN_32
 
     @staticmethod
     def resolve_product_variant(root, _info: ResolveInfo, channel=None):
@@ -973,9 +853,7 @@ class SaleCreated(SubscriptionObjectType, SaleBase):
         root_type = "Sale"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new sale is created." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new sale is created." + ADDED_IN_32
 
 
 class SaleUpdated(SubscriptionObjectType, SaleBase):
@@ -983,7 +861,7 @@ class SaleUpdated(SubscriptionObjectType, SaleBase):
         root_type = "Sale"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when sale is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        description = "Event sent when sale is updated." + ADDED_IN_32
 
 
 class SaleDeleted(SubscriptionObjectType, SaleBase):
@@ -991,7 +869,7 @@ class SaleDeleted(SubscriptionObjectType, SaleBase):
         root_type = "Sale"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when sale is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
+        description = "Event sent when sale is deleted." + ADDED_IN_32
 
 
 class SaleToggle(SubscriptionObjectType, SaleBase):
@@ -1000,16 +878,14 @@ class SaleToggle(SubscriptionObjectType, SaleBase):
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
-        description="The sale the event relates to." + ADDED_IN_35 + PREVIEW_FEATURE,
+        description="The sale the event relates to." + ADDED_IN_35,
     )
 
     class Meta:
         root_type = "Sale"
         enable_dry_run = True
         description = (
-            "The event informs about the start or end of the sale."
-            + ADDED_IN_35
-            + PREVIEW_FEATURE
+            "The event informs about the start or end of the sale." + ADDED_IN_35
         )
         interfaces = (Event,)
 
@@ -1046,9 +922,7 @@ class InvoiceRequested(SubscriptionObjectType, InvoiceBase):
         root_type = "Invoice"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when invoice is requested." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when invoice is requested." + ADDED_IN_32
 
 
 class InvoiceDeleted(SubscriptionObjectType, InvoiceBase):
@@ -1056,9 +930,7 @@ class InvoiceDeleted(SubscriptionObjectType, InvoiceBase):
         root_type = "Invoice"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when invoice is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when invoice is deleted." + ADDED_IN_32
 
 
 class InvoiceSent(SubscriptionObjectType, InvoiceBase):
@@ -1066,7 +938,7 @@ class InvoiceSent(SubscriptionObjectType, InvoiceBase):
         root_type = "Invoice"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when invoice is sent." + ADDED_IN_32 + PREVIEW_FEATURE
+        description = "Event sent when invoice is sent." + ADDED_IN_32
 
 
 class FulfillmentBase(AbstractType):
@@ -1095,11 +967,7 @@ class FulfillmentCreated(SubscriptionObjectType, FulfillmentBase):
         root_type = "Fulfillment"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new fulfillment is created."
-            + ADDED_IN_34
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when new fulfillment is created." + ADDED_IN_34
 
 
 class FulfillmentCanceled(SubscriptionObjectType, FulfillmentBase):
@@ -1107,9 +975,7 @@ class FulfillmentCanceled(SubscriptionObjectType, FulfillmentBase):
         root_type = "Fulfillment"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when fulfillment is canceled." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when fulfillment is canceled." + ADDED_IN_34
 
 
 class FulfillmentApproved(SubscriptionObjectType, FulfillmentBase):
@@ -1117,9 +983,7 @@ class FulfillmentApproved(SubscriptionObjectType, FulfillmentBase):
         root_type = "Fulfillment"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when fulfillment is approved." + ADDED_IN_37 + PREVIEW_FEATURE
-        )
+        description = "Event sent when fulfillment is approved." + ADDED_IN_37
 
 
 class FulfillmentMetadataUpdated(SubscriptionObjectType, FulfillmentBase):
@@ -1127,11 +991,7 @@ class FulfillmentMetadataUpdated(SubscriptionObjectType, FulfillmentBase):
         root_type = "Fulfillment"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when fulfillment metadata is updated."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when fulfillment metadata is updated." + ADDED_IN_38
 
 
 class UserBase(AbstractType):
@@ -1151,11 +1011,7 @@ class CustomerCreated(SubscriptionObjectType, UserBase):
         root_type = "User"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new customer user is created."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when new customer user is created." + ADDED_IN_32
 
 
 class CustomerUpdated(SubscriptionObjectType, UserBase):
@@ -1163,9 +1019,7 @@ class CustomerUpdated(SubscriptionObjectType, UserBase):
         root_type = "User"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when customer user is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when customer user is updated." + ADDED_IN_32
 
 
 class CustomerMetadataUpdated(SubscriptionObjectType, UserBase):
@@ -1173,11 +1027,7 @@ class CustomerMetadataUpdated(SubscriptionObjectType, UserBase):
         root_type = "User"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when customer user metadata is updated."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when customer user metadata is updated." + ADDED_IN_38
 
 
 class CollectionBase(AbstractType):
@@ -1200,9 +1050,7 @@ class CollectionCreated(SubscriptionObjectType, CollectionBase):
         root_type = "Collection"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new collection is created." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new collection is created." + ADDED_IN_32
 
 
 class CollectionUpdated(SubscriptionObjectType, CollectionBase):
@@ -1210,9 +1058,7 @@ class CollectionUpdated(SubscriptionObjectType, CollectionBase):
         root_type = "Collection"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when collection is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when collection is updated." + ADDED_IN_32
 
 
 class CollectionDeleted(SubscriptionObjectType, CollectionBase):
@@ -1220,9 +1066,7 @@ class CollectionDeleted(SubscriptionObjectType, CollectionBase):
         root_type = "Collection"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when collection is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when collection is deleted." + ADDED_IN_32
 
 
 class CollectionMetadataUpdated(SubscriptionObjectType, CollectionBase):
@@ -1230,11 +1074,7 @@ class CollectionMetadataUpdated(SubscriptionObjectType, CollectionBase):
         root_type = "Collection"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when collection metadata is updated."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when collection metadata is updated." + ADDED_IN_38
 
 
 class CheckoutBase(AbstractType):
@@ -1254,9 +1094,7 @@ class CheckoutCreated(SubscriptionObjectType, CheckoutBase):
         root_type = "Checkout"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new checkout is created." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new checkout is created." + ADDED_IN_32
 
 
 class CheckoutUpdated(SubscriptionObjectType, CheckoutBase):
@@ -1264,9 +1102,7 @@ class CheckoutUpdated(SubscriptionObjectType, CheckoutBase):
         root_type = "Checkout"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when checkout is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when checkout is updated." + ADDED_IN_32
 
 
 class CheckoutFullyPaid(SubscriptionObjectType, CheckoutBase):
@@ -1286,11 +1122,7 @@ class CheckoutMetadataUpdated(SubscriptionObjectType, CheckoutBase):
         root_type = "Checkout"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when checkout metadata is updated."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when checkout metadata is updated." + ADDED_IN_38
 
 
 class PageBase(AbstractType):
@@ -1309,9 +1141,7 @@ class PageCreated(SubscriptionObjectType, PageBase):
         root_type = "Page"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new page is created." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new page is created." + ADDED_IN_32
 
 
 class PageUpdated(SubscriptionObjectType, PageBase):
@@ -1319,7 +1149,7 @@ class PageUpdated(SubscriptionObjectType, PageBase):
         root_type = "Page"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when page is updated." + ADDED_IN_32 + PREVIEW_FEATURE
+        description = "Event sent when page is updated." + ADDED_IN_32
 
 
 class PageDeleted(SubscriptionObjectType, PageBase):
@@ -1327,7 +1157,7 @@ class PageDeleted(SubscriptionObjectType, PageBase):
         root_type = "Page"
         enable_dry_run = True
         interfaces = (Event,)
-        description = "Event sent when page is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
+        description = "Event sent when page is deleted." + ADDED_IN_32
 
 
 class PageTypeBase(AbstractType):
@@ -1347,9 +1177,7 @@ class PageTypeCreated(SubscriptionObjectType, PageTypeBase):
         root_type = "PageType"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new page type is created." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new page type is created." + ADDED_IN_35
 
 
 class PageTypeUpdated(SubscriptionObjectType, PageTypeBase):
@@ -1357,9 +1185,7 @@ class PageTypeUpdated(SubscriptionObjectType, PageTypeBase):
         root_type = "PageType"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when page type is updated." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when page type is updated." + ADDED_IN_35
 
 
 class PageTypeDeleted(SubscriptionObjectType, PageTypeBase):
@@ -1367,9 +1193,7 @@ class PageTypeDeleted(SubscriptionObjectType, PageTypeBase):
         root_type = "PageType"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when page type is deleted." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when page type is deleted." + ADDED_IN_35
 
 
 class PermissionGroupBase(AbstractType):
@@ -1389,11 +1213,7 @@ class PermissionGroupCreated(SubscriptionObjectType, PermissionGroupBase):
         root_type = "Group"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new permission group is created."
-            + ADDED_IN_36
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when new permission group is created." + ADDED_IN_36
 
 
 class PermissionGroupUpdated(SubscriptionObjectType, PermissionGroupBase):
@@ -1401,11 +1221,7 @@ class PermissionGroupUpdated(SubscriptionObjectType, PermissionGroupBase):
         root_type = "Group"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when permission group is updated."
-            + ADDED_IN_36
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when permission group is updated." + ADDED_IN_36
 
 
 class PermissionGroupDeleted(SubscriptionObjectType, PermissionGroupBase):
@@ -1413,11 +1229,7 @@ class PermissionGroupDeleted(SubscriptionObjectType, PermissionGroupBase):
         root_type = "Group"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when permission group is deleted."
-            + ADDED_IN_36
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when permission group is deleted." + ADDED_IN_36
 
 
 class ShippingPriceBase(AbstractType):
@@ -1452,11 +1264,7 @@ class ShippingPriceCreated(SubscriptionObjectType, ShippingPriceBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = (
-            "Event sent when new shipping price is created."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when new shipping price is created." + ADDED_IN_32
 
 
 class ShippingPriceUpdated(SubscriptionObjectType, ShippingPriceBase):
@@ -1464,9 +1272,7 @@ class ShippingPriceUpdated(SubscriptionObjectType, ShippingPriceBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = (
-            "Event sent when shipping price is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when shipping price is updated." + ADDED_IN_32
 
 
 class ShippingPriceDeleted(SubscriptionObjectType, ShippingPriceBase):
@@ -1474,9 +1280,7 @@ class ShippingPriceDeleted(SubscriptionObjectType, ShippingPriceBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = (
-            "Event sent when shipping price is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when shipping price is deleted." + ADDED_IN_32
 
 
 class ShippingZoneBase(AbstractType):
@@ -1499,11 +1303,7 @@ class ShippingZoneCreated(SubscriptionObjectType, ShippingZoneBase):
         root_type = "ShippingZone"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new shipping zone is created."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when new shipping zone is created." + ADDED_IN_32
 
 
 class ShippingZoneUpdated(SubscriptionObjectType, ShippingZoneBase):
@@ -1511,9 +1311,7 @@ class ShippingZoneUpdated(SubscriptionObjectType, ShippingZoneBase):
         root_type = "ShippingZone"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when shipping zone is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when shipping zone is updated." + ADDED_IN_32
 
 
 class ShippingZoneDeleted(SubscriptionObjectType, ShippingZoneBase):
@@ -1521,9 +1319,7 @@ class ShippingZoneDeleted(SubscriptionObjectType, ShippingZoneBase):
         root_type = "ShippingZone"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when shipping zone is deleted." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when shipping zone is deleted." + ADDED_IN_32
 
 
 class ShippingZoneMetadataUpdated(SubscriptionObjectType, ShippingZoneBase):
@@ -1531,11 +1327,7 @@ class ShippingZoneMetadataUpdated(SubscriptionObjectType, ShippingZoneBase):
         root_type = "ShippingZone"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when shipping zone metadata is updated."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when shipping zone metadata is updated." + ADDED_IN_38
 
 
 class StaffCreated(SubscriptionObjectType, UserBase):
@@ -1543,9 +1335,7 @@ class StaffCreated(SubscriptionObjectType, UserBase):
         root_type = "User"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new staff user is created." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new staff user is created." + ADDED_IN_35
 
 
 class StaffUpdated(SubscriptionObjectType, UserBase):
@@ -1553,9 +1343,7 @@ class StaffUpdated(SubscriptionObjectType, UserBase):
         root_type = "User"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when staff user is updated." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when staff user is updated." + ADDED_IN_35
 
 
 class StaffDeleted(SubscriptionObjectType, UserBase):
@@ -1563,9 +1351,7 @@ class StaffDeleted(SubscriptionObjectType, UserBase):
         root_type = "User"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when staff user is deleted." + ADDED_IN_35 + PREVIEW_FEATURE
-        )
+        description = "Event sent when staff user is deleted." + ADDED_IN_35
 
 
 class TransactionAction(SubscriptionObjectType, AbstractType):
@@ -1793,7 +1579,7 @@ class TransactionProcessSession(TransactionSessionBase):
 class TransactionItemMetadataUpdated(SubscriptionObjectType):
     transaction = graphene.Field(
         TransactionItem,
-        description="Look up a transaction." + PREVIEW_FEATURE,
+        description="Look up a transaction.",
     )
 
     class Meta:
@@ -1801,9 +1587,7 @@ class TransactionItemMetadataUpdated(SubscriptionObjectType):
         enable_dry_run = True
         interfaces = (Event,)
         description = (
-            "Event sent when transaction item metadata is updated."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
+            "Event sent when transaction item metadata is updated." + ADDED_IN_38
         )
 
     @staticmethod
@@ -1841,11 +1625,7 @@ class TranslationCreated(SubscriptionObjectType, TranslationBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = (
-            "Event sent when new translation is created."
-            + ADDED_IN_32
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when new translation is created." + ADDED_IN_32
 
 
 class TranslationUpdated(SubscriptionObjectType, TranslationBase):
@@ -1853,9 +1633,7 @@ class TranslationUpdated(SubscriptionObjectType, TranslationBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = (
-            "Event sent when translation is updated." + ADDED_IN_32 + PREVIEW_FEATURE
-        )
+        description = "Event sent when translation is updated." + ADDED_IN_32
 
 
 class VoucherBase(AbstractType):
@@ -1878,9 +1656,7 @@ class VoucherCreated(SubscriptionObjectType, VoucherBase):
         root_type = "Voucher"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new voucher is created." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new voucher is created." + ADDED_IN_34
 
 
 class VoucherUpdated(SubscriptionObjectType, VoucherBase):
@@ -1888,9 +1664,7 @@ class VoucherUpdated(SubscriptionObjectType, VoucherBase):
         root_type = "Voucher"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when voucher is updated." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when voucher is updated." + ADDED_IN_34
 
 
 class VoucherDeleted(SubscriptionObjectType, VoucherBase):
@@ -1898,9 +1672,7 @@ class VoucherDeleted(SubscriptionObjectType, VoucherBase):
         root_type = "Voucher"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when voucher is deleted." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when voucher is deleted." + ADDED_IN_34
 
 
 class VoucherMetadataUpdated(SubscriptionObjectType, VoucherBase):
@@ -1908,11 +1680,7 @@ class VoucherMetadataUpdated(SubscriptionObjectType, VoucherBase):
         root_type = "Voucher"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when voucher metadata is updated."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when voucher metadata is updated." + ADDED_IN_38
 
 
 class PaymentBase(AbstractType):
@@ -1932,7 +1700,7 @@ class PaymentAuthorize(SubscriptionObjectType, PaymentBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = "Authorize payment." + ADDED_IN_36 + PREVIEW_FEATURE
+        description = "Authorize payment." + ADDED_IN_36
 
 
 class PaymentCaptureEvent(SubscriptionObjectType, PaymentBase):
@@ -1940,7 +1708,7 @@ class PaymentCaptureEvent(SubscriptionObjectType, PaymentBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = "Capture payment." + ADDED_IN_36 + PREVIEW_FEATURE
+        description = "Capture payment." + ADDED_IN_36
 
 
 class PaymentRefundEvent(SubscriptionObjectType, PaymentBase):
@@ -1948,7 +1716,7 @@ class PaymentRefundEvent(SubscriptionObjectType, PaymentBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = "Refund payment." + ADDED_IN_36 + PREVIEW_FEATURE
+        description = "Refund payment." + ADDED_IN_36
 
 
 class PaymentVoidEvent(SubscriptionObjectType, PaymentBase):
@@ -1956,7 +1724,7 @@ class PaymentVoidEvent(SubscriptionObjectType, PaymentBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = "Void payment." + ADDED_IN_36 + PREVIEW_FEATURE
+        description = "Void payment." + ADDED_IN_36
 
 
 class PaymentConfirmEvent(SubscriptionObjectType, PaymentBase):
@@ -1964,7 +1732,7 @@ class PaymentConfirmEvent(SubscriptionObjectType, PaymentBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = "Confirm payment." + ADDED_IN_36 + PREVIEW_FEATURE
+        description = "Confirm payment." + ADDED_IN_36
 
 
 class PaymentProcessEvent(SubscriptionObjectType, PaymentBase):
@@ -1972,7 +1740,7 @@ class PaymentProcessEvent(SubscriptionObjectType, PaymentBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = "Process payment." + ADDED_IN_36 + PREVIEW_FEATURE
+        description = "Process payment." + ADDED_IN_36
 
 
 class PaymentListGateways(SubscriptionObjectType, CheckoutBase):
@@ -1980,15 +1748,14 @@ class PaymentListGateways(SubscriptionObjectType, CheckoutBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = "List payment gateways." + ADDED_IN_36 + PREVIEW_FEATURE
+        description = "List payment gateways." + ADDED_IN_36
 
 
 class ShippingListMethodsForCheckout(SubscriptionObjectType, CheckoutBase):
     shipping_methods = NonNullList(
         ShippingMethod,
         description="Shipping methods that can be used with this checkout."
-        + ADDED_IN_36
-        + PREVIEW_FEATURE,
+        + ADDED_IN_36,
     )
 
     @staticmethod
@@ -2001,9 +1768,7 @@ class ShippingListMethodsForCheckout(SubscriptionObjectType, CheckoutBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = (
-            "List shipping methods for checkout." + ADDED_IN_36 + PREVIEW_FEATURE
-        )
+        description = "List shipping methods for checkout." + ADDED_IN_36
 
 
 class CalculateTaxes(SubscriptionObjectType):
@@ -2016,9 +1781,7 @@ class CalculateTaxes(SubscriptionObjectType):
         enable_dry_run = False
         interfaces = (Event,)
         description = (
-            "Synchronous webhook for calculating checkout/order taxes."
-            + ADDED_IN_37
-            + PREVIEW_FEATURE
+            "Synchronous webhook for calculating checkout/order taxes." + ADDED_IN_37
         )
 
     @staticmethod
@@ -2031,8 +1794,7 @@ class CheckoutFilterShippingMethods(SubscriptionObjectType, CheckoutBase):
     shipping_methods = NonNullList(
         ShippingMethod,
         description="Shipping methods that can be used with this checkout."
-        + ADDED_IN_36
-        + PREVIEW_FEATURE,
+        + ADDED_IN_36,
     )
 
     @staticmethod
@@ -2045,17 +1807,14 @@ class CheckoutFilterShippingMethods(SubscriptionObjectType, CheckoutBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = (
-            "Filter shipping methods for checkout." + ADDED_IN_36 + PREVIEW_FEATURE
-        )
+        description = "Filter shipping methods for checkout." + ADDED_IN_36
 
 
 class OrderFilterShippingMethods(SubscriptionObjectType, OrderBase):
     shipping_methods = NonNullList(
         ShippingMethod,
         description="Shipping methods that can be used with this checkout."
-        + ADDED_IN_36
-        + PREVIEW_FEATURE,
+        + ADDED_IN_36,
     )
 
     @staticmethod
@@ -2078,9 +1837,7 @@ class OrderFilterShippingMethods(SubscriptionObjectType, OrderBase):
         root_type = None
         enable_dry_run = False
         interfaces = (Event,)
-        description = (
-            "Filter shipping methods for order." + ADDED_IN_36 + PREVIEW_FEATURE
-        )
+        description = "Filter shipping methods for order." + ADDED_IN_36
 
 
 class WarehouseBase(AbstractType):
@@ -2100,9 +1857,7 @@ class WarehouseCreated(SubscriptionObjectType, WarehouseBase):
         root_type = "Warehouse"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when new warehouse is created." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when new warehouse is created." + ADDED_IN_34
 
 
 class WarehouseUpdated(SubscriptionObjectType, WarehouseBase):
@@ -2110,9 +1865,7 @@ class WarehouseUpdated(SubscriptionObjectType, WarehouseBase):
         root_type = "Warehouse"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when warehouse is updated." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when warehouse is updated." + ADDED_IN_34
 
 
 class WarehouseDeleted(SubscriptionObjectType, WarehouseBase):
@@ -2120,9 +1873,7 @@ class WarehouseDeleted(SubscriptionObjectType, WarehouseBase):
         root_type = "Warehouse"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when warehouse is deleted." + ADDED_IN_34 + PREVIEW_FEATURE
-        )
+        description = "Event sent when warehouse is deleted." + ADDED_IN_34
 
 
 class WarehouseMetadataUpdated(SubscriptionObjectType, WarehouseBase):
@@ -2130,17 +1881,13 @@ class WarehouseMetadataUpdated(SubscriptionObjectType, WarehouseBase):
         root_type = "Warehouse"
         enable_dry_run = True
         interfaces = (Event,)
-        description = (
-            "Event sent when warehouse metadata is updated."
-            + ADDED_IN_38
-            + PREVIEW_FEATURE
-        )
+        description = "Event sent when warehouse metadata is updated." + ADDED_IN_38
 
 
 class Subscription(SubscriptionObjectType):
     event = graphene.Field(
         Event,
-        description="Look up subscription event." + ADDED_IN_32 + PREVIEW_FEATURE,
+        description="Look up subscription event." + ADDED_IN_32,
     )
 
     @staticmethod


### PR DESCRIPTION
Drop preview label for changes marked as such starting from 3.1 up to 3.9. These changes are now considered stable.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
