### PR TITLE
Fix setting webhook activity using `isActive` field in the App manifest

### DIFF
--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -94,6 +94,7 @@ def install_app(app_installation: AppInstallation, activate: bool = False):
         Webhook(
             app=app,
             name=webhook["name"],
+            is_active=webhook["isActive"],
             target_url=webhook["targetUrl"],
             subscription_query=webhook["query"],
         )

--- a/saleor/app/manifest_validations.py
+++ b/saleor/app/manifest_validations.py
@@ -208,6 +208,15 @@ def clean_webhooks(manifest_data, errors):
                 )
             )
 
+        webhook["isActive"] = webhook.get("isActive", True)
+        if not isinstance(webhook["isActive"], bool):
+            errors["webhooks"].append(
+                ValidationError(
+                    "Incorrect value for field: isActive.",
+                    code=AppErrorCode.INVALID.value,
+                )
+            )
+
         webhook["events"] = []
         for e_type in webhook.get("asyncEvents", []):
             try:

--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -376,6 +376,47 @@ def test_install_app_webhook_incorrect_url(
     assert error_dict["webhooks"][0].message == "Invalid target url."
 
 
+@pytest.mark.parametrize("is_active", (True, False))
+def test_install_app_with_webhook_is_active(
+    is_active, app_manifest, app_manifest_webhook, app_installation, monkeypatch
+):
+    # given
+    app_manifest_webhook["isActive"] = is_active
+    app_manifest["webhooks"] = [app_manifest_webhook]
+
+    mocked_get_response = Mock()
+    mocked_get_response.json.return_value = app_manifest
+    monkeypatch.setattr(requests, "get", Mock(return_value=mocked_get_response))
+    monkeypatch.setattr("saleor.app.installation_utils.send_app_token", Mock())
+
+    # when
+    app, _ = install_app(app_installation, activate=True)
+
+    # then
+    webhook = app.webhooks.get()
+    assert webhook.is_active == is_active
+
+
+def test_install_app_with_webhook_incorrect_is_active_value(
+    app_manifest, app_manifest_webhook, app_installation, monkeypatch
+):
+    # given
+    app_manifest_webhook["isActive"] = "incorrect value"
+    app_manifest["webhooks"] = [app_manifest_webhook]
+
+    mocked_get_response = Mock()
+    mocked_get_response.json.return_value = app_manifest
+    monkeypatch.setattr(requests, "get", Mock(return_value=mocked_get_response))
+
+    # when & then
+    with pytest.raises(ValidationError) as excinfo:
+        install_app(app_installation, activate=True)
+
+    error_dict = excinfo.value.error_dict
+    assert "webhooks" in error_dict
+    assert error_dict["webhooks"][0].message == "Incorrect value for field: isActive."
+
+
 def test_install_app_webhook_incorrect_query(
     app_manifest, app_manifest_webhook, app_installation, monkeypatch
 ):


### PR DESCRIPTION
Port of https://github.com/saleor/saleor/pull/12714

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
