### PR TITLE
Allow setting metadata during user creating and updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - `staffCreate`
     - `staffUpdate`
     - `accountUpdate`
+    - `customerBulkUpdate`
 
 ### Saleor Apps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### GraphQL API
 - Add `path` field to `ProductVariantBulkError` - #12534 by @SzymJ
+- Allow setting metadata during user creating and updating - #12577 by @IKarbowiak
+  - The following mutations have been updated:
+    - `customerCreate`
+    - `customerUpdate`
+    - `staffCreate`
+    - `staffUpdate`
+    - `accountUpdate`
 
 ### Saleor Apps
 

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -20,6 +20,7 @@ from ....order.utils import match_orders_with_new_user
 from ....permission.auth_filters import AuthorizationFilters
 from ...channel.utils import clean_channel
 from ...core import ResolveInfo
+from ...core.descriptions import ADDED_IN_314
 from ...core.doc_category import DOC_CATEGORY_USERS
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
@@ -43,11 +44,6 @@ class AccountBaseInput(BaseInputObjectType):
     language_code = graphene.Argument(
         LanguageCodeEnum, required=False, description="User language code."
     )
-    metadata = NonNullList(
-        MetadataInput,
-        description="User public metadata.",
-        required=False,
-    )
 
 
 class AccountRegisterInput(AccountBaseInput):
