### PR TITLE
Update category and collection mutations to recalculated products discounted price

### DIFF
--- a/saleor/graphql/product/mutations/collection/collection_add_products.py
+++ b/saleor/graphql/product/mutations/collection/collection_add_products.py
@@ -5,7 +5,7 @@ from .....core.tracing import traced_atomic_transaction
 from .....permission.enums import ProductPermissions
 from .....product import models
 from .....product.error_codes import CollectionErrorCode
-from .....product.tasks import update_products_discounted_prices_of_catalogues_task
+from .....product.tasks import update_products_discounted_prices_task
 from .....product.utils import get_products_ids_without_variants
 from ....channel import ChannelContext
 from ....core import ResolveInfo
@@ -55,9 +55,7 @@ class CollectionAddProducts(BaseMutation):
             collection.products.add(*products)
             if collection.sale_set.exists():
                 # Updated the db entries, recalculating discounts of affected products
-                update_products_discounted_prices_of_catalogues_task.delay(
-                    product_ids=[pq.pk for pq in products]
-                )
+                update_products_discounted_prices_task.delay([pq.pk for pq in products])
             for product in products:
                 cls.call_event(manager.product_updated, product)
 

--- a/saleor/graphql/product/mutations/collection/collection_delete.py
+++ b/saleor/graphql/product/mutations/collection/collection_delete.py
@@ -2,6 +2,7 @@ import graphene
 
 from .....permission.enums import ProductPermissions
 from .....product import models
+from .....product.tasks import update_products_discounted_prices_task
 from ....channel import ChannelContext
 from ....core import ResolveInfo
 from ....core.mutations import ModelDeleteMutation
@@ -32,12 +33,18 @@ class CollectionDelete(ModelDeleteMutation):
                 single_object=False
             )
         )
+        collection_on_sale = instance.sale_set.exists()
 
         result = super().perform_mutation(_root, info, id=id)
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.collection_deleted, instance)
         for product in products:
             cls.call_event(manager.product_updated, product)
+
+        if collection_on_sale:
+            update_products_discounted_prices_task.delay(
+                [product.id for product in products]
+            )
 
         return CollectionDelete(
             collection=ChannelContext(node=result.collection, channel_slug=None)

--- a/saleor/graphql/product/mutations/collection/collection_remove_products.py
+++ b/saleor/graphql/product/mutations/collection/collection_remove_products.py
@@ -2,7 +2,7 @@ import graphene
 
 from .....permission.enums import ProductPermissions
 from .....product import models
-from .....product.tasks import update_products_discounted_prices_of_catalogues_task
+from .....product.tasks import update_products_discounted_prices_task
 from ....channel import ChannelContext
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_PRODUCTS
@@ -51,9 +51,7 @@ class CollectionRemoveProducts(BaseMutation):
             cls.call_event(manager.product_updated, product)
         if collection.sale_set.exists():
             # Updated the db entries, recalculating discounts of affected products
-            update_products_discounted_prices_of_catalogues_task.delay(
-                product_ids=[p.pk for p in products]
-            )
+            update_products_discounted_prices_task.delay([p.pk for p in products])
         return CollectionRemoveProducts(
             collection=ChannelContext(node=collection, channel_slug=None)
         )

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -62,24 +62,44 @@ MUTATION_CATEGORY_BULK_DELETE = """
 """
 
 
-def test_delete_categories(staff_api_client, category_list, permission_manage_products):
+@patch("saleor.product.tasks.update_products_discounted_prices_task.delay")
+def test_delete_categories(
+    update_products_discounted_price_task_mock,
+    staff_api_client,
+    category_list,
+    product_list,
+    permission_manage_products,
+):
+    # given
+    for product, category in zip(product_list, category_list):
+        product.category = category
+
+    Product.objects.bulk_update(product_list, ["category"])
+
     variables = {
         "ids": [
             graphene.Node.to_global_id("Category", category.id)
             for category in category_list
         ]
     }
+
+    # when
     response = staff_api_client.post_graphql(
         MUTATION_CATEGORY_BULK_DELETE,
         variables,
         permissions=[permission_manage_products],
     )
+
+    # then
     content = get_graphql_content(response)
 
     assert content["data"]["categoryBulkDelete"]["count"] == 3
     assert not Category.objects.filter(
         id__in=[category.id for category in category_list]
     ).exists()
+    update_products_discounted_price_task_mock.assert_called_once()
+    args, kwargs = update_products_discounted_price_task_mock.call_args
+    assert set(kwargs["product_ids"]) == {product.id for product in product_list}
 
 
 @patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")

--- a/saleor/graphql/product/tests/test_product_discounted_price.py
+++ b/saleor/graphql/product/tests/test_product_discounted_price.py
@@ -93,10 +93,10 @@ def test_category_delete_updates_discounted_price(
 
 @patch(
     "saleor.graphql.product.mutations.collection.collection_add_products"
-    ".update_products_discounted_prices_of_catalogues_task"
+    ".update_products_discounted_prices_task.delay"
 )
 def test_collection_add_products_updates_discounted_price(
-    mock_update_products_discounted_prices_of_catalogues,
+    mock_update_products_discounted_prices_task,
     staff_api_client,
     sale,
     collection,
@@ -130,17 +130,17 @@ def test_collection_add_products_updates_discounted_price(
     data = content["data"]["collectionAddProducts"]
     assert data["errors"] == []
 
-    mock_update_products_discounted_prices_of_catalogues.delay.assert_called_once_with(
-        product_ids=[p.pk for p in product_list]
-    )
+    mock_update_products_discounted_prices_task.assert_called_once()
+    args = set(mock_update_products_discounted_prices_task.call_args.args[0])
+    assert args == {product.id for product in product_list}
 
 
 @patch(
     "saleor.graphql.product.mutations.collection.collection_remove_products"
-    ".update_products_discounted_prices_of_catalogues_task"
+    ".update_products_discounted_prices_task.delay"
 )
 def test_collection_remove_products_updates_discounted_price(
-    mock_update_products_discounted_prices_of_catalogues,
+    mock_update_products_discounted_prices_task,
     staff_api_client,
     sale,
     collection,
@@ -174,9 +174,9 @@ def test_collection_remove_products_updates_discounted_price(
     data = content["data"]["collectionRemoveProducts"]
     assert data["errors"] == []
 
-    mock_update_products_discounted_prices_of_catalogues.delay.assert_called_once_with(
-        product_ids=[p.pk for p in product_list]
-    )
+    mock_update_products_discounted_prices_task.assert_called_once()
+    args = set(mock_update_products_discounted_prices_task.call_args.args[0])
+    assert args == {product.id for product in product_list}
 
 
 @freeze_time("2010-05-31 12:00:01")


### PR DESCRIPTION
Ensure that the task for product discounted price recalculation is called in category and collection mutations. 

Mutations that call the product discounted price recalculation:
- `CollectionAddProducts`
- `CollectionRemoveProducts`
- `CollectionDelete`
- `CategoryDelete`
- `CategoryBulkDelete`
- `CollectionBulkDelete`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
