### PR TITLE
Add flag to StripePlugin to control if receipt_email should be included in the request

### DIFF
--- a/saleor/payment/gateways/stripe/tests/conftest.py
+++ b/saleor/payment/gateways/stripe/tests/conftest.py
@@ -75,6 +75,7 @@ def stripe_plugin(settings, monkeypatch, channel_USD):
         webhook_secret_key="ABCD",
         active=True,
         auto_capture=True,
+        include_receipt_email=None,
     ):
         public_api_key = public_api_key or "test_key"
         secret_api_key = secret_api_key or "secret_key"
@@ -94,6 +95,10 @@ def stripe_plugin(settings, monkeypatch, channel_USD):
         if webhook_secret_key:
             configuration.append(
                 {"name": "webhook_secret_key", "value": webhook_secret_key}
+            )
+        if include_receipt_email is not None:
+            configuration.append(
+                {"name": "include_receipt_email", "value": include_receipt_email}
             )
         PluginConfiguration.objects.create(
             identifier=StripeGatewayPlugin.PLUGIN_ID,

--- a/saleor/payment/gateways/stripe/tests/test_plugin.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin.py
@@ -223,6 +223,7 @@ def test_process_payment_with_disabled_include_receipt_email(
     payment_stripe_for_checkout,
     channel_USD,
 ):
+    # given
     payment_intent = Mock()
     mocked_payment_intent.return_value = payment_intent
     client_secret = "client-secret"
@@ -241,8 +242,10 @@ def test_process_payment_with_disabled_include_receipt_email(
         payment_stripe_for_checkout,
     )
 
+    # when
     response = plugin.process_payment(payment_info, None)
 
+    # then
     assert response.is_success is True
     assert response.action_required is True
     assert response.kind == TransactionKind.ACTION_TO_CONFIRM
@@ -266,6 +269,66 @@ def test_process_payment_with_disabled_include_receipt_email(
             "channel": channel_USD.slug,
             "payment_id": payment_info.graphql_payment_id,
         },
+    )
+    assert not mocked_customer.called
+
+
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
+def test_process_payment_with_enabled_include_receipt_email(
+    mocked_payment_intent,
+    mocked_customer,
+    stripe_plugin,
+    payment_stripe_for_checkout,
+    channel_USD,
+):
+    # given
+    payment_intent = Mock()
+    mocked_payment_intent.return_value = payment_intent
+    client_secret = "client-secret"
+    dummy_response = {
+        "id": "evt_1Ip9ANH1Vac4G4dbE9ch7zGS",
+    }
+    payment_intent_id = "payment-intent-id"
+    payment_intent.id = payment_intent_id
+    payment_intent.client_secret = client_secret
+    payment_intent.last_response.data = dummy_response
+    payment_intent.status = "requires_payment_method"
+
+    plugin = stripe_plugin(auto_capture=True, include_receipt_email=True)
+
+    payment_info = create_payment_information(
+        payment_stripe_for_checkout,
+    )
+
+    # when
+    response = plugin.process_payment(payment_info, None)
+
+    # then
+    assert response.is_success is True
+    assert response.action_required is True
+    assert response.kind == TransactionKind.ACTION_TO_CONFIRM
+    assert response.amount == payment_info.amount
+    assert response.currency == payment_info.currency
+    assert response.transaction_id == payment_intent_id
+    assert response.error is None
+    assert response.raw_response == dummy_response
+    assert response.action_required_data == {
+        "client_secret": client_secret,
+        "id": payment_intent_id,
+    }
+
+    api_key = plugin.config.connection_params["secret_api_key"]
+    mocked_payment_intent.assert_called_once_with(
+        api_key=api_key,
+        amount=price_to_minor_unit(payment_info.amount, payment_info.currency),
+        currency=payment_info.currency,
+        capture_method=AUTOMATIC_CAPTURE_METHOD,
+        metadata={
+            "channel": channel_USD.slug,
+            "payment_id": payment_info.graphql_payment_id,
+        },
+        receipt_email=payment_stripe_for_checkout.checkout.email,
     )
     assert not mocked_customer.called
 

--- a/saleor/payment/gateways/stripe/tests/test_plugin.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin.py
@@ -216,6 +216,62 @@ def test_process_payment(
 
 @patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
 @patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
+def test_process_payment_with_disabled_include_receipt_email(
+    mocked_payment_intent,
+    mocked_customer,
+    stripe_plugin,
+    payment_stripe_for_checkout,
+    channel_USD,
+):
+    payment_intent = Mock()
+    mocked_payment_intent.return_value = payment_intent
+    client_secret = "client-secret"
+    dummy_response = {
+        "id": "evt_1Ip9ANH1Vac4G4dbE9ch7zGS",
+    }
+    payment_intent_id = "payment-intent-id"
+    payment_intent.id = payment_intent_id
+    payment_intent.client_secret = client_secret
+    payment_intent.last_response.data = dummy_response
+    payment_intent.status = "requires_payment_method"
+
+    plugin = stripe_plugin(auto_capture=True, include_receipt_email=False)
+
+    payment_info = create_payment_information(
+        payment_stripe_for_checkout,
+    )
+
+    response = plugin.process_payment(payment_info, None)
+
+    assert response.is_success is True
+    assert response.action_required is True
+    assert response.kind == TransactionKind.ACTION_TO_CONFIRM
+    assert response.amount == payment_info.amount
+    assert response.currency == payment_info.currency
+    assert response.transaction_id == payment_intent_id
+    assert response.error is None
+    assert response.raw_response == dummy_response
+    assert response.action_required_data == {
+        "client_secret": client_secret,
+        "id": payment_intent_id,
+    }
+
+    api_key = plugin.config.connection_params["secret_api_key"]
+    mocked_payment_intent.assert_called_once_with(
+        api_key=api_key,
+        amount=price_to_minor_unit(payment_info.amount, payment_info.currency),
+        currency=payment_info.currency,
+        capture_method=AUTOMATIC_CAPTURE_METHOD,
+        metadata={
+            "channel": channel_USD.slug,
+            "payment_id": payment_info.graphql_payment_id,
+        },
+    )
+    assert not mocked_customer.called
+
+
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
 def test_process_payment_with_customer(
     mocked_payment_intent,
     mocked_customer_create,


### PR DESCRIPTION
I want to merge this change because it is port of changes https://github.com/saleor/saleor/pull/12790

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
