### PR TITLE
Drop default EMAIL_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,18 @@ All notable, unreleased changes to this project will be documented in this file.
 3.14.0 [Unreleased]
 
 ### Breaking changes
+
 - `path` field for errors related with product variants input in `ProductBulkCreate` will return more detailed paths: `variants.1.stocks.0.warehouse` instead of `variants.1.warehouses` - #12534 by @SzymJ
 
 ### GraphQL API
+
 - Add `path` field to `ProductVariantBulkError` - #12534 by @SzymJ
 
 ### Saleor Apps
 
 ### Other changes
+
+- Remove default `EMAIL_URL` value pointing to console output; from now on EMAIL_URL has to be set explicitly - #12580 by @maarcingebala
 
 # 3.13.0
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -125,18 +125,16 @@ if not EMAIL_URL and SENDGRID_USERNAME and SENDGRID_PASSWORD:
         f":{SENDGRID_PASSWORD}@smtp.sendgrid.net:587/?tls=True"
     )
 
-email_config = dj_email_url.parse(
-    EMAIL_URL or "console://demo@example.com:console@example/"
-)
+email_config = dj_email_url.parse(EMAIL_URL or "")
 
-EMAIL_FILE_PATH: str = email_config["EMAIL_FILE_PATH"]
-EMAIL_HOST_USER: str = email_config["EMAIL_HOST_USER"]
-EMAIL_HOST_PASSWORD: str = email_config["EMAIL_HOST_PASSWORD"]
-EMAIL_HOST: str = email_config["EMAIL_HOST"]
-EMAIL_PORT: int = email_config["EMAIL_PORT"]
-EMAIL_BACKEND: str = email_config["EMAIL_BACKEND"]
-EMAIL_USE_TLS: bool = email_config["EMAIL_USE_TLS"]
-EMAIL_USE_SSL: bool = email_config["EMAIL_USE_SSL"]
+EMAIL_FILE_PATH: str = email_config.get("EMAIL_FILE_PATH", "")
+EMAIL_HOST_USER: str = email_config.get("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD: str = email_config.get("EMAIL_HOST_PASSWORD", "")
+EMAIL_HOST: str = email_config.get("EMAIL_HOST", "")
+EMAIL_PORT: str = str(email_config.get("EMAIL_PORT", ""))
+EMAIL_BACKEND: str = email_config.get("EMAIL_BACKEND", "")
+EMAIL_USE_TLS: bool = email_config.get("EMAIL_USE_TLS", False)
+EMAIL_USE_SSL: bool = email_config.get("EMAIL_USE_SSL", False)
 
 # If enabled, make sure you have set proper storefront address in ALLOWED_CLIENT_HOSTS.
 ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL = get_bool_from_env(

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -146,7 +146,9 @@ ENABLE_SSL = get_bool_from_env("ENABLE_SSL", False)
 if ENABLE_SSL:
     SECURE_SSL_REDIRECT = not DEBUG
 
-DEFAULT_FROM_EMAIL: str = os.environ.get("DEFAULT_FROM_EMAIL", EMAIL_HOST_USER)
+DEFAULT_FROM_EMAIL: str = os.environ.get(
+    "DEFAULT_FROM_EMAIL", EMAIL_HOST_USER or "noreply@example.com"
+)
 
 MEDIA_ROOT: str = os.path.join(PROJECT_ROOT, "media")
 MEDIA_URL: str = os.environ.get("MEDIA_URL", "/media/")


### PR DESCRIPTION
Drop default `EMAIL_URL`; instead, it should be explicitly set by the user. As for the local development, `saleor-platform` sets the default EMAIL_URL to work with Mailpit.

This fixes an issue with enabling the admin email plugin locally with Mailpit. The default email URL we had translated to `username=demo@example.com` and `password=console`, which were not accepted by Mailpit and threw an error:

```
Traceback (most recent call last):
  File "./saleor/plugins/email_common.py", line 299, in validate_default_email_configuration
    validate_email_config(config)
  File "./saleor/plugins/email_common.py", line 238, in validate_email_config
    with email_backend:
  File "/Users/marcin/.pyenv/versions/3.9.1/envs/saleor/lib/python3.9/site-packages/django/core/mail/backends/base.py", line 45, in __enter__
    self.open()
  File "/Users/marcin/.pyenv/versions/3.9.1/envs/saleor/lib/python3.9/site-packages/django/core/mail/backends/smtp.py", line 91, in open
    self.connection.login(self.username, self.password)
  File "/Users/marcin/.pyenv/versions/3.9.1/lib/python3.9/smtplib.py", line 700, in login
    raise SMTPNotSupportedError(
smtplib.SMTPNotSupportedError: SMTP AUTH extension not supported by server.
```
When using Mailpit, the EMAIL_URL has to be set without a username and password.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
