### PR TITLE
Improve feature_request template to format graphql

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -36,13 +36,13 @@ assignees: ""
 
 ### Mutations
 
-```
+```graphql
 
 ```
 
 ### Types
 
-```
+```graphql
 
 ```
 


### PR DESCRIPTION
I want to merge this change because...

It automatically formats code blocks with mutations and types with graphql syntax