### PR TITLE
Add missing descriptions to csv export types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add missing descriptions to channel module. - #13166 by @fowczarek
 - Add missing descriptions to checkout module. - #13167 by @fowczarek
 - Add missing descriptions to attribute module. - #13165 by @fowczarek
+- Add missing descriptions to csv module. - #13184 by @fowczarek
 
 # 3.14.0
 

--- a/saleor/graphql/csv/types.py
+++ b/saleor/graphql/csv/types.py
@@ -71,14 +71,14 @@ class ExportEvent(ModelObjectType[models.ExportEvent]):
 
 
 class ExportFile(ModelObjectType[models.ExportFile]):
-    id = graphene.GlobalID(required=True)
+    id = graphene.GlobalID(required=True, description="The ID of the export file.")
     url = graphene.String(description="The URL of field to download.")
     events = NonNullList(
         ExportEvent,
         description="List of events associated with the export.",
     )
-    user = graphene.Field(User)
-    app = graphene.Field(App)
+    user = graphene.Field(User, description="The user who requests file export.")
+    app = graphene.Field(App, description="The app which requests file export.")
 
     class Meta:
         description = "Represents a job data of exported file."

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12926,6 +12926,7 @@ enum VoucherSortField {
 
 """Represents a job data of exported file."""
 type ExportFile implements Node & Job {
+  """The ID of the export file."""
   id: ID!
 
   """Job status."""
@@ -12945,7 +12946,11 @@ type ExportFile implements Node & Job {
 
   """List of events associated with the export."""
   events: [ExportEvent!]
+
+  """The user who requests file export."""
   user: User
+
+  """The app which requests file export."""
   app: App
 }
 


### PR DESCRIPTION
I want to merge this change because of adding missing descriptions to csv export types.

Part of https://github.com/saleor/saleor/issues/13142
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
