### PR TITLE
Fix change_user_address function for anonymize plugin

### DIFF
--- a/saleor/plugins/anonymize/plugin.py
+++ b/saleor/plugins/anonymize/plugin.py
@@ -39,8 +39,8 @@ class AnonymizePlugin(BasePlugin):
         address: "Address",
         address_type: Optional[str],
         user: Optional["User"],
+        save: bool,
         previous_value: "Address",
-        save: bool = True,
     ) -> "Address":
         if address.phone:
             address.phone = ""  # type: ignore

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -374,7 +374,7 @@ class BasePlugin:
     channel_status_changed: Callable[["Channel", None], None]
 
     change_user_address: Callable[
-        ["Address", Union[str, None], Union["User", None], "Address", bool], "Address"
+        ["Address", Union[str, None], Union["User", None], bool, "Address"], "Address"
     ]
 
     # Retrieves the balance remaining on a shopper's gift card

--- a/saleor/plugins/tests/test_plugins.py
+++ b/saleor/plugins/tests/test_plugins.py
@@ -242,6 +242,6 @@ def test_change_user_address_in_anonymize_plugin_reset_phone(address, settings):
     assert address.phone
 
     new_address = anonymize_plugin.change_user_address(
-        address=address, address_type=None, user=None, previous_value=address
+        address=address, address_type=None, user=None, save=True, previous_value=address
     )
     assert not new_address.phone


### PR DESCRIPTION
I want to merge this change because it fixes `change_user_address` for anonymize plugin. `previous_value` should be always last argument.
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
