### PR TITLE
Fix error on shipping zone update mutation when countires are missing

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ The following releases of Saleor are currently supported.
 Please DO NOT report security vulnerabilities using a public GitHub issue. If you believe you've found a security issue, please contact us through one of the following methods:
 - https://github.com/saleor/saleor/security/advisories
 - https://huntr.dev/repos/saleor/saleor
-- Alternavely, through our mailing list: security@saleor.io
+- Alternatively, through our mailing list: security@saleor.io
 
 At this time we do not have a bounty program in place so we are not able to offer monetary rewards for any problems reported.
 You can claim bounty rewards by reporting vulnerabilities using Huntr: https://huntr.dev.

--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -280,7 +280,9 @@ class ShippingZoneMixin:
                 )
             else:
                 countries = get_countries_without_shipping_zone()
-                data["countries"].extend([country for country in countries])
+                data.setdefault("countries", []).extend(
+                    [country for country in countries]
+                )
         else:
             data["default"] = False
         return data

--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -279,10 +279,7 @@ class ShippingZoneMixin:
                     }
                 )
             else:
-                countries = get_countries_without_shipping_zone()
-                data.setdefault("countries", []).extend(
-                    [country for country in countries]
-                )
+                cls._extend_shipping_zone_countries(data)
         else:
             data["default"] = False
         return data
@@ -373,6 +370,14 @@ class ShippingZoneMixin:
         WarehouseShippingZone.objects.filter(
             id__in=shipping_zone_warehouses_to_delete
         ).delete()
+
+    @classmethod
+    def _extend_shipping_zone_countries(cls, data):
+        countries = get_countries_without_shipping_zone()
+        try:
+            data["countries"].extend([country for country in countries])
+        except (KeyError, AttributeError):
+            data["countries"] = [country for country in countries]
 
 
 class ShippingZoneCreate(ShippingZoneMixin, ModelMutation):

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
@@ -2,6 +2,7 @@ import json
 from unittest import mock
 
 import graphene
+import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
@@ -54,6 +55,25 @@ UPDATE_SHIPPING_ZONE_MUTATION = """
                 code
                 warehouses
                 channels
+            }
+        }
+    }
+"""
+
+SHIPPING_ZONE_UPDATE_DEFAULT_TRUE_MUTATION = """
+    mutation ShippingZoneUpdate($id: ID!, $input: ShippingZoneUpdateInput!) {
+        shippingZoneUpdate(id: $id, input: $input) {
+            errors {
+                code
+                field
+                message
+            }
+            shippingZone {
+                id
+                default
+                countries {
+                    code
+                }
             }
         }
     }
@@ -641,3 +661,39 @@ def test_update_shipping_zone_remove_channels_remove_common_warehouse_channel(
     )
     assert len(shipping_zone_data["warehouses"]) == 1
     assert shipping_zone_data["warehouses"][0]["slug"] == warehouses[1].slug
+
+
+@pytest.mark.parametrize(
+    "input, expected_countries",
+    (
+        ({"default": True, "countries": ["PL"]}, [{"code": "PL"}]),
+        ({"default": True, "countries": []}, []),
+        ({"default": True, "countries": None}, []),
+        ({"default": True}, []),
+    ),
+)
+def test_shipping_method_update_countries(
+    staff_api_client,
+    shipping_zone,
+    permission_manage_shipping,
+    input,
+    expected_countries,
+):
+    # given
+    variables = {
+        "id": graphene.Node.to_global_id("ShippingZone", shipping_zone.id),
+        "input": input,
+    }
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_shipping)
+    response = staff_api_client.post_graphql(
+        SHIPPING_ZONE_UPDATE_DEFAULT_TRUE_MUTATION, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["shippingZoneUpdate"]
+    assert data["errors"] == []
+    assert data["shippingZone"]["default"] is True
+    assert data["shippingZone"]["countries"] == expected_countries

--- a/saleor/graphql/shipping/tests/test_shipping_zones_query.py
+++ b/saleor/graphql/shipping/tests/test_shipping_zones_query.py
@@ -49,21 +49,6 @@ SHIPPING_ZONE_QUERY = """
     }
 """
 
-SHIPPING_ZONE_UPDATE_DEFAULT_TRUE_MUTATION = """
-    mutation ShippingZoneUpdate($id: ID!, $input: ShippingZoneUpdateInput!) {
-        shippingZoneUpdate(id: $id, input: $input) {
-            errors {
-                code
-                field
-                message
-            }
-            shippingZone {
-                id
-            }
-        }
-    }
-"""
-
 
 def test_shipping_zone_query(
     staff_api_client, shipping_zone, permission_manage_shipping, channel_USD
@@ -405,26 +390,3 @@ def test_shipping_method_tax_class_query_by_staff(
     content = get_graphql_content(response)
     data = content["data"]
     assert data["shippingZone"]["shippingMethods"][0]["taxClass"]["id"]
-
-
-def test_shipping_method_update_no_countries_in_data(
-    staff_api_client, shipping_zone, permission_manage_shipping
-):
-    # given
-    variables = {
-        "id": graphene.Node.to_global_id(
-            "ShippingMethod", shipping_zone.shipping_methods.first().id
-        ),
-        "input": {"default": True},
-    }
-
-    # when
-    staff_api_client.user.user_permissions.add(permission_manage_shipping)
-    response = staff_api_client.post_graphql(
-        SHIPPING_ZONE_UPDATE_DEFAULT_TRUE_MUTATION, variables
-    )
-
-    # then
-    content = get_graphql_content(response)
-    data = content["data"]
-    assert "errors" not in data


### PR DESCRIPTION
I want to merge this change because this fixes `KeyError` error.

Fixed #12429.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
