### PR TITLE
Fix fetching available shipping methods for checkout with specific product voucher

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -548,7 +548,13 @@ def get_valid_internal_shipping_method_list_for_checkout_info(
     is_shipping_voucher = (
         checkout_info.voucher and checkout_info.voucher.type == VoucherType.SHIPPING
     )
-    if not is_shipping_voucher:
+
+    is_voucher_for_specific_product = (
+        checkout_info.voucher
+        and checkout_info.voucher.type == VoucherType.SPECIFIC_PRODUCT
+    )
+
+    if not is_shipping_voucher and not is_voucher_for_specific_product:
         subtotal -= checkout_info.checkout.discount
 
     valid_shipping_methods = get_valid_internal_shipping_methods_for_checkout(

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 from unittest import mock
 
 import graphene
-import ipdb
 import pytest
 from django.core.exceptions import ValidationError
 from django.db.models import Sum

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from unittest import mock
 
 import graphene
+import ipdb
 import pytest
 from django.core.exceptions import ValidationError
 from django.db.models import Sum
@@ -19,7 +20,9 @@ from ....checkout.checkout_cleaner import (
 )
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from ....checkout.utils import add_voucher_to_checkout
 from ....core.prices import quantize_price
+from ....discount import DiscountValueType, VoucherType
 from ....payment import TransactionAction
 from ....plugins.manager import get_plugins_manager
 from ....plugins.tests.sample_plugins import ActiveDummyPaymentGateway
@@ -590,6 +593,69 @@ def test_checkout_shipping_methods_with_price_based_shipping_and_shipping_discou
     content = get_graphql_content(response)
     data = content["data"]["checkout"]
 
+    shipping_methods = [method["name"] for method in data["availableShippingMethods"]]
+    assert shipping_method.name in shipping_methods
+
+
+def test_checkout_shipping_methods_with_price_based_method_and_product_voucher(
+    api_client, checkout_with_item, address, shipping_method, voucher, channel_USD
+):
+    """Ensure that price based shipping method is returned when
+    checkout with discounts subtotal is lower than maximal order price with
+    specific product discount."""
+
+    # given
+    checkout_with_item.shipping_address = address
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+
+    line = checkout_with_item.lines.first()
+
+    voucher.products.add(line.variant.product)
+    voucher.type = VoucherType.SPECIFIC_PRODUCT
+    voucher.discount_value_type = DiscountValueType.PERCENTAGE
+    voucher.save()
+
+    voucher_percent_value = Decimal(50)
+    voucher_channel_listing = voucher.channel_listings.get(channel=channel_USD)
+    voucher_channel_listing.discount_value = voucher_percent_value
+    voucher_channel_listing.save()
+
+    checkout_with_item.save(update_fields=["shipping_address"])
+
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
+    add_voucher_to_checkout(manager, checkout_info, lines, voucher)
+
+    subtotal = calculations.checkout_subtotal(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=checkout_with_item.shipping_address,
+    )
+    shipping_method.name = "Price based"
+    shipping_method.save(update_fields=["name"])
+
+    shipping_channel_listing = shipping_method.channel_listings.get(
+        channel=checkout_with_item.channel
+    )
+    shipping_channel_listing.price_amount = Decimal(0)
+
+    # set minimum order price on 50% of total. It's to ensure that discount was not
+    # doubled during shipping methods fetching. If it was subtotal would be 0
+    shipping_channel_listing.minimum_order_price_amount = subtotal.gross.amount / 2
+    shipping_channel_listing.save(
+        update_fields=["minimum_order_price_amount", "price_amount"]
+    )
+
+    query = GET_CHECKOUT_AVAILABLE_SHIPPING_METHODS
+    variables = {"id": to_global_id_or_none(checkout_with_item)}
+
+    # when
+    response = api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkout"]
     shipping_methods = [method["name"] for method in data["availableShippingMethods"]]
     assert shipping_method.name in shipping_methods
 


### PR DESCRIPTION
I want to merge this change because it fixes a case of applying discounts multiple times for specific product vouchers during fetching available shipping methods. 

It fixes https://github.com/saleor/saleor/issues/12500

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
