### PR TITLE
fix checkout metadata fetches to not create checkout metadata objects

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -83,7 +83,11 @@ from .checkout_cleaner import (
 )
 from .fetch import CheckoutInfo, CheckoutLineInfo
 from .models import Checkout
-from .utils import get_or_create_checkout_metadata, get_voucher_for_checkout_info
+from .utils import (
+    get_checkout_metadata,
+    get_or_create_checkout_metadata,
+    get_voucher_for_checkout_info,
+)
 
 if TYPE_CHECKING:
     from ..app.models import App
@@ -587,7 +591,7 @@ def _create_order(
 
     # assign checkout payments to the order
     checkout.payments.update(order=order)
-    checkout_metadata = get_or_create_checkout_metadata(checkout)
+    checkout_metadata = get_checkout_metadata(checkout)
 
     # store current tax configuration
     update_order_display_gross_prices(order)

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -37,6 +37,7 @@ from ..utils import (
     change_shipping_address_in_checkout,
     clear_delivery_method,
     delete_external_shipping_id,
+    get_checkout_metadata,
     get_external_shipping_id,
     get_voucher_discount_for_checkout,
     get_voucher_for_checkout_info,
@@ -1758,3 +1759,25 @@ def test_checkout_has_currency(checkout):
 
 def test_checkout_line_has_currency(checkout_line):
     assert hasattr(checkout_line, "currency")
+
+
+def test_get_checkout_metadata_no_metadata_storage(checkout):
+    # given
+    checkout.metadata_storage.delete()
+
+    # when
+    metadata_container = get_checkout_metadata(checkout)
+
+    # then
+    assert metadata_container
+
+
+def test_get_checkout_metadata(checkout):
+    # given
+    assert checkout.metadata_storage.id
+
+    # when
+    metadata_container = get_checkout_metadata(checkout)
+
+    # then
+    assert metadata_container

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -874,7 +874,7 @@ def clear_delivery_method(checkout_info: "CheckoutInfo"):
             "last_change",
         ]
     )
