### PR TITLE
Assign app and user to transactionEvent request

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1361,12 +1361,17 @@ class TransactionRequestAction(BaseMutation):
 
     @classmethod
     def handle_transaction_action(
-        cls, action, action_kwargs, action_value: Optional[Decimal]
+        cls,
+        action,
+        action_kwargs,
+        action_value: Optional[Decimal],
+        user: Optional["User"],
+        app: Optional[App],
     ):
         if action == TransactionAction.VOID or action == TransactionAction.CANCEL:
             transaction = action_kwargs["transaction"]
             request_event = cls.create_transaction_event_requested(
-                transaction, 0, action
+                transaction, 0, action, user=user, app=app
             )
             request_cancelation_action(
                 **action_kwargs,
@@ -1379,7 +1384,7 @@ class TransactionRequestAction(BaseMutation):
             action_value = action_value or transaction.authorized_value
             action_value = min(action_value, transaction.authorized_value)
             request_event = cls.create_transaction_event_requested(
-                transaction, action_value, TransactionAction.CHARGE
+                transaction, action_value, TransactionAction.CHARGE, user=user, app=app
             )
             request_charge_action(
                 **action_kwargs, charge_value=action_value, request_event=request_event
@@ -1389,14 +1394,16 @@ class TransactionRequestAction(BaseMutation):
             action_value = action_value or transaction.charged_value
             action_value = min(action_value, transaction.charged_value)
             request_event = cls.create_transaction_event_requested(
-                transaction, action_value, TransactionAction.REFUND
+                transaction, action_value, TransactionAction.REFUND, user=user, app=app
             )
             request_refund_action(
                 **action_kwargs, refund_value=action_value, request_event=request_event
             )
 
     @classmethod
-    def create_transaction_event_requested(cls, transaction, action_value, action):
+    def create_transaction_event_requested(
+        cls, transaction, action_value, action, user=None, app=None
+    ):
         if action in (TransactionAction.CANCEL, TransactionAction.VOID):
             type = TransactionEventType.CANCEL_REQUEST
         elif action == TransactionAction.CHARGE:
@@ -1416,6 +1423,9 @@ class TransactionRequestAction(BaseMutation):
             amount_value=action_value,
             currency=transaction.currency,
             type=type,
+            user=user,
+            app=app,
+            app_identifier=app.identifier if app else None,
         )
 
     @classmethod
@@ -1432,18 +1442,21 @@ class TransactionRequestAction(BaseMutation):
             channel = checkout.channel
         cls.check_channel_permissions(info, [channel.id])
         channel_slug = channel.slug
+        user = info.context.user
         app = get_app_promise(info.context).get()
         manager = get_plugin_manager_promise(info.context).get()
         action_kwargs = {
             "channel_slug": channel_slug,
-            "user": info.context.user,
+            "user": user,
             "app": app,
             "transaction": transaction,
             "manager": manager,
         }
 
         try:
-            cls.handle_transaction_action(action_type, action_kwargs, action_value)
+            cls.handle_transaction_action(
+                action_type, action_kwargs, action_value, user, app
+            )
         except PaymentError as e:
             error_enum = TransactionRequestActionErrorCode
             code = error_enum.MISSING_TRANSACTION_ACTION_REQUEST_WEBHOOK.value

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -5075,6 +5075,17 @@ def permission_group_manage_apps(permission_manage_apps, staff_users):
 
 
 @pytest.fixture
+def permission_group_handle_payments(permission_manage_payments, staff_users):
+    group = Group.objects.create(
+        name="Manage apps group.", restricted_access_to_channels=False
+    )
+    group.permissions.add(permission_manage_payments)
+
+    group.user_set.add(staff_users[1])
+    return group
+
+
+@pytest.fixture
 def permission_group_all_perms_all_channels(
     permission_manage_users, staff_users, channel_USD, channel_PLN
 ):


### PR DESCRIPTION
I want to merge this change because it covers the issue with missing `user` and `app` assigned to `TransactionEvent` when calling `transactionRequestAction` mutation
Reported here: https://github.com/saleor/saleor/issues/12787#issuecomment-1553087106

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
