### PR TITLE
Removed extend from countries keyword

### DIFF
--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -280,7 +280,7 @@ class ShippingZoneMixin:
                 )
             else:
                 countries = get_countries_without_shipping_zone()
-                data["countries"].extend([country for country in countries])
+                data["countries"] = [country for country in countries]
         else:
             data["default"] = False
         return data


### PR DESCRIPTION
I want to merge this change because,
removed extend function as no key named "countries" received from data, so assigned it directly to list . Issue: #12429

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
