### PR TITLE
Where filters by ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - [Preview] Add `AttributeBulkTranslate` and `AttributeValueBulkTranslate` mutation - #12965 by @SzymJ
 - [Preview] Add `where` and `search` filtering option on `products` query - #12960 by @zedzior
 - Add `externalReference` field to `AttributeValueInput`, `BulkAttributeValueInput` and `AttributeValueSelectableTypeInput` - #12823 by @SzymJ
+- [Preview] Add `where` filtering option with `ids` filter for `product_variants`, `collections` and `categories` query - #13004 by @zedzior
 
 ### Saleor Apps
 

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -1037,6 +1037,14 @@ class ProductVariantFilter(MetadataFilterBase):
         return queryset.filter(qs)
 
 
+class ProductVariantWhere(MetadataFilterBase):
+    ids = GlobalIDMultipleChoiceFilter(method=filter_by_id("ProductVariant"))
+
+    class Meta:
+        model = ProductVariant
+        fields = []
+
+
 class CollectionFilter(MetadataFilterBase):
     published = EnumFilter(
         input_class=CollectionPublished, method="filter_is_published"
@@ -1064,6 +1072,14 @@ class CollectionFilter(MetadataFilterBase):
         return queryset
 
 
+class CollectionWhere(MetadataFilterBase):
+    ids = GlobalIDMultipleChoiceFilter(method=filter_by_id("Collection"))
+
+    class Meta:
+        model = Collection
+        fields = []
+
+
 class CategoryFilter(MetadataFilterBase):
     search = django_filters.CharFilter(method="category_filter_search")
     ids = GlobalIDMultipleChoiceFilter(field_name="id")
@@ -1084,6 +1100,14 @@ class CategoryFilter(MetadataFilterBase):
         )
 
         return queryset.filter(name_slug_desc_qs)
+
+
+class CategoryWhere(MetadataFilterBase):
+    ids = GlobalIDMultipleChoiceFilter(method=filter_by_id("Category"))
+
+    class Meta:
+        model = Category
+        fields = []
 
 
 class ProductTypeFilter(MetadataFilterBase):
@@ -1128,16 +1152,34 @@ class ProductVariantFilterInput(FilterInputObjectType):
         filterset_class = ProductVariantFilter
 
 
+class ProductVariantWhereInput(WhereInputObjectType):
+    class Meta:
+        doc_category = DOC_CATEGORY_PRODUCTS
+        filterset_class = ProductVariantWhere
+
+
 class CollectionFilterInput(ChannelFilterInputObjectType):
     class Meta:
         doc_category = DOC_CATEGORY_PRODUCTS
         filterset_class = CollectionFilter
 
 
+class CollectionWhereInput(WhereInputObjectType):
+    class Meta:
+        doc_category = DOC_CATEGORY_PRODUCTS
+        filterset_class = CollectionWhere
+
+
 class CategoryFilterInput(FilterInputObjectType):
     class Meta:
         doc_category = DOC_CATEGORY_PRODUCTS
         filterset_class = CategoryFilter
