### PR TITLE
Add TransactionRequestRefundForGrantedRefund mutation

### DIFF
--- a/saleor/graphql/core/enums.py
+++ b/saleor/graphql/core/enums.py
@@ -221,6 +221,10 @@ TransactionRequestActionErrorCode = graphene.Enum.from_enum(
 )
 TransactionRequestActionErrorCode.doc_category = DOC_CATEGORY_PAYMENTS
 
+TransactionRequestRefundForGrantedRefundErrorCode = graphene.Enum.from_enum(
+    payment_error_codes.TransactionRequestRefundForGrantedRefundErrorCode
+)
+TransactionRequestRefundForGrantedRefundErrorCode.doc_category = DOC_CATEGORY_PAYMENTS
 TransactionEventReportErrorCode = graphene.Enum.from_enum(
     payment_error_codes.TransactionEventReportErrorCode
 )

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -72,6 +72,7 @@ from ..enums import (
     TransactionInitializeErrorCode,
     TransactionProcessErrorCode,
     TransactionRequestActionErrorCode,
+    TransactionRequestRefundForGrantedRefundErrorCode,
     TransactionUpdateErrorCode,
     TranslationErrorCode,
     UploadErrorCode,
@@ -577,6 +578,15 @@ class TransactionUpdateError(Error):
 
 class TransactionRequestActionError(Error):
     code = TransactionRequestActionErrorCode(
+        description="The error code.", required=True
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_PAYMENTS
+
+
+class TransactionRequestRefundForGrantedRefundError(Error):
+    code = TransactionRequestRefundForGrantedRefundErrorCode(
         description="The error code.", required=True
     )
 

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -85,6 +85,7 @@ from ..core.descriptions import (
     ADDED_IN_31,
     ADDED_IN_34,
     ADDED_IN_313,
+    ADDED_IN_314,
     DEPRECATED_IN_3X_INPUT,
     PREVIEW_FEATURE,
     PREVIEW_FEATURE_DEPRECATED_IN_313_INPUT,
@@ -94,6 +95,7 @@ from ..core.enums import (
     PaymentGatewayInitializeErrorCode,
     TransactionEventReportErrorCode,
     TransactionInitializeErrorCode,
+    TransactionRequestRefundForGrantedRefundErrorCode,
 )
 from ..core.fields import JSONString
 from ..core.mutations import BaseMutation, ModelMutation
@@ -103,7 +105,6 @@ from ..core.types import common as common_types
 from ..core.utils import from_global_id_or_error
 from ..meta.mutations import MetadataInput
 from ..plugins.dataloaders import get_plugin_manager_promise
-from ..utils import get_user_or_app_from_context
 from .enums import (
     StorePaymentMethodEnum,
     TransactionActionEnum,
@@ -1349,17 +1350,6 @@ class TransactionRequestAction(BaseMutation):
         permissions = (PaymentPermissions.HANDLE_PAYMENTS,)
 
     @classmethod
-    def check_permissions(cls, context, permissions=None, **data):
-        required_permissions = permissions or cls._meta.permissions
-        requestor = get_user_or_app_from_context(context)
-        for required_permission in required_permissions:
-            # We want to allow to call this mutation for requestor with one of following
-            # permission: manage_orders, handle_payments
-            if requestor and requestor.has_perm(required_permission):
-                return True
-        return False
-
-    @classmethod
     def handle_transaction_action(
         cls, action, action_kwargs, action_value: Optional[Decimal]
     ):
@@ -1449,6 +1439,100 @@ class TransactionRequestAction(BaseMutation):
             code = error_enum.MISSING_TRANSACTION_ACTION_REQUEST_WEBHOOK.value
             raise ValidationError(str(e), code=code)
         return TransactionRequestAction(transaction=transaction)
+
+
+class TransactionRequestRefundForGrantedRefund(BaseMutation):
+    transaction = graphene.Field(TransactionItem)
+
+    class Arguments:
+        id = graphene.ID(
+            description="The ID of the transaction.",
+            required=True,
+        )
+        granted_refund_id = graphene.ID(
+            required=True,
+            description="The ID of the granted refund.",
+        )
+
+    class Meta:
+        description = (
+            "Request a refund for payment transaction based on granted refund."
+            + ADDED_IN_314
+            + PREVIEW_FEATURE
+        )
+        doc_category = DOC_CATEGORY_PAYMENTS
+        error_type_class = common_types.TransactionRequestRefundForGrantedRefundError
+        permissions = (PaymentPermissions.HANDLE_PAYMENTS,)
+
+    @classmethod
+    def clean_input(
+        cls, info, transaction_id: str, granted_refund_id: str
+    ) -> tuple[payment_models.TransactionItem, order_models.OrderGrantedRefund]:
+        transaction_item = get_transaction_item(transaction_id)
+        granted_refund = cls.get_node_or_error(
+            info,
+            granted_refund_id,
+            field="granted_refund_id",
+            only_type="OrderGrantedRefund",
+            qs=order_models.OrderGrantedRefund.objects.select_related(
+                "order__channel"
+            ).all(),
+        )
+        granted_refund = cast(order_models.OrderGrantedRefund, granted_refund)
+        if transaction_item.order_id != granted_refund.order_id:
+            error_code = TransactionRequestRefundForGrantedRefundErrorCode.INVALID.value
+            raise ValidationError(
+                {
+                    "granted_refund_id": ValidationError(
+                        "The granted refund belongs to different order than "
+                        "transaction.",
+                        code=error_code,
+                    ),
+                    "id": ValidationError(
+                        "The transaction belongs to different order than "
+                        "granted refund.",
+                        code=error_code,
+                    ),
+                }
+            )
+        return transaction_item, granted_refund
+
+    @classmethod
+    def perform_mutation(  # type: ignore[override]
+        cls, root, info: ResolveInfo, /, id, granted_refund_id
+    ):
+        transaction_item, granted_refund = cls.clean_input(info, id, granted_refund_id)
+        order = granted_refund.order
+
+        channel = order.channel
+        cls.check_channel_permissions(info, [channel.id])
+        channel_slug = channel.slug
+
+        app = get_app_promise(info.context).get()
+        manager = get_plugin_manager_promise(info.context).get()
+        action_value = granted_refund.amount_value or transaction_item.charged_value
+        action_value = min(action_value, transaction_item.charged_value)
+        request_event = transaction_item.events.create(
+            amount_value=action_value,
+            currency=transaction_item.currency,
+            type=TransactionEventType.REFUND_REQUEST,
+        )
+
+        try:
+            request_refund_action(
+                transaction=transaction_item,
+                manager=manager,
+                refund_value=action_value,
+                request_event=request_event,
+                channel_slug=channel_slug,
+                user=info.context.user,
+                app=app,
+            )
+        except PaymentError as e:
+            error_enum = TransactionRequestActionErrorCode
+            code = error_enum.MISSING_TRANSACTION_ACTION_REQUEST_WEBHOOK.value
+            raise ValidationError(str(e), code=code)
+        return cls(transaction=transaction_item)
 
 
 class TransactionEventReport(ModelMutation):

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -20,6 +20,7 @@ from .mutations import (
     TransactionInitialize,
     TransactionProcess,
     TransactionRequestAction,
+    TransactionRequestRefundForGrantedRefund,
     TransactionUpdate,
 )
 from .resolvers import resolve_payment_by_id, resolve_payments, resolve_transaction
@@ -88,6 +89,9 @@ class PaymentMutations(graphene.ObjectType):
     transaction_create = TransactionCreate.Field()
     transaction_update = TransactionUpdate.Field()
     transaction_request_action = TransactionRequestAction.Field()
+    transaction_request_refund_for_granted_refund = (
+        TransactionRequestRefundForGrantedRefund.Field()
+    )
     transaction_event_report = TransactionEventReport.Field()
 
     payment_gateway_initialize = PaymentGatewayInitialize.Field()

--- a/saleor/graphql/payment/tests/mutations/test_transaction_request_action.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_request_action.py
@@ -579,7 +579,7 @@ def test_transaction_action_request_uses_handle_payment_permission(
 
 
 def test_transaction_request_action_missing_permission(
-    app_api_client, order_with_lines
+    app_api_client, order_with_lines, permission_manage_orders
 ):
     # given
 
@@ -599,7 +599,9 @@ def test_transaction_request_action_missing_permission(
 
     # when
     response = app_api_client.post_graphql(
-        MUTATION_TRANSACTION_REQUEST_ACTION, variables, permissions=[]
+        MUTATION_TRANSACTION_REQUEST_ACTION,
+        variables,
+        permissions=[permission_manage_orders],
     )
 
     # then

--- a/saleor/graphql/payment/tests/mutations/transaction_request_refund_for_granted_refund.py
+++ b/saleor/graphql/payment/tests/mutations/transaction_request_refund_for_granted_refund.py
@@ -1,0 +1,378 @@
+from decimal import Decimal
+
+import graphene
+from mock import patch
+
+from saleor.graphql.core.enums import TransactionRequestRefundForGrantedRefundErrorCode
+from saleor.graphql.core.utils import to_global_id_or_none
+from saleor.graphql.tests.utils import assert_no_permission, get_graphql_content
+from saleor.payment import TransactionAction, TransactionEventType
+from saleor.payment.interface import TransactionActionData
+from saleor.payment.models import TransactionEvent
+from saleor.webhook.event_types import WebhookEventSyncType
+
+TRANSACTION_REQUEST_REFUND_FOR_GRANTED_REFUND = """
+mutation TransactionRequestRefundForGrantedRefund($id: ID!, $grantedRefundID: ID!) {
+  transactionRequestRefundForGrantedRefund(id: $id, grantedRefundId: $grantedRefundID) {
+    transaction {
+      id
+      events {
+        type
+        amount {
+          amount
+        }
+      }
+    }
+    errors {
+      field
+      message
+      code
+    }
+  }
+}
+"""
+
+
+def test_missing_permission_for_app(
+    app_api_client,
+    order_with_lines,
+    permission_manage_orders,
+    transaction_item_generator,
+):
+    # given
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=Decimal("10.00")
+    )
+    transaction_item = transaction_item_generator(
+        order_id=order_with_lines.pk, charged_value=order_with_lines.total_gross.amount
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "grantedRefundID": to_global_id_or_none(granted_refund),
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        TRANSACTION_REQUEST_REFUND_FOR_GRANTED_REFUND,
+        variables,
+        permissions=[permission_manage_orders],
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_missing_permission_for_user(
+    staff_api_client,
+    order_with_lines,
+    transaction_item_generator,
+    permission_group_no_perms_all_channels,
+):
+    # given
+    permission_group_no_perms_all_channels.user_set.add(staff_api_client.user)
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=Decimal("10.00")
+    )
+    transaction_item = transaction_item_generator(
+        order_id=order_with_lines.pk, charged_value=order_with_lines.total_gross.amount
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "grantedRefundID": to_global_id_or_none(granted_refund),
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        TRANSACTION_REQUEST_REFUND_FOR_GRANTED_REFUND,
+        variables,
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_transaction_doesnt_exist(
+    app_api_client,
+    order_with_lines,
+    permission_manage_payments,
+):
+    # given
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=Decimal("10.00")
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", "1"),
+        "grantedRefundID": to_global_id_or_none(granted_refund),
+    }
+    # when
+    response = app_api_client.post_graphql(
+        TRANSACTION_REQUEST_REFUND_FOR_GRANTED_REFUND,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    error_class = TransactionRequestRefundForGrantedRefundErrorCode
+    content = get_graphql_content(response)
+    data = content["data"]["transactionRequestRefundForGrantedRefund"]
+    assert data["errors"][0]["field"] == "id"
+    assert data["errors"][0]["code"] == error_class.NOT_FOUND.name
+
+
+def test_granted_refund_doesnt_exist(
+    app_api_client,
+    order_with_lines,
+    permission_manage_payments,
+    transaction_item_generator,
+):
+    # given
+    transaction_item = transaction_item_generator(
+        order_id=order_with_lines.pk, charged_value=order_with_lines.total_gross.amount
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "grantedRefundID": graphene.Node.to_global_id("OrderGrantedRefund", 1),
+    }
+    # when
+    response = app_api_client.post_graphql(
+        TRANSACTION_REQUEST_REFUND_FOR_GRANTED_REFUND,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    error_class = TransactionRequestRefundForGrantedRefundErrorCode
+    content = get_graphql_content(response)
+
+    data = content["data"]["transactionRequestRefundForGrantedRefund"]
+    assert data["errors"][0]["field"] == "grantedRefundId"
+    assert data["errors"][0]["code"] == error_class.NOT_FOUND.name
+
+
+def test_transaction_belongs_to_different_order_than_granted_refund_order(
+    app_api_client,
+    order_with_lines,
+    permission_manage_payments,
+    transaction_item_generator,
+    order_with_lines_for_cc,
+):
+    # given
+    transaction_item = transaction_item_generator(
+        order_id=order_with_lines.pk, charged_value=order_with_lines.total_gross.amount
+    )
+
+    granted_refund = order_with_lines_for_cc.granted_refunds.create(
+        amount_value=Decimal("10.00")
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "grantedRefundID": to_global_id_or_none(granted_refund),
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        TRANSACTION_REQUEST_REFUND_FOR_GRANTED_REFUND,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    error_class = TransactionRequestRefundForGrantedRefundErrorCode
+    data = content["data"]["transactionRequestRefundForGrantedRefund"]
+    assert len(data["errors"]) == 2
+    assert any([err["field"] == "grantedRefundId" for err in data["errors"]])
+    assert any([err["field"] == "id" for err in data["errors"]])
+    assert all([err["code"] == error_class.INVALID.name for err in data["errors"]])
+
+
+@patch("saleor.payment.gateway.get_webhooks_for_event")
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+def test_missing_assigned_webhook_event(
+    mocked_is_active,
+    mocked_get_webhooks,
+    app_api_client,
+    order_with_lines,
+    permission_manage_payments,
+    transaction_item_generator,
+    app,
+):
+    # given
+    transaction_item = transaction_item_generator(
+        order_id=order_with_lines.pk,
+        charged_value=order_with_lines.total_gross.amount,
+        app=app,
+    )
+
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=Decimal("10.00")
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "grantedRefundID": to_global_id_or_none(granted_refund),
+    }
+
+    mocked_get_webhooks.return_value = []
+    mocked_is_active.return_value = False
+
+    # when
+    response = app_api_client.post_graphql(
+        TRANSACTION_REQUEST_REFUND_FOR_GRANTED_REFUND,
+        variables,
+        permissions=[permission_manage_payments],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["transactionRequestRefundForGrantedRefund"]
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["message"] == (
+        "No app or plugin is configured to handle payment action requests."
+    )
+    error_class = TransactionRequestRefundForGrantedRefundErrorCode
+    assert data["errors"][0]["code"] == (
+        error_class.MISSING_TRANSACTION_ACTION_REQUEST_WEBHOOK.name
+    )
+
+    assert mocked_is_active.called
+    assert mocked_get_webhooks.called
+    mocked_get_webhooks.assert_called_once_with(
+        event_type=WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED,
+        apps_ids=[app.id],
+    )
+
+
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.transaction_refund_requested")
+def test_triggers_refund_request_for_app(
+    mocked_payment_action_request,
+    mocked_is_active,
+    app_api_client,
+    order_with_lines,
+    permission_manage_payments,
+    transaction_item_generator,
+    app,
+):
+    # given
+    app.permissions.set([permission_manage_payments])
+    webhook = app.webhooks.create(
+        name="Request", is_active=True, target_url="http://localhost:8000/endpoint/"
+    )
+    webhook.events.create(event_type=WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED)
+    transaction_item = transaction_item_generator(
+        order_id=order_with_lines.pk,
+        charged_value=order_with_lines.total_gross.amount,
+        app=app,
+    )
+    expected_refund_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=expected_refund_amount
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "grantedRefundID": to_global_id_or_none(granted_refund),
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        TRANSACTION_REQUEST_REFUND_FOR_GRANTED_REFUND,
+        variables,
+    )
+
+    get_graphql_content(response)
+
+    request_event = TransactionEvent.objects.filter(
+        type=TransactionEventType.REFUND_REQUEST,
+    ).first()
+    assert request_event
+    assert mocked_is_active.called
+    mocked_payment_action_request.assert_called_once_with(
+        TransactionActionData(
+            transaction=transaction_item,
+            action_type=TransactionAction.REFUND,
+            action_value=expected_refund_amount,
+            event=request_event,
+            transaction_app_owner=app,
+        ),
+        order_with_lines.channel.slug,
+    )
+
+    assert TransactionEvent.objects.get(
+        transaction=transaction_item,
+        type=TransactionEventType.REFUND_REQUEST,
+        amount_value=expected_refund_amount,
+    )
+
+
+@patch("saleor.plugins.manager.PluginsManager.is_event_active_for_any_plugin")
+@patch("saleor.plugins.manager.PluginsManager.transaction_refund_requested")
+def test_triggers_refund_request_for_staff_user(
+    mocked_payment_action_request,
+    mocked_is_active,
+    staff_api_client,
+    order_with_lines,
+    permission_manage_payments,
+    transaction_item_generator,
+    app,
+    permission_group_no_perms_all_channels,
+):
+    # given
+    permission_group_no_perms_all_channels.user_set.add(staff_api_client.user)
+    staff_api_client.user.user_permissions.add(permission_manage_payments)
+
+    webhook = app.webhooks.create(
+        name="Request", is_active=True, target_url="http://localhost:8000/endpoint/"
+    )
+    webhook.events.create(event_type=WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED)
+    transaction_item = transaction_item_generator(
+        order_id=order_with_lines.pk,
+        charged_value=order_with_lines.total_gross.amount,
+        app=app,
+    )
+    expected_refund_amount = Decimal("10.00")
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=expected_refund_amount
+    )
+
+    variables = {
+        "id": graphene.Node.to_global_id("TransactionItem", transaction_item.token),
+        "grantedRefundID": to_global_id_or_none(granted_refund),
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        TRANSACTION_REQUEST_REFUND_FOR_GRANTED_REFUND,
+        variables,
+    )
+
+    get_graphql_content(response)
+
+    request_event = TransactionEvent.objects.filter(
+        type=TransactionEventType.REFUND_REQUEST,
+    ).first()
+    assert request_event
+    assert mocked_is_active.called
+    mocked_payment_action_request.assert_called_once_with(
+        TransactionActionData(
+            transaction=transaction_item,
+            action_type=TransactionAction.REFUND,
+            action_value=expected_refund_amount,
+            event=request_event,
+            transaction_app_owner=app,
+        ),
+        order_with_lines.channel.slug,
+    )
+
+    assert TransactionEvent.objects.get(
+        transaction=transaction_item,
+        type=TransactionEventType.REFUND_REQUEST,
+        amount_value=expected_refund_amount,
+    )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14311,6 +14311,23 @@ type Mutation {
   ): TransactionRequestAction @doc(category: "Payments")
 
   """
+  Request a refund for payment transaction based on granted refund.
+  
+  Added in Saleor 3.14.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  
+  Requires one of the following permissions: HANDLE_PAYMENTS.
+  """
+  transactionRequestRefundForGrantedRefund(
+    """The ID of the granted refund."""
+    grantedRefundId: ID!
+
+    """The ID of the transaction."""
+    id: ID!
+  ): TransactionRequestRefundForGrantedRefund @doc(category: "Payments")
+
+  """
   Report the event for the transaction.
   
   Added in Saleor 3.13.
@@ -21098,6 +21115,41 @@ type TransactionRequestActionError @doc(category: "Payments") {
 
 """An enumeration."""
 enum TransactionRequestActionErrorCode @doc(category: "Payments") {
+  INVALID
+  GRAPHQL_ERROR
+  NOT_FOUND
+  MISSING_TRANSACTION_ACTION_REQUEST_WEBHOOK
+}
+
+"""
+Request a refund for payment transaction based on granted refund.
+
+Added in Saleor 3.14.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+
+Requires one of the following permissions: HANDLE_PAYMENTS.
+"""
+type TransactionRequestRefundForGrantedRefund @doc(category: "Payments") {
+  transaction: TransactionItem
+  errors: [TransactionRequestRefundForGrantedRefundError!]!
+}
+
+type TransactionRequestRefundForGrantedRefundError @doc(category: "Payments") {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: TransactionRequestRefundForGrantedRefundErrorCode!
+}
+
+"""An enumeration."""
+enum TransactionRequestRefundForGrantedRefundErrorCode @doc(category: "Payments") {
   INVALID
   GRAPHQL_ERROR
   NOT_FOUND

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -48,6 +48,15 @@ class TransactionRequestActionErrorCode(Enum):
     )
 
 
+class TransactionRequestRefundForGrantedRefundErrorCode(Enum):
+    INVALID = "invalid"
+    GRAPHQL_ERROR = "graphql_error"
+    NOT_FOUND = "not_found"
+    MISSING_TRANSACTION_ACTION_REQUEST_WEBHOOK = (
+        "missing_transaction_action_request_webhook"
+    )
+
+
 class TransactionEventReportErrorCode(Enum):
     INVALID = "invalid"
     GRAPHQL_ERROR = "graphql_error"


### PR DESCRIPTION
I want to merge this change because it adds new mutation that is used to trigger the refund request based on the provided `grantedRefund`

RFC: https://github.com/saleor/saleor/issues/12831

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
