### PR TITLE
Allow setting metadata during invoice creating and updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - `staffUpdate`
     - `accountUpdate`
     - `customerBulkUpdate`
+- Allow setting metadata during invoice creating and updating - #12641 by @IKarbowiak
 
 ### Saleor Apps
 

--- a/saleor/graphql/invoice/mutations.py
+++ b/saleor/graphql/invoice/mutations.py
@@ -12,9 +12,11 @@ from ...order import events as order_events
 from ...permission.enums import OrderPermissions
 from ..app.dataloaders import get_app_promise
 from ..core import ResolveInfo
+from ..core.descriptions import ADDED_IN_314
 from ..core.doc_category import DOC_CATEGORY_ORDERS
 from ..core.mutations import ModelDeleteMutation, ModelMutation
-from ..core.types import BaseInputObjectType, InvoiceError
+from ..core.types import BaseInputObjectType, InvoiceError, NonNullList
+from ..meta.mutations import MetadataInput
 from ..order.types import Order
 from ..plugins.dataloaders import get_plugin_manager_promise
 from .types import Invoice
@@ -114,6 +116,18 @@ class InvoiceRequest(ModelMutation):
 class InvoiceCreateInput(BaseInputObjectType):
     number = graphene.String(required=True, description="Invoice number.")
     url = graphene.String(required=True, description="URL of an invoice to download.")
