### PR TITLE
[Tests] Add a dedicated API Client for E2E test

### DIFF
--- a/saleor/graphql/tests/fixtures.py
+++ b/saleor/graphql/tests/fixtures.py
@@ -20,7 +20,7 @@ from .utils import assert_no_permission
 API_PATH = reverse("api")
 
 
-class ApiClient(Client):
+class BaseApiClient(Client):
     """GraphQL API client."""
 
     def __init__(self, *args, **kwargs):
@@ -72,6 +72,8 @@ class ApiClient(Client):
         kwargs["content_type"] = "application/json"
         return super().post(self.api_path, data, **kwargs)
 
+
+class ApiClient(BaseApiClient):
     def post_graphql(
         self,
         query,
@@ -95,13 +97,13 @@ class ApiClient(Client):
         if permissions:
             if check_no_permissions:
                 with mock.patch("saleor.graphql.utils.handled_errors_logger"):
-                    response = super().post(self.api_path, data, **kwargs)
+                    response = super(Client, self).post(self.api_path, data, **kwargs)
                 assert_no_permission(response)
             if self.app:
                 self.app.permissions.add(*permissions)
             else:
                 self.user.user_permissions.add(*permissions)
-        result = super().post(self.api_path, data, **kwargs)
+        result = super(Client, self).post(self.api_path, data, **kwargs)
         flush_post_commit_hooks()
         return result
 
@@ -114,10 +116,10 @@ class ApiClient(Client):
         kwargs["content_type"] = MULTIPART_CONTENT
 
         if permissions:
-            response = super().post(self.api_path, *args, **kwargs)
+            response = super(Client, self).post(self.api_path, *args, **kwargs)
             assert_no_permission(response)
             self.user.user_permissions.add(*permissions)
-        result = super().post(self.api_path, *args, **kwargs)
+        result = super(Client, self).post(self.api_path, *args, **kwargs)
         flush_post_commit_hooks()
         return result
 

--- a/saleor/tests/e2e/conftest.py
+++ b/saleor/tests/e2e/conftest.py
@@ -1,0 +1,60 @@
+import json
+
+import pytest
+from django.core.serializers.json import DjangoJSONEncoder
+from django.test.client import MULTIPART_CONTENT, Client
+
+from ...account.models import User
+from ...graphql.tests.fixtures import BaseApiClient
+from ..utils import flush_post_commit_hooks
+
+
+class E2eApiClient(BaseApiClient):
+    def post_graphql(
+        self,
+        query,
+        variables=None,
+        **kwargs,
+    ):
+        """Dedicated helper for posting GraphQL queries.
+
+        Sets the `application/json` content type and json.dumps the variables
+        if present.
+        """
+        data = {"query": query}
+        if variables is not None:
+            data["variables"] = variables
+        data = json.dumps(data, cls=DjangoJSONEncoder)
+        kwargs["content_type"] = "application/json"
+
+        result = super(Client, self).post(self.api_path, data, **kwargs)
+        flush_post_commit_hooks()
+        return result
+
+    def post_multipart(self, *args, permissions=None, **kwargs):
+        """Send a multipart POST request.
+
+        This is used to send multipart requests to GraphQL API when e.g.
+        uploading files.
+        """
+        kwargs["content_type"] = MULTIPART_CONTENT
+
+        result = super(Client, self).post(self.api_path, *args, **kwargs)
+        flush_post_commit_hooks()
+        return result
+
+
+@pytest.fixture
+def e2e_staff_api_client():
+    e2e_staff_user = User.objects.create_user(
+        email="e2e_staff_test@example.com",
+        password="password",
+        is_staff=True,
+        is_active=True,
+    )
+    return E2eApiClient(user=e2e_staff_user)
+
+
+@pytest.fixture
+def e2e_not_logged_api_client():
+    return E2eApiClient()


### PR DESCRIPTION
I want to merge this change because of adding a dedicated API Client for E2E test.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
