### PR TITLE
Add webhook description to menu's mutations

### DIFF
--- a/saleor/graphql/menu/bulk_mutations/menu_bulk_delete.py
+++ b/saleor/graphql/menu/bulk_mutations/menu_bulk_delete.py
@@ -2,9 +2,11 @@ import graphene
 
 from ....menu import models
 from ....permission.enums import MenuPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.mutations import ModelBulkDeleteMutation
 from ...core.types import MenuError, NonNullList
+from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Menu
 
@@ -22,6 +24,12 @@ class MenuBulkDelete(ModelBulkDeleteMutation):
         permissions = (MenuPermissions.MANAGE_MENUS,)
         error_type_class = MenuError
         error_type_field = "menu_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.MENU_DELETED,
+                description="A menu was deleted.",
+            ),
+        ]
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):

--- a/saleor/graphql/menu/bulk_mutations/menu_item_bulk_delete.py
+++ b/saleor/graphql/menu/bulk_mutations/menu_item_bulk_delete.py
@@ -2,9 +2,11 @@ import graphene
 
 from ....menu import models
 from ....permission.enums import MenuPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.mutations import ModelBulkDeleteMutation
 from ...core.types import MenuError, NonNullList
+from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import MenuItem
 
@@ -22,6 +24,12 @@ class MenuItemBulkDelete(ModelBulkDeleteMutation):
         permissions = (MenuPermissions.MANAGE_MENUS,)
         error_type_class = MenuError
         error_type_field = "menu_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.MENU_ITEM_DELETED,
+                description="A menu item was deleted.",
+            ),
+        ]
 
     @classmethod
     def bulk_action(cls, info: ResolveInfo, queryset, /):

--- a/saleor/graphql/menu/mutations/menu_create.py
+++ b/saleor/graphql/menu/mutations/menu_create.py
@@ -4,10 +4,12 @@ from django.core.exceptions import ValidationError
 from ....menu import models
 from ....menu.error_codes import MenuErrorCode
 from ....permission.enums import MenuPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...channel import ChannelContext
 from ...core import ResolveInfo
 from ...core.mutations import ModelMutation
 from ...core.types import MenuError, NonNullList
+from ...core.utils import WebhookEventInfo
 from ...core.validators import validate_slug_and_generate_if_needed
 from ...page.types import Page
 from ...plugins.dataloaders import get_plugin_manager_promise
@@ -38,6 +40,12 @@ class MenuCreate(ModelMutation):
         permissions = (MenuPermissions.MANAGE_MENUS,)
         error_type_class = MenuError
         error_type_field = "menu_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.MENU_CREATED,
+                description="A menu was created.",
+            ),
+        ]
 
     @classmethod
     def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):

--- a/saleor/graphql/menu/mutations/menu_delete.py
+++ b/saleor/graphql/menu/mutations/menu_delete.py
@@ -2,10 +2,12 @@ import graphene
 
 from ....menu import models
 from ....permission.enums import MenuPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...channel import ChannelContext
 from ...core import ResolveInfo
 from ...core.mutations import ModelDeleteMutation
 from ...core.types import MenuError
+from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Menu
 
@@ -21,6 +23,12 @@ class MenuDelete(ModelDeleteMutation):
         permissions = (MenuPermissions.MANAGE_MENUS,)
         error_type_class = MenuError
         error_type_field = "menu_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.MENU_DELETED,
+                description="A menu was deleted.",
+            ),
+        ]
 
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):

--- a/saleor/graphql/menu/mutations/menu_item_create.py
+++ b/saleor/graphql/menu/mutations/menu_item_create.py
@@ -9,10 +9,12 @@ from ....menu.error_codes import MenuErrorCode
 from ....page import models as page_models
 from ....permission.enums import MenuPermissions
 from ....product import models as product_models
+from ....webhook.event_types import WebhookEventAsyncType
 from ...channel import ChannelContext
 from ...core import ResolveInfo
 from ...core.mutations import ModelMutation
 from ...core.types import MenuError
+from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import MenuItem
 
@@ -57,6 +59,12 @@ class MenuItemCreate(ModelMutation):
         permissions = (MenuPermissions.MANAGE_MENUS,)
         error_type_class = MenuError
         error_type_field = "menu_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.MENU_ITEM_CREATED,
