### PR TITLE
import: HttpRequest object for type checking

### DIFF
--- a/saleor/core/auth.py
+++ b/saleor/core/auth.py
@@ -1,13 +1,14 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
-from django.http import HttpRequest
+if TYPE_CHECKING:
+    from django.http import HttpRequest
 
 SALEOR_AUTH_HEADER = "HTTP_AUTHORIZATION_BEARER"
 DEFAULT_AUTH_HEADER = "HTTP_AUTHORIZATION"
 AUTH_HEADER_PREFIXES = ["JWT", "BEARER"]
 
 
-def get_token_from_request(request: HttpRequest) -> Optional[str]:
+def get_token_from_request(request: "HttpRequest") -> Optional[str]:
     auth_token: Optional[str] = request.META.get(SALEOR_AUTH_HEADER)
 
     if not auth_token:


### PR DESCRIPTION
I want to merge this change because the `HttpRequest` object is only used for type checking in `auth.py`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