+    metadata = NonNullList(
+        MetadataInput,
+        description="Fields required to update the invoice metadata." + ADDED_IN_314,
+        required=False,
+    )
+    private_metadata = NonNullList(
+        MetadataInput,
+        description=(
+            "Fields required to update the invoice private metadata." + ADDED_IN_314
+        ),
+        required=False,
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS
@@ -135,6 +149,8 @@ class InvoiceCreate(ModelMutation):
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = InvoiceError
         error_type_field = "invoice_errors"
+        support_meta_field = True
+        support_private_meta_field = True
 
     @classmethod
     def clean_input(cls, _info: ResolveInfo, _instance, data):  # type: ignore[override]
@@ -179,10 +195,16 @@ class InvoiceCreate(ModelMutation):
         order = cls.get_node_or_error(info, order_id, only_type=Order, field="orderId")
         cls.clean_order(info, order)
         cleaned_input = cls.clean_input(info, order, input)
+
+        metadata_list = cleaned_input.pop("metadata", None)
+        private_metadata_list = cleaned_input.pop("private_metadata", None)
+
         invoice = models.Invoice(**cleaned_input)
         invoice.order = order
         invoice.status = JobStatus.SUCCESS
+        cls.validate_and_update_metadata(invoice, metadata_list, private_metadata_list)
         invoice.save()
+
         app = get_app_promise(info.context).get()
         events.invoice_created_event(
             user=info.context.user,
@@ -256,6 +278,18 @@ class InvoiceDelete(ModelDeleteMutation):
 class UpdateInvoiceInput(BaseInputObjectType):
     number = graphene.String(description="Invoice number")
     url = graphene.String(description="URL of an invoice to download.")
+    metadata = NonNullList(
+        MetadataInput,
+        description="Fields required to update the invoice metadata." + ADDED_IN_314,
+        required=False,
+    )
+    private_metadata = NonNullList(
+        MetadataInput,
+        description=(
+            "Fields required to update the invoice private metadata." + ADDED_IN_314
+        ),
+        required=False,
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS
@@ -275,6 +309,8 @@ class InvoiceUpdate(ModelMutation):
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = InvoiceError
         error_type_field = "invoice_errors"
+        support_meta_field = True
+        support_private_meta_field = True
 
     @classmethod
     def clean_input(cls, _info: ResolveInfo, instance, data):  # type: ignore[override]
@@ -304,11 +340,23 @@ class InvoiceUpdate(ModelMutation):
     ):
         instance = cls.get_instance(info, id=id)
         cleaned_input = cls.clean_input(info, instance, input)
+        metadata_list = cleaned_input.pop("metadata", None)
+        private_metadata_list = cleaned_input.pop("private_metadata", None)
+        cls.validate_and_update_metadata(instance, metadata_list, private_metadata_list)
         instance.update_invoice(
             number=cleaned_input.get("number"), url=cleaned_input.get("url")
         )
         instance.status = JobStatus.SUCCESS
-        instance.save(update_fields=["external_url", "number", "updated_at", "status"])
+        instance.save(
+            update_fields=[
+                "external_url",
+                "number",
+                "updated_at",
+                "status",
+                "metadata",
+                "private_metadata",
+            ]
+        )
         app = get_app_promise(info.context).get()
         order_events.invoice_updated_event(
             order=instance.order,

--- a/saleor/graphql/invoice/tests/test_invoice_create.py
+++ b/saleor/graphql/invoice/tests/test_invoice_create.py
@@ -10,13 +10,10 @@ from ....invoice.models import Invoice, InvoiceEvent, InvoiceEvents
 from ....order import OrderEvents, OrderStatus
 
 INVOICE_CREATE_MUTATION = """
-    mutation InvoiceCreate($orderId: ID!, $number: String!, $url: String!) {
+    mutation InvoiceCreate($orderId: ID!, $input: InvoiceCreateInput!) {
         invoiceCreate(
             orderId: $orderId,
-            input: {
-                number: $number,
-                url: $url
-            }
+            input: $input
         ) {
             invoice {
                 status
@@ -24,6 +21,14 @@ INVOICE_CREATE_MUTATION = """
                 url
                 order {
                     id
+                }
+                metadata {
+                    key
+                    value
+                }
+                privateMetadata {
+                    key
+                    value
                 }
             }
             errors {
@@ -36,20 +41,36 @@ INVOICE_CREATE_MUTATION = """
 
 
 def test_create_invoice(staff_api_client, permission_manage_orders, order):
+    # given
     number = "01/12/2020/TEST"
     url = "http://www.example.com"
     order_id = graphene.Node.to_global_id("Order", order.pk)
+    metadata = [{"key": "test key", "value": "test value"}]
+    private_metadata = [{"key": "private test key", "value": "private test value"}]
     variables = {
         "orderId": order_id,
-        "number": number,
-        "url": url,
+        "input": {
+            "number": number,
+            "url": url,
+            "metadata": metadata,
+            "privateMetadata": private_metadata,
+        },
     }
+
+    # when
     response = staff_api_client.post_graphql(
         INVOICE_CREATE_MUTATION, variables, permissions=[permission_manage_orders]
     )
+
+    # then
     content = get_graphql_content(response)
     invoice = Invoice.objects.get(order=order, status=JobStatus.SUCCESS)
     assert order_id == content["data"]["invoiceCreate"]["invoice"]["order"]["id"]
+    assert content["data"]["invoiceCreate"]["invoice"]["metadata"] == metadata
+    assert (
+        content["data"]["invoiceCreate"]["invoice"]["privateMetadata"]
+        == private_metadata
+    )
     assert invoice.url == content["data"]["invoiceCreate"]["invoice"]["url"]
     assert invoice.number == content["data"]["invoiceCreate"]["invoice"]["number"]
     assert (
@@ -80,8 +101,10 @@ def test_create_invoice_no_billing_address(
     url = "http://www.example.com"
     variables = {
         "orderId": graphene.Node.to_global_id("Order", order.pk),
-        "number": number,
-        "url": url,
+        "input": {
+            "number": number,
+            "url": url,
+        },
     }
     response = staff_api_client.post_graphql(
         INVOICE_CREATE_MUTATION, variables, permissions=[permission_manage_orders]
@@ -106,8 +129,10 @@ def test_create_invoice_invalid_order_status(
     url = "http://www.example.com"
     variables = {
         "orderId": graphene.Node.to_global_id("Order", order.pk),
-        "number": number,
-        "url": url,
+        "input": {
+            "number": number,
+            "url": url,
+        },
     }
     response = staff_api_client.post_graphql(
         INVOICE_CREATE_MUTATION, variables, permissions=[permission_manage_orders]
@@ -123,8 +148,10 @@ def test_create_invoice_invalid_order_status(
 def test_create_invoice_invalid_id(staff_api_client, permission_manage_orders):
     variables = {
         "orderId": graphene.Node.to_global_id("Order", uuid.uuid4()),
-        "number": "01/12/2020/TEST",
-        "url": "http://www.example.com",
+        "input": {
+            "number": "01/12/2020/TEST",
+            "url": "http://www.example.com",
+        },
     }
     response = staff_api_client.post_graphql(
         INVOICE_CREATE_MUTATION, variables, permissions=[permission_manage_orders]
@@ -138,8 +165,10 @@ def test_create_invoice_invalid_id(staff_api_client, permission_manage_orders):
 def test_create_invoice_empty_params(staff_api_client, permission_manage_orders, order):
     variables = {
         "orderId": graphene.Node.to_global_id("Order", order.pk),
-        "number": "",
-        "url": "",
+        "input": {
+            "number": "",
+            "url": "",
+        },
     }
     response = staff_api_client.post_graphql(
         INVOICE_CREATE_MUTATION, variables, permissions=[permission_manage_orders]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22572,6 +22572,20 @@ input InvoiceCreateInput @doc(category: "Orders") {
 
   """URL of an invoice to download."""
   url: String!
+
+  """
+  Fields required to update the invoice metadata.
+  
+  Added in Saleor 3.14.
+  """
+  metadata: [MetadataInput!]
+
+  """
+  Fields required to update the invoice private metadata.
+  
+  Added in Saleor 3.14.
+  """
+  privateMetadata: [MetadataInput!]
 }
 
 """
@@ -22602,6 +22616,20 @@ input UpdateInvoiceInput @doc(category: "Orders") {
 
   """URL of an invoice to download."""
   url: String
+
+  """
+  Fields required to update the invoice metadata.
+  
+  Added in Saleor 3.14.
+  """
+  metadata: [MetadataInput!]
+
+  """
+  Fields required to update the invoice private metadata.
+  
+  Added in Saleor 3.14.
+  """
+  privateMetadata: [MetadataInput!]
 }
 
 """


### PR DESCRIPTION
Allow defining `metadata` and `private_metadata` in the following invoice mutations:
- `invoiceCreate`
- `invoiceUpdate`

Resolves: https://github.com/saleor/saleor/issues/11798

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
