### PR TITLE
Factories in fixtures

### DIFF
--- a/saleor/attribute/tests/test_utils.py
+++ b/saleor/attribute/tests/test_utils.py
@@ -47,13 +47,19 @@ def test_associate_attribute_to_product_instance_without_values(product):
     assert new_assignment.values.count() == 0
 
 
-def test_associate_attribute_to_product_instance_multiple_values(product):
+def test_associate_attribute_to_product_instance_multiple_values(
+    product, attribute_value_generator
+):
     """Ensure multiple values in proper order are assigned."""
     old_assignment = product.attributes.first()
     assert old_assignment is not None, "The product doesn't have attribute-values"
     assert old_assignment.values.count() == 1
 
     attribute = old_assignment.attribute
+    attribute_value_generator(
+        attribute=attribute,
+        slug="attr-value2",
+    )
     values = attribute.values.all()
 
     # Assign new values
@@ -91,10 +97,16 @@ def test_associate_attribute_to_page_instance_multiple_values(page):
     ) == [(values[1].pk, 0), (values[0].pk, 1)]
 
 
-def test_associate_attribute_to_variant_instance_multiple_values(variant):
+def test_associate_attribute_to_variant_instance_multiple_values(
+    variant, attribute_value_generator
+):
     """Ensure multiple values in proper order are assigned."""
 
     attribute = variant.product.product_type.variant_attributes.first()
