### PR TITLE
Don't require query for sync webhooks in app manifest

### DIFF
--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -92,7 +92,7 @@ def install_app(app_installation: AppInstallation, activate: bool = False):
             app=app,
             name=webhook["name"],
             target_url=webhook["targetUrl"],
-            subscription_query=webhook["query"],
+            subscription_query=webhook.get("query", None),
             custom_headers=webhook.get("customHeaders", None),
         )
         for webhook in manifest_data.get("webhooks", [])

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -6665,6 +6665,15 @@ def app_manifest_webhook():
 
 
 @pytest.fixture
+def app_manifest_sync_webhook():
+    return {
+        "name": "sync_webhook",
+        "syncEvents": ["PAYMENT_PROCESS", "PAYMENT_REFUND"],
+        "targetUrl": "https://app.example/api/sync_webhook",
+    }
+
+
+@pytest.fixture
 def event_payload():
     """Return event payload."""
     return EventPayload.objects.create(payload='{"payload_key": "payload_value"}')


### PR DESCRIPTION
I want to merge this change because it fixes #12559

This is what I've been using locally to work around the problem and register sync webhooks with an app manifest. It works with the app I'm working on, but I haven't exhaustively tested different cases.

As always, not sure if this is the best solution but hopefully it can start a conversation or help things along at least!

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
