### PR TITLE
Add 'promotions' query.

### DIFF
--- a/saleor/graphql/discount/resolvers.py
+++ b/saleor/graphql/discount/resolvers.py
@@ -1,3 +1,5 @@
+from django.db.models import QuerySet
+
 from ...discount import models
 from ..channel import ChannelContext, ChannelQsContext
 from .filters import filter_sale_search, filter_voucher_search
@@ -39,3 +41,7 @@ def resolve_sales(info, channel_slug, **kwargs) -> ChannelQsContext:
 
 def resolve_promotion(id):
     return models.Promotion.objects.filter(id=id).first()
+
+
+def resolve_promotions() -> QuerySet:
+    return models.Promotion.objects.all()

--- a/saleor/graphql/discount/sorters.py
+++ b/saleor/graphql/discount/sorters.py
@@ -3,7 +3,7 @@ from django.db.models import Min, Q, QuerySet
 
 from ..core.descriptions import CHANNEL_REQUIRED
 from ..core.doc_category import DOC_CATEGORY_DISCOUNTS
-from ..core.types import BaseEnum, ChannelSortInputObjectType
+from ..core.types import BaseEnum, ChannelSortInputObjectType, SortInputObjectType
 
 
 class SaleSortField(BaseEnum):
@@ -98,3 +98,28 @@ class VoucherSortingInput(ChannelSortInputObjectType):
         doc_category = DOC_CATEGORY_DISCOUNTS
         sort_enum = VoucherSortField
         type_name = "vouchers"
+
+
+class PromotionSortField(BaseEnum):
+    NAME = ["name", "pk"]
+    START_DATE = ["start_date", "name", "pk"]
+    END_DATE = ["end_date", "name", "pk"]
+    CREATED_AT = ["created_at", "pk"]
+
+    class Meta:
+        doc_category = DOC_CATEGORY_DISCOUNTS
+
+    @property
+    def description(self):
+        if self.name in PromotionSortField.__enum__._member_names_:
+            sort_name = self.name.lower().replace("_", " ")
+            description = f"Sort promotions by {sort_name}."
+            return description
+        raise ValueError(f"Unsupported enum value: {self.value}")
+
+
+class PromotionSortingInput(SortInputObjectType):
+    class Meta:
+        doc_category = DOC_CATEGORY_DISCOUNTS
+        sort_enum = PromotionSortField
+        type_name = "promotions"

