### PR TITLE
Use `webhookDryRun` mutation's context instead of creating dummy one

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -27192,7 +27192,7 @@ Added in Saleor 3.13.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
-type GiftCardSent implements Event {
+type GiftCardSent implements Event @doc(category: "Gift cards") {
   """Time of the event."""
   issuedAt: DateTime
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -27192,7 +27192,7 @@ Added in Saleor 3.13.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
-type GiftCardSent implements Event @doc(category: "Gift cards") {
+type GiftCardSent implements Event {
   """Time of the event."""
   issuedAt: DateTime
 

--- a/saleor/graphql/webhook/mutations/webhook_dry_run.py
+++ b/saleor/graphql/webhook/mutations/webhook_dry_run.py
@@ -10,10 +10,7 @@ from ...core.fields import JSONString
 from ...core.mutations import BaseMutation
 from ...core.types import WebhookDryRunError
 from ...core.utils import raise_validation_error
-from ..subscription_payload import (
-    generate_payload_from_subscription,
-    initialize_request,
-)
+from ..subscription_payload import generate_payload_from_subscription
 from ..subscription_query import SubscriptionQuery
 from ..subscription_types import WEBHOOK_TYPES_MAP
 
@@ -114,7 +111,7 @@ class WebhookDryRun(BaseMutation):
         event_type, object, query = cls.validate_input(info, **data)
         payload = None
         if all([event_type, object, query]):
-            request = initialize_request()
+            request = info.context
             payload = generate_payload_from_subscription(
                 event_type, object, query, request
             )

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -561,8 +561,8 @@ class GiftCardSent(SubscriptionObjectType, GiftCardBase):
     )
 
     class Meta:
-        root_type = "GiftCard"
-        enable_dry_run = True
+        root_type = None
+        enable_dry_run = False
         interfaces = (Event,)
         description = (
             "Event sent when gift card is e-mailed." + ADDED_IN_313 + PREVIEW_FEATURE

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -43,6 +43,7 @@ from ..core.descriptions import (
 )
 from ..core.doc_category import (
     DOC_CATEGORY_CHECKOUT,
+    DOC_CATEGORY_GIFT_CARDS,
     DOC_CATEGORY_ORDERS,
     DOC_CATEGORY_PAYMENTS,
     DOC_CATEGORY_PRODUCTS,
@@ -567,6 +568,7 @@ class GiftCardSent(SubscriptionObjectType, GiftCardBase):
         description = (
             "Event sent when gift card is e-mailed." + ADDED_IN_313 + PREVIEW_FEATURE
         )
+        doc_category = DOC_CATEGORY_GIFT_CARDS
 
     @staticmethod
     def resolve_gift_card(root, info: ResolveInfo):

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
@@ -603,6 +603,7 @@ def test_webhook_dry_run_root_type(
     for event_name, event_type in WEBHOOK_TYPES_MAP.items():
         if not event_type._meta.enable_dry_run:
             continue
+
         webhook = async_subscription_webhooks_with_root_objects[event_name][0]
         object = async_subscription_webhooks_with_root_objects[event_name][1]
         object_id = graphene.Node.to_global_id(object.__class__.__name__, object.pk)
@@ -615,7 +616,9 @@ def test_webhook_dry_run_root_type(
 
         # then
         assert not content["data"]["webhookDryRun"]["errors"]
-        assert content["data"]["webhookDryRun"]["payload"]
+        payload = content["data"]["webhookDryRun"]["payload"]
+        assert payload
+        assert not json.loads(payload).get("errors")
 
 
 def test_webhook_dry_run_root_type_for_transaction_item_metadata_updated(


### PR DESCRIPTION
I want to merge this change, because it uses mutation's context with user data to generate payload from subscription.

It also disables dry run option for `GiftCardSent` webhook, as current implementation doesn't allow to perform it due to its specific root type. Currently dry run works for webhooks with subscriptable object being model instance.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
