### PR TITLE
Clean up discount mutations

### DIFF
--- a/saleor/graphql/discount/mutations/__init__.py
+++ b/saleor/graphql/discount/mutations/__init__.py
@@ -1,0 +1,27 @@
+from .sale.sale_add_catalogues import SaleAddCatalogues
+from .sale.sale_channel_listing_update import SaleChannelListingUpdate
+from .sale.sale_create import SaleCreate
+from .sale.sale_delete import SaleDelete
+from .sale.sale_remove_catalogues import SaleRemoveCatalogues
+from .sale.sale_update import SaleUpdate
+from .voucher.voucher_add_catalogues import VoucherAddCatalogues
+from .voucher.voucher_channel_listing_update import VoucherChannelListingUpdate
+from .voucher.voucher_create import VoucherCreate
+from .voucher.voucher_delete import VoucherDelete
+from .voucher.voucher_remove_catalogues import VoucherRemoveCatalogues
+from .voucher.voucher_update import VoucherUpdate
+
+__all__ = [
+    "SaleAddCatalogues",
+    "SaleChannelListingUpdate",
+    "SaleCreate",
+    "SaleUpdate",
+    "SaleDelete",
+    "SaleRemoveCatalogues",
+    "VoucherAddCatalogues",
+    "VoucherChannelListingUpdate",
+    "VoucherCreate",
+    "VoucherDelete",
+    "VoucherRemoveCatalogues",
+    "VoucherUpdate",
+]

--- a/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
@@ -1,17 +1,17 @@
 from typing import cast
 
-from ....core.tracing import traced_atomic_transaction
-from ....discount import models
-from ....discount.utils import fetch_catalogue_info
-from ....permission.enums import DiscountPermissions
-from ...channel import ChannelContext
-from ...core import ResolveInfo
-from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
-from ...core.types import DiscountError
-from ...plugins.dataloaders import get_plugin_manager_promise
-from ..types import Sale
+from .....core.tracing import traced_atomic_transaction
+from .....discount import models
+from .....discount.utils import fetch_catalogue_info
+from .....permission.enums import DiscountPermissions
+from ....channel import ChannelContext
+from ....core import ResolveInfo
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ....core.types import DiscountError
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import Sale
+from ..utils import convert_catalogue_info_to_global_ids
 from .sale_base_catalogue import SaleBaseCatalogueMutation
-from .utils import convert_catalogue_info_to_global_ids
 
 
 class SaleAddCatalogues(SaleBaseCatalogueMutation):

--- a/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
+++ b/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
@@ -1,8 +1,8 @@
 import graphene
 
-from ..types import Sale
+from ...types import Sale
+from ..voucher.voucher_add_catalogues import CatalogueInput
 from .sale_base_discount_catalogue import BaseDiscountCatalogueMutation
-from .voucher_add_catalogues import CatalogueInput
 
 
 class SaleBaseCatalogueMutation(BaseDiscountCatalogueMutation):

--- a/saleor/graphql/discount/mutations/sale/sale_base_discount_catalogue.py
+++ b/saleor/graphql/discount/mutations/sale/sale_base_discount_catalogue.py
@@ -1,10 +1,10 @@
 from django.core.exceptions import ValidationError
 
-from ....discount.error_codes import DiscountErrorCode
-from ....product.tasks import update_products_discounted_prices_of_catalogues_task
-from ....product.utils import get_products_ids_without_variants
-from ...core.mutations import BaseMutation
-from ...product.types import Category, Collection, Product, ProductVariant
+from .....discount.error_codes import DiscountErrorCode
+from .....product.tasks import update_products_discounted_prices_of_catalogues_task
+from .....product.utils import get_products_ids_without_variants
+from ....core.mutations import BaseMutation
+from ....product.types import Category, Collection, Product, ProductVariant
 
 
 class BaseDiscountCatalogueMutation(BaseMutation):