+
+
+class CategoryWhereInput(WhereInputObjectType):
+    class Meta:
+        doc_category = DOC_CATEGORY_PRODUCTS
+        filterset_class = CategoryWhere
 
 
 class ProductTypeFilterInput(FilterInputObjectType):

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -47,10 +47,13 @@ from .bulk_mutations import (
 )
 from .filters import (
     CategoryFilterInput,
+    CategoryWhereInput,
     CollectionFilterInput,
+    CollectionWhereInput,
     ProductFilterInput,
     ProductTypeFilterInput,
     ProductVariantFilterInput,
+    ProductVariantWhereInput,
     ProductWhereInput,
 )
 from .mutations import (
@@ -173,6 +176,9 @@ class ProductQueries(graphene.ObjectType):
     categories = FilterConnectionField(
         CategoryCountableConnection,
         filter=CategoryFilterInput(description="Filtering options for categories."),
+        where=CategoryWhereInput(
+            description="Where filtering options." + ADDED_IN_314 + PREVIEW_FEATURE
+        ),
         sort_by=CategorySortingInput(description="Sort categories."),
         level=graphene.Argument(
             graphene.Int,
@@ -208,6 +214,9 @@ class ProductQueries(graphene.ObjectType):
     collections = FilterConnectionField(
         CollectionCountableConnection,
         filter=CollectionFilterInput(description="Filtering options for collections."),
+        where=CollectionWhereInput(
+            description="Where filtering options." + ADDED_IN_314 + PREVIEW_FEATURE
+        ),
         sort_by=CollectionSortingInput(description="Sort collections."),
         description=(
             "List of the shop's collections. Requires one of the following permissions "
@@ -306,6 +315,9 @@ class ProductQueries(graphene.ObjectType):
         ),
         filter=ProductVariantFilterInput(
             description="Filtering options for product variant."
+        ),
+        where=ProductVariantWhereInput(
+            description="Where filtering options." + ADDED_IN_314 + PREVIEW_FEATURE
         ),
         sort_by=ProductVariantSortingInput(description="Sort products variants."),
         description=(

--- a/saleor/graphql/product/tests/queries/test_product_variants_query_with_where.py
+++ b/saleor/graphql/product/tests/queries/test_product_variants_query_with_where.py
@@ -1,0 +1,39 @@
+import graphene
+
+from ....tests.utils import get_graphql_content
+
+PRODUCT_VARIANTS_WHERE_QUERY = """
+    query($where: ProductVariantWhereInput!, $channel: String) {
+      productVariants(first: 10, where: $where, channel: $channel) {
+        edges {
+          node {
+            id
+            name
+            sku
+          }
+        }
+      }
+    }
+"""
+
+
+def test_product_variant_filter_by_ids(api_client, product_variant_list, channel_USD):
+    # given
+    ids = [
+        graphene.Node.to_global_id("ProductVariant", variant.pk)
+        for variant in product_variant_list[:2]
+    ]
+    variables = {"channel": channel_USD.slug, "where": {"AND": [{"ids": ids}]}}
+
+    # when
+    response = api_client.post_graphql(PRODUCT_VARIANTS_WHERE_QUERY, variables)
+
+    # then
+    data = get_graphql_content(response)
+    variants = data["data"]["productVariants"]["edges"]
+    assert len(variants) == 2
+    returned_slugs = {node["node"]["sku"] for node in variants}
+    assert returned_slugs == {
+        product_variant_list[0].sku,
+        product_variant_list[1].sku,
+    }

--- a/saleor/graphql/product/tests/test_collection_filtering_and_sorting_with_channels.py
+++ b/saleor/graphql/product/tests/test_collection_filtering_and_sorting_with_channels.py
@@ -1,5 +1,6 @@
 import datetime
 
+import graphene
 import pytest
 import pytz
 
@@ -386,3 +387,39 @@ def test_collections_with_filtering_and_not_existing_channel(
     content = get_graphql_content(response)
     collections_nodes = content["data"]["collections"]["edges"]
     assert len(collections_nodes) == 0
+
+
+COLLECTION_WHERE_QUERY = """
+    query($where: CollectionWhereInput!, $channel: String) {
+      collections(first: 10, where: $where, channel: $channel) {
+        edges {
+          node {
+            id
+            slug
+          }
+        }
+      }
+    }
+"""
+
+
+def test_collections_where_by_ids(api_client, collection_list, channel_USD):
+    # given
+    ids = [
+        graphene.Node.to_global_id("Collection", collection.pk)
+        for collection in collection_list[:2]
+    ]
+    variables = {"channel": channel_USD.slug, "where": {"AND": [{"ids": ids}]}}
+
+    # when
+    response = api_client.post_graphql(COLLECTION_WHERE_QUERY, variables)
+
+    # then
+    data = get_graphql_content(response)
+    collections = data["data"]["collections"]["edges"]
+    assert len(collections) == 2
+    returned_slugs = {node["node"]["slug"] for node in collections}
+    assert returned_slugs == {
+        collection_list[0].slug,
+        collection_list[1].slug,
+    }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -344,6 +344,15 @@ type Query {
     """Filtering options for categories."""
     filter: CategoryFilterInput
 
+    """
+    Where filtering options.
+    
+    Added in Saleor 3.14.
+    
+    Note: this API is currently in Feature Preview and can be subject to changes at later point.
+    """
+    where: CategoryWhereInput
+
     """Sort categories."""
     sortBy: CategorySortingInput
 
@@ -396,6 +405,15 @@ type Query {
   collections(
     """Filtering options for collections."""
     filter: CollectionFilterInput
+
+    """
+    Where filtering options.
+    
+    Added in Saleor 3.14.
+    
+    Note: this API is currently in Feature Preview and can be subject to changes at later point.
+    """
+    where: CollectionWhereInput
 
     """Sort collections."""
     sortBy: CollectionSortingInput
@@ -551,6 +569,15 @@ type Query {
 
     """Filtering options for product variant."""
     filter: ProductVariantFilterInput
+
+    """
+    Where filtering options.
+    
+    Added in Saleor 3.14.
+    
+    Note: this API is currently in Feature Preview and can be subject to changes at later point.
+    """
+    where: ProductVariantWhereInput
 
     """Sort products variants."""
     sortBy: ProductVariantSortingInput
@@ -11960,6 +11987,17 @@ input CategoryFilterInput @doc(category: "Products") {
   slugs: [String!]
 }
 
+input CategoryWhereInput @doc(category: "Products") {
+  metadata: [MetadataFilter!]
+  ids: [ID!]
+
+  """List of conditions that must be met."""
+  AND: [CategoryWhereInput!]
+
+  """A list of conditions of which at least one must be met."""
+  OR: [CategoryWhereInput!]
+}
+
 input CategorySortingInput @doc(category: "Products") {
   """Specifies the direction in which to sort categories."""
   direction: OrderDirection!
@@ -12004,6 +12042,17 @@ input CollectionFilterInput @doc(category: "Products") {
 enum CollectionPublished @doc(category: "Products") {
   PUBLISHED
   HIDDEN
+}
+
+input CollectionWhereInput @doc(category: "Products") {
+  metadata: [MetadataFilter!]
+  ids: [ID!]
+
+  """List of conditions that must be met."""
+  AND: [CollectionWhereInput!]
+
+  """A list of conditions of which at least one must be met."""
+  OR: [CollectionWhereInput!]
 }
 
 input CollectionSortingInput @doc(category: "Products") {
@@ -12095,6 +12144,17 @@ input ProductVariantFilterInput @doc(category: "Products") {
   metadata: [MetadataFilter!]
   isPreorder: Boolean
   updatedAt: DateTimeRangeInput
+}
+
+input ProductVariantWhereInput @doc(category: "Products") {
+  metadata: [MetadataFilter!]
+  ids: [ID!]
+
+  """List of conditions that must be met."""
+  AND: [ProductVariantWhereInput!]
+
+  """A list of conditions of which at least one must be met."""
+  OR: [ProductVariantWhereInput!]
 }
 
 input ProductVariantSortingInput @doc(category: "Products") {


### PR DESCRIPTION
I want to merge this change, because I want to apply `where` filtering for `ProductVariants`, `Collections` and `Categories`. This PR only add filtering by `ids`, because it is a blocker for new promotions api. It should be extended with other filters.

`where` filters RFC: https://github.com/saleor/saleor/issues/11432 
It is a part of: https://github.com/saleor/saleor/issues/12370

**Example**
```graphql
query($where: CategoryWhereInput!) {
      categories(first: 10, where: $where) {
        edges {
          node {
            id
            slug
          }
        }
      }
    }
```

```
{
  "where": {
    "AND": [
      {"ids": ["Q29sbGVjdGlvbjox", "Q29sbGVjdGlvbjoy"]}
    ]
  }
}
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
