### PR TITLE
Allow adding shipping voucher before shipping step in checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,15 +33,18 @@ All notable, unreleased changes to this project will be documented in this file.
 - Introduce channel permissions - #10423 by @IKarbowiak
   - Limit staff users to access only certain channels. Granted permissions only apply to channels that the user has already been given access to.
 - Add `enable_account_confirmation_by_email` to `SiteSettings` model and allow to update it via `shopSettingsUpdate` mutation - #12781 by @SzymJ
+- Allow adding shipping voucher before shipping step in checkout - #12922 by @maarcingebala
 
 ### Saleor Apps
+
 - Introduce channel permissions - #10423 by @IKarbowiak
   - Extend the OpenID connect configuration with `Staff user domains` and `Default permission group name for new staff users`.
   - When the OpenID plugin is active, the default staff permission group is created and all staff users are assigned to it.
   - To ensure the proper functioning of OAuth permissions, ensure that the
-  `Default permission group name for new staff users` is set to a permission group with no channel restrictions.
+    `Default permission group name for new staff users` is set to a permission group with no channel restrictions.
 
 ### Other changes
+
 - Fix saving `description_plaintext` for product - #12586 by @SzymJ
 - Remove default `EMAIL_URL` value pointing to console output; from now on EMAIL_URL has to be set explicitly - #12580 by @maarcingebala
 - Fix sending `product_created` event in `ProductBulkCreate` mutation - #12605 by @SzymJ

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -378,7 +378,6 @@ def _get_shipping_voucher_discount_for_checkout(
     address: Optional["Address"],
 ):
     """Calculate discount value for a voucher of shipping type."""
-
     # check if voucher is limited to specified countries
     if address:
         if voucher.countries and address.country.code not in voucher.countries:

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -378,13 +378,6 @@ def _get_shipping_voucher_discount_for_checkout(
     address: Optional["Address"],
 ):
     """Calculate discount value for a voucher of shipping type."""
-    if not is_shipping_required(lines):
-        msg = "Your order does not require shipping."
-        raise NotApplicable(msg)
-    shipping_method = checkout_info.delivery_method_info.delivery_method
-    if not shipping_method:
-        msg = "Please select a delivery method first."
-        raise NotApplicable(msg)
 
     # check if voucher is limited to specified countries
     if address:

--- a/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_delivery_method_update.py
@@ -9,6 +9,7 @@ from ....checkout.fetch import (
     CheckoutLineInfo,
     fetch_checkout_info,
     fetch_checkout_lines,
+    update_delivery_method_lists_for_checkout_info,
 )
 from ....checkout.utils import (
     delete_external_shipping_id,
@@ -230,11 +231,25 @@ class CheckoutDeliveryMethodUpdate(BaseMutation):
             )
         else:
             delete_external_shipping_id(checkout=checkout)
+
         checkout.shipping_method = shipping_method
         checkout.collection_point = collection_point
+
+        shipping_channel_listings = checkout.channel.shipping_method_listings.all()
+        update_delivery_method_lists_for_checkout_info(
+            checkout_info,
+            shipping_method,
+            collection_point,
+            checkout_info.shipping_address,
+            lines,
+            manager,
+            shipping_channel_listings,
+        )
+
         invalidate_prices_updated_fields = invalidate_checkout_prices(
             checkout_info, lines, manager, save=False
         )
+
         checkout.save(
             update_fields=[
                 "shipping_method",

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -99,6 +99,7 @@ def test_checkout_delivery_method_update(
     )
     data = get_graphql_content(response)["data"]["checkoutDeliveryMethodUpdate"]
     checkout.refresh_from_db()
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     mock_clean_delivery.assert_called_once_with(
         checkout_info=checkout_info, lines=lines, method=shipping_method_data
@@ -174,6 +175,7 @@ def test_checkout_delivery_method_update_no_checkout_metadata(
     # then
     data = get_graphql_content(response)["data"]["checkoutDeliveryMethodUpdate"]
     checkout.refresh_from_db()
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     mock_clean_delivery.assert_called_once_with(
         checkout_info=checkout_info, lines=lines, method=shipping_method_data
@@ -498,6 +500,7 @@ def test_checkout_delivery_method_update_with_not_all_required_shipping_address_
     # then
     data = get_graphql_content(response)["data"]["checkoutDeliveryMethodUpdate"]
     checkout.refresh_from_db()
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     mock_clean_delivery.assert_called_once_with(
         checkout_info=checkout_info, lines=lines, method=shipping_method_data
@@ -573,6 +576,7 @@ def test_checkout_delivery_method_update_with_not_valid_address_data(
     # then
     data = get_graphql_content(response)["data"]["checkoutDeliveryMethodUpdate"]
     checkout.refresh_from_db()
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     mock_clean_delivery.assert_called_once_with(
         checkout_info=checkout_info, lines=lines, method=shipping_method_data


### PR DESCRIPTION
Fixes https://github.com/saleor/saleor/issues/12844

Acceptance criteria:
- `checkoutAddPromoCode` allows adding a shipping voucher when:
  -  shipping is not required
      - no checkout lines were added
      - checkout lines with products without shipping are added
  - shipping is required, but the shipping method is not set
      - when the voucher is added, and then the shipping method is added, it should correctly calculate the discount to make the shipping free  

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