--- a/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
@@ -4,21 +4,21 @@ from typing import TYPE_CHECKING, Dict, List
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....core.tracing import traced_atomic_transaction
-from ....discount import DiscountValueType
-from ....discount.error_codes import DiscountErrorCode
-from ....discount.models import SaleChannelListing
-from ....permission.enums import DiscountPermissions
-from ....product.tasks import update_products_discounted_prices_of_sale_task
-from ...channel import ChannelContext
-from ...channel.mutations import BaseChannelListingMutation
-from ...core import ResolveInfo
-from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
-from ...core.scalars import PositiveDecimal
-from ...core.types import BaseInputObjectType, DiscountError, NonNullList
-from ...core.validators import validate_price_precision
-from ...discount.types import Sale
-from ..dataloaders import SaleChannelListingBySaleIdLoader
+from .....core.tracing import traced_atomic_transaction
+from .....discount import DiscountValueType
+from .....discount.error_codes import DiscountErrorCode
+from .....discount.models import SaleChannelListing
+from .....permission.enums import DiscountPermissions
+from .....product.tasks import update_products_discounted_prices_of_sale_task
+from ....channel import ChannelContext
+from ....channel.mutations import BaseChannelListingMutation
+from ....core import ResolveInfo
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ....core.scalars import PositiveDecimal
+from ....core.types import BaseInputObjectType, DiscountError, NonNullList
+from ....core.validators import validate_price_precision
+from ....discount.types import Sale
+from ...dataloaders import SaleChannelListingBySaleIdLoader
 
 if TYPE_CHECKING:
     from ....discount.models import Sale as SaleModel

--- a/saleor/graphql/discount/mutations/sale/sale_create.py
+++ b/saleor/graphql/discount/mutations/sale/sale_create.py
@@ -4,24 +4,24 @@ import graphene
 import pytz
 from django.core.exceptions import ValidationError
 
-from ....core.tracing import traced_atomic_transaction
-from ....discount import models
-from ....discount.error_codes import DiscountErrorCode
-from ....discount.utils import fetch_catalogue_info
-from ....permission.enums import DiscountPermissions
-from ....product.tasks import update_products_discounted_prices_of_sale_task
-from ...channel import ChannelContext
-from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_31
-from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
-from ...core.mutations import ModelMutation
-from ...core.scalars import PositiveDecimal
-from ...core.types import BaseInputObjectType, DiscountError, NonNullList
-from ...core.validators import validate_end_is_after_start
-from ...plugins.dataloaders import get_plugin_manager_promise
-from ..enums import DiscountValueTypeEnum
-from ..types import Sale
-from .utils import convert_catalogue_info_to_global_ids
+from .....core.tracing import traced_atomic_transaction
+from .....discount import models
+from .....discount.error_codes import DiscountErrorCode
+from .....discount.utils import fetch_catalogue_info
+from .....permission.enums import DiscountPermissions
+from .....product.tasks import update_products_discounted_prices_of_sale_task
+from ....channel import ChannelContext
+from ....core import ResolveInfo
+from ....core.descriptions import ADDED_IN_31
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ....core.mutations import ModelMutation
+from ....core.scalars import PositiveDecimal
+from ....core.types import BaseInputObjectType, DiscountError, NonNullList
+from ....core.validators import validate_end_is_after_start
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...enums import DiscountValueTypeEnum
+from ...types import Sale
+from ..utils import convert_catalogue_info_to_global_ids
 
 
 class SaleInput(BaseInputObjectType):

--- a/saleor/graphql/discount/mutations/sale/sale_delete.py
+++ b/saleor/graphql/discount/mutations/sale/sale_delete.py
@@ -1,17 +1,17 @@
 import graphene
 
-from ....core.tracing import traced_atomic_transaction
-from ....discount import models
-from ....discount.utils import fetch_catalogue_info
-from ....graphql.core.mutations import ModelDeleteMutation
-from ....permission.enums import DiscountPermissions
-from ....product.tasks import update_products_discounted_prices_of_catalogues_task
-from ...channel import ChannelContext
-from ...core import ResolveInfo
-from ...core.types import DiscountError
-from ...plugins.dataloaders import get_plugin_manager_promise
-from ..types import Sale
-from .utils import convert_catalogue_info_to_global_ids
+from .....core.tracing import traced_atomic_transaction
+from .....discount import models
+from .....discount.utils import fetch_catalogue_info
+from .....graphql.core.mutations import ModelDeleteMutation
+from .....permission.enums import DiscountPermissions
+from .....product.tasks import update_products_discounted_prices_of_catalogues_task
+from ....channel import ChannelContext
+from ....core import ResolveInfo
+from ....core.types import DiscountError
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import Sale
+from ..utils import convert_catalogue_info_to_global_ids
 
 
 class SaleDelete(ModelDeleteMutation):

--- a/saleor/graphql/discount/mutations/sale/sale_remove_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale/sale_remove_catalogues.py
@@ -1,17 +1,17 @@
 from typing import cast
 
