### PR TITLE
[TEST] Should be able to create account and login

### DIFF
--- a/saleor/graphql/account/tests/mutations/account/test_account_register.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_register.py
@@ -51,9 +51,7 @@ ACCOUNT_REGISTER_MUTATION = """
 """
 
 
-@override_settings(
-    ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL=True, ALLOWED_CLIENT_HOSTS=["localhost"]
-)
+@override_settings(ALLOWED_CLIENT_HOSTS=["localhost"])
 @patch("saleor.account.notifications.default_token_generator.make_token")
 @patch("saleor.plugins.manager.PluginsManager.notify")
 def test_customer_register(

--- a/saleor/graphql/account/tests/mutations/account/test_account_register.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_register.py
@@ -51,7 +51,9 @@ ACCOUNT_REGISTER_MUTATION = """
 """
 
 
-@override_settings(ALLOWED_CLIENT_HOSTS=["localhost"])
+@override_settings(
+    ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL=True, ALLOWED_CLIENT_HOSTS=["localhost"]
+)
 @patch("saleor.account.notifications.default_token_generator.make_token")
 @patch("saleor.plugins.manager.PluginsManager.notify")
 def test_customer_register(

--- a/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
@@ -1,0 +1,28 @@
+import pytest
+from django.test import override_settings
+
+from ..channel.utils import create_channel
+from ..utils import assign_permissions
+from .utils import account_register
+
+
+@override_settings(ALLOWED_CLIENT_HOSTS=["localhost"])
+@pytest.mark.e2e
+def test_should_create_account_without_email_confirmation_core_1502(
+    e2e_not_logged_api_client,
+    e2e_staff_api_client,
+    permission_manage_channels,
+):
+    assign_permissions(e2e_staff_api_client, [permission_manage_channels])
+    chanel_data = create_channel(e2e_staff_api_client)
+    channel_slug = chanel_data["slug"]
+
+    # Step 1 Create account for the new customer
+    user_account = account_register(
+        e2e_not_logged_api_client,
+        "new-user@saleor.io",
+        "password!",
+        channel_slug,
+    )
+
+    assert user_account["id"] is not None

--- a/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
@@ -3,10 +3,13 @@ from django.test import override_settings
 
 from ..channel.utils import create_channel
 from ..utils import assign_permissions
-from .utils import account_register
+from .utils import account_register, token_create
 
 
-@override_settings(ALLOWED_CLIENT_HOSTS=["localhost"])
+@override_settings(
+    ALLOWED_CLIENT_HOSTS=["localhost"],
+    ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL=False,
+)
 @pytest.mark.e2e
 def test_should_create_account_without_email_confirmation_core_1502(
     e2e_not_logged_api_client,
@@ -17,12 +20,21 @@ def test_should_create_account_without_email_confirmation_core_1502(
     chanel_data = create_channel(e2e_staff_api_client)
     channel_slug = chanel_data["slug"]
 
-    # Step 1 Create account for the new customer
+    test_email = "new-user@saleor.io"
+    test_password = "password!"
+
+    # Step 1 - Create account for the new customer
     user_account = account_register(
         e2e_not_logged_api_client,
-        "new-user@saleor.io",
-        "password!",
+        test_email,
+        test_password,
         channel_slug,
     )
 
     assert user_account["id"] is not None
+
+    # Step 2 - Authenticate as new created user
+
+    login_data = token_create(e2e_not_logged_api_client, test_email, test_password)
+
+    assert login_data["email"] == test_email

--- a/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
@@ -1,24 +1,27 @@
 import pytest
-from django.test import override_settings
 
 from ..channel.utils import create_channel
+from ..shop.utils import update_shop_settings
 from ..utils import assign_permissions
 from .utils import account_register, token_create
 
 
-@override_settings(
-    ALLOWED_CLIENT_HOSTS=["localhost"],
-    ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL=False,
-)
 @pytest.mark.e2e
 def test_should_create_account_without_email_confirmation_core_1502(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
     permission_manage_channels,
+    permission_manage_settings,
 ):
-    assign_permissions(e2e_staff_api_client, [permission_manage_channels])
+    # Before
+    permissions = [permission_manage_channels, permission_manage_settings]
+
+    assign_permissions(e2e_staff_api_client, permissions)
+
     chanel_data = create_channel(e2e_staff_api_client)
     channel_slug = chanel_data["slug"]
+
+    update_shop_settings(e2e_staff_api_client, enableAccountConfirmationByEmail=False)
 
     test_email = "new-user@saleor.io"
     test_password = "password!"
@@ -30,11 +33,12 @@ def test_should_create_account_without_email_confirmation_core_1502(
         test_password,
         channel_slug,
     )
-
-    assert user_account["id"] is not None
+    user_id = user_account["id"]
+    assert user_account["isActive"] is True
 
     # Step 2 - Authenticate as new created user
 
     login_data = token_create(e2e_not_logged_api_client, test_email, test_password)
 
+    assert login_data["id"] == user_id
     assert login_data["email"] == test_email

--- a/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
@@ -15,7 +15,6 @@ def test_should_create_account_without_email_confirmation_core_1502(
 ):
     # Before
     permissions = [permission_manage_channels, permission_manage_settings]
-
     assign_permissions(e2e_staff_api_client, permissions)
 
     chanel_data = create_channel(e2e_staff_api_client)

--- a/saleor/tests/e2e/account/utils.py
+++ b/saleor/tests/e2e/account/utils.py
@@ -1,0 +1,49 @@
+from ..utils import get_graphql_content
+
+ACCOUNT_REGISTER_MUTATION = """
+mutation AccountRegister($input: AccountRegisterInput!) {
+  accountRegister(input: $input) {
+    errors {
+      field
+      message
+      code
+    }
+    requiresConfirmation
+    user{
+      id
+      email
+    }
+  }
+}
+"""
+
+
+def account_register(
+    e2e_not_logged_api_client,
+    email,
+    password,
+    channel_slug,
+    redirectUrl="http://localhost:3000/",
+):
+    variables = {
+        "input": {
+            "email": email,
+            "password": password,
+            "channel_slug": channel_slug,
+            "redirectUrl": redirectUrl,
+        }
+    }
+
+    response = e2e_not_logged_api_client.post_graphql(
+        ACCOUNT_REGISTER_MUTATION,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["accountRegister"]["errors"] == []
+
+    data = content["data"]["accountRegister"]["user"]
+    assert data["id"] is not None
+    assert data["email"] == email
+
+    return data

--- a/saleor/tests/e2e/account/utils/__init__.py
+++ b/saleor/tests/e2e/account/utils/__init__.py
@@ -1,0 +1,5 @@
+from .account_register import account_register
+
+__all__ = [
+    "account_register",
+]

--- a/saleor/tests/e2e/account/utils/__init__.py
+++ b/saleor/tests/e2e/account/utils/__init__.py
@@ -1,5 +1,7 @@
 from .account_register import account_register
+from .token_create import token_create
 
 __all__ = [
     "account_register",
+    "token_create",
 ]

--- a/saleor/tests/e2e/account/utils/account_register.py
+++ b/saleor/tests/e2e/account/utils/account_register.py
@@ -12,6 +12,7 @@ mutation AccountRegister($input: AccountRegisterInput!) {
     user{
       id
       email
+      isActive
     }
   }
 }
@@ -23,14 +24,12 @@ def account_register(
     email,
     password,
     channel_slug,
-    redirectUrl="http://localhost:3000/",
 ):
     variables = {
         "input": {
             "email": email,
             "password": password,
             "channel": channel_slug,
-            "redirectUrl": redirectUrl,
         }
     }
 

--- a/saleor/tests/e2e/account/utils/account_register.py
+++ b/saleor/tests/e2e/account/utils/account_register.py
@@ -1,4 +1,4 @@
-from ..utils import get_graphql_content
+from ...utils import get_graphql_content
 
 ACCOUNT_REGISTER_MUTATION = """
 mutation AccountRegister($input: AccountRegisterInput!) {
@@ -29,7 +29,7 @@ def account_register(
         "input": {
             "email": email,
             "password": password,
-            "channel_slug": channel_slug,
+            "channel": channel_slug,
             "redirectUrl": redirectUrl,
         }
     }

--- a/saleor/tests/e2e/account/utils/account_register.py
+++ b/saleor/tests/e2e/account/utils/account_register.py
@@ -9,7 +9,7 @@ mutation AccountRegister($input: AccountRegisterInput!) {
       code
     }
     requiresConfirmation
-    user{
+    user {
       id
       email
       isActive

--- a/saleor/tests/e2e/account/utils/token_create.py
+++ b/saleor/tests/e2e/account/utils/token_create.py
@@ -1,0 +1,43 @@
+from ...utils import get_graphql_content
+
+TOKEN_CREATE_MUTATION = """
+mutation TokenCreate($email: String!, $password: String!) {
+  tokenCreate(email: $email, password: $password) {
+    errors {
+      field
+      message
+      code
+    }
+    token
+    refreshToken
+    user {
+      id
+      email
+    }
+  }
+}
+"""
+
+
+def token_create(
+    e2e_not_logged_api_client,
+    email,
+    password,
+):
+    variables = {"email": email, "password": password}
+
+    response = e2e_not_logged_api_client.post_graphql(
+        TOKEN_CREATE_MUTATION,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["tokenCreate"]["errors"] == []
+
+    assert content["data"]["tokenCreate"]["token"] == "123"
+
+    data = content["data"]["tokenCreate"]["user"]
+    assert data["id"] is not None
+    assert data["email"] == email
+
+    return data

--- a/saleor/tests/e2e/account/utils/token_create.py
+++ b/saleor/tests/e2e/account/utils/token_create.py
@@ -34,7 +34,8 @@ def token_create(
 
     assert content["data"]["tokenCreate"]["errors"] == []
 
-    assert content["data"]["tokenCreate"]["token"] == "123"
+    assert content["data"]["tokenCreate"]["token"] is not None
+    assert content["data"]["tokenCreate"]["refreshToken"] is not None
 
     data = content["data"]["tokenCreate"]["user"]
     assert data["id"] is not None

--- a/saleor/tests/e2e/shop/utils.py
+++ b/saleor/tests/e2e/shop/utils.py
@@ -1,0 +1,34 @@
+from ..utils import get_graphql_content
+
+SHOP_SETTING_UPDATE_MUTATION = """
+mutation ShopSettingsUpdate($input: ShopSettingsInput!) {
+  shopSettingsUpdate(input: $input) {
+    errors {
+      field
+      message
+      code
+    }
+    shop {
+      enableAccountConfirmationByEmail
+    }
+  }
+}
+"""
+
+
+def update_shop_settings(staff_api_client, enableAccountConfirmationByEmail=False):
+    variables = {
+        "input": {
+            "enableAccountConfirmationByEmail": enableAccountConfirmationByEmail,
+        }
+    }
+
+    response = staff_api_client.post_graphql(SHOP_SETTING_UPDATE_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    assert content["data"]["shopSettingsUpdate"]["errors"] == []
+
+    data = content["data"]["shopSettingsUpdate"]["shop"]
+    assert data["enableAccountConfirmationByEmail"] == enableAccountConfirmationByEmail
+
+    return data


### PR DESCRIPTION
I want to merge this change because it adds a test for creating an account and login CORE_1502

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
