### PR TITLE
Add ACCOUNT_CONFIRMATION_REQUESTED event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add missing descriptions to csv module. - #13184 by @fowczarek
 - Add missing descriptions to Account module. - #13155 by @fowczarek
 - Add `ACCOUNT_CONFIRMATION_REQUESTED` async event - #13162 by @SzymJ
+- Add `ACCOUNT_DELETE_REQUESTED` async event - #13170 by @SzymJ
 
 # 3.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add missing descriptions to checkout module. - #13167 by @fowczarek
 - Add missing descriptions to attribute module. - #13165 by @fowczarek
 - Add missing descriptions to csv module. - #13184 by @fowczarek
+- Add missing descriptions to Account module. - #13155 by @fowczarek
+- Add `ACCOUNT_CONFIRMATION_REQUESTED` async event - #13162 by @SzymJ
 
 # 3.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add missing descriptions to csv module. - #13184 by @fowczarek
 - Add missing descriptions to Account module. - #13155 by @fowczarek
 - Add `ACCOUNT_CONFIRMATION_REQUESTED` async event - #13162 by @SzymJ
-- Add `ACCOUNT_DELETE_REQUESTED` async event - #13170 by @SzymJ
 
 # 3.14.0
 

--- a/saleor/account/notifications.py
+++ b/saleor/account/notifications.py
@@ -63,9 +63,11 @@ def send_password_reset_notification(
     manager.notify(event, payload=payload, channel_slug=channel_slug)
 
 
-def send_account_confirmation(user, redirect_url, manager, channel_slug):
+def send_account_confirmation(user, redirect_url, manager, channel_slug, token=None):
     """Trigger sending an account confirmation notification for the given user."""
-    token = default_token_generator.make_token(user)
+
+    if not token:
+        token = default_token_generator.make_token(user)
     params = urlencode({"email": user.email, "token": token})
     confirm_url = prepare_url(params, redirect_url)
     payload = {

--- a/saleor/graphql/account/mutations/account/account_register.py
+++ b/saleor/graphql/account/mutations/account/account_register.py
@@ -1,13 +1,16 @@
+from urllib.parse import urlencode
+
 import graphene
 from django.conf import settings
 from django.contrib.auth import password_validation
+from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
 
 from .....account import events as account_events
 from .....account import models, notifications, search
 from .....account.error_codes import AccountErrorCode
 from .....core.tracing import traced_atomic_transaction
-from .....core.utils.url import validate_storefront_url
+from .....core.utils.url import prepare_url, validate_storefront_url
 from ....channel.utils import clean_channel
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
@@ -131,18 +134,36 @@ class AccountRegister(ModelMutation):
         )
         manager = get_plugin_manager_promise(info.context).get()
         site = get_site_promise(info.context).get()
+        token = default_token_generator.make_token(user)
+        redirect_url = cleaned_input.get("redirect_url")
 
         with traced_atomic_transaction():
             if site.settings.enable_account_confirmation_by_email:
                 user.is_active = False
                 user.save()
+
+                # Notifications will be deprecated in the future
                 notifications.send_account_confirmation(
                     user,
-                    cleaned_input["redirect_url"],
+                    redirect_url,
                     manager,
                     channel_slug=cleaned_input["channel"],
+                    token=token,
                 )
             else:
                 user.save()
+
+            if redirect_url:
+                params = urlencode({"email": user.email, "token": token})
+                redirect_url = prepare_url(params, redirect_url)
+
+            cls.call_event(
+                manager.account_confirmation_requested,
+                user,
+                cleaned_input["channel"],
+                token,
+                redirect_url,
+            )
+
             cls.call_event(manager.customer_created, user)
         account_events.customer_account_created_event(user=user)

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -1,10 +1,8 @@
 from collections import defaultdict
 from typing import List
-from urllib.parse import urlencode
 
 import graphene
 from django.core.exceptions import ValidationError
-from django.contrib.auth.tokens import default_token_generator
 
 from ....account import events as account_events
 from ....account.error_codes import AccountErrorCode
@@ -13,7 +11,6 @@ from ....account.search import prepare_user_search_document_value
 from ....checkout import AddressType
 from ....core.exceptions import PermissionDenied
 from ....core.tracing import traced_atomic_transaction
-from ....core.utils.url import prepare_url
 from ....core.utils.url import validate_storefront_url
 from ....graphql.utils import get_user_or_app_from_context
 from ....permission.auth_filters import AuthorizationFilters
@@ -329,13 +326,6 @@ class BaseCustomerCreate(ModelMutation, I18nMixin):
                     channel_slug, error_class=AccountErrorCode
                 ).slug
 
