### PR TITLE
Improve search indexing order in search building tasks

### DIFF
--- a/saleor/core/search_tasks.py
+++ b/saleor/core/search_tasks.py
@@ -28,7 +28,7 @@ def set_user_search_document_values(updated_count: int = 0) -> None:
     users = list(
         User.objects.filter(search_document="")
         .prefetch_related("addresses")
-        .order_by()[:BATCH_SIZE]
+        .order_by("-id")[:BATCH_SIZE]
     )
 
     if not users:
@@ -62,7 +62,7 @@ def set_order_search_document_values(updated_count: int = 0) -> None:
             "discounts",
             "lines",
         )
-        .order_by()[:BATCH_SIZE]
+        .order_by("-number")[:BATCH_SIZE]
     )
 
     if not orders:
@@ -87,7 +87,7 @@ def set_product_search_document_values(updated_count: int = 0) -> None:
     products = list(
         Product.objects.filter(search_vector=None)
         .prefetch_related(*PRODUCT_FIELDS_TO_PREFETCH)
-        .order_by()[:BATCH_SIZE]
+        .order_by("-id")[:BATCH_SIZE]
     )
 
     if not products:


### PR DESCRIPTION
This is a port of https://github.com/saleor/saleor/pull/12993/
I want to merge this change because it makes search tasks update entities in reverse order. As a user, I'm more likely to perform a search on something new rather than old, so it's a good idea to prioritize newer things when building the search indexes.
Resolves https://github.com/saleor/saleor/issues/12281

set_user_search_document_values
before: Seq Scan on account_user
after: Index Scan Backward using userprofile_user_pkey on account_user

set_order_search_document_values
before: Seq Scan on order_order
after: Index Scan Backward using order_order_number_49f061b_uniq on order_order

set_product_search_document_values
before: Seq Scan on product_product
after: Index Scan Backward using product_product_pkey on product_product


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