-from ....core.tracing import traced_atomic_transaction
-from ....discount import models
-from ....discount.utils import fetch_catalogue_info
-from ....graphql.channel import ChannelContext
-from ....permission.enums import DiscountPermissions
-from ...core import ResolveInfo
-from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
-from ...core.types import DiscountError
-from ...plugins.dataloaders import get_plugin_manager_promise
-from ..types import Sale
+from .....core.tracing import traced_atomic_transaction
+from .....discount import models
+from .....discount.utils import fetch_catalogue_info
+from .....graphql.channel import ChannelContext
+from .....permission.enums import DiscountPermissions
+from ....core import ResolveInfo
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ....core.types import DiscountError
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import Sale
+from ..utils import convert_catalogue_info_to_global_ids
 from .sale_base_catalogue import SaleBaseCatalogueMutation
-from .utils import convert_catalogue_info_to_global_ids
 
 
 class SaleRemoveCatalogues(SaleBaseCatalogueMutation):

--- a/saleor/graphql/discount/mutations/sale/sale_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_update.py
@@ -4,19 +4,19 @@ from datetime import datetime
 import graphene
 import pytz
 
-from ....core.tracing import traced_atomic_transaction
-from ....discount import models
-from ....discount.utils import CATALOGUE_FIELDS, fetch_catalogue_info
-from ....permission.enums import DiscountPermissions
-from ....product.tasks import update_products_discounted_prices_of_catalogues_task
-from ...channel import ChannelContext
-from ...core import ResolveInfo
-from ...core.mutations import ModelMutation
-from ...core.types import DiscountError
-from ...plugins.dataloaders import get_plugin_manager_promise
-from ..types import Sale
+from .....core.tracing import traced_atomic_transaction
+from .....discount import models
+from .....discount.utils import CATALOGUE_FIELDS, fetch_catalogue_info
+from .....permission.enums import DiscountPermissions
+from .....product.tasks import update_products_discounted_prices_of_catalogues_task
+from ....channel import ChannelContext
+from ....core import ResolveInfo
+from ....core.mutations import ModelMutation
+from ....core.types import DiscountError
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import Sale
+from ..utils import convert_catalogue_info_to_global_ids
 from .sale_create import SaleInput
-from .utils import convert_catalogue_info_to_global_ids
 
 
 class SaleUpdate(ModelMutation):

--- a/saleor/graphql/discount/mutations/voucher/voucher_add_catalogues.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_add_catalogues.py
@@ -1,14 +1,14 @@
 import graphene
 
-from ....permission.enums import DiscountPermissions
-from ...channel import ChannelContext
-from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_31
-from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
-from ...core.types import BaseInputObjectType, DiscountError, NonNullList
-from ...plugins.dataloaders import get_plugin_manager_promise
-from ..types import Voucher
-from .sale_base_discount_catalogue import BaseDiscountCatalogueMutation
+from .....permission.enums import DiscountPermissions
+from ....channel import ChannelContext
+from ....core import ResolveInfo
+from ....core.descriptions import ADDED_IN_31
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ....core.types import BaseInputObjectType, DiscountError, NonNullList
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import Voucher
+from ..sale.sale_base_discount_catalogue import BaseDiscountCatalogueMutation
 
 
 class CatalogueInput(BaseInputObjectType):

--- a/saleor/graphql/discount/mutations/voucher/voucher_channel_listing_update.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_channel_listing_update.py
@@ -4,19 +4,19 @@ from typing import Dict, List
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....core.tracing import traced_atomic_transaction
-from ....discount import DiscountValueType, models
-from ....discount.error_codes import DiscountErrorCode
-from ....permission.enums import DiscountPermissions
-from ...channel import ChannelContext
-from ...channel.mutations import BaseChannelListingMutation
-from ...core import ResolveInfo
-from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
-from ...core.scalars import PositiveDecimal
-from ...core.types import BaseInputObjectType, DiscountError, NonNullList
-from ...core.validators import validate_price_precision
-from ...plugins.dataloaders import get_plugin_manager_promise
-from ..types import Voucher
+from .....core.tracing import traced_atomic_transaction
+from .....discount import DiscountValueType, models
+from .....discount.error_codes import DiscountErrorCode
+from .....permission.enums import DiscountPermissions
+from ....channel import ChannelContext
+from ....channel.mutations import BaseChannelListingMutation
+from ....core import ResolveInfo
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ....core.scalars import PositiveDecimal
+from ....core.types import BaseInputObjectType, DiscountError, NonNullList
+from ....core.validators import validate_price_precision
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import Voucher
 
 
 class VoucherChannelListingAddInput(BaseInputObjectType):

