### PR TITLE
Update last_login on externalRefresh mutation

### DIFF
--- a/saleor/graphql/account/mutations/authentication/external_refresh.py
+++ b/saleor/graphql/account/mutations/authentication/external_refresh.py
@@ -1,4 +1,5 @@
 import graphene
+from django.utils import timezone
 
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_AUTH
@@ -45,8 +46,11 @@ class ExternalRefresh(BaseMutation):
         access_tokens_response = manager.external_refresh(plugin_id, input, request)
         setattr(info.context, "refresh_token", access_tokens_response.refresh_token)
 
-        if access_tokens_response.user and access_tokens_response.user.id:
-            info.context._cached_user = access_tokens_response.user
+        if access_tokens_response.user:
+            if access_tokens_response.user.id:
+                info.context._cached_user = access_tokens_response.user
+            access_tokens_response.user.last_login = timezone.now()
+            access_tokens_response.user.save(update_fields=["last_login", "updated_at"])
 
         return cls(
             token=access_tokens_response.token,

--- a/saleor/graphql/account/tests/mutations/authentication/test_external_refresh.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_external_refresh.py
@@ -1,6 +1,8 @@
 import json
 from unittest.mock import Mock, patch
 
+from freezegun import freeze_time
+
 from ......plugins.base_plugin import ExternalAccessTokens
 from .....tests.utils import get_graphql_content
 
@@ -33,6 +35,7 @@ def test_external_refresh_plugin_not_active(api_client, customer_user):
     assert data["user"] is None
 
 
+@freeze_time("2018-05-31 12:00:00")
 @patch("saleor.core.middleware.jwt_decode_with_exception_handler")
 def test_external_refresh(
     mock_refresh_token_middleware, api_client, customer_user, monkeypatch, rf
@@ -52,12 +55,17 @@ def test_external_refresh(
         "saleor.plugins.manager.PluginsManager.external_refresh", mocked_plugin_fun
     )
     variables = {"pluginId": "pluginId1", "input": json.dumps({"refreshToken": "ABCD"})}
+    assert customer_user.last_login is None
     response = api_client.post_graphql(MUTATION_EXTERNAL_REFRESH, variables)
     content = get_graphql_content(response)
+    customer_user.refresh_from_db()
     data = content["data"]["externalRefresh"]
     assert data["token"] == expected_token
     assert data["refreshToken"] == expected_refresh_token
     assert data["csrfToken"] == expected_csrf_token
     assert data["user"]["email"] == customer_user.email
+    assert customer_user.last_login
+    last_login = customer_user.last_login.strftime("%Y-%m-%d %H:%M:%S")
+    assert last_login == "2018-05-31 12:00:00"
     assert mocked_plugin_fun.called
     assert mock_refresh_token_middleware.called


### PR DESCRIPTION
I want to merge this change because it updates `last_login` on `externalRefresh` mutation.
Resolves https://github.com/saleor/saleor/issues/13435

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
