### PR TITLE
App id in tracing

### DIFF
--- a/saleor/core/tracing.py
+++ b/saleor/core/tracing.py
@@ -23,13 +23,14 @@ def opentracing_trace(span_name, component_name, service_name):
 
 
 @contextmanager
-def webhooks_opentracing_trace(span_name, domain, sync=False, app_name=None):
+def webhooks_opentracing_trace(span_name, domain, sync=False, app=None):
     with opentracing.global_tracer().start_active_span(
         f"webhooks.{span_name}"
     ) as scope:
         span = scope.span
-        if app_name:
-            span.set_tag("app.name", app_name)
+        if app:
+            span.set_tag("app.id", app.id)
+            span.set_tag("app.name", app.name)
         span.set_tag(opentracing.tags.COMPONENT, "webhooks")
         span.set_tag("service.name", "webhooks")
         span.set_tag("webhooks.domain", domain)

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -336,6 +336,7 @@ class GraphQLView(View):
             except Exception as e:
                 span.set_tag(opentracing.tags.ERROR, True)
                 if app := getattr(request, "app", None):
+                    span.set_tag("app.id", app.id)
                     span.set_tag("app.name", app.name)
                 # In the graphql-core version that we are using,
                 # the Exception is raised for too big integers value.

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -258,7 +258,7 @@ def trigger_webhook_sync(
     if timeout:
         kwargs = {"timeout": timeout}
 
-    return send_webhook_request_sync(webhook.app.name, delivery, **kwargs)
+    return send_webhook_request_sync(webhook.app, delivery, **kwargs)
 
 
 R = TypeVar("R")
@@ -312,7 +312,7 @@ def trigger_all_webhooks_sync(
                 webhook=webhook,
             )
 
-        response_data = send_webhook_request_sync(webhook.app.name, delivery)
+        response_data = send_webhook_request_sync(webhook.app, delivery)
         if parsed_response := parse_response(response_data):
             return parsed_response
     return None
@@ -562,9 +562,7 @@ def send_webhook_request_async(self, event_delivery_id):
                 "Event delivery id: %r has no payload." % event_delivery_id
             )
         data = delivery.payload.payload
