### PR TITLE
Set missing transaction fields when calling orderMarkAsPaid

### DIFF
--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -19,6 +19,7 @@ from ..payment import (
     ChargeStatus,
     CustomPaymentChoices,
     PaymentError,
+    TransactionAction,
     TransactionKind,
     gateway,
 )
@@ -78,6 +79,7 @@ logger = logging.getLogger(__name__)
 
 OrderLineIDType = UUID
 QuantityType = int
+MARK_AS_PAID_TRANSACTION_NAME = "Mark-as-paid transaction"
 
 
 class OrderFulfillmentLineInfo(TypedDict):
@@ -603,6 +605,8 @@ def mark_order_as_paid_with_transaction(
             app=app,
             psp_reference=external_reference,
             charged_value=order.total.gross.amount,
+            available_actions=[TransactionAction.REFUND],
+            name=MARK_AS_PAID_TRANSACTION_NAME,
         )
         updates_amounts_for_order(order)
         events.order_manually_marked_as_paid_event(

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1339,8 +1339,11 @@ def create_transaction_item(
     user: Optional[User],
     app: Optional[App],
     psp_reference: Optional[str],
+    available_actions: Optional[list[str]] = None,
+    name: str = "",
 ):
     return TransactionItem.objects.create(
+        name=name,
         checkout_id=source_object.pk if isinstance(source_object, Checkout) else None,
         order_id=source_object.pk if isinstance(source_object, Order) else None,
         currency=source_object.currency,
@@ -1348,6 +1351,7 @@ def create_transaction_item(
         app_identifier=app.identifier if app else None,
         user=user,
         psp_reference=psp_reference,
+        available_actions=available_actions if available_actions else [],
     )
 
 
@@ -1357,9 +1361,16 @@ def create_transaction_for_order(
     app: Optional["App"],
     psp_reference: Optional[str],
     charged_value: Decimal,
+    available_actions: Optional[list[str]] = None,
+    name: str = "",
 ) -> TransactionItem:
     transaction = create_transaction_item(
-        source_object=order, user=user, app=app, psp_reference=psp_reference
+        source_object=order,
+        user=user,
+        app=app,
+        psp_reference=psp_reference,
+        available_actions=available_actions,
+        name=name,
     )
     create_manual_adjustment_events(
         transaction=transaction,


### PR DESCRIPTION
I want to merge this change because it fixes https://github.com/saleor/saleor/issues/12847

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
