### PR TITLE
Fix permission message in description

### DIFF
--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -1,6 +1,8 @@
 import graphene
 
+from ...permission.auth_filters import AuthorizationFilters
 from ...permission.enums import AccountPermissions, OrderPermissions
+from ...permission.utils import message_one_of_permissions_required
 from ..app.dataloaders import app_promise_callback
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
@@ -127,7 +129,10 @@ class AccountQueries(graphene.ObjectType):
         id=graphene.Argument(
             graphene.ID, description="ID of an address.", required=True
         ),
-        description="Look up an address by ID.",
+        description="Look up an address by ID."
+        + message_one_of_permissions_required(
+            [AccountPermissions.MANAGE_USERS, AuthorizationFilters.OWNER]
+        ),
         doc_category=DOC_CATEGORY_USERS,
     )
     customers = FilterConnectionField(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1430,7 +1430,11 @@ type Query {
     cityArea: String
   ): AddressValidationData @doc(category: "Users")
 
-  """Look up an address by ID."""
+  """
+  Look up an address by ID.
+  
+  Requires one of the following permissions: MANAGE_USERS, OWNER.
+  """
   address(
     """ID of an address."""
     id: ID!


### PR DESCRIPTION
Fix missing info about required permissions in `address` query.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
