### PR TITLE
The Avalara tests should be able to use credentials from env

### DIFF
--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -4166,7 +4166,7 @@ def test_plugin_uses_configuration_from_db(
     settings,
 ):
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
-    configuration = plugin_configuration(username="test", password="test", sandbox=True)
+    configuration = plugin_configuration()
     manager = get_plugins_manager()
 
     monkeypatch.setattr(

--- a/saleor/plugins/avatax/tests/test_tasks.py
+++ b/saleor/plugins/avatax/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import asdict
 from urllib.parse import urljoin
 
@@ -22,8 +23,8 @@ def test_api_post_request_task_sends_request(
     site_settings.company_address = address_usa
     site_settings.save()
     config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
+        username_or_account=os.environ.get("AVALARA_USERNAME", ""),
+        password_or_license=os.environ.get("AVALARA_PASSWORD", ""),
         use_sandbox=True,
         from_street_address="Tęczowa 7",
         from_city="WROCŁAW",
@@ -54,8 +55,8 @@ def test_api_post_request_task_creates_order_event(
     site_settings.save()
 
     config = AvataxConfiguration(
-        username_or_account="",
-        password_or_license="",
+        username_or_account=os.environ.get("AVALARA_USERNAME", ""),
+        password_or_license=os.environ.get("AVALARA_PASSWORD", ""),
         use_sandbox=True,
         from_street_address="Tęczowa 7",
         from_city="WROCŁAW",


### PR DESCRIPTION
I want to merge this change because The Avalara tests should be able to use credentials from env. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
