### PR TITLE
Add dataloader for ShippingZone warehouses

### DIFF
--- a/saleor/graphql/shipping/tests/benchmark/test_shipping_zones.py
+++ b/saleor/graphql/shipping/tests/benchmark/test_shipping_zones.py
@@ -1,0 +1,41 @@
+import pytest
+
+from ....tests.utils import get_graphql_content
+
+SHIPPING_ZONES_QUERY = """
+query GetShippingZones($channel: String) {
+  shippingZones(first: 100, channel: $channel) {
+    edges {
+      node {
+        warehouses {
+            id
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_shipping_zones_query(
+    staff_api_client,
+    shipping_zones_with_warehouses,
+    channel_USD,
+    permission_manage_shipping,
+    count_queries,
+):
+    variables = {"channel": channel_USD.slug}
+    response = get_graphql_content(
+        staff_api_client.post_graphql(
+            SHIPPING_ZONES_QUERY,
+            variables,
+            permissions=[permission_manage_shipping],
+            check_no_permissions=False,
+        )
+    )
+    data = response["data"]["shippingZones"]["edges"]
+    assert len(data) == 10
+    for zone in data:
+        assert len(zone["node"]["warehouses"]) == 2

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
@@ -238,8 +238,10 @@ def test_update_shipping_zone_add_second_warehouses(
     data = content["data"]["shippingZoneUpdate"]
     assert not data["errors"]
     data = content["data"]["shippingZoneUpdate"]["shippingZone"]
-    assert data["warehouses"][1]["slug"] == warehouse.slug
-    assert data["warehouses"][0]["slug"] == warehouse_no_shipping_zone.slug
+    response_warehouses_slugs = set([wh["slug"] for wh in data["warehouses"]])
+    assert response_warehouses_slugs == set(
+        [warehouse.slug, warehouse_no_shipping_zone.slug]
+    )
 
 
 def test_update_shipping_zone_remove_warehouses(

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -43,6 +43,7 @@ from ..tax.dataloaders import TaxClassByIdLoader
 from ..tax.types import TaxClass
 from ..translations.fields import TranslationField
 from ..translations.types import ShippingMethodTranslation
+from ..warehouse.dataloaders import WarehousesByShippingZoneIdLoader
 from ..warehouse.types import Warehouse
 from .dataloaders import (
     ChannelsByShippingZoneIdLoader,
@@ -330,8 +331,8 @@ class ShippingZone(ChannelContextTypeWithMetadata[models.ShippingZone]):
         )
 
     @staticmethod
-    def resolve_warehouses(root: ChannelContext[models.ShippingZone], _info):
-        return root.node.warehouses.all()
+    def resolve_warehouses(root: ChannelContext[models.ShippingZone], info):
+        return WarehousesByShippingZoneIdLoader(info.context).load(root.node.id)
 
     @staticmethod
     def resolve_channels(root: ChannelContext[models.ShippingZone], info):

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -590,3 +590,34 @@ class WarehousesByChannelIdLoader(DataLoader):
             .load_many({pk for pk, _ in warehouse_and_channel_in_pairs})
             .then(map_warehouses)
         )
+
+
+class WarehousesByShippingZoneIdLoader(DataLoader):
+    context_key = "warehouses_by_shipping_zone_id"
+
+    def batch_load(self, keys):
+        warehouse_and_shipping_zone_in_pairs = (
+            ShippingZone.warehouses.through.objects.using(self.database_connection_name)  # type: ignore[attr-defined] # raw access to the through model # noqa: E501
+            .filter(shippingzone_id__in=keys)
+            .values_list("warehouse_id", "shippingzone_id")
+        )
+
+        shipping_zone_warehouse_map = defaultdict(list)
+        for warehouse_id, shipping_zone_id in warehouse_and_shipping_zone_in_pairs:
+            shipping_zone_warehouse_map[shipping_zone_id].append(warehouse_id)
+
+        def map_warehouses(warehouses):
+            warehouse_map = {warehouse.pk: warehouse for warehouse in warehouses}
+            return [
+                [
+                    warehouse_map[warehouse_id]
+                    for warehouse_id in shipping_zone_warehouse_map[shipping_zone_id]
+                ]
+                for shipping_zone_id in keys
+            ]
+
+        return (
+            WarehouseByIdLoader(self.context)
+            .load_many({pk for pk, _ in warehouse_and_shipping_zone_in_pairs})
+            .then(map_warehouses)
+        )

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1189,6 +1189,24 @@ def shipping_zones(db, channel_USD, channel_PLN):
     return [shipping_zone_poland, shipping_zone_usa]
 
 
+def chunks(it, n):
+    for i in range(0, len(it), n):
+        yield it[i : i + n]
+
+
+@pytest.fixture
+def shipping_zones_with_warehouses(address, channel_USD):
+    zones = [ShippingZone(name=f"{i}_zone") for i in range(10)]
+    warehouses = [Warehouse(slug=f"{i}_warehouse", address=address) for i in range(20)]
+    warehouses = Warehouse.objects.bulk_create(warehouses)
+    warehouses_in_batches = list(chunks(warehouses, 2))
+    for i, zone in enumerate(ShippingZone.objects.bulk_create(zones)):
+        zone.channels.add(channel_USD)
+        for warehouse in warehouses_in_batches[i]:
+            zone.warehouses.add(warehouse)
+    return zones
+
+
 @pytest.fixture
 def shipping_zones_with_different_channels(db, channel_USD, channel_PLN):
     shipping_zone_poland, shipping_zone_usa = ShippingZone.objects.bulk_create(


### PR DESCRIPTION
I want to merge this change because it adds a new dataloader for the warehouses field on the shipping zone type.
Includes benchmark tests.
Benchmark for test_shipping_zones_query before dataloader: **14 hits**
Benchmark for test_shipping_zones_query after dataloader: **6 hits**
:information_source:  This is a port of https://github.com/saleor/saleor/pull/13152

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
