### PR TITLE
Improve docstring for GraphQL refreshToken mutation

### DIFF
--- a/saleor/graphql/account/mutations/authentication.py
+++ b/saleor/graphql/account/mutations/authentication.py
@@ -201,7 +201,7 @@ class RefreshToken(BaseMutation):
 
     class Meta:
         description = (
-            "Refresh JWT token. Mutation tries to take refreshToken from the input."
+            "Refresh JWT token. Mutation tries to take refreshToken from the input. "
             "If it fails it will try to take `refreshToken` from the http-only cookie "
             f"`{JWT_REFRESH_TOKEN_COOKIE_NAME}`. "
             "`csrfToken` is required when `refreshToken` is provided as a cookie."

--- a/saleor/graphql/account/mutations/authentication.py
+++ b/saleor/graphql/account/mutations/authentication.py
@@ -195,15 +195,15 @@ class RefreshToken(BaseMutation):
             required=False,
             description=(
                 "CSRF token required to refresh token. This argument is "
-                "required when refreshToken is provided as a cookie."
+                "required when `refreshToken` is provided as a cookie."
             ),
         )
 
     class Meta:
         description = (
             "Refresh JWT token. Mutation tries to take refreshToken from the input."
-            "If it fails it will try to take refreshToken from the http-only cookie -"
-            f"{JWT_REFRESH_TOKEN_COOKIE_NAME}. csrfToken is required when refreshToken "
+            "If it fails it will try to take `refreshToken` from the http-only cookie "
+            f"`{JWT_REFRESH_TOKEN_COOKIE_NAME}`. csrfToken is required when `refreshToken` "
             "is provided as a cookie."
         )
         doc_category = DOC_CATEGORY_AUTH

--- a/saleor/graphql/account/mutations/authentication.py
+++ b/saleor/graphql/account/mutations/authentication.py
@@ -203,8 +203,8 @@ class RefreshToken(BaseMutation):
         description = (
             "Refresh JWT token. Mutation tries to take refreshToken from the input."
             "If it fails it will try to take `refreshToken` from the http-only cookie "
-            f"`{JWT_REFRESH_TOKEN_COOKIE_NAME}`. csrfToken is required when `refreshToken` "
-            "is provided as a cookie."
+            f"`{JWT_REFRESH_TOKEN_COOKIE_NAME}`. "
+            "`csrfToken` is required when `refreshToken` is provided as a cookie."
         )
         doc_category = DOC_CATEGORY_AUTH
         error_type_class = AccountError

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16350,11 +16350,11 @@ type Mutation {
   ): CreateToken @doc(category: "Authentication")
 
   """
-  Refresh JWT token. Mutation tries to take refreshToken from the input.If it fails it will try to take refreshToken from the http-only cookie -refreshToken. csrfToken is required when refreshToken is provided as a cookie.
+  Refresh JWT token. Mutation tries to take refreshToken from the input.If it fails it will try to take `refreshToken` from the http-only cookie `refreshToken`. csrfToken is required when `refreshToken` is provided as a cookie.
   """
   tokenRefresh(
     """
-    CSRF token required to refresh token. This argument is required when refreshToken is provided as a cookie.
+    CSRF token required to refresh token. This argument is required when `refreshToken` is provided as a cookie.
     """
     csrfToken: String
 
@@ -24958,7 +24958,7 @@ enum AccountErrorCode @doc(category: "Users") {
 }
 
 """
-Refresh JWT token. Mutation tries to take refreshToken from the input.If it fails it will try to take refreshToken from the http-only cookie -refreshToken. csrfToken is required when refreshToken is provided as a cookie.
+Refresh JWT token. Mutation tries to take refreshToken from the input.If it fails it will try to take `refreshToken` from the http-only cookie `refreshToken`. csrfToken is required when `refreshToken` is provided as a cookie.
 """
 type RefreshToken @doc(category: "Authentication") {
   """JWT token, required to authenticate."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16350,7 +16350,7 @@ type Mutation {
   ): CreateToken @doc(category: "Authentication")
 
   """
-  Refresh JWT token. Mutation tries to take refreshToken from the input.If it fails it will try to take `refreshToken` from the http-only cookie `refreshToken`. csrfToken is required when `refreshToken` is provided as a cookie.
+  Refresh JWT token. Mutation tries to take refreshToken from the input.If it fails it will try to take `refreshToken` from the http-only cookie `refreshToken`. `csrfToken` is required when `refreshToken` is provided as a cookie.
   """
   tokenRefresh(
     """
@@ -24958,7 +24958,7 @@ enum AccountErrorCode @doc(category: "Users") {
 }
 
 """
-Refresh JWT token. Mutation tries to take refreshToken from the input.If it fails it will try to take `refreshToken` from the http-only cookie `refreshToken`. csrfToken is required when `refreshToken` is provided as a cookie.
+Refresh JWT token. Mutation tries to take refreshToken from the input.If it fails it will try to take `refreshToken` from the http-only cookie `refreshToken`. `csrfToken` is required when `refreshToken` is provided as a cookie.
 """
 type RefreshToken @doc(category: "Authentication") {
   """JWT token, required to authenticate."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16350,7 +16350,7 @@ type Mutation {
   ): CreateToken @doc(category: "Authentication")
 
   """
-  Refresh JWT token. Mutation tries to take refreshToken from the input.If it fails it will try to take `refreshToken` from the http-only cookie `refreshToken`. `csrfToken` is required when `refreshToken` is provided as a cookie.
+  Refresh JWT token. Mutation tries to take refreshToken from the input. If it fails it will try to take `refreshToken` from the http-only cookie `refreshToken`. `csrfToken` is required when `refreshToken` is provided as a cookie.
   """
   tokenRefresh(
     """
@@ -24958,7 +24958,7 @@ enum AccountErrorCode @doc(category: "Users") {
 }
 
 """
-Refresh JWT token. Mutation tries to take refreshToken from the input.If it fails it will try to take `refreshToken` from the http-only cookie `refreshToken`. `csrfToken` is required when `refreshToken` is provided as a cookie.
+Refresh JWT token. Mutation tries to take refreshToken from the input. If it fails it will try to take `refreshToken` from the http-only cookie `refreshToken`. `csrfToken` is required when `refreshToken` is provided as a cookie.
 """
 type RefreshToken @doc(category: "Authentication") {
   """JWT token, required to authenticate."""


### PR DESCRIPTION
This improves the auto-generated documentation at https://docs.saleor.io/docs/3.x/api-reference/authentication/mutations/token-refresh by removing a out of the place or accidental `-` and will format variable names and cookie name as inline code (`<code>`). 



<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
