### PR TITLE
Add release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -27,4 +27,4 @@ This issue tracks the release progress of Saleor <X.Y.Z>.
 - [ ] Accepts release PR to sandbox - @michalina-graczyk
 - [ ] Inform about approved release PR to sandbox  - @michalina-graczyk
 - [ ] Merge release PR to sandbox - @cmiacz
-- [ ] Inform about stable release (sandbox) - @czarek
+- [ ] Inform about stable release (sandbox) - @cmiacz

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -13,7 +13,7 @@ This issue tracks the release progress of Saleor <X.Y.Z>.
 - [ ] Release alpha tag - @maarcingebala
 - [ ] Inform about alpha tag - @maarcingebala
 - [ ] Release alpha tag - @andrzejewsky
-- [ ] inform about alpha tag - @andrzejewsky
+- [ ] Inform about alpha tag - @andrzejewsky
 - [ ] Prepare environments for the new minor and trigger deployments - @cmiacz
 - [ ] Inform about finished deployment on slack channel - @cmiacz
 - [ ] Perform alpha tests migration on staging - @michalina-graczyk

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,30 @@
+---
+name: New release
+about: Template for issues to track Saleor releases
+title: "Release <X.Y.Z>"
+labels: release
+assignees: ""
+---
+
+This issue tracks the release progress of Saleor <X.Y.Z>.
+
+## Steps
+
+- [ ] Release alpha tag - @maarcingebala
+- [ ] Inform about alpha tag - @maarcingebala
+- [ ] Release alpha tag - @andrzejewsky
+- [ ] inform about alpha tag - @andrzejewsky
+- [ ] Prepare environments for the new minor and trigger deployments - @cmiacz
+- [ ] Inform about finished deployment on slack channel - @cmiacz
+- [ ] Perform alpha tests migration on staging - @michalina-graczyk
+- [ ] Cypress tests review - @michalina-graczyk
+- [ ] Check the change log and do smoke tests - @michalina-graczyk
+- [ ] Inform the team about results of the tests - @michalina-graczyk
+- [ ] Perform smoke check on demo and storefront - @michalina-graczyk
+- [ ] Inform about finished tests - @michalina-graczyk
+- [ ] Release stable tag - @maarcingebala
+- [ ] Release stable tag  - @andrzejewsky
+- [ ] Accepts release PR to sandbox - @michalina-graczyk
+- [ ] Inform about approved release PR to sandbox  - @michalina-graczyk
+- [ ] Merge release PR to sandbox - @cmiacz
+- [ ] Inform about stable release (sandbox) - @czarek

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -15,7 +15,7 @@ This issue tracks the release progress of Saleor <X.Y.Z>.
 - [ ] Release alpha tag - @andrzejewsky
 - [ ] Inform about alpha tag - @andrzejewsky
 - [ ] Prepare environments for the new minor and trigger deployments - @cmiacz
-- [ ] Inform about finished deployment on slack channel - @cmiacz
+- [ ] Inform about finished deployment - @cmiacz
 - [ ] Perform alpha tests migration on staging - @michalina-graczyk
 - [ ] Cypress tests review - @michalina-graczyk
 - [ ] Check the change log and do smoke tests - @michalina-graczyk


### PR DESCRIPTION
This template will be used to create issues where we'll be tracking progress on new minor releases of Saleor.
