### PR TITLE
Extend refund request webhook subscription by adding granted refund

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1527,6 +1527,7 @@ class TransactionRequestRefundForGrantedRefund(BaseMutation):
                 channel_slug=channel_slug,
                 user=info.context.user,
                 app=app,
+                granted_refund=granted_refund,
             )
         except PaymentError as e:
             error_enum = TransactionRequestActionErrorCode

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -29335,6 +29335,15 @@ type TransactionRefundRequested implements Event @doc(category: "Payments") {
 
   """Requested action data."""
   action: TransactionAction!
+
+  """
+  Granted refund related to refund request.
+  
+  Added in Saleor 3.14.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  grantedRefund: OrderGrantedRefund
 }
 
 """

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -53,6 +53,7 @@ from ..core.scalars import JSON, PositiveDecimal
 from ..core.types import NonNullList, SubscriptionObjectType
 from ..core.types.order_or_checkout import OrderOrCheckout
 from ..order.dataloaders import OrderByIdLoader
+from ..order.types import OrderGrantedRefund
 from ..payment.enums import TransactionActionEnum
 from ..payment.types import TransactionItem
 from ..plugins.dataloaders import plugin_manager_promise_callback
@@ -1472,6 +1473,13 @@ class TransactionChargeRequested(TransactionActionBase, SubscriptionObjectType):
 
 
 class TransactionRefundRequested(TransactionActionBase, SubscriptionObjectType):
+    granted_refund = graphene.Field(
+        OrderGrantedRefund,
+        description="Granted refund related to refund request."
+        + ADDED_IN_314
+        + PREVIEW_FEATURE,
+    )
+
     class Meta:
         interfaces = (Event,)
         root_type = None
@@ -1482,6 +1490,12 @@ class TransactionRefundRequested(TransactionActionBase, SubscriptionObjectType):
             + PREVIEW_FEATURE
         )
         doc_category = DOC_CATEGORY_PAYMENTS
+
+    @staticmethod
+    def resolve_granted_refund(root, _info: ResolveInfo):
+        _, transaction_action_data = root
+        transaction_action_data: TransactionActionData
+        return transaction_action_data.granted_refund
 
 
 class TransactionCancelationRequested(TransactionActionBase, SubscriptionObjectType):

--- a/saleor/payment/gateway.py
+++ b/saleor/payment/gateway.py
@@ -11,6 +11,7 @@ from ..order.events import (
     event_transaction_charge_requested,
     event_transaction_refund_requested,
 )
