### PR TITLE
Always send all lines to Avalara

### DIFF
--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -287,10 +287,9 @@ def generate_request_data_from_checkout_lines(
         product = line_info.product
         product_type = line_info.product_type
         tax_code = _get_product_tax_code(product, product_type)
-        is_non_taxable_product = tax_code == TAX_CODE_NON_TAXABLE_PRODUCT
 
         tax_override_data = {}
-        if not charge_taxes or is_non_taxable_product:
+        if not charge_taxes:
             if not is_entire_order_discount:
                 continue
             # if there is a voucher for the entire order we need to attach this line
@@ -365,7 +364,7 @@ def get_order_lines_data(
         "variant__product__category",
         "variant__product__collections",
         "variant__product__product_type",
-    ).filter(variant__product__charge_taxes=True)
+    )
 
     tax_configuration = order.channel.tax_configuration
     prices_entered_with_tax = tax_configuration.prices_entered_with_tax

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -940,7 +940,7 @@ def test_calculate_order_shipping_order_not_valid(
     variant = order_line.variant
     product = variant.product
     product.metadata = {}
-    product.save(update_fields=["metadata", "charge_taxes"])
+    product.save(update_fields=["metadata"])
 
     order = order_line.order
 
@@ -4831,6 +4831,40 @@ def test_generate_request_data_from_checkout_lines_with_shipping_method(
     assert lines_data[-1]["itemCode"] == "Shipping"
 
 
+def test_generate_request_data_from_checkout_lines_adds_lines_with_taxes_disabled_for_line(  # noqa: E501
+    settings,
+    channel_USD,
+    plugin_configuration,
+    checkout_with_item,
+    avatax_config,
+    tax_class_zero_rates,
+):
+    # given
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    plugin_configuration(channel=channel_USD)
+
+    line = checkout_with_item.lines.first()
+    line.variant.product.tax_class = tax_class_zero_rates
+    line.variant.product.charge_taxes = False
+    line.variant.product.save(update_fields=["tax_class", "charge_taxes"])
+
+    checkout_with_item.shipping_method = None
+    checkout_with_item.save(update_fields=["shipping_method"])
+
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, lines, [], get_plugins_manager()
+    )
+
+    # when
+    lines_data = generate_request_data_from_checkout_lines(
+        checkout_info, lines, avatax_config
+    )
+
+    # then
+    assert len(lines_data) == len(checkout_with_item.lines.all())
+
+
 def test_get_order_lines_data_gets_tax_code_from_product_tax_class(
     settings, channel_USD, plugin_configuration, order_with_lines, avatax_config
 ):
@@ -4974,6 +5008,33 @@ def test_get_order_lines_data_sets_different_tax_code_only_for_zero_amount(
     # then
     assert lines_data[0]["amount"] == "10.000"
     assert lines_data[0]["taxCode"] == "taxcode"
+
+
+def test_get_order_lines_data_adds_lines_with_taxes_disabled_for_line(
+    settings,
+    channel_USD,
+    plugin_configuration,
+    order_with_lines,
+    avatax_config,
+    tax_class_zero_rates,
+):
+    # given
+    settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    plugin_configuration(channel=channel_USD)
+
+    order_with_lines.base_shipping_price_amount = Decimal("0")
+    order_with_lines.save(update_fields=["base_shipping_price_amount"])
+
+    line = order_with_lines.lines.first()
+    line.variant.product.tax_class = tax_class_zero_rates
+    line.variant.product.charge_taxes = False
+    line.variant.product.save(update_fields=["charge_taxes", "tax_class"])
+
+    # when
+    lines_data = get_order_lines_data(order_with_lines, avatax_config, discounted=False)
+
+    # then
+    assert len(lines_data) == len(order_with_lines.lines.all())
 
 
 def test_assign_tax_code_to_object_meta(

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -411,7 +411,6 @@ class Product(SeoModel, ModelWithMetadata):
     )
     created_at = models.DateTimeField(auto_now_add=True, db_index=True)
     updated_at = models.DateTimeField(auto_now=True, db_index=True)
-    charge_taxes = models.BooleanField(default=True)
     weight = MeasurementField(
         measurement=Weight,
         unit_choices=WeightUnits.CHOICES,  # type: ignore
@@ -433,6 +432,9 @@ class Product(SeoModel, ModelWithMetadata):
         null=True,
         on_delete=models.SET_NULL,
     )
+
+    # deprecated
+    charge_taxes = models.BooleanField(default=True)
 
     objects = models.Manager.from_queryset(ProductsQueryset)()
     translated = TranslationProxy()


### PR DESCRIPTION
- Fix sending order data to Avalara not to use the deprecated `Product.charge_taxes` field. This was a bug since this field is no longer used in API and cannot be set. Instead, send all order lines to Avalara and let it decide, based on the assigned tax code, whether to calculate tax.
- Similarly, change sending checkout data to Avalara always to send all checkout lines.

Acceptance criteria:
- Have a "zero tax" tax class; the name can be anything, but the metadata needs to contain: `{'avatax.code': 'NT', 'avatax.description': 'No taxes'}`  - this should skip tax calculation in Avatax
- Have another tax class with a valid Avatax tax code in metadata, example: `{'avatax.code': 'O9999999',
 'avatax.description': 'Temporary Unmapped Other SKU - taxable default'}`
- Create a checkout with different lines that use the above tax classes. All lines should be sent to Avatax for tax calculation.
- Create a draft order with different lines that use the above tax classes. All lines should be sent to Avatax for tax calculation.
- Edit: use-cases provided by Maciej: https://github.com/saleor/saleor/pull/12681#pullrequestreview-1401283163

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