--- a/saleor/graphql/discount/tests/queries/test_promotions.py
+++ b/saleor/graphql/discount/tests/queries/test_promotions.py
@@ -1,0 +1,407 @@
+from datetime import timedelta
+
+import graphene
+import pytest
+from django.utils import timezone
+
+from ....tests.utils import assert_no_permission, get_graphql_content
+
+QUERY_PROMOTIONS = """
+    query Promotions($where: PromotionWhereInput, $sortBy: PromotionSortingInput){
+        promotions(first: 10, where: $where, sortBy: $sortBy) {
+            edges {
+                node {
+                    id
+                    name
+                    description
+                    startDate
+                    rules {
+                        id
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
+def test_query_promotions_by_staff_user(
+    promotion_list, staff_api_client, permission_manage_discounts
+):
+    # given
+    variables = {}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PROMOTIONS, variables, permissions=(permission_manage_discounts,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    promotions = content["data"]["promotions"]["edges"]
+    assert len(promotions) == len(promotion_list)
+    assert promotions[0]["node"]["name"] == promotion_list[0].name
+    assert promotions[0]["node"]["description"] == promotion_list[0].description
+    assert (
+        promotions[0]["node"]["startDate"] == promotion_list[0].start_date.isoformat()
+    )
+    assert len(promotions[0]["node"]["rules"]) == len(promotion_list[0].rules.all())
+
+
+def test_query_promotions_by_app(
+    promotion_list, app_api_client, permission_manage_discounts
+):
+    # given
+    variables = {}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_PROMOTIONS, variables, permissions=(permission_manage_discounts,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    promotions = content["data"]["promotions"]["edges"]
+    assert len(promotions) == len(promotion_list)
+    assert promotions[0]["node"]["name"] == promotion_list[0].name
+    assert promotions[0]["node"]["description"] == promotion_list[0].description
+    assert (
+        promotions[0]["node"]["startDate"] == promotion_list[0].start_date.isoformat()
+    )
+    assert len(promotions[0]["node"]["rules"]) == len(promotion_list[0].rules.all())
+
+
+def test_query_promotions_by_customer(
+    promotion_list, api_client, permission_manage_discounts
+):
+    # given
+    variables = {}
+
+    # when
+    response = api_client.post_graphql(QUERY_PROMOTIONS, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_query_promotions_filter_by_id(
+    promotion_list, staff_api_client, permission_manage_discounts
+):
+    # given
+    ids = [
+        graphene.Node.to_global_id("Promotion", promotion.pk)
+        for promotion in promotion_list[:2]
+    ]
+    variables = {"where": {"ids": ids}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PROMOTIONS, variables, permissions=(permission_manage_discounts,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    promotions = content["data"]["promotions"]["edges"]
+    assert len(promotions) == 2
+    names = {node["node"]["name"] for node in promotions}
+    assert names == {promotion_list[0].name, promotion_list[1].name}
+
+
+def test_query_promotions_filter_by_name(
+    promotion_list, staff_api_client, permission_manage_discounts
+):
+    # given
+    variables = {"where": {"name": {"oneOf": ["Promotion 1", "Promotion 3"]}}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PROMOTIONS, variables, permissions=(permission_manage_discounts,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    promotions = content["data"]["promotions"]["edges"]
+    assert len(promotions) == 2
+    names = {node["node"]["name"] for node in promotions}
+    assert names == {promotion_list[0].name, promotion_list[2].name}
+
+
+def test_query_promotions_filter_by_end_date(
+    promotion_list, staff_api_client, permission_manage_discounts
+):
+    # given
+    variables = {
+        "where": {
+            "endDate": {
+                "gte": timezone.now() + timedelta(days=5),
+                "lte": timezone.now() + timedelta(days=25),
+            }
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PROMOTIONS, variables, permissions=(permission_manage_discounts,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    promotions = content["data"]["promotions"]["edges"]
+    assert len(promotions) == 2
+    names = {node["node"]["name"] for node in promotions}
+    assert names == {promotion_list[0].name, promotion_list[1].name}
+
+
+def test_query_promotions_filter_by_start_date(
+    promotion_list, staff_api_client, permission_manage_discounts
+):
+    # given
+    variables = {
+        "where": {
+            "startDate": {
+                "gte": timezone.now() + timedelta(days=3),
+            }
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PROMOTIONS, variables, permissions=(permission_manage_discounts,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    promotions = content["data"]["promotions"]["edges"]
+    assert len(promotions) == 2
+    names = {node["node"]["name"] for node in promotions}
+    assert names == {promotion_list[1].name, promotion_list[2].name}
+
+
+@pytest.mark.parametrize("value,indexes", [(True, [0]), (False, [1, 2])])
+def test_query_promotions_filter_by_is_old_sale(
+    value, indexes, promotion_list, staff_api_client, permission_manage_discounts
+):
+    # given
+    promotion_list[0].old_sale = True
+    promotion_list[0].save(update_fields=["old_sale"])
+    variables = {"where": {"isOldSale": value}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PROMOTIONS, variables, permissions=(permission_manage_discounts,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    promotions = content["data"]["promotions"]["edges"]
+    assert len(promotions) == len(indexes)
+    assert {promotion_list[index].name for index in indexes} == {
+        promotion["node"]["name"] for promotion in promotions
+    }
+
+
+@pytest.mark.parametrize("direction", ("ASC", "DESC"))
+def test_sorting_promotions_by_name(
+    direction,
+    staff_api_client,
+    promotion,
+    promotion_list,
+    permission_manage_discounts,
+):
+    # given
+    promotion_list.insert(0, promotion)
+    variables = {
+        "sortBy": {
+            "direction": direction,
+            "field": "NAME",
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PROMOTIONS, variables, permissions=[permission_manage_discounts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    promotions = content["data"]["promotions"]["edges"]
+    if direction == "DESC":
+        promotions.reverse()
+    assert len(promotions) == 4
+    assert [promotion["node"]["name"] for promotion in promotions] == [
+        promotion.name for promotion in promotion_list
+    ]
+
+
+@pytest.mark.parametrize("direction", ("ASC", "DESC"))
+def test_sorting_promotions_by_end_date(
+    direction,
+    staff_api_client,
+    promotion,
+    promotion_list,
+    permission_manage_discounts,
+):
+    # given
+    promotion_list.insert(2, promotion)
+    variables = {
+        "sortBy": {
+            "direction": direction,
+            "field": "END_DATE",
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PROMOTIONS, variables, permissions=[permission_manage_discounts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    promotions = content["data"]["promotions"]["edges"]
+    if direction == "DESC":
+        promotions.reverse()
+    assert len(promotions) == 4
+    assert [promotion["node"]["name"] for promotion in promotions] == [
+        promotion.name for promotion in promotion_list
+    ]
+
+
+@pytest.mark.parametrize("direction", ("ASC", "DESC"))
+def test_sorting_promotions_by_start_date(
+    direction,
+    staff_api_client,
+    promotion,
+    promotion_list,
+    permission_manage_discounts,
+):
+    # given
+    promotion.start_date = timezone.now() + timedelta(days=3)
+    promotion.save(update_fields=["start_date"])
+    promotion_list.insert(1, promotion)
+    variables = {
+        "sortBy": {
+            "direction": direction,
+            "field": "START_DATE",
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PROMOTIONS, variables, permissions=[permission_manage_discounts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    promotions = content["data"]["promotions"]["edges"]
+    if direction == "DESC":
+        promotions.reverse()
+    assert len(promotions) == 4
+    assert [promotion["node"]["name"] for promotion in promotions] == [
+        promotion.name for promotion in promotion_list
+    ]
+
+
+@pytest.mark.parametrize("direction", ("ASC", "DESC"))
+def test_sorting_promotions_by_created_at(
+    direction,
+    staff_api_client,
+    promotion_list,
+    permission_manage_discounts,
+):
+    # given
+    variables = {
+        "sortBy": {
+            "direction": direction,
+            "field": "CREATED_AT",
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PROMOTIONS, variables, permissions=[permission_manage_discounts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    promotions = content["data"]["promotions"]["edges"]
+    if direction == "DESC":
+        promotions.reverse()
+    assert len(promotions) == 3
+    assert [promotion["node"]["name"] for promotion in promotions] == [
+        promotion.name for promotion in promotion_list
+    ]
+
+
+QUERY_PROMOTIONS_PAGINATION = """
+    query Promotions(
+        $first: Int, $last: Int, $after: String, $before: String,
+        $where: PromotionWhereInput, $sortBy: PromotionSortingInput
+    ){
+        promotions(
+            first: $first, last: $last, after: $after, before: $before,
+            where: $where, sortBy: $sortBy
+        ) {
+            edges {
+                node {
+                    id
+                    name
+                }
+            }
+            pageInfo{
+                startCursor
+                endCursor
+                hasNextPage
+                hasPreviousPage
+            }
+        }
+    }
+"""
+
+
+def test_query_promotions_pagination(
+    promotion_list, promotion, staff_api_client, permission_manage_discounts
+):
+    # given
+    end_cursor = None
+    has_next_page = True
+    object_count = 0
+    queries_count = 0
+    names = []
+
+    variables = {
+        "first": 2,
+        "after": None,
+        "sortBy": {
+            "direction": "DESC",
+            "field": "NAME",
+        },
+        "where": {
+            "endDate": {
+                "gte": timezone.now() + timedelta(days=15),
+            }
+        },
+    }
+
+    # when
+    while has_next_page:
+        variables["after"] = end_cursor
+        response = staff_api_client.post_graphql(
+            QUERY_PROMOTIONS_PAGINATION,
+            variables,
+            check_no_permissions=False,
+            permissions=(permission_manage_discounts,),
+        )
+        content = get_graphql_content(response)
+        promotions = content["data"]["promotions"]
+        page_info = promotions["pageInfo"]
+        has_next_page = page_info["hasNextPage"]
+        end_cursor = page_info["endCursor"]
+
+        queries_count += 1
+        object_count += len(promotions["edges"])
+        names.extend(promotion["node"]["name"] for promotion in promotions["edges"])
+
+    # then
+    assert object_count == 3
+    assert queries_count == 2
+    assert promotion_list[0].name not in names

--- a/saleor/graphql/discount/types/promotions.py
+++ b/saleor/graphql/discount/types/promotions.py
@@ -5,6 +5,7 @@ from ....discount import models
 from ....permission.auth_filters import AuthorizationFilters
 from ...channel.types import Channel
 from ...core import ResolveInfo
+from ...core.connection import CountableConnection
 from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import PermissionsField
@@ -99,3 +100,9 @@ class PromotionRule(ModelObjectType[models.PromotionRule]):
     @staticmethod
     def resolve_channels(root: models.PromotionRule, info: ResolveInfo):
         return ChannelsByPromotionRuleIdLoader(info.context).load(root.id)
+
+
+class PromotionCountableConnection(CountableConnection):
+    class Meta:
+        doc_category = DOC_CATEGORY_DISCOUNTS
+        node = Promotion

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1185,6 +1185,39 @@ type Query {
   ): Promotion @doc(category: "Discounts")
 
   """
