### PR TITLE
Fix product created event on bulk product create main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Other changes
 
 - Remove default `EMAIL_URL` value pointing to console output; from now on EMAIL_URL has to be set explicitly - #12580 by @maarcingebala
+- Fix sending `product_created` event in `ProductBulkCreate` mutation
+
 
 # 3.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Other changes
 
 - Remove default `EMAIL_URL` value pointing to console output; from now on EMAIL_URL has to be set explicitly - #12580 by @maarcingebala
-- Fix sending `product_created` event in `ProductBulkCreate` mutation
+- Fix sending `product_created` event in `ProductBulkCreate` mutation - #12605 by @SzymJ
 
 
 # 3.13.0

--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -822,7 +822,7 @@ class ProductBulkCreate(BaseMutation):
     def post_save_actions(cls, info, products, variants, channels):
         manager = get_plugin_manager_promise(info.context).get()
         for product in products:
-            cls.call_event(manager.product_created, product)
+            cls.call_event(manager.product_created, product.node)
 
         for variant in variants:
             cls.call_event(manager.product_variant_created, variant)

--- a/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
@@ -198,6 +198,8 @@ def test_product_bulk_create_send_product_created_webhook(
     assert not data["results"][1]["errors"]
     assert data["count"] == 2
     assert created_webhook_mock.call_count == 2
+    for call in created_webhook_mock.call_args_list:
+        assert isinstance(call.args[0], Product)
 
 
 def test_product_bulk_create_with_same_name_and_no_slug(


### PR DESCRIPTION
I want to merge this change because it fixes bug with sending `product_created `event in `ProductBulkMutation`.

Port of #12595
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
