### PR TITLE
Fix: Cannot return null for non-nullable field Webhook.name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Other changes
 - Expand metric units to support more types of products. - #13043 by @FremahA
-
+- Fix Error Cannot return null for non-nullable field Webhook.name. - #12989 by @cyborg7898
 # 3.14.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Other changes
 - Expand metric units to support more types of products. - #13043 by @FremahA
 - Fix Error Cannot return null for non-nullable field Webhook.name. - #12989 by @cyborg7898
+
 # 3.14.0
 
 ### Breaking changes

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1609,7 +1609,7 @@ type Query {
 """Webhook."""
 type Webhook implements Node @doc(category: "Webhooks") {
   id: ID!
-  name: String!
+  name: String
 
   """List of webhook events."""
   events: [WebhookEvent!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `asyncEvents` or `syncEvents` instead.")

--- a/saleor/graphql/webhook/tests/queries/test_webhook.py
+++ b/saleor/graphql/webhook/tests/queries/test_webhook.py
@@ -170,10 +170,13 @@ def test_webhook_with_invalid_object_type(
     assert content["data"]["webhook"] is None
 
 
-def test_webhook_without_name(staff_api_client, webhook_without_name):
+def test_webhook_without_name(
+    staff_api_client, webhook_without_name, permission_manage_apps
+):
     query = QUERY_WEBHOOK
     webhook_id = graphene.Node.to_global_id("Webhook", webhook_without_name.pk)
     variables = {"id": webhook_id}
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
     response = staff_api_client.post_graphql(query, variables=variables)
     content = get_graphql_content(response)
     webhook_response = content["data"]["webhook"]

--- a/saleor/graphql/webhook/tests/queries/test_webhook.py
+++ b/saleor/graphql/webhook/tests/queries/test_webhook.py
@@ -14,6 +14,7 @@ QUERY_WEBHOOK = """
       webhook(id: $id) {
         id
         isActive
+        name
         subscriptionQuery
         asyncEvents {
           eventType
@@ -167,3 +168,15 @@ def test_webhook_with_invalid_object_type(
     response = staff_api_client.post_graphql(QUERY_WEBHOOK, variables)
     content = get_graphql_content(response)
     assert content["data"]["webhook"] is None
+
+
+def test_webhook_without_name(staff_api_client, webhook_without_name):
+    query = QUERY_WEBHOOK
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook_without_name.pk)
+    variables = {"id": webhook_id}
+    response = staff_api_client.post_graphql(query, variables=variables)
+    content = get_graphql_content(response)
+    webhook_response = content["data"]["webhook"]
+    assert webhook_response["name"] is None
+    events = webhook_without_name.events.all()
+    assert len(events) == 1

--- a/saleor/graphql/webhook/types.py
+++ b/saleor/graphql/webhook/types.py
@@ -147,7 +147,7 @@ class EventDeliveryCountableConnection(CountableConnection):
 
 class Webhook(ModelObjectType[models.Webhook]):
     id = graphene.GlobalID(required=True)
-    name = graphene.String(required=True)
+    name = graphene.String(required=False)
     events = NonNullList(
         WebhookEvent,
         description="List of webhook events.",

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -6295,6 +6295,13 @@ def webhook(app):
 
 
 @pytest.fixture
+def webhook_without_name(app):
+    webhook = Webhook.objects.create(app=app, target_url="http://www.example.com/test")
+    webhook.events.create(event_type=WebhookEventAsyncType.ORDER_CREATED)
+    return webhook
+
+
+@pytest.fixture
 def any_webhook(app):
     webhook = Webhook.objects.create(
         name="Any webhook", app=app, target_url="http://www.example.com/any"


### PR DESCRIPTION
I want to merge this change because 
It closes #12989 


# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
