### PR TITLE
Allow apps to perform `webhookUpdate` mutation

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12811,7 +12811,7 @@ type Mutation {
   """
   Updates a webhook subscription. 
   
-  Requires one of the following permissions: MANAGE_APPS.
+  Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
   """
   webhookUpdate(
     """ID of a webhook to update."""
@@ -16934,7 +16934,7 @@ type WebhookDelete @doc(category: "Webhooks") {
 """
 Updates a webhook subscription. 
 
-Requires one of the following permissions: MANAGE_APPS.
+Requires one of the following permissions: MANAGE_APPS, AUTHENTICATED_APP.
 """
 type WebhookUpdate @doc(category: "Webhooks") {
   webhookErrors: [WebhookError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")

--- a/saleor/graphql/webhook/mutations/webhook_update.py
+++ b/saleor/graphql/webhook/mutations/webhook_update.py
@@ -1,8 +1,10 @@
 import graphene
 
+from ....permission.auth_filters import AuthorizationFilters
 from ....permission.enums import AppPermission
 from ....webhook import models
 from ....webhook.validators import HEADERS_LENGTH_LIMIT, HEADERS_NUMBER_LIMIT
+from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
 from ...core.descriptions import (
     ADDED_IN_32,
@@ -84,7 +86,10 @@ class WebhookUpdate(WebhookCreate):
         description = "Updates a webhook subscription."
         model = models.Webhook
         object_type = Webhook
-        permissions = (AppPermission.MANAGE_APPS,)
+        permissions = (
+            AppPermission.MANAGE_APPS,
+            AuthorizationFilters.AUTHENTICATED_APP,
+        )
         error_type_class = WebhookError
         error_type_field = "webhook_errors"
 
@@ -103,4 +108,6 @@ class WebhookUpdate(WebhookCreate):
 
     @classmethod
     def get_instance(cls, info: ResolveInfo, **data):
+        if app := get_app_promise(info.context).get():
+            data["qs"] = app.webhooks
         return super(WebhookCreate, cls).get_instance(info, **data)

--- a/saleor/graphql/webhook/tests/deprecated/test_webhook.py
+++ b/saleor/graphql/webhook/tests/deprecated/test_webhook.py
@@ -176,18 +176,6 @@ WEBHOOK_UPDATE = """
 """
 
 
-def test_webhook_update_not_allowed_by_app(app_api_client, app, webhook):
-    query = WEBHOOK_UPDATE
-    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
-    variables = {
-        "id": webhook_id,
-        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
-        "is_active": False,
-    }
-    response = app_api_client.post_graphql(query, variables=variables)
-    assert_no_permission(response)
-
-
 def test_webhook_update_by_staff(
     staff_api_client, app, webhook, permission_manage_apps
 ):

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_update.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_update.py
@@ -2,6 +2,7 @@ import json
 
 import graphene
 
+from .....app.models import App
 from ....core.enums import WebhookErrorCode
 from ....tests.utils import assert_no_permission, get_graphql_content
 from ...enums import WebhookEventTypeAsyncEnum
@@ -29,19 +30,118 @@ WEBHOOK_UPDATE = """
 """
 
 
-def test_webhook_update_not_allowed_by_app(app_api_client, app, webhook):
+def test_webhook_update_by_app(app_api_client, app, webhook):
     # given
-    query = WEBHOOK_UPDATE
     webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    custom_headers = {"x-key": "Value", "authorization-key": "Value"}
     variables = {
         "id": webhook_id,
         "input": {
             "asyncEvents": [WebhookEventTypeAsyncEnum.ORDER_CREATED.name],
             "isActive": False,
+            "customHeaders": json.dumps(custom_headers),
         },
     }
     # when
-    response = app_api_client.post_graphql(query, variables=variables)
+    response = app_api_client.post_graphql(WEBHOOK_UPDATE, variables=variables)
+    content = get_graphql_content(response)
+    webhook.refresh_from_db()
+
+    # then
+    assert webhook.is_active is False
+    events = webhook.events.all()
+    assert len(events) == 1
+    assert events[0].event_type == WebhookEventTypeAsyncEnum.ORDER_CREATED.value
+
+    data = content["data"]["webhookUpdate"]
+    assert not data["errors"]
+    assert len(data["webhook"]["asyncEvents"]) == 1
+    assert (
+        data["webhook"]["asyncEvents"][0]["eventType"]
+        == WebhookEventTypeAsyncEnum.ORDER_CREATED.name
+    )
+    assert data["webhook"]["isActive"] is False
+    assert data["webhook"]["customHeaders"] == json.dumps(custom_headers)
+
+
+def test_webhook_update_by_other_app(app_api_client, webhook):
+    # given
+    other_app = App.objects.create(name="other")
+    webhook.app = other_app
+    webhook.save()
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {"id": webhook_id, "input": {"isActive": False}}
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_UPDATE, variables=variables)
+    content = get_graphql_content(response)
+    errors = content["data"]["webhookUpdate"]["errors"]
+    webhook.refresh_from_db()
+
+    # then
+    assert errors[0]["code"] == "NOT_FOUND"
+    assert webhook.is_active is True
+
+
+def test_webhook_update_by_inactive_app(app_api_client, webhook):
+    # given
+    app = webhook.app
+    app.is_active = False
+    app.save()
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {"id": webhook_id, "input": {"isActive": False}}
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_UPDATE, variables=variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_webhook_update_app_cant_change_webhooks_ownership(
+    app_api_client, app, webhook
+):
+    # given
+    other_app = App.objects.create(name="other")
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    other_app_id = graphene.Node.to_global_id("App", other_app.pk)
+    variables = {"id": webhook_id, "input": {"app": other_app_id, "isActive": False}}
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_UPDATE, variables=variables)
+    content = get_graphql_content(response)
+    errors = content["data"]["webhookUpdate"]["errors"]
+    webhook.refresh_from_db()
+
+    # then
+    assert len(errors) == 0
+    assert webhook.app_id == app.id
+    assert webhook.is_active is False
+
+
+def test_webhook_update_by_app_and_missing_webhook(app_api_client, webhook):
+    # given
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {"id": webhook_id, "input": {"isActive": False}}
+    webhook.delete()
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_UPDATE, variables=variables)
+    content = get_graphql_content(response)
+
+    # then
+    errors = content["data"]["webhookUpdate"]["errors"]
+    assert errors[0]["code"] == "NOT_FOUND"
+
+
+def test_webhook_update_when_app_doesnt_exist(app_api_client, app):
+    # given
+    app.delete()
+    webhook_id = graphene.Node.to_global_id("Webhook", 1)
+    variables = {"id": webhook_id, "input": {"isActive": False}}
+
+    # when
+    response = app_api_client.post_graphql(WEBHOOK_UPDATE, variables=variables)
 
     # then
     assert_no_permission(response)


### PR DESCRIPTION
I want to merge this change because it makes it possible for an app to trigger `webhookUpdate` mutation and update its webhook. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
