### PR TITLE
Expand metric units to support more types of products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Match `Orders` to `User` when creating user using OIDC plugin. - #12863 by @kadewu
 - Allow defining a custom price in draft orders - #12855 by @KirillPlaksin
 - Update price resolvers - use `discounted_price` on `ProductChannelListing` and `ProductVariantChannelListing` channel listings to return the pricing - #12713 by @IKarbowiak
-- Expand metric units to support more types of products #13007 by @FremahA
+- Expand metric units to support more types of products - #13007 by @FremahA
 
 # 3.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Match `Orders` to `User` when creating user using OIDC plugin. - #12863 by @kadewu
 - Allow defining a custom price in draft orders - #12855 by @KirillPlaksin
 - Update price resolvers - use `discounted_price` on `ProductChannelListing` and `ProductVariantChannelListing` channel listings to return the pricing - #12713 by @IKarbowiak
+- Expand metric units to support more types of products #13007 by @FremahA
 
 # 3.13.0
 

--- a/saleor/core/units.py
+++ b/saleor/core/units.py
@@ -1,5 +1,7 @@
 class DistanceUnits:
+    MM = "mm"
     CM = "cm"
+    DM = "dm"
     M = "m"
     KM = "km"
     FT = "ft"
@@ -7,7 +9,9 @@ class DistanceUnits:
     INCH = "inch"
 
     CHOICES = [
+        (MM, "Millimeter"),
         (CM, "Centimeter"),
+        (DM, "Decimeter"),
         (M, "Meter"),
         (KM, "Kilometers"),
         (FT, "Feet"),
@@ -17,7 +21,9 @@ class DistanceUnits:
 
 
 class AreaUnits:
+    SQ_MM = "sq_mm"
     SQ_CM = "sq_cm"
+    SQ_DM = "sq_dm"
     SQ_M = "sq_m"
     SQ_KM = "sq_km"
     SQ_FT = "sq_ft"
@@ -25,7 +31,9 @@ class AreaUnits:
     SQ_INCH = "sq_inch"
 
     CHOICES = [
+        (SQ_MM, "Square millimeter"),
         (SQ_CM, "Square centimeters"),
+        (SQ_DM, "Square decimeter"),
         (SQ_M, "Square meters"),
         (SQ_KM, "Square kilometers"),
         (SQ_FT, "Square feet"),

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5917,7 +5917,9 @@ enum AttributeTypeEnum @doc(category: "Attributes") {
 
 """An enumeration."""
 enum MeasurementUnitsEnum {
+  MM
   CM
+  DM
   M
   KM
   FT
@@ -26800,7 +26802,9 @@ union IssuingPrincipal = App | User
 
 """An enumeration."""
 enum DistanceUnitsEnum {
+  MM
   CM
+  DM
   M
   KM
   FT
@@ -26810,7 +26814,9 @@ enum DistanceUnitsEnum {
 
 """An enumeration."""
 enum AreaUnitsEnum {
+  SQ_MM
   SQ_CM
+  SQ_DM
   SQ_M
   SQ_KM
   SQ_FT


### PR DESCRIPTION
I want to merge this change because it expands metric units to support more types of products.


It fixes #13002

# Impact

* [ x] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
