### PR TITLE
Change how mutex for celery task cancelling order work

### DIFF
--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -135,7 +135,7 @@ def expire_orders_task():
     try:
         with celery_task_lock(task_name) as (lock_obj, acquired):
             if not acquired:
-                if lock_obj.created_at < now - timedelta(hours=1):
+                if lock_obj.updated_at < now - timedelta(hours=1):
                     logger.error("%s task exceeded 1h working time.", [task_name])
             else:
                 _expire_orders(manager, now)


### PR DESCRIPTION
I want to merge this change because when shutting down `celery worker` database row wasn't removed which cause to have lock that was never released. In this PR I'm chaning the way how lock is being acquired and released.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