@@ -63,6 +59,11 @@ class AccountRegisterInput(AccountBaseInput):
     )
     language_code = graphene.Argument(
         LanguageCodeEnum, required=False, description="User language code."
+    )
+    metadata = NonNullList(
+        MetadataInput,
+        description="User public metadata.",
+        required=False,
     )
     channel = graphene.String(
         description=(
@@ -171,6 +172,11 @@ class AccountInput(AccountBaseInput):
     )
     default_shipping_address = AddressInput(
         description="Shipping address of the customer."
+    )
+    metadata = NonNullList(
+        MetadataInput,
+        description="Fields required to update the user metadata." + ADDED_IN_314,
+        required=False,
     )
 
     class Meta:

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -43,6 +43,11 @@ class AccountBaseInput(BaseInputObjectType):
     language_code = graphene.Argument(
         LanguageCodeEnum, required=False, description="User language code."
     )
+    metadata = NonNullList(
+        MetadataInput,
+        description="User public metadata.",
+        required=False,
+    )
 
 
 class AccountRegisterInput(AccountBaseInput):
@@ -58,11 +63,6 @@ class AccountRegisterInput(AccountBaseInput):
     )
     language_code = graphene.Argument(
         LanguageCodeEnum, required=False, description="User language code."
-    )
-    metadata = NonNullList(
-        MetadataInput,
-        description="User public metadata.",
-        required=False,
     )
     channel = graphene.String(
         description=(
@@ -194,6 +194,7 @@ class AccountUpdate(BaseCustomerCreate):
         permissions = (AuthorizationFilters.AUTHENTICATED_USER,)
         error_type_class = AccountError
         error_type_field = "account_errors"
+        support_meta_field = True
 
     @classmethod
     def perform_mutation(cls, root, info: ResolveInfo, /, **data):

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -459,6 +459,18 @@ class UserInput(BaseInputObjectType):
     email = graphene.String(description="The unique email address of the user.")
     is_active = graphene.Boolean(required=False, description="User account is active.")
     note = graphene.String(description="A note about the user.")
+    metadata = NonNullList(
+        MetadataInput,
+        description="Fields required to update the user metadata." + ADDED_IN_314,
+        required=False,
+    )
+    private_metadata = NonNullList(
+        MetadataInput,
+        description=(
+            "Fields required to update the user private metadata." + ADDED_IN_314
+        ),
+        required=False,
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_USERS
@@ -500,11 +512,6 @@ class UserCreateInput(CustomerInput):
             "Slug of a channel which will be used for notify user. Optional when "
             "only one channel exists."
         )
-    )
-    metadata = NonNullList(
-        MetadataInput,
-        description="Fields required to update the object's metadata." + ADDED_IN_314,
-        required=False,
     )
 
     class Meta:

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -100,6 +100,7 @@ class CustomerCreate(BaseCustomerCreate):
         model = models.User
         object_type = User
         permissions = (AccountPermissions.MANAGE_USERS,)
+        support_meta_field = True
         error_type_class = AccountError
         error_type_field = "account_errors"
 

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -408,6 +408,7 @@ class StaffUpdate(StaffCreate):
         permissions = (AccountPermissions.MANAGE_STAFF,)
         error_type_class = StaffError
         error_type_field = "staff_errors"
+        support_meta_field = True
 
     @classmethod
     def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -782,6 +782,14 @@ class ModelMutation(BaseMutation):
         cls.clean_instance(info, instance)
         cls.save(info, instance, cleaned_input)
         cls._save_m2m(info, instance, cleaned_input)
+
+        # add to cleaned_input popped metadata to allow running post save events
+        # that depends on the metadata inputs
+        if metadata_list:
+            cleaned_input["metadata"] = metadata_list
+        if private_metadata_list:
+            cleaned_input["private_metadata"] = private_metadata_list
+
         cls.post_save_action(info, instance, cleaned_input)
         return cls.success_response(instance)
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -25197,6 +25197,9 @@ input AccountRegisterInput @doc(category: "Users") {
   """User language code."""
   languageCode: LanguageCodeEnum
 
+  """User public metadata."""
+  metadata: [MetadataInput!]
+
   """The email address of the user."""
   email: String!
 
@@ -25205,9 +25208,6 @@ input AccountRegisterInput @doc(category: "Users") {
 
   """Base of frontend URL that will be needed to create confirmation URL."""
   redirectUrl: String
-
-  """User public metadata."""
-  metadata: [MetadataInput!]
 
   """
   Slug of a channel which will be used to notify users. Optional when only one channel exists.
@@ -25236,6 +25236,9 @@ input AccountInput @doc(category: "Users") {
 
   """User language code."""
   languageCode: LanguageCodeEnum
+
+  """User public metadata."""
+  metadata: [MetadataInput!]
 
   """Billing address of the customer."""
   defaultBillingAddress: AddressInput

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -25368,6 +25368,13 @@ input UserCreateInput @doc(category: "Users") {
   Slug of a channel which will be used for notify user. Optional when only one channel exists.
   """
   channel: String
+
+  """
+  Fields required to update the object's metadata.
+  
+  Added in Saleor 3.14.
+  """
+  metadata: [MetadataInput!]
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -25566,6 +25566,13 @@ input StaffCreateInput @doc(category: "Users") {
   addGroups: [ID!]
 
   """
+  Fields required to update the object's metadata.
+  
+  Added in Saleor 3.14.
+  """
+  metadata: [MetadataInput!]
+
+  """
   URL of a view where users should be redirected to set the password. URL in RFC 1808 format.
   """
   redirectUrl: String
@@ -25601,6 +25608,13 @@ input StaffUpdateInput @doc(category: "Users") {
 
   """List of permission group IDs to which user should be assigned."""
   addGroups: [ID!]
+
+  """
+  Fields required to update the object's metadata.
+  
+  Added in Saleor 3.14.
+  """
+  metadata: [MetadataInput!]
 
   """List of permission group IDs from which user should be unassigned."""
   removeGroups: [ID!]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -25197,9 +25197,6 @@ input AccountRegisterInput @doc(category: "Users") {
   """User language code."""
   languageCode: LanguageCodeEnum
 
-  """User public metadata."""
-  metadata: [MetadataInput!]
-
   """The email address of the user."""
   email: String!
 
@@ -25208,6 +25205,9 @@ input AccountRegisterInput @doc(category: "Users") {
 
   """Base of frontend URL that will be needed to create confirmation URL."""
   redirectUrl: String
+
+  """User public metadata."""
+  metadata: [MetadataInput!]
 
   """
   Slug of a channel which will be used to notify users. Optional when only one channel exists.
@@ -25237,14 +25237,18 @@ input AccountInput @doc(category: "Users") {
   """User language code."""
   languageCode: LanguageCodeEnum
 
-  """User public metadata."""
-  metadata: [MetadataInput!]
-
   """Billing address of the customer."""
   defaultBillingAddress: AddressInput
 
   """Shipping address of the customer."""
   defaultShippingAddress: AddressInput
+
+  """
+  Fields required to update the user metadata.
+  
+  Added in Saleor 3.14.
+  """
+  metadata: [MetadataInput!]
 }
 
 """
@@ -25352,6 +25356,20 @@ input UserCreateInput @doc(category: "Users") {
   """A note about the user."""
   note: String
 
+  """
+  Fields required to update the user metadata.
+  
+  Added in Saleor 3.14.
+  """
+  metadata: [MetadataInput!]
+
+  """
+  Fields required to update the user private metadata.
+  
+  Added in Saleor 3.14.
+  """
+  privateMetadata: [MetadataInput!]
+
   """User language code."""
   languageCode: LanguageCodeEnum
 
@@ -25371,13 +25389,6 @@ input UserCreateInput @doc(category: "Users") {
   Slug of a channel which will be used for notify user. Optional when only one channel exists.
   """
   channel: String
-
-  """
-  Fields required to update the object's metadata.
-  
-  Added in Saleor 3.14.
-  """
-  metadata: [MetadataInput!]
 }
 
 """
@@ -25412,6 +25423,20 @@ input CustomerInput @doc(category: "Users") {
 
   """A note about the user."""
   note: String
+
+  """
+  Fields required to update the user metadata.
+  
+  Added in Saleor 3.14.
+  """
+  metadata: [MetadataInput!]
+
+  """
+  Fields required to update the user private metadata.
+  
+  Added in Saleor 3.14.
+  """
+  privateMetadata: [MetadataInput!]
 
   """User language code."""
   languageCode: LanguageCodeEnum
@@ -25562,15 +25587,22 @@ input StaffCreateInput @doc(category: "Users") {
   """A note about the user."""
   note: String
 
-  """List of permission group IDs to which user should be assigned."""
-  addGroups: [ID!]
-
   """
-  Fields required to update the object's metadata.
+  Fields required to update the user metadata.
   
   Added in Saleor 3.14.
   """
   metadata: [MetadataInput!]
+
+  """
+  Fields required to update the user private metadata.
+  
+  Added in Saleor 3.14.
+  """
+  privateMetadata: [MetadataInput!]
+
+  """List of permission group IDs to which user should be assigned."""
+  addGroups: [ID!]
 
   """
   URL of a view where users should be redirected to set the password. URL in RFC 1808 format.
@@ -25606,15 +25638,22 @@ input StaffUpdateInput @doc(category: "Users") {
   """A note about the user."""
   note: String
 
-  """List of permission group IDs to which user should be assigned."""
-  addGroups: [ID!]
-
   """
-  Fields required to update the object's metadata.
+  Fields required to update the user metadata.
   
   Added in Saleor 3.14.
   """
   metadata: [MetadataInput!]
+
+  """
+  Fields required to update the user private metadata.
+  
+  Added in Saleor 3.14.
+  """
+  privateMetadata: [MetadataInput!]
+
+  """List of permission group IDs to which user should be assigned."""
+  addGroups: [ID!]
 
   """List of permission group IDs from which user should be unassigned."""
   removeGroups: [ID!]

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -5018,6 +5018,15 @@ def permission_group_manage_users(permission_manage_users, staff_users):
 
 
 @pytest.fixture
+def permission_group_manage_staff(permission_manage_staff, staff_users):
+    group = Group.objects.create(name="Manage staff groups.")
+    group.permissions.add(permission_manage_staff)
+
+    group.user_set.add(staff_users[1])
+    return group
+
+
+@pytest.fixture
 def collection(db):
     collection = Collection.objects.create(
         name="Collection",


### PR DESCRIPTION
Allow settings `metadata` and `privateMetadata` in the following mutations:
- `customerCreate`
- `customerUpdate`
- `staffCreate`
- `staffUpdate`
- `customerBulkUpdate`
- `accountUpdate` (only `metadata`)

Resolves: https://github.com/saleor/saleor/issues/12546
Resolves: https://github.com/saleor/saleor/issues/11799

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
