### PR TITLE
Add cache for SHIPPING_LIST_METHODS_FOR_CHECKOUT event

### DIFF
--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -865,11 +865,11 @@ def test_add_checkout_lines_with_external_shipping(
         api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
     )
     assert not response["data"]["checkoutLinesAdd"]["errors"]
-    # Three api calls:
+    # Two api calls :
     # - post-mutate() logic used to validate currently selected method
-    # - fetch_checkout_data - calculating all prices for checkout
-    # - in check_stock_quantity_bulk to check if the shipping method is set
-    assert mock_send_request.call_count == 3
+    # - fetch_checkout_prices_if_expired - calculating all prices for checkout
+    # - (cached) in check_stock_quantity_bulk to check if the shipping method is set
+    assert mock_send_request.call_count == 2
 
 
 @pytest.mark.django_db

--- a/saleor/plugins/webhook/shipping.py
+++ b/saleor/plugins/webhook/shipping.py
@@ -1,4 +1,5 @@
 import base64
+import hashlib
 import json
 import logging
 from collections import defaultdict
@@ -203,3 +204,18 @@ def parse_excluded_shipping_methods(
             )
         )
     return excluded_methods_map
+
+
+def generate_cache_key_for_shipping_list_methods_for_checkout(
+    payload: str, target_url: str
+) -> str:
+    key_data = json.loads(payload)
+
+    # drop fields that change between requests but are not relevant for cache key
+    key_data[0].pop("last_change")
+    key_data[0]["meta"].pop("issued_at")
+
+    # make cache key
+    key = json.dumps(key_data)
+    key = f"{target_url}-{hashlib.sha256(key.encode('utf-8')).hexdigest()}"
+    return key

--- a/saleor/plugins/webhook/tests/test_list_shipping_methods_for_checkout.py
+++ b/saleor/plugins/webhook/tests/test_list_shipping_methods_for_checkout.py
@@ -1,0 +1,173 @@
+import json
+from datetime import timedelta
+from decimal import Decimal
+from unittest import mock
+
+from django.utils import timezone
+
+from ....webhook.payloads import generate_checkout_payload
+from ..shipping import generate_cache_key_for_shipping_list_methods_for_checkout
+
+
+@mock.patch("saleor.plugins.webhook.plugin.cache.set")
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_get_shipping_methods_for_checkout_set_cache(
+    mocked_webhook,
+    mocked_cache_set,
+    webhook_plugin,
+    checkout_with_item,
+    shipping_app,
+):
+    # given
+    mocked_webhook.return_value = [
+        {
+            "id": "method-1",
+            "name": "Standard Shipping",
+            "amount": Decimal("5.5"),
+            "currency": "GBP",
+        }
+    ]
+    plugin = webhook_plugin()
+
+    # when
+    plugin.get_shipping_methods_for_checkout(checkout_with_item, None)
+
+    # then
+    assert mocked_webhook.called
+    assert mocked_cache_set.called
+
+
+@mock.patch("saleor.plugins.webhook.plugin.cache.set")
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_get_shipping_methods_no_webhook_response_does_not_set_cache(
+    mocked_webhook,
+    mocked_cache_set,
+    webhook_plugin,
+    checkout_with_item,
+    shipping_app,
+):
+    # given
+    mocked_webhook.return_value = None
+    plugin = webhook_plugin()
+
+    # when
+    plugin.get_shipping_methods_for_checkout(checkout_with_item, None)
+
+    # then
+    assert mocked_webhook.called
+    assert not mocked_cache_set.called
+
+
+@mock.patch("saleor.plugins.webhook.plugin.cache.get")
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_get_shipping_methods_for_checkout_use_cache(
+    mocked_webhook,
+    mocked_cache_get,
+    webhook_plugin,
+    checkout_with_item,
+    shipping_app,
+):
+    # given
+    mocked_cache_get.return_value = [
+        {
+            "id": "method-1",
+            "name": "Standard Shipping",
+            "amount": Decimal("5.5"),
+            "currency": "GBP",
+        }
+    ]
+    plugin = webhook_plugin()
+
+    # when
+    plugin.get_shipping_methods_for_checkout(checkout_with_item, None)
+
+    # then
+    assert not mocked_webhook.called
+    assert mocked_cache_get.called
+
+
+@mock.patch("saleor.plugins.webhook.plugin.cache.get")
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_get_shipping_methods_for_checkout_use_cache_for_empty_list(
+    mocked_webhook,
+    mocked_cache_get,
+    webhook_plugin,
+    checkout_with_item,
+    shipping_app,
+):
+    # given
+    mocked_cache_get.return_value = []
+    plugin = webhook_plugin()
+
+    # when
+    plugin.get_shipping_methods_for_checkout(checkout_with_item, None)
+
+    # then
+    assert not mocked_webhook.called
+    assert mocked_cache_get.called
+
+
+def test_checkout_change_invalidates_cache_key(checkout_with_item, shipping_app):
+    # given
+    payload = generate_checkout_payload(checkout_with_item)
+    target_url = shipping_app.webhooks.first().target_url
+    cache_key = generate_cache_key_for_shipping_list_methods_for_checkout(
+        payload, target_url
+    )
+
+    # when
+    checkout_with_item.email = "newemail@example.com"
+    checkout_with_item.save(update_fields=["email"])
+    new_payload = generate_checkout_payload(checkout_with_item)
+    new_cache_key = generate_cache_key_for_shipping_list_methods_for_checkout(
+        new_payload, target_url
+    )
+
+    # then
+    assert cache_key != new_cache_key
+
+
+def test_ignore_selected_fields_on_generating_cache_key(
+    checkout_with_item, shipping_app
+):
+    # given
+    target_url = shipping_app.webhooks.first().target_url
+
+    payload = generate_checkout_payload(checkout_with_item)
+    cache_key = generate_cache_key_for_shipping_list_methods_for_checkout(
+        payload, target_url
+    )
+
+    # when
+    checkout_with_item.last_change = timezone.now() + timedelta(seconds=30)
+    checkout_with_item.save(update_fields=["last_change"])
+
+    new_payload = generate_checkout_payload(checkout_with_item)
+    new_payload_data = json.loads(new_payload)
+    new_payload_data[0]["meta"]["issued_at"] = timezone.now().isoformat()
+    new_payload = json.dumps(new_payload_data)
+    new_cache_key = generate_cache_key_for_shipping_list_methods_for_checkout(
+        new_payload, target_url
+    )
+
+    # then
+    assert cache_key == new_cache_key
+
+
+def test_different_target_urls_produce_different_cache_key(checkout_with_item):
+    # given
+    target_url_1 = "http://example.com/1"
+    target_url_2 = "http://example.com/2"
+
+    payload = generate_checkout_payload(checkout_with_item)
+
+    # when
+    cache_key_1 = generate_cache_key_for_shipping_list_methods_for_checkout(
+        payload, target_url_1
+    )
+    cache_key_2 = generate_cache_key_for_shipping_list_methods_for_checkout(
+        payload, target_url_2
+    )
+
+    # then
+    assert cache_key_1 != cache_key_2


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/12716

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
