### PR TITLE
utilised django method to compare csrf tokens

### DIFF
--- a/saleor/graphql/account/mutations/authentication.py
+++ b/saleor/graphql/account/mutations/authentication.py
@@ -4,9 +4,9 @@ import graphene
 import jwt
 from django.core.exceptions import ValidationError
 from django.middleware.csrf import (  # type: ignore
+    _compare_masked_tokens,
     _get_new_csrf_string,
     _mask_cipher_secret,
-    _compare_masked_tokens,
 )
 from django.utils import timezone
 from django.utils.crypto import get_random_string

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -12,6 +12,7 @@ from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.db.models import QuerySet
+from django.middleware.csrf import _compare_masked_tokens
 from django.utils.timezone import make_aware
 from jwt import PyJWTError
 
@@ -26,10 +27,7 @@ from ...core.jwt import (
     jwt_encode,
     jwt_user_payload,
 )
-from ...graphql.account.mutations.authentication import (
-    _does_token_match,
-    _get_new_csrf_token,
-)
+from ...graphql.account.mutations.authentication import _get_new_csrf_token
 from ...permission.enums import get_permission_names, get_permissions_from_codenames
 from ...permission.models import Permission
 from ..error_codes import PluginErrorCode
@@ -553,7 +551,7 @@ def validate_refresh_token(refresh_token, data):
                     )
                 }
             )
-        is_valid = _does_token_match(csrf_token, refresh_payload[CSRF_FIELD])
+        is_valid = _compare_masked_tokens(csrf_token, refresh_payload[CSRF_FIELD])
         if not is_valid:
             raise ValidationError(
                 {


### PR DESCRIPTION
I want to merge this change because django has a `_compare_masked_tokens` method.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
