### PR TITLE
Fix the permission check in webhook resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add missing descriptions to Product module. - #13259 by @FremahA
 - Add missing description for Invoice module - #13265 by @DevilsAutumn
 - Add missing descriptions to Discount module - #13261 by @devilsautumn
+- Fix error handling in the permission check for `Query.webhook` - #13378 by @patrys
 
 # 3.14.0
 

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -8,17 +8,18 @@ from ...permission.enums import AppPermission
 from ...webhook import models, payloads
 from ...webhook.deprecated_event_types import WebhookEventType
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
+from ..core import ResolveInfo
 from ..core.tracing import traced_resolver
 from ..core.utils import from_global_id_or_error
 from .types import Webhook, WebhookEvent
 
 
-def resolve_webhook(info, id, app):
+def resolve_webhook(info: ResolveInfo, id, app):
     _, id = from_global_id_or_error(id, Webhook)
     if app:
         return app.webhooks.filter(id=id).first()
     user = info.context.user
-    if user.has_perm(AppPermission.MANAGE_APPS):
+    if user and user.has_perm(AppPermission.MANAGE_APPS):
         return models.Webhook.objects.filter(pk=id).first()
     raise PermissionDenied(permissions=[AppPermission.MANAGE_APPS])
 
@@ -31,7 +32,7 @@ def resolve_webhook_events():
 
 
 @traced_resolver
-def resolve_sample_payload(info, event_name, app):
+def resolve_sample_payload(info: ResolveInfo, event_name, app):
     user = info.context.user
     required_permission = WebhookEventAsyncType.PERMISSIONS.get(
         event_name, WebhookEventSyncType.PERMISSIONS.get(event_name)
@@ -46,7 +47,7 @@ def resolve_sample_payload(info, event_name, app):
         raise PermissionDenied(permissions=[required_permission])
 
 
-def resolve_shipping_methods_for_checkout(info, checkout, manager):
+def resolve_shipping_methods_for_checkout(info: ResolveInfo, checkout, manager):
     lines, _ = fetch_checkout_lines(checkout)
     shipping_channel_listings = checkout.channel.shipping_method_listings.all()
     checkout_info = fetch_checkout_info(

--- a/saleor/graphql/webhook/tests/queries/test_webhook.py
+++ b/saleor/graphql/webhook/tests/queries/test_webhook.py
@@ -105,6 +105,21 @@ def test_query_webhook_by_app_without_permission(app_api_client):
     assert webhook_response is None
 
 
+def test_query_webhook_by_anonymnous_client(api_client):
+    second_app = App.objects.create(name="Sample app account", is_active=True)
+    webhook = Webhook.objects.create(
+        app=second_app, target_url="http://www.example.com/test"
+    )
+    webhook.events.create(event_type="order_created")
+
+    query = QUERY_WEBHOOK
+    webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
+    variables = {"id": webhook_id}
+    response = api_client.post_graphql(query, variables=variables)
+    content = get_graphql_content(response, ignore_errors=True)
+    assert content["data"]["webhook"] is None
+
+
 def test_query_webhook_sync_and_async_events(
     staff_api_client, webhook, permission_manage_apps
 ):


### PR DESCRIPTION
Fixes a crash when the resolver is called but the user is `None`.

Sentry trace: https://saleor.sentry.io/issues/3827257742/

Also add type information for the info parameter to avoid similar issues in the future.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
