### PR TITLE
Fix failing test after changes in kwargs used for webhook request

### DIFF
--- a/saleor/plugins/webhook/tests/test_tasks.py
+++ b/saleor/plugins/webhook/tests/test_tasks.py
@@ -795,5 +795,9 @@ def test_handle_transaction_request_task_with_available_actions(
     )
 
     mocked_post_request.assert_called_once_with(
-        target_url, data=payload.encode("utf-8"), headers=mock.ANY, timeout=mock.ANY
+        target_url,
+        allow_redirects=False,
+        data=payload.encode("utf-8"),
+        headers=mock.ANY,
+        timeout=mock.ANY,
     )


### PR DESCRIPTION
I want to merge this change because it fixes a test `saleor/plugins/webhook/tests/test_tasks.py:711 test_handle_transaction_request_task_with_available_actions`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
