### PR TITLE
Add promotion mutations

### DIFF
--- a/saleor/discount/error_codes.py
+++ b/saleor/discount/error_codes.py
@@ -17,3 +17,10 @@ class PromotionCreateErrorCode(Enum):
     NOT_FOUND = "not_found"
     REQUIRED = "required"
     INVALID = "invalid"
+
+
+class PromotionUpdateErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
+    NOT_FOUND = "not_found"
+    REQUIRED = "required"
+    INVALID = "invalid"

--- a/saleor/discount/error_codes.py
+++ b/saleor/discount/error_codes.py
@@ -10,3 +10,8 @@ class DiscountErrorCode(Enum):
     UNIQUE = "unique"
     CANNOT_MANAGE_PRODUCT_WITHOUT_VARIANT = "cannot_manage_product_without_variant"
     DUPLICATED_INPUT_ITEM = "duplicated_input_item"
+
+
+class PromotionCreateErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
+    NOT_FOUND = "not_found"

--- a/saleor/discount/error_codes.py
+++ b/saleor/discount/error_codes.py
@@ -24,3 +24,8 @@ class PromotionUpdateErrorCode(Enum):
     NOT_FOUND = "not_found"
     REQUIRED = "required"
     INVALID = "invalid"
+
+
+class PromotionDeleteErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
+    NOT_FOUND = "not_found"

--- a/saleor/discount/error_codes.py
+++ b/saleor/discount/error_codes.py
@@ -15,3 +15,5 @@ class DiscountErrorCode(Enum):
 class PromotionCreateErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
+    REQUIRED = "required"
+    INVALID = "invalid"

--- a/saleor/graphql/discount/enums.py
+++ b/saleor/graphql/discount/enums.py
@@ -1,4 +1,12 @@
-from ...discount import DiscountType, DiscountValueType, RewardValueType, VoucherType
+import graphene
+
+from ...discount import (
+    DiscountType,
+    DiscountValueType,
+    RewardValueType,
+    VoucherType,
+    error_codes,
+)
 from ..core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ..core.enums import to_enum
 from ..core.types import BaseEnum
@@ -7,6 +15,8 @@ OrderDiscountTypeEnum = to_enum(DiscountType, type_name="OrderDiscountType")
 OrderDiscountTypeEnum.doc_category = DOC_CATEGORY_DISCOUNTS
 RewardValueTypeEnum = to_enum(RewardValueType, type_name="RewardValueTypeEnum")
 RewardValueTypeEnum.doc_category = DOC_CATEGORY_DISCOUNTS
+
+PromotionCreateErrorCode = graphene.Enum.from_enum(error_codes.PromotionCreateErrorCode)
 
 
 class SaleType(BaseEnum):

--- a/saleor/graphql/discount/enums.py
+++ b/saleor/graphql/discount/enums.py
@@ -17,6 +17,7 @@ RewardValueTypeEnum = to_enum(RewardValueType, type_name="RewardValueTypeEnum")
 RewardValueTypeEnum.doc_category = DOC_CATEGORY_DISCOUNTS
 
 PromotionCreateErrorCode = graphene.Enum.from_enum(error_codes.PromotionCreateErrorCode)
+PromotionUpdateErrorCode = graphene.Enum.from_enum(error_codes.PromotionUpdateErrorCode)
 
 
 class SaleType(BaseEnum):

--- a/saleor/graphql/discount/enums.py
+++ b/saleor/graphql/discount/enums.py
@@ -18,6 +18,7 @@ RewardValueTypeEnum.doc_category = DOC_CATEGORY_DISCOUNTS
 
 PromotionCreateErrorCode = graphene.Enum.from_enum(error_codes.PromotionCreateErrorCode)
 PromotionUpdateErrorCode = graphene.Enum.from_enum(error_codes.PromotionUpdateErrorCode)
+PromotionDeleteErrorCode = graphene.Enum.from_enum(error_codes.PromotionDeleteErrorCode)
 
 
 class SaleType(BaseEnum):

