### PR TITLE
Add ACCOUNT_CHANGE_EMAIL_REQUESTED event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add missing descriptions to Account module. - #13155 by @fowczarek
 - Add `ACCOUNT_CONFIRMATION_REQUESTED` async event - #13162 by @SzymJ
 - Add `ACCOUNT_DELETE_REQUESTED` async event - #13170 by @SzymJ
--
+- Add `ACCOUNT_CHANGE_EMAIL_REQUESTED` async event - #13233 by @SzymJ
+
 # 3.14.0
 
 ### Breaking changes

--- a/saleor/graphql/account/mutations/account/request_email_change.py
+++ b/saleor/graphql/account/mutations/account/request_email_change.py
@@ -1,4 +1,5 @@
 from typing import cast
+from urllib.parse import urlencode
 
 import graphene
 from django.conf import settings
@@ -7,7 +8,7 @@ from django.core.exceptions import ValidationError
 from .....account import models, notifications
 from .....account.error_codes import AccountErrorCode
 from .....core.jwt import create_token
-from .....core.utils.url import validate_storefront_url
+from .....core.utils.url import prepare_url, validate_storefront_url
 from .....permission.auth_filters import AuthorizationFilters
 from .....webhook.event_types import WebhookEventAsyncType
 from ....channel.utils import clean_channel
@@ -102,6 +103,9 @@ class RequestEmailChange(BaseMutation):
         }
         token = create_token(token_payload, settings.JWT_TTL_REQUEST_EMAIL_CHANGE)
         manager = get_plugin_manager_promise(info.context).get()
+        params = urlencode({"token": token})
+
+        # Notifications will be deprecated in the future
         notifications.send_request_user_change_email_notification(
             redirect_url,
             user,
@@ -110,4 +114,14 @@ class RequestEmailChange(BaseMutation):
             manager,
             channel_slug=channel_slug,
         )
+
+        cls.call_event(
+            manager.account_change_email_requested,
+            user,
+            channel_slug,
+            token,
+            new_email,
+            prepare_url(params, redirect_url),
+        )
+
         return RequestEmailChange(user=user)

--- a/saleor/graphql/account/mutations/account/request_email_change.py
+++ b/saleor/graphql/account/mutations/account/request_email_change.py
@@ -120,8 +120,8 @@ class RequestEmailChange(BaseMutation):
             user,
             channel_slug,
             token,
-            new_email,
             prepare_url(params, redirect_url),
+            new_email,
         )
 
         return RequestEmailChange(user=user)