+                description="A menu item was created.",
+            ),
+        ]
 
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):

--- a/saleor/graphql/menu/mutations/menu_item_delete.py
+++ b/saleor/graphql/menu/mutations/menu_item_delete.py
@@ -2,10 +2,12 @@ import graphene
 
 from ....menu import models
 from ....permission.enums import MenuPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...channel import ChannelContext
 from ...core import ResolveInfo
 from ...core.mutations import ModelDeleteMutation
 from ...core.types import MenuError
+from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import MenuItem
 
@@ -21,6 +23,12 @@ class MenuItemDelete(ModelDeleteMutation):
         permissions = (MenuPermissions.MANAGE_MENUS,)
         error_type_class = MenuError
         error_type_field = "menu_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.MENU_ITEM_DELETED,
+                description="A menu item was deleted.",
+            ),
+        ]
 
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):

--- a/saleor/graphql/menu/mutations/menu_item_move.py
+++ b/saleor/graphql/menu/mutations/menu_item_move.py
@@ -8,11 +8,13 @@ from ....core.tracing import traced_atomic_transaction
 from ....menu import models
 from ....menu.error_codes import MenuErrorCode
 from ....permission.enums import MenuPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...channel import ChannelContext
 from ...core import ResolveInfo
 from ...core.doc_category import DOC_CATEGORY_MENU
 from ...core.mutations import BaseMutation
 from ...core.types import MenuError, NonNullList
+from ...core.utils import WebhookEventInfo
 from ...core.utils.reordering import perform_reordering
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..dataloaders import MenuItemsByParentMenuLoader
@@ -42,6 +44,15 @@ class MenuItemMove(BaseMutation):
         permissions = (MenuPermissions.MANAGE_MENUS,)
         error_type_class = MenuError
         error_type_field = "menu_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.MENU_ITEM_UPDATED,
+                description=(
+                    "Optionally triggered when sort order or parent changed for "
+                    "menu item."
+                ),
+            ),
+        ]
 
     @classmethod
     def success_response(cls, instance):

--- a/saleor/graphql/menu/mutations/menu_item_update.py
+++ b/saleor/graphql/menu/mutations/menu_item_update.py
@@ -2,8 +2,10 @@ import graphene
 
 from ....menu import models
 from ....permission.enums import MenuPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.types import MenuError
+from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import MenuItem
 from .menu_item_create import MenuItemCreate, MenuItemInput
@@ -27,6 +29,12 @@ class MenuItemUpdate(MenuItemCreate):
         permissions = (MenuPermissions.MANAGE_MENUS,)
         error_type_class = MenuError
         error_type_field = "menu_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.MENU_ITEM_UPDATED,
+                description="A menu item was updated.",
+            ),
+        ]
 
     @classmethod
     def construct_instance(cls, instance, cleaned_data):

--- a/saleor/graphql/menu/mutations/menu_update.py
+++ b/saleor/graphql/menu/mutations/menu_update.py
@@ -2,10 +2,12 @@ import graphene
 
 from ....menu import models
 from ....permission.enums import MenuPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...channel import ChannelContext
 from ...core import ResolveInfo
 from ...core.mutations import ModelMutation
 from ...core.types import MenuError
+from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Menu
 
@@ -29,6 +31,12 @@ class MenuUpdate(ModelMutation):
         permissions = (MenuPermissions.MANAGE_MENUS,)
         error_type_class = MenuError
         error_type_field = "menu_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.MENU_UPDATED,
