### PR TITLE
Fix thread race between checkoutComplete and payment webhooks

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1283,6 +1283,15 @@ def complete_checkout(
     :raises ValidationError
     """
     with transaction_with_commit_on_errors():
+        checkout = (
+            Checkout.objects.select_for_update()
+            .filter(pk=checkout_info.checkout.pk)
+            .first()
+        )
+        if not checkout:
+            order = Order.objects.get_by_checkout_token(checkout_info.checkout.token)
+            return order, False, {}
+
         payment, customer_id, order_data = complete_checkout_pre_payment_part(
             manager=manager,
             checkout_info=checkout_info,
@@ -1294,15 +1303,6 @@ def complete_checkout(
             redirect_url=redirect_url,
         )
         reservations = _reserve_stocks_without_availability_check(checkout_info, lines)
-
-    # Fetch the checkout with a lock just to ensure that no payment is created
-    # for this checkout right now.
-    with transaction.atomic():
-        (
-            Checkout.objects.select_for_update()
-            .filter(pk=checkout_info.checkout.pk)
-            .first()
-        )
 
     # Process payments out of transaction to unlock stock rows for another user,
     # who potentially can order the same product variants.
@@ -1331,6 +1331,15 @@ def complete_checkout(
             )
 
     with transaction_with_commit_on_errors():
+        checkout = (
+            Checkout.objects.select_for_update()
+            .filter(pk=checkout_info.checkout.pk)
+            .first()
+        )
+        if not checkout:
+            order = Order.objects.get_by_checkout_token(checkout_info.checkout.token)
+            return order, False, {}
+
         # Run pre-payment checks to make sure, that nothing has changed to the
         # checkout, during processing payment.
         checkout_info.checkout.voucher_code = None


### PR DESCRIPTION
I want to merge this change because it is port of changes from #12647

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
