### PR TITLE
Fix saving seo fields

### DIFF
--- a/saleor/graphql/core/validators/__init__.py
+++ b/saleor/graphql/core/validators/__init__.py
@@ -141,10 +141,13 @@ def validate_slug_value(cleaned_input, slug_field_name: str = "slug"):
 
 def clean_seo_fields(data):
     """Extract and assign seo fields to given dictionary."""
-    seo_fields = data.pop("seo", None)
-    if seo_fields:
-        data["seo_title"] = seo_fields.get("title")
-        data["seo_description"] = seo_fields.get("description")
+    seo_fields = data.pop("seo", {})
+
+    if "title" in seo_fields:
+        data["seo_title"] = seo_fields["title"]
+
+    if "description" in seo_fields:
+        data["seo_description"] = seo_fields["description"]
 
 
 def validate_required_string_field(cleaned_input, field_name: str):


### PR DESCRIPTION
I want to merge this change because it fixes updating SEO fields. When one of `seo` fields wasn't sent in `SeoInput` that field was cleaned. After this change only sent fields will be updated.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