-    get_or_create_checkout_metadata(checkout).save(
+    get_checkout_metadata(checkout).save(
         update_fields=[
             "private_metadata",
         ]

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -975,4 +975,4 @@ def get_checkout_metadata(checkout: "Checkout"):
     if hasattr(checkout, "metadata_storage"):
         return checkout.metadata_storage
     else:
-        return CheckoutMetadata()
+        return CheckoutMetadata(checkout)

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -975,4 +975,4 @@ def get_checkout_metadata(checkout: "Checkout"):
     if hasattr(checkout, "metadata_storage"):
         return checkout.metadata_storage
     else:
-        return CheckoutMetadata(checkout)
+        return CheckoutMetadata(checkout=checkout)

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -953,7 +953,7 @@ def set_external_shipping_id(checkout: Checkout, app_shipping_id: str):
 
 def get_external_shipping_id(container: Union["Checkout", "Order"]):
     if type(container) == Checkout:
-        container = get_or_create_checkout_metadata(container)
+        container = get_checkout_metadata(container)
     return container.get_value_from_private_metadata(  # type:ignore
         PRIVATE_META_APP_SHIPPING_ID
     )
@@ -969,3 +969,10 @@ def get_or_create_checkout_metadata(checkout: "Checkout"):
         return checkout.metadata_storage
     else:
         return CheckoutMetadata.objects.create(checkout=checkout)
+
+
+def get_checkout_metadata(checkout: "Checkout"):
+    if hasattr(checkout, "metadata_storage"):
+        return checkout.metadata_storage
+    else:
+        return CheckoutMetadata()

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -7,7 +7,7 @@ from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.utils import (
     delete_external_shipping_id,
-    get_or_create_checkout_metadata,
+    get_checkout_metadata,
     invalidate_checkout_prices,
     is_shipping_required,
     set_external_shipping_id,
@@ -202,7 +202,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             ]
             + invalidate_prices_updated_fields
         )
-        get_or_create_checkout_metadata(checkout).save(
+        get_checkout_metadata(checkout).save(
             update_fields=[
                 "private_metadata",
             ]
@@ -243,9 +243,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
             ]
             + invalidate_prices_updated_fields
         )
-        get_or_create_checkout_metadata(checkout).save(
-            update_fields=["private_metadata"]
-        )
+        get_checkout_metadata(checkout).save(update_fields=["private_metadata"])
         cls.call_event(manager.checkout_updated, checkout)
 
         return CheckoutShippingMethodUpdate(checkout=checkout)

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -390,7 +390,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(67):
+    with django_assert_num_queries(66):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -408,7 +408,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(67):
+    with django_assert_num_queries(66):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -485,6 +485,84 @@ def test_checkout_complete_with_metadata_updates_existing_keys(
 
 
 @pytest.mark.integration
+@patch("saleor.plugins.manager.PluginsManager.order_confirmed")
+def test_checkout_complete_with_metadata_checkout_without_metadata(
+    order_confirmed_mock,
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    payment_dummy,
+    address,
+    shipping_method,
+):
+    """Ensure that checkout is properly completed with provided metadata when the
+    checkout object hasn't assigned any metadata."""
+    # given
+    assert not gift_card.last_used_on
+
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    # delete the current metadata
+    checkout.metadata_storage.delete()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+    channel = checkout.channel
+    channel.automatically_confirm_all_new_orders = True
+    channel.save()
+    payment = payment_dummy
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.checkout = checkout
+    payment.save()
+    assert not payment.transactions.exists()
+
+    orders_count = Order.objects.count()
+    redirect_url = "https://www.example.com"
+    metadata_value = "metaValue"
+    metadata_key = "metaKey"
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "redirectUrl": redirect_url,
+        "metadata": [{"key": metadata_key, "value": metadata_value}],
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+
+    # then
+    assert not data["errors"]
+    assert Order.objects.count() == orders_count + 1
+    order = Order.objects.first()
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.origin == OrderOrigin.CHECKOUT
+    assert not order.original
+
+    assert order.metadata == {
+        **checkout.metadata_storage.metadata,
+        **{metadata_key: metadata_value},
+    }
+    assert order.private_metadata == checkout.metadata_storage.private_metadata
+
+    assert not Checkout.objects.filter(
+        pk=checkout.pk
+    ).exists(), "Checkout should have been deleted"
+    order_confirmed_mock.assert_called_once_with(order)
+
+
+@pytest.mark.integration
 @patch("saleor.graphql.checkout.mutations.checkout_complete.complete_checkout")
 def test_checkout_complete_by_app(
     mocked_complete_checkout,

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -369,6 +369,79 @@ def test_order_from_checkout_with_metadata(
     order_confirmed_mock.assert_called_once_with(order)
 
 
+@pytest.mark.integration
+@patch("saleor.plugins.manager.PluginsManager.order_confirmed")
+def test_order_from_checkout_with_metadata_checkout_without_metadata(
+    order_confirmed_mock,
+    app_api_client,
+    permission_handle_checkouts,
+    permission_manage_checkouts,
+    site_settings,
+    checkout_with_gift_card,
+    gift_card,
+    address,
+    shipping_method,
+):
+    # given
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    metadata_key = "md key"
+    metadata_value = "md value"
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+    channel = checkout.channel
+    channel.automatically_confirm_all_new_orders = True
+    channel.save()
+
+    # delete the current metadata
+    checkout.metadata_storage.delete()
+
+    orders_count = Order.objects.count()
+    variables = {
+        "id": graphene.Node.to_global_id("Checkout", checkout.pk),
+        "metadata": [{"key": metadata_key, "value": metadata_value}],
+        "privateMetadata": [{"key": metadata_key, "value": metadata_value}],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        MUTATION_ORDER_CREATE_FROM_CHECKOUT,
+        variables,
+        permissions=[permission_handle_checkouts, permission_manage_checkouts],
+    )
+
+    content = get_graphql_content(response)
+    data = content["data"]["orderCreateFromCheckout"]
+    assert not data["errors"]
+
+    order_token = data["order"]["token"]
+    assert Order.objects.count() == orders_count + 1
+    order = Order.objects.first()
+    assert order.status == OrderStatus.UNCONFIRMED
+    assert order.origin == OrderOrigin.CHECKOUT
+    assert not order.original
+    assert str(order.pk) == order_token
+    assert order.total.gross == total.gross
+    assert order.metadata == {
+        **checkout.metadata_storage.metadata,
+        **{metadata_key: metadata_value},
+    }
+    assert order.private_metadata == {
+        **checkout.metadata_storage.private_metadata,
+        **{metadata_key: metadata_value},
+    }
+    order_confirmed_mock.assert_called_once_with(order)
+
+
 def test_order_from_checkout_by_app_with_missing_permission(
     app_api_client,
     checkout_with_item,

--- a/saleor/graphql/meta/types.py
+++ b/saleor/graphql/meta/types.py
@@ -4,7 +4,7 @@ import graphene
 from graphene.types.generic import GenericScalar
 
 from ...checkout.models import Checkout
-from ...checkout.utils import get_or_create_checkout_metadata
+from ...checkout.utils import get_checkout_metadata
 from ...core.models import ModelWithMetadata
 from ..channel import ChannelContext
 from ..core import ResolveInfo
@@ -164,5 +164,5 @@ class ObjectWithMetadata(graphene.Interface):
 
 def get_valid_metadata_instance(instance):
     if isinstance(instance, Checkout):
-        instance = get_or_create_checkout_metadata(instance)
+        instance = get_checkout_metadata(instance)
     return instance

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -18,7 +18,7 @@ from .....checkout.calculations import (
 )
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout
-from .....checkout.utils import is_shipping_required, get_checkout_metadata
+from .....checkout.utils import get_checkout_metadata, is_shipping_required
 from .....discount.utils import fetch_active_discounts
 from .....payment.models import Payment
 from .....plugins.manager import get_plugins_manager
@@ -352,9 +352,7 @@ def request_data_for_gateway_config(
         country_code = country.code
     else:
         country_code = Country(settings.DEFAULT_COUNTRY).code
-    channel = get_checkout_metadata(checkout).get_value_from_metadata(
-        "channel", "web"
-    )
+    channel = get_checkout_metadata(checkout).get_value_from_metadata("channel", "web")
     return {
         "merchantAccount": merchant_account,
         "countryCode": country_code,

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -18,7 +18,7 @@ from .....checkout.calculations import (
 )
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout
-from .....checkout.utils import get_or_create_checkout_metadata, is_shipping_required
+from .....checkout.utils import is_shipping_required, get_checkout_metadata
 from .....discount.utils import fetch_active_discounts
 from .....payment.models import Payment
 from .....plugins.manager import get_plugins_manager
@@ -352,7 +352,7 @@ def request_data_for_gateway_config(
         country_code = country.code
     else:
         country_code = Country(settings.DEFAULT_COUNTRY).code
-    channel = get_or_create_checkout_metadata(checkout).get_value_from_metadata(
+    channel = get_checkout_metadata(checkout).get_value_from_metadata(
         "channel", "web"
     )
     return {

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -194,9 +194,9 @@ def create_payment_information(
         email = cast(str, checkout.get_customer_email())
         user_id = checkout.user_id
         checkout_token = str(checkout.token)
-        from ..checkout.utils import get_or_create_checkout_metadata
+        from ..checkout.utils import get_checkout_metadata
 
-        checkout_metadata = get_or_create_checkout_metadata(checkout).metadata
+        checkout_metadata = get_checkout_metadata(checkout).metadata
     elif order := payment.order:
         billing = order.billing_address
         shipping = order.shipping_address

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -26,7 +26,7 @@ from ..attribute.models import AttributeValueTranslation
 from ..checkout import base_calculations
 from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
 from ..checkout.models import Checkout
-from ..checkout.utils import get_or_create_checkout_metadata
+from ..checkout.utils import get_checkout_metadata
 from ..core.prices import quantize_price, quantize_price_fields
 from ..core.utils import build_absolute_uri
 from ..core.utils.anonymization import (
@@ -592,12 +592,12 @@ def generate_checkout_payload(
             # a checkout payload
             "token": graphene.Node.to_global_id("Checkout", checkout.token),
             "metadata": (
-                lambda c=checkout: get_or_create_checkout_metadata(c).metadata
+                lambda c=checkout: get_checkout_metadata(c).metadata
                 if hasattr(c, "metadata_storage")
                 else {}
             ),
             "private_metadata": (
-                lambda c=checkout: get_or_create_checkout_metadata(c).private_metadata
+                lambda c=checkout: get_checkout_metadata(c).private_metadata
                 if hasattr(c, "metadata_storage")
                 else {}
             ),
@@ -1344,7 +1344,7 @@ def generate_checkout_payload_for_tax_calculation(
             "discounts": discounts,
             "lines": lines_dict_data,
             "metadata": (
-                lambda c=checkout: get_or_create_checkout_metadata(c).metadata
+                lambda c=checkout: get_checkout_metadata(c).metadata
                 if hasattr(c, "metadata_storage")
                 else {}
             ),


### PR DESCRIPTION
I want to merge this change because it prevents fetches of checkout metadata to create checkout metadata objects in db. Otherwise it can cause a thread race during shipping method and payment method fetching during `checkoutCreate`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
