### PR TITLE
Take into account legacy error settings for checkout line

### DIFF
--- a/saleor/checkout/problems.py
+++ b/saleor/checkout/problems.py
@@ -157,7 +157,7 @@ def get_checkout_lines_problems(
         for line_info, available_quantity in insufficient_stock:
             problems[str(line_info.line.pk)].append(
                 CheckoutLineProblemInsufficientStock(
-                    available_quantity=available_quantity,
+                    available_quantity=max(available_quantity, 0),
                     line=line_info.line,
                     variant=ChannelContext(
                         node=line_info.variant, channel_slug=line_info.channel.slug

--- a/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/mutations/checkout_add_promo_code.py
@@ -74,7 +74,10 @@ class CheckoutAddPromoCode(BaseMutation):
         manager = get_plugin_manager_promise(info.context).get()
         lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
 
-        if unavailable_variant_pks:
+        if (
+            unavailable_variant_pks
+            and checkout.channel.use_legacy_error_flow_for_checkout
+        ):
             not_available_variants_ids = {
                 graphene.Node.to_global_id("ProductVariant", pk)
                 for pk in unavailable_variant_pks

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -134,9 +134,15 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
                 "lines__variant__product__product_type"
             ),
         )
+        use_legacy_error_flow_for_checkout = (
+            checkout.channel.use_legacy_error_flow_for_checkout
+        )
 
-        lines, _ = fetch_checkout_lines(checkout)
-        if not is_shipping_required(lines):
+        lines, _ = fetch_checkout_lines(
+            checkout,
+        )
+
+        if use_legacy_error_flow_for_checkout and not is_shipping_required(lines):
             raise ValidationError(
                 {
                     "shipping_address": ValidationError(
@@ -167,7 +173,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         checkout.set_country(country, commit=True)
 
         # Resolve and process the lines, validating variants quantities
-        if lines:
+        if lines and use_legacy_error_flow_for_checkout:
             cls.process_checkout_lines(
                 info,
                 lines,

--- a/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_method_update.py
@@ -104,10 +104,14 @@ class CheckoutShippingMethodUpdate(BaseMutation):
     ):
         checkout = get_checkout(cls, info, checkout_id=checkout_id, token=token, id=id)
 
+        use_legacy_error_flow_for_checkout = (
+            checkout.channel.use_legacy_error_flow_for_checkout
+        )
+
         manager = get_plugin_manager_promise(info.context).get()
 
         lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
-        if unavailable_variant_pks:
+        if use_legacy_error_flow_for_checkout and unavailable_variant_pks:
             not_available_variants_ids = {
                 graphene.Node.to_global_id("ProductVariant", pk)
                 for pk in unavailable_variant_pks
@@ -122,7 +126,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
                 }
             )
         checkout_info = fetch_checkout_info(checkout, lines, manager)
-        if not is_shipping_required(lines):
+        if use_legacy_error_flow_for_checkout and not is_shipping_required(lines):
             raise ValidationError(
                 {
                     "shipping_method": ValidationError(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -1183,7 +1183,7 @@ def test_checkout_add_voucher_code_invalidates_price(
     assert data["checkout"]["totalPrice"]["gross"]["amount"] == expected_total
 
 
-def test_new_error_flow(
+def test_with_active_problems_flow(
     api_client,
     checkout_with_problems,
     voucher,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -1181,3 +1181,29 @@ def test_checkout_add_voucher_code_invalidates_price(
     assert data["checkout"]["voucherCode"] == voucher.code
     assert data["checkout"]["subtotalPrice"]["gross"]["amount"] == expected_total
     assert data["checkout"]["totalPrice"]["gross"]["amount"] == expected_total
+
+
+def test_new_error_flow(
+    api_client,
+    checkout_with_problems,
+    voucher,
+):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_problems),
+        "promoCode": voucher.code,
+    }
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_CHECKOUT_ADD_PROMO_CODE,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutAddPromoCode"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -558,7 +558,7 @@ def test_checkout_billing_address_update_with_disabled_fields_normalization(
     assert billing_address.street_address_1 == address_data["streetAddress1"]
 
 
-def test_new_error_flow(
+def test_with_active_problems_flow(
     api_client,
     checkout_with_problems,
     graphql_address_data,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -556,3 +556,29 @@ def test_checkout_billing_address_update_with_disabled_fields_normalization(
     assert billing_address.country_area == address_data["countryArea"]
     assert billing_address.postal_code == address_data["postalCode"]
     assert billing_address.street_address_1 == address_data["streetAddress1"]
+
+
+def test_new_error_flow(
+    api_client,
+    checkout_with_problems,
+    graphql_address_data,
+):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    new_address = graphql_address_data
+    variables = {
+        "id": to_global_id_or_none(checkout_with_problems),
+        "billingAddress": new_address,
+    }
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutBillingAddressUpdate"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
@@ -210,7 +210,7 @@ def test_checkout_customer_attach_user_to_checkout_with_user(
     assert_no_permission(response)
 
 
-def test_new_error_flow(user_api_client, checkout_with_problems):
+def test_with_active_problems_flow(user_api_client, checkout_with_problems):
     # given
     channel = checkout_with_problems.channel
     channel.use_legacy_error_flow_for_checkout = False

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_attach.py
@@ -208,3 +208,22 @@ def test_checkout_customer_attach_user_to_checkout_with_user(
     variables = {"id": checkout_id, "customerId": customer_id}
     response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
+
+
+def test_new_error_flow(user_api_client, checkout_with_problems):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    variables = {"id": to_global_id_or_none(checkout_with_problems), "customerId": None}
+
+    # when
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_CUSTOMER_ATTACH,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutCustomerAttach"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
@@ -86,3 +86,22 @@ def test_checkout_customer_detach_by_app_without_permissions(
     assert_no_permission(response)
     checkout.refresh_from_db()
     assert checkout.last_change == previous_last_change
+
+
+def test_new_error_flow(user_api_client, checkout_with_problems):
+    # given
+    checkout_with_problems.user = user_api_client.user
+    checkout_with_problems.save(update_fields=["user"])
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    variables = {"id": to_global_id_or_none(checkout_with_problems)}
+
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_CUSTOMER_DETACH, variables
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutCustomerDetach"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_customer_detach.py
@@ -88,7 +88,7 @@ def test_checkout_customer_detach_by_app_without_permissions(
     assert checkout.last_change == previous_last_change
 
 
-def test_new_error_flow(user_api_client, checkout_with_problems):
+def test_with_active_problems_flow(user_api_client, checkout_with_problems):
     # given
     checkout_with_problems.user = user_api_client.user
     checkout_with_problems.save(update_fields=["user"])

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -591,7 +591,7 @@ def test_checkout_delivery_method_update_with_not_valid_address_data(
         assert checkout.collection_point is None
 
 
-def test_new_error_flow(
+def test_with_active_problems_flow(
     api_client,
     checkout_with_problems,
     shipping_method,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -589,3 +589,29 @@ def test_checkout_delivery_method_update_with_not_valid_address_data(
         )
         assert checkout.shipping_method is None
         assert checkout.collection_point is None
+
+
+def test_new_error_flow(
+    api_client,
+    checkout_with_problems,
+    shipping_method,
+):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    method_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_UPDATE_DELIVERY_METHOD,
+        {
+            "id": to_global_id_or_none(checkout_with_problems),
+            "deliveryMethodId": method_id,
+        },
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutDeliveryMethodUpdate"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -58,7 +58,7 @@ def test_checkout_email_update_validation(user_api_client, checkout_with_item):
     assert checkout_with_item.last_change == previous_last_change
 
 
-def test_new_error_flow(api_client, checkout_with_problems):
+def test_with_active_problems_flow(api_client, checkout_with_problems):
     # given
     channel = checkout_with_problems.channel
     channel.use_legacy_error_flow_for_checkout = False

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_email_update.py
@@ -56,3 +56,25 @@ def test_checkout_email_update_validation(user_api_client, checkout_with_item):
     checkout_errors = content["data"]["checkoutEmailUpdate"]["errors"]
     assert checkout_errors[0]["code"] == CheckoutErrorCode.REQUIRED.name
     assert checkout_with_item.last_change == previous_last_change
+
+
+def test_new_error_flow(api_client, checkout_with_problems):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_problems),
+        "email": "admin@example.com",
+    }
+
+    # when
+    response = api_client.post_graphql(
+        CHECKOUT_EMAIL_UPDATE_MUTATION,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutEmailUpdate"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
@@ -41,7 +41,7 @@ def test_checkout_update_language_code(
     assert checkout.last_change != previous_last_change
 
 
-def test_new_error_flow(api_client, checkout_with_problems):
+def test_with_active_problems_flow(api_client, checkout_with_problems):
     # given
     channel = checkout_with_problems.channel
     channel.use_legacy_error_flow_for_checkout = False

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_language_code_update.py
@@ -39,3 +39,25 @@ def test_checkout_update_language_code(
     checkout.refresh_from_db()
     assert checkout.language_code == language_code.lower()
     assert checkout.last_change != previous_last_change
+
+
+def test_new_error_flow(api_client, checkout_with_problems):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_problems),
+        "languageCode": "PL",
+    }
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_CHECKOUT_UPDATE_LANGUAGE_CODE,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutLanguageCodeUpdate"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -138,3 +138,36 @@ def test_checkout_line_delete_remove_shipping_if_removed_product_with_shipping(
     checkout.refresh_from_db()
     assert checkout.lines.count() == 1
     assert not checkout.shipping_method
+
+
+def test_new_error_flow(
+    api_client, checkout_with_problems, product_with_single_variant
+):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    variant = product_with_single_variant.variants.first()
+
+    checkout_info = fetch_checkout_info(
+        checkout_with_problems, [], get_plugins_manager()
+    )
+    add_variant_to_checkout(checkout_info, variant, 1)
+
+    line = checkout_info.checkout.lines.last()
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_problems),
+        "lineId": to_global_id_or_none(line),
+    }
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_CHECKOUT_LINE_DELETE,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutLineDelete"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -140,7 +140,7 @@ def test_checkout_line_delete_remove_shipping_if_removed_product_with_shipping(
     assert not checkout.shipping_method
 
 
-def test_new_error_flow(
+def test_with_active_problems_flow(
     api_client, checkout_with_problems, product_with_single_variant
 ):
     # given

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -1040,7 +1040,7 @@ def test_checkout_lines_invalid_variant_id(user_api_client, checkout, stock):
     assert data["errors"][0]["field"] == "variantId"
 
 
-def test_new_error_flow(
+def test_with_active_problems_flow(
     api_client, checkout_with_problems, product_with_single_variant
 ):
     # given

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -1038,3 +1038,29 @@ def test_checkout_lines_invalid_variant_id(user_api_client, checkout, stock):
     )
     assert data["errors"][0]["message"] == error_msg
     assert data["errors"][0]["field"] == "variantId"
+
+
+def test_new_error_flow(
+    api_client, checkout_with_problems, product_with_single_variant
+):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    variant = product_with_single_variant.variants.first()
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_problems),
+        "lines": [{"variantId": to_global_id_or_none(variant), "quantity": 1}],
+    }
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_CHECKOUT_LINES_ADD,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutLinesAdd"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
@@ -117,7 +117,7 @@ def tests_checkout_lines_delete_invalid_lines_ids(user_api_client, checkout_with
     assert checkout.last_change == previous_last_change
 
 
-def test_new_error_flow(api_client, checkout_with_problems):
+def test_with_active_problems_flow(api_client, checkout_with_problems):
     # given
     channel = checkout_with_problems.channel
     channel.use_legacy_error_flow_for_checkout = False

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
@@ -115,3 +115,28 @@ def tests_checkout_lines_delete_invalid_lines_ids(user_api_client, checkout_with
     errors = content["errors"][0]
     assert errors["extensions"]["exception"]["code"] == "GraphQLError"
     assert checkout.last_change == previous_last_change
+
+
+def test_new_error_flow(api_client, checkout_with_problems):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    line = checkout_with_problems.lines.first()
+    first_line_id = to_global_id_or_none(line)
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_problems),
+        "linesIds": [first_line_id],
+    }
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_CHECKOUT_LINES_DELETE,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutLinesDelete"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -1133,7 +1133,7 @@ def test_checkout_lines_update_remove_shipping_if_removed_product_with_shipping(
     assert not checkout.shipping_method
 
 
-def test_new_error_flow(
+def test_with_active_problems_flow(
     api_client, checkout_with_problems, product_with_single_variant
 ):
     # given

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -1131,3 +1131,34 @@ def test_checkout_lines_update_remove_shipping_if_removed_product_with_shipping(
     checkout.refresh_from_db()
     assert checkout.lines.count() == 1
     assert not checkout.shipping_method
+
+
+def test_new_error_flow(
+    api_client, checkout_with_problems, product_with_single_variant
+):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    variant = product_with_single_variant.variants.first()
+
+    checkout_info = fetch_checkout_info(
+        checkout_with_problems, [], get_plugins_manager()
+    )
+    add_variant_to_checkout(checkout_info, variant, 1)
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_problems),
+        "lines": [{"variantId": to_global_id_or_none(variant), "quantity": 3}],
+    }
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_CHECKOUT_LINES_UPDATE,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutLinesUpdate"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -295,3 +295,36 @@ def test_checkout_remove_voucher_code_invalidates_price(
     assert not data["errors"]
     assert data["checkout"]["subtotalPrice"]["gross"]["amount"] == subtotal.amount
     assert data["checkout"]["totalPrice"]["gross"]["amount"] == expected_total
+
+
+def test_new_error_flow(
+    api_client,
+    checkout_with_problems,
+    voucher,
+):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    checkout_with_problems.voucher_code = voucher.code
+    checkout_with_problems.save(
+        update_fields=[
+            "voucher_code",
+        ]
+    )
+
+    variables = {
+        "id": to_global_id_or_none(checkout_with_problems),
+        "promoCode": voucher.code,
+    }
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_CHECKOUT_REMOVE_PROMO_CODE,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutRemovePromoCode"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -297,7 +297,7 @@ def test_checkout_remove_voucher_code_invalidates_price(
     assert data["checkout"]["totalPrice"]["gross"]["amount"] == expected_total
 
 
-def test_new_error_flow(
+def test_with_active_problems_flow(
     api_client,
     checkout_with_problems,
     voucher,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -916,7 +916,7 @@ def test_checkout_shipping_address_update_with_not_applicable_voucher(
     assert checkout_with_item.voucher_code is None
 
 
-def test_new_error_flow(
+def test_with_active_problems_flow(
     api_client,
     checkout_with_problems,
     graphql_address_data,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -914,3 +914,29 @@ def test_checkout_shipping_address_update_with_not_applicable_voucher(
 
     assert checkout_with_item.shipping_address.country == new_address["country"]
     assert checkout_with_item.voucher_code is None
+
+
+def test_new_error_flow(
+    api_client,
+    checkout_with_problems,
+    graphql_address_data,
+):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    new_address = graphql_address_data
+    variables = {
+        "id": to_global_id_or_none(checkout_with_problems),
+        "shippingAddress": new_address,
+    }
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE, variables
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutShippingAddressUpdate"]["errors"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -458,7 +458,7 @@ def test_checkout_update_shipping_method_with_digital(
     assert checkout.shipping_method is None
 
 
-def test_new_error_flow(
+def test_with_active_problems_flow(
     api_client,
     checkout_with_problems,
     shipping_method,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -456,3 +456,29 @@ def test_checkout_update_shipping_method_with_digital(
     # Ensure the shipping method was unchanged
     checkout.refresh_from_db(fields=["shipping_method"])
     assert checkout.shipping_method is None
+
+
+def test_new_error_flow(
+    api_client,
+    checkout_with_problems,
+    shipping_method,
+):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    method_id = graphene.Node.to_global_id("ShippingMethod", shipping_method.id)
+
+    # when
+    response = api_client.post_graphql(
+        MUTATION_UPDATE_SHIPPING_METHOD,
+        {
+            "id": to_global_id_or_none(checkout_with_problems),
+            "shippingMethodId": method_id,
+        },
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutShippingMethodUpdate"]["errors"]

--- a/saleor/graphql/payment/mutations/payment/checkout_payment_create.py
+++ b/saleor/graphql/payment/mutations/payment/checkout_payment_create.py
@@ -213,6 +213,10 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
     ):
         checkout = get_checkout(cls, info, checkout_id=checkout_id, token=token, id=id)
 
+        use_legacy_error_flow_for_checkout = (
+            checkout.channel.use_legacy_error_flow_for_checkout
+        )
+
         cls.validate_checkout_email(checkout)
 
         gateway = input["gateway"]
@@ -222,7 +226,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         cls.validate_return_url(input)
 
         lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
-        if unavailable_variant_pks:
+        if use_legacy_error_flow_for_checkout and unavailable_variant_pks:
             not_available_variants_ids = {
                 graphene.Node.to_global_id("ProductVariant", pk)
                 for pk in unavailable_variant_pks

--- a/saleor/graphql/payment/tests/mutations/test_checkout_payment_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_checkout_payment_create.py
@@ -778,7 +778,7 @@ def test_checkout_add_payment_run_multiple_times(
     assert payments.filter(is_active=True).count() == 1
 
 
-def test_new_error_flow(
+def test_with_active_problems_flow(
     api_client,
     checkout_with_problems,
     shipping_method,

--- a/saleor/graphql/payment/tests/mutations/test_checkout_payment_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_checkout_payment_create.py
@@ -776,3 +776,34 @@ def test_checkout_add_payment_run_multiple_times(
     payments = Payment.objects.filter(checkout=checkout)
     assert payments.count() == 2
     assert payments.filter(is_active=True).count() == 1
+
+
+def test_new_error_flow(
+    api_client,
+    checkout_with_problems,
+    shipping_method,
+):
+    # given
+    channel = checkout_with_problems.channel
+    channel.use_legacy_error_flow_for_checkout = False
+    channel.save(update_fields=["use_legacy_error_flow_for_checkout"])
+
+    return_url = "https://www.example.com"
+    variables = {
+        "id": to_global_id_or_none(checkout_with_problems),
+        "input": {
+            "gateway": DUMMY_GATEWAY,
+            "token": "sample-token",
+            "returnUrl": return_url,
+        },
+    }
+
+    # when
+    response = api_client.post_graphql(
+        CREATE_PAYMENT_MUTATION,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["checkoutPaymentCreate"]["errors"]


### PR DESCRIPTION
I want to merge this change because:
- it adds support to checkout mutations to take into account the setting flag for legacy errors
- it adds a single test for each mutation to confirm that we don't raise unneeded error when calling the mutation

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
