### PR TITLE
Fix query cost - fragment complexity not multiplied recursively

### DIFF
--- a/saleor/graphql/core/tests/test_query_cost_validation.py
+++ b/saleor/graphql/core/tests/test_query_cost_validation.py
@@ -1,4 +1,5 @@
 import graphene
+import pytest
 from django.test import override_settings
 
 
@@ -131,3 +132,110 @@ def test_query_below_cost_limit_with_multiplied_complexity_passes_validation(
     query_cost = json_response["extensions"]["cost"]["requestedQueryCost"]
     assert query_cost == 5
     assert len(json_response["data"]) == 1
+
+
+PRODUCTS_QUERY = """
+query productsQueryCost($channel: String, $first: Int) {
+  products(channel: $channel, first: $first) {
+    edges {
+      node {
+        id
+        category{
+          products(channel: $channel, first: $first) {
+            edges{
+              node{
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+PRODUCTS_QUERY_WITH_INLINE_FRAGMENT = """
+query productsQueryCost($channel: String, $first: Int) {
+  products(channel: $channel, first: $first) {
+    edges {
+      node {
+        id
+        category {
+          ... on Category {
+            products(channel: $channel, first: $first) {
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+PRODUCTS_QUERY_WITH_FRAGMENT = """
+fragment category on Category {
+  products(channel: $channel, first: $first) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+
+query productsQueryCost($channel: String, $first: Int) {
+  products(channel: $channel, first: $first) {
+    edges {
+      node {
+        id
+        category {
+          ...category
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        PRODUCTS_QUERY,
+        PRODUCTS_QUERY_WITH_INLINE_FRAGMENT,
+        PRODUCTS_QUERY_WITH_FRAGMENT,
+    ],
+)
+@override_settings(GRAPHQL_QUERY_MAX_COMPLEXITY=100000)
+def test_query_with_fragments_have_same_multiplied_complexity_cost(
+    query, api_client, product, channel_USD
+):
+    # given
+    variables = {"channel": channel_USD.slug, "first": 10}
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    # when
+    response = api_client.post_graphql(query, variables)
+    json_response = response.json()
+    # then
+    assert "errors" not in json_response
+    expected_data = {
+        "products": {
+            "edges": [
+                {
+                    "node": {
+                        "id": product_id,
+                        "category": {
+                            "products": {"edges": [{"node": {"id": product_id}}]}
+                        },
+                    }
+                }
+            ]
+        }
+    }
+    assert json_response["data"] == expected_data
+    query_cost = json_response["extensions"]["cost"]["requestedQueryCost"]
+    assert query_cost == 120

--- a/saleor/graphql/core/validators/query_cost.py
+++ b/saleor/graphql/core/validators/query_cost.py
@@ -112,14 +112,18 @@ class CostValidator(ValidationRule):
                     fragment_type = self.context.get_schema().get_type(
                         fragment.type_condition.name.value
                     )
-                    node_cost = self.compute_node_cost(fragment, fragment_type)
+                    node_cost = self.compute_node_cost(
+                        fragment, fragment_type, self.operation_multipliers
+                    )
             if isinstance(child_node, InlineFragment):
                 inline_fragment_type = type_def
                 if child_node.type_condition and child_node.type_condition.name:
                     inline_fragment_type = self.context.get_schema().get_type(
                         child_node.type_condition.name.value
                     )
-                node_cost = self.compute_node_cost(child_node, inline_fragment_type)
+                node_cost = self.compute_node_cost(
+                    child_node, inline_fragment_type, self.operation_multipliers
+                )
             total += node_cost
         return total
 


### PR DESCRIPTION
I want to merge this change because the same query (with and without fragments) should have the same "query cost". 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
