### PR TITLE
Simplify permissionGroupCreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - `voidedAmount` - Use `canceledAmount` instead.
   - `TransactionActionRequest` - Use `TransactionChargeRequested`, `TransactionRefundRequested`, `TransactionCancelationRequested` instead.
 
+- Simplify permissionGroupCreate permissions - #13363 by @8r2y5
 - Remove `OrderBulkCreateInput.trackingClientId` field - #13146 by @SzymJ
 - Drop backend integration with Open Exchange Rates API - #13175 by @maarcingebala
   - Note: this changes doesn't affect Saleor Cloud users, as the integration was never enabled there.

--- a/saleor/graphql/account/mutations/permission_group/permission_group_create.py
+++ b/saleor/graphql/account/mutations/permission_group/permission_group_create.py
@@ -54,7 +54,7 @@ class PermissionGroupInput(BaseInputObjectType):
 class PermissionGroupCreateInput(PermissionGroupInput):
     name = graphene.String(description="Group name.", required=True)
     restricted_access_to_channels = graphene.Boolean(
-        description=("Determine if the group has restricted access to channels.")
+        description="Determine if the group has restricted access to channels."
         + ADDED_IN_314
         + PREVIEW_FEATURE,
         required=False,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -28056,13 +28056,13 @@ input PermissionGroupCreateInput @doc(category: "Users") {
   name: String!
 
   """
-  Determine if the group has restricted access to channels.  DEFAULT: False
+  Determine if the group has restricted access to channels.
   
   Added in Saleor 3.14.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
-  restrictedAccessToChannels: Boolean = false
+  restrictedAccessToChannels: Boolean
 }
 
 """


### PR DESCRIPTION
I want to merge this change because it simplifies permissionGroupCreate.
Fixes https://github.com/saleor/saleor/issues/13026

Documentation PR: https://github.com/saleor/saleor-docs/pull/823

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [x] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