+from ..order.models import OrderGrantedRefund
 from ..payment.interface import (
     CustomerSource,
     PaymentGateway,
@@ -124,6 +125,7 @@ def request_refund_action(
     channel_slug: str,
     user: Optional[User],
     app: Optional[App],
+    granted_refund: Optional[OrderGrantedRefund] = None,
 ):
     if refund_value is None:
         refund_value = transaction.charged_value
@@ -133,6 +135,7 @@ def request_refund_action(
         action_type=TransactionAction.REFUND,
         action_value=refund_value,
         request_event=request_event,
+        granted_refund=granted_refund,
     )
     _request_payment_action(
         transaction_action_data=transaction_action_data,
@@ -192,6 +195,7 @@ def _create_transaction_data(
     action_type: "str",
     action_value: Optional[Decimal],
     request_event: TransactionEvent,
+    granted_refund: Optional[OrderGrantedRefund] = None,
 ):
     app_owner = None
     if transaction.app_id:
@@ -205,6 +209,7 @@ def _create_transaction_data(
         action_value=action_value,
         event=request_event,
         transaction_app_owner=app_owner,
+        granted_refund=granted_refund,
     )
 
 

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -12,7 +12,7 @@ from ..payment.models import TransactionEvent, TransactionItem
 if TYPE_CHECKING:
     from ..app.models import App
     from ..checkout.models import Checkout
-    from ..order.models import Order
+    from ..order.models import Order, OrderGrantedRefund
 
 JSONValue = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 JSONType = Union[Dict[str, JSONValue], List[JSONValue]]
@@ -25,6 +25,7 @@ class TransactionActionData:
     event: "TransactionEvent"
     transaction_app_owner: Optional["App"]
     action_value: Optional[Decimal] = None
+    granted_refund: Optional["OrderGrantedRefund"] = None
 
 
 @dataclass

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_refund_requested.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_refund_requested.py
@@ -31,6 +31,41 @@ subscription {
 }
 """
 )
+TRANSACTION_REFUND_REQUESTED_WITH_GRANTED_REFUND_SUBSCRIPTION = (
+    fragments.TRANSACTION_ITEM_DETAILS
+    + """
+subscription {
+  event {
+    ... on TransactionRefundRequested {
+      transaction {
+        ...TransactionFragment
+      }
+      grantedRefund{
+        id
+        amount{
+          amount
+        }
+        lines{
+          id
+          quantity
+          orderLine{
+            unitPrice{
+              gross{
+                amount
+              }
+            }
+          }
+        }
+      }
+      action {
+        actionType
+        amount
+      }
+    }
+  }
+}
+"""
+)
 
 
 @freeze_time("2020-03-18 12:00:00")
@@ -102,5 +137,107 @@ def test_transaction_refund_request(order, webhook_app, permission_manage_paymen
         "action": {
             "actionType": "REFUND",
             "amount": quantize_price(action_value, "USD"),
+        },
+    }
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_transaction_refund_request_with_granted_refund(
+    order_with_lines, webhook_app, permission_manage_payments
+):
+    # given
+    charged_value = Decimal("10")
+    webhook_app.permissions.add(permission_manage_payments)
+    transaction = TransactionItem.objects.create(
+        status="Captured",
+        name="Credit card",
+        psp_reference="PSP ref",
+        available_actions=["refund"],
+        currency="USD",
+        order_id=order_with_lines.pk,
+        charged_value=charged_value,
+    )
+
+    order_line = order_with_lines.lines.first()
+    expected_amount = order_line.unit_price_gross_amount
+
+    granted_refund = order_with_lines.granted_refunds.create(
+        amount_value=expected_amount
+    )
+    granted_refund_line = granted_refund.lines.create(
+        quantity=1,
+        order_line=order_line,
+    )
+
+    action_value = expected_amount
+    request_event = transaction.events.create(
+        amount_value=action_value,
+        currency=transaction.currency,
+        type=TransactionEventType.REFUND_REQUEST,
+    )
+
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        target_url="http://www.example.com/any",
+        subscription_query=(
+            TRANSACTION_REFUND_REQUESTED_WITH_GRANTED_REFUND_SUBSCRIPTION
+        ),
+    )
+    event_type = WebhookEventSyncType.TRANSACTION_REFUND_REQUESTED
+    webhook.events.create(event_type=event_type)
+
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    transaction_data = TransactionActionData(
+        transaction=transaction,
+        action_type=TransactionAction.REFUND,
+        action_value=action_value,
+        event=request_event,
+        transaction_app_owner=None,
+        granted_refund=granted_refund,
+    )
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, transaction_data, [webhook]
+    )
+
+    # then
+    assert json.loads(deliveries[0].payload.payload) == {
+        "transaction": {
+            "id": transaction_id,
+            "createdAt": "2020-03-18T12:00:00+00:00",
+            "actions": ["REFUND"],
+            "authorizedAmount": {"currency": "USD", "amount": 0.0},
+            "refundedAmount": {"currency": "USD", "amount": 0.0},
+            "voidedAmount": {"currency": "USD", "amount": 0.0},
+            "chargedAmount": {
+                "currency": "USD",
+                "amount": quantize_price(charged_value, "USD"),
+            },
+            "events": [
+                {"id": graphene.Node.to_global_id("TransactionEvent", request_event.id)}
+            ],
+            "status": "Captured",
+            "type": "Credit card",
+            "reference": "PSP ref",
+            "pspReference": "PSP ref",
+            "order": {"id": graphene.Node.to_global_id("Order", order_with_lines.id)},
+        },
+        "grantedRefund": {
+            "amount": {"amount": 12.3},
+            "id": graphene.Node.to_global_id("OrderGrantedRefund", granted_refund.id),
+            "lines": [
+                {
+                    "id": graphene.Node.to_global_id(
+                        "OrderGrantedRefundLine", granted_refund_line.id
+                    ),
+                    "orderLine": {"unitPrice": {"gross": {"amount": 12.3}}},
+                    "quantity": 1,
+                }
+            ],
+        },
+        "action": {
+            "actionType": "REFUND",
+            "amount": 12.3,
         },
     }

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -636,10 +636,15 @@ class WebhookEventSyncType:
         PAYMENT_VOID,
     ]
 
+    # Events that are used only in the mutation logic can be excluded from the
+    # circular query check.
     ALLOWED_IN_CIRCULAR_QUERY = [
         PAYMENT_GATEWAY_INITIALIZE_SESSION,
         TRANSACTION_INITIALIZE_SESSION,
         TRANSACTION_PROCESS_SESSION,
+        TRANSACTION_CHARGE_REQUESTED,
+        TRANSACTION_REFUND_REQUESTED,
+        TRANSACTION_CANCELATION_REQUESTED,
     ]
 
     PERMISSIONS = {


### PR DESCRIPTION
I want to merge this change because it extends the refund request subscription with granted refund details.

RFC: https://github.com/saleor/saleor/issues/12831

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
