### PR TITLE
Fix order migration 0163 to use apps get_model method

### DIFF
--- a/saleor/order/migrations/0163_order_events_rename_transaction_events.py
+++ b/saleor/order/migrations/0163_order_events_rename_transaction_events.py
@@ -32,11 +32,13 @@ def update_type_to_transaction_cancel_requested(qs: QuerySet[OrderEvent]):
         qs.update(type="transaction_cancel_requested")
 
 
-def order_events_rename_transaction_void_events_task():
-    events = OrderEvent.objects.filter(type="transaction_void_requested").order_by("pk")
+def order_events_rename_transaction_void_events_task(order_event_model):
+    events = order_event_model.objects.filter(
+        type="transaction_void_requested"
+    ).order_by("pk")
 
     for ids in queryset_in_batches(events):
-        qs = OrderEvent.objects.filter(pk__in=ids)
+        qs = order_event_model.objects.filter(pk__in=ids)
         update_type_to_transaction_cancel_requested(qs)
 
 
@@ -47,19 +49,20 @@ def update_type_to_transaction_charge_requested(qs: QuerySet[OrderEvent]):
         qs.update(type="transaction_charge_requested")
 
 
-def order_events_rename_transaction_capture_events_task():
-    events = OrderEvent.objects.filter(type="transaction_capture_requested").order_by(
-        "pk"
-    )
+def order_events_rename_transaction_capture_events_task(order_event_model):
+    events = order_event_model.objects.filter(
+        type="transaction_capture_requested"
+    ).order_by("pk")
 
     for ids in queryset_in_batches(events):
-        qs = OrderEvent.objects.filter(pk__in=ids)
+        qs = order_event_model.objects.filter(pk__in=ids)
         update_type_to_transaction_charge_requested(qs)
 
 
 def rename_order_events(apps, _schema_editor):
-    order_events_rename_transaction_capture_events_task()
-    order_events_rename_transaction_void_events_task()
+    OrderEvent = apps.get_model("order", "OrderEvent")
+    order_events_rename_transaction_capture_events_task(OrderEvent)
+    order_events_rename_transaction_void_events_task(OrderEvent)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Fix possible problem introduced in https://github.com/saleor/saleor/pull/12806

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