+  List of the promotions.
+  
+  Added in Saleor 3.15.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  
+  Requires one of the following permissions: MANAGE_DISCOUNTS.
+  """
+  promotions(
+    """Where filtering options."""
+    where: PromotionWhereInput
+
+    """Sort promotions."""
+    sortBy: PromotionSortingInput
+
+    """Return the elements in the list that come before the specified cursor."""
+    before: String
+
+    """Return the elements in the list that come after the specified cursor."""
+    after: String
+
+    """
+    Retrieve the first n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    first: Int
+
+    """
+    Retrieve the last n elements from the list. Note that the system only allows fetching a maximum of 100 objects in a single query.
+    """
+    last: Int
+  ): PromotionCountableConnection @doc(category: "Discounts")
+
+  """
   Look up a export file by ID.
   
   Requires one of the following permissions: MANAGE_PRODUCTS.
@@ -12963,6 +12996,66 @@ type PromotionRule implements Node @doc(category: "Discounts") {
 enum RewardValueTypeEnum @doc(category: "Discounts") {
   FIXED
   PERCENTAGE
+}
+
+type PromotionCountableConnection @doc(category: "Discounts") {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+  edges: [PromotionCountableEdge!]!
+
+  """A total count of items in the collection."""
+  totalCount: Int
+}
+
+type PromotionCountableEdge @doc(category: "Discounts") {
+  """The item at the end of the edge."""
+  node: Promotion!
+
+  """A cursor for use in pagination."""
+  cursor: String!
+}
+
+input PromotionWhereInput @doc(category: "Discounts") {
+  metadata: [MetadataFilter!]
+  ids: [ID!]
+
+  """Filter by promotion name."""
+  name: StringFilterInput
+
+  """Filter promotions by end date."""
+  endDate: DateTimeRangeInput
+
+  """Filter promotions by start date."""
+  startDate: DateTimeRangeInput
+  isOldSale: Boolean
+
+  """List of conditions that must be met."""
+  AND: [PromotionWhereInput!]
+
+  """A list of conditions of which at least one must be met."""
+  OR: [PromotionWhereInput!]
+}
+
+input PromotionSortingInput @doc(category: "Discounts") {
+  """Specifies the direction in which to sort promotions."""
+  direction: OrderDirection!
+
+  """Sort promotions by the selected field."""
+  field: PromotionSortField!
+}
+
+enum PromotionSortField @doc(category: "Discounts") {
+  """Sort promotions by name."""
+  NAME
+
+  """Sort promotions by start date."""
+  START_DATE
+
+  """Sort promotions by end date."""
+  END_DATE
+
+  """Sort promotions by created at."""
+  CREATED_AT
 }
 
 """Represents a job data of exported file."""

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -5089,6 +5089,79 @@ def promotion(channel_USD, product, collection):
 
 
 @pytest.fixture
+def promotion_list(channel_USD, product, collection):
+    promotions = Promotion.objects.bulk_create(
+        [
+            Promotion(
+                name="Promotion 1",
+                description=dummy_editorjs("Promotion 1 description."),
+                start_date=timezone.now() + timedelta(days=1),
+                end_date=timezone.now() + timedelta(days=10),
+            ),
+            Promotion(
+                name="Promotion 2",
+                description=dummy_editorjs("Promotion 2 description."),
+                start_date=timezone.now() + timedelta(days=5),
+                end_date=timezone.now() + timedelta(days=20),
+            ),
+            Promotion(
+                name="Promotion 3",
+                description=dummy_editorjs("TePromotion 3 description."),
+                start_date=timezone.now() + timedelta(days=15),
+                end_date=timezone.now() + timedelta(days=30),
+            ),
+        ]
+    )
+    rules = PromotionRule.objects.bulk_create(
+        [
+            PromotionRule(
+                name="Promotion 1 percentage rule",
+                promotion=promotions[0],
+                description=dummy_editorjs(
+                    "Test description for promotion 1 percentage rule."
+                ),
+                catalogue_predicate={"productPredicate": {"ids": [product.id]}},
+                reward_value_type=RewardValueType.PERCENTAGE,
+                reward_value=Decimal("10"),
+            ),
+            PromotionRule(
+                name="Promotion 1 fixed rule",
+                promotion=promotions[0],
+                description=dummy_editorjs(
+                    "Test description for promotion 1 fixed rule."
+                ),
+                catalogue_predicate={"collectionPredicate": {"ids": [collection.id]}},
+                reward_value_type=RewardValueType.FIXED,
+                reward_value=Decimal("5"),
+            ),
+            PromotionRule(
+                name="Promotion 2 percentage rule",
+                promotion=promotions[1],
+                description=dummy_editorjs(
+                    "Test description for promotion 2 percentage rule."
+                ),
+                catalogue_predicate={"productPredicate": {"ids": [product.id]}},
+                reward_value_type=RewardValueType.PERCENTAGE,
+                reward_value=Decimal("10"),
+            ),
+            PromotionRule(
+                name="Promotion 3 fixed rule",
+                promotion=promotions[2],
+                description=dummy_editorjs(
+                    "Test description for promotion 3 fixed rule."
+                ),
+                catalogue_predicate={"collectionPredicate": {"ids": [collection.id]}},
+                reward_value_type=RewardValueType.FIXED,
+                reward_value=Decimal("5"),
+            ),
+        ]
+    )
+    for rule in rules:
+        rule.channels.add(channel_USD)
+    return promotions
+
+
+@pytest.fixture
 def permission_manage_staff():
     return Permission.objects.get(codename="manage_staff")
 


### PR DESCRIPTION
I want to merge this change, because it adds `promotions` query with  filtering and sorting.

```graphql
promotions(
    where: PromotionWhereInput
    sortBy: PromotionSortingInput
    before: String
    after: String
    first: Int
    last: Int
  ): PromotionCountableConnection @doc(category: "Discounts")
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
