### PR TITLE
Add CheckoutLineProblemVariantNotAvailable error

### DIFF
--- a/saleor/graphql/checkout/tests/test_checkout_line_problems.py
+++ b/saleor/graphql/checkout/tests/test_checkout_line_problems.py
@@ -1,3 +1,8 @@
+import datetime
+
+import pytz
+
+from ....product.models import ProductChannelListing, ProductVariantChannelListing
 from ...core.utils import to_global_id_or_none
 from ...tests.utils import get_graphql_content
 
@@ -16,6 +21,11 @@ query checkout($id: ID) {
           id
         }
       }
+      ... on CheckoutLineProblemVariantNotAvailable{
+        line{
+          id
+        }
+      }
     }
     lines{
       id
@@ -26,6 +36,11 @@ query checkout($id: ID) {
           variant{
             id
           }
+          line{
+            id
+          }
+        }
+        ... on CheckoutLineProblemVariantNotAvailable{
           line{
             id
           }
@@ -252,3 +267,219 @@ def test_lines_with_same_variant(api_client, checkout_with_items_and_shipping):
         second_line_without_stock["problems"][0]["availableQuantity"]
         == available_quantity
     )
+
+
+def test_product_is_not_published(checkout_with_items_and_shipping, api_client):
+    # given
+    checkout = checkout_with_items_and_shipping
+    checkout_line = checkout.lines.first()
+
+    product = checkout_line.variant.product
+    product.channel_listings.update(is_published=False)
+
+    checkout_line_id = to_global_id_or_none(checkout_line)
+
+    checkout_id = to_global_id_or_none(checkout)
+    variables = {"id": checkout_id, "channel": checkout.channel.slug}
+
+    # when
+    response = api_client.post_graphql(QUERY_CHECKOUT_WITH_PROBLEMS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["checkout"]["id"] == checkout_id
+    assert len(content["data"]["checkout"]["problems"]) == 1
+    assert (
+        content["data"]["checkout"]["problems"][0]["__typename"]
+        == "CheckoutLineProblemVariantNotAvailable"
+    )
+    assert content["data"]["checkout"]["problems"][0]["line"][
+        "id"
+    ] == to_global_id_or_none(checkout_line)
+
+    line_without_stock = [
+        line
+        for line in content["data"]["checkout"]["lines"]
+        if line["id"] == checkout_line_id
+    ][0]
+    assert len(line_without_stock["problems"]) == 1
+    assert (
+        line_without_stock["problems"][0]["__typename"]
+        == "CheckoutLineProblemVariantNotAvailable"
+    )
+    assert line_without_stock["problems"][0]["line"]["id"] == checkout_line_id
+
+
+def test_product_doesnt_have_channel_listing(
+    checkout_with_items_and_shipping, api_client
+):
+    # given
+    checkout = checkout_with_items_and_shipping
+    checkout_line = checkout.lines.first()
+
+    available_at = datetime.datetime.now(pytz.UTC) + datetime.timedelta(days=5)
+    product = checkout_line.variant.product
+    product.channel_listings.update(available_for_purchase_at=available_at)
+
+    checkout_line_id = to_global_id_or_none(checkout_line)
+
+    checkout_id = to_global_id_or_none(checkout)
+    variables = {"id": checkout_id, "channel": checkout.channel.slug}
+
+    # when
+    response = api_client.post_graphql(QUERY_CHECKOUT_WITH_PROBLEMS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["checkout"]["id"] == checkout_id
+    assert len(content["data"]["checkout"]["problems"]) == 1
+    assert (
+        content["data"]["checkout"]["problems"][0]["__typename"]
+        == "CheckoutLineProblemVariantNotAvailable"
+    )
+    assert content["data"]["checkout"]["problems"][0]["line"][
+        "id"
+    ] == to_global_id_or_none(checkout_line)
+
+    line_without_stock = [
+        line
+        for line in content["data"]["checkout"]["lines"]
+        if line["id"] == checkout_line_id
+    ][0]
+    assert len(line_without_stock["problems"]) == 1
+    assert (
+        line_without_stock["problems"][0]["__typename"]
+        == "CheckoutLineProblemVariantNotAvailable"
+    )
+    assert line_without_stock["problems"][0]["line"]["id"] == checkout_line_id
+
+
+def test_product_is_not_available_to_purchase(
+    checkout_with_items_and_shipping, api_client
+):
+    # given
+    checkout = checkout_with_items_and_shipping
+    checkout_line = checkout.lines.first()
+
+    product = checkout_line.variant.product
+    ProductChannelListing.objects.filter(product=product).delete()
+
+    checkout_line_id = to_global_id_or_none(checkout_line)
+
+    checkout_id = to_global_id_or_none(checkout)
+    variables = {"id": checkout_id, "channel": checkout.channel.slug}
+
+    # when
+    response = api_client.post_graphql(QUERY_CHECKOUT_WITH_PROBLEMS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["checkout"]["id"] == checkout_id
+    assert len(content["data"]["checkout"]["problems"]) == 1
+    assert (
+        content["data"]["checkout"]["problems"][0]["__typename"]
+        == "CheckoutLineProblemVariantNotAvailable"
+    )
+    assert content["data"]["checkout"]["problems"][0]["line"][
+        "id"
+    ] == to_global_id_or_none(checkout_line)
+
+    line_without_stock = [
+        line
+        for line in content["data"]["checkout"]["lines"]
+        if line["id"] == checkout_line_id
+    ][0]
+    assert len(line_without_stock["problems"]) == 1
+    assert (
+        line_without_stock["problems"][0]["__typename"]
+        == "CheckoutLineProblemVariantNotAvailable"
+    )
+    assert line_without_stock["problems"][0]["line"]["id"] == checkout_line_id
+
+
+def test_product_variant_doesnt_have_channel_listing(
+    checkout_with_items_and_shipping, api_client
+):
+    # given
+    checkout = checkout_with_items_and_shipping
+    checkout_line = checkout.lines.first()
+
+    variant = checkout_line.variant
+    ProductVariantChannelListing.objects.filter(variant=variant).delete()
+
+    checkout_line_id = to_global_id_or_none(checkout_line)
+
+    checkout_id = to_global_id_or_none(checkout)
+    variables = {"id": checkout_id, "channel": checkout.channel.slug}
+
+    # when
+    response = api_client.post_graphql(QUERY_CHECKOUT_WITH_PROBLEMS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["checkout"]["id"] == checkout_id
+    assert len(content["data"]["checkout"]["problems"]) == 1
+    assert (
+        content["data"]["checkout"]["problems"][0]["__typename"]
+        == "CheckoutLineProblemVariantNotAvailable"
+    )
+    assert content["data"]["checkout"]["problems"][0]["line"][
+        "id"
+    ] == to_global_id_or_none(checkout_line)
+
+    line_without_stock = [
+        line
+        for line in content["data"]["checkout"]["lines"]
+        if line["id"] == checkout_line_id
+    ][0]
+    assert len(line_without_stock["problems"]) == 1
+    assert (
+        line_without_stock["problems"][0]["__typename"]
+        == "CheckoutLineProblemVariantNotAvailable"
+    )
+    assert line_without_stock["problems"][0]["line"]["id"] == checkout_line_id
+
+
+def test_product_variant_channel_listing_doesnt_have_price_amount(
+    checkout_with_items_and_shipping, api_client
+):
+    # given
+    checkout = checkout_with_items_and_shipping
+    checkout_line = checkout.lines.first()
+
+    variant = checkout_line.variant
+    ProductVariantChannelListing.objects.filter(variant=variant).update(
+        price_amount=None
+    )
+
+    checkout_line_id = to_global_id_or_none(checkout_line)
+
+    checkout_id = to_global_id_or_none(checkout)
+    variables = {"id": checkout_id, "channel": checkout.channel.slug}
+
+    # when
+    response = api_client.post_graphql(QUERY_CHECKOUT_WITH_PROBLEMS, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["checkout"]["id"] == checkout_id
+    assert len(content["data"]["checkout"]["problems"]) == 1
+    assert (
+        content["data"]["checkout"]["problems"][0]["__typename"]
+        == "CheckoutLineProblemVariantNotAvailable"
+    )
+    assert content["data"]["checkout"]["problems"][0]["line"][
+        "id"
+    ] == to_global_id_or_none(checkout_line)
+
+    line_without_stock = [
+        line
+        for line in content["data"]["checkout"]["lines"]
+        if line["id"] == checkout_line_id
+    ][0]
+    assert len(line_without_stock["problems"]) == 1
+    assert (
+        line_without_stock["problems"][0]["__typename"]
+        == "CheckoutLineProblemVariantNotAvailable"
+    )
+    assert line_without_stock["problems"][0]["line"]["id"] == checkout_line_id


### PR DESCRIPTION
I want to merge this change because:
- it simplifies the data loader used for `problems`
- it adds a new error `CheckoutLineProblemVariantNotAvailable`

`CheckoutLineProblemVariantNotAvailable` - will be raised in the case when the variant is not available to purchase, is not published, doesn't have a proper price, or a channel listing doesn't exist. It is a single structure for multiple errors that we had previously. From one perspective, for storefront it doesn't matter if the line is not publised or doesn't have a proper price provided. The most important thing is that the variant is not available. 
If you don't like this assumption, we can discuss it & I can apply any changes that we agree

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
