### PR TITLE
Cancelling orders change logging error to warning

### DIFF
--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -136,9 +136,9 @@ def expire_orders_task():
         with celery_task_lock(task_name) as (lock_obj, acquired):
             if not acquired:
                 if lock_obj.created_at < now - timedelta(hours=1):
-                    logger.error("%s task exceeded 1h working time.", [task_name])
+                    logger.warning("%s task exceeded 1h working time.", [task_name])
             else:
                 _expire_orders(manager, now)
 
     except SoftTimeLimitExceeded as e:
-        logger.error(e)
+        logger.warning(e)

--- a/saleor/order/tests/test_tasks.py
+++ b/saleor/order/tests/test_tasks.py
@@ -363,7 +363,7 @@ def test_expire_orders_task_after(order_list, allocations, channel_USD):
     ).exists()
 
 
-@patch("logging.Logger.error")
+@patch("logging.Logger.warning")
 def test_expire_orders_task_locked_over_hour(logger_mock, order_list, allocations):
     # given
     task_name = "expire_orders"


### PR DESCRIPTION
I want to merge this change because I want to log warnings instead of errors.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
