### PR TITLE
Fix returning error messages using product names with % sign

### DIFF
--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -114,12 +114,10 @@ class OrderFulfill(BaseMutation):
 
             if line_total_quantity > line_quantity_unfulfilled:
                 msg = (
-                    "Only %(quantity)d item%(item_pluralize)s remaining "
-                    "to fulfill: %(order_line)s."
+                    "Only %(quantity)d item%(item_pluralize)s remaining to fulfill."
                 ) % {
                     "quantity": line_quantity_unfulfilled,
                     "item_pluralize": pluralize(line_quantity_unfulfilled),
-                    "order_line": order_line,
                 }
                 order_line_global_id = graphene.Node.to_global_id(
                     "OrderLine", order_line.pk

--- a/saleor/graphql/order/tests/mutations/test_fulfillment_approve.py
+++ b/saleor/graphql/order/tests/mutations/test_fulfillment_approve.py
@@ -30,6 +30,7 @@ APPROVE_FULFILLMENT_MUTATION = """
                 field
                 code
                 message
+                orderLines
             }
         }
     }
@@ -208,7 +209,8 @@ def test_fulfillment_approve_delete_products_before_approval_allow_stock_exceede
     expected_errors = [
         {
             **error_field_and_code,
-            "message": f"Insufficient product stock: {line.order_line}",
+            "orderLines": [graphene.Node.to_global_id("OrderLine", line.order_line_id)],
+            "message": "Insufficient product stock.",
         }
         for line in fulfillment.lines.all()
     ]
@@ -372,7 +374,8 @@ def test_fulfillment_approve_when_stock_is_exceeded_and_flag_disabled(
     expected_errors = [
         {
             **error_field_and_code,
-            "message": f"Insufficient product stock: {line.order_line}",
+            "message": "Insufficient product stock.",
+            "orderLines": [graphene.Node.to_global_id("OrderLine", line.order_line_id)],
         }
         for line in fulfillment.lines.all()
     ]

--- a/saleor/graphql/order/tests/mutations/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/mutations/test_order_fulfill.py
@@ -294,10 +294,12 @@ def test_order_fulfill_with_stock_exceeded_with_flag_disabled(
 
     errors = data["errors"]
     assert errors[0]["code"] == "INSUFFICIENT_STOCK"
-    assert errors[0]["message"] == f"Insufficient product stock: {order_line}"
+    assert errors[0]["message"] == "Insufficient product stock."
+    assert errors[1]["orderLines"] == [order_line2_id]
 
     assert errors[1]["code"] == "INSUFFICIENT_STOCK"
-    assert errors[1]["message"] == f"Insufficient product stock: {order_line2}"
+    assert errors[1]["message"] == "Insufficient product stock."
+    assert errors[1]["orderLines"] == [order_line2_id]
 
 
 def test_order_fulfill_with_stock_exceeded_with_flag_enabled(

--- a/saleor/graphql/order/tests/test_draft_order_validate.py
+++ b/saleor/graphql/order/tests/test_draft_order_validate.py
@@ -122,7 +122,7 @@ def test_validate_draft_order_out_of_stock_variant(draft_order):
 
     with pytest.raises(ValidationError) as e:
         validate_draft_order(order, "US", get_plugins_manager())
-    msg = "Insufficient product stock: SKU_AA"
+    msg = "Insufficient product stock."
     assert e.value.error_dict["lines"][0].message == msg
 
 

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -300,9 +300,10 @@ def prepare_insufficient_stock_order_validation_errors(exc):
             if item.warehouse_pk
             else None
         )
+
         errors.append(
             ValidationError(
-                f"Insufficient product stock: {item.order_line or item.variant}",
+                "Insufficient product stock.",
                 code=OrderErrorCode.INSUFFICIENT_STOCK.value,
                 params={
                     "order_lines": [order_line_global_id]


### PR DESCRIPTION
I want to merge this change because it fixes an issue where error messages containing product names with `%` sign were causing `TypeError`.

Port of #12692

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
