### PR TITLE
Drop duplicsted sale toggle task

### DIFF
--- a/saleor/discount/tasks.py
+++ b/saleor/discount/tasks.py
@@ -18,12 +18,6 @@ task_logger = get_task_logger(__name__)
 
 
 @app.task
-def send_sale_toggle_notifications():
-    # The task is DEPRECATED, should be dropped in version 3.15
-    handle_sale_toggle()
-
-
-@app.task
 def handle_sale_toggle():
     """Send the notification about sales toggle and recalculate discounted prcies.
 


### PR DESCRIPTION
Drop `send_sale_toggle_notifications` task, as both task for the sale toggle will be run in 3.13 (PR https://github.com/saleor/saleor/pull/12805), it can be dropped in 3.14.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
