### PR TITLE
Add missing descriptions to account types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Remove unused `django-versatileimagefield` package - #13148 by @SzymJ
 - Remove unused `google-measurement-protocol` package - #13146 by @SzymJ
 - Drop TranslationProxy and replace `translated` model property with `get_translation` function where needed. - #13156 by @zedzior
+- Add missing descriptions to Account module. - #13155 by @fowczarek
 
 
 # 3.14.0

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -201,7 +201,7 @@ class AccountQueries(graphene.ObjectType):
         country_code,
         country_area=None,
         city=None,
-        city_area=None
+        city_area=None,
     ):
         return resolve_address_validation_rules(
             info,

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -82,19 +82,35 @@ class AddressInput(BaseInputObjectType):
 
 @federated_entity("id")
 class Address(ModelObjectType[models.Address]):
-    id = graphene.GlobalID(required=True)
-    first_name = graphene.String(required=True)
-    last_name = graphene.String(required=True)
-    company_name = graphene.String(required=True)
-    street_address_1 = graphene.String(required=True)
-    street_address_2 = graphene.String(required=True)
-    city = graphene.String(required=True)
-    city_area = graphene.String(required=True)
-    postal_code = graphene.String(required=True)
-    country = graphene.Field(
-        CountryDisplay, required=True, description="Shop's default country."
+    id = graphene.GlobalID(required=True, description="The ID of the address.")
+    first_name = graphene.String(
+        required=True, description="The given name of the address."
     )
-    country_area = graphene.String(required=True)
+    last_name = graphene.String(
+        required=True, description="The family name of the address."
+    )
+    company_name = graphene.String(
+        required=True, description="Company or organization."
+    )
+    street_address_1 = graphene.String(
+        required=True, description="The first line of the address."
+    )
+    street_address_2 = graphene.String(
+        required=True, description="The second line of the address."
+    )
+    city = graphene.String(required=True, description="The city of the address.")
+    city_area = graphene.String(
+        required=True, description="The district of the address"
+    )
+    postal_code = graphene.String(
+        required=True, description="The postal code of the address."
+    )
+    country = graphene.Field(
+        CountryDisplay, required=True, description="The count of the address."
+    )
+    country_area = graphene.String(
+        required=True, description="The country area of the address,"
+    )
     phone = graphene.String()
     is_default_shipping_address = graphene.Boolean(
         required=False, description="Address is user's default shipping address."
@@ -171,7 +187,7 @@ class Address(ModelObjectType[models.Address]):
 
 
 class CustomerEvent(ModelObjectType[models.CustomerEvent]):
-    id = graphene.GlobalID(required=True)
+    id = graphene.GlobalID(required=True, description="The ID of the customer event.")
     date = graphene.types.datetime.DateTime(
         description="Date when event happened at in ISO 8601 format."
     )
@@ -265,12 +281,20 @@ class UserPermission(Permission):
 @federated_entity("id")
 @federated_entity("email")
 class User(ModelObjectType[models.User]):
-    id = graphene.GlobalID(required=True)
-    email = graphene.String(required=True)
-    first_name = graphene.String(required=True)
-    last_name = graphene.String(required=True)
-    is_staff = graphene.Boolean(required=True)
-    is_active = graphene.Boolean(required=True)
+    id = graphene.GlobalID(required=True, description="The ID of the user.")
+    email = graphene.String(required=True, description="The email address of the user.")
+    first_name = graphene.String(
+        required=True, description="The given name of the address."
+    )
+    last_name = graphene.String(
+        required=True, description="The family name of the address."
+    )
+    is_staff = graphene.Boolean(
+        required=True, description="Determine if the user is a staff admin."
+    )
+    is_active = graphene.Boolean(
+        required=True, description="Determine if the user is active."
+    )
     addresses = NonNullList(
         Address, description="List of all user's addresses.", required=True
     )
@@ -349,7 +373,7 @@ class User(ModelObjectType[models.User]):
         + ADDED_IN_314
         + PREVIEW_FEATURE,
     )
-    avatar = ThumbnailField()
+    avatar = ThumbnailField(description="The avatar of the user.")
     events = PermissionsField(
         NonNullList(CustomerEvent),
         description="List of events associated with the user.",
@@ -365,15 +389,26 @@ class User(ModelObjectType[models.User]):
     language_code = graphene.Field(
         LanguageCodeEnum, description="User language code.", required=True
     )
-    default_shipping_address = graphene.Field(Address)
-    default_billing_address = graphene.Field(Address)
+    default_shipping_address = graphene.Field(
+        Address, description="The default shipping address of the user."
+    )
+    default_billing_address = graphene.Field(
+        Address, description="The default billing address of the user."
+    )
     external_reference = graphene.String(
         description=f"External ID of this user. {ADDED_IN_310}", required=False
     )
 
-    last_login = graphene.DateTime()
-    date_joined = graphene.DateTime(required=True)
-    updated_at = graphene.DateTime(required=True)
+    last_login = graphene.DateTime(
+        description="The date when the user last time log in to the system."
+    )
+    date_joined = graphene.DateTime(
+        required=True, description="The data when the user create account."
+    )
+    updated_at = graphene.DateTime(
+        required=True,
+        description="The data when the user last update the account information.",
+    )
 
     class Meta:
         description = "Represents user data."
@@ -621,28 +656,119 @@ class UserCountableConnection(CountableConnection):
 
 
 class ChoiceValue(graphene.ObjectType):
-    raw = graphene.String()
-    verbose = graphene.String()
+    raw = graphene.String(description="The raw name of the choice.")
+    verbose = graphene.String(description="The verbose name of the choice.")
+
+
+FORMAT_FILED_DESCRIPTION = (
+    "\n\nMany fields in the JSON refer to address fields by one-letter "
+    "abbreviations. These are defined as follows:\n\n"
+    "- `N`: Name\n"
+    "- `O`: Organisation\n"
+    "- `A`: Street Address Line(s)\n"
+    "- `D`: Dependent locality (may be an inner-city district or a suburb)\n"
+    "- `C`: City or Locality\n"
+    "- `S`: Administrative area such as a state, province, island etc\n"
+    "- `Z`: Zip or postal code\n"
+    "- `X`: Sorting code\n\n"
+    "[Click here for more information.](https://github.com/google/libaddressinput/wiki/AddressValidationMetadata)"
+)
 
 
 class AddressValidationData(BaseObjectType):
-    country_code = graphene.String(required=True)
-    country_name = graphene.String(required=True)
-    address_format = graphene.String(required=True)
-    address_latin_format = graphene.String(required=True)
-    allowed_fields = NonNullList(graphene.String, required=True)
-    required_fields = NonNullList(graphene.String, required=True)
-    upper_fields = NonNullList(graphene.String, required=True)
-    country_area_type = graphene.String(required=True)
-    country_area_choices = NonNullList(ChoiceValue, required=True)
-    city_type = graphene.String(required=True)
-    city_choices = NonNullList(ChoiceValue, required=True)
-    city_area_type = graphene.String(required=True)
-    city_area_choices = NonNullList(ChoiceValue, required=True)
-    postal_code_type = graphene.String(required=True)
-    postal_code_matchers = NonNullList(graphene.String, required=True)
-    postal_code_examples = NonNullList(graphene.String, required=True)
-    postal_code_prefix = graphene.String(required=True)
+    country_code = graphene.String(
+        required=True, description="The country code of the address validation rule."
+    )
+    country_name = graphene.String(
+        required=True, description="The country name of the address validation rule."
+    )
+    address_format = graphene.String(
+        required=True,
+        description=(
+            "The address format of the address validation rule."
+            + FORMAT_FILED_DESCRIPTION
+        ),
+    )
+    address_latin_format = graphene.String(
+        required=True,
+        description=(
+            "The latin address format of the address validation rule."
+            + FORMAT_FILED_DESCRIPTION
+        ),
+    )
+    allowed_fields = NonNullList(
+        graphene.String,
+        required=True,
+        description="The allowed fields to use in address.",
+    )
+    required_fields = NonNullList(
+        graphene.String,
+        required=True,
+        description="The required fields to create a valid address.",
+    )
+    upper_fields = NonNullList(
+        graphene.String,
+        required=True,
+        description=(
+            "The list of fields that should be in upper case for address "
+            "validation rule."
+        ),
+    )
+    country_area_type = graphene.String(
+        required=True,
+        description=(
+            "The formal name of the county area of the address validation rule."
+        ),
+    )
+    country_area_choices = NonNullList(
+        ChoiceValue,
+        required=True,
+        description=(
+            "The available choices for the country area of the address validation rule."
+        ),
+    )
+    city_type = graphene.String(
+        required=True,
+        description="The formal name of the city of the address validation rule.",
+    )
+    city_choices = NonNullList(
+        ChoiceValue,
+        required=True,
+        description=(
+            "The available choices for the city of the address validation rule."
+        ),
+    )
+    city_area_type = graphene.String(
+        required=True,
+        description="The formal name of the city area of the address validation rule.",
+    )
+    city_area_choices = NonNullList(
+        ChoiceValue,
+        required=True,
+        description=(
+            "The available choices for the city area of the address validation rule."
+        ),
+    )
+    postal_code_type = graphene.String(
+        required=True,
+        description=(
+            "The formal name of the postal code of the address validation rule."
+        ),
+    )
+    postal_code_matchers = NonNullList(
+        graphene.String,
+        required=True,
+        description=("The regular expression for postal code validation."),
+    )
+    postal_code_examples = NonNullList(
+        graphene.String,
+        required=True,
+        description="The example postal code of the address validation rule.",
+    )
+    postal_code_prefix = graphene.String(
+        required=True,
+        description="The postal code prefix of the address validation rule.",
+    )
 
     class Meta:
         description = "Represents address validation rules for a country."
@@ -650,7 +776,9 @@ class AddressValidationData(BaseObjectType):
 
 
 class StaffNotificationRecipient(graphene.ObjectType):
-    id = graphene.ID(required=True)
+    id = graphene.ID(
+        required=True, description="The ID of the staff notification recipient."
+    )
     user = graphene.Field(
         User,
         description="Returns a user subscribed to email notifications.",
@@ -697,8 +825,8 @@ class StaffNotificationRecipient(graphene.ObjectType):
 
 @federated_entity("id")
 class Group(ModelObjectType[models.Group]):
-    id = graphene.GlobalID(required=True)
-    name = graphene.String(required=True)
+    id = graphene.GlobalID(required=True, description="The ID of the group.")
+    name = graphene.String(required=True, description="The name of the group.")
     users = PermissionsField(
         NonNullList(User),
         description="List of group users",

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -77,7 +77,13 @@ class AddressInput(BaseInputObjectType):
     postal_code = graphene.String(description="Postal code.")
     country = CountryCodeEnum(description="Country.")
     country_area = graphene.String(description="State or province.")
-    phone = graphene.String(description="Phone number.")
+    phone = graphene.String(
+        description=(
+            "Phone number.\n\n"
+            "Phone numbers are validated with Google's "
+            "[libphonenumber](https://github.com/google/libphonenumber) library."
+        )
+    )
 
 
 @federated_entity("id")
@@ -90,7 +96,7 @@ class Address(ModelObjectType[models.Address]):
         required=True, description="The family name of the address."
     )
     company_name = graphene.String(
-        required=True, description="Company or organization."
+        required=True, description="Company or organization name."
     )
     street_address_1 = graphene.String(
         required=True, description="The first line of the address."
@@ -100,18 +106,18 @@ class Address(ModelObjectType[models.Address]):
     )
     city = graphene.String(required=True, description="The city of the address.")
     city_area = graphene.String(
-        required=True, description="The district of the address"
+        required=True, description="The district of the address."
     )
     postal_code = graphene.String(
         required=True, description="The postal code of the address."
     )
     country = graphene.Field(
-        CountryDisplay, required=True, description="The count of the address."
+        CountryDisplay, required=True, description="The country of the address."
     )
     country_area = graphene.String(
-        required=True, description="The country area of the address,"
+        required=True, description="The country area of the address."
     )
-    phone = graphene.String()
+    phone = graphene.String(description="The phone number assigned the address.")
     is_default_shipping_address = graphene.Boolean(
         required=False, description="Address is user's default shipping address."
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3524,6 +3524,7 @@ type Warehouse implements Node & ObjectWithMetadata @doc(category: "Products") {
 
 """Represents user address data."""
 type Address implements Node & ObjectWithMetadata @doc(category: "Users") {
+  """The ID of the address."""
   id: ID!
 
   """
@@ -3583,17 +3584,35 @@ type Address implements Node & ObjectWithMetadata @doc(category: "Users") {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   metafields(keys: [String!]): Metadata
+
+  """The given name of the address."""
   firstName: String!
+
+  """The family name of the address."""
   lastName: String!
+
+  """Company or organization."""
   companyName: String!
+
+  """The first line of the address."""
   streetAddress1: String!
+
+  """The second line of the address."""
   streetAddress2: String!
+
+  """The city of the address."""
   city: String!
+
+  """The district of the address"""
   cityArea: String!
+
+  """The postal code of the address."""
   postalCode: String!
 
-  """Shop's default country."""
+  """The count of the address."""
   country: CountryDisplay!
+
+  """The country area of the address,"""
   countryArea: String!
   phone: String
 
@@ -9332,6 +9351,7 @@ type ShopTranslation implements Node @doc(category: "Shop") {
 Represents a recipient of email notifications send by Saleor, such as notifications about new orders. Notifications can be assigned to staff users or arbitrary email addresses.
 """
 type StaffNotificationRecipient implements Node {
+  """The ID of the staff notification recipient."""
   id: ID!
 
   """Returns a user subscribed to email notifications."""
@@ -9346,6 +9366,7 @@ type StaffNotificationRecipient implements Node {
 
 """Represents user data."""
 type User implements Node & ObjectWithMetadata @doc(category: "Users") {
+  """The ID of the user."""
   id: ID!
 
   """List of private metadata items. Requires staff permissions to access."""
@@ -9393,10 +9414,20 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   metafields(keys: [String!]): Metadata
+
+  """The email address of the user."""
   email: String!
+
+  """The given name of the address."""
   firstName: String!
+
+  """The family name of the address."""
   lastName: String!
+
+  """Determine if the user is a staff admin."""
   isStaff: Boolean!
+
+  """Determine if the user is active."""
   isActive: Boolean!
 
   """List of all user's addresses."""
@@ -9516,6 +9547,8 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   restrictedAccessToChannels: Boolean!
+
+  """The avatar of the user."""
   avatar(
     """
     Desired longest side the image in pixels. Defaults to 4096. Images are never cropped. Pass 0 to retrieve the original size (not recommended).
@@ -9545,7 +9578,11 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """User language code."""
   languageCode: LanguageCodeEnum!
+
+  """The default shipping address of the user."""
   defaultShippingAddress: Address
+
+  """The default billing address of the user."""
   defaultBillingAddress: Address
 
   """
@@ -9554,8 +9591,14 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   Added in Saleor 3.10.
   """
   externalReference: String
+
+  """The date when the user last time log in to the system."""
   lastLogin: DateTime
+
+  """The data when the user create account."""
   dateJoined: DateTime!
+
+  """The data when the user last update the account information."""
   updatedAt: DateTime!
 }
 
@@ -11829,7 +11872,10 @@ type UserPermission @doc(category: "Users") {
 
 """Represents permission group data."""
 type Group implements Node @doc(category: "Users") {
+  """The ID of the group."""
   id: ID!
+
+  """The name of the group."""
   name: String!
 
   """
@@ -11868,6 +11914,7 @@ type Group implements Node @doc(category: "Users") {
 
 """History log of the customer."""
 type CustomerEvent implements Node @doc(category: "Users") {
+  """The ID of the customer event."""
   id: ID!
 
   """Date when event happened at in ISO 8601 format."""
@@ -13102,27 +13149,99 @@ input AppExtensionFilterInput @doc(category: "Apps") {
 
 """Represents address validation rules for a country."""
 type AddressValidationData @doc(category: "Users") {
+  """The country code of the address validation rule."""
   countryCode: String!
+
+  """The country name of the address validation rule."""
   countryName: String!
+
+  """
+  The address format of the address validation rule.
+  
+  Many fields in the JSON refer to address fields by one-letter abbreviations. These are defined as follows:
+  
+  - `N`: Name
+  - `O`: Organisation
+  - `A`: Street Address Line(s)
+  - `D`: Dependent locality (may be an inner-city district or a suburb)
+  - `C`: City or Locality
+  - `S`: Administrative area such as a state, province, island etc
+  - `Z`: Zip or postal code
+  - `X`: Sorting code
+  
+  [Click here for more information.](https://github.com/google/libaddressinput/wiki/AddressValidationMetadata)
+  """
   addressFormat: String!
+
+  """
+  The latin address format of the address validation rule.
+  
+  Many fields in the JSON refer to address fields by one-letter abbreviations. These are defined as follows:
+  
+  - `N`: Name
+  - `O`: Organisation
+  - `A`: Street Address Line(s)
+  - `D`: Dependent locality (may be an inner-city district or a suburb)
+  - `C`: City or Locality
+  - `S`: Administrative area such as a state, province, island etc
+  - `Z`: Zip or postal code
+  - `X`: Sorting code
+  
+  [Click here for more information.](https://github.com/google/libaddressinput/wiki/AddressValidationMetadata)
+  """
   addressLatinFormat: String!
+
+  """The allowed fields to use in address."""
   allowedFields: [String!]!
+
+  """The required fields to create a valid address."""
   requiredFields: [String!]!
+
+  """
+  The list of fields that should be in upper case for address validation rule.
+  """
   upperFields: [String!]!
+
+  """The formal name of the county area of the address validation rule."""
   countryAreaType: String!
+
+  """
+  The available choices for the country area of the address validation rule.
+  """
   countryAreaChoices: [ChoiceValue!]!
+
+  """The formal name of the city of the address validation rule."""
   cityType: String!
+
+  """The available choices for the city of the address validation rule."""
   cityChoices: [ChoiceValue!]!
+
+  """The formal name of the city area of the address validation rule."""
   cityAreaType: String!
+
+  """
+  The available choices for the city area of the address validation rule.
+  """
   cityAreaChoices: [ChoiceValue!]!
+
+  """The formal name of the postal code of the address validation rule."""
   postalCodeType: String!
+
+  """The regular expression for postal code validation."""
   postalCodeMatchers: [String!]!
+
+  """The example postal code of the address validation rule."""
   postalCodeExamples: [String!]!
+
+  """The postal code prefix of the address validation rule."""
   postalCodePrefix: String!
 }
 
 type ChoiceValue {
+  """The raw name of the choice."""
   raw: String
+
+  """The verbose name of the choice."""
   verbose: String
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3591,7 +3591,7 @@ type Address implements Node & ObjectWithMetadata @doc(category: "Users") {
   """The family name of the address."""
   lastName: String!
 
-  """Company or organization."""
+  """Company or organization name."""
   companyName: String!
 
   """The first line of the address."""
@@ -3603,17 +3603,19 @@ type Address implements Node & ObjectWithMetadata @doc(category: "Users") {
   """The city of the address."""
   city: String!
 
-  """The district of the address"""
+  """The district of the address."""
   cityArea: String!
 
   """The postal code of the address."""
   postalCode: String!
 
-  """The count of the address."""
+  """The country of the address."""
   country: CountryDisplay!
 
-  """The country area of the address,"""
+  """The country area of the address."""
   countryArea: String!
+
+  """The phone number assigned the address."""
   phone: String
 
   """Address is user's default shipping address."""
@@ -7168,7 +7170,11 @@ input AddressInput {
   """State or province."""
   countryArea: String
 
-  """Phone number."""
+  """
+  Phone number.
+  
+  Phone numbers are validated with Google's [libphonenumber](https://github.com/google/libphonenumber) library.
+  """
   phone: String
 }
 


### PR DESCRIPTION
I want to merge this change because of adding missing descriptions to account types.

Part of #13142

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
