### PR TITLE
Remove invalid default values from error_policy enums

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -191,8 +191,8 @@ class ProductBulkCreate(BaseMutation):
         )
         error_policy = ErrorPolicyEnum(
             required=False,
-            default_value=ErrorPolicyEnum.REJECT_EVERYTHING.value,
-            description="Policies of error handling.",
+            description="Policies of error handling. DEFAULT: "
+            + ErrorPolicyEnum.REJECT_EVERYTHING.name,
         )
 
     class Meta:
@@ -834,7 +834,7 @@ class ProductBulkCreate(BaseMutation):
     @traced_atomic_transaction()
     def perform_mutation(cls, root, info, **data):
         index_error_map: dict = defaultdict(list)
-        error_policy = data["error_policy"]
+        error_policy = data.get("error_policy", ErrorPolicyEnum.REJECT_EVERYTHING.value)
 
         # clean and validate inputs
         cleaned_inputs_map = cls.clean_products(info, data["products"], index_error_map)

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -250,7 +250,6 @@ class ProductVariantBulkCreate(BaseMutation):
         )
         error_policy = ErrorPolicyEnum(
             required=False,
-            default_value=ErrorPolicyEnum.REJECT_EVERYTHING.value,
             description=(
                 "Policies of error handling. DEFAULT: "
                 + ErrorPolicyEnum.REJECT_EVERYTHING.name
@@ -908,7 +907,7 @@ class ProductVariantBulkCreate(BaseMutation):
             models.Product,
             cls.get_node_or_error(info, data["product_id"], only_type="Product"),
         )
-        error_policy = data["error_policy"]
+        error_policy = data.get("error_policy", ErrorPolicyEnum.REJECT_EVERYTHING.value)
         errors: dict = defaultdict(list)
         index_error_map: dict = defaultdict(list)
 

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -139,7 +139,6 @@ class ProductVariantBulkUpdate(BaseMutation):
         )
         error_policy = ErrorPolicyEnum(
             required=False,
-            default_value=ErrorPolicyEnum.REJECT_EVERYTHING.value,
             description=(
                 "Policies of error handling. DEFAULT: "
                 + ErrorPolicyEnum.REJECT_EVERYTHING.name
@@ -657,7 +656,7 @@ class ProductVariantBulkUpdate(BaseMutation):
     @traced_atomic_transaction()
     def perform_mutation(cls, _root, info, **data):
         index_error_map: dict = defaultdict(list)
-        error_policy = data["error_policy"]
+        error_policy = data.get("error_policy", ErrorPolicyEnum.REJECT_EVERYTHING.value)
         product = cast(
             models.Product,
             cls.get_node_or_error(info, data["product_id"], only_type="Product"),

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13037,7 +13037,7 @@ type Mutation {
   """
   stockBulkUpdate(
     """Policies of error handling. DEFAULT: REJECT_EVERYTHING"""
-    errorPolicy: ErrorPolicyEnum = reject_everything
+    errorPolicy: ErrorPolicyEnum
 
     """Input list of stocks to update."""
     stocks: [StockBulkUpdateInput!]!
@@ -13534,8 +13534,8 @@ type Mutation {
   Requires one of the following permissions: MANAGE_PRODUCTS.
   """
   productBulkCreate(
-    """Policies of error handling."""
-    errorPolicy: ErrorPolicyEnum = reject_everything
+    """Policies of error handling. DEFAULT: REJECT_EVERYTHING"""
+    errorPolicy: ErrorPolicyEnum
 
     """Input list of products to create."""
     products: [ProductBulkCreateInput!]!
@@ -13835,7 +13835,7 @@ type Mutation {
     
     Note: this API is currently in Feature Preview and can be subject to changes at later point.
     """
-    errorPolicy: ErrorPolicyEnum = reject_everything
+    errorPolicy: ErrorPolicyEnum
 
     """ID of the product to create the variants for."""
     product: ID!
@@ -13855,7 +13855,7 @@ type Mutation {
   """
   productVariantBulkUpdate(
     """Policies of error handling. DEFAULT: REJECT_EVERYTHING"""
-    errorPolicy: ErrorPolicyEnum = reject_everything
+    errorPolicy: ErrorPolicyEnum
 
     """ID of the product to update the variants for."""
     product: ID!

--- a/saleor/graphql/warehouse/bulk_mutations/stock_bulk_update.py
+++ b/saleor/graphql/warehouse/bulk_mutations/stock_bulk_update.py
@@ -73,7 +73,6 @@ class StockBulkUpdate(BaseMutation):
         )
         error_policy = ErrorPolicyEnum(
             required=False,
-            default_value=ErrorPolicyEnum.REJECT_EVERYTHING.value,
             description=(
                 "Policies of error handling. DEFAULT: "
                 + ErrorPolicyEnum.REJECT_EVERYTHING.name
@@ -375,7 +374,7 @@ class StockBulkUpdate(BaseMutation):
     @classmethod
     @traced_atomic_transaction()
     def perform_mutation(cls, _root, info, **data):
-        error_policy = data["error_policy"]
+        error_policy = data.get("error_policy", ErrorPolicyEnum.REJECT_EVERYTHING.value)
         index_error_map: dict = defaultdict(list)
         cleaned_inputs_map = cls.clean_stocks(data["stocks"], index_error_map)
 


### PR DESCRIPTION
I want to merge this change because it fixes #12327 and allows GraphQL clients to parse the schema without issues.

I noticed that the `customerBulkUpdate` mutation uses a different approach for the default value, which doesn't cause issues with the GraphQL clients I'm using, so I copied that across to the other mutations.

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
