### PR TITLE
Add possibility to easily set API patch for test APIClient

### DIFF
--- a/saleor/graphql/tests/fixtures.py
+++ b/saleor/graphql/tests/fixtures.py
@@ -26,6 +26,7 @@ class ApiClient(Client):
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user", None)
         app = kwargs.pop("app", None)
+        api_path = kwargs.pop("api_path", None)
         self._user = None
         self.token = None
         self.user = user
@@ -36,6 +37,9 @@ class ApiClient(Client):
         elif app:
             _, auth_token = app.tokens.create(name="Default")
             self.app_token = auth_token
+        self.api_path = API_PATH
+        if api_path:
+            self.api_path = api_path
         super().__init__(*args, **kwargs)
 
     def _base_environ(self, **request):
@@ -66,7 +70,7 @@ class ApiClient(Client):
         if data:
             data = json.dumps(data, cls=DjangoJSONEncoder)
         kwargs["content_type"] = "application/json"
-        return super().post(API_PATH, data, **kwargs)
+        return super().post(self.api_path, data, **kwargs)
 
     def post_graphql(
         self,
@@ -91,13 +95,13 @@ class ApiClient(Client):
         if permissions:
             if check_no_permissions:
                 with mock.patch("saleor.graphql.utils.handled_errors_logger"):
-                    response = super().post(API_PATH, data, **kwargs)
+                    response = super().post(self.api_path, data, **kwargs)
                 assert_no_permission(response)
             if self.app:
                 self.app.permissions.add(*permissions)
             else:
                 self.user.user_permissions.add(*permissions)
-        result = super().post(API_PATH, data, **kwargs)
+        result = super().post(self.api_path, data, **kwargs)
         flush_post_commit_hooks()
         return result
 
@@ -110,10 +114,10 @@ class ApiClient(Client):
         kwargs["content_type"] = MULTIPART_CONTENT
 
         if permissions:
-            response = super().post(API_PATH, *args, **kwargs)
+            response = super().post(self.api_path, *args, **kwargs)
             assert_no_permission(response)
             self.user.user_permissions.add(*permissions)
-        result = super().post(API_PATH, *args, **kwargs)
+        result = super().post(self.api_path, *args, **kwargs)
         flush_post_commit_hooks()
         return result
 


### PR DESCRIPTION
I want to merge this change because of adding the possibility to easily set API patch for test APIClient.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
