### PR TITLE
Extend order grant refund mutations

### DIFF
--- a/saleor/graphql/order/enums.py
+++ b/saleor/graphql/order/enums.py
@@ -64,6 +64,10 @@ OrderGrantRefundCreateLineErrorCode = graphene.Enum.from_enum(
     error_codes.OrderGrantRefundCreateLineErrorCode
 )
 
+OrderGrantRefundUpdateLineErrorCode = graphene.Enum.from_enum(
+    error_codes.OrderGrantRefundUpdateLineErrorCode
+)
+
 OrderGrantRefundCreateErrorCode.doc_category = DOC_CATEGORY_ORDERS
 
 OrderGrantRefundUpdateErrorCode = graphene.Enum.from_enum(

--- a/saleor/graphql/order/enums.py
+++ b/saleor/graphql/order/enums.py
@@ -60,6 +60,10 @@ OrderChargeStatusEnum.doc_category = DOC_CATEGORY_ORDERS
 OrderGrantRefundCreateErrorCode = graphene.Enum.from_enum(
     error_codes.OrderGrantRefundCreateErrorCode
 )
+OrderGrantRefundCreateLineErrorCode = graphene.Enum.from_enum(
+    error_codes.OrderGrantRefundCreateLineErrorCode
+)
+
 OrderGrantRefundCreateErrorCode.doc_category = DOC_CATEGORY_ORDERS
 
 OrderGrantRefundUpdateErrorCode = graphene.Enum.from_enum(

--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -1,27 +1,79 @@
-import graphene
+import decimal
+import uuid
+from collections import defaultdict
+from typing import Any, Optional, Union, cast
 
+import graphene
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from graphql import GraphQLError
+
+from ....order import models
 from ....permission.enums import OrderPermissions
 from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_313, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_313, ADDED_IN_314, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.scalars import Decimal
 from ...core.types import BaseInputObjectType
-from ...core.types.common import Error
-from ..enums import OrderGrantRefundCreateErrorCode
+from ...core.types.common import Error, NonNullList
+from ...core.utils import from_global_id_or_error
+from ..enums import OrderGrantRefundCreateErrorCode, OrderGrantRefundCreateLineErrorCode
 from ..types import Order, OrderGrantedRefund
+
+
+class OrderGrantRefundCreateLineError(Error):
+    code = OrderGrantRefundCreateLineErrorCode(
+        description="The error code.", required=True
+    )
+    order_line_id = graphene.ID(
+        description="The ID of the line related to the error.", required=True
+    )
 
 
 class OrderGrantRefundCreateError(Error):
     code = OrderGrantRefundCreateErrorCode(description="The error code.", required=True)
+    lines = NonNullList(
+        OrderGrantRefundCreateLineError,
+        description="List of lines which cause the error.",
+        required=False,
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_ORDERS
+
+
+class OrderGrantRefundOrderLineInput(BaseInputObjectType):
+    order_line_id = graphene.ID(description="The ID of the order line.", required=True)
+    quantity = graphene.Int(
+        description="The quantity of line items to be marked to refund.", required=True
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS
 
 
 class OrderGrantRefundCreateInput(BaseInputObjectType):
-    amount = Decimal(required=True, description="Amount of the granted refund.")
+    amount = Decimal(
+        description=(
+            "Amount of the granted refund. If not provided, the amount will be "
+            "calculated automatically based on provided `lines` and "
+            "`grantRefundForShipping`."
+        )
+    )
     reason = graphene.String(description="Reason of the granted refund.")
+    lines = NonNullList(
+        OrderGrantRefundOrderLineInput,
+        description="Lines to assing to granted refund."
+        + ADDED_IN_314
+        + PREVIEW_FEATURE,
+        required=False,
+    )
+    grant_refund_for_shipping = graphene.Boolean(
+        description="Determine if granted refund should include shipping costs."
+        + ADDED_IN_314
+        + PREVIEW_FEATURE
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS
@@ -51,17 +103,199 @@ class OrderGrantRefundCreate(BaseMutation):
         doc_category = DOC_CATEGORY_ORDERS
 
     @classmethod
+    def clean_input_lines(
+        cls, order: models.Order, lines: list[dict[str, Union[str, int]]]
+    ) -> tuple[
+        Optional[list[tuple[models.OrderLine, int]]], Optional[list[dict[str, str]]]
+    ]:
+        errors = []
+        input_lines_data = {}
+        for line in lines:
+            order_line_id = cast(str, line["order_line_id"])
+            try:
+                _, pk = from_global_id_or_error(order_line_id, only_type="OrderLine")
+                input_lines_data[pk] = int(line["quantity"])
+            except GraphQLError as e:
+                errors.append(
+                    {
+                        "order_line_id": line["order_line_id"],
+                        "field": "orderLineId",
+                        "code": OrderGrantRefundCreateLineErrorCode.GRAPHQL_ERROR.value,
+                        "message": str(e),
+                    }
+                )
+
+        input_line_ids = list(input_lines_data.keys())
+        lines = order.lines.filter(id__in=input_line_ids)
+        lines_dict = {line.pk: line for line in lines}
+        if len(lines_dict.keys()) != len(input_line_ids):
+            invalid_ids = set(input_line_ids).difference(set(lines_dict.keys()))
+            for invalid_id in invalid_ids:
+                errors.append(
+                    {
+                        "order_line_id": graphene.Node.to_global_id(
+                            "OrderLine", invalid_id
+                        ),
+                        "field": "orderLineId",
+                        "message": "Could not resolve to a line.",
+                        "code": OrderGrantRefundCreateLineErrorCode.NOT_FOUND.value,
+                    }
+                )
+        all_granted_refund_ids = order.granted_refunds.all().values_list(
+            "id", flat=True
+        )
+        all_granted_refund_lines = models.OrderGrantedRefundLine.objects.filter(
+            granted_refund_id__in=all_granted_refund_ids
+        )
+        lines_with_quantity_already_refunded: dict[uuid.UUID, int] = defaultdict(int)
+        for line in all_granted_refund_lines:
+            lines_with_quantity_already_refunded[line.order_line_id] += line.quantity
+
+        for line in lines_dict.values():
+            quantity_already_refunded = lines_with_quantity_already_refunded[line.pk]
+            if (
+                input_lines_data[str(line.pk)] + quantity_already_refunded
+                > line.quantity
+            ):
+                error_code_class = OrderGrantRefundCreateLineErrorCode
+
+                errors.append(
+                    {
+                        "order_line_id": graphene.Node.to_global_id(
+                            "OrderLine", line.pk
+                        ),
+                        "field": "quantity",
+                        "message": (
+                            "Cannot grant refund for more than the available quantity "
+                            f"of the line ({line.quantity-quantity_already_refunded})."
+                        ),
+                        "code": error_code_class.QUANTITY_GREATER_THAN_AVAILABLE.value,
+                    }
+                )
+
+        if errors:
+            return None, errors
+
+        return [
+            (line, input_lines_data[str(line.pk)]) for line in lines_dict.values()
+        ], None
+
+    @classmethod
+    def shipping_costs_already_granted(cls, order: models.Order):
+        if order.granted_refunds.filter(shipping_costs_included=True):
+            return True
+        return False
+
+    @classmethod
+    def calculate_amount(
+        cls,
+        order: models.Order,
+        cleaned_input_lines: list[tuple[models.OrderLine, int]],
+        grant_refund_for_shipping: bool,
+    ) -> decimal.Decimal:
+        amount = decimal.Decimal(0)
+        for line, quantity in cleaned_input_lines:
+            amount += line.unit_price_gross_amount * quantity
+        if grant_refund_for_shipping:
+            amount += order.shipping_price_gross_amount
+        return amount
+
+    @classmethod
+    def clean_input(cls, order: models.Order, input: dict[str, Any]):
+        amount = input.get("amount")
+        reason = input.get("reason", "")
+        input_lines = input.get("lines", [])
+        grant_refund_for_shipping = input.get("grant_refund_for_shipping", False)
+
+        if amount is None and not input_lines and not grant_refund_for_shipping:
+            error_msg = (
+                "You must provide at least one of `amount`, `lines`, "
+                "`grantRefundForShipping`."
+            )
+            raise ValidationError(
+                {
+                    "amount": ValidationError(
+                        error_msg,
+                        code=OrderGrantRefundCreateErrorCode.REQUIRED.value,
+                    ),
+                    "lines": ValidationError(
+                        error_msg,
+                        code=OrderGrantRefundCreateErrorCode.REQUIRED.value,
+                    ),
+                    "grant_refund_for_shipping": ValidationError(
+                        error_msg,
+                        code=OrderGrantRefundCreateErrorCode.REQUIRED.value,
+                    ),
+                }
+            )
+        cleaned_input_lines: Optional[list[tuple[models.OrderLine, int]]] = []
+        if input_lines:
+            cleaned_input_lines, errors = cls.clean_input_lines(order, input_lines)
+            if errors:
+                raise ValidationError(
+                    {
+                        "lines": ValidationError(
+                            "Provided input for lines is invalid.",
+                            code=OrderGrantRefundCreateErrorCode.INVALID.value,
+                            params={"lines": errors},
+                        ),
+                    }
+                )
+        if grant_refund_for_shipping and cls.shipping_costs_already_granted(order):
+            error_code = OrderGrantRefundCreateErrorCode.SHIPPING_COSTS_ALREADY_GRANTED
+            raise ValidationError(
+                {
+                    "grant_refund_for_shipping": ValidationError(
+                        "Shipping costs have already been granted.",
+                        code=error_code.value,
+                    )
+                }
+            )
+
+        if amount is None:
+            cleaned_input_lines = cast(
+                list[tuple[models.OrderLine, int]], cleaned_input_lines
+            )
+            amount = cls.calculate_amount(
+                order, cleaned_input_lines, grant_refund_for_shipping
+            )
+
+        return {
+            "amount": amount,
+            "reason": reason,
+            "lines": cleaned_input_lines,
+            "grant_refund_for_shipping": grant_refund_for_shipping,
+        }
+
+    @classmethod
     def perform_mutation(  # type: ignore[override]
         cls, _root, info: ResolveInfo, /, *, id, input
     ):
         order = cls.get_node_or_error(info, id, only_type=Order)
-        amount = input["amount"]
-        reason = input.get("reason", "")
-        granted_refund = order.granted_refunds.create(
-            amount_value=amount,
-            currency=order.currency,
-            reason=reason,
-            user=info.context.user,
-            app=info.context.app,
-        )
+        cleaned_input = cls.clean_input(order, input)
+        amount = cleaned_input["amount"]
+        reason = cleaned_input["reason"]
+        cleaned_input_lines = cleaned_input["lines"]
+        grant_refund_for_shipping = cleaned_input["grant_refund_for_shipping"]
+
+        with transaction.atomic():
+            granted_refund = order.granted_refunds.create(
+                amount_value=amount,
+                currency=order.currency,
+                reason=reason,
+                user=info.context.user,
+                app=info.context.app,
+                shipping_costs_included=grant_refund_for_shipping,
+            )
+            if cleaned_input_lines:
+                models.OrderGrantedRefundLine.objects.bulk_create(
+                    [
+                        models.OrderGrantedRefundLine(
+                            order_line=line,
+                            quantity=quantity,
+                            granted_refund=granted_refund,
+                        )
+                        for line, quantity in cleaned_input_lines
+                    ]
+                )
         return cls(order=order, granted_refund=granted_refund)

--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -35,7 +35,7 @@ class OrderGrantRefundCreateError(Error):
     code = OrderGrantRefundCreateErrorCode(description="The error code.", required=True)
     lines = NonNullList(
         OrderGrantRefundCreateLineError,
-        description="List of lines which cause the error.",
+        description="List of lines which cause the error." + ADDED_IN_314,
         required=False,
     )
 
@@ -64,15 +64,13 @@ class OrderGrantRefundCreateInput(BaseInputObjectType):
     reason = graphene.String(description="Reason of the granted refund.")
     lines = NonNullList(
         OrderGrantRefundOrderLineInput,
-        description="Lines to assing to granted refund."
-        + ADDED_IN_314
-        + PREVIEW_FEATURE,
+        description="Lines to assign to granted refund." + ADDED_IN_314,
         required=False,
     )
     grant_refund_for_shipping = graphene.Boolean(
         description="Determine if granted refund should include shipping costs."
-        + ADDED_IN_314
-        + PREVIEW_FEATURE
+        + ADDED_IN_314,
+        required=False,
     )
 
     class Meta:

--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -160,16 +160,13 @@ class OrderGrantRefundCreate(BaseMutation):
                 "You must provide at least one of `amount`, `lines`, "
                 "`grantRefundForShipping`."
             )
+            error_code = OrderGrantRefundCreateErrorCode.REQUIRED.value
             raise ValidationError(
                 {
-                    "amount": ValidationError(
-                        error_msg, code=OrderGrantRefundCreateErrorCode.REQUIRED.value
-                    ),
-                    "lines": ValidationError(
-                        error_msg, code=OrderGrantRefundCreateErrorCode.REQUIRED.value
-                    ),
+                    "amount": ValidationError(error_msg, code=error_code),
+                    "lines": ValidationError(error_msg, code=error_code),
                     "grant_refund_for_shipping": ValidationError(
-                        error_msg, code=OrderGrantRefundCreateErrorCode.REQUIRED.value
+                        error_msg, code=error_code
                     ),
                 }
             )

--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -43,7 +43,7 @@ class OrderGrantRefundCreateError(Error):
         doc_category = DOC_CATEGORY_ORDERS
 
 
-class OrderGrantRefundOrderLineInput(BaseInputObjectType):
+class OrderGrantRefundCreateLineInput(BaseInputObjectType):
     order_line_id = graphene.ID(description="The ID of the order line.", required=True)
     quantity = graphene.Int(
         description="The quantity of line items to be marked to refund.", required=True
@@ -63,7 +63,7 @@ class OrderGrantRefundCreateInput(BaseInputObjectType):
     )
     reason = graphene.String(description="Reason of the granted refund.")
     lines = NonNullList(
-        OrderGrantRefundOrderLineInput,
+        OrderGrantRefundCreateLineInput,
         description="Lines to assign to granted refund." + ADDED_IN_314,
         required=False,
     )

--- a/saleor/graphql/order/mutations/order_grant_refund_update.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_update.py
@@ -1,34 +1,96 @@
+from typing import Any, Union
+
 import graphene
 from django.core.exceptions import ValidationError
+from graphql import GraphQLError
 
 from ....order import models
 from ....permission.enums import OrderPermissions
-from ...core.descriptions import ADDED_IN_313, PREVIEW_FEATURE
+from ...core import ResolveInfo
+from ...core.descriptions import ADDED_IN_313, ADDED_IN_314, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_ORDERS
-from ...core.mutations import ModelMutation
+from ...core.mutations import BaseMutation
 from ...core.scalars import Decimal
 from ...core.types import BaseInputObjectType
-from ...core.types.common import Error
-from ..enums import OrderGrantRefundUpdateErrorCode
+from ...core.types.common import Error, NonNullList
+from ...core.utils import from_global_id_or_error
+from ..enums import OrderGrantRefundUpdateErrorCode, OrderGrantRefundUpdateLineErrorCode
 from ..types import Order, OrderGrantedRefund
+from .order_grant_refund_utils import (
+    get_input_lines_data,
+    get_lines_map,
+    handle_lines_with_quantity_already_refunded,
+    shipping_costs_already_granted,
+)
+
+
+class OrderGrantRefundUpdateLineError(Error):
+    code = OrderGrantRefundUpdateLineErrorCode(
+        description="The error code.", required=True
+    )
+    line_id = graphene.ID(
+        description="The ID of the line related to the error.", required=True
+    )
 
 
 class OrderGrantRefundUpdateError(Error):
     code = OrderGrantRefundUpdateErrorCode(description="The error code.", required=True)
+
+    add_lines = NonNullList(
+        OrderGrantRefundUpdateLineError,
+        description="List of lines to add which cause the error." + ADDED_IN_314,
+        required=False,
+    )
+    remove_lines = NonNullList(
+        OrderGrantRefundUpdateLineError,
+        description="List of lines to remove which cause the error." + ADDED_IN_314,
+        required=False,
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_ORDERS
+
+
+class OrderGrantRefundUpdateLineAddInput(BaseInputObjectType):
+    id = graphene.ID(description="The ID of the order line.", required=True)
+    quantity = graphene.Int(
+        description="The quantity of line items to be marked to refund.", required=True
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS
 
 
 class OrderGrantRefundUpdateInput(BaseInputObjectType):
-    amount = Decimal(description="Amount of the granted refund.")
+    amount = Decimal(
+        description=(
+            "Amount of the granted refund. if not provided and `addLines` or "
+            "`removeLines` or `grantRefundForShipping` is provided, amount will be "
+            "calculated automatically."
+        )
+    )
     reason = graphene.String(description="Reason of the granted refund.")
+    add_lines = NonNullList(
+        OrderGrantRefundUpdateLineAddInput,
+        description="Lines to assign to granted refund." + ADDED_IN_314,
+        required=False,
+    )
+    remove_lines = NonNullList(
+        graphene.ID,
+        description="Lines to remove from granted refund." + ADDED_IN_314,
+        required=False,
+    )
+    grant_refund_for_shipping = graphene.Boolean(
+        description="Determine if granted refund should include shipping costs."
+        + ADDED_IN_314,
+        required=False,
+    )
 
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS
 
 
-class OrderGrantRefundUpdate(ModelMutation):
+class OrderGrantRefundUpdate(BaseMutation):
     order = graphene.Field(
         Order, description="Order which has assigned updated grant refund."
     )
@@ -47,16 +109,23 @@ class OrderGrantRefundUpdate(ModelMutation):
         description = "Updates granted refund." + ADDED_IN_313 + PREVIEW_FEATURE
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderGrantRefundUpdateError
-        model = models.OrderGrantedRefund
-        object_type = OrderGrantedRefund
         doc_category = DOC_CATEGORY_ORDERS
 
     @classmethod
-    def validate_input(cls, amount, reason):
-        if not amount and not reason:
-            error_msg = (
-                "At least amount or reason need to be provided to process update."
-            )
+    def validate_input(cls, input: dict[str, Any]):
+        amount = input.get("amount")
+        reason = input.get("reason", "")
+        input_lines = input.get("add_lines", [])
+        remove_lines = input.get("remove_lines", [])
+        grant_refund_for_shipping = input.get("grant_refund_for_shipping", False)
+        if (
+            not amount
+            and not reason
+            and not input_lines
+            and not grant_refund_for_shipping
+            and not remove_lines
+        ):
+            error_msg = "At least one field needs to be provided to process update."
             raise ValidationError(
                 {
                     "input": ValidationError(
@@ -66,14 +135,197 @@ class OrderGrantRefundUpdate(ModelMutation):
             )
 
     @classmethod
-    def success_response(cls, instance):
-        return cls(order=instance.order, granted_refund=instance)
+    def clean_remove_lines(
+        cls,
+        granted_refund: models.OrderGrantedRefund,
+        lines_to_remove: list[str],
+        errors: list[dict[str, Any]],
+    ):
+        lines_pk_to_remove = set()
+        for line_id in lines_to_remove:
+            try:
+                _, pk = from_global_id_or_error(
+                    line_id, only_type="OrderGrantedRefundLine", raise_error=True
+                )
+                lines_pk_to_remove.add(int(pk))
+            except GraphQLError as e:
+                errors.append(
+                    {
+                        "line_id": line_id,
+                        "code": OrderGrantRefundUpdateLineErrorCode.GRAPHQL_ERROR.value,
+                        "message": str(e),
+                    }
+                )
+        line_ids_from_granted_refund = granted_refund.lines.filter(
+            id__in=lines_pk_to_remove
+        ).values_list("id", flat=True)
+        invalid_ids = lines_pk_to_remove.difference(set(line_ids_from_granted_refund))
+        if invalid_ids:
+            for invalid_id in invalid_ids:
+                errors.append(
+                    {
+                        "line_id": graphene.Node.to_global_id(
+                            "OrderGrantedRefundLine", invalid_id
+                        ),
+                        "message": "Could not resolve to a line.",
+                        "code": OrderGrantRefundUpdateLineErrorCode.NOT_FOUND.value,
+                    }
+                )
+
+        return lines_pk_to_remove
 
     @classmethod
-    def clean_input(cls, info, instance, data, input_cls=None):
-        cleaned_input = super().clean_input(info, instance, data, input_cls=input_cls)
-        amount = cleaned_input.pop("amount", None)
-        cls.validate_input(amount, data.get("reason"))
+    def clean_add_lines(
+        cls,
+        order: models.Order,
+        lines: list[dict[str, Union[str, int]]],
+        errors: list[dict[str, Any]],
+        line_ids_exclude: list[int],
+    ):
+        input_lines_data = get_input_lines_data(
+            lines, errors, OrderGrantRefundUpdateLineErrorCode.GRAPHQL_ERROR.value
+        )
+        lines_dict = get_lines_map(
+            order,
+            input_lines_data,
+            errors,
+            OrderGrantRefundUpdateLineErrorCode.NOT_FOUND.value,
+        )
+        handle_lines_with_quantity_already_refunded(
+            order,
+            lines_dict,
+            input_lines_data,
+            errors,
+            OrderGrantRefundUpdateLineErrorCode.QUANTITY_GREATER_THAN_AVAILABLE.value,
+            granted_refund_lines_to_exclude=line_ids_exclude,
+        )
+
+        return [(line, input_lines_data[str(line.pk)]) for line in lines_dict.values()]
+
+    @classmethod
+    def clean_input(
+        cls,
+        granted_refund: models.OrderGrantedRefund,
+        input: dict[str, Any],
+    ):
+        add_errors: list[dict[str, Any]] = []
+        remove_errors: list[dict[str, Any]] = []
+        errors = {}
+        cls.validate_input(input)
+        order = granted_refund.order
+        amount = input.get("amount")
+        reason = input.get("reason", None)
+        add_lines = input.get("add_lines", [])
+        remove_lines = input.get("remove_lines", [])
+        grant_refund_for_shipping = input.get("grant_refund_for_shipping", None)
+
+        line_ids_to_remove = []
+        if remove_lines:
+            line_ids_to_remove = cls.clean_remove_lines(
+                granted_refund, remove_lines, remove_errors
+            )
+
+        if remove_errors:
+            errors["remove_lines"] = ValidationError(
+                "Provided input for lines is invalid.",
+                code=OrderGrantRefundUpdateErrorCode.INVALID.value,
+                params={"remove_lines": remove_errors},
+            )
+
+        lines_to_add = []
+        if add_lines:
+            lines_to_add = cls.clean_add_lines(
+                order, add_lines, add_errors, line_ids_to_remove
+            )
+
+        if add_errors:
+            errors["add_lines"] = ValidationError(
+                "Provided input for lines is invalid.",
+                code=OrderGrantRefundUpdateErrorCode.INVALID.value,
+                params={"add_lines": add_errors},
+            )
+
+        if grant_refund_for_shipping and shipping_costs_already_granted(order):
+            error_code = OrderGrantRefundUpdateErrorCode.SHIPPING_COSTS_ALREADY_GRANTED
+            errors["grant_refund_for_shipping"] = ValidationError(
+                "Shipping costs have already been granted.",
+                code=error_code.value,
+            )
+
+        if errors:
+            raise ValidationError(errors)
+
+        return {
+            "amount": amount,
+            "reason": reason,
+            "add_lines": lines_to_add,
+            "remove_lines": line_ids_to_remove,
+            "grant_refund_for_shipping": grant_refund_for_shipping,
+        }
+
+    @classmethod
+    def process_update_for_granted_refund(
+        cls,
+        order: models.Order,
+        granted_refund: models.OrderGrantedRefund,
+        cleaned_input: dict,
+    ):
+        lines_to_remove = cleaned_input.get("remove_lines")
+        lines_to_add = cleaned_input.get("add_lines")
+        if lines_to_remove:
+            granted_refund.lines.filter(id__in=lines_to_remove).delete()
+        if lines_to_add:
+            granted_refund.lines.bulk_create(
+                [
+                    models.OrderGrantedRefundLine(
+                        order_line=line,
+                        quantity=quantity,
+                        granted_refund=granted_refund,
+                    )
+                    for line, quantity in lines_to_add
+                ]
+            )
+        grant_refund_for_shipping = cleaned_input.get("grant_refund_for_shipping")
+        if grant_refund_for_shipping is not None:
+            granted_refund.shipping_costs_included = grant_refund_for_shipping
+
+        amount = cleaned_input.get("amount")
         if amount is not None:
-            cleaned_input["amount_value"] = amount
-        return cleaned_input
+            granted_refund.amount_value = amount
+        elif amount is None and (
+            lines_to_add or lines_to_remove or grant_refund_for_shipping is not None
+        ):
+            lines = granted_refund.lines.select_related("order_line")
+            amount = sum(
+                [
+                    line.order_line.unit_price_gross_amount * line.quantity
+                    for line in lines
+                ]
+            )
+            if granted_refund.shipping_costs_included:
+                amount += order.shipping_price_gross_amount
+            granted_refund.amount_value = amount
+
+        reason = cleaned_input.get("reason")
+        if reason is not None:
+            granted_refund.reason = reason
+
+        granted_refund.save(
+            update_fields=[
+                "amount_value",
+                "reason",
+                "shipping_costs_included",
+                "updated_at",
+            ]
+        )
+
+    @classmethod
+    def perform_mutation(  # type: ignore[override]
+        cls, _root, info: ResolveInfo, /, *, id, input
+    ):
+        granted_refund = cls.get_node_or_error(info, id, only_type=OrderGrantedRefund)
+        order = granted_refund.order
+
+        cleaned_input = cls.clean_input(granted_refund, input)
+        cls.process_update_for_granted_refund(order, granted_refund, cleaned_input)
+        return cls(order=order, granted_refund=granted_refund)

--- a/saleor/graphql/order/mutations/order_grant_refund_utils.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_utils.py
@@ -1,0 +1,98 @@
+import uuid
+from collections import defaultdict
+from typing import Any, Optional, Union, cast
+
+import graphene
+from graphql import GraphQLError
+
+from ....order import models
+from ...core.utils import from_global_id_or_error
+
+
+def shipping_costs_already_granted(order: models.Order):
+    if order.granted_refunds.filter(shipping_costs_included=True):
+        return True
+    return False
+
+
+def handle_lines_with_quantity_already_refunded(
+    order: models.Order,
+    lines_dict: dict[uuid.UUID, models.OrderLine],
+    input_lines_data: dict[str, int],
+    errors: list[dict[str, Any]],
+    error_code: str,
+    granted_refund_lines_to_exclude: Optional[list[int]] = None,
+):
+    all_granted_refund_ids = order.granted_refunds.all().values_list("id", flat=True)
+    all_granted_refund_lines = models.OrderGrantedRefundLine.objects.filter(
+        granted_refund_id__in=all_granted_refund_ids
+    )
+    if granted_refund_lines_to_exclude:
+        all_granted_refund_lines.exclude(pk__in=granted_refund_lines_to_exclude)
+
+    lines_with_quantity_already_refunded: dict[uuid.UUID, int] = defaultdict(int)
+    for line in all_granted_refund_lines:
+        lines_with_quantity_already_refunded[line.order_line_id] += line.quantity
+
+    for line in lines_dict.values():
+        quantity_already_refunded = lines_with_quantity_already_refunded[line.pk]
+        if input_lines_data[str(line.pk)] + quantity_already_refunded > line.quantity:
+            errors.append(
+                {
+                    "line_id": graphene.Node.to_global_id("OrderLine", line.pk),
+                    "field": "quantity",
+                    "message": (
+                        "Cannot grant refund for more than the available quantity "
+                        f"of the line ({line.quantity - quantity_already_refunded})."
+                    ),
+                    "code": error_code,
+                }
+            )
+
+
+def get_input_lines_data(
+    lines: list[dict[str, Union[str, int]]],
+    errors: list[dict[str, str]],
+    error_code: str,
+) -> dict[str, int]:
+    input_lines_data = {}
+    for line in lines:
+        order_line_id = cast(str, line["id"])
+        try:
+            _, pk = from_global_id_or_error(
+                order_line_id, only_type="OrderLine", raise_error=True
+            )
+            input_lines_data[pk] = int(line["quantity"])
+        except GraphQLError as e:
+            errors.append(
+                {
+                    "line_id": order_line_id,
+                    "field": "id",
+                    "code": error_code,
+                    "message": str(e),
+                }
+            )
+    return input_lines_data
+
+
+def get_lines_map(
+    order: models.Order,
+    input_lines_data: dict[str, int],
+    errors: list[dict[str, str]],
+    error_code: str,
+) -> dict[uuid.UUID, models.OrderLine]:
+    input_line_ids = list(input_lines_data.keys())
+    lines = order.lines.filter(id__in=input_line_ids)
+    lines_dict = {line.pk: line for line in lines}
+    if len(lines_dict.keys()) != len(input_line_ids):
+        invalid_ids = set(input_line_ids).difference(set(lines_dict.keys()))
+        for invalid_id in invalid_ids:
+            errors.append(
+                {
+                    "line_id": graphene.Node.to_global_id("OrderLine", invalid_id),
+                    "field": "id",
+                    "message": "Could not resolve to a line.",
+                    "code": error_code,
+                }
+            )
+    return lines_dict

--- a/saleor/graphql/order/tests/mutations/test_order_grant_refund_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_grant_refund_create.py
@@ -1,8 +1,13 @@
 from decimal import Decimal
 
+from saleor.core.prices import quantize_price
+
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import assert_no_permission, get_graphql_content
-from ...enums import OrderGrantRefundCreateErrorCode
+from ...enums import (
+    OrderGrantRefundCreateErrorCode,
+    OrderGrantRefundCreateLineErrorCode,
+)
 
 ORDER_GRANT_REFUND_CREATE = """
 mutation OrderGrantRefundCreate(
@@ -23,6 +28,14 @@ mutation OrderGrantRefundCreate(
       app{
         id
       }
+      shippingCostsIncluded
+      lines{
+        id
+        orderLine{
+          id
+        }
+        quantity
+      }
     }
     order{
       id
@@ -40,11 +53,25 @@ mutation OrderGrantRefundCreate(
         user{
           id
         }
+        shippingCostsIncluded
+        lines{
+          id
+          orderLine{
+            id
+          }
+          quantity
+        }
       }
     }
     errors{
       field
       code
+      lines{
+        field
+        code
+        orderLineId
+        message
+      }
     }
   }
 }
@@ -189,3 +216,443 @@ def test_grant_refund_incorrect_order_id(staff_api_client, permission_manage_ord
     assert len(errors) == 1
     assert errors[0]["field"] == "id"
     assert errors[0]["code"] == OrderGrantRefundCreateErrorCode.GRAPHQL_ERROR.name
+
+
+def test_grant_refund_with_only_include_grant_refund_for_shipping(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order_id = to_global_id_or_none(order_with_lines)
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {"grantRefundForShipping": True},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert not errors
+
+    assert order_id == data["order"]["id"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+    granted_refund_from_db = order_with_lines.granted_refunds.first()
+    order_granted_refund = data["order"]["grantedRefunds"][0]
+    assert (
+        granted_refund_from_db.shipping_costs_included
+        == order_granted_refund["shippingCostsIncluded"]
+        is True
+    )
+    assert data["grantedRefund"]["shippingCostsIncluded"] is True
+
+
+def test_grant_refund_with_only_lines(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}]
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert not errors
+
+    assert order_id == data["order"]["id"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+
+    granted_refund_from_db = order.granted_refunds.first()
+    order_granted_refund = data["order"]["grantedRefunds"][0]
+    assert data["grantedRefund"]["shippingCostsIncluded"] is False
+    assert len(order_granted_refund["lines"]) == 1
+    assert order_granted_refund["lines"][0]["quantity"] == 1
+    assert order_granted_refund["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        first_line
+    )
+    assert granted_refund_from_db.amount_value == first_line.unit_price_gross_amount * 1
+    assert quantize_price(
+        granted_refund_from_db.amount_value, order.currency
+    ) == quantize_price(
+        Decimal(order_granted_refund["amount"]["amount"]), order.currency
+    )
+
+
+def test_grant_refund_with_include_grant_refund_for_shipping_and_lines(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "grantRefundForShipping": True,
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert not errors
+
+    assert order_id == data["order"]["id"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+    granted_refund_from_db = order.granted_refunds.first()
+    order_granted_refund = data["order"]["grantedRefunds"][0]
+    assert (
+        granted_refund_from_db.shipping_costs_included
+        == order_granted_refund["shippingCostsIncluded"]
+        is True
+    )
+    assert data["grantedRefund"]["shippingCostsIncluded"] is True
+    assert len(order_granted_refund["lines"]) == 1
+    assert order_granted_refund["lines"][0]["quantity"] == 1
+    assert order_granted_refund["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        first_line
+    )
+    assert granted_refund_from_db.amount_value == (
+        first_line.unit_price_gross_amount * 1 + order.shipping_price_gross_amount
+    )
+    assert quantize_price(
+        granted_refund_from_db.amount_value, order.currency
+    ) == quantize_price(
+        Decimal(order_granted_refund["amount"]["amount"]), order.currency
+    )
+
+
+def test_grant_refund_with_provided_lines_shipping_and_amount(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    expected_amount = Decimal("10.0")
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "grantRefundForShipping": True,
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}],
+            "amount": expected_amount,
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert not errors
+
+    assert order_id == data["order"]["id"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+    granted_refund_from_db = order.granted_refunds.first()
+    order_granted_refund = data["order"]["grantedRefunds"][0]
+    assert (
+        granted_refund_from_db.shipping_costs_included
+        == order_granted_refund["shippingCostsIncluded"]
+        is True
+    )
+    assert data["grantedRefund"]["shippingCostsIncluded"] is True
+    assert len(order_granted_refund["lines"]) == 1
+    assert order_granted_refund["lines"][0]["quantity"] == 1
+    assert order_granted_refund["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        first_line
+    )
+    assert granted_refund_from_db.amount_value == expected_amount
+    assert quantize_price(
+        granted_refund_from_db.amount_value, order.currency
+    ) == quantize_price(
+        Decimal(order_granted_refund["amount"]["amount"]), order.currency
+    )
+
+
+def test_grant_refund_without_lines_and_amount_and_grant_for_shipping(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "reason": "Reason",
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 3
+    assert set([error["field"] for error in errors]) == {
+        "amount",
+        "lines",
+        "grantRefundForShipping",
+    }
+    assert set([error["code"] for error in errors]) == {"REQUIRED"}
+
+
+def test_grant_refund_with_incorrect_line_id(
+    staff_api_client, permission_manage_orders, order_with_lines
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "lines": [{"orderLineId": "incorrect_id", "quantity": 1}],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "lines"
+    assert error["code"] == OrderGrantRefundCreateErrorCode.INVALID.name
+    assert len(error["lines"]) == 1
+    line = error["lines"][0]
+    assert line["orderLineId"] == "incorrect_id"
+    assert line["field"] == "orderLineId"
+    assert line["code"] == OrderGrantRefundCreateLineErrorCode.GRAPHQL_ERROR.name
+
+
+def test_grant_refund_with_line_that_belongs_to_another_order(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    order_with_lines_for_cc,
+):
+    # given
+    order = order_with_lines
+    another_order = order_with_lines_for_cc
+    another_order_id = to_global_id_or_none(another_order)
+    first_line = order.lines.first()
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": another_order_id,
+        "input": {
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "lines"
+    assert error["code"] == OrderGrantRefundCreateErrorCode.INVALID.name
+    assert len(error["lines"]) == 1
+    line = error["lines"][0]
+    assert line["orderLineId"] == to_global_id_or_none(first_line)
+    assert line["field"] == "orderLineId"
+    assert line["code"] == OrderGrantRefundCreateLineErrorCode.NOT_FOUND.name
+
+
+def test_grant_refund_with_bigger_quantity_than_available(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "lines": [
+                {"orderLineId": to_global_id_or_none(first_line), "quantity": 100}
+            ],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "lines"
+    assert error["code"] == OrderGrantRefundCreateErrorCode.INVALID.name
+    assert len(error["lines"]) == 1
+    line = error["lines"][0]
+    assert line["orderLineId"] == to_global_id_or_none(first_line)
+    assert line["field"] == "quantity"
+    assert (
+        line["code"]
+        == OrderGrantRefundCreateLineErrorCode.QUANTITY_GREATER_THAN_AVAILABLE.name
+    )
+
+
+def test_grant_refund_with_refund_for_shipping_already_processed(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "grantRefundForShipping": True,
+        },
+    }
+    order.granted_refunds.create(shipping_costs_included=True)
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "grantRefundForShipping"
+    assert (
+        error["code"]
+        == OrderGrantRefundCreateErrorCode.SHIPPING_COSTS_ALREADY_GRANTED.name
+    )
+
+
+def test_grant_refund_with_lines_and_existing_other_grant_refund(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    first_line.quantity = 2
+    first_line.save(update_fields=["quantity"])
+
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}],
+        },
+    }
+    granted_refund = order.granted_refunds.create(shipping_costs_included=False)
+    granted_refund.lines.create(order_line=first_line, quantity=1)
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert not errors
+
+    assert order_id == data["order"]["id"]
+    assert len(data["order"]["grantedRefunds"]) == 2
+
+    granted_refund_from_db = order.granted_refunds.last()
+    order_granted_refund = data["order"]["grantedRefunds"][1]
+    assert data["grantedRefund"]["shippingCostsIncluded"] is False
+    assert len(order_granted_refund["lines"]) == 1
+    assert order_granted_refund["lines"][0]["quantity"] == 1
+    assert order_granted_refund["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        first_line
+    )
+    assert granted_refund_from_db.amount_value == first_line.unit_price_gross_amount * 1
+    assert quantize_price(
+        granted_refund_from_db.amount_value, order.currency
+    ) == quantize_price(
+        Decimal(order_granted_refund["amount"]["amount"]), order.currency
+    )
+
+
+def test_grant_refund_with_lines_and_existing_other_grant_and_refund_exceeding_quantity(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+):
+    # given
+    order = order_with_lines
+    order_id = to_global_id_or_none(order)
+    first_line = order.lines.first()
+    first_line.quantity = 1
+    first_line.save(update_fields=["quantity"])
+
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    variables = {
+        "id": order_id,
+        "input": {
+            "lines": [{"orderLineId": to_global_id_or_none(first_line), "quantity": 1}],
+        },
+    }
+    granted_refund = order.granted_refunds.create(shipping_costs_included=False)
+    granted_refund.lines.create(order_line=first_line, quantity=1)
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_GRANT_REFUND_CREATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundCreate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "lines"
+    assert error["code"] == OrderGrantRefundCreateErrorCode.INVALID.name
+    assert len(error["lines"]) == 1
+    line = error["lines"][0]
+    assert line["orderLineId"] == to_global_id_or_none(first_line)
+    assert line["field"] == "quantity"
+    assert (
+        line["code"]
+        == OrderGrantRefundCreateLineErrorCode.QUANTITY_GREATER_THAN_AVAILABLE.name
+    )

--- a/saleor/graphql/order/tests/mutations/test_order_grant_refund_update.py
+++ b/saleor/graphql/order/tests/mutations/test_order_grant_refund_update.py
@@ -1,12 +1,17 @@
 from decimal import Decimal
 
+from saleor.core.prices import quantize_price
+
 from ....core.utils import to_global_id_or_none
 from ....tests.utils import (
     assert_no_permission,
     get_graphql_content,
     get_graphql_content_from_response,
 )
-from ...enums import OrderGrantRefundUpdateErrorCode
+from ...enums import (
+    OrderGrantRefundUpdateErrorCode,
+    OrderGrantRefundUpdateLineErrorCode,
+)
 
 ORDER_GRANT_REFUND_UPDATE = """
 mutation OrderGrantRefundUpdate(
@@ -27,6 +32,14 @@ mutation OrderGrantRefundUpdate(
       app {
         id
       }
+      shippingCostsIncluded
+      lines{
+        id
+        orderLine{
+          id
+        }
+        quantity
+      }
     }
     order {
       id
@@ -44,11 +57,32 @@ mutation OrderGrantRefundUpdate(
         user{
           id
         }
+        shippingCostsIncluded
+        lines{
+          id
+          orderLine{
+            id
+          }
+          quantity
+        }
       }
     }
     errors {
       field
       code
+      message
+      addLines{
+        field
+        code
+        lineId
+        message
+      }
+      removeLines{
+        field
+        code
+        lineId
+        message
+      }
     }
   }
 }
@@ -422,3 +456,693 @@ def test_grant_refund_update_by_app_missing_input(
     assert len(errors) == 1
     assert errors[0]["code"] == OrderGrantRefundUpdateErrorCode.REQUIRED.name
     assert errors[0]["field"] == "input"
+
+
+def test_grant_refund_update_include_grant_refund_for_shipping(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {"grantRefundForShipping": True},
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    assert not data["errors"]
+
+    granted_refund_assigned_to_order = data["order"]["grantedRefunds"][0]
+    assert granted_refund_assigned_to_order["id"] == data["grantedRefund"]["id"]
+    granted_refund.refresh_from_db()
+    assert (
+        granted_refund.shipping_costs_included
+        == granted_refund_assigned_to_order["shippingCostsIncluded"]
+        is True
+    )
+    assert granted_refund_assigned_to_order["shippingCostsIncluded"] is True
+    assert granted_refund.amount_value == order_with_lines.shipping_price_gross_amount
+    assert quantize_price(
+        granted_refund.amount_value, order_with_lines.currency
+    ) == quantize_price(
+        Decimal(granted_refund_assigned_to_order["amount"]["amount"]),
+        order_with_lines.currency,
+    )
+
+
+def test_grant_refund_update_with_only_add_lines(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    order_line = order_with_lines.lines.first()
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    expected_quantity = 1
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {
+            "addLines": [
+                {"id": to_global_id_or_none(order_line), "quantity": expected_quantity}
+            ]
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    assert not data["errors"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+    granted_refund_data = data["order"]["grantedRefunds"][0]
+    assert len(granted_refund_data["lines"]) == 1
+    assert granted_refund_data["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        order_line
+    )
+
+    assert len(granted_refund.lines.all()) == 1
+    granted_refund_line = granted_refund.lines.first()
+    assert granted_refund_line.order_line == order_line
+    assert granted_refund_line.quantity == expected_quantity
+
+    assert (
+        granted_refund.amount_value
+        == order_line.unit_price_gross_amount * expected_quantity
+    )
+    assert quantize_price(
+        granted_refund.amount_value, order_with_lines.currency
+    ) == quantize_price(
+        Decimal(granted_refund_data["amount"]["amount"]), order_with_lines.currency
+    )
+
+
+def test_grant_refund_update_with_only_remove_lines(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    order_line = order_with_lines.lines.first()
+    granted_refund_line = granted_refund.lines.create(order_line=order_line, quantity=1)
+    granted_refund_line_id = to_global_id_or_none(granted_refund_line)
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {"removeLines": [granted_refund_line_id]},
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+
+    assert not data["errors"]
+
+    assert len(data["order"]["grantedRefunds"]) == 1
+    granted_refund_data = data["order"]["grantedRefunds"][0]
+    assert len(granted_refund_data["lines"]) == 0
+    assert len(granted_refund.lines.all()) == 0
+
+    assert granted_refund.amount_value == 0
+    assert quantize_price(
+        granted_refund.amount_value, order_with_lines.currency
+    ) == quantize_price(
+        Decimal(granted_refund_data["amount"]["amount"]), order_with_lines.currency
+    )
+
+
+def test_grant_refund_update_with_add_and_remove_lines(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    last_order_line = order_with_lines.lines.last()
+    granted_refund_line_to_remove = granted_refund.lines.create(
+        order_line=last_order_line, quantity=1
+    )
+
+    order_line = order_with_lines.lines.first()
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    expected_quantity = 1
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {
+            "addLines": [
+                {"id": to_global_id_or_none(order_line), "quantity": expected_quantity}
+            ],
+            "removeLines": [to_global_id_or_none(granted_refund_line_to_remove)],
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    assert not data["errors"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+    granted_refund_data = data["order"]["grantedRefunds"][0]
+    assert len(granted_refund_data["lines"]) == 1
+    assert granted_refund_data["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        order_line
+    )
+
+    assert len(granted_refund.lines.all()) == 1
+    granted_refund_line = granted_refund.lines.first()
+    assert granted_refund_line.order_line == order_line
+    assert granted_refund_line.quantity == expected_quantity
+
+    assert (
+        granted_refund.amount_value
+        == order_line.unit_price_gross_amount * expected_quantity
+    )
+    assert quantize_price(
+        granted_refund.amount_value, order_with_lines.currency
+    ) == quantize_price(
+        Decimal(granted_refund_data["amount"]["amount"]), order_with_lines.currency
+    )
+
+
+def test_grant_refund_update_with_add_and_remove_lines_and_shipping_included(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    last_order_line = order_with_lines.lines.last()
+    granted_refund_line_to_remove = granted_refund.lines.create(
+        order_line=last_order_line, quantity=1
+    )
+
+    order_line = order_with_lines.lines.first()
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    expected_quantity = 1
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {
+            "addLines": [
+                {"id": to_global_id_or_none(order_line), "quantity": expected_quantity}
+            ],
+            "removeLines": [to_global_id_or_none(granted_refund_line_to_remove)],
+            "grantRefundForShipping": True,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    assert not data["errors"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+    granted_refund_data = data["order"]["grantedRefunds"][0]
+    assert len(granted_refund_data["lines"]) == 1
+    assert granted_refund_data["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        order_line
+    )
+
+    assert len(granted_refund.lines.all()) == 1
+    granted_refund_line = granted_refund.lines.first()
+    assert granted_refund_line.order_line == order_line
+    assert granted_refund_line.quantity == expected_quantity
+
+    assert (
+        granted_refund.amount_value
+        == order_line.unit_price_gross_amount * expected_quantity
+        + order_with_lines.shipping_price_gross_amount
+    )
+    assert quantize_price(
+        granted_refund.amount_value, order_with_lines.currency
+    ) == quantize_price(
+        Decimal(granted_refund_data["amount"]["amount"]), order_with_lines.currency
+    )
+
+
+def test_grant_refund_update_with_add_and_remove_lines_and_shipping_included_and_amount(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    last_order_line = order_with_lines.lines.last()
+    granted_refund_line_to_remove = granted_refund.lines.create(
+        order_line=last_order_line, quantity=1
+    )
+
+    order_line = order_with_lines.lines.first()
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    expected_quantity = 1
+    expected_amount = Decimal("20.000")
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {
+            "amount": expected_amount,
+            "addLines": [
+                {"id": to_global_id_or_none(order_line), "quantity": expected_quantity}
+            ],
+            "removeLines": [to_global_id_or_none(granted_refund_line_to_remove)],
+            "grantRefundForShipping": True,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    assert not data["errors"]
+    assert len(data["order"]["grantedRefunds"]) == 1
+    granted_refund_data = data["order"]["grantedRefunds"][0]
+    assert len(granted_refund_data["lines"]) == 1
+    assert granted_refund_data["lines"][0]["orderLine"]["id"] == to_global_id_or_none(
+        order_line
+    )
+
+    assert len(granted_refund.lines.all()) == 1
+    granted_refund_line = granted_refund.lines.first()
+    assert granted_refund_line.order_line == order_line
+    assert granted_refund_line.quantity == expected_quantity
+
+    assert granted_refund.amount_value == expected_amount
+    assert quantize_price(
+        granted_refund.amount_value, order_with_lines.currency
+    ) == quantize_price(
+        Decimal(granted_refund_data["amount"]["amount"]), order_with_lines.currency
+    )
+
+
+def test_grant_refund_update_with_incorrect_add_line_id(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    expected_quantity = 1
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {"addLines": [{"id": "incorrect-id", "quantity": expected_quantity}]},
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "addLines"
+    assert error["code"] == OrderGrantRefundUpdateErrorCode.INVALID.name
+    assert len(error["addLines"]) == 1
+    line = error["addLines"][0]
+    assert line["lineId"] == "incorrect-id"
+    assert line["field"] == "id"
+    assert line["code"] == OrderGrantRefundUpdateLineErrorCode.GRAPHQL_ERROR.name
+    assert len(granted_refund.lines.all()) == 0
+
+
+def test_grant_refund_update_with_incorrect_remove_line_id(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    order_line = order_with_lines.lines.first()
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    granted_refund_line = granted_refund.lines.create(order_line=order_line, quantity=1)
+
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {"removeLines": ["incorrect-id"]},
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "removeLines"
+    assert error["code"] == OrderGrantRefundUpdateErrorCode.INVALID.name
+    assert len(error["removeLines"]) == 1
+    line = error["removeLines"][0]
+    assert line["lineId"] == "incorrect-id"
+    assert line["field"] is None
+    assert line["code"] == OrderGrantRefundUpdateLineErrorCode.GRAPHQL_ERROR.name
+    assert len(granted_refund.lines.all()) == 1
+    assert granted_refund.lines.all()[0] == granted_refund_line
+
+
+def test_grant_refund_update_with_add_line_belongs_to_another_order(
+    app_api_client,
+    staff_user,
+    permission_manage_orders,
+    order_with_lines,
+    order_with_lines_for_cc,
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    order_line_from_another_order = order_with_lines_for_cc.lines.first()
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    order_line_from_another_order_id = to_global_id_or_none(
+        order_line_from_another_order
+    )
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    expected_quantity = 1
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {
+            "addLines": [
+                {"id": order_line_from_another_order_id, "quantity": expected_quantity}
+            ]
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "addLines"
+    assert error["code"] == OrderGrantRefundUpdateErrorCode.INVALID.name
+    assert len(error["addLines"]) == 1
+    line = error["addLines"][0]
+    assert line["lineId"] == order_line_from_another_order_id
+    assert line["field"] == "id"
+    assert line["code"] == OrderGrantRefundUpdateLineErrorCode.NOT_FOUND.name
+    assert len(granted_refund.lines.all()) == 0
+
+
+def test_grant_refund_update_with_remove_line_belong_to_another_granted_refund(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    order_line = order_with_lines.lines.first()
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    granted_refund_line = granted_refund.lines.create(order_line=order_line, quantity=1)
+
+    second_granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+
+    second_granted_refund_id = to_global_id_or_none(second_granted_refund)
+    granted_refund_line_id = to_global_id_or_none(granted_refund_line)
+
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    variables = {
+        "id": second_granted_refund_id,
+        "input": {"removeLines": [granted_refund_line_id]},
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "removeLines"
+    assert error["code"] == OrderGrantRefundUpdateErrorCode.INVALID.name
+    assert len(error["removeLines"]) == 1
+    line = error["removeLines"][0]
+    assert line["lineId"] == granted_refund_line_id
+    assert line["field"] is None
+    assert line["code"] == OrderGrantRefundUpdateLineErrorCode.NOT_FOUND.name
+
+
+def test_grant_refund_update_with_add_line_quantity_bigger_than_order_line_quantity(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    order_line = order_with_lines.lines.first()
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    order_line_id = to_global_id_or_none(order_line)
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    expected_quantity = 100
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {"addLines": [{"id": order_line_id, "quantity": expected_quantity}]},
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "addLines"
+    assert error["code"] == OrderGrantRefundUpdateErrorCode.INVALID.name
+    assert len(error["addLines"]) == 1
+    line = error["addLines"][0]
+    assert line["lineId"] == order_line_id
+    assert line["field"] == "quantity"
+    assert (
+        line["code"]
+        == OrderGrantRefundUpdateLineErrorCode.QUANTITY_GREATER_THAN_AVAILABLE.name
+    )
+    assert len(granted_refund.lines.all()) == 0
+
+
+def test_grant_refund_update_with_add_line_quantity_bigger_than_available_quantity(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    order_line = order_with_lines.lines.first()
+    second_granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    second_granted_refund.lines.create(
+        order_line=order_line, quantity=order_line.quantity
+    )
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    order_line_id = to_global_id_or_none(order_line)
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    expected_quantity = 1
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {"addLines": [{"id": order_line_id, "quantity": expected_quantity}]},
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "addLines"
+    assert error["code"] == OrderGrantRefundUpdateErrorCode.INVALID.name
+    assert len(error["addLines"]) == 1
+    line = error["addLines"][0]
+    assert line["lineId"] == order_line_id
+    assert line["field"] == "quantity"
+    assert (
+        line["code"]
+        == OrderGrantRefundUpdateLineErrorCode.QUANTITY_GREATER_THAN_AVAILABLE.name
+    )
+    assert len(granted_refund.lines.all()) == 0
+
+
+def test_grant_refund_update_with_shipping_cost_already_included(
+    app_api_client, staff_user, permission_manage_orders, order_with_lines
+):
+    # given
+    current_reason = "Granted refund reason."
+    current_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+    )
+    order_line = order_with_lines.lines.first()
+    order_with_lines.granted_refunds.create(
+        amount_value=current_amount,
+        currency=order_with_lines.currency,
+        reason=current_reason,
+        user=staff_user,
+        shipping_costs_included=True,
+    )
+    granted_refund_id = to_global_id_or_none(granted_refund)
+    order_line_id = to_global_id_or_none(order_line)
+    app_api_client.app.permissions.set([permission_manage_orders])
+
+    expected_quantity = 1
+
+    variables = {
+        "id": granted_refund_id,
+        "input": {
+            "addLines": [{"id": order_line_id, "quantity": expected_quantity}],
+            "grantRefundForShipping": True,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(ORDER_GRANT_REFUND_UPDATE, variables)
+
+    # then
+    granted_refund.refresh_from_db()
+    content = get_graphql_content(response)
+    data = content["data"]["orderGrantRefundUpdate"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "grantRefundForShipping"
+    assert (
+        error["code"]
+        == OrderGrantRefundUpdateErrorCode.SHIPPING_COSTS_ALREADY_GRANTED.name
+    )
+    assert len(granted_refund.lines.all()) == 0

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22113,7 +22113,7 @@ type OrderGrantRefundCreateLineError {
   code: OrderGrantRefundCreateLineErrorCode!
 
   """The ID of the line related to the error."""
-  orderLineId: ID!
+  lineId: ID!
 }
 
 """An enumeration."""
@@ -22157,7 +22157,7 @@ scalar Decimal
 
 input OrderGrantRefundCreateLineInput @doc(category: "Orders") {
   """The ID of the order line."""
-  orderLineId: ID!
+  id: ID!
 
   """The quantity of line items to be marked to refund."""
   quantity: Int!
@@ -22179,7 +22179,6 @@ type OrderGrantRefundUpdate @doc(category: "Orders") {
   """Created granted refund."""
   grantedRefund: OrderGrantedRefund
   errors: [OrderGrantRefundUpdateError!]!
-  orderGrantedRefund: OrderGrantedRefund
 }
 
 type OrderGrantRefundUpdateError @doc(category: "Orders") {
@@ -22193,6 +22192,20 @@ type OrderGrantRefundUpdateError @doc(category: "Orders") {
 
   """The error code."""
   code: OrderGrantRefundUpdateErrorCode!
+
+  """
+  List of lines to add which cause the error.
+  
+  Added in Saleor 3.14.
+  """
+  addLines: [OrderGrantRefundUpdateLineError!]
+
+  """
+  List of lines to remove which cause the error.
+  
+  Added in Saleor 3.14.
+  """
+  removeLines: [OrderGrantRefundUpdateLineError!]
 }
 
 """An enumeration."""
@@ -22200,14 +22213,70 @@ enum OrderGrantRefundUpdateErrorCode @doc(category: "Orders") {
   GRAPHQL_ERROR
   NOT_FOUND
   REQUIRED
+  INVALID
+  SHIPPING_COSTS_ALREADY_GRANTED
+}
+
+type OrderGrantRefundUpdateLineError {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: OrderGrantRefundUpdateLineErrorCode!
+
+  """The ID of the line related to the error."""
+  lineId: ID!
+}
+
+"""An enumeration."""
+enum OrderGrantRefundUpdateLineErrorCode {
+  GRAPHQL_ERROR
+  NOT_FOUND
+  QUANTITY_GREATER_THAN_AVAILABLE
 }
 
 input OrderGrantRefundUpdateInput @doc(category: "Orders") {
-  """Amount of the granted refund."""
+  """
+  Amount of the granted refund. if not provided and `addLines` or `removeLines` or `grantRefundForShipping` is provided, amount will be calculated automatically.
+  """
   amount: Decimal
 
   """Reason of the granted refund."""
   reason: String
+
+  """
+  Lines to assign to granted refund.
+  
+  Added in Saleor 3.14.
+  """
+  addLines: [OrderGrantRefundUpdateLineAddInput!]
+
+  """
+  Lines to remove from granted refund.
+  
+  Added in Saleor 3.14.
+  """
+  removeLines: [ID!]
+
+  """
+  Determine if granted refund should include shipping costs.
+  
+  Added in Saleor 3.14.
+  """
+  grantRefundForShipping: Boolean
+}
+
+input OrderGrantRefundUpdateLineAddInput @doc(category: "Orders") {
+  """The ID of the order line."""
+  id: ID!
+
+  """The quantity of line items to be marked to refund."""
+  quantity: Int!
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22082,20 +22082,69 @@ type OrderGrantRefundCreateError @doc(category: "Orders") {
 
   """The error code."""
   code: OrderGrantRefundCreateErrorCode!
+
+  """List of lines which cause the error."""
+  lines: [OrderGrantRefundCreateLineError!]
 }
 
 """An enumeration."""
 enum OrderGrantRefundCreateErrorCode @doc(category: "Orders") {
   GRAPHQL_ERROR
   NOT_FOUND
+  SHIPPING_COSTS_ALREADY_GRANTED
+  REQUIRED
+  INVALID
+}
+
+type OrderGrantRefundCreateLineError {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: OrderGrantRefundCreateLineErrorCode!
+
+  """The ID of the line related to the error."""
+  orderLineId: ID!
+}
+
+"""An enumeration."""
+enum OrderGrantRefundCreateLineErrorCode {
+  GRAPHQL_ERROR
+  NOT_FOUND
+  QUANTITY_GREATER_THAN_AVAILABLE
 }
 
 input OrderGrantRefundCreateInput @doc(category: "Orders") {
-  """Amount of the granted refund."""
-  amount: Decimal!
+  """
+  Amount of the granted refund. If not provided, the amount will be calculated automatically based on provided `lines` and `grantRefundForShipping`.
+  """
+  amount: Decimal
 
   """Reason of the granted refund."""
   reason: String
+
+  """
+  Lines to assing to granted refund.
+  
+  Added in Saleor 3.14.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  lines: [OrderGrantRefundOrderLineInput!]
+
+  """
+  Determine if granted refund should include shipping costs.
+  
+  Added in Saleor 3.14.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  grantRefundForShipping: Boolean
 }
 
 """
@@ -22105,6 +22154,14 @@ Returns Decimal as a float in the API,
 parses float to the Decimal on the way back.
 """
 scalar Decimal
+
+input OrderGrantRefundOrderLineInput @doc(category: "Orders") {
+  """The ID of the order line."""
+  orderLineId: ID!
+
+  """The quantity of line items to be marked to refund."""
+  quantity: Int!
+}
 
 """
 Updates granted refund.

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22083,7 +22083,11 @@ type OrderGrantRefundCreateError @doc(category: "Orders") {
   """The error code."""
   code: OrderGrantRefundCreateErrorCode!
 
-  """List of lines which cause the error."""
+  """
+  List of lines which cause the error.
+  
+  Added in Saleor 3.14.
+  """
   lines: [OrderGrantRefundCreateLineError!]
 }
 
@@ -22129,11 +22133,9 @@ input OrderGrantRefundCreateInput @doc(category: "Orders") {
   reason: String
 
   """
-  Lines to assing to granted refund.
+  Lines to assign to granted refund.
   
   Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   lines: [OrderGrantRefundOrderLineInput!]
 
@@ -22141,8 +22143,6 @@ input OrderGrantRefundCreateInput @doc(category: "Orders") {
   Determine if granted refund should include shipping costs.
   
   Added in Saleor 3.14.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   grantRefundForShipping: Boolean
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22137,7 +22137,7 @@ input OrderGrantRefundCreateInput @doc(category: "Orders") {
   
   Added in Saleor 3.14.
   """
-  lines: [OrderGrantRefundOrderLineInput!]
+  lines: [OrderGrantRefundCreateLineInput!]
 
   """
   Determine if granted refund should include shipping costs.
@@ -22155,7 +22155,7 @@ parses float to the Decimal on the way back.
 """
 scalar Decimal
 
-input OrderGrantRefundOrderLineInput @doc(category: "Orders") {
+input OrderGrantRefundCreateLineInput @doc(category: "Orders") {
   """The ID of the order line."""
   orderLineId: ID!
 

--- a/saleor/order/error_codes.py
+++ b/saleor/order/error_codes.py
@@ -48,9 +48,17 @@ class OrderGrantRefundUpdateErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
     REQUIRED = "required"
+    INVALID = "invalid"
+    SHIPPING_COSTS_ALREADY_GRANTED = "shipping_costs_already_granted"
 
 
 class OrderGrantRefundCreateLineErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
+    NOT_FOUND = "not_found"
+    QUANTITY_GREATER_THAN_AVAILABLE = "quantity_greater_than_available"
+
+
+class OrderGrantRefundUpdateLineErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
     QUANTITY_GREATER_THAN_AVAILABLE = "quantity_greater_than_available"

--- a/saleor/order/error_codes.py
+++ b/saleor/order/error_codes.py
@@ -39,9 +39,18 @@ class OrderErrorCode(Enum):
 class OrderGrantRefundCreateErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
+    SHIPPING_COSTS_ALREADY_GRANTED = "shipping_costs_already_granted"
+    REQUIRED = "required"
+    INVALID = "invalid"
 
 
 class OrderGrantRefundUpdateErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
     REQUIRED = "required"
+
+
+class OrderGrantRefundCreateLineErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
+    NOT_FOUND = "not_found"
+    QUANTITY_GREATER_THAN_AVAILABLE = "quantity_greater_than_available"


### PR DESCRIPTION
I want to merge this change because it introduces the changes for orderGrantRefund mutation to give a possibility to connect OrderLines&Quantity to the granted refund.

RFC: https://github.com/saleor/saleor/issues/12831

> **Warning**
> Please ignore failing CI. The tests are passing there but for unknown reasons, the CI is pointing to the main branch (instead of the feature branch).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