-        with webhooks_opentracing_trace(
-            delivery.event_type, domain, app_name=webhook.app.name
-        ):
+        with webhooks_opentracing_trace(delivery.event_type, domain, app=webhook.app):
             response = send_webhook_using_scheme_method(
                 webhook.target_url,
                 domain,
@@ -596,7 +594,7 @@ def send_webhook_request_async(self, event_delivery_id):
 
 
 def _send_webhook_request_sync(
-    app_name, delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT, attempt=None
+    app, delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT, attempt=None
 ) -> Tuple[WebhookResponse, Optional[Dict[Any, Any]]]:
     event_payload = delivery.payload
     data = event_payload.payload
@@ -622,7 +620,7 @@ def _send_webhook_request_sync(
 
     try:
         with webhooks_opentracing_trace(
-            delivery.event_type, domain, sync=True, app_name=app_name
+            delivery.event_type, domain, sync=True, app=app
         ):
             response = send_webhook_using_http(
                 webhook.target_url,
@@ -669,9 +667,9 @@ def _send_webhook_request_sync(
 
 
 def send_webhook_request_sync(
-    app_name, delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT
+    app, delivery, timeout=settings.WEBHOOK_SYNC_TIMEOUT
 ) -> Optional[Dict[Any, Any]]:
-    response, response_data = _send_webhook_request_sync(app_name, delivery, timeout)
+    response, response_data = _send_webhook_request_sync(app, delivery, timeout)
     return response_data if response.status == EventDeliveryStatus.SUCCESS else None
 
 
@@ -816,7 +814,7 @@ def trigger_transaction_request(
     call_event(
         handle_transaction_request_task.delay,
         delivery.id,
-        webhook.app.name,
+        webhook.app,
         transaction_data.event.id,
     )
     return None
@@ -827,7 +825,7 @@ def trigger_transaction_request(
     retry_backoff=10,
     retry_kwargs={"max_retries": 5},
 )
-def handle_transaction_request_task(self, delivery_id, app_name, request_event_id):
+def handle_transaction_request_task(self, delivery_id, app, request_event_id):
     delivery = get_delivery_for_webhook(delivery_id)
     if not delivery:
         logger.error(
@@ -843,9 +841,7 @@ def handle_transaction_request_task(self, delivery_id, app_name, request_event_i
         )
         return None
     attempt = create_attempt(delivery, self.request.id)
-    response, response_data = _send_webhook_request_sync(
-        app_name, delivery, attempt=attempt
-    )
+    response, response_data = _send_webhook_request_sync(app, delivery, attempt=attempt)
     if response.response_status_code and response.response_status_code >= 500:
         handle_webhook_retry(
             self, delivery.webhook, response.content, delivery, attempt

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
@@ -78,7 +78,7 @@ def test_trigger_webhook_sync_with_subscription(
 
     # then
     assert json.loads(event_delivery.payload.payload) == expected_payment_payload
-    mock_request.assert_called_once_with(payment_app.name, event_delivery)
+    mock_request.assert_called_once_with(payment_app, event_delivery)
 
 
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")

--- a/saleor/plugins/webhook/tests/test_payment_gateway_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_gateway_initialize_session_webhook.py
@@ -82,7 +82,7 @@ def _assert_fields(payload, webhook, expected_data, response, mock_request):
     )
     assert delivery.payload == event_payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook.app.name, delivery)
+    mock_request.assert_called_once_with(webhook.app, delivery)
     assert response == [
         PaymentGatewayData(app_identifier=webhook_app.identifier, data=expected_data)
     ]

--- a/saleor/plugins/webhook/tests/test_payment_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook.py
@@ -55,7 +55,7 @@ def test_trigger_webhook_sync(mock_request, payment_app):
         WebhookEventSyncType.PAYMENT_CAPTURE, data, payment_app.webhooks.first()
     )
     event_delivery = EventDelivery.objects.first()
-    mock_request.assert_called_once_with(payment_app.name, event_delivery)
+    mock_request.assert_called_once_with(payment_app, event_delivery)
 
 
 @mock.patch("saleor.plugins.webhook.tasks.create_delivery_for_subscription_sync_event")
@@ -76,7 +76,7 @@ def test_trigger_webhook_sync_with_subscription(
         payment_app.webhooks.first(),
         payment,
     )
-    mock_request.assert_called_once_with(payment_app.name, fake_delivery)
+    mock_request.assert_called_once_with(payment_app, fake_delivery)
 
 
 @mock.patch("saleor.plugins.webhook.tasks.observability.report_event_delivery_attempt")
@@ -97,7 +97,7 @@ def test_send_webhook_request_sync_failed_attempt(
     mock_post().status_code = expected_data["status_code"]
     mock_post().elapsed = expected_data["duration"]
     # when
-    response_data = send_webhook_request_sync(app.name, event_delivery)
+    response_data = send_webhook_request_sync(app, event_delivery)
     attempt = EventDeliveryAttempt.objects.first()
 
     # then
@@ -130,7 +130,7 @@ def test_send_webhook_request_sync_successful_attempt(
     mock_post().status_code = expected_data["status_code"]
     mock_post().elapsed = expected_data["duration"]
     # when
-    response_data = send_webhook_request_sync(app.name, event_delivery)
+    response_data = send_webhook_request_sync(app, event_delivery)
 
     attempt = EventDeliveryAttempt.objects.first()
 
@@ -163,7 +163,7 @@ def test_send_webhook_request_sync_request_exception(
     )
 
     # when
-    response_data = send_webhook_request_sync(app.name, event_delivery)
+    response_data = send_webhook_request_sync(app, event_delivery)
     attempt = EventDeliveryAttempt.objects.first()
 
     # then
@@ -189,7 +189,7 @@ def test_send_webhook_request_sync_when_exception_with_response(
     mock_response.status_code = 302
     mock_post.side_effect = TooManyRedirects(response=mock_response)
     # when
-    send_webhook_request_sync(app.name, event_delivery)
+    send_webhook_request_sync(app, event_delivery)
     attempt = EventDeliveryAttempt.objects.first()
 
     # then
@@ -217,7 +217,7 @@ def test_send_webhook_request_sync_json_parsing_error(
     mock_post().status_code = expected_data["status_code"]
 
     # when
-    response_data = send_webhook_request_sync(app.name, event_delivery)
+    response_data = send_webhook_request_sync(app, event_delivery)
     attempt = EventDeliveryAttempt.objects.first()
 
     # then
@@ -237,7 +237,7 @@ def test_send_webhook_request_with_proper_timeout(mock_post, event_delivery, app
     mock_post().headers = {"header_key": "header_val"}
     mock_post().elapsed = datetime.timedelta(seconds=1)
     mock_post().status_code = 200
-    send_webhook_request_sync(app.name, event_delivery)
+    send_webhook_request_sync(app, event_delivery)
     assert mock_post.call_args.kwargs["timeout"] == settings.WEBHOOK_SYNC_TIMEOUT
 
 
@@ -253,7 +253,7 @@ def test_send_webhook_request_sync_invalid_scheme(webhook, app):
             payload=event_payload,
             webhook=webhook,
         )
-        send_webhook_request_sync(app.name, delivery)
+        send_webhook_request_sync(app, delivery)
 
 
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -518,7 +518,7 @@ def test_trigger_webhook_sync(mock_request, shipping_app):
         WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT, data, webhook
     )
     event_delivery = EventDelivery.objects.first()
-    mock_request.assert_called_once_with(shipping_app.name, event_delivery)
+    mock_request.assert_called_once_with(shipping_app, event_delivery)
 
 
 @mock.patch("saleor.plugins.webhook.shipping.cache.set")

--- a/saleor/plugins/webhook/tests/test_tasks.py
+++ b/saleor/plugins/webhook/tests/test_tasks.py
@@ -80,7 +80,7 @@ def test_trigger_transaction_request(
     assert generated_delivery.webhook == webhook
     assert generated_delivery.payload == generated_payload
 
-    mocked_task.assert_called_once_with(generated_delivery.id, app.name, event.id)
+    mocked_task.assert_called_once_with(generated_delivery.id, app, event.id)
 
 
 @freeze_time("2022-06-11 12:50")
@@ -158,7 +158,7 @@ def test_trigger_transaction_request_with_webhook_subscription(
 
     assert generated_delivery.payload == generated_payload
 
-    mocked_task.assert_called_once_with(generated_delivery.id, app.name, event.id)
+    mocked_task.assert_called_once_with(generated_delivery.id, app, event.id)
 
 
 @freeze_time("2022-06-11 12:50")
@@ -210,7 +210,7 @@ def test_handle_transaction_request_task_with_only_psp_reference(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app.name, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
 
     # then
     assert TransactionEvent.objects.count() == 1
@@ -277,7 +277,7 @@ def test_handle_transaction_request_task_with_server_error(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app.name, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
 
     # then
     assert mocked_webhook_retry.called
@@ -330,7 +330,7 @@ def test_handle_transaction_request_task_with_missing_psp_reference(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app.name, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
 
     # then
     assert (
@@ -413,7 +413,7 @@ def test_handle_transaction_request_task_with_missing_required_event_field(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app.name, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
 
     # then
     assert (
@@ -505,7 +505,7 @@ def test_handle_transaction_request_task_with_result_event(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app.name, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
 
     # then
     assert TransactionEvent.objects.all().count() == 2
@@ -596,7 +596,7 @@ def test_handle_transaction_request_task_with_only_required_fields_for_result_ev
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app.name, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
 
     # then
     assert TransactionEvent.objects.all().count() == 2
@@ -700,7 +700,7 @@ def test_handle_transaction_request_task_calls_recalculation_of_amounts(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app.name, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
 
     # then
     mocked_recalculation.assert_called_once_with(transaction, save=False)
@@ -764,7 +764,7 @@ def test_handle_transaction_request_task_with_available_actions(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app.name, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
 
     # then
     assert TransactionEvent.objects.all().count() == 2

--- a/saleor/plugins/webhook/tests/test_tax_webhook.py
+++ b/saleor/plugins/webhook/tests/test_tax_webhook.py
@@ -63,7 +63,7 @@ def test_get_taxes_for_order(
     assert delivery.event_type == WebhookEventSyncType.ORDER_CALCULATE_TAXES
     assert delivery.payload == payload
     assert delivery.webhook == tax_order_webhook
-    mock_request.assert_called_once_with(tax_order_webhook.app.name, delivery)
+    mock_request.assert_called_once_with(tax_order_webhook.app, delivery)
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)
 
@@ -181,7 +181,7 @@ def test_get_taxes_for_order_with_sync_subscription(
     assert delivery.event_type == WebhookEventSyncType.ORDER_CALCULATE_TAXES
     assert delivery.payload == payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook.app.name, delivery)
+    mock_request.assert_called_once_with(webhook.app, delivery)
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)
 
@@ -222,6 +222,6 @@ def test_get_taxes_for_checkout_with_sync_subscription(
     assert delivery.event_type == WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
     assert delivery.payload == payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook.app.name, delivery)
+    mock_request.assert_called_once_with(webhook.app, delivery)
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)

--- a/saleor/plugins/webhook/tests/test_tax_webhook_tasks.py
+++ b/saleor/plugins/webhook/tests/test_tax_webhook_tasks.py
@@ -58,7 +58,7 @@ def test_trigger_tax_webhook_sync(
     assert delivery.event_type == event_type
     assert delivery.payload == payload
     assert delivery.webhook == tax_checkout_webhook
-    mock_request.assert_called_once_with(tax_checkout_webhook.app.name, delivery)
+    mock_request.assert_called_once_with(tax_checkout_webhook.app, delivery)
     assert tax_data == parse_tax_data(tax_data_response)
 
 
@@ -86,7 +86,7 @@ def test_trigger_tax_webhook_sync_multiple_webhooks_first(
     assert delivery.event_type == event_type
     assert delivery.payload == payload
     assert delivery.webhook == successful_webhook
-    mock_request.assert_called_once_with(successful_webhook.app.name, delivery)
+    mock_request.assert_called_once_with(successful_webhook.app, delivery)
     assert tax_data == parse_tax_data(tax_data_response)
 
 
@@ -116,7 +116,7 @@ def test_trigger_tax_webhook_sync_multiple_webhooks_last(
         assert delivery.event_type == event_type
         assert delivery.payload == payload
         assert delivery.webhook == webhook
-        assert call[0] == (webhook.app.name, delivery)
+        assert call[0] == (webhook.app, delivery)
 
     assert mock_request.call_count == 3
     assert tax_data == parse_tax_data(tax_data_response)

--- a/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
@@ -110,7 +110,7 @@ def _assert_fields(payload, webhook, expected_response, response, mock_request):
     assert delivery.event_type == WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION
     assert delivery.payload == event_payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook_app.name, delivery)
+    mock_request.assert_called_once_with(webhook_app, delivery)
     assert response == PaymentGatewayData(
         app_identifier=webhook_app.identifier, data=expected_response, error=None
     )

--- a/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
@@ -110,7 +110,7 @@ def _assert_fields(payload, webhook, expected_response, response, mock_request):
     assert delivery.event_type == WebhookEventSyncType.TRANSACTION_PROCESS_SESSION
     assert delivery.payload == event_payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook_app.name, delivery)
+    mock_request.assert_called_once_with(webhook_app, delivery)
     assert response == PaymentGatewayData(
         app_identifier=webhook_app.identifier, data=expected_response, error=None
     )


### PR DESCRIPTION
I want to merge this change because it's a port of https://github.com/saleor/saleor/pull/13223
It adds App ID to tracing spans.
The issue is that app names are not unique. One may create few apps with the same name and webhooks - in trace you'll see a couple of requests created by same app but the might be different apps. Now that we have ID these will be easy to differentiate.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