-            token = default_token_generator.make_token(instance)
-            params = urlencode({"email": instance.email, "token": token})
-            confirm_url = prepare_url(params, cleaned_input["redirect_url"])
-
-            manager.account_confirmation_requested(
-                instance, channel_slug, token, confirm_url
-            )
             send_set_password_notification(
                 cleaned_input.get("redirect_url"),
                 instance,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -27451,13 +27451,13 @@ type AccountConfirmationRequested implements Event @doc(category: "Users") {
   """The URL to redirect the user after he accepts the request."""
   redirectUrl: String
 
-  """The user assigned to the webhook."""
+  """The user the event relates to."""
   user: User
 
-  """The channel assigned to the webhook."""
+  """The channel data."""
   channel: Channel
 
-  """The token required to confirm the user."""
+  """The token required to confirm request."""
   token: String
 
   """Shop data."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1687,6 +1687,7 @@ type WebhookEvent @doc(category: "Webhooks") {
 enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   """All the events."""
   ANY_EVENTS
+  ACCOUNT_CONFIRMATION_REQUESTED
 
   """A new address created."""
   ADDRESS_CREATED
@@ -2318,6 +2319,7 @@ type WebhookEventAsync @doc(category: "Webhooks") {
 enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   """All the events."""
   ANY_EVENTS
+  ACCOUNT_CONFIRMATION_REQUESTED
 
   """A new address created."""
   ADDRESS_CREATED
@@ -3317,6 +3319,7 @@ scalar JSONString
 
 """An enumeration."""
 enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
+  ACCOUNT_CONFIRMATION_REQUESTED
   ADDRESS_CREATED
   ADDRESS_UPDATED
   ADDRESS_DELETED
@@ -27425,6 +27428,40 @@ enum VolumeUnitsEnum {
   FL_OZ
   ACRE_IN
   ACRE_FT
+}
+
+"""
+Event sent when account confirmation requested.
+
+Added in Saleor 3.15.
+"""
+type AccountConfirmationRequested implements Event @doc(category: "Users") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The URL to redirect the user after he accepts the request."""
+  redirectUrl: String
+
+  """The user assigned to the webhook."""
+  user: User
+
+  """The channel assigned to the webhook."""
+  channel: Channel
+
+  """The token required to confirm the user."""
+  token: String
+
+  """Shop data."""
+  shop: Shop
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1687,6 +1687,8 @@ type WebhookEvent @doc(category: "Webhooks") {
 enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   """All the events."""
   ANY_EVENTS
+
+  """An account confirmation requested."""
   ACCOUNT_CONFIRMATION_REQUESTED
 
   """A new address created."""
@@ -2319,6 +2321,8 @@ type WebhookEventAsync @doc(category: "Webhooks") {
 enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   """All the events."""
   ANY_EVENTS
+
+  """An account confirmation requested."""
   ACCOUNT_CONFIRMATION_REQUESTED
 
   """A new address created."""
@@ -27431,7 +27435,7 @@ enum VolumeUnitsEnum {
 }
 
 """
-Event sent when account confirmation requested.
+Event sent when account confirmation requested. This event is always sent. enableAccountConfirmationByEmail flag set to True is not required.
 
 Added in Saleor 3.15.
 """

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -33,6 +33,9 @@ order_updated_event_enum_description = (
 
 
 WEBHOOK_EVENT_DESCRIPTION = {
+    WebhookEventAsyncType.ACCOUNT_CONFIRMATION_REQUESTED: (
+        "An account confirmation requested."
+    ),
     WebhookEventAsyncType.ADDRESS_CREATED: "A new address created.",
     WebhookEventAsyncType.ADDRESS_UPDATED: "An address updated.",
     WebhookEventAsyncType.ADDRESS_DELETED: "An address deleted.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -140,13 +140,13 @@ class AccountOperationBase(AbstractType):
     )
     user = graphene.Field(
         UserType,
-        description="The user assigned to the webhook.",
+        description="The user the event relates to.",
     )
     channel = graphene.Field(
         "saleor.graphql.channel.types.Channel",
-        description="The channel assigned to the webhook.",
+        description="The channel data.",
     )
-    token = graphene.String(description="The token required to confirm the user.")
+    token = graphene.String(description="The token required to confirm request.")
     shop = graphene.Field(Shop, description="Shop data.")
 
     @staticmethod

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -180,7 +180,11 @@ class AccountConfirmationRequested(SubscriptionObjectType, AccountOperationBase)
         root_type = "User"
         enable_dry_run = False
         interfaces = (Event,)
-        description = "Event sent when account confirmation requested." + ADDED_IN_315
+        description = (
+            "Event sent when account confirmation requested. This event is always sent."
+            " enableAccountConfirmationByEmail flag set to True is not required."
+            + ADDED_IN_315
+        )
 
 
 class AddressBase(AbstractType):

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -136,7 +136,8 @@ class Event(graphene.Interface):
 
 class AccountOperationBase(AbstractType):
     redirect_url = graphene.String(
-        description="The URL to redirect the user after he accepts the request."
+        description="The URL to redirect the user after he accepts the request.",
+        required=False,
     )
     user = graphene.Field(
         UserType,
@@ -157,7 +158,7 @@ class AccountOperationBase(AbstractType):
     @staticmethod
     def resolve_redirect_url(root, _info: ResolveInfo):
         _, data = root
-        return data["redirect_url"]
+        return data.get("redirect_url")
 
     @staticmethod
     def resolve_channel(root, _info: ResolveInfo):

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -149,6 +149,12 @@ class BasePlugin:
     def __str__(self):
         return self.PLUGIN_NAME
 
+    # Trigger when account confirmation is requested.
+    #
+    # Overwrite this method if you need to trigger specific logic after an account
+    # confirmation is requested.
+    account_confirmation_requested: Callable[["User", None], None]
+
     # Trigger when address is created.
     #
     # Overwrite this method if you need to trigger specific logic after an address is

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -153,7 +153,7 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after an account
     # confirmation is requested.
-    account_confirmation_requested: Callable[["User", None], None]
+    account_confirmation_requested: Callable[["User", str, str, str, None], None]
 
     # Trigger when address is created.
     #

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -153,7 +153,9 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after an account
     # confirmation is requested.
-    account_confirmation_requested: Callable[["User", str, str, str, None], None]
+    account_confirmation_requested: Callable[
+        ["User", str, str, Optional[str], None], None
+    ]
 
     # Trigger when address is created.
     #

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1061,6 +1061,19 @@ class PluginsManager(PaymentInterface):
             "transaction_item_metadata_updated", default_value, transaction_item
         )
 
+    def account_confirmation_requested(
+        self, user: "User", channel_slug: str, token: str, redirect_url: str
+    ):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "account_confirmation_requested",
+            default_value,
+            user,
+            channel_slug,
+            token=token,
+            redirect_url=redirect_url,
+        )
+
     def address_created(self, address: "Address"):
         default_value = None
         return self.__run_method_on_plugins("address_created", default_value, address)

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1062,7 +1062,7 @@ class PluginsManager(PaymentInterface):
         )
 
     def account_confirmation_requested(
-        self, user: "User", channel_slug: str, token: str, redirect_url: str
+        self, user: "User", channel_slug: str, token: str, redirect_url: Optional[str]
     ):
         default_value = None
         return self.__run_method_on_plugins(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -168,6 +168,39 @@ class WebhookPlugin(BasePlugin):
                 payload, event_type, webhooks, address, self.requestor
             )
 
+    def account_confirmation_requested(
+        self,
+        user: "User",
+        channel_slug: str,
+        token: str,
+        redirect_url: str,
+        previous_value: None,
+    ) -> None:
+        if not self.active:
+            return previous_value
+        if webhooks := get_webhooks_for_event(
+            WebhookEventAsyncType.ACCOUNT_CONFIRMATION_REQUESTED
+        ):
+            payload = self._serialize_payload(
+                {
+                    "id": graphene.Node.to_global_id("User", user.id),
+                    "token": token,
+                    "redirect_url": redirect_url,
+                }
+            )
+            trigger_webhooks_async(
+                payload,
+                WebhookEventAsyncType.ACCOUNT_CONFIRMATION_REQUESTED,
+                webhooks,
+                {
+                    "user": user,
+                    "channel_slug": channel_slug,
+                    "token": token,
+                    "redirect_url": redirect_url,
+                },
+                self.requestor,
+            )
+
     def address_created(self, address: "Address", previous_value: None) -> None:
         if not self.active:
             return previous_value

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -173,7 +173,7 @@ class WebhookPlugin(BasePlugin):
         user: "User",
         channel_slug: str,
         token: str,
-        redirect_url: str,
+        redirect_url: Optional[str],
         previous_value: None,
     ) -> None:
         if not self.active:

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -21,6 +21,14 @@ def subscription_webhook(webhook_app):
 
 
 @pytest.fixture
+def subscription_account_confirmation_requested_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.ACCOUNT_CONFIRMATION_REQUESTED,
+        WebhookEventAsyncType.ACCOUNT_CONFIRMATION_REQUESTED,
+    )
+
+
+@pytest.fixture
 def subscription_address_created_webhook(subscription_webhook):
     return subscription_webhook(
         queries.ADDRESS_CREATED, WebhookEventAsyncType.ADDRESS_CREATED

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1,5 +1,33 @@
 from .....graphql.tests.queries import fragments
 
+ACCOUNT_CONFIRMATION_REQUESTED = (
+    fragments.CUSTOMER_DETAILS
+    + """
+    subscription{
+      event{
+        ...on AccountConfirmationRequested{
+          user{
+            ...CustomerDetails
+          }
+          token
+          redirectUrl
+          channel{
+            slug
+            id
+          }
+          shop{
+            domain{
+                host
+                url
+            }
+          }
+        }
+      }
+    }
+"""
+)
+
+
 ADDRESS_CREATED = (
     fragments.ADDRESS_DETAILS
     + """

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -78,6 +78,48 @@ def test_subscription_query_with_meta(
     assert deliveries[0].webhook == webhooks[0]
 
 
+def test_account_confirmation_requested(
+    customer_user, channel_USD, subscription_account_confirmation_requested_webhook
+):
+    # given
+    webhooks = [subscription_account_confirmation_requested_webhook]
+    event_type = WebhookEventAsyncType.ACCOUNT_CONFIRMATION_REQUESTED
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type,
+        {
+            "user": customer_user,
+            "channel_slug": channel_USD.slug,
+            "token": "token",
+            "redirect_url": "http://www.example.com?token=token",
+        },
+        webhooks,
+    )
+
+    # then
+    expected_payload = json.dumps(
+        {
+            **generate_customer_payload(customer_user),
+            **{
+                "token": "token",
+                "redirectUrl": "http://www.example.com?token=token",
+                "channel": {
+                    "slug": channel_USD.slug,
+                    "id": graphene.Node.to_global_id("Channel", channel_USD.id),
+                },
+                "shop": {
+                    "domain": {"host": "mirumee.com", "url": "http://mirumee.com/"}
+                },
+            },
+        }
+    )
+
+    assert deliveries[0].payload.payload == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
 def test_address_created(address, subscription_address_created_webhook):
     # given
     webhooks = [subscription_address_created_webhook]

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -19,6 +19,8 @@ from ..permission.enums import (
 class WebhookEventAsyncType:
     ANY = "any_events"
 
+    ACCOUNT_CONFIRMATION_REQUESTED = "account_confirmation_requested"
+
     ADDRESS_CREATED = "address_created"
     ADDRESS_UPDATED = "address_updated"
     ADDRESS_DELETED = "address_deleted"
@@ -172,6 +174,7 @@ class WebhookEventAsyncType:
 
     DISPLAY_LABELS = {
         ANY: "Any events",
+        ACCOUNT_CONFIRMATION_REQUESTED: "Account confirmation requested",
         ADDRESS_CREATED: "Address created",
         ADDRESS_UPDATED: "Address updated",
         ADDRESS_DELETED: "Address deleted",
@@ -294,6 +297,10 @@ class WebhookEventAsyncType:
 
     CHOICES = [
         (ANY, DISPLAY_LABELS[ANY]),
+        (
+            ACCOUNT_CONFIRMATION_REQUESTED,
+            DISPLAY_LABELS[ACCOUNT_CONFIRMATION_REQUESTED],
+        ),
         (ADDRESS_CREATED, DISPLAY_LABELS[ADDRESS_CREATED]),
         (ADDRESS_UPDATED, DISPLAY_LABELS[ADDRESS_UPDATED]),
         (ADDRESS_DELETED, DISPLAY_LABELS[ADDRESS_DELETED]),
@@ -426,6 +433,7 @@ class WebhookEventAsyncType:
     ALL = [event[0] for event in CHOICES]
 
     PERMISSIONS = {
+        ACCOUNT_CONFIRMATION_REQUESTED: AccountPermissions.MANAGE_USERS,
         ADDRESS_CREATED: AccountPermissions.MANAGE_USERS,
         ADDRESS_UPDATED: AccountPermissions.MANAGE_USERS,
         ADDRESS_DELETED: AccountPermissions.MANAGE_USERS,


### PR DESCRIPTION
I want to merge this change because it adds `ACCOUNT_CONFIRMATION_REQUESTED` event.

Part of #12317 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
