### PR TITLE
Fix failing mutations when updating checkout metadata

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -874,11 +874,7 @@ def clear_delivery_method(checkout_info: "CheckoutInfo"):
             "last_change",
         ]
     )
-    get_checkout_metadata(checkout).save(
-        update_fields=[
-            "private_metadata",
-        ]
-    )
+    get_checkout_metadata(checkout).save()
 
 
 def is_fully_paid(

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -251,11 +251,7 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             ]
             + invalidate_prices_updated_fields
         )
-        get_or_create_checkout_metadata(checkout).save(
-            update_fields=[
-                "private_metadata",
-            ]
-        )
+        get_or_create_checkout_metadata(checkout).save()
         cls.call_event(manager.checkout_updated, checkout)
 
     @staticmethod

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -166,9 +166,12 @@ def test_checkout_delivery_method_update_no_checkout_metadata(
 
     method_id = graphene.Node.to_global_id(node_name, delivery_method.id)
 
+    # when
     response = api_client.post_graphql(
         query, {"id": to_global_id_or_none(checkout), "deliveryMethodId": method_id}
     )
+
+    # then
     data = get_graphql_content(response)["data"]["checkoutDeliveryMethodUpdate"]
     checkout.refresh_from_db()
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -119,6 +119,78 @@ def test_checkout_delivery_method_update(
 
 
 @pytest.mark.parametrize("is_valid_delivery_method", (True, False))
+@pytest.mark.parametrize(
+    "delivery_method, node_name, attribute_name",
+    [
+        ("warehouse", "Warehouse", "collection_point"),
+        ("shipping_method", "ShippingMethod", "shipping_method"),
+    ],
+    indirect=("delivery_method",),
+)
+@patch(
+    "saleor.graphql.checkout.mutations.checkout_delivery_method_update."
+    "clean_delivery_method"
+)
+@patch(
+    "saleor.graphql.checkout.mutations.checkout_delivery_method_update."
+    "invalidate_checkout_prices",
+    wraps=invalidate_checkout_prices,
+)
+def test_checkout_delivery_method_update_no_checkout_metadata(
+    mock_invalidate_checkout_prices,
+    mock_clean_delivery,
+    api_client,
+    delivery_method,
+    node_name,
+    attribute_name,
+    checkout_with_item_for_cc,
+    is_valid_delivery_method,
+):
+    # given
+    mock_clean_delivery.return_value = is_valid_delivery_method
+
+    checkout = checkout_with_item_for_cc
+    checkout.metadata_storage.delete()
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+
+    shipping_method_data = delivery_method
+    if attribute_name == "shipping_method":
+        shipping_method_data = convert_to_shipping_method_data(
+            delivery_method,
+            delivery_method.channel_listings.get(),
+        )
+    query = MUTATION_UPDATE_DELIVERY_METHOD
+    mock_clean_delivery.return_value = is_valid_delivery_method
+
+    method_id = graphene.Node.to_global_id(node_name, delivery_method.id)
+
+    response = api_client.post_graphql(
+        query, {"id": to_global_id_or_none(checkout), "deliveryMethodId": method_id}
+    )
+    data = get_graphql_content(response)["data"]["checkoutDeliveryMethodUpdate"]
+    checkout.refresh_from_db()
+
+    mock_clean_delivery.assert_called_once_with(
+        checkout_info=checkout_info, lines=lines, method=shipping_method_data
+    )
+    errors = data["errors"]
+    if is_valid_delivery_method:
+        assert not errors
+        assert getattr(checkout, attribute_name) == delivery_method
+        assert mock_invalidate_checkout_prices.call_count == 1
+    else:
+        assert len(errors) == 1
+        assert errors[0]["field"] == "deliveryMethodId"
+        assert (
+            errors[0]["code"] == CheckoutErrorCode.DELIVERY_METHOD_NOT_APPLICABLE.name
+        )
+        assert checkout.shipping_method is None
+        assert checkout.collection_point is None
+
+
+@pytest.mark.parametrize("is_valid_delivery_method", (True, False))
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
 @patch(
     "saleor.graphql.checkout.mutations.checkout_delivery_method_update."

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -118,6 +118,40 @@ def test_update_checkout_shipping_method_if_invalid(
     assert checkout.shipping_method is None
 
 
+def test_update_checkout_shipping_method_if_invalid_no_checkout_metadata(
+    checkout_with_single_item,
+    address,
+    shipping_method,
+    other_shipping_method,
+    shipping_zone_without_countries,
+):
+    # If the shipping method is invalid, it should be removed.
+
+    # given
+    checkout = checkout_with_single_item
+    checkout.metadata_storage.delete()
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+
+    shipping_method.shipping_zone = shipping_zone_without_countries
+    shipping_method.save(update_fields=["shipping_zone"])
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+
+    # when
+    update_checkout_shipping_method_if_invalid(checkout_info, lines)
+
+    # then
+    assert checkout.shipping_method is None
+    assert checkout_info.delivery_method_info.delivery_method is None
+
+    # Ensure the checkout's shipping method was saved
+    checkout.refresh_from_db(fields=["shipping_method"])
+    assert checkout.shipping_method is None
+
+
 @pytest.fixture
 def expected_dummy_gateway():
     return {

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -389,6 +389,27 @@ def test_add_public_metadata_for_checkout(api_client, checkout):
     )
 
 
+def test_add_public_metadata_for_checkout_no_checkout_metadata_storage(
+    api_client, checkout
+):
+    # given
+    checkout.metadata_storage.delete()
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
+    response = execute_update_public_metadata_for_item(
+        api_client, None, checkout_id, "Checkout"
+    )
+
+    # then
+    checkout.refresh_from_db()
+    assert item_contains_proper_public_metadata(
+        response["data"]["updateMetadata"]["item"],
+        checkout.metadata_storage,
+        checkout_id,
+    )
+
+
 def test_add_public_metadata_for_checkout_line(api_client, checkout_line):
     # given
     checkout_line_id = graphene.Node.to_global_id("CheckoutLine", checkout_line.pk)
@@ -2508,6 +2529,28 @@ def test_add_private_metadata_for_checkout(
     )
 
     # then
+    assert item_contains_proper_private_metadata(
+        response["data"]["updatePrivateMetadata"]["item"],
+        checkout.metadata_storage,
+        checkout_id,
+    )
+
+
+def test_add_private_metadata_for_checkout_no_checkout_metadata_storage(
+    staff_api_client, checkout, permission_manage_checkouts
+):
+    # given
+    checkout.metadata_storage.delete()
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
+    response = execute_update_private_metadata_for_item(
+        staff_api_client, permission_manage_checkouts, checkout_id, "Checkout"
+    )
+
+    # then
+    checkout.refresh_from_db()
     assert item_contains_proper_private_metadata(
         response["data"]["updatePrivateMetadata"]["item"],
         checkout.metadata_storage,

--- a/saleor/graphql/meta/types.py
+++ b/saleor/graphql/meta/types.py
@@ -4,7 +4,7 @@ import graphene
 from graphene.types.generic import GenericScalar
 
 from ...checkout.models import Checkout
-from ...checkout.utils import get_checkout_metadata
+from ...checkout.utils import get_or_create_checkout_metadata
 from ...core.models import ModelWithMetadata
 from ..channel import ChannelContext
 from ..core import ResolveInfo
@@ -162,7 +162,12 @@ class ObjectWithMetadata(graphene.Interface):
         return item_type
 
 
+# `instance = get_checkout_metadata(instance)` is calling the
+# `get_checkout_metadata` function to retrieve the metadata associated with a
+# checkout instance. This function is defined in the `.../checkout/utils.py` file
+# and takes a `Checkout` instance as an argument. It returns a dictionary
+# containing the metadata associated with the checkout.
 def get_valid_metadata_instance(instance):
     if isinstance(instance, Checkout):
-        instance = get_checkout_metadata(instance)
+        instance = get_or_create_checkout_metadata(instance)
     return instance


### PR DESCRIPTION
Fix the following failing mutations:
- `UpdatePrivateMetadata`
- `UpdateMetadata`
- `CheckoutDeliveryMethodUpdate`
- `CheckoutLinesAdd`
- `CheckoutLinesUpdate`
- `CheckoutLineDelete`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