--- a/saleor/graphql/discount/mutations/voucher/voucher_create.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_create.py
@@ -1,20 +1,20 @@
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....core.utils.promo_code import generate_promo_code, is_available_promo_code
-from ....discount import models
-from ....discount.error_codes import DiscountErrorCode
-from ....permission.enums import DiscountPermissions
-from ...channel import ChannelContext
-from ...core import ResolveInfo
-from ...core.descriptions import ADDED_IN_31
-from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
-from ...core.mutations import ModelMutation
-from ...core.types import BaseInputObjectType, DiscountError, NonNullList
-from ...core.validators import validate_end_is_after_start
-from ...plugins.dataloaders import get_plugin_manager_promise
-from ..enums import DiscountValueTypeEnum, VoucherTypeEnum
-from ..types import Voucher
+from .....core.utils.promo_code import generate_promo_code, is_available_promo_code
+from .....discount import models
+from .....discount.error_codes import DiscountErrorCode
+from .....permission.enums import DiscountPermissions
+from ....channel import ChannelContext
+from ....core import ResolveInfo
+from ....core.descriptions import ADDED_IN_31
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ....core.mutations import ModelMutation
+from ....core.types import BaseInputObjectType, DiscountError, NonNullList
+from ....core.validators import validate_end_is_after_start
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...enums import DiscountValueTypeEnum, VoucherTypeEnum
+from ...types import Voucher
 
 
 class VoucherInput(BaseInputObjectType):

--- a/saleor/graphql/discount/mutations/voucher/voucher_delete.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_delete.py
@@ -2,13 +2,13 @@ import graphene
 
 from saleor.discount import models
 
-from ....permission.enums import DiscountPermissions
-from ...channel import ChannelContext
-from ...core import ResolveInfo
-from ...core.mutations import ModelDeleteMutation
-from ...core.types import DiscountError
-from ...plugins.dataloaders import get_plugin_manager_promise
-from ..types import Voucher
+from .....permission.enums import DiscountPermissions
+from ....channel import ChannelContext
+from ....core import ResolveInfo
+from ....core.mutations import ModelDeleteMutation
+from ....core.types import DiscountError
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import Voucher
 
 
 class VoucherDelete(ModelDeleteMutation):

--- a/saleor/graphql/discount/mutations/voucher/voucher_remove_catalogues.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_remove_catalogues.py
@@ -1,9 +1,9 @@
-from ....permission.enums import DiscountPermissions
-from ...core import ResolveInfo
-from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
-from ...core.types import DiscountError
-from ...plugins.dataloaders import get_plugin_manager_promise
-from ..types import Voucher
+from .....permission.enums import DiscountPermissions
+from ....core import ResolveInfo
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ....core.types import DiscountError
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import Voucher
 from .voucher_add_catalogues import VoucherBaseCatalogueMutation
 
 

--- a/saleor/graphql/discount/mutations/voucher/voucher_update.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_update.py
@@ -1,11 +1,11 @@
 import graphene
 
-from ....discount import models
-from ....permission.enums import DiscountPermissions
-from ...core import ResolveInfo
-from ...core.types import DiscountError
-from ...plugins.dataloaders import get_plugin_manager_promise
-from ..types import Voucher
+from .....discount import models
+from .....permission.enums import DiscountPermissions
+from ....core import ResolveInfo
+from ....core.types import DiscountError
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import Voucher
 from .voucher_create import VoucherCreate, VoucherInput
 
 

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -10,19 +10,21 @@ from ..core.types import FilterInputObjectType
 from ..core.utils import from_global_id_or_error
 from ..translations.mutations import SaleTranslate, VoucherTranslate
 from .filters import SaleFilter, VoucherFilter
+from .mutations import (
+    SaleAddCatalogues,
+    SaleChannelListingUpdate,
+    SaleCreate,
+    SaleDelete,
+    SaleRemoveCatalogues,
+    SaleUpdate,
+    VoucherAddCatalogues,
+    VoucherChannelListingUpdate,
+    VoucherCreate,
+    VoucherDelete,
+    VoucherRemoveCatalogues,
+    VoucherUpdate,
+)
 from .mutations.bulk_mutations import SaleBulkDelete, VoucherBulkDelete
-from .mutations.sale_add_catalogues import SaleAddCatalogues
-from .mutations.sale_channel_listing_update import SaleChannelListingUpdate
-from .mutations.sale_create import SaleCreate
-from .mutations.sale_delete import SaleDelete
-from .mutations.sale_remove_catalogues import SaleRemoveCatalogues
-from .mutations.sale_update import SaleUpdate
-from .mutations.voucher_add_catalogues import VoucherAddCatalogues
-from .mutations.voucher_channel_listing_update import VoucherChannelListingUpdate
-from .mutations.voucher_create import VoucherCreate
-from .mutations.voucher_delete import VoucherDelete
-from .mutations.voucher_remove_catalogues import VoucherRemoveCatalogues
-from .mutations.voucher_update import VoucherUpdate
 from .resolvers import resolve_sale, resolve_sales, resolve_voucher, resolve_vouchers
 from .sorters import SaleSortingInput, VoucherSortingInput
 from .types import Sale, SaleCountableConnection, Voucher, VoucherCountableConnection

