### PR TITLE
Replave given, when, then on steps

### DIFF
--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
@@ -28,7 +28,7 @@ def test_process_checkout_with_digital_product(
     permission_manage_shipping,
     media_root,
 ):
-    # given
+    # Before
     permissions = [
         permission_manage_products,
         permission_manage_channels,
@@ -88,23 +88,25 @@ def test_process_checkout_with_digital_product(
 
     create_digital_content(e2e_staff_api_client, product_variant_id)
 
-    # when
+    # Step 1
     lines = [
         {"variantId": product_variant_id, "quantity": 1},
     ]
     checkout_data = checkout_create(e2e_not_logged_api_client, lines, channel_slug)
     checkout_id = checkout_data["id"]
     total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    assert checkout_data["isShippingRequired"] is False
 
+    # Step 2
     checkout_billing_address_update(e2e_not_logged_api_client, checkout_id)
 
+    # Step 3
     checkout_dummy_payment_create(
         e2e_not_logged_api_client, checkout_id, total_gross_amount
     )
 
+    # Step 4
     order_data = checkout_complete(e2e_not_logged_api_client, checkout_id)
-
-    # then
     assert order_data["isShippingRequired"] is False
     assert order_data["status"] == "UNFULFILLED"
     assert order_data["total"]["gross"]["amount"] == total_gross_amount

--- a/saleor/tests/e2e/checkout/utils/checkout_create.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_create.py
@@ -14,6 +14,7 @@ mutation CreateCheckout($input: CheckoutCreateInput!) {
       channel {
         slug
       }
+      isShippingRequired
       totalPrice {
         gross {
           amount


### PR DESCRIPTION
I want to merge this change because replacing `given`, `when`, and `then` on `steps` in E2E tests.

In the first implementation of [Unlogged customer should be able to order digital product](https://saleor.testmo.net/repositories/5?group_id=125&case_id=747), I try to use `given`, `when`, and `then`. 
During the implementation of the second test case, I realize that E2E test should be split into `Before`, `Step 1`, `Step 2`, ... `Step X`. 


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
