### PR TITLE
E2E test refacto.

### DIFF
--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
@@ -19,16 +19,14 @@ from .utils import (
 )
 
 
-def test_process_checkout_with_digital_product(
-    e2e_not_logged_api_client,
+def prepare_product(
     e2e_staff_api_client,
     permission_manage_product_types_and_attributes,
     permission_manage_channels,
     permission_manage_products,
     permission_manage_shipping,
-    media_root,
+    channel_slug,
 ):
-    # Before
     permissions = [
         permission_manage_products,
         permission_manage_channels,
@@ -41,9 +39,10 @@ def test_process_checkout_with_digital_product(
     warehouse_id = warehouse_data["id"]
 
     warehouse_ids = [warehouse_id]
-    channel_data = create_channel(e2e_staff_api_client, warehouse_ids=warehouse_ids)
+    channel_data = create_channel(
+        e2e_staff_api_client, slug=channel_slug, warehouse_ids=warehouse_ids
+    )
     channel_id = channel_data["id"]
-    channel_slug = channel_data["slug"]
 
     channel_ids = [channel_id]
     create_shipping_zone(
@@ -87,6 +86,28 @@ def test_process_checkout_with_digital_product(
     )
 
     create_digital_content(e2e_staff_api_client, product_variant_id)
+    return product_variant_id
+
+
+def test_process_checkout_with_digital_product(
+    e2e_not_logged_api_client,
+    e2e_staff_api_client,
+    permission_manage_product_types_and_attributes,
+    permission_manage_channels,
+    permission_manage_products,
+    permission_manage_shipping,
+    media_root,
+):
+    # Before
+    channel_slug = "test-channel"
+    product_variant_id = prepare_product(
+        e2e_staff_api_client,
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        channel_slug,
+    )
 
     # Step 1
     lines = [

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ..channel.utils import create_channel
 from ..product.utils import (
     create_category,
@@ -89,6 +91,7 @@ def prepare_product(
     return product_variant_id
 
 
+@pytest.mark.e2e
 def test_process_checkout_with_digital_product(
     e2e_not_logged_api_client,
     e2e_staff_api_client,

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ..channel.utils import create_channel
 from ..product.utils import (
     create_category,
@@ -100,6 +102,7 @@ def prepare_product(
     return product_variant_id
 
 
+@pytest.mark.e2e
 def test_process_checkout_with_physical_product(
     e2e_staff_api_client,
     e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
@@ -23,15 +23,14 @@ from .utils import (
 )
 
 
-def test_process_checkout_with_physical_product(
+def prepare_product(
     e2e_staff_api_client,
-    e2e_not_logged_api_client,
     permission_manage_products,
     permission_manage_channels,
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
+    channel_slug,
 ):
-    # Before
     permissions = [
         permission_manage_products,
         permission_manage_channels,
@@ -44,9 +43,10 @@ def test_process_checkout_with_physical_product(
     warehouse_id = warehouse_data["id"]
 
     warehouse_ids = [warehouse_id]
-    channel_data = create_channel(e2e_staff_api_client, warehouse_ids=warehouse_ids)
+    channel_data = create_channel(
+        e2e_staff_api_client, slug=channel_slug, warehouse_ids=warehouse_ids
+    )
     channel_id = channel_data["id"]
-    channel_slug = channel_data["slug"]
 
     channel_ids = [channel_id]
     shipping_zone_data = create_shipping_zone(
@@ -95,6 +95,28 @@ def test_process_checkout_with_physical_product(
         e2e_staff_api_client,
         product_variant_id,
         channel_id,
+    )
+
+    return product_variant_id
+
+
+def test_process_checkout_with_physical_product(
+    e2e_staff_api_client,
+    e2e_not_logged_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_shipping,
+    permission_manage_product_types_and_attributes,
+):
+    # Before
+    channel_slug = "test-channel"
+    product_variant_id = prepare_product(
+        e2e_staff_api_client,
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        channel_slug,
     )
 
     # Step 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ filterwarnings =
     ignore::PendingDeprecationWarning
 markers =
     integration
+    e2e
 
 [flake8]
 exclude =


### PR DESCRIPTION
I want to merge this change because:
- Move Before section to separate functions
- Add e2e mark to pytest

To run all tests we use the normal `pytest` command without any parameters. 
```
pytest
```

To run only E2E test we use:
```
pytest -m "e2e"
```

To run all tests except E2E we use:
```
pytest -m "not e2e"
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
