### PR TITLE
Update variant mutations to recalculated products discounted price

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_delete.py
@@ -17,6 +17,7 @@ from ....order.tasks import recalculate_orders_task
 from ....permission.enums import ProductPermissions
 from ....product import models
 from ....product.search import prepare_product_search_vector_value
+from ....product.tasks import update_products_discounted_prices_task
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_38
@@ -122,6 +123,9 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
                     "updated_at",
                 ]
             )
+
+        # Recalculate the "discounted price" for the related products
+        update_products_discounted_prices_task.delay(product_pks)
 
         return response
 

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
@@ -91,9 +91,11 @@ PRODUCT_VARIANT_BULK_CREATE_MUTATION = """
 """
 
 
+@patch("saleor.product.tasks.update_product_discounted_price_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_created")
 def test_product_variant_bulk_create_by_name(
     product_variant_created_webhook_mock,
+    update_product_discounted_price_task_mock,
     staff_api_client,
     product,
     size_attribute,
@@ -145,11 +147,14 @@ def test_product_variant_bulk_create_by_name(
     product.refresh_from_db()
     assert product.default_variant == product_variant
     assert product_variant_created_webhook_mock.call_count == data["count"]
+    update_product_discounted_price_task_mock.assert_called_once_with(product.id)
 
 
+@patch("saleor.product.tasks.update_product_discounted_price_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_created")
 def test_product_variant_bulk_create_by_attribute_id(
     product_variant_created_webhook_mock,
+    update_product_discounted_price_task_mock,
     staff_api_client,
     product,
     size_attribute,
@@ -192,6 +197,7 @@ def test_product_variant_bulk_create_by_attribute_id(
     product.refresh_from_db()
     assert product.default_variant == product_variant
     assert product_variant_created_webhook_mock.call_count == data["count"]
+    update_product_discounted_price_task_mock.assert_called_once_with(product.id)
 
 
 def test_product_variant_bulk_create_with_swatch_attribute(
@@ -1791,8 +1797,13 @@ def test_product_variant_bulk_create_without_sku(
     assert ProductVariant.objects.filter(sku__isnull=True).count() == 2
 
 
+@patch("saleor.product.tasks.update_product_discounted_price_task.delay")
 def test_product_variant_bulk_create_many_errors(
-    staff_api_client, product, size_attribute, permission_manage_products
+    update_product_discounted_price_task_mock,
+    staff_api_client,
+    product,
+    size_attribute,
+    permission_manage_products,
 ):
     # given
     product_variant_count = ProductVariant.objects.count()
@@ -1852,6 +1863,7 @@ def test_product_variant_bulk_create_many_errors(
         "channels": None,
     }
     assert product_variant_count == ProductVariant.objects.count()
+    update_product_discounted_price_task_mock.assert_not_called()
 
 
 def test_product_variant_bulk_create_many_errors_with_ignore_failed(

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -67,9 +67,11 @@ PRODUCT_VARIANT_BULK_UPDATE_MUTATION = """
 """
 
 
+@patch("saleor.product.tasks.update_product_discounted_price_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
 def test_product_variant_bulk_update(
     product_variant_created_webhook_mock,
+    update_product_discounted_price_task_mock,
     staff_api_client,
     product_with_single_variant,
     size_attribute,
@@ -113,9 +115,14 @@ def test_product_variant_bulk_update(
     assert product_with_single_variant.variants.count() == 1
     assert old_name != new_name
     assert product_variant_created_webhook_mock.call_count == data["count"]
+    update_product_discounted_price_task_mock.assert_called_once_with(
+        product_with_single_variant.id
+    )
 
 
+@patch("saleor.product.tasks.update_product_discounted_price_task.delay")
 def test_product_variant_bulk_update_stocks(
+    update_product_discounted_price_task_mock,
     staff_api_client,
     variant_with_many_stocks,
     warehouse,
@@ -175,6 +182,9 @@ def test_product_variant_bulk_update_stocks(
     assert stock_to_update.quantity == new_quantity
     assert variant.stocks.count() == 3
     assert variant.stocks.last().quantity == new_stock_quantity
+    update_product_discounted_price_task_mock.assert_called_once_with(
+        variant.product_id
+    )
 
 
 def test_product_variant_bulk_update_and_remove_stock(
@@ -218,7 +228,9 @@ def test_product_variant_bulk_update_and_remove_stock(
     assert variant.stocks.count() == 1
 
 
+@patch("saleor.product.tasks.update_product_discounted_price_task.delay")
 def test_product_variant_bulk_update_and_remove_stock_when_stock_not_exists(
+    update_product_discounted_price_task_mock,
     staff_api_client,
     variant_with_many_stocks,
     warehouse,
@@ -256,6 +268,7 @@ def test_product_variant_bulk_update_and_remove_stock_when_stock_not_exists(
     assert variant.stocks.count() == 2
     error = data["results"][0]["errors"][0]
     assert error["code"] == ProductVariantBulkErrorCode.NOT_FOUND.name
+    update_product_discounted_price_task_mock.assert_not_called()
 
 
 def test_product_variant_bulk_update_stocks_with_invalid_warehouse(

--- a/saleor/graphql/product/tests/mutations/test_product_variant_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_create.py
@@ -76,11 +76,13 @@ CREATE_VARIANT_MUTATION = """
 """
 
 
+@patch("saleor.product.tasks.update_product_discounted_price_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_created")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
 def test_create_variant_with_name(
     updated_webhook_mock,
     created_webhook_mock,
+    update_product_discounted_price_task_mock,
     staff_api_client,
     product,
     product_type,
@@ -149,6 +151,7 @@ def test_create_variant_with_name(
 
     created_webhook_mock.assert_called_once_with(product.variants.last())
     updated_webhook_mock.assert_not_called()
+    update_product_discounted_price_task_mock.assert_called_once_with(product.id)
 
 
 @patch("saleor.plugins.manager.PluginsManager.product_variant_created")

--- a/saleor/graphql/product/tests/mutations/test_product_variant_delete.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_delete.py
@@ -22,11 +22,13 @@ DELETE_VARIANT_BY_SKU_MUTATION = """
 """
 
 
+@patch("saleor.product.tasks.update_product_discounted_price_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_deleted")
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
 def test_delete_variant_by_sku(
     mocked_recalculate_orders_task,
     product_variant_deleted_webhook_mock,
+    update_product_discounted_price_task_mock,
     staff_api_client,
     product,
     permission_manage_products,
@@ -52,6 +54,7 @@ def test_delete_variant_by_sku(
     with pytest.raises(variant._meta.model.DoesNotExist):
         variant.refresh_from_db()
     mocked_recalculate_orders_task.assert_not_called()
+    update_product_discounted_price_task_mock.assert_called_once_with(product.id)
 
 
 DELETE_VARIANT_MUTATION = """
@@ -66,11 +69,13 @@ DELETE_VARIANT_MUTATION = """
 """
 
 
+@patch("saleor.product.tasks.update_product_discounted_price_task.delay")
 @patch("saleor.plugins.manager.PluginsManager.product_variant_deleted")
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
 def test_delete_variant(
     mocked_recalculate_orders_task,
     product_variant_deleted_webhook_mock,
+    update_product_discounted_price_task_mock,
     staff_api_client,
     product,
     permission_manage_products,
@@ -92,6 +97,7 @@ def test_delete_variant(
     with pytest.raises(variant._meta.model.DoesNotExist):
         variant.refresh_from_db()
     mocked_recalculate_orders_task.assert_not_called()
+    update_product_discounted_price_task_mock.assert_called_once_with(product.id)
 
 
 def test_delete_variant_remove_checkout_lines(

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -967,6 +967,7 @@ def test_delete_product_variants_by_sku_task_for_recalculate_product_prices_call
         == content["data"]["productVariantBulkDelete"]["count"]
     )
     mocked_recalculate_orders_task.assert_not_called()
+    update_products_discounted_price_task_mock.assert_called_once()
     args = set(update_products_discounted_price_task_mock.call_args.args[0])
     assert args == {product.id for product in product_list}
 
@@ -1067,12 +1068,18 @@ def test_delete_product_variants_task_for_recalculate_product_prices_called(
         == content["data"]["productVariantBulkDelete"]["count"]
     )
     mocked_recalculate_orders_task.assert_not_called()
+    update_products_discounted_price_task_mock.assert_called_once()
     args = set(update_products_discounted_price_task_mock.call_args.args[0])
     assert args == {product.id for product in product_list}
 
 
+@patch("saleor.product.tasks.update_products_discounted_prices_task.delay")
 def test_delete_product_variants_invalid_object_typed_of_given_ids(
-    staff_api_client, product_variant_list, permission_manage_products, staff_user
+    update_products_discounted_price_task_mock,
+    staff_api_client,
+    product_variant_list,
+    permission_manage_products,
+    staff_user,
 ):
     query = PRODUCT_VARIANT_BULK_DELETE_MUTATION
     staff_user.user_permissions.add(permission_manage_products)
@@ -1091,6 +1098,7 @@ def test_delete_product_variants_invalid_object_typed_of_given_ids(
     assert errors[0]["code"] == ProductErrorCode.GRAPHQL_ERROR.name
     assert errors[0]["field"] == "ids"
     assert data["count"] == 0
+    update_products_discounted_price_task_mock.assert_not_called()
 
 
 def test_delete_product_variants_removes_checkout_lines(

--- a/saleor/graphql/product/tests/test_variant_channel_listing_update.py
+++ b/saleor/graphql/product/tests/test_variant_channel_listing_update.py
@@ -182,8 +182,14 @@ def test_variant_channel_listing_update_with_too_many_decimal_places_in_price(
     assert error["code"] == ProductErrorCode.INVALID.name
 
 
+@patch("saleor.product.tasks.update_product_discounted_price_task.delay")
 def test_variant_channel_listing_update_as_staff_user(
-    staff_api_client, product, permission_manage_products, channel_USD, channel_PLN
+    update_product_discounted_price_task_mock,
+    staff_api_client,
+    product,
+    permission_manage_products,
+    channel_USD,
+    channel_PLN,
 ):
     # given
     ProductChannelListing.objects.create(
@@ -240,6 +246,7 @@ def test_variant_channel_listing_update_as_staff_user(
     assert channel_pln_data["price"]["amount"] == second_price
     assert channel_pln_data["costPrice"]["amount"] == second_price
     assert channel_pln_data["channel"]["slug"] == channel_PLN.slug
+    update_product_discounted_price_task_mock.assert_called_once_with(product.id)
 
 
 def test_variant_channel_listing_update_by_sku(


### PR DESCRIPTION
Ensure that the task for product discounted price recalculation is called in variant mutations. 

Mutations that call the product discounted price recalculation:
- `productVariantCreate`
- `productVariantDelete`
- `productVariantChannelListingUpdate`
- `productVariantBulkCreate`
- `productVariantBulkDelete`
- `productVariantBulkUpdate`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
