### PR TITLE
Extend orderGrantRefundCreate mutation to accept lines

### DIFF
--- a/saleor/graphql/order/enums.py
+++ b/saleor/graphql/order/enums.py
@@ -60,6 +60,10 @@ OrderChargeStatusEnum.doc_category = DOC_CATEGORY_ORDERS
 OrderGrantRefundCreateErrorCode = graphene.Enum.from_enum(
     error_codes.OrderGrantRefundCreateErrorCode
 )
+OrderGrantRefundCreateLineErrorCode = graphene.Enum.from_enum(
+    error_codes.OrderGrantRefundCreateLineErrorCode
+)
+
 OrderGrantRefundCreateErrorCode.doc_category = DOC_CATEGORY_ORDERS
 
 OrderGrantRefundUpdateErrorCode = graphene.Enum.from_enum(

--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -1,27 +1,79 @@
-import graphene
+import decimal
+import uuid
+from collections import defaultdict
+from typing import Any, Optional, Union, cast
 
+import graphene
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from graphql import GraphQLError
+
+from ....order import models
 from ....permission.enums import OrderPermissions
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_313, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_313, ADDED_IN_314, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.scalars import Decimal
 from ...core.types import BaseInputObjectType
-from ...core.types.common import Error
-from ..enums import OrderGrantRefundCreateErrorCode
+from ...core.types.common import Error, NonNullList
+from ...core.utils import from_global_id_or_error
+from ..enums import OrderGrantRefundCreateErrorCode, OrderGrantRefundCreateLineErrorCode
 from ..types import Order, OrderGrantedRefund
+
+
+class OrderGrantRefundCreateLineError(Error):
+    code = OrderGrantRefundCreateLineErrorCode(
+        description="The error code.", required=True
+    )
+    order_line_id = graphene.ID(
+        description="The ID of the line related to the error.", required=True
+    )
 
 
 class OrderGrantRefundCreateError(Error):
     code = OrderGrantRefundCreateErrorCode(description="The error code.", required=True)
+    lines = NonNullList(
+        OrderGrantRefundCreateLineError,
+        description="List of lines which cause the error.",
+        required=False,
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_ORDERS
+
+
+class OrderGrantRefundOrderLineInput(BaseInputObjectType):
+    order_line_id = graphene.ID(description="The ID of the order line.", required=True)
+    quantity = graphene.Int(
+        description="The quantity of line items to be marked to refund.", required=True
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS
 
 
 class OrderGrantRefundCreateInput(BaseInputObjectType):
-    amount = Decimal(required=True, description="Amount of the granted refund.")
+    amount = Decimal(
+        description=(
+            "Amount of the granted refund. If not provided, the amount will be "
+            "calculated automatically based on provided `lines` and "
+            "`grantRefundForShipping`."
+        )
+    )
     reason = graphene.String(description="Reason of the granted refund.")
+    lines = NonNullList(
+        OrderGrantRefundOrderLineInput,
+        description="Lines to assing to granted refund."
+        + ADDED_IN_314
+        + PREVIEW_FEATURE,
+        required=False,
+    )
+    grant_refund_for_shipping = graphene.Boolean(
+        description="Determine if granted refund should include shipping costs."
+        + ADDED_IN_314
+        + PREVIEW_FEATURE
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS
@@ -51,17 +103,199 @@ class OrderGrantRefundCreate(BaseMutation):
         doc_category = DOC_CATEGORY_ORDERS
 
     @classmethod
+    def clean_input_lines(
+        cls, order: models.Order, lines: list[dict[str, Union[str, int]]]
+    ) -> tuple[
+        Optional[list[tuple[models.OrderLine, int]]], Optional[list[dict[str, str]]]
+    ]:
+        errors = []
+        input_lines_data = {}
+        for line in lines:
+            order_line_id = cast(str, line["order_line_id"])
+            try:
+                _, pk = from_global_id_or_error(order_line_id, only_type="OrderLine")
+                input_lines_data[pk] = int(line["quantity"])
+            except GraphQLError as e:
+                errors.append(
+                    {
+                        "order_line_id": line["order_line_id"],
+                        "field": "orderLineId",
+                        "code": OrderGrantRefundCreateLineErrorCode.GRAPHQL_ERROR.value,
+                        "message": str(e),
+                    }
+                )
+
+        input_line_ids = list(input_lines_data.keys())
+        lines = order.lines.filter(id__in=input_line_ids)
+        lines_dict = {line.pk: line for line in lines}
+        if len(lines_dict.keys()) != len(input_line_ids):
+            invalid_ids = set(input_line_ids).difference(set(lines_dict.keys()))
+            for invalid_id in invalid_ids:
+                errors.append(
+                    {
+                        "order_line_id": graphene.Node.to_global_id(
+                            "OrderLine", invalid_id
+                        ),
+                        "field": "orderLineId",
+                        "message": "Could not resolve to a line.",
+                        "code": OrderGrantRefundCreateLineErrorCode.NOT_FOUND.value,
+                    }
+                )
+        all_granted_refund_ids = order.granted_refunds.all().values_list(
+            "id", flat=True
+        )
+        all_granted_refund_lines = models.OrderGrantedRefundLine.objects.filter(
+            granted_refund_id__in=all_granted_refund_ids
+        )
+        lines_with_quantity_already_refunded: dict[uuid.UUID, int] = defaultdict(int)
+        for line in all_granted_refund_lines:
+            lines_with_quantity_already_refunded[line.order_line_id] += line.quantity
+
+        for line in lines_dict.values():
+            quantity_already_refunded = lines_with_quantity_already_refunded[line.pk]
+            if (
+                input_lines_data[str(line.pk)] + quantity_already_refunded
+                > line.quantity
+            ):
+                error_code_class = OrderGrantRefundCreateLineErrorCode
+
+                errors.append(
+                    {
+                        "order_line_id": graphene.Node.to_global_id(
+                            "OrderLine", line.pk
+                        ),
+                        "field": "quantity",
+                        "message": (
+                            "Cannot grant refund for more than the available quantity "
+                            f"of the line ({line.quantity-quantity_already_refunded})."
+                        ),
+                        "code": error_code_class.QUANTITY_GREATER_THAN_AVAILABLE.value,
+                    }
+                )
+
+        if errors:
+            return None, errors
+
+        return [
+            (line, input_lines_data[str(line.pk)]) for line in lines_dict.values()
+        ], None
+
+    @classmethod
+    def shipping_costs_already_granted(cls, order: models.Order):
+        if order.granted_refunds.filter(shipping_costs_included=True):
+            return True
+        return False
+
+    @classmethod
+    def calculate_amount(
+        cls,
+        order: models.Order,
+        cleaned_input_lines: list[tuple[models.OrderLine, int]],
+        grant_refund_for_shipping: bool,
+    ) -> decimal.Decimal:
+        amount = decimal.Decimal(0)
+        for line, quantity in cleaned_input_lines:
+            amount += line.unit_price_gross_amount * quantity
+        if grant_refund_for_shipping:
+            amount += order.shipping_price_gross_amount
+        return amount
+
+    @classmethod
+    def clean_input(cls, order: models.Order, input: dict[str, Any]):
+        amount = input.get("amount")
+        reason = input.get("reason", "")
+        input_lines = input.get("lines", [])
+        grant_refund_for_shipping = input.get("grant_refund_for_shipping", False)
+
+        if amount is None and not input_lines and not grant_refund_for_shipping:
+            error_msg = (
+                "You must provide at least one of `amount`, `lines`, "
+                "`grantRefundForShipping`."
+            )
+            raise ValidationError(
+                {
+                    "amount": ValidationError(
+                        error_msg,
+                        code=OrderGrantRefundCreateErrorCode.REQUIRED.value,
+                    ),
+                    "lines": ValidationError(
+                        error_msg,
+                        code=OrderGrantRefundCreateErrorCode.REQUIRED.value,
+                    ),
+                    "grant_refund_for_shipping": ValidationError(
+                        error_msg,
+                        code=OrderGrantRefundCreateErrorCode.REQUIRED.value,
+                    ),
+                }
+            )
+        cleaned_input_lines: Optional[list[tuple[models.OrderLine, int]]] = []
+        if input_lines:
+            cleaned_input_lines, errors = cls.clean_input_lines(order, input_lines)
+            if errors:
+                raise ValidationError(
+                    {
+                        "lines": ValidationError(
+                            "Provided input for lines is invalid.",
+                            code=OrderGrantRefundCreateErrorCode.INVALID.value,
+                            params={"lines": errors},
+                        ),
+                    }
+                )
+        if grant_refund_for_shipping and cls.shipping_costs_already_granted(order):
+            error_code = OrderGrantRefundCreateErrorCode.SHIPPING_COSTS_ALREADY_GRANTED
+            raise ValidationError(
+                {
+                    "grant_refund_for_shipping": ValidationError(
+                        "Shipping costs have already been granted.",
+                        code=error_code.value,
+                    )
+                }
+            )
+
+        if amount is None:
+            cleaned_input_lines = cast(
+                list[tuple[models.OrderLine, int]], cleaned_input_lines
+            )
+            amount = cls.calculate_amount(
+                order, cleaned_input_lines, grant_refund_for_shipping
+            )
+
+        return {
+            "amount": amount,
+            "reason": reason,
+            "lines": cleaned_input_lines,
+            "grant_refund_for_shipping": grant_refund_for_shipping,
+        }
+
+    @classmethod
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, id, input
     ):
         order = cls.get_node_or_error(info, id, only_type=Order)
-        amount = input["amount"]
-        reason = input.get("reason", "")
-        granted_refund = order.granted_refunds.create(
-            amount_value=amount,
-            currency=order.currency,
-            reason=reason,
-            user=info.context.user,
-            app=info.context.app,
-        )
+        cleaned_input = cls.clean_input(order, input)
+        amount = cleaned_input["amount"]
+        reason = cleaned_input["reason"]
+        cleaned_input_lines = cleaned_input["lines"]
+        grant_refund_for_shipping = cleaned_input["grant_refund_for_shipping"]
+
+        with transaction.atomic():
+            granted_refund = order.granted_refunds.create(
+                amount_value=amount,
+                currency=order.currency,
+                reason=reason,
+                user=info.context.user,
+                app=info.context.app,
+                shipping_costs_included=grant_refund_for_shipping,
+            )
+            if cleaned_input_lines:
+                models.OrderGrantedRefundLine.objects.bulk_create(
+                    [
+                        models.OrderGrantedRefundLine(
+                            order_line=line,
+                            quantity=quantity,
+                            granted_refund=granted_refund,
+                        )
+                        for line, quantity in cleaned_input_lines
+                    ]
+                )
         return cls(order=order, granted_refund=granted_refund)

--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -35,7 +35,7 @@ class OrderGrantRefundCreateError(Error):
     code = OrderGrantRefundCreateErrorCode(description="The error code.", required=True)
     lines = NonNullList(
         OrderGrantRefundCreateLineError,
-        description="List of lines which cause the error.",
+        description="List of lines which cause the error." + ADDED_IN_314,
         required=False,
     )
 
@@ -64,15 +64,13 @@ class OrderGrantRefundCreateInput(BaseInputObjectType):
     reason = graphene.String(description="Reason of the granted refund.")
     lines = NonNullList(
         OrderGrantRefundOrderLineInput,
-        description="Lines to assing to granted refund."
-        + ADDED_IN_314
-        + PREVIEW_FEATURE,
+        description="Lines to assign to granted refund." + ADDED_IN_314,
         required=False,
     )
     grant_refund_for_shipping = graphene.Boolean(
         description="Determine if granted refund should include shipping costs."
-        + ADDED_IN_314
-        + PREVIEW_FEATURE
+        + ADDED_IN_314,
+        required=False,
     )
 
     class Meta:

--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -43,7 +43,7 @@ class OrderGrantRefundCreateError(Error):
         doc_category = DOC_CATEGORY_ORDERS
 
 
-class OrderGrantRefundOrderLineInput(BaseInputObjectType):
+class OrderGrantRefundCreateLineInput(BaseInputObjectType):
     order_line_id = graphene.ID(description="The ID of the order line.", required=True)
     quantity = graphene.Int(
         description="The quantity of line items to be marked to refund.", required=True
@@ -63,7 +63,7 @@ class OrderGrantRefundCreateInput(BaseInputObjectType):
     )
     reason = graphene.String(description="Reason of the granted refund.")
     lines = NonNullList(
-        OrderGrantRefundOrderLineInput,
+        OrderGrantRefundCreateLineInput,
         description="Lines to assign to granted refund." + ADDED_IN_314,
         required=False,
     )

--- a/saleor/graphql/order/tests/mutations/test_order_grant_refund_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_grant_refund_create.py
@@ -1,8 +1,13 @@
 from decimal import Decimal
 
+from saleor.core.prices import quantize_price
+
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
-from ...enums import OrderGrantRefundCreateErrorCode
+from ...enums import (
+    OrderGrantRefundCreateErrorCode,
+    OrderGrantRefundCreateLineErrorCode,
+)
 
 ORDER_GRANT_REFUND_CREATE = """
 mutation OrderGrantRefundCreate(
@@ -23,6 +28,14 @@ mutation OrderGrantRefundCreate(
       app{
         id
       }
+      shippingCostsIncluded
+      lines{
+        id
+        orderLine{
+          id
+        }
+        quantity
+      }
     }
     order{
       id
@@ -40,11 +53,25 @@ mutation OrderGrantRefundCreate(
         user{
           id
         }
+        shippingCostsIncluded
+        lines{
+          id
+          orderLine{
+            id
+          }
+          quantity
+        }
       }
     }
     errors{
       field
       code
+      lines{
+        field
+        code
+        orderLineId
+        message
+      }
     }
   }
 }
@@ -189,3 +216,443 @@ def test_grant_refund_incorrect_order_id(staff_api_client, permission_manage_ord
     assert len(errors) == 1
     assert errors[0]["field"] == "id"
     assert errors[0]["code"] == OrderGrantRefundCreateErrorCode.GRAPHQL_ERROR.name
+
+
+def test_grant_refund_with_only_include_grant_refund_for_shipping(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order_id = to_global_id_or_none(order_with_lines)
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {"grantRefundForShipping": True},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert not errors
+
+    assert order_id == data["order"]["id"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+    granted_refund_from_db = order_with_lines.granted_refunds.first()
+    order_granted_refund = data["order"]["grantedRefunds"][0]
+    assert (
+        granted_refund_from_db.shipping_costs_included
+        == order_granted_refund["shippingCostsIncluded"]
+        is True
+    )
+    assert data["grantedRefund"]["shippingCostsIncluded"] is True
+
+
+def test_grant_refund_with_only_lines(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}]
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert not errors
+
+    assert order_id == data["order"]["id"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+
+    granted_refund_from_db = order.granted_refunds.first()
+    order_granted_refund = data["order"]["grantedRefunds"][0]
+    assert data["grantedRefund"]["shippingCostsIncluded"] is False
+    assert len(order_granted_refund["lines"]) == 1
+    assert order_granted_refund["lines"][0]["quantity"] == 1
+    assert order_granted_refund["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        first_line
+    )
+    assert granted_refund_from_db.amount_value == first_line.unit_price_gross_amount * 1
+    assert quantize_price(
+        granted_refund_from_db.amount_value, order.currency
+    ) == quantize_price(
+        Decimal(order_granted_refund["amount"]["amount"]), order.currency
+    )
+
+
+def test_grant_refund_with_include_grant_refund_for_shipping_and_lines(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "grantRefundForShipping": True,
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert not errors
+
+    assert order_id == data["order"]["id"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+    granted_refund_from_db = order.granted_refunds.first()
+    order_granted_refund = data["order"]["grantedRefunds"][0]
+    assert (
+        granted_refund_from_db.shipping_costs_included
+        == order_granted_refund["shippingCostsIncluded"]
+        is True
+    )
+    assert data["grantedRefund"]["shippingCostsIncluded"] is True
+    assert len(order_granted_refund["lines"]) == 1
+    assert order_granted_refund["lines"][0]["quantity"] == 1
+    assert order_granted_refund["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        first_line
+    )
+    assert granted_refund_from_db.amount_value == (
+        first_line.unit_price_gross_amount * 1 + order.shipping_price_gross_amount
+    )
+    assert quantize_price(
+        granted_refund_from_db.amount_value, order.currency
+    ) == quantize_price(
+        Decimal(order_granted_refund["amount"]["amount"]), order.currency
+    )
+
+
+def test_grant_refund_with_provided_lines_shipping_and_amount(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    expected_amount = Decimal("10.0")
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "grantRefundForShipping": True,
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}],
+            "amount": expected_amount,
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert not errors
+
+    assert order_id == data["order"]["id"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+    granted_refund_from_db = order.granted_refunds.first()
+    order_granted_refund = data["order"]["grantedRefunds"][0]
+    assert (
+        granted_refund_from_db.shipping_costs_included
+        == order_granted_refund["shippingCostsIncluded"]
+        is True
+    )
+    assert data["grantedRefund"]["shippingCostsIncluded"] is True
+    assert len(order_granted_refund["lines"]) == 1
+    assert order_granted_refund["lines"][0]["quantity"] == 1
+    assert order_granted_refund["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        first_line
+    )
+    assert granted_refund_from_db.amount_value == expected_amount
+    assert quantize_price(
+        granted_refund_from_db.amount_value, order.currency
+    ) == quantize_price(
+        Decimal(order_granted_refund["amount"]["amount"]), order.currency
+    )
+
+
+def test_grant_refund_without_lines_and_amount_and_grant_for_shipping(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "reason": "Reason",
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 3
+    assert set([error["field"] for error in errors]) == {
+        "amount",
+        "lines",
+        "grantRefundForShipping",
+    }
+    assert set([error["code"] for error in errors]) == {"REQUIRED"}
+
+
+def test_grant_refund_with_incorrect_line_id(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "lines": [{"orderLineId": "incorrect_id", "quantity": 1}],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "lines"
+    assert error["code"] == OrderGrantRefundCreateErrorCode.INVALID.name
+    assert len(error["lines"]) == 1
+    line = error["lines"][0]
+    assert line["orderLineId"] == "incorrect_id"
+    assert line["field"] == "orderLineId"
+    assert line["code"] == OrderGrantRefundCreateLineErrorCode.GRAPHQL_ERROR.name
+
+
+def test_grant_refund_with_line_that_belongs_to_another_order(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    order_with_lines_for_cc,
+):
+    # given
+    order = order_with_lines
+    another_order = order_with_lines_for_cc
+    another_order_id = to_global_id_or_none(another_order)
+    first_line = order.lines.first()
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": another_order_id,
+        "input": {
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "lines"
+    assert error["code"] == OrderGrantRefundCreateErrorCode.INVALID.name
+    assert len(error["lines"]) == 1
+    line = error["lines"][0]
+    assert line["orderLineId"] == to_global_id_or_none(first_line)
+    assert line["field"] == "orderLineId"
+    assert line["code"] == OrderGrantRefundCreateLineErrorCode.NOT_FOUND.name
+
+
+def test_grant_refund_with_bigger_quantity_than_available(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "lines": [
+                {"orderLineId": to_global_id_or_none(first_line), "quantity": 100}
+            ],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "lines"
+    assert error["code"] == OrderGrantRefundCreateErrorCode.INVALID.name
+    assert len(error["lines"]) == 1
+    line = error["lines"][0]
+    assert line["orderLineId"] == to_global_id_or_none(first_line)
+    assert line["field"] == "quantity"
+    assert (
+        line["code"]
+        == OrderGrantRefundCreateLineErrorCode.QUANTITY_GREATER_THAN_AVAILABLE.name
+    )
+
+
+def test_grant_refund_with_refund_for_shipping_already_processed(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "grantRefundForShipping": True,
+        },
+    }
+    order.granted_refunds.create(shipping_costs_included=True)
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "grantRefundForShipping"
+    assert (
+        error["code"]
+        == OrderGrantRefundCreateErrorCode.SHIPPING_COSTS_ALREADY_GRANTED.name
+    )
+
+
+def test_grant_refund_with_lines_and_existing_other_grant_refund(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    first_line.quantity = 2
+    first_line.save(update_fields=["quantity"])
+
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}],
+        },
+    }
+    granted_refund = order.granted_refunds.create(shipping_costs_included=False)
+    granted_refund.lines.create(order_line=first_line, quantity=1)
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert not errors
+
+    assert order_id == data["order"]["id"]
+    assert len(data["order"]["grantedRefunds"]) == 2
+
+    granted_refund_from_db = order.granted_refunds.last()
+    order_granted_refund = data["order"]["grantedRefunds"][1]
+    assert data["grantedRefund"]["shippingCostsIncluded"] is False
+    assert len(order_granted_refund["lines"]) == 1
+    assert order_granted_refund["lines"][0]["quantity"] == 1
+    assert order_granted_refund["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        first_line
+    )
+    assert granted_refund_from_db.amount_value == first_line.unit_price_gross_amount * 1
+    assert quantize_price(
+        granted_refund_from_db.amount_value, order.currency
+    ) == quantize_price(
+        Decimal(order_granted_refund["amount"]["amount"]), order.currency
+    )
+
+
+def test_grant_refund_with_lines_and_existing_other_grant_and_refund_exceeding_quantity(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    first_line.quantity = 1
+    first_line.save(update_fields=["quantity"])
+
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}],
+        },
+    }
+    granted_refund = order.granted_refunds.create(shipping_costs_included=False)
+    granted_refund.lines.create(order_line=first_line, quantity=1)
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "lines"
+    assert error["code"] == OrderGrantRefundCreateErrorCode.INVALID.name
+    assert len(error["lines"]) == 1
+    line = error["lines"][0]
+    assert line["orderLineId"] == to_global_id_or_none(first_line)
+    assert line["field"] == "quantity"
+    assert (
+        line["code"]
+        == OrderGrantRefundCreateLineErrorCode.QUANTITY_GREATER_THAN_AVAILABLE.name
+    )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22082,20 +22082,69 @@ type OrderGrantRefundCreateError @doc(category: "Orders") {
 
   """The error code."""
   code: OrderGrantRefundCreateErrorCode!
+
+  """List of lines which cause the error."""
+  lines: [OrderGrantRefundCreateLineError!]
 }
 
 """An enumeration."""
 enum OrderGrantRefundCreateErrorCode @doc(category: "Orders") {
   GRAPHQL_ERROR
   NOT_FOUND
+  SHIPPING_COSTS_ALREADY_GRANTED
+  REQUIRED
+  INVALID
+}
+
+type OrderGrantRefundCreateLineError {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: OrderGrantRefundCreateLineErrorCode!
+
+  """The ID of the line related to the error."""
+  orderLineId: ID!
+}
+
+"""An enumeration."""
+enum OrderGrantRefundCreateLineErrorCode {
+  GRAPHQL_ERROR
+  NOT_FOUND
+  QUANTITY_GREATER_THAN_AVAILABLE
 }
 
 input OrderGrantRefundCreateInput @doc(category: "Orders") {
-  """Amount of the granted refund."""
-  amount: Decimal!
+  """
+  Amount of the granted refund. If not provided, the amount will be calculated automatically based on provided `lines` and `grantRefundForShipping`.
+  """
+  amount: Decimal
 
   """Reason of the granted refund."""
   reason: String
+
+  """
+  Lines to assing to granted refund.
+  
+  Added in Saleor 3.14.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  lines: [OrderGrantRefundOrderLineInput!]
+
+  """
+  Determine if granted refund should include shipping costs.
+  
+  Added in Saleor 3.14.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  grantRefundForShipping: Boolean
 }
 
 """
@@ -22105,6 +22154,14 @@ Returns Decimal as a float in the API,
 parses float to the Decimal on the way back.
 """
 scalar Decimal
+
+input OrderGrantRefundOrderLineInput @doc(category: "Orders") {
+  """The ID of the order line."""
+  orderLineId: ID!
+
+  """The quantity of line items to be marked to refund."""
+  quantity: Int!
+}
 
 """
 Updates granted refund.

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22083,7 +22083,11 @@ type OrderGrantRefundCreateError @doc(category: "Orders") {
   """The error code."""
   code: OrderGrantRefundCreateErrorCode!
 
-  """List of lines which cause the error."""
+  """
+  List of lines which cause the error.
+  
+  Added in Saleor 3.14.
+  """
   lines: [OrderGrantRefundCreateLineError!]
 }
 
@@ -22129,11 +22133,9 @@ input OrderGrantRefundCreateInput @doc(category: "Orders") {
   reason: String
 
   """
-  Lines to assing to granted refund.
+  Lines to assign to granted refund.
   
   Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   lines: [OrderGrantRefundOrderLineInput!]
 
@@ -22141,8 +22143,6 @@ input OrderGrantRefundCreateInput @doc(category: "Orders") {
   Determine if granted refund should include shipping costs.
   
   Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   grantRefundForShipping: Boolean
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22137,7 +22137,7 @@ input OrderGrantRefundCreateInput @doc(category: "Orders") {
   
   Added in Saleor 3.14.
   """
-  lines: [OrderGrantRefundOrderLineInput!]
+  lines: [OrderGrantRefundCreateLineInput!]
 
   """
   Determine if granted refund should include shipping costs.
@@ -22155,7 +22155,7 @@ parses float to the Decimal on the way back.
 """
 scalar Decimal
 
-input OrderGrantRefundOrderLineInput @doc(category: "Orders") {
+input OrderGrantRefundCreateLineInput @doc(category: "Orders") {
   """The ID of the order line."""
   orderLineId: ID!
 

--- a/saleor/order/error_codes.py
+++ b/saleor/order/error_codes.py
@@ -39,9 +39,18 @@ class OrderErrorCode(Enum):
 class OrderGrantRefundCreateErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
+    SHIPPING_COSTS_ALREADY_GRANTED = "shipping_costs_already_granted"
+    REQUIRED = "required"
+    INVALID = "invalid"
 
 
 class OrderGrantRefundUpdateErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
     REQUIRED = "required"
+
+
+class OrderGrantRefundCreateLineErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
+    NOT_FOUND = "not_found"
+    QUANTITY_GREATER_THAN_AVAILABLE = "quantity_greater_than_available"


### PR DESCRIPTION
I want to merge this change because it extends orderGrantRefundCreate mutation to accept the lines.
RFC: https://github.com/saleor/saleor/issues/12831

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
