### PR TITLE
fix: #13181 dataloaders for `is_shipping_required` resolver

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1923,8 +1923,12 @@ class Order(ModelObjectType[models.Order]):
         return InvoicesByOrderIdLoader(info.context).load(root.id)
 
     @staticmethod
-    def resolve_is_shipping_required(root: models.Order, _info):
-        return root.is_shipping_required()
+    def resolve_is_shipping_required(root: models.Order, info):
+        return (
+            OrderLinesByOrderIdLoader(info.context)
+            .load(root.id)
+            .then(lambda lines: any(line.is_shipping_required for line in lines))
+        )
 
     @staticmethod
     def resolve_gift_cards(root: models.Order, info):


### PR DESCRIPTION
I want to merge this change because #13181

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
