### PR TITLE
Fix adding new lines to draft order when existing line has deleted product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix sending `product_created` event in `ProductBulkCreate` mutation - #12605 by @SzymJ
 - Add `ORDER_REFUNDED`, `ORDER_FULLY_REFUNDED`, `ORDER_PAID` webhooks - #12533 by @korycins
 - Handle error raised by 0Auth when fetching token - #12672 by @IKarbowiakg
-
+- Fix adding new lines to draft order when existing line has deleted product - #12711 by @SzymJ
 
 # 3.13.0
 

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -201,7 +201,9 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             return
 
         line_info = list(
-            filter(lambda x: (x.variant.pk == int(variant_id)), lines_info)
+            filter(
+                lambda x: (x.variant and x.variant.pk == int(variant_id)), lines_info
+            )
         )
 
         if not line_info or len(line_info) > 1:


### PR DESCRIPTION
I want to merge this change because it fixes `Internal Server Error` when new lines are added to the draft order with the existing line that has deleted the product.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