--- a/saleor/graphql/discount/inputs.py
+++ b/saleor/graphql/discount/inputs.py
@@ -1,0 +1,87 @@
+import graphene
+
+from ..core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ..core.types import BaseInputObjectType, NonNullList
+
+
+class ProductVariantPredicateInput(BaseInputObjectType):
+    ids = NonNullList(graphene.ID, description="The list of product variant ids.")
+
+    class Meta:
+        doc_category = DOC_CATEGORY_DISCOUNTS
+
+
+class ProductPredicateInput(BaseInputObjectType):
+    ids = NonNullList(graphene.ID, description="The list of product ids.")
+
+    class Meta:
+        doc_category = DOC_CATEGORY_DISCOUNTS
+
+
+class CategoryPredicateInput(BaseInputObjectType):
+    ids = NonNullList(graphene.ID, description="The list of category ids.")
+
+    class Meta:
+        doc_category = DOC_CATEGORY_DISCOUNTS
+
+
+class CollectionPredicateInput(BaseInputObjectType):
+    ids = NonNullList(graphene.ID, description="The list of collection ids.")
+
+    class Meta:
+        doc_category = DOC_CATEGORY_DISCOUNTS
+
+
+class PredicateInputObjectType(BaseInputObjectType):
+    """Class for defining the predicate input.
+
+    AND, OR, and NOT class type fields are automatically added to available input
+    fields, allowing to create complex filter statements.
+    """
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def __init_subclass_with_meta__(cls, _meta=None, **options):
+        super().__init_subclass_with_meta__(_meta=_meta, **options)
+        cls._meta.fields.update(
+            {
+                "AND": graphene.Field(
+                    NonNullList(
+                        cls,
+                    ),
+                    description="List of conditions that must be met.",
+                ),
+                "OR": graphene.Field(
+                    NonNullList(
+                        cls,
+                    ),
+                    description=(
+                        "A list of conditions of which at least one must be met."
+                    ),
+                ),
+                # TODO: needs optimization
+                # "NOT": graphene.Field(
+                #     cls, description="A condition that cannot be met."
+                # ),
+            }
+        )
+
+
+class CataloguePredicateInput(PredicateInputObjectType):
+    variant_predicate = ProductVariantPredicateInput(
+        description="Defines the product variant conditions to be met."
+    )
+    product_predicate = ProductPredicateInput(
+        description="Defines the product conditions to be met."
+    )
+    category_predicate = CategoryPredicateInput(
+        description="Defines the category conditions to be met."
+    )
+    collection_predicate = CollectionPredicateInput(
+        description="Defines the collection conditions to be met."
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_DISCOUNTS

--- a/saleor/graphql/discount/mutations/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion_create.py
@@ -63,15 +63,18 @@ class PromotionRuleInput(BaseInputObjectType):
         doc_category = DOC_CATEGORY_DISCOUNTS
 
 
-class PromotionCreateInput(BaseInputObjectType):
-    name = graphene.String(description="Promotion name.")
-    description = JSON(description="Promotion description.", required=False)
+class PromotionInput(BaseInputObjectType):
+    description = JSON(description="Promotion description.")
     start_date = graphene.types.datetime.DateTime(
         description="The start date of the promotion in ISO 8601 format."
     )
     end_date = graphene.types.datetime.DateTime(
         description="The end date of the promotion in ISO 8601 format."
     )
+
+
+class PromotionCreateInput(PromotionInput):
+    name = graphene.String(description="Promotion name.", required=True)
     rules = NonNullList(PromotionRuleInput, description="List of promotion rules.")
 
     class Meta:
@@ -90,6 +93,7 @@ class PromotionCreate(ModelMutation):
         object_type = Promotion
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
         error_type_class = PromotionCreateError
+        doc_category = DOC_CATEGORY_DISCOUNTS
 
     @classmethod
     def clean_input(

--- a/saleor/graphql/discount/mutations/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion_create.py
@@ -1,0 +1,77 @@
+import graphene
+
+from ....discount import models
+from ....permission.enums import DiscountPermissions
+from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ...core.mutations import ModelMutation
+from ...core.scalars import JSON, PositiveDecimal
+from ...core.types import BaseInputObjectType, Error, NonNullList
+from ..enums import PromotionCreateErrorCode, RewardValueTypeEnum
+from ..inputs import CataloguePredicateInput
+from ..types import Promotion
+
+
+class PromotionCreateError(Error):
+    code = PromotionCreateErrorCode(description="The error code.", required=True)
+
+
+class PromotionRuleInput(BaseInputObjectType):
+    name = graphene.String(description="Promotion rule name.")
+    description = JSON(description="Promotion rule description.", required=False)
+    channels = NonNullList(
+        graphene.ID,
+        description="List of channel ids to which the rule should apply to.",
+    )
+    catalogue_predicate = CataloguePredicateInput(
+        description=(
+            "Defines the conditions on the catalogue level that must be met "
+            "for the reward to be applied."
+        ),
+        required=False,
+    )
+    reward_value_type = RewardValueTypeEnum(
+        description=(
+            "Defines the promotion rule reward value type. "
+            "Must be provided together with reward value."
+        ),
+        required=False,
+    )
+    reward_value = PositiveDecimal(
+        description=(
+            "Defines the discount value. Required when catalogue predicate is provided."
+        ),
+        required=False,
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_DISCOUNTS
+
+
+class PromotionCreateInput(BaseInputObjectType):
+    name = graphene.String(description="Promotion name.")
+    description = JSON(description="Promotion description.", required=False)
+    start_date = graphene.types.datetime.DateTime(
+        description="The start date of the promotion in ISO 8601 format."
+    )
+    end_date = graphene.types.datetime.DateTime(
+        description="The end date of the promotion in ISO 8601 format."
+    )
+    rules = NonNullList(PromotionRuleInput, description="List of promotion rules.")
+
+    class Meta:
+        doc_category = DOC_CATEGORY_DISCOUNTS
+
+
+class PromotionCreate(ModelMutation):
+    class Arguments:
+        input = PromotionCreateInput(
+            description="Fields requires to create a promotion.", required=True
+        )
+
+    class Meta:
+        description = "Creates a new promotion." + ADDED_IN_315 + PREVIEW_FEATURE
+        model = models.Promotion
+        object_type = Promotion
+        permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
+        error_type_class = PromotionCreateError

--- a/saleor/graphql/discount/mutations/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion_create.py
@@ -1,19 +1,31 @@
-import graphene
+from collections import defaultdict
+from typing import DefaultDict, List
 
+import graphene
+from django.core.exceptions import ValidationError
+
+from ....core.tracing import traced_atomic_transaction
 from ....discount import models
 from ....permission.enums import DiscountPermissions
+from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.mutations import ModelMutation
 from ...core.scalars import JSON, PositiveDecimal
 from ...core.types import BaseInputObjectType, Error, NonNullList
+from ...core.validators import validate_end_is_after_start
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ..enums import PromotionCreateErrorCode, RewardValueTypeEnum
 from ..inputs import CataloguePredicateInput
 from ..types import Promotion
+from ..utils import clean_predicate
 
 
 class PromotionCreateError(Error):
     code = PromotionCreateErrorCode(description="The error code.", required=True)
+    index = graphene.Int(
+        description="Index of an input list item that caused the error."
+    )
 
 
 class PromotionRuleInput(BaseInputObjectType):
@@ -75,3 +87,114 @@ class PromotionCreate(ModelMutation):
         object_type = Promotion
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
         error_type_class = PromotionCreateError
+
+    @classmethod
+    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+
+        errors: DefaultDict[str, List[ValidationError]] = defaultdict(list)
+        start_date = cleaned_input.get("start_date")
+        end_date = cleaned_input.get("end_date")
+        try:
+            validate_end_is_after_start(start_date, end_date)
+        except ValidationError as error:
+            error.code = PromotionCreateErrorCode.INVALID.value
+            errors["end_date"].append(error)
+
+        if rules := cleaned_input.get("rules"):
+            cleaned_rules, errors = cls.clean_rules(info, rules, errors)
+            cleaned_input["rules"] = cleaned_rules
+
+        if errors:
+            raise ValidationError(errors)
+
+        return cleaned_input
+
+    @classmethod
+    def clean_rules(cls, info: ResolveInfo, rules_data, errors):
+        cleaned_rules = []
+        for index, rule_data in enumerate(rules_data):
+            if channel_ids := rule_data.get("channels"):
+                channels = cls.clean_channels(info, channel_ids, errors)
+                rule_data["channels"] = channels
+
+            if "catalogue_predicate" not in rule_data:
+                errors["catalogue_predicate"].append(
+                    ValidationError(
+                        "The cataloguePredicate field is required.",
+                        code=PromotionCreateErrorCode.REQUIRED.value,
+                        params={"index": index},
+                    )
+                )
+            else:
+                if "reward_value_type" not in rule_data:
+                    errors["reward_value_type"].append(
+                        ValidationError(
+                            "The rewardValueType is required for when "
+                            "cataloguePredicate is provided.",
+                            code=PromotionCreateErrorCode.REQUIRED.value,
+                            params={"index": index},
+                        )
+                    )
+                if "reward_value" not in rule_data:
+                    errors["reward_value_type"].append(
+                        ValidationError(
+                            "The rewardValue is required for when cataloguePredicate "
+                            "is provided.",
+                            code=PromotionCreateErrorCode.REQUIRED.value,
+                            params={"index": index},
+                        )
+                    )
+                rule_data["catalogue_predicate"] = clean_predicate(
+                    rule_data.get("catalogue_predicate")
+                )
+            cleaned_rules.append(rule_data)
+
+        return cleaned_rules, errors
+
+    @classmethod
+    def clean_channels(cls, info: ResolveInfo, channel_ids, errors):
+        try:
+            channels = cls.get_nodes_or_error(
+                channel_ids, "Channel", schema=info.schema
+            )
+        except ValidationError as error:
+            errors["channels"].append(error)
+            return []
+        return channels
+
+    @classmethod
+    def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
+        instance = cls.get_instance(info, **data)
+        data = data.get("input")
+        cleaned_input = cls.clean_input(info, instance, data)
+        instance = cls.construct_instance(instance, cleaned_input)
+        manager = get_plugin_manager_promise(info.context).get()
+
+        cls.clean_instance(info, instance)
+        with traced_atomic_transaction():
+            cls.save(info, instance, cleaned_input)
+            cls._save_m2m(info, instance, cleaned_input)
+            cls.send_sale_notifications(manager, instance)
+        return cls.success_response(instance)
+
+    @classmethod
+    def _save_m2m(cls, info: ResolveInfo, instance, cleaned_data):
+        super()._save_m2m(info, instance, cleaned_data)
+        rules_with_channels_to_add = []
+        if rules_data := cleaned_data.get("rules"):
+            rules = []
+            for rule_data in rules_data:
+                channels = rule_data.pop("channels", None)
+                rule = models.PromotionRule(promotion=instance, **rule_data)
+                rules_with_channels_to_add.append((rule, channels))
+                rules.append(rule)
+            models.PromotionRule.objects.bulk_create(rules)
+
+        for rule, channels in rules_with_channels_to_add:
+            rule.channels.set(channels)
+
+    @classmethod
+    def send_sale_notifications(cls, manager, instance):
+        # TODO: implement the notifications
+        pass

--- a/saleor/graphql/discount/mutations/promotion_delete.py
+++ b/saleor/graphql/discount/mutations/promotion_delete.py
@@ -1,0 +1,28 @@
+import graphene
+
+from ....discount import models
+from ....graphql.core.mutations import ModelDeleteMutation
+from ....permission.enums import DiscountPermissions
+from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ...core.types import Error
+from ..enums import PromotionDeleteErrorCode
+from ..types import Promotion
+
+
+class PromotionDeleteError(Error):
+    code = PromotionDeleteErrorCode(description="The error code.", required=True)
+
+
+class PromotionDelete(ModelDeleteMutation):
+    class Arguments:
+        id = graphene.ID(
+            required=True, description="The ID of the promotion to remove."
+        )
+
+    class Meta:
+        description = "Deletes a promotion."
+        model = models.Promotion
+        object_type = Promotion
+        permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
+        error_type_class = PromotionDeleteError
+        doc_category = DOC_CATEGORY_DISCOUNTS

--- a/saleor/graphql/discount/mutations/promotion_update.py
+++ b/saleor/graphql/discount/mutations/promotion_update.py
@@ -1,0 +1,57 @@
+import graphene
+from django.core.exceptions import ValidationError
+
+from ....discount import models
+from ....permission.enums import DiscountPermissions
+from ...core import ResolveInfo
+from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ...core.mutations import ModelMutation
+from ...core.types import Error
+from ...core.validators import validate_end_is_after_start
+from ..enums import PromotionUpdateErrorCode
+from ..types import Promotion
+from .promotion_create import PromotionInput
+
+
+class PromotionUpdateError(Error):
+    code = PromotionUpdateErrorCode(description="The error code.", required=True)
+
+
+class PromotionUpdateInput(PromotionInput):
+    name = graphene.String(description="Promotion name.")
+
+
+class PromotionUpdate(ModelMutation):
+    class Arguments:
+        id = graphene.ID(required=True, description="ID of the promotion to update.")
+        input = PromotionUpdateInput(
+            description="Fields required to update a promotion.", required=True
+        )
+
+    class Meta:
+        description = "Updates an existing promotion." + ADDED_IN_315 + PREVIEW_FEATURE
+        model = models.Promotion
+        object_type = Promotion
+        permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
+        error_type_class = PromotionUpdateError
+        doc_category = DOC_CATEGORY_DISCOUNTS
+
+    @classmethod
+    def clean_input(
+        cls, info: ResolveInfo, instance: models.Promotion, data: dict, **kwargs
+    ):
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+        start_date = cleaned_input.get("start_date")
+        end_date = cleaned_input.get("end_date")
+        try:
+            validate_end_is_after_start(start_date, end_date)
+        except ValidationError as error:
+            error.code = PromotionUpdateErrorCode.INVALID.value
+            raise ValidationError({"endDate": error})
+        return cleaned_input
+
+    @classmethod
+    def send_sale_notifications(cls, manager, instance):
+        # TODO: implement the notifications
+        pass

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -11,6 +11,7 @@ from ..core.utils import from_global_id_or_error
 from ..translations.mutations import SaleTranslate, VoucherTranslate
 from .filters import SaleFilter, VoucherFilter
 from .mutations.bulk_mutations import SaleBulkDelete, VoucherBulkDelete
+from .mutations.promotion_create import PromotionCreate
 from .mutations.sale_add_catalogues import SaleAddCatalogues
 from .mutations.sale_channel_listing_update import SaleChannelListingUpdate
 from .mutations.sale_create import SaleCreate
@@ -160,6 +161,8 @@ class DiscountQueries(graphene.ObjectType):
 
 
 class DiscountMutations(graphene.ObjectType):
+    promotion_create = PromotionCreate.Field()
+
     sale_create = SaleCreate.Field()
     sale_delete = SaleDelete.Field()
     sale_bulk_delete = SaleBulkDelete.Field()

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -12,6 +12,7 @@ from ..translations.mutations import SaleTranslate, VoucherTranslate
 from .filters import SaleFilter, VoucherFilter
 from .mutations.bulk_mutations import SaleBulkDelete, VoucherBulkDelete
 from .mutations.promotion_create import PromotionCreate
+from .mutations.promotion_update import PromotionUpdate
 from .mutations.sale_add_catalogues import SaleAddCatalogues
 from .mutations.sale_channel_listing_update import SaleChannelListingUpdate
 from .mutations.sale_create import SaleCreate
@@ -162,6 +163,7 @@ class DiscountQueries(graphene.ObjectType):
 
 class DiscountMutations(graphene.ObjectType):
     promotion_create = PromotionCreate.Field()
+    promotion_update = PromotionUpdate.Field()
 
     sale_create = SaleCreate.Field()
     sale_delete = SaleDelete.Field()

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -12,6 +12,7 @@ from ..translations.mutations import SaleTranslate, VoucherTranslate
 from .filters import SaleFilter, VoucherFilter
 from .mutations.bulk_mutations import SaleBulkDelete, VoucherBulkDelete
 from .mutations.promotion_create import PromotionCreate
+from .mutations.promotion_delete import PromotionDelete
 from .mutations.promotion_update import PromotionUpdate
 from .mutations.sale_add_catalogues import SaleAddCatalogues
 from .mutations.sale_channel_listing_update import SaleChannelListingUpdate
@@ -164,6 +165,7 @@ class DiscountQueries(graphene.ObjectType):
 class DiscountMutations(graphene.ObjectType):
     promotion_create = PromotionCreate.Field()
     promotion_update = PromotionUpdate.Field()
+    promotion_delete = PromotionDelete.Field()
 
     sale_create = SaleCreate.Field()
     sale_delete = SaleDelete.Field()

--- a/saleor/graphql/discount/tests/mutations/test_promotion_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_create.py
@@ -1,12 +1,13 @@
 from datetime import timedelta
 from decimal import Decimal
+from unittest.mock import ANY
 
 import graphene
 from django.utils import timezone
 from freezegun import freeze_time
 
 from ....tests.utils import assert_no_permission, get_graphql_content
-from ...enums import RewardValueTypeEnum
+from ...enums import PromotionCreateErrorCode, RewardValueTypeEnum
 
 PROMOTION_CREATE_MUTATION = """
     mutation promotionCreate($input: PromotionCreateInput!) {
@@ -36,6 +37,7 @@ PROMOTION_CREATE_MUTATION = """
             errors {
                 field
                 code
+                index
                 message
             }
         }
@@ -150,8 +152,6 @@ def test_promotion_create_by_app(
     channel_USD,
     variant,
     product,
-    collection,
-    category,
 ):
     # given
     start_date = timezone.now() - timedelta(days=30)
@@ -168,16 +168,6 @@ def test_promotion_create_by_app(
             {
                 "productPredicate": {
                     "ids": [graphene.Node.to_global_id("Product", product.id)]
-                }
-            },
-            {
-                "categoryPredicate": {
-                    "ids": [graphene.Node.to_global_id("Category", category.id)]
-                }
-            },
-            {
-                "collectionPredicate": {
-                    "ids": [graphene.Node.to_global_id("Collection", collection.id)]
                 }
             },
         ]
@@ -228,28 +218,9 @@ def test_promotion_create_by_customer(
     channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
     promotion_name = "test promotion"
     catalogue_predicate = {
-        "OR": [
-            {
-                "variantPredicate": {
-                    "ids": [graphene.Node.to_global_id("ProductVariant", variant.id)]
-                }
-            },
-            {
-                "productPredicate": {
-                    "ids": [graphene.Node.to_global_id("Product", product.id)]
-                }
-            },
-            {
-                "categoryPredicate": {
-                    "ids": [graphene.Node.to_global_id("Category", category.id)]
-                }
-            },
-            {
-                "collectionPredicate": {
-                    "ids": [graphene.Node.to_global_id("Collection", collection.id)]
-                }
-            },
-        ]
+        "variantPredicate": {
+            "ids": [graphene.Node.to_global_id("ProductVariant", variant.id)]
+        }
     }
 
     variables = {
@@ -276,3 +247,354 @@ def test_promotion_create_by_customer(
 
     # then
     assert_no_permission(response)
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_missing_catalogue_predicate(
+    staff_api_client,
+    permission_group_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    product,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    start_date = timezone.now() - timedelta(days=30)
+    end_date = timezone.now() + timedelta(days=30)
+
+    promotion_name = "test promotion"
+    catalogue_predicate = {
+        "productPredicate": {"ids": [graphene.Node.to_global_id("Product", product.id)]}
+    }
+
+    rule_1_name = "test promotion rule 1"
+    rule_2_name = "test promotion rule 2"
+    reward_value = Decimal("10")
+    reward_value_type_1 = RewardValueTypeEnum.FIXED.name
+    reward_value_type_2 = RewardValueTypeEnum.PERCENTAGE.name
+    rule_1_channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    rule_2_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+
+    variables = {
+        "input": {
+            "name": promotion_name,
+            "description": description_json,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "rules": [
+                {
+                    "name": rule_1_name,
+                    "description": description_json,
+                    "channels": rule_1_channel_ids,
+                    "rewardValueType": reward_value_type_1,
+                    "rewardValue": reward_value,
+                    "cataloguePredicate": catalogue_predicate,
+                },
+                {
+                    "name": rule_2_name,
+                    "description": description_json,
+                    "channels": rule_2_channel_ids,
+                    "rewardValueType": reward_value_type_2,
+                    "rewardValue": reward_value,
+                },
+            ],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionCreate"]
+    errors = data["errors"]
+
+    assert not data["promotion"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionCreateErrorCode.REQUIRED.name
+    assert errors[0]["field"] == "cataloguePredicate"
+    assert errors[0]["index"] == 1
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_missing_reward_value(
+    staff_api_client,
+    permission_group_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    product,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    start_date = timezone.now() - timedelta(days=30)
+    end_date = timezone.now() + timedelta(days=30)
+
+    promotion_name = "test promotion"
+    catalogue_predicate = {
+        "productPredicate": {"ids": [graphene.Node.to_global_id("Product", product.id)]}
+    }
+
+    rule_1_name = "test promotion rule 1"
+    rule_2_name = "test promotion rule 2"
+    reward_value = Decimal("10")
+    reward_value_type_1 = RewardValueTypeEnum.FIXED.name
+    reward_value_type_2 = RewardValueTypeEnum.PERCENTAGE.name
+    rule_1_channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    rule_2_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+
+    variables = {
+        "input": {
+            "name": promotion_name,
+            "description": description_json,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "rules": [
+                {
+                    "name": rule_1_name,
+                    "description": description_json,
+                    "channels": rule_1_channel_ids,
+                    "rewardValueType": reward_value_type_1,
+                    "cataloguePredicate": catalogue_predicate,
+                },
+                {
+                    "name": rule_2_name,
+                    "description": description_json,
+                    "channels": rule_2_channel_ids,
+                    "rewardValueType": reward_value_type_2,
+                    "rewardValue": reward_value,
+                    "cataloguePredicate": catalogue_predicate,
+                },
+            ],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionCreate"]
+    errors = data["errors"]
+
+    assert not data["promotion"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionCreateErrorCode.REQUIRED.name
+    assert errors[0]["field"] == "rewardValue"
+    assert errors[0]["index"] == 0
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_missing_reward_value_type(
+    staff_api_client,
+    permission_group_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    product,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    start_date = timezone.now() - timedelta(days=30)
+    end_date = timezone.now() + timedelta(days=30)
+
+    promotion_name = "test promotion"
+    catalogue_predicate = {
+        "productPredicate": {"ids": [graphene.Node.to_global_id("Product", product.id)]}
+    }
+
+    rule_1_name = "test promotion rule 1"
+    rule_2_name = "test promotion rule 2"
+    reward_value = Decimal("10")
+    rule_1_channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    rule_2_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+
+    variables = {
+        "input": {
+            "name": promotion_name,
+            "description": description_json,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "rules": [
+                {
+                    "name": rule_1_name,
+                    "description": description_json,
+                    "channels": rule_1_channel_ids,
+                    "rewardValue": reward_value,
+                    "cataloguePredicate": catalogue_predicate,
+                },
+                {
+                    "name": rule_2_name,
+                    "description": description_json,
+                    "channels": rule_2_channel_ids,
+                    "rewardValue": reward_value,
+                    "cataloguePredicate": catalogue_predicate,
+                },
+            ],
+        }
+    }
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionCreate"]
+    errors = data["errors"]
+
+    assert not data["promotion"]
+    assert len(errors) == 2
+    expected_errors = [
+        {
+            "code": PromotionCreateErrorCode.REQUIRED.name,
+            "field": "rewardValueType",
+            "index": 0,
+            "message": ANY,
+        },
+        {
+            "code": PromotionCreateErrorCode.REQUIRED.name,
+            "field": "rewardValueType",
+            "index": 1,
+            "message": ANY,
+        },
+    ]
+    for error in expected_errors:
+        assert error in errors
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_invalid_channel_id(
+    staff_api_client,
+    permission_group_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    product,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    start_date = timezone.now() - timedelta(days=30)
+    end_date = timezone.now() + timedelta(days=30)
+
+    promotion_name = "test promotion"
+    catalogue_predicate = {
+        "productPredicate": {"ids": [graphene.Node.to_global_id("Product", product.id)]}
+    }
+
+    rule_1_name = "test promotion rule 1"
+    rule_2_name = "test promotion rule 2"
+    reward_value = Decimal("10")
+    reward_value_type_1 = RewardValueTypeEnum.FIXED.name
+    reward_value_type_2 = RewardValueTypeEnum.PERCENTAGE.name
+    rule_1_channel_ids = [graphene.Node.to_global_id("Channel", -1)]
+    rule_2_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+
+    variables = {
+        "input": {
+            "name": promotion_name,
+            "description": description_json,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "rules": [
+                {
+                    "name": rule_1_name,
+                    "description": description_json,
+                    "channels": rule_1_channel_ids,
+                    "rewardValueType": reward_value_type_1,
+                    "rewardValue": reward_value,
+                    "cataloguePredicate": catalogue_predicate,
+                },
+                {
+                    "name": rule_2_name,
+                    "description": description_json,
+                    "channels": rule_2_channel_ids,
+                    "rewardValueType": reward_value_type_2,
+                    "rewardValue": reward_value,
+                    "cataloguePredicate": catalogue_predicate,
+                },
+            ],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionCreate"]
+    errors = data["errors"]
+
+    assert not data["promotion"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionCreateErrorCode.GRAPHQL_ERROR.name
+    assert errors[0]["field"] == "channels"
+    assert errors[0]["index"] == 0
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_multiple_errors(
+    staff_api_client,
+    permission_group_manage_discounts,
+    description_json,
+    product,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    start_date = timezone.now() - timedelta(days=30)
+    end_date = timezone.now() + timedelta(days=30)
+
+    channel_ids = [graphene.Node.to_global_id("Channel", -1)]
+    promotion_name = "test promotion"
+    catalogue_predicate = {
+        "productPredicate": {"ids": [graphene.Node.to_global_id("Product", product.id)]}
+    }
+
+    variables = {
+        "input": {
+            "name": promotion_name,
+            "description": description_json,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "rules": [
+                {
+                    "name": "test promotion rule 1",
+                    "description": description_json,
+                    "channels": channel_ids,
+                    "cataloguePredicate": catalogue_predicate,
+                }
+            ],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionCreate"]
+    errors = data["errors"]
+
+    assert not data["promotion"]
+    assert len(errors) == 3
+    expected_errors = [
+        {
+            "code": PromotionCreateErrorCode.REQUIRED.name,
+            "field": "rewardValue",
+            "index": 0,
+            "message": ANY,
+        },
+        {
+            "code": PromotionCreateErrorCode.REQUIRED.name,
+            "field": "rewardValueType",
+            "index": 0,
+            "message": ANY,
+        },
+        {
+            "code": PromotionCreateErrorCode.GRAPHQL_ERROR.name,
+            "field": "channels",
+            "index": 0,
+            "message": ANY,
+        },
+    ]
+    for error in expected_errors:
+        assert error in errors

--- a/saleor/graphql/discount/tests/mutations/test_promotion_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_create.py
@@ -1,0 +1,278 @@
+from datetime import timedelta
+from decimal import Decimal
+
+import graphene
+from django.utils import timezone
+from freezegun import freeze_time
+
+from ....tests.utils import assert_no_permission, get_graphql_content
+from ...enums import RewardValueTypeEnum
+
+PROMOTION_CREATE_MUTATION = """
+    mutation promotionCreate($input: PromotionCreateInput!) {
+        promotionCreate(input: $input) {
+            promotion {
+                id
+                name
+                description
+                startDate
+                endDate
+                createdAt
+                updatedAt
+                rules {
+                    name
+                    description
+                    promotion {
+                        id
+                    }
+                    channels {
+                        id
+                    }
+                    rewardValueType
+                    rewardValue
+                    cataloguePredicate
+                }
+            }
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_by_staff_user(
+    staff_api_client,
+    permission_group_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    variant,
+    product,
+    collection,
+    category,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    start_date = timezone.now() - timedelta(days=30)
+    end_date = timezone.now() + timedelta(days=30)
+
+    rule_1_channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    rule_2_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+    promotion_name = "test promotion"
+    catalogue_predicate = {
+        "OR": [
+            {
+                "variantPredicate": {
+                    "ids": [graphene.Node.to_global_id("ProductVariant", variant.id)]
+                }
+            },
+            {
+                "productPredicate": {
+                    "ids": [graphene.Node.to_global_id("Product", product.id)]
+                }
+            },
+            {
+                "categoryPredicate": {
+                    "ids": [graphene.Node.to_global_id("Category", category.id)]
+                }
+            },
+            {
+                "collectionPredicate": {
+                    "ids": [graphene.Node.to_global_id("Collection", collection.id)]
+                }
+            },
+        ]
+    }
+    rule_1_name = "test promotion rule 1"
+    rule_2_name = "test promotion rule 2"
+    reward_value = Decimal("10")
+    reward_value_type_1 = RewardValueTypeEnum.FIXED.name
+    reward_value_type_2 = RewardValueTypeEnum.PERCENTAGE.name
+
+    variables = {
+        "input": {
+            "name": promotion_name,
+            "description": description_json,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "rules": [
+                {
+                    "name": rule_1_name,
+                    "description": description_json,
+                    "channels": rule_1_channel_ids,
+                    "rewardValueType": reward_value_type_1,
+                    "rewardValue": reward_value,
+                    "cataloguePredicate": catalogue_predicate,
+                },
+                {
+                    "name": rule_2_name,
+                    "description": description_json,
+                    "channels": rule_2_channel_ids,
+                    "rewardValueType": reward_value_type_2,
+                    "rewardValue": reward_value,
+                    "cataloguePredicate": catalogue_predicate,
+                },
+            ],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionCreate"]
+    promotion_data = data["promotion"]
+
+    assert not data["errors"]
+    assert promotion_data["name"] == promotion_name
+    assert promotion_data["startDate"] == start_date.isoformat()
+    assert promotion_data["endDate"] == end_date.isoformat()
+
+    assert len(promotion_data["rules"]) == 2
+    for rule_data in variables["input"]["rules"]:
+        rule_data["promotion"] = {"id": promotion_data["id"]}
+        rule_data["channels"] = [
+            {"id": channel_id} for channel_id in rule_data["channels"]
+        ]
+        assert rule_data in promotion_data["rules"]
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_by_app(
+    app_api_client,
+    permission_manage_discounts,
+    description_json,
+    channel_USD,
+    variant,
+    product,
+    collection,
+    category,
+):
+    # given
+    start_date = timezone.now() - timedelta(days=30)
+    end_date = timezone.now() + timedelta(days=30)
+    channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    promotion_name = "test promotion"
+    catalogue_predicate = {
+        "OR": [
+            {
+                "variantPredicate": {
+                    "ids": [graphene.Node.to_global_id("ProductVariant", variant.id)]
+                }
+            },
+            {
+                "productPredicate": {
+                    "ids": [graphene.Node.to_global_id("Product", product.id)]
+                }
+            },
+            {
+                "categoryPredicate": {
+                    "ids": [graphene.Node.to_global_id("Category", category.id)]
+                }
+            },
+            {
+                "collectionPredicate": {
+                    "ids": [graphene.Node.to_global_id("Collection", collection.id)]
+                }
+            },
+        ]
+    }
+
+    variables = {
+        "input": {
+            "name": promotion_name,
+            "description": description_json,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "rules": [
+                {
+                    "name": "test promotion rule",
+                    "description": description_json,
+                    "channels": channel_ids,
+                    "rewardValueType": RewardValueTypeEnum.FIXED.name,
+                    "rewardValue": Decimal("10"),
+                    "cataloguePredicate": catalogue_predicate,
+                }
+            ],
+        }
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_CREATE_MUTATION, variables, permissions=(permission_manage_discounts,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionCreate"]
+    promotion_data = data["promotion"]
+
+    assert not data["errors"]
+    assert promotion_data["name"] == promotion_name
+    assert promotion_data["startDate"] == start_date.isoformat()
+    assert promotion_data["endDate"] == end_date.isoformat()
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_by_customer(
+    api_client, description_json, channel_USD, variant, product, collection, category
+):
+    # given
+    start_date = timezone.now() - timedelta(days=30)
+    end_date = timezone.now() + timedelta(days=30)
+    channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    promotion_name = "test promotion"
+    catalogue_predicate = {
+        "OR": [
+            {
+                "variantPredicate": {
+                    "ids": [graphene.Node.to_global_id("ProductVariant", variant.id)]
+                }
+            },
+            {
+                "productPredicate": {
+                    "ids": [graphene.Node.to_global_id("Product", product.id)]
+                }
+            },
+            {
+                "categoryPredicate": {
+                    "ids": [graphene.Node.to_global_id("Category", category.id)]
+                }
+            },
+            {
+                "collectionPredicate": {
+                    "ids": [graphene.Node.to_global_id("Collection", collection.id)]
+                }
+            },
+        ]
+    }
+
+    variables = {
+        "input": {
+            "name": promotion_name,
+            "description": description_json,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "rules": [
+                {
+                    "name": "test promotion rule",
+                    "description": description_json,
+                    "channels": channel_ids,
+                    "rewardValueType": RewardValueTypeEnum.FIXED.name,
+                    "rewardValue": Decimal("10"),
+                    "cataloguePredicate": catalogue_predicate,
+                }
+            ],
+        }
+    }
+
+    # when
+    response = api_client.post_graphql(PROMOTION_CREATE_MUTATION, variables)
+
+    # then
+    assert_no_permission(response)

--- a/saleor/graphql/discount/tests/mutations/test_promotion_delete.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_delete.py
@@ -1,0 +1,68 @@
+import graphene
+import pytest
+
+from ....tests.utils import assert_no_permission, get_graphql_content
+
+PROMOTION_DELETE_MUTATION = """
+    mutation promotionDelete($id: ID!) {
+        promotionDelete(id: $id) {
+            promotion {
+                name
+                id
+            }
+            errors {
+                field
+                code
+                message
+            }
+            }
+        }
+"""
+
+
+def test_promotion_delete_by_staff_user(
+    staff_api_client, permission_group_manage_discounts, promotion
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    variables = {"id": graphene.Node.to_global_id("Promotion", promotion.id)}
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_DELETE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionDelete"]
+    assert data["promotion"]["name"] == promotion.name
+    with pytest.raises(promotion._meta.model.DoesNotExist):
+        promotion.refresh_from_db()
+
+
+def test_promotion_delete_by_staff_app(
+    app_api_client, permission_manage_discounts, promotion
+):
+    # given
+    variables = {"id": graphene.Node.to_global_id("Promotion", promotion.id)}
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_DELETE_MUTATION, variables, permissions=(permission_manage_discounts,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionDelete"]
+    assert data["promotion"]["name"] == promotion.name
+    with pytest.raises(promotion._meta.model.DoesNotExist):
+        promotion.refresh_from_db()
+
+
+def test_promotion_delete_by_customer(api_client, promotion):
+    # given
+    variables = {"id": graphene.Node.to_global_id("Promotion", promotion.id)}
+
+    # when
+    response = api_client.post_graphql(PROMOTION_DELETE_MUTATION, variables)
+
+    # then
+    assert_no_permission(response)

--- a/saleor/graphql/discount/tests/mutations/test_promotion_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_update.py
@@ -1,0 +1,158 @@
+from datetime import timedelta
+
+import graphene
+from django.utils import timezone
+from freezegun import freeze_time
+
+from .....discount.error_codes import PromotionCreateErrorCode
+from ....tests.utils import assert_no_permission, get_graphql_content
+
+PROMOTION_UPDATE_MUTATION = """
+    mutation promotionUpdate($id: ID!, $input: PromotionUpdateInput!) {
+        promotionUpdate(id: $id, input: $input) {
+            promotion {
+                id
+                name
+                description
+                startDate
+                endDate
+                createdAt
+                updatedAt
+            }
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_by_staff_user(
+    staff_api_client, permission_group_manage_discounts, promotion
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    start_date = timezone.now() + timedelta(days=1)
+    end_date = timezone.now() + timedelta(days=10)
+
+    new_promotion_name = "new test promotion"
+    variables = {
+        "id": graphene.Node.to_global_id("Promotion", promotion.id),
+        "input": {
+            "name": new_promotion_name,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionUpdate"]
+    promotion_data = data["promotion"]
+
+    assert not data["errors"]
+    assert promotion_data["name"] == new_promotion_name
+    assert promotion_data["description"] == promotion.description
+    assert promotion_data["startDate"] == start_date.isoformat()
+    assert promotion_data["endDate"] == end_date.isoformat()
+    assert promotion_data["createdAt"] == promotion.created_at.isoformat()
+    assert promotion_data["updatedAt"] == timezone.now().isoformat()
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_by_app(
+    app_api_client, permission_manage_discounts, promotion
+):
+    # given
+    start_date = timezone.now() + timedelta(days=1)
+    end_date = timezone.now() + timedelta(days=10)
+
+    new_promotion_name = "new test promotion"
+    variables = {
+        "id": graphene.Node.to_global_id("Promotion", promotion.id),
+        "input": {
+            "name": new_promotion_name,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_UPDATE_MUTATION, variables, permissions=(permission_manage_discounts,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionUpdate"]
+    promotion_data = data["promotion"]
+
+    assert not data["errors"]
+    assert promotion_data["name"] == new_promotion_name
+    assert promotion_data["description"] == promotion.description
+    assert promotion_data["startDate"] == start_date.isoformat()
+    assert promotion_data["endDate"] == end_date.isoformat()
+    assert promotion_data["createdAt"] == promotion.created_at.isoformat()
+    assert promotion_data["updatedAt"] == timezone.now().isoformat()
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_by_customer(api_client, promotion):
+    # given
+    start_date = timezone.now() + timedelta(days=1)
+    end_date = timezone.now() + timedelta(days=10)
+
+    new_promotion_name = "new test promotion"
+    variables = {
+        "id": graphene.Node.to_global_id("Promotion", promotion.id),
+        "input": {
+            "name": new_promotion_name,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+        },
+    }
+
+    # when
+    response = api_client.post_graphql(PROMOTION_UPDATE_MUTATION, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_promotion_create_end_date_before_start_date(
+    staff_api_client, permission_group_manage_discounts, description_json, promotion
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    start_date = timezone.now() + timedelta(days=1)
+    end_date = timezone.now() - timedelta(days=10)
+
+    new_promotion_name = "new test promotion"
+    variables = {
+        "id": graphene.Node.to_global_id("Promotion", promotion.id),
+        "input": {
+            "name": new_promotion_name,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionUpdate"]
+    errors = data["errors"]
+
+    assert not data["promotion"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionCreateErrorCode.INVALID.name
+    assert errors[0]["field"] == "endDate"

--- a/saleor/graphql/discount/utils.py
+++ b/saleor/graphql/discount/utils.py
@@ -1,0 +1,16 @@
+from graphene.utils.str_converters import to_camel_case
+
+
+def clean_predicate(predicate):
+    """Convert camel cases keys into snake case."""
+    if isinstance(predicate, list):
+        return [
+            clean_predicate(item) if isinstance(item, (dict, list)) else item
+            for item in predicate
+        ]
+    return {
+        to_camel_case(key): clean_predicate(value)
+        if isinstance(value, (dict, list))
+        else value
+        for key, value in predicate.items()
+    }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15525,7 +15525,24 @@ type Mutation {
   promotionCreate(
     """Fields requires to create a promotion."""
     input: PromotionCreateInput!
-  ): PromotionCreate
+  ): PromotionCreate @doc(category: "Discounts")
+
+  """
+  Updates an existing promotion.
+  
+  Added in Saleor 3.15.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  
+  Requires one of the following permissions: MANAGE_DISCOUNTS.
+  """
+  promotionUpdate(
+    """ID of the promotion to update."""
+    id: ID!
+
+    """Fields required to update a promotion."""
+    input: PromotionUpdateInput!
+  ): PromotionUpdate @doc(category: "Discounts")
 
   """
   Creates a new sale. 
@@ -23362,7 +23379,7 @@ Note: this API is currently in Feature Preview and can be subject to changes at 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 """
-type PromotionCreate {
+type PromotionCreate @doc(category: "Discounts") {
   errors: [PromotionCreateError!]!
   promotion: Promotion
 }
@@ -23392,9 +23409,6 @@ enum PromotionCreateErrorCode {
 }
 
 input PromotionCreateInput @doc(category: "Discounts") {
-  """Promotion name."""
-  name: String
-
   """Promotion description."""
   description: JSON
 
@@ -23403,6 +23417,9 @@ input PromotionCreateInput @doc(category: "Discounts") {
 
   """The end date of the promotion in ISO 8601 format."""
   endDate: DateTime
+
+  """Promotion name."""
+  name: String!
 
   """List of promotion rules."""
   rules: [PromotionRuleInput!]
@@ -23472,6 +23489,55 @@ input CategoryPredicateInput @doc(category: "Discounts") {
 input CollectionPredicateInput @doc(category: "Discounts") {
   """The list of collection ids."""
   ids: [ID!]
+}
+
+"""
+Updates an existing promotion.
+
+Added in Saleor 3.15.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+
+Requires one of the following permissions: MANAGE_DISCOUNTS.
+"""
+type PromotionUpdate @doc(category: "Discounts") {
+  errors: [PromotionUpdateError!]!
+  promotion: Promotion
+}
+
+type PromotionUpdateError {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: PromotionUpdateErrorCode!
+}
+
+"""An enumeration."""
+enum PromotionUpdateErrorCode {
+  GRAPHQL_ERROR
+  NOT_FOUND
+  REQUIRED
+  INVALID
+}
+
+input PromotionUpdateInput {
+  """Promotion description."""
+  description: JSON
+
+  """The start date of the promotion in ISO 8601 format."""
+  startDate: DateTime
+
+  """The end date of the promotion in ISO 8601 format."""
+  endDate: DateTime
+
+  """Promotion name."""
+  name: String
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23378,6 +23378,9 @@ type PromotionCreateError {
 
   """The error code."""
   code: PromotionCreateErrorCode!
+
+  """Index of an input list item that caused the error."""
+  index: Int
 }
 
 """An enumeration."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23387,6 +23387,8 @@ type PromotionCreateError {
 enum PromotionCreateErrorCode {
   GRAPHQL_ERROR
   NOT_FOUND
+  REQUIRED
+  INVALID
 }
 
 input PromotionCreateInput @doc(category: "Discounts") {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15514,6 +15514,20 @@ type Mutation {
   ): ExternalNotificationTrigger
 
   """
+  Creates a new promotion.
+  
+  Added in Saleor 3.15.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  
+  Requires one of the following permissions: MANAGE_DISCOUNTS.
+  """
+  promotionCreate(
+    """Fields requires to create a promotion."""
+    input: PromotionCreateInput!
+  ): PromotionCreate
+
+  """
   Creates a new sale. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
@@ -23337,6 +23351,122 @@ input ExternalNotificationTriggerInput {
   External event type. This field is passed to a plugin as an event type.
   """
   externalEventType: String!
+}
+
+"""
+Creates a new promotion.
+
+Added in Saleor 3.15.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+
+Requires one of the following permissions: MANAGE_DISCOUNTS.
+"""
+type PromotionCreate {
+  errors: [PromotionCreateError!]!
+  promotion: Promotion
+}
+
+type PromotionCreateError {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: PromotionCreateErrorCode!
+}
+
+"""An enumeration."""
+enum PromotionCreateErrorCode {
+  GRAPHQL_ERROR
+  NOT_FOUND
+}
+
+input PromotionCreateInput @doc(category: "Discounts") {
+  """Promotion name."""
+  name: String
+
+  """Promotion description."""
+  description: JSON
+
+  """The start date of the promotion in ISO 8601 format."""
+  startDate: DateTime
+
+  """The end date of the promotion in ISO 8601 format."""
+  endDate: DateTime
+
+  """List of promotion rules."""
+  rules: [PromotionRuleInput!]
+}
+
+input PromotionRuleInput @doc(category: "Discounts") {
+  """Promotion rule name."""
+  name: String
+
+  """Promotion rule description."""
+  description: JSON
+
+  """List of channel ids to which the rule should apply to."""
+  channels: [ID!]
+
+  """
+  Defines the conditions on the catalogue level that must be met for the reward to be applied.
+  """
+  cataloguePredicate: CataloguePredicateInput
+
+  """
+  Defines the promotion rule reward value type. Must be provided together with reward value.
+  """
+  rewardValueType: RewardValueTypeEnum
+
+  """
+  Defines the discount value. Required when catalogue predicate is provided.
+  """
+  rewardValue: PositiveDecimal
+}
+
+input CataloguePredicateInput @doc(category: "Discounts") {
+  """Defines the product variant conditions to be met."""
+  variantPredicate: ProductVariantPredicateInput
+
+  """Defines the product conditions to be met."""
+  productPredicate: ProductPredicateInput
+
+  """Defines the category conditions to be met."""
+  categoryPredicate: CategoryPredicateInput
+
+  """Defines the collection conditions to be met."""
+  collectionPredicate: CollectionPredicateInput
+
+  """List of conditions that must be met."""
+  AND: [CataloguePredicateInput!]
+
+  """A list of conditions of which at least one must be met."""
+  OR: [CataloguePredicateInput!]
+}
+
+input ProductVariantPredicateInput @doc(category: "Discounts") {
+  """The list of product variant ids."""
+  ids: [ID!]
+}
+
+input ProductPredicateInput @doc(category: "Discounts") {
+  """The list of product ids."""
+  ids: [ID!]
+}
+
+input CategoryPredicateInput @doc(category: "Discounts") {
+  """The list of category ids."""
+  ids: [ID!]
+}
+
+input CollectionPredicateInput @doc(category: "Discounts") {
+  """The list of collection ids."""
+  ids: [ID!]
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15545,6 +15545,16 @@ type Mutation {
   ): PromotionUpdate @doc(category: "Discounts")
 
   """
+  Deletes a promotion. 
+  
+  Requires one of the following permissions: MANAGE_DISCOUNTS.
+  """
+  promotionDelete(
+    """The ID of the promotion to remove."""
+    id: ID!
+  ): PromotionDelete @doc(category: "Discounts")
+
+  """
   Creates a new sale. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
@@ -23538,6 +23548,35 @@ input PromotionUpdateInput {
 
   """Promotion name."""
   name: String
+}
+
+"""
+Deletes a promotion. 
+
+Requires one of the following permissions: MANAGE_DISCOUNTS.
+"""
+type PromotionDelete @doc(category: "Discounts") {
+  errors: [PromotionDeleteError!]!
+  promotion: Promotion
+}
+
+type PromotionDeleteError {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: PromotionDeleteErrorCode!
+}
+
+"""An enumeration."""
+enum PromotionDeleteErrorCode {
+  GRAPHQL_ERROR
+  NOT_FOUND
 }
 
 """


### PR DESCRIPTION
Add promotion mutations:
- `promotionCreate`
- `promotionUpdate`
- `promotionDelete`

⚠️ 
The mutations are missing the toggle notifications, events, and calling undiscounted price recalculations. It will be added separately.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
