### PR TITLE
Call discounted prices recalculation every time sale toggle

### DIFF
--- a/saleor/discount/tasks.py
+++ b/saleor/discount/tasks.py
@@ -18,6 +18,12 @@ task_logger = get_task_logger(__name__)
 
 
 @app.task
+def send_sale_toggle_notifications():
+    # The task is DEPRECATED, should be dropped in version 3.15
+    handle_sale_toggle()
+
+
+@app.task
 def handle_sale_toggle():
     """Send the notification about sales toggle and recalculate discounted prcies.
 

--- a/saleor/discount/tests/test_tasks.py
+++ b/saleor/discount/tests/test_tasks.py
@@ -47,11 +47,10 @@ def test_fetch_catalogue_infos(sale, new_sale):
 
 @freeze_time("2020-03-18 12:00:00")
 @patch(
-    "saleor.graphql.product.mutations.collection.collection_add_products"
-    ".update_products_discounted_prices_of_catalogues_task.delay"
+    "saleor.product.tasks.update_products_discounted_prices_of_catalogues_task.delay"
 )
 @patch("saleor.plugins.manager.PluginsManager.sale_toggle")
-def test_send_sale_toggle_notifications(
+def test_handle_sale_toggle(
     sale_toggle_mock,
     mock_update_products_discounted_prices_of_catalogues,
     collection_list,

--- a/saleor/discount/tests/test_tasks.py
+++ b/saleor/discount/tests/test_tasks.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import timedelta
 from unittest.mock import ANY, patch
 
@@ -6,7 +7,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from ..models import Sale
-from ..tasks import fetch_catalogue_infos, send_sale_toggle_notifications
+from ..tasks import fetch_catalogue_infos, handle_sale_toggle
 
 
 def test_fetch_catalogue_infos(sale, new_sale):
@@ -14,35 +15,62 @@ def test_fetch_catalogue_infos(sale, new_sale):
     sales = Sale.objects.all()
 
     # when
-    catalogue_infos = fetch_catalogue_infos(sales)
+    sale_id_to_catalogue_infos, catalogue_infos = fetch_catalogue_infos(sales)
 
     # then
+    expected_catalogue_info = defaultdict(set)
     for sale_instance in sales:
-        catalogue_info = catalogue_infos[sale_instance.id]
+        catalogue_info = sale_id_to_catalogue_infos[sale_instance.id]
+        category_ids = sale_instance.categories.all().values_list("id", flat=True)
+        collection_ids = sale_instance.collections.all().values_list("id", flat=True)
+        product_ids = sale_instance.products.all().values_list("id", flat=True)
+        variant_ids = sale_instance.variants.all().values_list("id", flat=True)
         assert catalogue_info["categories"] == set(
-            graphene.Node.to_global_id("Category", id)
-            for id in sale_instance.categories.all().values_list("id", flat=True)
+            graphene.Node.to_global_id("Category", id) for id in category_ids
         )
         assert catalogue_info["collections"] == set(
-            graphene.Node.to_global_id("Collection", id)
-            for id in sale_instance.collections.all().values_list("id", flat=True)
+            graphene.Node.to_global_id("Collection", id) for id in collection_ids
         )
         assert catalogue_info["products"] == set(
-            graphene.Node.to_global_id("Product", id)
-            for id in sale_instance.products.all().values_list("id", flat=True)
+            graphene.Node.to_global_id("Product", id) for id in product_ids
         )
         assert catalogue_info["variants"] == set(
-            graphene.Node.to_global_id("ProductVariant", id)
-            for id in sale_instance.variants.all().values_list("id", flat=True)
+            graphene.Node.to_global_id("ProductVariant", id) for id in variant_ids
         )
+        expected_catalogue_info["categories"].update(set(category_ids))
+        expected_catalogue_info["collections"].update(set(collection_ids))
+        expected_catalogue_info["products"].update(set(product_ids))
+        expected_catalogue_info["variants"].update(set(variant_ids))
+
+    assert catalogue_infos == expected_catalogue_info
 
 
 @freeze_time("2020-03-18 12:00:00")
+@patch(
+    "saleor.graphql.product.mutations.collection.collection_add_products"
+    ".update_products_discounted_prices_of_catalogues_task.delay"
+)
 @patch("saleor.plugins.manager.PluginsManager.sale_toggle")
-def test_send_sale_toggle_notifications(sale_toggle_mock):
+def test_send_sale_toggle_notifications(
+    sale_toggle_mock,
+    mock_update_products_discounted_prices_of_catalogues,
+    collection_list,
+    product_list,
+    category,
+):
     # given
     now = timezone.now()
     sales = Sale.objects.bulk_create([Sale(name=f"Sale-{i}") for i in range(10)])
+
+    variant_ids = []
+    for collection, product, sale in zip(collection_list, product_list, sales):
+        sale.collections.add(collection)
+        sale.products.add(product)
+        variant = product.variants.first()
+        sale.variants.add(variant)
+        variant_ids.append(variant.id)
+
+    sales[7].categories.add(category)
 
     # sales with start date before current date
     # without notification sent day - should be sent
@@ -100,19 +128,29 @@ def test_send_sale_toggle_notifications(sale_toggle_mock):
             "notification_sent_datetime",
         ],
     )
+    indexes_of_toggle_sales = [0, 2, 5, 7]
 
     # when
-    send_sale_toggle_notifications()
+    handle_sale_toggle()
 
     # then
     assert sale_toggle_mock.call_count == 4
 
     started_args_list = [args.args for args in sale_toggle_mock.call_args_list]
-    assert (sales[0], ANY) in started_args_list
-    assert (sales[2], ANY) in started_args_list
-    assert (sales[5], ANY) in started_args_list
-    assert (sales[7], ANY) in started_args_list
+    for index in indexes_of_toggle_sales:
+        assert (sales[index], ANY) in started_args_list
 
-    for index in [0, 2, 5, 7]:
+    for index in indexes_of_toggle_sales:
         sales[index].refresh_from_db()
         assert sales[index].notification_sent_datetime == now
+
+    mock_update_products_discounted_prices_of_catalogues.assert_called_once()
+    args, kwargs = mock_update_products_discounted_prices_of_catalogues.call_args
+    # get ids of instances assigned to sales that toggle
+    assert set(kwargs["product_ids"]) == {product_list[0].id, product_list[2].id}
+    assert set(kwargs["category_ids"]) == {category.id}
+    assert set(kwargs["collection_ids"]) == {
+        collection_list[0].id,
+        collection_list[2].id,
+    }
+    assert set(kwargs["variant_ids"]) == {variant_ids[0], variant_ids[2]}

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -597,8 +597,8 @@ CELERY_BEAT_SCHEDULE = {
         "task": "saleor.csv.tasks.delete_old_export_files",
         "schedule": crontab(hour=1, minute=0),
     },
-    "send-sale-toggle-notifications": {
-        "task": "saleor.discount.tasks.send_sale_toggle_notifications",
+    "handle-sale-toggle": {
+        "task": "saleor.discount.tasks.handle_sale_toggle",
         "schedule": initiated_sale_webhook_schedule,
     },
     "update-products-search-vectors": {


### PR DESCRIPTION
Update the `send-sale-toggle-notifications` schedule to also call the discounted price recalculation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
