### PR TITLE
Prevent crashing `CreateOrderFromCehckout` when the line is deleted in the meantime

### DIFF
--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -143,7 +143,6 @@ class OrderCreateFromCheckout(BaseMutation):
         try:
             order = create_order_from_checkout(
                 checkout_info=checkout_info,
-                checkout_lines=checkout_lines,
                 discounts=discounts,
                 manager=manager,
                 user=user,


### PR DESCRIPTION
Apply the fix https://github.com/saleor/saleor/pull/12734 als on  `create_order_from_checkout` method

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
