### PR TITLE
Fix saving seo fields

### DIFF
--- a/saleor/graphql/core/validators/__init__.py
+++ b/saleor/graphql/core/validators/__init__.py
@@ -153,10 +153,13 @@ def validate_slug_value(cleaned_input, slug_field_name: str = "slug"):
 
 def clean_seo_fields(data):
     """Extract and assign seo fields to given dictionary."""
-    seo_fields = data.pop("seo", None)
-    if seo_fields:
-        data["seo_title"] = seo_fields.get("title")
-        data["seo_description"] = seo_fields.get("description")
+    seo_fields = data.pop("seo", {})
+
+    if "title" in seo_fields:
+        data["seo_title"] = seo_fields["title"]
+
+    if "description" in seo_fields:
+        data["seo_description"] = seo_fields["description"]
 
 
 def validate_required_string_field(cleaned_input, field_name: str):

--- a/saleor/graphql/product/tests/mutations/test_product_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_update.py
@@ -283,6 +283,82 @@ def test_update_product_doesnt_clear_description_plaintext_when_no_description(
     assert product.description_plaintext == description_plaintext
 
 
+def test_update_product_seo_field_title(
+    staff_api_client,
+    non_default_category,
+    product,
+    other_description_json,
+    permission_manage_products,
+    color_attribute,
+):
+    query = MUTATION_UPDATE_PRODUCT
+    old_seo_description = "old seo description"
+    product.seo_description = old_seo_description
+    product.seo_title = "old_seo_title"
+    product.save(update_fields=["seo_description", "seo_title"])
+
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    new_seo_title = "new_seo_title"
+
+    variables = {
+        "productId": product_id,
+        "input": {
+            "seo": {
+                "title": new_seo_title,
+            },
+        },
+    }
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productUpdate"]
+    assert not data["errors"]
+
+    product.refresh_from_db()
+    assert product.seo_description == old_seo_description
+    assert product.seo_title == new_seo_title
+
+
+def test_update_product_seo_field_description(
+    staff_api_client,
+    non_default_category,
+    product,
+    other_description_json,
+    permission_manage_products,
+    color_attribute,
+):
+    query = MUTATION_UPDATE_PRODUCT
+    old_seo_title = "old_seo_title"
+    product.seo_description = "old seo description"
+    product.seo_title = old_seo_title
+    product.save(update_fields=["seo_description", "seo_title"])
+
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    new_seo_description = "new_seo_description"
+
+    variables = {
+        "productId": product_id,
+        "input": {
+            "seo": {
+                "description": new_seo_description,
+            },
+        },
+    }
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productUpdate"]
+    assert not data["errors"]
+
+    product.refresh_from_db()
+    assert product.seo_description == new_seo_description
+    assert product.seo_title == old_seo_title
+
+
 @patch("saleor.plugins.manager.PluginsManager.product_updated")
 def test_update_product_with_boolean_attribute_value(
     updated_webhook_mock,


### PR DESCRIPTION
I want to merge this change because it fixes updating SEO fields. When one of `seo` fields wasn't sent in `SeoInput` that field was cleaned. After this change only sent fields will be updated.

Port of #12581
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