--- a/saleor/graphql/account/tests/mutations/account/test_request_email_change.py
+++ b/saleor/graphql/account/tests/mutations/account/test_request_email_change.py
@@ -158,3 +158,39 @@ def test_request_email_change_with_invalid_password(user_api_client, customer_us
     assert not data["user"]
     assert data["errors"][0]["code"] == AccountErrorCode.INVALID_CREDENTIALS.name
     assert data["errors"][0]["field"] == "password"
+
+
+@patch("saleor.graphql.account.mutations.account.request_email_change.create_token")
+@patch("saleor.plugins.manager.PluginsManager.account_change_email_requested")
+def test_request_email_change_send_event(
+    account_change_email_requested_mock,
+    create_token_mock,
+    user_api_client,
+    customer_user,
+    channel_PLN,
+):
+    create_token_mock.return_value = "token"
+    redirect_url = "http://www.example.com"
+    new_email = "new_email@example.com"
+    variables = {
+        "password": "password",
+        "new_email": new_email,
+        "redirect_url": redirect_url,
+        "channel": channel_PLN.slug,
+    }
+
+    response = user_api_client.post_graphql(REQUEST_EMAIL_CHANGE_QUERY, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["requestEmailChange"]
+    assert data["user"]["email"] == customer_user.email
+
+    params = urlencode({"token": "token"})
+    change_email_url = prepare_url(params, redirect_url)
+
+    account_change_email_requested_mock.assert_called_once_with(
+        customer_user,
+        channel_PLN.slug,
+        "token",
+        new_email,
+        change_email_url,
+    )

--- a/saleor/graphql/account/tests/mutations/account/test_request_email_change.py
+++ b/saleor/graphql/account/tests/mutations/account/test_request_email_change.py
@@ -188,9 +188,5 @@ def test_request_email_change_send_event(
     change_email_url = prepare_url(params, redirect_url)
 
     account_change_email_requested_mock.assert_called_once_with(
-        customer_user,
-        channel_PLN.slug,
-        "token",
-        new_email,
-        change_email_url,
+        customer_user, channel_PLN.slug, "token", change_email_url, new_email
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1700,6 +1700,9 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   """An account confirmation is requested."""
   ACCOUNT_CONFIRMATION_REQUESTED
 
+  """An account change email is requested."""
+  ACCOUNT_CHANGE_EMAIL_REQUESTED
+
   """An account delete is requested."""
   ACCOUNT_DELETE_REQUESTED
 
@@ -2336,6 +2339,9 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """An account confirmation is requested."""
   ACCOUNT_CONFIRMATION_REQUESTED
+
+  """An account change email is requested."""
+  ACCOUNT_CHANGE_EMAIL_REQUESTED
 
   """An account delete is requested."""
   ACCOUNT_DELETE_REQUESTED
@@ -3339,6 +3345,7 @@ scalar JSONString
 """An enumeration."""
 enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   ACCOUNT_CONFIRMATION_REQUESTED
+  ACCOUNT_CHANGE_EMAIL_REQUESTED
   ACCOUNT_DELETE_REQUESTED
   ADDRESS_CREATED
   ADDRESS_UPDATED
@@ -28371,6 +28378,43 @@ type AccountConfirmationRequested implements Event @doc(category: "Users") {
 
   """Shop data."""
   shop: Shop
+}
+
+"""
+Event sent when account change email is requested.
+
+Added in Saleor 3.15.
+"""
+type AccountChangeEmailRequested implements Event @doc(category: "Users") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The URL to redirect the user after he accepts the request."""
+  redirectUrl: String
+
+  """The user the event relates to."""
+  user: User
+
+  """The channel data."""
+  channel: Channel
+
+  """The token required to confirm request."""
+  token: String
+
+  """Shop data."""
+  shop: Shop
+
+  """The new email address the user wants to change to."""
+  newEmail: String
 }
 
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1700,7 +1700,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   """An account confirmation is requested."""
   ACCOUNT_CONFIRMATION_REQUESTED
 
-  """An account change email is requested."""
+  """Account email change is requested."""
   ACCOUNT_CHANGE_EMAIL_REQUESTED
 
   """An account delete is requested."""
@@ -2340,7 +2340,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   """An account confirmation is requested."""
   ACCOUNT_CONFIRMATION_REQUESTED
 
-  """An account change email is requested."""
+  """Account email change is requested."""
   ACCOUNT_CHANGE_EMAIL_REQUESTED
 
   """An account delete is requested."""

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -36,6 +36,9 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.ACCOUNT_CONFIRMATION_REQUESTED: (
         "An account confirmation is requested."
     ),
+    WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED: (
+        "An account change email is requested."
+    ),
     WebhookEventAsyncType.ACCOUNT_DELETE_REQUESTED: "An account delete is requested.",
     WebhookEventAsyncType.ADDRESS_CREATED: "A new address created.",
     WebhookEventAsyncType.ADDRESS_UPDATED: "An address updated.",

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -37,7 +37,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
         "An account confirmation is requested."
     ),
     WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED: (
-        "An account change email is requested."
+        "Account email change is requested."
     ),
     WebhookEventAsyncType.ACCOUNT_DELETE_REQUESTED: "An account delete is requested.",
     WebhookEventAsyncType.ADDRESS_CREATED: "A new address created.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -187,6 +187,25 @@ class AccountConfirmationRequested(SubscriptionObjectType, AccountOperationBase)
         )
 
 
+class AccountChangeEmailRequested(SubscriptionObjectType, AccountOperationBase):
+    new_email = graphene.String(
+        description="The new email address the user wants to change to.",
+    )
+
+    class Meta:
+        root_type = "User"
+        enable_dry_run = False
+        interfaces = (Event,)
+        description = (
+            "Event sent when account change email is requested." + ADDED_IN_315
+        )
+
+    @staticmethod
+    def resolve_new_email(root, _info: ResolveInfo):
+        _, data = root
+        return data["new_email"]
+
+
 class AccountDeleteRequested(SubscriptionObjectType, AccountOperationBase):
     class Meta:
         root_type = "User"
@@ -2106,6 +2125,7 @@ class ThumbnailCreated(SubscriptionObjectType):
 
 WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.ACCOUNT_CONFIRMATION_REQUESTED: AccountConfirmationRequested,
+    WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED: AccountChangeEmailRequested,
     WebhookEventAsyncType.ACCOUNT_DELETE_REQUESTED: AccountDeleteRequested,
     WebhookEventAsyncType.ADDRESS_CREATED: AddressCreated,
     WebhookEventAsyncType.ADDRESS_UPDATED: AddressUpdated,

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -157,6 +157,12 @@ class BasePlugin:
         ["User", str, str, Optional[str], None], None
     ]
 
+    # Trigger when account change email is requested.
+    #
+    # Overwrite this method if you need to trigger specific logic after an account
+    # change email is requested.
+    account_change_email_requested: Callable[["User", str, str, str, str, None], None]
+
     # Trigger when account delete is requested.
     #
     # Overwrite this method if you need to trigger specific logic after an account

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1079,8 +1079,8 @@ class PluginsManager(PaymentInterface):
         user: "User",
         channel_slug: str,
         token: str,
-        new_email: str,
         redirect_url: str,
+        new_email: str,
     ):
         default_value = None
         return self.__run_method_on_plugins(
@@ -1089,8 +1089,8 @@ class PluginsManager(PaymentInterface):
             user,
             channel_slug,
             token=token,
-            new_email=new_email,
             redirect_url=redirect_url,
+            new_email=new_email,
         )
 
     def account_delete_requested(

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1074,6 +1074,25 @@ class PluginsManager(PaymentInterface):
             redirect_url=redirect_url,
         )
 
+    def account_change_email_requested(
+        self,
+        user: "User",
+        channel_slug: str,
+        token: str,
+        new_email: str,
+        redirect_url: str,
+    ):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "account_change_email_requested",
+            default_value,
+            user,
+            channel_slug,
+            token=token,
+            new_email=new_email,
+            redirect_url=redirect_url,
+        )
+
     def account_delete_requested(
         self, user: "User", channel_slug: str, token: str, redirect_url: str
     ):

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -151,7 +151,7 @@ class WebhookPlugin(BasePlugin):
             )
 
     def _trigger_account_event(
-        self, event_type, user, channel_slug, token, redirect_url
+        self, event_type, user, channel_slug, token, redirect_url, new_email=None
     ):
         if webhooks := get_webhooks_for_event(event_type):
             payload = self._serialize_payload(
@@ -161,16 +161,22 @@ class WebhookPlugin(BasePlugin):
                     "redirect_url": redirect_url,
                 }
             )
+            data = {
+                "user": user,
+                "channel_slug": channel_slug,
+                "token": token,
+                "redirect_url": redirect_url,
+            }
+
+            if new_email:
+                payload["new_email"] = new_email
+                data["new_email"] = new_email
+
             trigger_webhooks_async(
                 payload,
                 event_type,
                 webhooks,
-                {
-                    "user": user,
-                    "channel_slug": channel_slug,
-                    "token": token,
-                    "redirect_url": redirect_url,
-                },
+                data,
                 self.requestor,
             )
 
@@ -197,8 +203,8 @@ class WebhookPlugin(BasePlugin):
         user: "User",
         channel_slug: str,
         token: str,
-        new_email: str,
         redirect_url: str,
+        new_email: str,
         previous_value: None,
     ) -> None:
         if not self.active:
@@ -208,8 +214,8 @@ class WebhookPlugin(BasePlugin):
             user,
             channel_slug,
             token,
-            new_email,
             redirect_url,
+            new_email,
         )
 
     def account_delete_requested(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -154,13 +154,11 @@ class WebhookPlugin(BasePlugin):
         self, event_type, user, channel_slug, token, redirect_url, new_email=None
     ):
         if webhooks := get_webhooks_for_event(event_type):
-            payload = self._serialize_payload(
-                {
-                    "id": graphene.Node.to_global_id("User", user.id),
-                    "token": token,
-                    "redirect_url": redirect_url,
-                }
-            )
+            raw_payload = {
+                "id": graphene.Node.to_global_id("User", user.id),
+                "token": token,
+                "redirect_url": redirect_url,
+            }
             data = {
                 "user": user,
                 "channel_slug": channel_slug,
@@ -169,11 +167,11 @@ class WebhookPlugin(BasePlugin):
             }
 
             if new_email:
-                payload["new_email"] = new_email
+                raw_payload["new_email"] = new_email
                 data["new_email"] = new_email
 
             trigger_webhooks_async(
-                payload,
+                self._serialize_payload(raw_payload),
                 event_type,
                 webhooks,
                 data,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -192,6 +192,26 @@ class WebhookPlugin(BasePlugin):
             redirect_url,
         )
 
+    def account_change_email_requested(
+        self,
+        user: "User",
+        channel_slug: str,
+        token: str,
+        new_email: str,
+        redirect_url: str,
+        previous_value: None,
+    ) -> None:
+        if not self.active:
+            return previous_value
+        self._trigger_account_event(
+            WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED,
+            user,
+            channel_slug,
+            token,
+            new_email,
+            redirect_url,
+        )
+
     def account_delete_requested(
         self,
         user: "User",

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -29,6 +29,14 @@ def subscription_account_confirmation_requested_webhook(subscription_webhook):
 
 
 @pytest.fixture
+def subscription_account_change_email_requested_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.ACCOUNT_CHANGE_EMAIL_REQUESTED,
+        WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED,
+    )
+
+
+@pytest.fixture
 def subscription_account_delete_requested_webhook(subscription_webhook):
     return subscription_webhook(
         queries.ACCOUNT_DELETE_REQUESTED,

--- a/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
@@ -8,23 +8,24 @@ from .....graphql.attribute.enums import AttributeInputTypeEnum, AttributeTypeEn
 from .....product.models import Product
 
 
-def generate_account_events_payload(customer_user, channel):
-    return json.dumps(
-        {
-            **generate_customer_payload(customer_user),
-            **{
-                "token": "token",
-                "redirectUrl": "http://www.mirumee.com?token=token",
-                "channel": {
-                    "slug": channel.slug,
-                    "id": graphene.Node.to_global_id("Channel", channel.id),
-                },
-                "shop": {
-                    "domain": {"host": "mirumee.com", "url": "http://mirumee.com/"}
-                },
+def generate_account_events_payload(customer_user, channel, new_email=None):
+    payload = {
+        **generate_customer_payload(customer_user),
+        **{
+            "token": "token",
+            "redirectUrl": "http://www.mirumee.com?token=token",
+            "channel": {
+                "slug": channel.slug,
+                "id": graphene.Node.to_global_id("Channel", channel.id),
             },
-        }
-    )
+            "shop": {"domain": {"host": "mirumee.com", "url": "http://mirumee.com/"}},
+        },
+    }
+
+    if new_email:
+        payload["newEmail"] = new_email
+
+    return json.dumps(payload)
 
 
 def generate_app_payload(app, app_global_id):

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -28,6 +28,35 @@ ACCOUNT_CONFIRMATION_REQUESTED = (
 )
 
 
+ACCOUNT_CHANGE_EMAIL_REQUESTED = (
+    fragments.CUSTOMER_DETAILS
+    + """
+    subscription{
+      event{
+        ...on AccountChangeEmailRequested{
+          user{
+            ...CustomerDetails
+          }
+          token
+          redirectUrl
+          channel{
+            slug
+            id
+          }
+          shop{
+            domain{
+                host
+                url
+            }
+          }
+          newEmail
+        }
+      }
+    }
+"""
+)
+
+
 ACCOUNT_DELETE_REQUESTED = (
     fragments.CUSTOMER_DETAILS
     + """

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -106,6 +106,36 @@ def test_account_confirmation_requested(
     assert deliveries[0].webhook == webhooks[0]
 
 
+def test_account_change_email_requested(
+    customer_user, channel_USD, subscription_account_change_email_requested_webhook
+):
+    # given
+    webhooks = [subscription_account_change_email_requested_webhook]
+    event_type = WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED
+    new_email = "new@example.com"
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type,
+        {
+            "user": customer_user,
+            "channel_slug": channel_USD.slug,
+            "token": "token",
+            "new_email": new_email,
+            "redirect_url": "http://www.mirumee.com?token=token",
+        },
+        webhooks,
+    )
+
+    # then
+    expected_payload = generate_account_events_payload(
+        customer_user, channel_USD, new_email=new_email
+    )
+    assert deliveries[0].payload.payload == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
 def test_account_delete_requested(
     customer_user, channel_USD, subscription_account_delete_requested_webhook
 ):

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -20,6 +20,7 @@ class WebhookEventAsyncType:
     ANY = "any_events"
 
     ACCOUNT_CONFIRMATION_REQUESTED = "account_confirmation_requested"
+    ACCOUNT_CHANGE_EMAIL_REQUESTED = "account_change_email_requested"
     ACCOUNT_DELETE_REQUESTED = "account_delete_requested"
 
     ADDRESS_CREATED = "address_created"
@@ -176,6 +177,7 @@ class WebhookEventAsyncType:
     DISPLAY_LABELS = {
         ANY: "Any events",
         ACCOUNT_CONFIRMATION_REQUESTED: "Account confirmation requested",
+        ACCOUNT_CHANGE_EMAIL_REQUESTED: "Account change email requested",
         ACCOUNT_DELETE_REQUESTED: "Account delete requested",
         ADDRESS_CREATED: "Address created",
         ADDRESS_UPDATED: "Address updated",
@@ -302,6 +304,10 @@ class WebhookEventAsyncType:
         (
             ACCOUNT_CONFIRMATION_REQUESTED,
             DISPLAY_LABELS[ACCOUNT_CONFIRMATION_REQUESTED],
+        ),
+        (
+            ACCOUNT_CHANGE_EMAIL_REQUESTED,
+            DISPLAY_LABELS[ACCOUNT_CHANGE_EMAIL_REQUESTED],
         ),
         (ACCOUNT_DELETE_REQUESTED, DISPLAY_LABELS[ACCOUNT_DELETE_REQUESTED]),
         (ADDRESS_CREATED, DISPLAY_LABELS[ADDRESS_CREATED]),
@@ -437,6 +443,7 @@ class WebhookEventAsyncType:
 
     PERMISSIONS = {
         ACCOUNT_CONFIRMATION_REQUESTED: AccountPermissions.MANAGE_USERS,
+        ACCOUNT_CHANGE_EMAIL_REQUESTED: AccountPermissions.MANAGE_USERS,
         ACCOUNT_DELETE_REQUESTED: AccountPermissions.MANAGE_USERS,
         ADDRESS_CREATED: AccountPermissions.MANAGE_USERS,
         ADDRESS_UPDATED: AccountPermissions.MANAGE_USERS,


### PR DESCRIPTION
I want to merge this change because it adds `ACCOUNT_CHANGE_EMAIL_REQUESTED` event.

Part of #12317

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
