### PR TITLE
Allow staff user to update transaction assigned to another staff

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1153,12 +1153,14 @@ class TransactionUpdate(TransactionCreate):
     class Meta:
         auto_permission_message = False
         description = (
-            "Create transaction for checkout or order."
+            "Update transaction."
             + ADDED_IN_34
             + PREVIEW_FEATURE
             + "\n\nRequires the following permissions: "
             + f"{AuthorizationFilters.OWNER.name} "
-            + f"and {PaymentPermissions.HANDLE_PAYMENTS.name}."
+            + f"and {PaymentPermissions.HANDLE_PAYMENTS.name} for apps, "
+            f"{PaymentPermissions.HANDLE_PAYMENTS.name} for staff users. "
+            f"Staff user cannot update a transaction that is owned by the app."
         )
         doc_category = DOC_CATEGORY_PAYMENTS
         error_type_class = common_types.TransactionUpdateError
@@ -1505,7 +1507,9 @@ class TransactionEventReport(ModelMutation):
             + PREVIEW_FEATURE
             + "\n\nRequires the following permissions: "
             + f"{AuthorizationFilters.OWNER.name} "
-            + f"and {PaymentPermissions.HANDLE_PAYMENTS.name}."
+            + f"and {PaymentPermissions.HANDLE_PAYMENTS.name} for apps, "
+            f"{PaymentPermissions.HANDLE_PAYMENTS.name} for staff users. "
+            f"Staff user cannot update a transaction that is owned by the app."
         )
         error_type_class = common_types.TransactionEventReportError
         permissions = (PaymentPermissions.HANDLE_PAYMENTS,)

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -209,6 +209,79 @@ def test_transaction_event_report_by_user(
     assert transaction.available_actions == [TransactionActionEnum.CANCEL.value]
 
 
+def test_transaction_event_report_by_another_user(
+    staff_api_client, permission_manage_payments, admin_user, transaction_item_generator
+):
+    # given
+    transaction = transaction_item_generator(user=admin_user)
+    event_time = timezone.now()
+    external_url = f"http://{TEST_SERVER_DOMAIN}/external-url"
+    message = "Sucesfull charge"
+    psp_reference = "111-abc"
+    amount = Decimal("11.00")
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": amount,
+        "pspReference": psp_reference,
+        "time": event_time.isoformat(),
+        "externalUrl": external_url,
+        "message": message,
+        "availableActions": [TransactionActionEnum.CANCEL.name],
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+       mutation TransactionEventReport(
+           $id: ID!
+           $type: TransactionEventTypeEnum!
+           $amount: PositiveDecimal!
+           $pspReference: String!
+           $time: DateTime
+           $externalUrl: String
+           $message: String
+           $availableActions: [TransactionActionEnum!]!
+       ) {
+           transactionEventReport(
+               id: $id
+               type: $type
+               amount: $amount
+               pspReference: $pspReference
+               time: $time
+               externalUrl: $externalUrl
+               message: $message
+               availableActions: $availableActions
+           ) {
+               ...TransactionEventData
+           }
+       }
+       """
+    )
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    get_graphql_content(response)
+    event = TransactionEvent.objects.get()
+    assert event.psp_reference == psp_reference
+    assert event.type == TransactionEventTypeEnum.CHARGE_SUCCESS.value
+    assert event.amount_value == amount
+    assert event.currency == transaction.currency
+    assert event.created_at == event_time
+    assert event.external_url == external_url
+    assert event.transaction == transaction
+    assert event.app_identifier is None
+    assert event.app is None
+    assert transaction.user != staff_api_client.user
+    assert event.user == staff_api_client.user
+
+    transaction.refresh_from_db()
+    assert transaction.available_actions == [TransactionActionEnum.CANCEL.value]
+
+
 def test_transaction_event_report_no_permission(
     transaction_item_created_by_app,
     app_api_client,

--- a/saleor/graphql/payment/utils.py
+++ b/saleor/graphql/payment/utils.py
@@ -26,7 +26,7 @@ def check_if_requestor_has_access(
     ):
         return True
 
-    if user and transaction.user_id == user.id:
+    if user and transaction.user_id:
         return True
 
     if app:

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14234,13 +14234,13 @@ type Mutation {
   ): TransactionCreate @doc(category: "Payments")
 
   """
-  Create transaction for checkout or order.
+  Update transaction.
   
   Added in Saleor 3.4.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires the following permissions: OWNER and HANDLE_PAYMENTS.
+  Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
   """
   transactionUpdate(
     """The ID of the transaction."""
@@ -14282,7 +14282,7 @@ type Mutation {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires the following permissions: OWNER and HANDLE_PAYMENTS.
+  Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
   """
   transactionEventReport(
     """The amount of the event to report."""
@@ -20915,13 +20915,13 @@ input TransactionEventInput @doc(category: "Payments") {
 }
 
 """
-Create transaction for checkout or order.
+Update transaction.
 
 Added in Saleor 3.4.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
-Requires the following permissions: OWNER and HANDLE_PAYMENTS.
+Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
 """
 type TransactionUpdate @doc(category: "Payments") {
   transaction: TransactionItem
@@ -21076,7 +21076,7 @@ Added in Saleor 3.13.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
-Requires the following permissions: OWNER and HANDLE_PAYMENTS.
+Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
 """
 type TransactionEventReport @doc(category: "Payments") {
   """Defines if the reported event hasn't been processed earlier."""


### PR DESCRIPTION
I want to merge this change because it solves https://github.com/saleor/saleor/issues/12835

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
