### PR TITLE
Add promotion rule mutations

### DIFF
--- a/saleor/discount/error_codes.py
+++ b/saleor/discount/error_codes.py
@@ -29,3 +29,10 @@ class PromotionUpdateErrorCode(Enum):
 class PromotionDeleteErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
+
+
+class PromotionRuleCreateErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
+    NOT_FOUND = "not_found"
+    REQUIRED = "required"
+    INVALID = "invalid"

--- a/saleor/discount/error_codes.py
+++ b/saleor/discount/error_codes.py
@@ -42,3 +42,8 @@ class PromotionRuleUpdateErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     NOT_FOUND = "not_found"
     DUPLICATED_INPUT_ITEM = "duplicated_input_item"
+
+
+class PromotionRuleDeleteErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
+    NOT_FOUND = "not_found"

--- a/saleor/discount/error_codes.py
+++ b/saleor/discount/error_codes.py
@@ -36,3 +36,9 @@ class PromotionRuleCreateErrorCode(Enum):
     NOT_FOUND = "not_found"
     REQUIRED = "required"
     INVALID = "invalid"
+
+
+class PromotionRuleUpdateErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
+    NOT_FOUND = "not_found"
+    DUPLICATED_INPUT_ITEM = "duplicated_input_item"

--- a/saleor/graphql/discount/enums.py
+++ b/saleor/graphql/discount/enums.py
@@ -25,6 +25,9 @@ PromotionRuleCreateErrorCode = graphene.Enum.from_enum(
 PromotionRuleUpdateErrorCode = graphene.Enum.from_enum(
     error_codes.PromotionRuleUpdateErrorCode
 )
+PromotionRuleDeleteErrorCode = graphene.Enum.from_enum(
+    error_codes.PromotionRuleDeleteErrorCode
+)
 
 
 class SaleType(BaseEnum):

--- a/saleor/graphql/discount/enums.py
+++ b/saleor/graphql/discount/enums.py
@@ -22,6 +22,9 @@ PromotionDeleteErrorCode = graphene.Enum.from_enum(error_codes.PromotionDeleteEr
 PromotionRuleCreateErrorCode = graphene.Enum.from_enum(
     error_codes.PromotionRuleCreateErrorCode
 )
+PromotionRuleUpdateErrorCode = graphene.Enum.from_enum(
+    error_codes.PromotionRuleUpdateErrorCode
+)
 
 
 class SaleType(BaseEnum):

--- a/saleor/graphql/discount/enums.py
+++ b/saleor/graphql/discount/enums.py
@@ -19,6 +19,9 @@ RewardValueTypeEnum.doc_category = DOC_CATEGORY_DISCOUNTS
 PromotionCreateErrorCode = graphene.Enum.from_enum(error_codes.PromotionCreateErrorCode)
 PromotionUpdateErrorCode = graphene.Enum.from_enum(error_codes.PromotionUpdateErrorCode)
 PromotionDeleteErrorCode = graphene.Enum.from_enum(error_codes.PromotionDeleteErrorCode)
+PromotionRuleCreateErrorCode = graphene.Enum.from_enum(
+    error_codes.PromotionRuleCreateErrorCode
+)
 
 
 class SaleType(BaseEnum):

--- a/saleor/graphql/discount/inputs.py
+++ b/saleor/graphql/discount/inputs.py
@@ -1,7 +1,9 @@
 import graphene
 
 from ..core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ..core.scalars import JSON, PositiveDecimal
 from ..core.types import BaseInputObjectType, NonNullList
+from .enums import RewardValueTypeEnum
 
 
 class ProductVariantPredicateInput(BaseInputObjectType):
@@ -81,3 +83,25 @@ class CataloguePredicateInput(PredicateInputObjectType):
 
     class Meta:
         doc_category = DOC_CATEGORY_DISCOUNTS
+
+
+class PromotionRuleBaseInput(BaseInputObjectType):
+    name = graphene.String(description="Promotion rule name.")
+    description = JSON(description="Promotion rule description.")
+    catalogue_predicate = CataloguePredicateInput(
+        description=(
+            "Defines the conditions on the catalogue level that must be met "
+            "for the reward to be applied."
+        ),
+    )
+    reward_value_type = RewardValueTypeEnum(
+        description=(
+            "Defines the promotion rule reward value type. "
+            "Must be provided together with reward value."
+        ),
+    )
+    reward_value = PositiveDecimal(
+        description=(
+            "Defines the discount value. Required when catalogue predicate is provided."
+        ),
+    )

--- a/saleor/graphql/discount/mutations/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion_create.py
@@ -14,13 +14,13 @@ from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.mutations import ModelMutation
-from ...core.scalars import JSON, PositiveDecimal
+from ...core.scalars import JSON
 from ...core.types import BaseInputObjectType, Error, NonNullList
 from ...core.validators import validate_end_is_after_start
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...utils import get_nodes
-from ..enums import PromotionCreateErrorCode, RewardValueTypeEnum
-from ..inputs import CataloguePredicateInput
+from ..enums import PromotionCreateErrorCode
+from ..inputs import PromotionRuleBaseInput
 from ..types import Promotion
 from ..utils import clean_predicate
 
@@ -32,29 +32,10 @@ class PromotionCreateError(Error):
     )
 
 
-class PromotionRuleInput(BaseInputObjectType):
-    name = graphene.String(description="Promotion rule name.")
-    description = JSON(description="Promotion rule description.")
+class PromotionRuleInput(PromotionRuleBaseInput):
     channels = NonNullList(
         graphene.ID,
         description="List of channel ids to which the rule should apply to.",
-    )
-    catalogue_predicate = CataloguePredicateInput(
-        description=(
-            "Defines the conditions on the catalogue level that must be met "
-            "for the reward to be applied."
-        ),
-    )
-    reward_value_type = RewardValueTypeEnum(
-        description=(
-            "Defines the promotion rule reward value type. "
-            "Must be provided together with reward value."
-        ),
-    )
-    reward_value = PositiveDecimal(
-        description=(
-            "Defines the discount value. Required when catalogue predicate is provided."
-        ),
     )
 
     class Meta:

--- a/saleor/graphql/discount/mutations/promotion_rule_create.py
+++ b/saleor/graphql/discount/mutations/promotion_rule_create.py
@@ -1,0 +1,80 @@
+from collections import defaultdict
+from typing import DefaultDict, List
+
+import graphene
+from django.core.exceptions import ValidationError
+
+from ....discount import models
+from ....permission.enums import DiscountPermissions
+from ...core import ResolveInfo
+from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ...core.mutations import ModelMutation
+from ...core.types import Error
+from ..enums import PromotionRuleCreateErrorCode
+from ..types import PromotionRule
+from ..utils import clean_predicate
+from .promotion_create import PromotionRuleInput
+
+
+class PromotionRuleCreateInput(PromotionRuleInput):
+    promotion = graphene.ID(
+        description="The ID of the promotion that rule belongs to.", required=True
+    )
+
+
+class PromotionRuleCreateError(Error):
+    code = PromotionRuleCreateErrorCode(description="The error code.", required=True)
+
+
+class PromotionRuleCreate(ModelMutation):
+    class Arguments:
+        input = PromotionRuleCreateInput(
+            description="Fields required to create a promotion rule.", required=True
+        )
+
+    class Meta:
+        description = "Creates a new promotion rule." + ADDED_IN_315 + PREVIEW_FEATURE
+        model = models.PromotionRule
+        object_type = PromotionRule
+        permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
+        error_type_class = PromotionRuleCreateError
+        doc_category = DOC_CATEGORY_DISCOUNTS
+
+    @classmethod
+    def clean_input(
+        cls, info: ResolveInfo, instance: models.PromotionRule, data: dict, **kwargs
+    ):
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+        errors: DefaultDict[str, List[ValidationError]] = defaultdict(list)
+
+        if "catalogue_predicate" not in cleaned_input:
+            errors["catalogue_predicate"].append(
+                ValidationError(
+                    "The cataloguePredicate field is required.",
+                    code=PromotionRuleCreateErrorCode.REQUIRED.value,
+                )
+            )
+        else:
+            if "reward_value_type" not in cleaned_input:
+                errors["reward_value_type"].append(
+                    ValidationError(
+                        "The rewardValueType is required for when "
+                        "cataloguePredicate is provided.",
+                        code=PromotionRuleCreateErrorCode.REQUIRED.value,
+                    )
+                )
+            if "reward_value" not in cleaned_input:
+                errors["reward_value"].append(
+                    ValidationError(
+                        "The rewardValue is required for when cataloguePredicate "
+                        "is provided.",
+                        code=PromotionRuleCreateErrorCode.REQUIRED.value,
+                    )
+                )
+            cleaned_input["catalogue_predicate"] = clean_predicate(
+                cleaned_input.get("catalogue_predicate")
+            )
+        if errors:
+            raise ValidationError(errors)
+        return cleaned_input

--- a/saleor/graphql/discount/mutations/promotion_rule_delete.py
+++ b/saleor/graphql/discount/mutations/promotion_rule_delete.py
@@ -1,0 +1,29 @@
+import graphene
+
+from ....discount import models
+from ....graphql.core.mutations import ModelDeleteMutation
+from ....permission.enums import DiscountPermissions
+from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ...core.types import Error
+from ..enums import PromotionRuleDeleteErrorCode
+from ..types import PromotionRule
+
+
+class PromotionRuleDeleteError(Error):
+    code = PromotionRuleDeleteErrorCode(description="The error code.", required=True)
+
+
+class PromotionRuleDelete(ModelDeleteMutation):
+    class Arguments:
+        id = graphene.ID(
+            required=True, description="The ID of the promotion to remove."
+        )
+
+    class Meta:
+        description = "Deletes a promotion rule." + ADDED_IN_315 + PREVIEW_FEATURE
+        model = models.PromotionRule
+        object_type = PromotionRule
+        permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
+        error_type_class = PromotionRuleDeleteError
+        doc_category = DOC_CATEGORY_DISCOUNTS

--- a/saleor/graphql/discount/mutations/promotion_rule_update.py
+++ b/saleor/graphql/discount/mutations/promotion_rule_update.py
@@ -1,7 +1,7 @@
 import graphene
 from django.core.exceptions import ValidationError
+from django.db import transaction
 
-from ....core.tracing import traced_atomic_transaction
 from ....discount import models
 from ....permission.enums import DiscountPermissions
 from ...core import ResolveInfo
@@ -72,7 +72,7 @@ class PromotionRuleUpdate(ModelMutation):
 
     @classmethod
     def _save_m2m(cls, info: ResolveInfo, instance, cleaned_data):
-        with traced_atomic_transaction():
+        with transaction.atomic():
             super()._save_m2m(info, instance, cleaned_data)
             if remove_channels := cleaned_data.get("remove_channels"):
                 instance.channels.remove(*remove_channels)

--- a/saleor/graphql/discount/mutations/promotion_rule_update.py
+++ b/saleor/graphql/discount/mutations/promotion_rule_update.py
@@ -1,0 +1,80 @@
+import graphene
+from django.core.exceptions import ValidationError
+
+from ....core.tracing import traced_atomic_transaction
+from ....discount import models
+from ....permission.enums import DiscountPermissions
+from ...core import ResolveInfo
+from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ...core.mutations import ModelMutation
+from ...core.types import Error, NonNullList
+from ...utils.validators import check_for_duplicates
+from ..enums import PromotionRuleUpdateErrorCode
+from ..inputs import PromotionRuleBaseInput
+from ..types import PromotionRule
+from ..utils import clean_predicate
+
+
+class PromotionRuleUpdateError(Error):
+    code = PromotionRuleUpdateErrorCode(description="The error code.", required=True)
+    channels = NonNullList(
+        graphene.ID,
+        description="List of channel IDs which causes the error.",
+        required=False,
+    )
+
+
+class PromotionRuleUpdateInput(PromotionRuleBaseInput):
+    add_channels = NonNullList(
+        graphene.ID,
+        description="List of channel ids to remove.",
+    )
+    remove_channels = NonNullList(
+        graphene.ID,
+        description="List of channel ids to remove.",
+    )
+
+
+class PromotionRuleUpdate(ModelMutation):
+    class Arguments:
+        id = graphene.ID(
+            description="ID of the promotion rule to update.", required=True
+        )
+        input = PromotionRuleUpdateInput(
+            description="Fields required to create a promotion rule.", required=True
+        )
+
+    class Meta:
+        description = (
+            "Updates an existing promotion rule." + ADDED_IN_315 + PREVIEW_FEATURE
+        )
+        model = models.PromotionRule
+        object_type = PromotionRule
+        permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
+        error_type_class = PromotionRuleUpdateError
+        doc_category = DOC_CATEGORY_DISCOUNTS
+
+    @classmethod
+    def clean_input(
+        cls, info: ResolveInfo, instance: models.PromotionRule, data: dict, **kwargs
+    ):
+        error = check_for_duplicates(
+            data, "add_channels", "remove_channels", error_class_field="channels"
+        )
+        if error:
+            error.code = PromotionRuleUpdateErrorCode.DUPLICATED_INPUT_ITEM.value
+            raise ValidationError({"addChannels": error, "removeChannels": error})
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+        if catalogue_predicate := cleaned_input.get("catalogue_predicate"):
+            cleaned_input["catalogue_predicate"] = clean_predicate(catalogue_predicate)
+        return cleaned_input
+
+    @classmethod
+    def _save_m2m(cls, info: ResolveInfo, instance, cleaned_data):
+        with traced_atomic_transaction():
+            super()._save_m2m(info, instance, cleaned_data)
+            if remove_channels := cleaned_data.get("remove_channels"):
+                instance.channels.remove(*remove_channels)
+            if add_channels := cleaned_data.get("add_channels"):
+                instance.channels.add(*add_channels)

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -13,6 +13,7 @@ from .filters import SaleFilter, VoucherFilter
 from .mutations.bulk_mutations import SaleBulkDelete, VoucherBulkDelete
 from .mutations.promotion_create import PromotionCreate
 from .mutations.promotion_delete import PromotionDelete
+from .mutations.promotion_rule_create import PromotionRuleCreate
 from .mutations.promotion_update import PromotionUpdate
 from .mutations.sale_add_catalogues import SaleAddCatalogues
 from .mutations.sale_channel_listing_update import SaleChannelListingUpdate
@@ -166,6 +167,7 @@ class DiscountMutations(graphene.ObjectType):
     promotion_create = PromotionCreate.Field()
     promotion_update = PromotionUpdate.Field()
     promotion_delete = PromotionDelete.Field()
+    promotion_rule_create = PromotionRuleCreate.Field()
 
     sale_create = SaleCreate.Field()
     sale_delete = SaleDelete.Field()

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -14,6 +14,7 @@ from .mutations.bulk_mutations import SaleBulkDelete, VoucherBulkDelete
 from .mutations.promotion_create import PromotionCreate
 from .mutations.promotion_delete import PromotionDelete
 from .mutations.promotion_rule_create import PromotionRuleCreate
+from .mutations.promotion_rule_update import PromotionRuleUpdate
 from .mutations.promotion_update import PromotionUpdate
 from .mutations.sale_add_catalogues import SaleAddCatalogues
 from .mutations.sale_channel_listing_update import SaleChannelListingUpdate
@@ -168,6 +169,7 @@ class DiscountMutations(graphene.ObjectType):
     promotion_update = PromotionUpdate.Field()
     promotion_delete = PromotionDelete.Field()
     promotion_rule_create = PromotionRuleCreate.Field()
+    promotion_rule_update = PromotionRuleUpdate.Field()
 
     sale_create = SaleCreate.Field()
     sale_delete = SaleDelete.Field()

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -14,6 +14,7 @@ from .mutations.bulk_mutations import SaleBulkDelete, VoucherBulkDelete
 from .mutations.promotion_create import PromotionCreate
 from .mutations.promotion_delete import PromotionDelete
 from .mutations.promotion_rule_create import PromotionRuleCreate
+from .mutations.promotion_rule_delete import PromotionRuleDelete
 from .mutations.promotion_rule_update import PromotionRuleUpdate
 from .mutations.promotion_update import PromotionUpdate
 from .mutations.sale_add_catalogues import SaleAddCatalogues
@@ -170,6 +171,7 @@ class DiscountMutations(graphene.ObjectType):
     promotion_delete = PromotionDelete.Field()
     promotion_rule_create = PromotionRuleCreate.Field()
     promotion_rule_update = PromotionRuleUpdate.Field()
+    promotion_rule_delete = PromotionRuleDelete.Field()
 
     sale_create = SaleCreate.Field()
     sale_delete = SaleDelete.Field()

--- a/saleor/graphql/discount/tests/mutations/test_promotion_rule_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_rule_create.py
@@ -1,0 +1,442 @@
+from decimal import Decimal
+from unittest.mock import ANY
+
+import graphene
+
+from .....discount.error_codes import PromotionRuleCreateErrorCode
+from ....tests.utils import assert_no_permission, get_graphql_content
+from ...enums import RewardValueTypeEnum
+
+PROMOTION_RULE_CREATE_MUTATION = """
+    mutation promotionRuleCreate($input: PromotionRuleCreateInput!) {
+        promotionRuleCreate(input: $input) {
+            promotionRule {
+                name
+                description
+                promotion {
+                    id
+                }
+                channels {
+                    id
+                }
+                rewardValueType
+                rewardValue
+                cataloguePredicate
+            }
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+
+def test_promotion_rule_create_by_staff_user(
+    staff_api_client,
+    permission_group_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    variant,
+    product,
+    collection,
+    category,
+    promotion,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+
+    channel_ids = [
+        graphene.Node.to_global_id("Channel", channel.pk)
+        for channel in [channel_USD, channel_PLN]
+    ]
+    catalogue_predicate = {
+        "OR": [
+            {
+                "variantPredicate": {
+                    "ids": [graphene.Node.to_global_id("ProductVariant", variant.id)]
+                }
+            },
+            {
+                "productPredicate": {
+                    "ids": [graphene.Node.to_global_id("Product", product.id)]
+                }
+            },
+            {
+                "categoryPredicate": {
+                    "ids": [graphene.Node.to_global_id("Category", category.id)]
+                }
+            },
+            {
+                "collectionPredicate": {
+                    "ids": [graphene.Node.to_global_id("Collection", collection.id)]
+                }
+            },
+        ]
+    }
+    name = "test promotion rule"
+    reward_value = Decimal("10")
+    reward_value_type = RewardValueTypeEnum.FIXED.name
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    rules_count = promotion.rules.count()
+
+    variables = {
+        "input": {
+            "name": name,
+            "promotion": promotion_id,
+            "description": description_json,
+            "channels": channel_ids,
+            "rewardValueType": reward_value_type,
+            "rewardValue": reward_value,
+            "cataloguePredicate": catalogue_predicate,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_RULE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleCreate"]
+    rule_data = data["promotionRule"]
+
+    assert not data["errors"]
+    assert rule_data["name"] == name
+    assert rule_data["description"] == description_json
+    assert {channel["id"] for channel in rule_data["channels"]} == set(channel_ids)
+    assert rule_data["cataloguePredicate"] == catalogue_predicate
+    assert rule_data["rewardValueType"] == reward_value_type
+    assert rule_data["rewardValue"] == reward_value
+    assert rule_data["promotion"]["id"] == promotion_id
+    assert promotion.rules.count() == rules_count + 1
+
+
+def test_promotion_rule_create_by_app(
+    app_api_client,
+    permission_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    collection,
+    category,
+    promotion,
+):
+    # given
+    channel_ids = [
+        graphene.Node.to_global_id("Channel", channel.pk)
+        for channel in [channel_USD, channel_PLN]
+    ]
+    catalogue_predicate = {
+        "OR": [
+            {
+                "categoryPredicate": {
+                    "ids": [graphene.Node.to_global_id("Category", category.id)]
+                }
+            },
+            {
+                "collectionPredicate": {
+                    "ids": [graphene.Node.to_global_id("Collection", collection.id)]
+                }
+            },
+        ]
+    }
+    name = "test promotion rule"
+    reward_value = Decimal("10")
+    reward_value_type = RewardValueTypeEnum.FIXED.name
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    rules_count = promotion.rules.count()
+
+    variables = {
+        "input": {
+            "name": name,
+            "promotion": promotion_id,
+            "description": description_json,
+            "channels": channel_ids,
+            "rewardValueType": reward_value_type,
+            "rewardValue": reward_value,
+            "cataloguePredicate": catalogue_predicate,
+        }
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_RULE_CREATE_MUTATION,
+        variables,
+        permissions=(permission_manage_discounts,),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleCreate"]
+    rule_data = data["promotionRule"]
+
+    assert not data["errors"]
+    assert rule_data["name"] == name
+    assert rule_data["description"] == description_json
+    assert {channel["id"] for channel in rule_data["channels"]} == set(channel_ids)
+    assert rule_data["cataloguePredicate"] == catalogue_predicate
+    assert rule_data["rewardValueType"] == reward_value_type
+    assert rule_data["rewardValue"] == reward_value
+    assert rule_data["promotion"]["id"] == promotion_id
+    assert promotion.rules.count() == rules_count + 1
+
+
+def test_promotion_rule_create_by_customer(
+    api_client,
+    permission_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    collection,
+    category,
+    promotion,
+):
+    # given
+    channel_ids = [
+        graphene.Node.to_global_id("Channel", channel.pk)
+        for channel in [channel_USD, channel_PLN]
+    ]
+    catalogue_predicate = {
+        "OR": [
+            {
+                "categoryPredicate": {
+                    "ids": [graphene.Node.to_global_id("Category", category.id)]
+                }
+            },
+            {
+                "collectionPredicate": {
+                    "ids": [graphene.Node.to_global_id("Collection", collection.id)]
+                }
+            },
+        ]
+    }
+    name = "test promotion rule"
+    reward_value = Decimal("10")
+    reward_value_type = RewardValueTypeEnum.FIXED.name
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+
+    variables = {
+        "input": {
+            "name": name,
+            "promotion": promotion_id,
+            "description": description_json,
+            "channels": channel_ids,
+            "rewardValueType": reward_value_type,
+            "rewardValue": reward_value,
+            "cataloguePredicate": catalogue_predicate,
+        }
+    }
+
+    # when
+    response = api_client.post_graphql(PROMOTION_RULE_CREATE_MUTATION, variables)
+    assert_no_permission(response)
+
+
+def test_promotion_rule_create_missing_catalogue_predicate(
+    staff_api_client,
+    permission_group_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    product,
+    promotion,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+
+    channel_ids = [
+        graphene.Node.to_global_id("Channel", channel.pk)
+        for channel in [channel_USD, channel_PLN]
+    ]
+    name = "test promotion rule"
+    reward_value = Decimal("10")
+    reward_value_type = RewardValueTypeEnum.FIXED.name
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    rules_count = promotion.rules.count()
+
+    variables = {
+        "input": {
+            "name": name,
+            "promotion": promotion_id,
+            "description": description_json,
+            "channels": channel_ids,
+            "rewardValueType": reward_value_type,
+            "rewardValue": reward_value,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_RULE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleCreate"]
+    errors = data["errors"]
+
+    assert not data["promotionRule"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionRuleCreateErrorCode.REQUIRED.name
+    assert errors[0]["field"] == "cataloguePredicate"
+    assert promotion.rules.count() == rules_count
+
+
+def test_promotion_rule_create_missing_reward_value(
+    staff_api_client,
+    permission_group_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    product,
+    promotion,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+
+    channel_ids = [
+        graphene.Node.to_global_id("Channel", channel.pk)
+        for channel in [channel_USD, channel_PLN]
+    ]
+    catalogue_predicate = {
+        "productPredicate": {"ids": [graphene.Node.to_global_id("Product", product.id)]}
+    }
+    name = "test promotion rule"
+    reward_value_type = RewardValueTypeEnum.FIXED.name
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    rules_count = promotion.rules.count()
+
+    variables = {
+        "input": {
+            "name": name,
+            "promotion": promotion_id,
+            "description": description_json,
+            "channels": channel_ids,
+            "rewardValueType": reward_value_type,
+            "cataloguePredicate": catalogue_predicate,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_RULE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleCreate"]
+    errors = data["errors"]
+
+    assert not data["promotionRule"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionRuleCreateErrorCode.REQUIRED.name
+    assert errors[0]["field"] == "rewardValue"
+    assert promotion.rules.count() == rules_count
+
+
+def test_promotion_rule_create_missing_reward_value_type(
+    staff_api_client,
+    permission_group_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    product,
+    promotion,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+
+    channel_ids = [
+        graphene.Node.to_global_id("Channel", channel.pk)
+        for channel in [channel_USD, channel_PLN]
+    ]
+    catalogue_predicate = {
+        "productPredicate": {"ids": [graphene.Node.to_global_id("Product", product.id)]}
+    }
+    name = "test promotion rule"
+    reward_value = Decimal("10")
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    rules_count = promotion.rules.count()
+
+    variables = {
+        "input": {
+            "name": name,
+            "promotion": promotion_id,
+            "description": description_json,
+            "channels": channel_ids,
+            "rewardValue": reward_value,
+            "cataloguePredicate": catalogue_predicate,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_RULE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleCreate"]
+    errors = data["errors"]
+
+    assert not data["promotionRule"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionRuleCreateErrorCode.REQUIRED.name
+    assert errors[0]["field"] == "rewardValueType"
+    assert promotion.rules.count() == rules_count
+
+
+def test_promotion_rule_create_multiple_errors(
+    staff_api_client,
+    permission_group_manage_discounts,
+    description_json,
+    channel_USD,
+    channel_PLN,
+    product,
+    promotion,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+
+    channel_ids = [
+        graphene.Node.to_global_id("Channel", channel.pk)
+        for channel in [channel_USD, channel_PLN]
+    ]
+    catalogue_predicate = {
+        "productPredicate": {"ids": [graphene.Node.to_global_id("Product", product.id)]}
+    }
+    name = "test promotion rule"
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    rules_count = promotion.rules.count()
+
+    variables = {
+        "input": {
+            "name": name,
+            "promotion": promotion_id,
+            "description": description_json,
+            "channels": channel_ids,
+            "cataloguePredicate": catalogue_predicate,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_RULE_CREATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleCreate"]
+    errors = data["errors"]
+
+    assert len(errors) == 2
+    expected_errors = [
+        {
+            "code": PromotionRuleCreateErrorCode.REQUIRED.name,
+            "field": "rewardValue",
+            "message": ANY,
+        },
+        {
+            "code": PromotionRuleCreateErrorCode.REQUIRED.name,
+            "field": "rewardValueType",
+            "message": ANY,
+        },
+    ]
+    for error in expected_errors:
+        assert error in errors
+
+    assert promotion.rules.count() == rules_count

--- a/saleor/graphql/discount/tests/mutations/test_promotion_rule_delete.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_rule_delete.py
@@ -1,0 +1,73 @@
+import graphene
+import pytest
+
+from ....tests.utils import assert_no_permission, get_graphql_content
+
+PROMOTION_RULE_DELETE_MUTATION = """
+    mutation promotionRuleDelete($id: ID!) {
+        promotionRuleDelete(id: $id) {
+            promotionRule {
+                name
+                id
+            }
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+
+def test_promotion_delete_by_staff_user(
+    staff_api_client, permission_group_manage_discounts, promotion
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    rule = promotion.rules.first()
+    variables = {"id": graphene.Node.to_global_id("PromotionRule", rule.id)}
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_RULE_DELETE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleDelete"]
+    assert data["promotionRule"]["name"] == rule.name
+    with pytest.raises(rule._meta.model.DoesNotExist):
+        rule.refresh_from_db()
+
+
+def test_promotion_delete_by_staff_app(
+    app_api_client, permission_manage_discounts, promotion
+):
+    # given
+    rule = promotion.rules.first()
+    variables = {"id": graphene.Node.to_global_id("PromotionRule", rule.id)}
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_RULE_DELETE_MUTATION,
+        variables,
+        permissions=(permission_manage_discounts,),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleDelete"]
+    assert data["promotionRule"]["name"] == rule.name
+    with pytest.raises(rule._meta.model.DoesNotExist):
+        rule.refresh_from_db()
+
+
+def test_promotion_delete_by_customer(api_client, promotion):
+    # given
+    rule = promotion.rules.first()
+    variables = {"id": graphene.Node.to_global_id("PromotionRule", rule.id)}
+
+    # when
+    response = api_client.post_graphql(PROMOTION_RULE_DELETE_MUTATION, variables)
+
+    # then
+    assert_no_permission(response)

--- a/saleor/graphql/discount/tests/mutations/test_promotion_rule_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_rule_update.py
@@ -1,0 +1,259 @@
+from decimal import Decimal
+from unittest.mock import ANY
+
+import graphene
+
+from .....discount.error_codes import PromotionRuleUpdateErrorCode
+from ....tests.utils import assert_no_permission, get_graphql_content
+from ...enums import RewardValueTypeEnum
+
+PROMOTION_RULE_UPDATE_MUTATION = """
+    mutation promotionRuleUpdate($id: ID!, $input: PromotionRuleUpdateInput!) {
+        promotionRuleUpdate(id: $id, input: $input) {
+            promotionRule {
+                name
+                description
+                promotion {
+                    id
+                }
+                channels {
+                    slug
+                }
+                rewardValueType
+                rewardValue
+                cataloguePredicate
+            }
+            errors {
+                field
+                code
+                message
+                channels
+            }
+        }
+    }
+"""
+
+
+def test_promotion_rule_update_by_staff_user(
+    staff_api_client,
+    permission_group_manage_discounts,
+    channel_USD,
+    channel_PLN,
+    collection,
+    category,
+    promotion,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    rule = promotion.rules.first()
+    rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
+
+    add_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+    remove_channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    catalogue_predicate = {
+        "OR": [
+            {
+                "categoryPredicate": {
+                    "ids": [graphene.Node.to_global_id("Category", category.id)]
+                }
+            },
+            {
+                "collectionPredicate": {
+                    "ids": [graphene.Node.to_global_id("Collection", collection.id)]
+                }
+            },
+        ]
+    }
+    reward_value = Decimal("10")
+    reward_value_type = RewardValueTypeEnum.FIXED.name
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    rules_count = promotion.rules.count()
+
+    variables = {
+        "id": rule_id,
+        "input": {
+            "addChannels": add_channel_ids,
+            "removeChannels": remove_channel_ids,
+            "rewardValueType": reward_value_type,
+            "rewardValue": reward_value,
+            "cataloguePredicate": catalogue_predicate,
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_RULE_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleUpdate"]
+    rule_data = data["promotionRule"]
+
+    assert not data["errors"]
+    assert rule_data["name"] == rule.name
+    assert rule_data["description"] == rule.description
+    assert len(rule_data["channels"]) == 1
+    assert rule_data["channels"][0]["slug"] == channel_PLN.slug
+    assert rule_data["cataloguePredicate"] == catalogue_predicate
+    assert rule_data["rewardValueType"] == reward_value_type
+    assert rule_data["rewardValue"] == reward_value
+    assert rule_data["promotion"]["id"] == promotion_id
+    assert promotion.rules.count() == rules_count
+
+
+def test_promotion_rule_update_by_app(
+    app_api_client,
+    permission_manage_discounts,
+    channel_USD,
+    channel_PLN,
+    promotion,
+):
+    # given
+    rule = promotion.rules.first()
+    rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
+
+    add_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+    remove_channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    reward_value = Decimal("10")
+    reward_value_type = RewardValueTypeEnum.FIXED.name
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+    rules_count = promotion.rules.count()
+
+    variables = {
+        "id": rule_id,
+        "input": {
+            "addChannels": add_channel_ids,
+            "removeChannels": remove_channel_ids,
+            "rewardValueType": reward_value_type,
+            "rewardValue": reward_value,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_RULE_UPDATE_MUTATION,
+        variables,
+        permissions=(permission_manage_discounts,),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleUpdate"]
+    rule_data = data["promotionRule"]
+
+    assert not data["errors"]
+    assert rule_data["name"] == rule.name
+    assert rule_data["description"] == rule.description
+    assert len(rule_data["channels"]) == 1
+    assert rule_data["channels"][0]["slug"] == channel_PLN.slug
+    assert rule_data["cataloguePredicate"] == rule.catalogue_predicate
+    assert rule_data["rewardValueType"] == reward_value_type
+    assert rule_data["rewardValue"] == reward_value
+    assert rule_data["promotion"]["id"] == promotion_id
+    assert promotion.rules.count() == rules_count
+
+
+def test_promotion_rule_update_by_customer(
+    api_client,
+    channel_USD,
+    channel_PLN,
+    promotion,
+):
+    # given
+    rule = promotion.rules.first()
+    rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
+
+    add_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+    remove_channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    reward_value = Decimal("10")
+    reward_value_type = RewardValueTypeEnum.FIXED.name
+
+    variables = {
+        "id": rule_id,
+        "input": {
+            "addChannels": add_channel_ids,
+            "removeChannels": remove_channel_ids,
+            "rewardValueType": reward_value_type,
+            "rewardValue": reward_value,
+        },
+    }
+
+    # when
+    response = api_client.post_graphql(PROMOTION_RULE_UPDATE_MUTATION, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_promotion_rule_update_duplicates_channels_in_add_and_remove_field(
+    staff_api_client,
+    permission_group_manage_discounts,
+    channel_USD,
+    channel_PLN,
+    collection,
+    category,
+    promotion,
+):
+    # given
+    permission_group_manage_discounts.user_set.add(staff_api_client.user)
+    rule = promotion.rules.first()
+    rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
+
+    add_channel_ids = [
+        graphene.Node.to_global_id("Channel", channel.pk)
+        for channel in [channel_PLN, channel_USD]
+    ]
+    remove_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+    catalogue_predicate = {
+        "OR": [
+            {
+                "categoryPredicate": {
+                    "ids": [graphene.Node.to_global_id("Category", category.id)]
+                }
+            },
+            {
+                "collectionPredicate": {
+                    "ids": [graphene.Node.to_global_id("Collection", collection.id)]
+                }
+            },
+        ]
+    }
+    reward_value = Decimal("10")
+    reward_value_type = RewardValueTypeEnum.FIXED.name
+
+    variables = {
+        "id": rule_id,
+        "input": {
+            "addChannels": add_channel_ids,
+            "removeChannels": remove_channel_ids,
+            "rewardValueType": reward_value_type,
+            "rewardValue": reward_value,
+            "cataloguePredicate": catalogue_predicate,
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PROMOTION_RULE_UPDATE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleUpdate"]
+    errors = data["errors"]
+
+    assert not data["promotionRule"]
+    assert len(errors) == 2
+    expected_errors = [
+        {
+            "code": PromotionRuleUpdateErrorCode.DUPLICATED_INPUT_ITEM.name,
+            "field": "addChannels",
+            "message": ANY,
+            "channels": [graphene.Node.to_global_id("Channel", channel_PLN.pk)],
+        },
+        {
+            "code": PromotionRuleUpdateErrorCode.DUPLICATED_INPUT_ITEM.name,
+            "field": "removeChannels",
+            "message": ANY,
+            "channels": [graphene.Node.to_global_id("Channel", channel_PLN.pk)],
+        },
+    ]
+    for error in expected_errors:
+        assert error in errors

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15573,6 +15573,23 @@ type Mutation {
   ): PromotionRuleCreate @doc(category: "Discounts")
 
   """
+  Updates an existing promotion rule.
+  
+  Added in Saleor 3.15.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  
+  Requires one of the following permissions: MANAGE_DISCOUNTS.
+  """
+  promotionRuleUpdate(
+    """ID of the promotion rule to update."""
+    id: ID!
+
+    """Fields required to create a promotion rule."""
+    input: PromotionRuleUpdateInput!
+  ): PromotionRuleUpdate @doc(category: "Discounts")
+
+  """
   Creates a new sale. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
@@ -23460,9 +23477,6 @@ input PromotionRuleInput @doc(category: "Discounts") {
   """Promotion rule description."""
   description: JSON
 
-  """List of channel ids to which the rule should apply to."""
-  channels: [ID!]
-
   """
   Defines the conditions on the catalogue level that must be met for the reward to be applied.
   """
@@ -23477,6 +23491,9 @@ input PromotionRuleInput @doc(category: "Discounts") {
   Defines the discount value. Required when catalogue predicate is provided.
   """
   rewardValue: PositiveDecimal
+
+  """List of channel ids to which the rule should apply to."""
+  channels: [ID!]
 }
 
 input CataloguePredicateInput @doc(category: "Discounts") {
@@ -23643,8 +23660,71 @@ input PromotionRuleCreateInput {
   """Promotion rule description."""
   description: JSON
 
+  """
+  Defines the conditions on the catalogue level that must be met for the reward to be applied.
+  """
+  cataloguePredicate: CataloguePredicateInput
+
+  """
+  Defines the promotion rule reward value type. Must be provided together with reward value.
+  """
+  rewardValueType: RewardValueTypeEnum
+
+  """
+  Defines the discount value. Required when catalogue predicate is provided.
+  """
+  rewardValue: PositiveDecimal
+
   """List of channel ids to which the rule should apply to."""
   channels: [ID!]
+
+  """The ID of the promotion that rule belongs to."""
+  promotion: ID!
+}
+
+"""
+Updates an existing promotion rule.
+
+Added in Saleor 3.15.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+
+Requires one of the following permissions: MANAGE_DISCOUNTS.
+"""
+type PromotionRuleUpdate @doc(category: "Discounts") {
+  errors: [PromotionRuleUpdateError!]!
+  promotionRule: PromotionRule
+}
+
+type PromotionRuleUpdateError {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: PromotionRuleUpdateErrorCode!
+
+  """List of channel IDs which causes the error."""
+  channels: [ID!]
+}
+
+"""An enumeration."""
+enum PromotionRuleUpdateErrorCode {
+  GRAPHQL_ERROR
+  NOT_FOUND
+  DUPLICATED_INPUT_ITEM
+}
+
+input PromotionRuleUpdateInput {
+  """Promotion rule name."""
+  name: String
+
+  """Promotion rule description."""
+  description: JSON
 
   """
   Defines the conditions on the catalogue level that must be met for the reward to be applied.
@@ -23661,8 +23741,11 @@ input PromotionRuleCreateInput {
   """
   rewardValue: PositiveDecimal
 
-  """The ID of the promotion that rule belongs to."""
-  promotion: ID!
+  """List of channel ids to remove."""
+  addChannels: [ID!]
+
+  """List of channel ids to remove."""
+  removeChannels: [ID!]
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15590,6 +15590,20 @@ type Mutation {
   ): PromotionRuleUpdate @doc(category: "Discounts")
 
   """
+  Deletes a promotion rule.
+  
+  Added in Saleor 3.15.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  
+  Requires one of the following permissions: MANAGE_DISCOUNTS.
+  """
+  promotionRuleDelete(
+    """The ID of the promotion to remove."""
+    id: ID!
+  ): PromotionRuleDelete @doc(category: "Discounts")
+
+  """
   Creates a new sale. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
@@ -23746,6 +23760,39 @@ input PromotionRuleUpdateInput {
 
   """List of channel ids to remove."""
   removeChannels: [ID!]
+}
+
+"""
+Deletes a promotion rule.
+
+Added in Saleor 3.15.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+
+Requires one of the following permissions: MANAGE_DISCOUNTS.
+"""
+type PromotionRuleDelete @doc(category: "Discounts") {
+  errors: [PromotionRuleDeleteError!]!
+  promotionRule: PromotionRule
+}
+
+type PromotionRuleDeleteError {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: PromotionRuleDeleteErrorCode!
+}
+
+"""An enumeration."""
+enum PromotionRuleDeleteErrorCode {
+  GRAPHQL_ERROR
+  NOT_FOUND
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15559,6 +15559,20 @@ type Mutation {
   ): PromotionDelete @doc(category: "Discounts")
 
   """
+  Creates a new promotion rule.
+  
+  Added in Saleor 3.15.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  
+  Requires one of the following permissions: MANAGE_DISCOUNTS.
+  """
+  promotionRuleCreate(
+    """Fields required to create a promotion rule."""
+    input: PromotionRuleCreateInput!
+  ): PromotionRuleCreate @doc(category: "Discounts")
+
+  """
   Creates a new sale. 
   
   Requires one of the following permissions: MANAGE_DISCOUNTS.
@@ -23585,6 +23599,70 @@ type PromotionDeleteError {
 enum PromotionDeleteErrorCode {
   GRAPHQL_ERROR
   NOT_FOUND
+}
+
+"""
+Creates a new promotion rule.
+
+Added in Saleor 3.15.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+
+Requires one of the following permissions: MANAGE_DISCOUNTS.
+"""
+type PromotionRuleCreate @doc(category: "Discounts") {
+  errors: [PromotionRuleCreateError!]!
+  promotionRule: PromotionRule
+}
+
+type PromotionRuleCreateError {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: PromotionRuleCreateErrorCode!
+}
+
+"""An enumeration."""
+enum PromotionRuleCreateErrorCode {
+  GRAPHQL_ERROR
+  NOT_FOUND
+  REQUIRED
+  INVALID
+}
+
+input PromotionRuleCreateInput {
+  """Promotion rule name."""
+  name: String
+
+  """Promotion rule description."""
+  description: JSON
+
+  """List of channel ids to which the rule should apply to."""
+  channels: [ID!]
+
+  """
+  Defines the conditions on the catalogue level that must be met for the reward to be applied.
+  """
+  cataloguePredicate: CataloguePredicateInput
+
+  """
+  Defines the promotion rule reward value type. Must be provided together with reward value.
+  """
+  rewardValueType: RewardValueTypeEnum
+
+  """
+  Defines the discount value. Required when catalogue predicate is provided.
+  """
+  rewardValue: PositiveDecimal
+
+  """The ID of the promotion that rule belongs to."""
+  promotion: ID!
 }
 
 """


### PR DESCRIPTION
Add promotion mutations:
- `promotionRuleCreate`
- `promotionRuleUpdate`
- `promotionRuleDelete`

Related RFC: https://github.com/saleor/saleor/issues/12539

⚠️ 
The mutations are missing events, and calling undiscounted price recalculations. It will be added separately.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
