### PR TITLE
Update product price resolvers

### DIFF
--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -361,6 +361,7 @@ def test_create_checkout_with_reservations(
                 variant=variant,
                 channel=channel_USD,
                 price_amount=Decimal(10),
+                discounted_price_amount=Decimal(10),
                 cost_price_amount=Decimal(1),
                 currency=channel_USD.currency_code,
             )
@@ -627,6 +628,7 @@ def test_update_checkout_lines_with_reservations(
                 variant=variant,
                 channel=channel_USD,
                 price_amount=Decimal(10),
+                discounted_price_amount=Decimal(10),
                 cost_price_amount=Decimal(1),
                 currency=channel_USD.currency_code,
             )
@@ -897,6 +899,7 @@ def test_add_checkout_lines_with_reservations(
                 variant=variant,
                 channel=channel_USD,
                 price_amount=Decimal(10),
+                discounted_price_amount=Decimal(10),
                 cost_price_amount=Decimal(1),
                 currency=channel_USD.currency_code,
             )

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -805,6 +805,9 @@ class ProductVariantBulkCreate(BaseMutation):
                 channel=listing_data["channel"],
                 variant=variant,
                 price_amount=listing_data["price"],
+                # set the discounted price the same as price for now, the discounted
+                # value will be calculated asynchronously in the celery task
+                discounted_price_amount=listing_data["price"],
                 cost_price_amount=listing_data.get("cost_price"),
                 currency=listing_data["channel"].currency_code,
                 preorder_quantity_threshold=listing_data.get("preorder_threshold"),

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -557,6 +557,9 @@ class ProductVariantBulkUpdate(BaseMutation):
                     channel=listing_data["channel"],
                     variant=variant,
                     price_amount=listing_data["price"],
+                    # set the discounted price the same as price for now, the discounted
+                    # value will be calculated asynchronously in the celery task
+                    discounted_price_amount=listing_data["price"],
                     cost_price_amount=listing_data.get("cost_price"),
                     currency=listing_data["channel"].currency_code,
                     preorder_quantity_threshold=listing_data.get("preorder_threshold"),
@@ -573,6 +576,9 @@ class ProductVariantBulkUpdate(BaseMutation):
                     ]
                 if "price" in listing_data:
                     listing.price_amount = listing_data["price"]
+                    # set the discounted price the same as price for now, the discounted
+                    # value will be calculated asynchronously in the celery task
+                    listing.discounted_price_amount = listing_data["price"]
                 if "cost_price" in listing_data:
                     listing.cost_price_amount = listing_data["cost_price"]
                 listings_to_update.append(listing)

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -519,6 +519,9 @@ class ProductVariantChannelListingUpdate(BaseMutation):
                 defaults = {"currency": channel.currency_code}
                 if "price" in channel_listing_data.keys():
                     defaults["price_amount"] = channel_listing_data.get("price", None)
+                    # set the discounted price the same as price for now, the discounted
+                    # value will be calculated asynchronously in the celery task
+                    defaults["discounted_price_amount"] = defaults["price_amount"]
                 if "cost_price" in channel_listing_data.keys():
                     defaults["cost_price_amount"] = channel_listing_data.get(
                         "cost_price", None

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_create.py
@@ -10,7 +10,11 @@ from freezegun import freeze_time
 
 from .....attribute import AttributeInputType
 from .....product.error_codes import ProductVariantBulkErrorCode
-from .....product.models import ProductChannelListing, ProductVariant
+from .....product.models import (
+    ProductChannelListing,
+    ProductVariant,
+    ProductVariantChannelListing,
+)
 from .....tests.utils import dummy_editorjs, flush_post_commit_hooks
 from ....core.enums import ErrorPolicyEnum
 from ....tests.utils import get_graphql_content
@@ -1185,6 +1189,15 @@ def test_product_variant_bulk_create_channel_listings_input(
                 for channelListing in variant_data["channelListings"]
             ]
         )