+                description="A menu was updated.",
+            ),
+        ]
 
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15789,36 +15789,48 @@ type Mutation {
   Creates a new Menu. 
   
   Requires one of the following permissions: MANAGE_MENUS.
+  
+  Triggers the following webhook events:
+  - MENU_CREATED (async): A menu was created.
   """
   menuCreate(
     """Fields required to create a menu."""
     input: MenuCreateInput!
-  ): MenuCreate @doc(category: "Menu")
+  ): MenuCreate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_CREATED], syncEvents: [])
 
   """
   Deletes a menu. 
   
   Requires one of the following permissions: MANAGE_MENUS.
+  
+  Triggers the following webhook events:
+  - MENU_DELETED (async): A menu was deleted.
   """
   menuDelete(
     """ID of a menu to delete."""
     id: ID!
-  ): MenuDelete @doc(category: "Menu")
+  ): MenuDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_DELETED], syncEvents: [])
 
   """
   Deletes menus. 
   
   Requires one of the following permissions: MANAGE_MENUS.
+  
+  Triggers the following webhook events:
+  - MENU_DELETED (async): A menu was deleted.
   """
   menuBulkDelete(
     """List of menu IDs to delete."""
     ids: [ID!]!
-  ): MenuBulkDelete @doc(category: "Menu")
+  ): MenuBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_DELETED], syncEvents: [])
 
   """
   Updates a menu. 
   
   Requires one of the following permissions: MANAGE_MENUS.
+  
+  Triggers the following webhook events:
+  - MENU_UPDATED (async): A menu was updated.
   """
   menuUpdate(
     """ID of a menu to update."""
@@ -15826,44 +15838,56 @@ type Mutation {
 
     """Fields required to update a menu."""
     input: MenuInput!
-  ): MenuUpdate @doc(category: "Menu")
+  ): MenuUpdate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_UPDATED], syncEvents: [])
 
   """
   Creates a new menu item. 
   
   Requires one of the following permissions: MANAGE_MENUS.
+  
+  Triggers the following webhook events:
+  - MENU_ITEM_CREATED (async): A menu item was created.
   """
   menuItemCreate(
     """
     Fields required to update a menu item. Only one of `url`, `category`, `page`, `collection` is allowed per item.
     """
     input: MenuItemCreateInput!
-  ): MenuItemCreate @doc(category: "Menu")
+  ): MenuItemCreate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_CREATED], syncEvents: [])
 
   """
   Deletes a menu item. 
   
   Requires one of the following permissions: MANAGE_MENUS.
+  
+  Triggers the following webhook events:
+  - MENU_ITEM_DELETED (async): A menu item was deleted.
   """
   menuItemDelete(
     """ID of a menu item to delete."""
     id: ID!
-  ): MenuItemDelete @doc(category: "Menu")
+  ): MenuItemDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_DELETED], syncEvents: [])
 
   """
   Deletes menu items. 
   
   Requires one of the following permissions: MANAGE_MENUS.
+  
+  Triggers the following webhook events:
+  - MENU_ITEM_DELETED (async): A menu item was deleted.
   """
   menuItemBulkDelete(
     """List of menu item IDs to delete."""
     ids: [ID!]!
-  ): MenuItemBulkDelete @doc(category: "Menu")
+  ): MenuItemBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_DELETED], syncEvents: [])
 
   """
   Updates a menu item. 
   
   Requires one of the following permissions: MANAGE_MENUS.
+  
+  Triggers the following webhook events:
+  - MENU_ITEM_UPDATED (async): A menu item was updated.
   """
   menuItemUpdate(
     """ID of a menu item to update."""
@@ -15873,7 +15897,7 @@ type Mutation {
     Fields required to update a menu item. Only one of `url`, `category`, `page`, `collection` is allowed per item.
     """
     input: MenuItemInput!
-  ): MenuItemUpdate @doc(category: "Menu")
+  ): MenuItemUpdate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_UPDATED], syncEvents: [])
 
   """
   Creates/updates translations for a menu item. 
@@ -15893,6 +15917,9 @@ type Mutation {
   Moves items of menus. 
   
   Requires one of the following permissions: MANAGE_MENUS.
+  
+  Triggers the following webhook events:
+  - MENU_ITEM_UPDATED (async): Optionally triggered when sort order or parent changed for menu item.
   """
   menuItemMove(
     """ID of the menu."""
@@ -15900,7 +15927,7 @@ type Mutation {
 
     """The menu position data."""
     moves: [MenuItemMoveInput!]!
-  ): MenuItemMove @doc(category: "Menu")
+  ): MenuItemMove @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_UPDATED], syncEvents: [])
 
   """
   Request an invoice for the order using plugin. 
@@ -24297,8 +24324,11 @@ enum NavigationType {
 Creates a new Menu. 
 
 Requires one of the following permissions: MANAGE_MENUS.
+
+Triggers the following webhook events:
+- MENU_CREATED (async): A menu was created.
 """
