### PR TITLE
Update product mutations to recalculated products discounted price

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -18,6 +18,7 @@ from ....core.utils.validators import get_oembed_data
 from ....permission.enums import ProductPermissions
 from ....product import ProductMediaTypes, models
 from ....product.error_codes import ProductBulkCreateErrorCode
+from ....product.tasks import update_products_discounted_prices_task
 from ....warehouse.models import Warehouse
 from ...attribute.types import AttributeValueInput
 from ...attribute.utils import AttributeAssignmentMixin
@@ -821,14 +822,18 @@ class ProductBulkCreate(BaseMutation):
     @classmethod
     def post_save_actions(cls, info, products, variants, channels):
         manager = get_plugin_manager_promise(info.context).get()
+        product_ids = []
         for product in products:
             cls.call_event(manager.product_created, product.node)
+            product_ids.append(product.node.id)
 
         for variant in variants:
             cls.call_event(manager.product_variant_created, variant)
 
         for channel in channels:
             cls.call_event(manager.channel_updated, channel)
+
+        update_products_discounted_prices_task.delay(product_ids)
 
     @classmethod
     @traced_atomic_transaction()

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -350,6 +350,7 @@ class ProductChannelListingUpdate(BaseChannelListingMutation):
             cls.update_channels(product, cleaned_input.get("update_channels", []))
             cls.remove_channels(product, cleaned_input.get("remove_channels", []))
             product = ProductModel.objects.prefetched_for_webhook().get(pk=product.pk)
+            update_product_discounted_price_task.delay(product.id)
             manager = get_plugin_manager_promise(info.context).get()
             cls.call_event(manager.product_updated, product)
 

--- a/saleor/graphql/product/mutations/product/product_create.py
+++ b/saleor/graphql/product/mutations/product/product_create.py
@@ -10,6 +10,7 @@ from .....permission.enums import ProductPermissions
 from .....product import models
 from .....product.error_codes import ProductErrorCode
 from .....product.search import update_product_search_vector
+from .....product.tasks import update_product_discounted_price_task
 from ....attribute.types import AttributeValueInput
 from ....attribute.utils import AttributeAssignmentMixin, AttrValuesInput
 from ....channel import ChannelContext
@@ -220,6 +221,7 @@ class ProductCreate(ModelMutation):
     def post_save_action(cls, info: ResolveInfo, instance, _cleaned_input):
         product = models.Product.objects.prefetched_for_webhook().get(pk=instance.pk)
         update_product_search_vector(instance)
+        update_product_discounted_price_task.delay(instance.id)
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.product_created, product)
 

--- a/saleor/graphql/product/mutations/product/product_update.py
+++ b/saleor/graphql/product/mutations/product/product_update.py
@@ -6,6 +6,7 @@ from .....attribute import models as attribute_models
 from .....permission.enums import ProductPermissions
 from .....product import models
 from .....product.search import update_product_search_vector
+from .....product.tasks import update_product_discounted_price_task
 from ....attribute.utils import AttributeAssignmentMixin, AttrValuesInput
 from ....core import ResolveInfo
 from ....core.descriptions import ADDED_IN_310
@@ -50,9 +51,11 @@ class ProductUpdate(ProductCreate, ModelWithExtRefMutation):
         return attributes
 
     @classmethod
-    def post_save_action(cls, info: ResolveInfo, instance, _cleaned_input):
+    def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
         product = models.Product.objects.prefetched_for_webhook().get(pk=instance.pk)
         update_product_search_vector(instance)
+        if "category" in cleaned_input or "collections" in cleaned_input:
+            update_product_discounted_price_task.delay(instance.id)
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.product_updated, product)
 

--- a/saleor/graphql/product/tests/deprecated/test_product_channel_listing_update.py
+++ b/saleor/graphql/product/tests/deprecated/test_product_channel_listing_update.py
@@ -58,8 +58,14 @@ mutation UpdateProductChannelListing(
 """
 
 
+@patch("saleor.product.tasks.update_product_discounted_price_task.delay")
 def test_product_channel_listing_update_as_staff_user(
-    staff_api_client, product, permission_manage_products, channel_USD, channel_PLN
+    update_product_discounted_price_task_mock,
+    staff_api_client,
+    product,
+    permission_manage_products,
+    channel_USD,
+    channel_PLN,
 ):
     # given
     publication_date = datetime.date.today()
@@ -129,6 +135,7 @@ def test_product_channel_listing_update_as_staff_user(
         product_data["channelListings"][1]["availableForPurchase"]
         == available_for_purchase_date.isoformat()
     )
+    update_product_discounted_price_task_mock.assert_called_once_with(product.id)
 
 
 @patch("saleor.plugins.manager.PluginsManager.product_updated")

--- a/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
@@ -74,7 +74,9 @@ PRODUCT_BULK_CREATE_MUTATION = """
 """
 
 
+@patch("saleor.product.tasks.update_products_discounted_prices_task.delay")
 def test_product_bulk_create_with_base_data(
+    update_products_discounted_price_task_mock,
     staff_api_client,
     product_type,
     category,
@@ -140,6 +142,10 @@ def test_product_bulk_create_with_base_data(
         assert product.description == description_json
         assert product.category == category
         assert product.product_type == product_type
+
+    update_products_discounted_price_task_mock.assert_called_once()
+    args = set(update_products_discounted_price_task_mock.call_args.args[0])
+    assert args == {product.id for product in products}
 
 
 @patch("saleor.plugins.manager.PluginsManager.product_created")


### PR DESCRIPTION
Ensure that the task for product discounted price recalculation is called in product mutations. 

Mutations that call the product discounted price recalculation:
- `ProductBulkCreate`
- `ProductCreate`
- `ProductUpdate` - when `collections` or `category` have changed
- `ProductChannelListingUpdate`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