+
+    # ensure all variants channel listings has discounted_price_amount set
+    assert all(
+        list(
+            ProductVariantChannelListing.objects.values_list(
+                "discounted_price_amount", flat=True
+            )
+        )
+    )
 
 
 def test_product_variant_bulk_create_preorder_channel_listings_input(

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -383,9 +383,17 @@ def test_product_variant_bulk_update_channel_listings_input(
     assert (
         new_variant_channel_listing.price_amount == not_existing_variant_listing_price
     )
+    assert (
+        new_variant_channel_listing.discounted_price_amount
+        == not_existing_variant_listing_price
+    )
     assert new_variant_channel_listing.channel == channel_PLN
     assert (
         existing_variant_listing.price_amount == new_price_for_existing_variant_listing
+    )
+    assert (
+        existing_variant_listing.discounted_price_amount
+        == new_price_for_existing_variant_listing
     )
 
 

--- a/saleor/graphql/product/tests/queries/test_products_query.py
+++ b/saleor/graphql/product/tests/queries/test_products_query.py
@@ -578,6 +578,7 @@ def test_sort_products(user_api_client, product, channel_USD):
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(20),
+        discounted_price_amount=Decimal(20),
         cost_price_amount=Decimal(2),
         currency=channel_USD.currency_code,
     )
@@ -688,6 +689,7 @@ def test_sort_products_by_price_as_staff(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(20),
+        discounted_price_amount=Decimal(20),
         cost_price_amount=Decimal(2),
         currency=channel_USD.currency_code,
     )

--- a/saleor/graphql/product/tests/test_variant_channel_listing_update.py
+++ b/saleor/graphql/product/tests/test_variant_channel_listing_update.py
@@ -192,7 +192,7 @@ def test_variant_channel_listing_update_as_staff_user(
     channel_PLN,
 ):
     # given
-    ProductChannelListing.objects.create(
+    pln_channel_listing = ProductChannelListing.objects.create(
         product=product,
         channel=channel_PLN,
         is_published=True,
@@ -246,6 +246,10 @@ def test_variant_channel_listing_update_as_staff_user(
     assert channel_pln_data["price"]["amount"] == second_price
     assert channel_pln_data["costPrice"]["amount"] == second_price
     assert channel_pln_data["channel"]["slug"] == channel_PLN.slug
+    usd_channel_listing = variant.channel_listings.get(channel=channel_USD)
+    pln_channel_listing = variant.channel_listings.get(channel=channel_PLN)
+    assert usd_channel_listing.discounted_price_amount == price
+    assert pln_channel_listing.discounted_price_amount == second_price
     update_product_discounted_price_task_mock.assert_called_once_with(product.id)
 
 

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -28,7 +28,6 @@ from ...core.fields import PermissionsField
 from ...core.scalars import Date
 from ...core.tracing import traced_resolver
 from ...core.types import BaseObjectType, ModelObjectType
-from ...discount.dataloaders import DiscountsByDateTimeLoader
 from ...tax.dataloaders import (
     TaxClassByProductIdLoader,
     TaxClassCountryRateByTaxClassIDLoader,
@@ -37,7 +36,6 @@ from ...tax.dataloaders import (
     TaxConfigurationPerCountryByTaxConfigurationIDLoader,
 )
 from ..dataloaders import (
-    CollectionsByProductIdLoader,
     ProductByIdLoader,
     ProductVariantsByProductIdLoader,
     VariantChannelListingByVariantIdAndChannelSlugLoader,
@@ -216,12 +214,9 @@ class ProductChannelListing(ModelObjectType[models.ProductChannelListing]):
 
         channel = ChannelByIdLoader(context).load(root.channel_id)
         product = ProductByIdLoader(context).load(root.product_id)
-        variants = ProductVariantsByProductIdLoader(context).load(root.product_id)
-        collections = CollectionsByProductIdLoader(context).load(root.product_id)
-        discounts = DiscountsByDateTimeLoader(context).load(info.context.request_time)
 
         def load_tax_configuration(data):
-            channel, product, variants, collections, discounts = data
+            channel, product = data
             country_code = address_country or channel.default_country.code
 
             def load_tax_country_exceptions(tax_config):
@@ -269,13 +264,8 @@ class ProductChannelListing(ModelObjectType[models.ProductChannelListing]):
                             prices_entered_with_tax = tax_config.prices_entered_with_tax
 
                             availability = get_product_availability(
-                                product=product,
                                 product_channel_listing=root,
-                                variants=variants,
                                 variants_channel_listing=variants_channel_listing,
-                                collections=collections,
-                                discounts=discounts,
-                                channel=channel,
                                 local_currency=local_currency,
                                 prices_entered_with_tax=prices_entered_with_tax,
                                 tax_calculation_strategy=tax_calculation_strategy,
@@ -317,9 +307,7 @@ class ProductChannelListing(ModelObjectType[models.ProductChannelListing]):
                 .then(load_tax_country_exceptions)
             )
 
-        return Promise.all([channel, product, variants, collections, discounts]).then(
-            load_tax_configuration
-        )
+        return Promise.all([channel, product]).then(load_tax_configuration)
 
 
 class PreorderThreshold(BaseObjectType):

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -356,7 +356,7 @@ class ProductVariantChannelListing(
     )
 
     class Meta:
-        description = "Represents product varaint channel listing."
+        description = "Represents product variant channel listing."
         model = models.ProductVariantChannelListing
         interfaces = [graphene.relay.Node]
 

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -85,7 +85,6 @@ from ...core.types import (
 )
 from ...core.utils import from_global_id_or_error
 from ...core.validators import validate_one_of_args_is_in_query
-from ...discount.dataloaders import DiscountsByDateTimeLoader
 from ...meta.types import ObjectWithMetadata
 from ...order.dataloaders import (
     OrderByIdLoader,
@@ -1066,24 +1065,18 @@ class Product(ChannelContextTypeWithMetadata[models.Product]):
         product_channel_listing = ProductChannelListingByProductIdAndChannelSlugLoader(
             context
         ).load((root.node.id, channel_slug))
-        variants = ProductVariantsByProductIdLoader(context).load(root.node.id)
         variants_channel_listing = (
             VariantsChannelListingByProductIdAndChannelSlugLoader(context).load(
                 (root.node.id, channel_slug)
             )
         )
-        collections = CollectionsByProductIdLoader(context).load(root.node.id)
-        discounts = DiscountsByDateTimeLoader(context).load(context.request_time)
         tax_class = TaxClassByProductIdLoader(context).load(root.node.id)
 
         def load_tax_configuration(data):
             (
                 channel,
                 product_channel_listing,
-                variants,
                 variants_channel_listing,
-                collections,
-                discounts,
                 tax_class,
             ) = data
 
@@ -1123,13 +1116,8 @@ class Product(ChannelContextTypeWithMetadata[models.Product]):
                         )
 
                         availability = get_product_availability(
-                            product=root.node,
                             product_channel_listing=product_channel_listing,
-                            variants=variants,
                             variants_channel_listing=variants_channel_listing,
-                            collections=collections,
-                            discounts=discounts,
-                            channel=channel,
                             local_currency=local_currency,
                             prices_entered_with_tax=tax_config.prices_entered_with_tax,
                             tax_calculation_strategy=tax_calculation_strategy,
@@ -1170,10 +1158,7 @@ class Product(ChannelContextTypeWithMetadata[models.Product]):
             [
                 channel,
                 product_channel_listing,
-                variants,
                 variants_channel_listing,
-                collections,
-                discounts,
                 tax_class,
             ]
         ).then(load_tax_configuration)

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -567,31 +567,23 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
         channel_slug = str(root.channel_slug)
         context = info.context
 
-        product = ProductByIdLoader(context).load(root.node.product_id)
         product_channel_listing = ProductChannelListingByProductIdAndChannelSlugLoader(
             context
         ).load((root.node.product_id, channel_slug))
         variant_channel_listing = VariantChannelListingByVariantIdAndChannelSlugLoader(
             context
         ).load((root.node.id, channel_slug))
-        collections = CollectionsByProductIdLoader(context).load(root.node.product_id)
         channel = ChannelBySlugLoader(context).load(channel_slug)
-        discounts = DiscountsByDateTimeLoader(context).load(info.context.request_time)
         tax_class = TaxClassByVariantIdLoader(context).load(root.node.id)
-        manager = get_plugin_manager_promise(info.context)
 
         address_country = address.country if address is not None else None
 
         def load_tax_configuration(data):
             (
-                product,
                 product_channel_listing,
                 variant_channel_listing,
-                collections,
                 channel,
                 tax_class,
-                discounts,
-                manager,
             ) = data
 
             if not variant_channel_listing or not product_channel_listing:
@@ -627,19 +619,18 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
                         )
 
                         availability = get_variant_availability(
-                            variant=root.node,
                             variant_channel_listing=variant_channel_listing,
-                            product=product,
                             product_channel_listing=product_channel_listing,
-                            collections=collections,
-                            discounts=discounts,
-                            channel=channel,
                             local_currency=local_currency,
                             prices_entered_with_tax=tax_config.prices_entered_with_tax,
                             tax_calculation_strategy=tax_calculation_strategy,
                             tax_rate=tax_rate,
                         )
-                        return VariantPricingInfo(**asdict(availability))
+                        return (
+                            VariantPricingInfo(**asdict(availability))
+                            if availability
+                            else None
+                        )
 
                     country_rates = (
                         TaxClassCountryRateByTaxClassIDLoader(context).load(
@@ -669,14 +660,10 @@ class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
 
         return Promise.all(
             [
-                product,
                 product_channel_listing,
                 variant_channel_listing,
-                collections,
                 channel,
                 tax_class,
-                discounts,
-                manager,
             ]
         ).then(load_tax_configuration)
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -6773,7 +6773,7 @@ type ProductVariant implements Node & ObjectWithMetadata @doc(category: "Product
   externalReference: String
 }
 
-"""Represents product varaint channel listing."""
+"""Represents product variant channel listing."""
 type ProductVariantChannelListing implements Node @doc(category: "Products") {
   id: ID!
   channel: Channel!

--- a/saleor/product/utils/availability.py
+++ b/saleor/product/utils/availability.py
@@ -1,20 +1,11 @@
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Iterable, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
 
-from ...channel.models import Channel
 from ...core.utils import to_local_currency
-from ...discount import DiscountInfo
-from ...discount.utils import calculate_discounted_price
-from ...product.models import (
-    Collection,
-    Product,
-    ProductChannelListing,
-    ProductVariant,
-    ProductVariantChannelListing,
-)
+from ...product.models import ProductChannelListing, ProductVariantChannelListing
 from ...tax import TaxCalculationStrategy
 from ...tax.calculations import calculate_flat_rate_tax
 
@@ -82,26 +73,6 @@ def _get_product_price_range(
             discount_local_currency = undiscounted_local.start - price_range_local.start
 
     return price_range_local, discount_local_currency
-
-
-def get_variant_price(
-    *,
-    variant: ProductVariant,
-    variant_channel_listing: ProductVariantChannelListing,
-    product: Product,
-    collections: Iterable[Collection],
-    discounts: Iterable[DiscountInfo],
-    channel: Channel
-):
-    collection_ids = {collection.id for collection in collections}
-    return calculate_discounted_price(
-        product=product,
-        price=variant_channel_listing.price,
-        collection_ids=collection_ids,
-        discounts=discounts,
-        channel=channel,
-        variant_id=variant.id,
-    )
 
 
 def get_product_price_range(

--- a/saleor/product/utils/availability.py
+++ b/saleor/product/utils/availability.py
@@ -242,40 +242,22 @@ def get_product_availability(
 
 def get_variant_availability(
     *,
-    variant: ProductVariant,
     variant_channel_listing: ProductVariantChannelListing,
-    product: Product,
     product_channel_listing: Optional[ProductChannelListing],
-    collections: Iterable[Collection],
-    discounts: Iterable[DiscountInfo],
-    channel: Channel,
     local_currency: Optional[str] = None,
     prices_entered_with_tax: bool,
     tax_calculation_strategy: str,
     tax_rate: Decimal
-) -> VariantAvailability:
-    discounted_price = get_variant_price(
-        variant=variant,
-        variant_channel_listing=variant_channel_listing,
-        product=product,
-        collections=collections,
-        discounts=discounts,
-        channel=channel,
-    )
+) -> Optional[VariantAvailability]:
+    if variant_channel_listing.price is None:
+        return None
     discounted_price_taxed = _calculate_product_price_with_taxes(
-        discounted_price,
+        variant_channel_listing.discounted_price,
         tax_rate,
         tax_calculation_strategy,
         prices_entered_with_tax,
     )
-    undiscounted_price = get_variant_price(
-        variant=variant,
-        variant_channel_listing=variant_channel_listing,
-        product=product,
-        collections=collections,
-        discounts=[],
-        channel=channel,
-    )
+    undiscounted_price = variant_channel_listing.price
     undiscounted_price_taxed = _calculate_product_price_with_taxes(
         undiscounted_price,
         tax_rate,

--- a/saleor/static/populatedb_data.json
+++ b/saleor/static/populatedb_data.json
@@ -3878,6 +3878,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "40.000",
+      "discounted_price_amount": "40.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -3890,6 +3891,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "10.000",
+      "discounted_price_amount": "10.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -3902,6 +3904,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "240.000",
+      "discounted_price_amount": "240.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -3914,6 +3917,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "80.000",
+      "discounted_price_amount": "80.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -3926,6 +3930,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "240.000",
+      "discounted_price_amount": "240.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -3938,6 +3943,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "240.000",
+      "discounted_price_amount": "240.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -3950,6 +3956,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "240.000",
+      "discounted_price_amount": "240.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -3962,6 +3969,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "240.000",
+      "discounted_price_amount": "240.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -3974,6 +3982,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "240.000",
+      "discounted_price_amount": "240.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -3986,6 +3995,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "240.000",
+      "discounted_price_amount": "240.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -3998,6 +4008,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "80.000",
+      "discounted_price_amount": "80.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4010,6 +4021,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "80.000",
+      "discounted_price_amount": "80.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4022,6 +4034,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "80.000",
+      "discounted_price_amount": "80.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4034,6 +4047,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "80.000",
+      "discounted_price_amount": "80.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4046,6 +4060,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "80.000",
+      "discounted_price_amount": "80.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4058,6 +4073,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "80.000",
+      "discounted_price_amount": "80.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4070,6 +4086,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "230.000",
+      "discounted_price_amount": "230.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4082,6 +4099,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "75.000",
+      "discounted_price_amount": "75.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4094,6 +4112,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "230.000",
+      "discounted_price_amount": "230.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4106,6 +4125,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "75.000",
+      "discounted_price_amount": "75.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4118,6 +4138,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "230.000",
+      "discounted_price_amount": "230.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4130,6 +4151,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "75.000",
+      "discounted_price_amount": "75.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4142,6 +4164,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "420.000",
+      "discounted_price_amount": "420.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4154,6 +4177,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4166,6 +4190,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "420.000",
+      "discounted_price_amount": "420.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4178,6 +4203,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4190,6 +4216,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "420.000",
+      "discounted_price_amount": "420.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4202,6 +4229,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4214,6 +4242,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "420.000",
+      "discounted_price_amount": "420.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4226,6 +4255,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4238,6 +4268,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "420.000",
+      "discounted_price_amount": "420.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4250,6 +4281,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4262,6 +4294,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "209.960",
+      "discounted_price_amount": "209.960",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4274,6 +4307,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "50.000",
+      "discounted_price_amount": "50.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4286,6 +4320,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "209.960",
+      "discounted_price_amount": "209.960",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4298,6 +4333,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "50.000",
+      "discounted_price_amount": "50.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4310,6 +4346,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "209.960",
+      "discounted_price_amount": "209.960",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4322,6 +4359,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "50.000",
+      "discounted_price_amount": "50.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4334,6 +4372,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "209.960",
+      "discounted_price_amount": "209.960",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4346,6 +4385,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "50.000",
+      "discounted_price_amount": "50.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4358,6 +4398,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "209.960",
+      "discounted_price_amount": "209.960",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4370,6 +4411,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "50.000",
+      "discounted_price_amount": "50.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4382,6 +4424,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "100.000",
+      "discounted_price_amount": "100.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4394,6 +4437,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "30.000",
+      "discounted_price_amount": "30.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4406,6 +4450,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "120.000",
+      "discounted_price_amount": "120.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4418,6 +4463,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "35.000",
+      "discounted_price_amount": "35.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4430,6 +4476,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "120.000",
+      "discounted_price_amount": "120.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4442,6 +4489,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "35.000",
+      "discounted_price_amount": "35.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4454,6 +4502,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4466,6 +4515,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "20.000",
+      "discounted_price_amount": "20.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4478,6 +4528,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4490,6 +4541,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "20.000",
+      "discounted_price_amount": "20.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4502,6 +4554,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4514,6 +4567,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "20.000",
+      "discounted_price_amount": "20.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4526,6 +4580,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4538,6 +4593,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "20.000",
+      "discounted_price_amount": "20.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4550,6 +4606,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4562,6 +4619,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "20.000",
+      "discounted_price_amount": "20.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4574,6 +4632,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "200.000",
+      "discounted_price_amount": "200.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4586,6 +4645,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "40.000",
+      "discounted_price_amount": "40.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4598,6 +4658,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "200.000",
+      "discounted_price_amount": "200.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4610,6 +4671,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "40.000",
+      "discounted_price_amount": "40.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4622,6 +4684,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "200.000",
+      "discounted_price_amount": "200.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4634,6 +4697,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "40.000",
+      "discounted_price_amount": "40.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4646,6 +4710,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "200.000",
+      "discounted_price_amount": "200.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4658,6 +4723,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "40.000",
+      "discounted_price_amount": "40.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4670,6 +4736,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "200.000",
+      "discounted_price_amount": "200.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4682,6 +4749,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "40.000",
+      "discounted_price_amount": "40.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4694,6 +4762,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "150.000",
+      "discounted_price_amount": "150.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4706,6 +4775,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4718,6 +4788,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "150.000",
+      "discounted_price_amount": "150.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4730,6 +4801,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4742,6 +4814,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "150.000",
+      "discounted_price_amount": "150.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4754,6 +4827,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4766,6 +4840,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "150.000",
+      "discounted_price_amount": "150.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4778,6 +4853,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4790,6 +4866,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "150.000",
+      "discounted_price_amount": "150.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4802,6 +4879,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4814,6 +4892,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "150.000",
+      "discounted_price_amount": "150.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4826,6 +4905,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4838,6 +4918,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "150.000",
+      "discounted_price_amount": "150.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4850,6 +4931,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4862,6 +4944,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "150.000",
+      "discounted_price_amount": "150.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4874,6 +4957,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4886,6 +4970,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "150.000",
+      "discounted_price_amount": "150.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4898,6 +4983,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4910,6 +4996,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "50.000",
+      "discounted_price_amount": "50.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4922,6 +5009,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "10.000",
+      "discounted_price_amount": "10.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4934,6 +5022,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4946,6 +5035,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "20.000",
+      "discounted_price_amount": "20.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4958,6 +5048,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "60.000",
+      "discounted_price_amount": "60.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4970,6 +5061,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "15.000",
+      "discounted_price_amount": "15.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4982,6 +5074,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -4994,6 +5087,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "10.000",
+      "discounted_price_amount": "10.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5006,6 +5100,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5018,6 +5113,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "10.000",
+      "discounted_price_amount": "10.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5030,6 +5126,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "45.000",
+      "discounted_price_amount": "45.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5042,6 +5139,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "10.000",
+      "discounted_price_amount": "10.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5054,6 +5152,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "29.990",
+      "discounted_price_amount": "29.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5066,6 +5165,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "8.990",
+      "discounted_price_amount": "8.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5078,6 +5178,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "29.990",
+      "discounted_price_amount": "29.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5090,6 +5191,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "8.990",
+      "discounted_price_amount": "8.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5102,6 +5204,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "29.990",
+      "discounted_price_amount": "29.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5114,6 +5217,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "8.990",
+      "discounted_price_amount": "8.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5126,6 +5230,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "29.990",
+      "discounted_price_amount": "29.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5138,6 +5243,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "8.990",
+      "discounted_price_amount": "8.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5150,6 +5256,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "9.990",
+      "discounted_price_amount": "9.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5162,6 +5269,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "2.000",
+      "discounted_price_amount": "2.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5174,6 +5282,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "9.990",
+      "discounted_price_amount": "9.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5186,6 +5295,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "2.000",
+      "discounted_price_amount": "2.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5198,6 +5308,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "29.990",
+      "discounted_price_amount": "29.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5210,6 +5321,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "11.990",
+      "discounted_price_amount": "11.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5222,6 +5334,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "70.000",
+      "discounted_price_amount": "70.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5234,6 +5347,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "18.000",
+      "discounted_price_amount": "18.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5246,6 +5360,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "5.990",
+      "discounted_price_amount": "5.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5258,6 +5373,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "1.990",
+      "discounted_price_amount": "1.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5270,6 +5386,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "5.990",
+      "discounted_price_amount": "5.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5282,6 +5399,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "1.990",
+      "discounted_price_amount": "1.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5294,6 +5412,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "5.990",
+      "discounted_price_amount": "5.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5306,6 +5425,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "1.990",
+      "discounted_price_amount": "1.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5318,6 +5438,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "5.990",
+      "discounted_price_amount": "5.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5330,6 +5451,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "1.990",
+      "discounted_price_amount": "1.990",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5342,6 +5464,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "90.000",
+      "discounted_price_amount": "90.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5354,6 +5477,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "17.000",
+      "discounted_price_amount": "17.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5366,6 +5490,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "120.000",
+      "discounted_price_amount": "120.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5378,6 +5503,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "25.000",
+      "discounted_price_amount": "25.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5390,6 +5516,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "120.000",
+      "discounted_price_amount": "120.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5402,6 +5529,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "25.000",
+      "discounted_price_amount": "25.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5414,6 +5542,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "450.000",
+      "discounted_price_amount": "450.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5426,6 +5555,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "100.000",
+      "discounted_price_amount": "100.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5438,6 +5568,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "130.000",
+      "discounted_price_amount": "130.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5450,6 +5581,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "30.000",
+      "discounted_price_amount": "30.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5462,6 +5594,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "130.000",
+      "discounted_price_amount": "130.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5474,6 +5607,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "30.000",
+      "discounted_price_amount": "30.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5486,6 +5620,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "130.000",
+      "discounted_price_amount": "130.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5498,6 +5633,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "30.000",
+      "discounted_price_amount": "30.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5510,6 +5646,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "130.000",
+      "discounted_price_amount": "130.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5522,6 +5659,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "30.000",
+      "discounted_price_amount": "30.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5534,6 +5672,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "130.000",
+      "discounted_price_amount": "130.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5546,6 +5685,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "30.000",
+      "discounted_price_amount": "30.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5558,6 +5698,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "230.000",
+      "discounted_price_amount": "230.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5570,6 +5711,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "50.000",
+      "discounted_price_amount": "50.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5582,6 +5724,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "2300.000",
+      "discounted_price_amount": "2300.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5594,6 +5737,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "500.000",
+      "discounted_price_amount": "500.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5606,6 +5750,7 @@
       "channel": 2,
       "currency": "PLN",
       "price_amount": "230.000",
+      "discounted_price_amount": "230.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }
@@ -5618,6 +5763,7 @@
       "channel": 1,
       "currency": "USD",
       "price_amount": "50.000",
+      "discounted_price_amount": "50.000",
       "cost_price_amount": null,
       "preorder_quantity_threshold": null
     }

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2217,6 +2217,7 @@ def product(product_type, category, warehouse, channel_USD, default_tax_class):
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2256,6 +2257,7 @@ def shippable_gift_card_product(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(100),
+        discounted_price_amount=Decimal(100),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2290,6 +2292,7 @@ def product_price_0(category, warehouse, channel_USD):
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(0),
+        discounted_price_amount=Decimal(0),
         cost_price_amount=Decimal(0),
         currency=channel_USD.currency_code,
     )
@@ -2313,6 +2316,7 @@ def product_in_channel_JPY(product, channel_JPY, warehouse_JPY):
         variant=variant,
         channel=channel_JPY,
         price_amount=Decimal(1200),
+        discounted_price_amount=Decimal(1200),
         cost_price_amount=Decimal(300),
         currency=channel_JPY.currency_code,
     )
@@ -2349,6 +2353,7 @@ def non_shippable_gift_card_product(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(250),
+        discounted_price_amount=Decimal(250),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2390,6 +2395,7 @@ def product_with_rich_text_attribute(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2419,6 +2425,7 @@ def product_available_in_many_channels(product, channel_PLN, channel_USD):
         variant=variant,
         channel=channel_PLN,
         price_amount=Decimal(50),
+        discounted_price_amount=Decimal(50),
         cost_price_amount=Decimal(1),
         currency=channel_PLN.currency_code,
     )
@@ -2445,6 +2452,7 @@ def product_with_single_variant(product_type, category, warehouse, channel_USD):
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(1.99),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2482,6 +2490,7 @@ def product_with_two_variants(product_type, category, warehouse, channel_USD):
             variant=variant,
             channel=channel_USD,
             price_amount=Decimal(10),
+            discounted_price_amount=Decimal(10),
             cost_price_amount=Decimal(1),
             currency=channel_USD.currency_code,
         )
@@ -2540,6 +2549,7 @@ def product_with_variant_with_two_attributes(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2602,6 +2612,7 @@ def product_with_variant_with_external_media(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2652,6 +2663,7 @@ def product_with_variant_with_file_attribute(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2710,6 +2722,7 @@ def product_with_default_variant(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2749,6 +2762,7 @@ def variant_without_inventory_tracking(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2765,6 +2779,7 @@ def variant(product, channel_USD) -> ProductVariant:
         variant=product_variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2799,6 +2814,7 @@ def preorder_variant_global_threshold(product, channel_USD):
         variant=product_variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2814,6 +2830,7 @@ def preorder_variant_channel_threshold(product, channel_USD):
         variant=product_variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
         preorder_quantity_threshold=10,
@@ -2862,6 +2879,7 @@ def preorder_variant_with_end_date(product, channel_USD):
         variant=product_variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2892,6 +2910,7 @@ def gift_card_shippable_variant(shippable_gift_card_product, channel_USD, wareho
         variant=product_variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2913,6 +2932,7 @@ def gift_card_non_shippable_variant(
         variant=product_variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -2941,6 +2961,7 @@ def product_variant_list(product, channel_USD, channel_PLN):
                 channel=channel_USD,
                 cost_price_amount=Decimal(1),
                 price_amount=Decimal(10),
+                discounted_price_amount=Decimal(10),
                 currency=channel_USD.currency_code,
             ),
             ProductVariantChannelListing(
@@ -2948,6 +2969,7 @@ def product_variant_list(product, channel_USD, channel_PLN):
                 channel=channel_USD,
                 cost_price_amount=Decimal(1),
                 price_amount=Decimal(10),
+                discounted_price_amount=Decimal(10),
                 currency=channel_USD.currency_code,
             ),
             ProductVariantChannelListing(
@@ -2955,6 +2977,7 @@ def product_variant_list(product, channel_USD, channel_PLN):
                 channel=channel_PLN,
                 cost_price_amount=Decimal(1),
                 price_amount=Decimal(10),
+                discounted_price_amount=Decimal(10),
                 currency=channel_PLN.currency_code,
             ),
             ProductVariantChannelListing(
@@ -2962,6 +2985,7 @@ def product_variant_list(product, channel_USD, channel_PLN):
                 channel=channel_USD,
                 cost_price_amount=Decimal(1),
                 price_amount=Decimal(10),
+                discounted_price_amount=Decimal(10),
                 currency=channel_USD.currency_code,
             ),
         ]
@@ -2996,6 +3020,7 @@ def product_without_shipping(category, warehouse, channel_USD):
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -3412,6 +3437,7 @@ def unavailable_product_with_variant(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -4044,6 +4070,7 @@ def order_with_lines(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
@@ -4096,6 +4123,7 @@ def order_with_lines(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(20),
+        discounted_price_amount=Decimal(20),
         cost_price_amount=Decimal(2),
         currency=channel_USD.currency_code,
     )
@@ -4329,6 +4357,7 @@ def order_with_lines_channel_PLN(
         variant=variant,
         channel=channel_PLN,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_PLN.currency_code,
     )
@@ -4380,6 +4409,7 @@ def order_with_lines_channel_PLN(
         variant=variant,
         channel=channel_PLN,
         price_amount=Decimal(20),
+        discounted_price_amount=Decimal(20),
         cost_price_amount=Decimal(2),
         currency=channel_PLN.currency_code,
     )
@@ -4498,6 +4528,7 @@ def order_with_preorder_lines(
         variant=variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
         preorder_quantity_threshold=10,
@@ -5786,6 +5817,7 @@ def digital_content(category, media_root, warehouse, channel_USD) -> DigitalCont
         variant=product_variant,
         channel=channel_USD,
         price_amount=Decimal(10),
+        discounted_price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3138,6 +3138,7 @@ def product_list(
                 channel=channel_USD,
                 cost_price_amount=Decimal(1),
                 price_amount=Decimal(10),
+                discounted_price_amount=Decimal(10),
                 currency=channel_USD.currency_code,
             ),
             ProductVariantChannelListing(
@@ -3145,6 +3146,7 @@ def product_list(
                 channel=channel_USD,
                 cost_price_amount=Decimal(1),
                 price_amount=Decimal(20),
+                discounted_price_amount=Decimal(20),
                 currency=channel_USD.currency_code,
             ),
             ProductVariantChannelListing(
@@ -3152,6 +3154,7 @@ def product_list(
                 channel=channel_USD,
                 cost_price_amount=Decimal(1),
                 price_amount=Decimal(30),
+                discounted_price_amount=Decimal(30),
                 currency=channel_USD.currency_code,
             ),
         ]


### PR DESCRIPTION
Update resolvers to use denormalized `dicounted_price` fields.

The changes are applied in:
- `ProductVariant.pricing`
- `Product.pricing`
- `ProductChannelListing.pricing`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