--- a/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
@@ -34,7 +34,7 @@ mutation UpdateSaleChannelListing(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_channel_listing_update"
+    "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
     ".update_products_discounted_prices_of_sale_task"
 )
 def test_sale_channel_listing_create_as_staff_user(
@@ -82,7 +82,7 @@ def test_sale_channel_listing_create_as_staff_user(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_channel_listing_update"
+    "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
     ".update_products_discounted_prices_of_sale_task"
 )
 def test_sale_channel_listing_update_as_staff_user(
@@ -163,7 +163,7 @@ def test_sale_channel_listing_update_with_negative_discounted_value(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_channel_listing_update"
+    "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
     ".update_products_discounted_prices_of_sale_task"
 )
 def test_sale_channel_listing_update_duplicated_ids_in_add_and_remove(
@@ -203,7 +203,7 @@ def test_sale_channel_listing_update_duplicated_ids_in_add_and_remove(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_channel_listing_update"
+    "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
     ".update_products_discounted_prices_of_sale_task"
 )
 def test_sale_channel_listing_update_duplicated_channel_in_add(
@@ -245,7 +245,7 @@ def test_sale_channel_listing_update_duplicated_channel_in_add(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_channel_listing_update"
+    "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
     ".update_products_discounted_prices_of_sale_task"
 )
 def test_sale_channel_listing_update_duplicated_channel_in_remove(
@@ -281,7 +281,7 @@ def test_sale_channel_listing_update_duplicated_channel_in_remove(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_channel_listing_update"
+    "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
     ".update_products_discounted_prices_of_sale_task"
 )
 def test_sale_channel_listing_update_with_invalid_decimal_places(
@@ -320,7 +320,7 @@ def test_sale_channel_listing_update_with_invalid_decimal_places(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_channel_listing_update"
+    "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
     ".update_products_discounted_prices_of_sale_task"
 )
 def test_sale_channel_listing_update_with_invalid_percentage_value(
@@ -395,7 +395,7 @@ mutation UpdateSaleChannelListing(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_channel_listing_update"
+    "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
     ".update_products_discounted_prices_of_sale_task"
 )
 def test_invalidate_data_sale_channel_listings_update(

--- a/saleor/graphql/product/tests/test_product_discounted_price.py
+++ b/saleor/graphql/product/tests/test_product_discounted_price.py
@@ -181,7 +181,7 @@ def test_collection_remove_products_updates_discounted_price(
 
 @freeze_time("2010-05-31 12:00:01")
 @patch(
-    "saleor.graphql.discount.mutations.sale_create"
+    "saleor.graphql.discount.mutations.sale.sale_create"
     ".update_products_discounted_prices_of_sale_task"
 )
 def test_sale_create_updates_products_discounted_prices(
@@ -234,7 +234,7 @@ def test_sale_create_updates_products_discounted_prices(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_update"
+    "saleor.graphql.discount.mutations.sale.sale_update"
     ".update_products_discounted_prices_of_catalogues_task.delay"
 )
 def test_sale_update_updates_products_discounted_prices(
@@ -284,7 +284,7 @@ def test_sale_update_updates_products_discounted_prices(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_delete"
+    "saleor.graphql.discount.mutations.sale.sale_delete"
     ".update_products_discounted_prices_of_catalogues_task.delay"
 )
 def test_sale_delete_updates_products_discounted_prices(
@@ -329,7 +329,7 @@ def test_sale_delete_updates_products_discounted_prices(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_base_discount_catalogue"
+    "saleor.graphql.discount.mutations.sale.sale_base_discount_catalogue"
     ".update_products_discounted_prices_of_catalogues_task"
 )
 def test_sale_add_catalogues_updates_products_discounted_prices(
@@ -389,7 +389,7 @@ def test_sale_add_catalogues_updates_products_discounted_prices(
 
 
 @patch(
-    "saleor.graphql.discount.mutations.sale_base_discount_catalogue"
+    "saleor.graphql.discount.mutations.sale.sale_base_discount_catalogue"
     ".update_products_discounted_prices_of_catalogues_task"
 )
 def test_sale_remove_catalogues_updates_products_discounted_prices(


### PR DESCRIPTION
Add `sale` and `voucher` directories in discount mutations. Move the corresponding mutations there.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
