### PR TITLE
Optimize ordersTotal resolving

### DIFF
--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -3,6 +3,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, cast
 
 import graphene
+from django.db.models import Sum
 from django.utils import timezone
 from prices import Money, TaxedMoney
 
@@ -559,9 +560,11 @@ def restock_fulfillment_lines(fulfillment, warehouse):
 
 
 def sum_order_totals(qs, currency_code):
-    zero = Money(0, currency=currency_code)
-    taxed_zero = TaxedMoney(zero, zero)
-    return sum([order.total for order in qs], taxed_zero)
+    totals = qs.aggregate(net=Sum("total_net_amount"), gross=Sum("total_gross_amount"))
+    return TaxedMoney(
+        Money(totals["net"] or 0, currency=currency_code),
+        Money(totals["gross"] or 0, currency=currency_code),
+    )
 
 
 def get_all_shipping_methods_for_order(


### PR DESCRIPTION
I want to merge this change because it optimizes ordersTotal resolving.
It was overfetching the whole queryset with all fields just to sum up totals in Python. Moved it entirely to the DB layer.

Local results (330k orders affected, filter by last month):
Before: 14.75s ❌ 
After: 0.036s ✅ 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
