### PR TITLE
Extend allowed mutations list for read only mode

### DIFF
--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -26,6 +26,12 @@ class ReadOnlyMiddleware:
         "tokenCreate",
         "tokenVerify",
         "tokenRefresh",
+        "paymentGatewayInitialize",
+        "transactionInitialize",
+        "transactionProcess",
+        "transactionRequestAction",
+        "orderGrantRefundCreate",
+        "orderGrantRefundUpdate",
     ]
 
     @staticmethod


### PR DESCRIPTION
I want to merge this change because it extends the ReadOnly middleware, to accept the mutations related to the new payment flow + it whitelists the mutation for granted refunds. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