+    attribute_value_generator(
+        attribute=attribute,
+        slug="attr-value2",
+    )
     values = attribute.values.all()
 
     new_assignment = associate_attribute_values_to_instance(

--- a/saleor/core/tests/test_search_tasks.py
+++ b/saleor/core/tests/test_search_tasks.py
@@ -1,3 +1,4 @@
+from ...core.postgres import FlatConcatSearchVector
 from ...core.search_tasks import (
     set_order_search_document_values,
     set_user_search_document_values,
@@ -21,10 +22,10 @@ def test_set_user_search_document_values(customer_user, customer_user2):
 
 
 def test_set_order_search_document_values_already_present(
-    order_with_search_vector_value,
+    order_generator,
 ):
     # given
-    order = order_with_search_vector_value
+    order = order_generator(search_vector_class=FlatConcatSearchVector)
     order.refresh_from_db()
     vector = order.search_vector
 

--- a/saleor/graphql/order/tests/queries/test_order_with_filter.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_filter.py
@@ -414,10 +414,10 @@ def test_order_query_with_filter_status(
     staff_api_client,
     payment_dummy,
     permission_group_manage_orders,
-    order,
+    order_generator,
     channel_USD,
 ):
-    order1 = order(status=status)
+    order1 = order_generator(status=status)
 
     variables = {"filter": orders_filter}
     permission_group_manage_orders.user_set.add(staff_api_client.user)
@@ -765,11 +765,11 @@ def test_orders_query_with_filter_search_by_global_payment_id(
 
 def test_orders_query_with_filter_search_by_number(
     orders_query_with_filter,
-    order_with_search_vector_value,
+    order_generator,
     staff_api_client,
     permission_group_manage_orders,
 ):
-    order = order_with_search_vector_value
+    order = order_generator(search_vector_class=FlatConcatSearchVector)
     variables = {"filter": {"search": order.number}}
     permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
@@ -779,11 +779,11 @@ def test_orders_query_with_filter_search_by_number(
 
 def test_orders_query_with_filter_search_by_number_with_hash(
     orders_query_with_filter,
-    order_with_search_vector_value,
+    order_generator,
     staff_api_client,
     permission_group_manage_orders,
 ):
-    order = order_with_search_vector_value
+    order = order_generator(search_vector_class=FlatConcatSearchVector)
     variables = {"filter": {"search": f"#{order.number}"}}
     permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
@@ -966,7 +966,6 @@ def test_order_query_with_filter_search_by_product_sku_multi_order_lines(
     channel_USD,
     order,
 ):
-    order = order()
     variants = ProductVariant.objects.bulk_create(
         [
             ProductVariant(product=product, sku="Var1"),
@@ -1300,14 +1299,14 @@ def test_order_query_with_filter_by_multiple_checkout_tokens(
     orders_query_with_filter,
     staff_api_client,
     permission_group_manage_orders,
-    order,
+    order_generator,
     orders_from_checkout,
     orders,
     checkout,
     checkout_JPY,
 ):
     # given
-    order_from_checkout_JPY = order(
+    order_from_checkout_JPY = order_generator(
         status=OrderStatus.CANCELED,
         channel=checkout_JPY.channel,
         checkout_token=checkout_JPY.token,

--- a/saleor/graphql/order/tests/queries/test_order_with_filter.py
+++ b/saleor/graphql/order/tests/queries/test_order_with_filter.py
@@ -417,17 +417,14 @@ def test_order_query_with_filter_status(
     order,
     channel_USD,
 ):
-    order.status = status
-    order.save()
-
-    Order.objects.create(channel=channel_USD)
+    order1 = order(status=status)
 
     variables = {"filter": orders_filter}
     permission_group_manage_orders.user_set.add(staff_api_client.user)
     response = staff_api_client.post_graphql(orders_query_with_filter, variables)
     content = get_graphql_content(response)
     orders = content["data"]["orders"]["edges"]
-    order_id = graphene.Node.to_global_id("Order", order.pk)
+    order_id = graphene.Node.to_global_id("Order", order1.pk)
 
     orders_ids_from_response = [o["node"]["id"] for o in orders]
     assert len(orders) == count
@@ -969,6 +966,7 @@ def test_order_query_with_filter_search_by_product_sku_multi_order_lines(
     channel_USD,
     order,
 ):
+    order = order()
     variants = ProductVariant.objects.bulk_create(
         [
             ProductVariant(product=product, sku="Var1"),
@@ -1302,13 +1300,18 @@ def test_order_query_with_filter_by_multiple_checkout_tokens(
     orders_query_with_filter,
     staff_api_client,
     permission_group_manage_orders,
+    order,
     orders_from_checkout,
-    order_from_checkout_JPY,
     orders,
     checkout,
     checkout_JPY,
 ):
     # given
+    order_from_checkout_JPY = order(
+        status=OrderStatus.CANCELED,
+        channel=checkout_JPY.channel,
+        checkout_token=checkout_JPY.token,
+    )
     permission_group_manage_orders.user_set.add(staff_api_client.user)
     variables = {
         "filter": {

--- a/saleor/graphql/order/tests/queries/test_pagination.py
+++ b/saleor/graphql/order/tests/queries/test_pagination.py
@@ -570,9 +570,9 @@ def test_draft_orders_query_pagination_with_filter_search(
 
 
 def test_orders_query_pagination_with_filter_search_by_number(
-    order_with_search_vector_value, staff_api_client, permission_group_manage_orders
+    order_generator, staff_api_client, permission_group_manage_orders
 ):
-    order = order_with_search_vector_value
+    order = order_generator(search_vector_class=FlatConcatSearchVector)
     page_size = 2
     variables = {"first": page_size, "after": None, "filter": {"search": order.number}}
     permission_group_manage_orders.user_set.add(staff_api_client.user)

--- a/saleor/graphql/product/tests/mutations/test_product_type_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_type_create.py
@@ -264,16 +264,6 @@ def test_create_product_type_with_rich_text_attribute(
                             "dateTime": None,
                         }
                     },
-                    {
-                        "node": {
-                            "name": "Blue",
-                            "richText": None,
-                            "plainText": None,
-                            "boolean": None,
-                            "date": None,
-                            "dateTime": None,
-                        }
-                    },
                 ]
             },
         },

--- a/saleor/graphql/product/tests/mutations/test_product_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_update.py
@@ -2332,7 +2332,6 @@ def test_update_product_with_dropdown_attribute_non_existing_value(
 def test_update_product_with_dropdown_attribute_existing_value(
     updated_webhook_mock,
     staff_api_client,
-    color_attribute,
     product,
     product_type,
     permission_manage_products,
@@ -2342,14 +2341,15 @@ def test_update_product_with_dropdown_attribute_existing_value(
     query = MUTATION_UPDATE_PRODUCT
 
     product_id = graphene.Node.to_global_id("Product", product.pk)
+    attribute = product_type.product_attributes.first()
 
-    attribute_id = graphene.Node.to_global_id("Attribute", color_attribute.pk)
-    attribute_value = color_attribute.values.model.objects.first()
+    attribute_id = graphene.Node.to_global_id("Attribute", attribute.pk)
+    attribute_value = attribute.values.model.objects.first()
     attribute_value_id = graphene.Node.to_global_id(
         "AttributeValue", attribute_value.pk
     )
-    attribute_value_name = color_attribute.values.model.objects.first().name
-    product_type.product_attributes.add(color_attribute)
+    attribute_value_name = attribute.values.model.objects.first().name
+    product_type.product_attributes.add(attribute)
 
     variables = {
         "productId": product_id,
@@ -2384,7 +2384,6 @@ def test_update_product_with_dropdown_attribute_existing_value(
 def test_update_product_with_dropdown_attribute_existing_value_passed_as_new_value(
     updated_webhook_mock,
     staff_api_client,
-    color_attribute,
     product,
     product_type,
     permission_manage_products,
@@ -2394,13 +2393,14 @@ def test_update_product_with_dropdown_attribute_existing_value_passed_as_new_val
     query = MUTATION_UPDATE_PRODUCT
 
     product_id = graphene.Node.to_global_id("Product", product.pk)
-    attribute_id = graphene.Node.to_global_id("Attribute", color_attribute.pk)
-    attribute_value = color_attribute.values.model.objects.first()
+    attribute = product_type.product_attributes.first()
+    attribute_id = graphene.Node.to_global_id("Attribute", attribute.pk)
+    attribute_value = attribute.values.model.objects.first()
     attribute_value_id = graphene.Node.to_global_id(
         "AttributeValue", attribute_value.pk
     )
-    attribute_value_name = color_attribute.values.model.objects.first().name
-    product_type.product_attributes.add(color_attribute)
+    attribute_value_name = attribute.values.model.objects.first().name
+    product_type.product_attributes.add(attribute)
 
     value_count = AttributeValue.objects.count()
 

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -410,7 +410,13 @@ def test_attribute_translation(user_api_client, color_attribute):
     assert attribute["translation"]["language"]["code"] == "PL"
 
 
-def test_attribute_value_translation(user_api_client, pink_attribute_value):
+def test_attribute_value_translation(user_api_client, attribute_value_generator):
+    # given
+    pink_attribute_value = attribute_value_generator(
+        slug="pink",
+        name="Pink",
+        value="#FF69B4",
+    )
     pink_attribute_value.translations.create(
         language_code="pl", name="Różowy", rich_text=dummy_editorjs("Pink")
     )
@@ -442,11 +448,14 @@ def test_attribute_value_translation(user_api_client, pink_attribute_value):
     attribute_value_id = graphene.Node.to_global_id(
         "AttributeValue", pink_attribute_value.id
     )
+
+    # when
     response = user_api_client.post_graphql(
         query, {"attributeValueId": attribute_value_id}
     )
     data = get_graphql_content(response)["data"]
 
+    # then
     attribute_value = data["attributes"]["edges"][0]["node"]["choices"]["edges"][-1][
         "node"
     ]

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1023,19 +1023,10 @@ def orders_from_checkout(customer_user, checkout):
 
 
 @pytest.fixture
-def order_from_checkout_JPY(customer_user, checkout_JPY):
-    return Order.objects.create(
-        user=customer_user,
-        status=OrderStatus.CANCELED,
-        channel=checkout_JPY.channel,
-        checkout_token=checkout_JPY.token,
-    )
-
-
-@pytest.fixture
 def order(customer_user, channel_USD):
     address = customer_user.default_billing_address.get_copy()
-    order = Order.objects.create(
+
+    def create_order(
         billing_address=address,
         channel=channel_USD,
         currency=channel_USD.currency_code,
@@ -1046,12 +1037,31 @@ def order(customer_user, channel_USD):
         should_refresh_prices=False,
         metadata={"key": "value"},
         private_metadata={"secret_key": "secret_value"},
-    )
-    return order
+        checkout_token="",
+        status=OrderStatus.UNFULFILLED,
+    ):
+        order = Order.objects.create(
+            billing_address=billing_address,
+            channel=channel,
+            currency=currency,
+            shipping_address=shipping_address,
+            user_email=user_email,
+            user=user,
+            origin=origin,
+            should_refresh_prices=should_refresh_prices,
+            metadata=metadata,
+            private_metadata=private_metadata,
+            checkout_token=checkout_token,
+            status=status,
+        )
+        return order
+
+    return create_order
 
 
 @pytest.fixture
 def order_with_search_vector_value(order):
+    order = order()
     order.search_vector = FlatConcatSearchVector(
         *prepare_order_search_vector_value(order)
     )
@@ -3634,6 +3644,7 @@ def voucher_customer(voucher, customer_user):
 
 @pytest.fixture
 def order_line(order, variant):
+    order = order()
     product = variant.product
     channel = order.channel
     channel_listing = variant.channel_listings.get(channel=channel)
@@ -3666,6 +3677,7 @@ def order_line(order, variant):
 def gift_card_non_shippable_order_line(
     order, gift_card_non_shippable_variant, warehouse
 ):
+    order = order()
     variant = gift_card_non_shippable_variant
     product = variant.product
     channel = order.channel
@@ -3699,6 +3711,7 @@ def gift_card_non_shippable_order_line(
 
 @pytest.fixture
 def gift_card_shippable_order_line(order, gift_card_shippable_variant, warehouse):
+    order = order()
     variant = gift_card_shippable_variant
     product = variant.product
     channel = order.channel
@@ -4031,6 +4044,7 @@ def gift_card_created_by_staff(staff_user):
 
 @pytest.fixture
 def gift_card_event(gift_card, order, app, staff_user):
+    order = order()
     parameters = {
         "message": "test message",
         "email": "testemail@email.com",
@@ -4120,6 +4134,7 @@ def order_with_lines(
     channel_USD,
     default_tax_class,
 ):
+    order = order()
     product = Product.objects.create(
         name="Test product",
         slug="test-product-8",
@@ -4539,6 +4554,7 @@ def order_with_lines_channel_PLN(
 def order_with_line_without_inventory_tracking(
     order, variant_without_inventory_tracking
 ):
+    order = order()
     variant = variant_without_inventory_tracking
     product = variant.product
     channel = order.channel
@@ -4577,6 +4593,7 @@ def order_with_line_without_inventory_tracking(
 def order_with_preorder_lines(
     order, product_type, category, shipping_zone, warehouse, channel_USD
 ):
+    order = order()
     product = Product.objects.create(
         name="Test product",
         slug="test-product-8",
@@ -5882,6 +5899,7 @@ def transaction_events_generator() -> (
 
 @pytest.fixture
 def transaction_item_created_by_app(order, app, transaction_item_generator):
+    order = order()
     charged_amount = Decimal("10.0")
     return transaction_item_generator(
         order_id=order.pk,
@@ -5894,6 +5912,7 @@ def transaction_item_created_by_app(order, app, transaction_item_generator):
 
 @pytest.fixture
 def transaction_item_created_by_user(order, staff_user, transaction_item_generator):
+    order = order()
     charged_amount = Decimal("10.0")
     return transaction_item_generator(
         order_id=order.pk,
@@ -5906,6 +5925,7 @@ def transaction_item_created_by_user(order, staff_user, transaction_item_generat
 
 @pytest.fixture
 def transaction_item(order, transaction_item_generator):
+    order = order()
     return transaction_item_generator(
         order_id=order.pk,
     )


### PR DESCRIPTION
Base on https://github.com/saleor/saleor/issues/3915

Added generators for:
- `Order` (without support for `OrderLines`)
- `ProductType`
- `Attribute`
- `Category`

Adjusted small amount of tests.

Continuation of work: https://github.com/saleor/saleor/pull/13182

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