-type MenuCreate @doc(category: "Menu") {
+type MenuCreate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_CREATED], syncEvents: []) {
   menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
@@ -24336,8 +24366,11 @@ input MenuItemInput {
 Deletes a menu. 
 
 Requires one of the following permissions: MANAGE_MENUS.
+
+Triggers the following webhook events:
+- MENU_DELETED (async): A menu was deleted.
 """
-type MenuDelete @doc(category: "Menu") {
+type MenuDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_DELETED], syncEvents: []) {
   menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
@@ -24347,8 +24380,11 @@ type MenuDelete @doc(category: "Menu") {
 Deletes menus. 
 
 Requires one of the following permissions: MANAGE_MENUS.
+
+Triggers the following webhook events:
+- MENU_DELETED (async): A menu was deleted.
 """
-type MenuBulkDelete @doc(category: "Menu") {
+type MenuBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_DELETED], syncEvents: []) {
   """Returns how many objects were affected."""
   count: Int!
   menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
@@ -24359,8 +24395,11 @@ type MenuBulkDelete @doc(category: "Menu") {
 Updates a menu. 
 
 Requires one of the following permissions: MANAGE_MENUS.
+
+Triggers the following webhook events:
+- MENU_UPDATED (async): A menu was updated.
 """
-type MenuUpdate @doc(category: "Menu") {
+type MenuUpdate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_UPDATED], syncEvents: []) {
   menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
@@ -24378,8 +24417,11 @@ input MenuInput {
 Creates a new menu item. 
 
 Requires one of the following permissions: MANAGE_MENUS.
+
+Triggers the following webhook events:
+- MENU_ITEM_CREATED (async): A menu item was created.
 """
-type MenuItemCreate @doc(category: "Menu") {
+type MenuItemCreate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_CREATED], syncEvents: []) {
   menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
@@ -24412,8 +24454,11 @@ input MenuItemCreateInput {
 Deletes a menu item. 
 
 Requires one of the following permissions: MANAGE_MENUS.
+
+Triggers the following webhook events:
+- MENU_ITEM_DELETED (async): A menu item was deleted.
 """
-type MenuItemDelete @doc(category: "Menu") {
+type MenuItemDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_DELETED], syncEvents: []) {
   menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
@@ -24423,8 +24468,11 @@ type MenuItemDelete @doc(category: "Menu") {
 Deletes menu items. 
 
 Requires one of the following permissions: MANAGE_MENUS.
+
+Triggers the following webhook events:
+- MENU_ITEM_DELETED (async): A menu item was deleted.
 """
-type MenuItemBulkDelete @doc(category: "Menu") {
+type MenuItemBulkDelete @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_DELETED], syncEvents: []) {
   """Returns how many objects were affected."""
   count: Int!
   menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
@@ -24435,8 +24483,11 @@ type MenuItemBulkDelete @doc(category: "Menu") {
 Updates a menu item. 
 
 Requires one of the following permissions: MANAGE_MENUS.
+
+Triggers the following webhook events:
+- MENU_ITEM_UPDATED (async): A menu item was updated.
 """
-type MenuItemUpdate @doc(category: "Menu") {
+type MenuItemUpdate @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_UPDATED], syncEvents: []) {
   menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
@@ -24457,8 +24508,11 @@ type MenuItemTranslate @doc(category: "Menu") {
 Moves items of menus. 
 
 Requires one of the following permissions: MANAGE_MENUS.
+
+Triggers the following webhook events:
+- MENU_ITEM_UPDATED (async): Optionally triggered when sort order or parent changed for menu item.
 """
-type MenuItemMove @doc(category: "Menu") {
+type MenuItemMove @doc(category: "Menu") @webhookEventsInfo(asyncEvents: [MENU_ITEM_UPDATED], syncEvents: []) {
   """Assigned menu to move within."""
   menu: Menu
   menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")


### PR DESCRIPTION
I want to merge this change because it adds webhook description to menu modules 
Next module explained in: https://github.com/saleor/saleor/issues/12591

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
