### PR TITLE
Remove deprecation warnings from tests

### DIFF
--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -2483,8 +2483,8 @@ def test_product_query_by_external_reference(
 
 
 PRODUCT_TAX_CLASS_QUERY = """
-    query getProduct($id: ID!) {
-        product(id: $id) {
+    query getProduct($id: ID!, $channel: String) {
+        product(id: $id, channel: $channel) {
             id
             taxClass {
                 id
@@ -2494,10 +2494,11 @@ PRODUCT_TAX_CLASS_QUERY = """
 """
 
 
-def test_product_tax_class_query_by_app(app_api_client, product):
+def test_product_tax_class_query_by_app(app_api_client, product, channel_USD):
     # given
     variables = {
         "id": graphene.Node.to_global_id("Product", product.id),
+        "channel": channel_USD.slug,
     }
 
     # when
@@ -2511,10 +2512,11 @@ def test_product_tax_class_query_by_app(app_api_client, product):
     assert data["product"]["taxClass"]["id"]
 
 
-def test_product_tax_class_query_by_staff(staff_api_client, product):
+def test_product_tax_class_query_by_staff(staff_api_client, product, channel_USD):
     # given
     variables = {
         "id": graphene.Node.to_global_id("Product", product.id),
+        "channel": channel_USD.slug,
     }
 
     # when


### PR DESCRIPTION
I want to merge this change because removing deprecation warnings from tests

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
