### PR TITLE
Use dataloader for channels in Order and Checkout

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,7 @@ pytest_plugins = [
     "saleor.graphql.tests.fixtures",
     "saleor.graphql.channel.tests.fixtures",
     "saleor.graphql.channel.tests.benchmark.fixtures",
+    "saleor.graphql.checkout.tests.benchmark.fixtures",
     "saleor.graphql.account.tests.benchmark.fixtures",
     "saleor.graphql.order.tests.benchmark.fixtures",
     "saleor.graphql.giftcard.tests.benchmark.fixtures",

--- a/saleor/graphql/checkout/tests/benchmark/fixtures.py
+++ b/saleor/graphql/checkout/tests/benchmark/fixtures.py
@@ -1,0 +1,29 @@
+import pytest
+from prices import Money, TaxedMoney
+
+from .....checkout.models import Checkout
+
+CHECKOUT_COUNT_IN_BENCHMARKS = 10
+
+
+@pytest.fixture
+def checkouts_for_benchmarks(
+    channel_USD,
+    channel_PLN,
+    address,
+    users_for_order_benchmarks,
+    variant_with_image,
+    shipping_method,
+):
+    checkouts = [
+        Checkout(
+            channel=channel_USD if i % 2 else channel_PLN,
+            billing_address=address.get_copy(),
+            shipping_address=address.get_copy(),
+            shipping_method=shipping_method,
+            user=users_for_order_benchmarks[i],
+            total=TaxedMoney(net=Money(i, "USD"), gross=Money(i, "USD")),
+        )
+        for i in range(CHECKOUT_COUNT_IN_BENCHMARKS)
+    ]
+    return Checkout.objects.bulk_create(checkouts)

--- a/saleor/graphql/checkout/tests/benchmark/test_checkouts.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkouts.py
@@ -1,0 +1,37 @@
+import pytest
+
+from ....tests.utils import get_graphql_content
+
+MULTIPLE_CHECKOUT_DETAILS_QUERY = """
+query multipleCheckouts {
+  checkouts(first: 100){
+    edges {
+      node {
+        id
+        channel {
+          id
+          slug
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_staff_multiple_checkouts(
+    staff_api_client,
+    permission_manage_checkouts,
+    permission_manage_users,
+    checkouts_for_benchmarks,
+    count_queries,
+):
+    staff_api_client.user.user_permissions.set(
+        [permission_manage_checkouts, permission_manage_users]
+    )
+    content = get_graphql_content(
+        staff_api_client.post_graphql(MULTIPLE_CHECKOUT_DETAILS_QUERY)
+    )
+    assert len(content["data"]["checkouts"]["edges"]) == 10

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -24,7 +24,7 @@ from ...warehouse.reservations import is_reservation_enabled
 from ..account.dataloaders import AddressByIdLoader
 from ..account.utils import check_is_owner_or_has_one_of_perms
 from ..channel import ChannelContext
-from ..channel.dataloaders import ChannelByCheckoutLineIDLoader
+from ..channel.dataloaders import ChannelByCheckoutLineIDLoader, ChannelByIdLoader
 from ..channel.types import Channel
 from ..core import ResolveInfo
 from ..core.connection import CountableConnection
@@ -528,6 +528,10 @@ class Checkout(ModelObjectType[models.Checkout]):
     @staticmethod
     def resolve_created(root: models.Checkout, _info: ResolveInfo):
         return root.created_at
+
+    @staticmethod
+    def resolve_channel(root: models.Checkout, info):
+        return ChannelByIdLoader(info.context).load(root.channel_id)
 
     @staticmethod
     def resolve_id(root: models.Checkout, _info: ResolveInfo):

--- a/saleor/graphql/order/tests/benchmark/fixtures.py
+++ b/saleor/graphql/order/tests/benchmark/fixtures.py
@@ -100,6 +100,7 @@ def users_for_order_benchmarks(address):
 @pytest.fixture
 def orders_for_benchmarks(
     channel_USD,
+    channel_PLN,
     address,
     payment_dummy,
     users_for_order_benchmarks,
@@ -109,7 +110,7 @@ def orders_for_benchmarks(
 ):
     orders = [
         Order(
-            channel=channel_USD,
+            channel=channel_USD if i % 2 else channel_PLN,
             billing_address=address.get_copy(),
             shipping_address=address.get_copy(),
             shipping_method=shipping_method,

--- a/saleor/graphql/order/tests/benchmark/test_order.py
+++ b/saleor/graphql/order/tests/benchmark/test_order.py
@@ -42,6 +42,10 @@ FRAGMENT_ORDER_DETAILS = (
         paymentStatus
         paymentStatusDisplay
         status
+        channel {
+          id
+          slug
+        }
         statusDisplay
         canFinalize
         isShippingRequired

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1317,6 +1317,10 @@ class Order(ModelObjectType[models.Order]):
         return root.created_at
 
     @staticmethod
+    def resolve_channel(root: models.Order, info):
+        return ChannelByIdLoader(info.context).load(root.channel_id)
+
+    @staticmethod
     def resolve_token(root: models.Order, info):
         return root.id
 


### PR DESCRIPTION
I want to merge this change because it uses dataloader when resolving channels in Order and Checkout types.
Benchmark for test_staff_multiple_checkouts before dataloader: **15 hits**
Benchmark for test_staff_multiple_checkouts after dataloader: **6 hits**
Benchmark for test_staff_multiple_orders before dataloader: **187**
Benchmark for test_staff_multiple_orders after dataloader: **182**
ℹ️ This is a port of https://github.com/saleor/saleor/pull/13169

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
