### PR TITLE
Set missing transaction fields when calling orderMarkAsPaid

### DIFF
--- a/saleor/graphql/order/tests/mutations/test_order_mark_as_paid.py
+++ b/saleor/graphql/order/tests/mutations/test_order_mark_as_paid.py
@@ -5,8 +5,9 @@ from prices import Money, TaxedMoney
 from .....channel import MarkAsPaidStrategy
 from .....order import OrderStatus
 from .....order import events as order_events
+from .....order.actions import MARK_AS_PAID_TRANSACTION_NAME
 from .....order.error_codes import OrderErrorCode
-from .....payment import TransactionEventType
+from .....payment import TransactionAction, TransactionEventType
 from ....tests.utils import get_graphql_content
 
 MUTATION_MARK_ORDER_AS_PAID = """
@@ -25,6 +26,10 @@ MUTATION_MARK_ORDER_AS_PAID = """
                 isPaid
                 events{
                     transactionReference
+                }
+                transactions{
+                    name
+                    actions
                 }
             }
         }
@@ -331,3 +336,73 @@ def test_draft_order_mark_as_paid_check_price_recalculation_transaction(
     event_order_paid = order.events.first()
     assert event_order_paid.type == order_events.OrderEvents.ORDER_MARKED_AS_PAID
     assert event_order_paid.user == staff_user
+
+
+def test_order_mark_as_paid_with_with_transaction_sets_available_actions(
+    staff_api_client, permission_manage_orders, order_with_lines, staff_user
+):
+    # given
+    order = order_with_lines
+    channel = order.channel
+    channel.order_mark_as_paid_strategy = MarkAsPaidStrategy.TRANSACTION_FLOW
+    channel.save(update_fields=["order_mark_as_paid_strategy"])
+
+    transaction_reference = "searchable-id"
+    query = MUTATION_MARK_ORDER_AS_PAID
+    assert not order.is_fully_paid()
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id, "transaction": transaction_reference}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    data = content["data"]["orderMarkAsPaid"]["order"]
+    order.refresh_from_db()
+    transactions = order.payment_transactions.filter(
+        psp_reference=transaction_reference
+    )
+    assert transactions.count() == 1
+    transaction = transactions.first()
+    assert transaction.available_actions == [TransactionAction.REFUND]
+    assert len(data["transactions"]) == 1
+    assert data["transactions"][0]["actions"] == [TransactionAction.REFUND.upper()]
+
+
+def test_order_mark_as_paid_with_with_transaction_sets_name(
+    staff_api_client, permission_manage_orders, order_with_lines, staff_user
+):
+    # given
+    order = order_with_lines
+    channel = order.channel
+    channel.order_mark_as_paid_strategy = MarkAsPaidStrategy.TRANSACTION_FLOW
+    channel.save(update_fields=["order_mark_as_paid_strategy"])
+
+    transaction_reference = "searchable-id"
+    query = MUTATION_MARK_ORDER_AS_PAID
+    assert not order.is_fully_paid()
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id, "transaction": transaction_reference}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    data = content["data"]["orderMarkAsPaid"]["order"]
+    order.refresh_from_db()
+    transactions = order.payment_transactions.filter(
+        psp_reference=transaction_reference
+    )
+    assert transactions.count() == 1
+    transaction = transactions.first()
+    assert transaction.name == MARK_AS_PAID_TRANSACTION_NAME
+    assert len(data["transactions"]) == 1
+    assert data["transactions"][0]["name"] == MARK_AS_PAID_TRANSACTION_NAME

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -19,6 +19,7 @@ from ..payment import (
     ChargeStatus,
     CustomPaymentChoices,
     PaymentError,
+    TransactionAction,
     TransactionKind,
     gateway,
 )
@@ -78,6 +79,7 @@ logger = logging.getLogger(__name__)
 
 OrderLineIDType = UUID
 QuantityType = int
+MARK_AS_PAID_TRANSACTION_NAME = "Mark-as-paid transaction"
 
 
 class OrderFulfillmentLineInfo(TypedDict):
@@ -552,6 +554,8 @@ def mark_order_as_paid_with_transaction(
             app=app,
             psp_reference=external_reference,
             charged_value=order.total.gross.amount,
+            available_actions=[TransactionAction.REFUND],
+            name=MARK_AS_PAID_TRANSACTION_NAME,
         )
         updates_amounts_for_order(order)
         events.order_manually_marked_as_paid_event(

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1344,8 +1344,11 @@ def create_transaction_item(
     user: Optional[User],
     app: Optional[App],
     psp_reference: Optional[str],
+    available_actions: Optional[list[str]] = None,
+    name: str = "",
 ):
     return TransactionItem.objects.create(
+        name=name,
         checkout_id=source_object.pk if isinstance(source_object, Checkout) else None,
         order_id=source_object.pk if isinstance(source_object, Order) else None,
         currency=source_object.currency,
@@ -1353,6 +1356,7 @@ def create_transaction_item(
         app_identifier=app.identifier if app else None,
         user=user,
         psp_reference=psp_reference,
+        available_actions=available_actions if available_actions else [],
     )
 
 
@@ -1362,9 +1366,16 @@ def create_transaction_for_order(
     app: Optional["App"],
     psp_reference: Optional[str],
     charged_value: Decimal,
+    available_actions: Optional[list[str]] = None,
+    name: str = "",
 ) -> TransactionItem:
     transaction = create_transaction_item(
-        source_object=order, user=user, app=app, psp_reference=psp_reference
+        source_object=order,
+        user=user,
+        app=app,
+        psp_reference=psp_reference,
+        available_actions=available_actions,
+        name=name,
     )
     create_manual_adjustment_events(
         transaction=transaction,


### PR DESCRIPTION
I want to merge this change because it is port of changes for #12848

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
