### PR TITLE
Call webhook SHOP_METADATA_UPDATED in shopSettingsUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,8 @@ Shipping methods can be removed by the user after it has been assigned to a chec
 ### Saleor Apps
 
 - Introduce `Saleor-Schema-Version` HTTP header in app manifest fetching and app installation handshake requests. - #13075 by @przlada
-- Add `SHOP_METADATA_UPDATED` webhook - #13364 by @maarcingebala
+- Add `SHOP_METADATA_UPDATED` webhook - #13364, #13388 by @maarcingebala
+  - Called when metadata is changed for the Shop object via the generic metadata API or the `shopSettingsUpdate` mutation.
 
 ### Other changes
 - Add POC of Core API tests - #13034 by @fowczarek

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13866,11 +13866,14 @@ type Mutation {
   Updates shop settings. 
   
   Requires one of the following permissions: MANAGE_SETTINGS.
+  
+  Triggers the following webhook events:
+  - SHOP_METADATA_UPDATED (async): Optionally triggered when public or private metadata is updated.
   """
   shopSettingsUpdate(
     """Fields required to update shop settings."""
     input: ShopSettingsInput!
-  ): ShopSettingsUpdate @doc(category: "Shop")
+  ): ShopSettingsUpdate @doc(category: "Shop") @webhookEventsInfo(asyncEvents: [SHOP_METADATA_UPDATED], syncEvents: [])
 
   """
   Fetch tax rates. 
@@ -19053,8 +19056,11 @@ input SiteDomainInput {
 Updates shop settings. 
 
 Requires one of the following permissions: MANAGE_SETTINGS.
+
+Triggers the following webhook events:
+- SHOP_METADATA_UPDATED (async): Optionally triggered when public or private metadata is updated.
 """
-type ShopSettingsUpdate @doc(category: "Shop") {
+type ShopSettingsUpdate @doc(category: "Shop") @webhookEventsInfo(asyncEvents: [SHOP_METADATA_UPDATED], syncEvents: []) {
   """Updated shop."""
   shop: Shop
   shopErrors: [ShopError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")

--- a/saleor/graphql/shop/mutations/shop_settings_update.py
+++ b/saleor/graphql/shop/mutations/shop_settings_update.py
@@ -5,6 +5,7 @@ from ....core.error_codes import ShopErrorCode
 from ....core.utils.url import validate_storefront_url
 from ....permission.enums import SitePermissions
 from ....site.models import DEFAULT_LIMIT_QUANTITY_PER_CHECKOUT
+from ....webhook.event_types import WebhookEventAsyncType
 from ...core import ResolveInfo
 from ...core.descriptions import (
     ADDED_IN_31,
@@ -17,7 +18,9 @@ from ...core.enums import WeightUnitsEnum
 from ...core.mutations import BaseMutation
 from ...core.types import ShopError
 from ...core.types import common as common_types
+from ...core.utils import WebhookEventInfo
 from ...meta.inputs import MetadataInput
+from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Shop
 
@@ -128,6 +131,14 @@ class ShopSettingsUpdate(BaseMutation):
         error_type_field = "shop_errors"
         support_meta_field = True
         support_private_meta_field = True
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.SHOP_METADATA_UPDATED,
+                description=(
+                    "Optionally triggered when public or private metadata is updated."
+                ),
+            ),
+        ]
 
     @classmethod
     def clean_input(cls, _info, _instance, data):
@@ -178,10 +189,22 @@ class ShopSettingsUpdate(BaseMutation):
         instance = site.settings
         data = data.get("input")
         cleaned_input = cls.clean_input(info, instance, data)
+
         metadata_list = cleaned_input.pop("metadata", None)
         private_metadata_list = cleaned_input.pop("private_metadata", None)
+        old_metadata = dict(instance.metadata)
+        old_private_metadata = dict(instance.private_metadata)
+
         instance = cls.construct_instance(instance, cleaned_input)
         cls.validate_and_update_metadata(instance, metadata_list, private_metadata_list)
         cls.clean_instance(info, instance)
         instance.save()
+
+        if (
+            instance.metadata != old_metadata
+            or instance.private_metadata != old_private_metadata
+        ):
+            manager = get_plugin_manager_promise(info.context).get()
+            manager.shop_metadata_updated(instance)
+
         return ShopSettingsUpdate(shop=Shop())

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -44,7 +44,7 @@ from ..core.utils import str_to_enum
 from ..meta.types import ObjectWithMetadata
 from ..plugins.dataloaders import plugin_manager_promise_callback
 from ..shipping.types import ShippingMethod
-from ..site.dataloaders import load_site_callback
+from ..site.dataloaders import get_site_promise, load_site_callback
 from ..translations.fields import TranslationField
 from ..translations.resolvers import resolve_translation
 from ..translations.types import ShopTranslation
@@ -371,8 +371,12 @@ class Shop(graphene.ObjectType):
         return site_models.SiteSettings
 
     @staticmethod
-    def get_node(_info: ResolveInfo, id):
-        return site_models.SiteSettings.objects.first() if id == SHOP_ID else None
+    def get_node(info: ResolveInfo, id):
+        if id == SHOP_ID:
+            site = get_site_promise(info.context).get()
+            return site.settings
+
+        return None
 
     @staticmethod
     def resolve_id(_, _info):


### PR DESCRIPTION
When shop metadata is changed via `shopSettingsUpdate` mutation, trigger the webhook `SHOP_METADATA_UPDATED`. Also improved resolving the SiteSettings instance in Shop's `get_node` to rely on current site.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
