### PR TITLE
Allow staff user to update transaction assigned to another staff

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1145,12 +1145,14 @@ class TransactionUpdate(TransactionCreate):
     class Meta:
         auto_permission_message = False
         description = (
-            "Create transaction for checkout or order."
+            "Update transaction."
             + ADDED_IN_34
             + PREVIEW_FEATURE
             + "\n\nRequires the following permissions: "
             + f"{AuthorizationFilters.OWNER.name} "
-            + f"and {PaymentPermissions.HANDLE_PAYMENTS.name}."
+            + f"and {PaymentPermissions.HANDLE_PAYMENTS.name} for apps, "
+            f"{PaymentPermissions.HANDLE_PAYMENTS.name} for staff users. "
+            f"Staff user cannot update a transaction that is owned by the app."
         )
         doc_category = DOC_CATEGORY_PAYMENTS
         error_type_class = common_types.TransactionUpdateError
@@ -1494,7 +1496,9 @@ class TransactionEventReport(ModelMutation):
             + PREVIEW_FEATURE
             + "\n\nRequires the following permissions: "
             + f"{AuthorizationFilters.OWNER.name} "
-            + f"and {PaymentPermissions.HANDLE_PAYMENTS.name}."
+            + f"and {PaymentPermissions.HANDLE_PAYMENTS.name} for apps, "
+            f"{PaymentPermissions.HANDLE_PAYMENTS.name} for staff users. "
+            f"Staff user cannot update a transaction that is owned by the app."
         )
         error_type_class = common_types.TransactionEventReportError
         permissions = (PaymentPermissions.HANDLE_PAYMENTS,)

--- a/saleor/graphql/payment/utils.py
+++ b/saleor/graphql/payment/utils.py
@@ -26,7 +26,7 @@ def check_if_requestor_has_access(
     ):
         return True
 
-    if user and transaction.user_id == user.id:
+    if user and transaction.user_id:
         return True
 
     if app:

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14127,13 +14127,13 @@ type Mutation {
   ): TransactionCreate @doc(category: "Payments")
 
   """
-  Create transaction for checkout or order.
+  Update transaction.
   
   Added in Saleor 3.4.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires the following permissions: OWNER and HANDLE_PAYMENTS.
+  Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
   """
   transactionUpdate(
     """The ID of the transaction."""
@@ -14175,7 +14175,7 @@ type Mutation {
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
-  Requires the following permissions: OWNER and HANDLE_PAYMENTS.
+  Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
   """
   transactionEventReport(
     """The amount of the event to report."""
@@ -20782,13 +20782,13 @@ input TransactionEventInput @doc(category: "Payments") {
 }
 
 """
-Create transaction for checkout or order.
+Update transaction.
 
 Added in Saleor 3.4.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
-Requires the following permissions: OWNER and HANDLE_PAYMENTS.
+Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
 """
 type TransactionUpdate @doc(category: "Payments") {
   transaction: TransactionItem
@@ -20943,7 +20943,7 @@ Added in Saleor 3.13.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 
-Requires the following permissions: OWNER and HANDLE_PAYMENTS.
+Requires the following permissions: OWNER and HANDLE_PAYMENTS for apps, HANDLE_PAYMENTS for staff users. Staff user cannot update a transaction that is owned by the app.
 """
 type TransactionEventReport @doc(category: "Payments") {
   """Defines if the reported event hasn't been processed earlier."""


### PR DESCRIPTION
I want to merge this change because it is port of changes: #12836

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
