### PR TITLE
Fix checkout lines dataloader

### DIFF
--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -12,12 +12,20 @@ from prices import Money, TaxedMoney
 
 from ...account.models import Address
 from ...core.taxes import zero_money
-from ...discount import DiscountValueType, VoucherType
-from ...discount.models import NotApplicable, Voucher, VoucherChannelListing
+from ...discount import DiscountType, DiscountValueType, RewardValueType, VoucherType
+from ...discount.models import (
+    CheckoutLineDiscount,
+    NotApplicable,
+    Voucher,
+    VoucherChannelListing,
+)
 from ...discount.utils import generate_sale_discount_objects_for_checkout
 from ...payment.models import Payment
 from ...plugins.manager import get_plugins_manager
-from ...product.models import ProductVariantChannelListing
+from ...product.models import (
+    ProductVariantChannelListing,
+    VariantChannelListingPromotionRule,
+)
 from ...shipping.interface import ShippingMethodData
 from ...shipping.models import ShippingZone
 from .. import base_calculations, calculations
@@ -25,6 +33,7 @@ from ..fetch import (
     CheckoutInfo,
     CheckoutLineInfo,
     DeliveryMethodBase,
+    VariantPromotionRuleInfo,
     fetch_checkout_info,
     fetch_checkout_lines,
     get_delivery_method_info,
@@ -1226,6 +1235,91 @@ def test_recalculate_checkout_discount_with_sale(
         lines=lines,
         address=checkout.shipping_address,
     ).gross == Money("13.50", "USD")
+
+
+def test_recalculate_checkout_discount_with_promotion(
+    checkout_with_voucher_percentage,
+    voucher_percentage,
+    promotion_without_rules,
+):
+    # given
+    checkout = checkout_with_voucher_percentage
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    voucher_discount = (
+        voucher_percentage.channel_listings.filter(channel=checkout.channel)
+        .first()
+        .discount_value
+    )
+
+    line_info = lines[0]
+    reward_value = Decimal("1")
+    rule = promotion_without_rules.rules.create(
+        name="Percentage promotion rule",
+        catalogue_predicate={
+            "productPredicate": {
+                "ids": [
+                    graphene.Node.to_global_id("Product", line_info.variant.product.id)
+                ]
+            }
+        },
+        reward_value_type=RewardValueType.FIXED,
+        reward_value=reward_value,
+    )
+    rule.channels.add(line_info.channel)
+
+    listing = line_info.channel_listing
+    discounted_price = listing.price.amount - reward_value
+    listing.discounted_price_amount = discounted_price
+    listing.save(update_fields=["discounted_price_amount"])
+
+    listing_promotion_rule = VariantChannelListingPromotionRule.objects.create(
+        variant_channel_listing=listing,
+        promotion_rule=rule,
+        discount_amount=reward_value,
+        currency=line_info.channel.currency_code,
+    )
+
+    line_discount = CheckoutLineDiscount.objects.create(
+        line=line_info.line,
+        type=DiscountType.PROMOTION,
+        value_type=DiscountValueType.FIXED,
+        amount_value=reward_value * line_info.line.quantity,
+        currency=line_info.channel.currency_code,
+        promotion_rule=rule,
+    )
+    line_info.discounts = [line_discount]
+    line_info.rules_info = [
+        VariantPromotionRuleInfo(
+            rule=rule,
+            variant_listing_promotion_rule=listing_promotion_rule,
+            promotion=promotion_without_rules,
+            promotion_translation=None,
+            rule_translation=None,
+        )
+    ]
+
+    # when
+    recalculate_checkout_discount(manager, checkout_info, lines)
+
+    # then
+    discounted_subtotal = listing.discounted_price_amount * line_info.line.quantity
+    voucher_discount = voucher_discount / 100 * discounted_subtotal
+    assert checkout.discount.amount == voucher_discount
+
+    checkout.price_expiration = timezone.now()
+    checkout.save()
+    assert (
+        calculations.checkout_total(
+            manager=manager,
+            checkout_info=checkout_info,
+            lines=lines,
+            address=checkout.shipping_address,
+        ).gross.amount
+        == discounted_subtotal - voucher_discount
+    )
 
 
 def test_recalculate_checkout_discount_voucher_not_applicable(

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -245,71 +245,67 @@ class VariantPromotionRuleInfoByCheckoutLineIdLoader(DataLoader):
     context_key = "variant_promotion_rule_info_by_checkout_line_id"
 
     def batch_load(self, keys):
-        def with_checkout_lines(results):
-            checkouts, checkout_lines = results
+        def with_checkout_lines(checkout_lines):
+            def with_checkouts(checkouts):
+                variants_pks = [line.variant_id for line in checkout_lines]
+                if not variants_pks:
+                    return []
 
-            variants_pks = set()
-            lines_pks = set()
-            for lines in checkout_lines:
-                for line in lines:
-                    lines_pks.add(line.id)
-                    variants_pks.add(line.variant_id)
-            lines_pks = list(lines_pks)
-            variants_pks = list(variants_pks)
-            if not variants_pks:
-                return [[] for _ in keys]
+                channel_pks = [checkout.channel_id for checkout in checkouts]
 
-            channel_pks = [checkout.channel_id for checkout in checkouts]
-
-            def with_channel_listings(channel_listings):
-                def with_channel_listing_promotion_rules(
-                    variant_listing_promotion_rules,
-                ):
-                    rule_ids: List[int] = []
-                    rule_ids_language_codes: List[Tuple[int, str]] = []
-                    for listing_promotion_rules, language_code in zip(
-                        variant_listing_promotion_rules, language_codes
+                def with_channel_listings(channel_listings):
+                    def with_channel_listing_promotion_rules(
+                        variant_listing_promotion_rules,
                     ):
-                        for listing_promotion_rule in listing_promotion_rules:
-                            rule_ids.append(listing_promotion_rule.promotion_rule_id)
-                            rule_ids_language_codes.append(
-                                (
-                                    listing_promotion_rule.promotion_rule_id,
-                                    language_code,
+                        rule_ids: List[int] = []
+                        rule_ids_language_codes: List[Tuple[int, str]] = []
+                        for listing_promotion_rules, language_code in zip(
+                            variant_listing_promotion_rules, language_codes
+                        ):
+                            for listing_promotion_rule in listing_promotion_rules:
+                                rule_ids.append(
+                                    listing_promotion_rule.promotion_rule_id
                                 )
-                            )
-
-                    def with_promotion_rules(results):
-                        promotion_rules, promotions, rule_translations = results
-
-                        promotion_ids_language_codes = [
-                            (rule.promotion_id, language_code)
-                            for rule, (_rule_id, language_code) in zip(
-                                promotion_rules, rule_ids_language_codes
-                            )
-                        ]
-
-                        def with_promotion_translations(promotion_translations):
-                            channel_listings_map = dict(
-                                zip(variant_ids_channel_ids, channel_listings)
-                            )
-                            listing_promotion_rules_map = dict(
-                                zip(
-                                    channel_listing_ids, variant_listing_promotion_rules
+                                rule_ids_language_codes.append(
+                                    (
+                                        listing_promotion_rule.promotion_rule_id,
+                                        language_code,
+                                    )
                                 )
-                            )
-                            rule_map = dict(zip(rule_ids, promotion_rules))
-                            rule_id_to_promotion_map = dict(zip(rule_ids, promotions))
-                            rule_id_to_rule_translation = dict(
-                                zip(rule_ids, rule_translations)
-                            )
-                            rule_id_to_promotion_translation = dict(
-                                zip(rule_ids, promotion_translations)
-                            )
 
-                            rules_info_map = defaultdict(list)
-                            for checkout, lines in zip(checkouts, checkout_lines):
-                                for line in lines:
+                        def with_promotion_rules(results):
+                            promotion_rules, promotions, rule_translations = results
+
+                            promotion_ids_language_codes = [
+                                (rule.promotion_id, language_code)
+                                for rule, (_rule_id, language_code) in zip(
+                                    promotion_rules, rule_ids_language_codes
+                                )
+                            ]
+
+                            def with_promotion_translations(promotion_translations):
+                                channel_listings_map = dict(
+                                    zip(variant_ids_channel_ids, channel_listings)
+                                )
+                                listing_promotion_rules_map = dict(
+                                    zip(
+                                        channel_listing_ids,
+                                        variant_listing_promotion_rules,
+                                    )
+                                )
+                                rule_map = dict(zip(rule_ids, promotion_rules))
+                                rule_id_to_promotion_map = dict(
+                                    zip(rule_ids, promotions)
+                                )
+                                rule_id_to_rule_translation = dict(
+                                    zip(rule_ids, rule_translations)
+                                )
+                                rule_id_to_promotion_translation = dict(
+                                    zip(rule_ids, promotion_translations)
+                                )
+
+                                rules_info_map = defaultdict(list)
+                                for checkout, line in zip(checkouts, checkout_lines):
                                     channel_listing = channel_listings_map[
                                         (line.variant_id, checkout.channel_id)
                                     ]
@@ -318,81 +314,86 @@ class VariantPromotionRuleInfoByCheckoutLineIdLoader(DataLoader):
                                         if channel_listing
                                         else []
                                     )
-                                    rules_info_map[line.id].append(
-                                        [
-                                            VariantPromotionRuleInfo(
-                                                rule=rule_map[
-                                                    listing_rule.promotion_rule_id
-                                                ],
-                                                variant_listing_promotion_rule=listing_rule,
-                                                promotion=rule_id_to_promotion_map[
-                                                    listing_rule.promotion_rule_id
-                                                ],
-                                                rule_translation=rule_id_to_rule_translation[
-                                                    listing_rule.promotion_rule_id
-                                                ],
-                                                promotion_translation=rule_id_to_promotion_translation[
-                                                    listing_rule.promotion_rule_id
-                                                ],
-                                            )
-                                            for listing_rule in listing_promotion_rules
-                                        ]
-                                    )
+                                    rules_info_map[line.id] = [
+                                        VariantPromotionRuleInfo(
+                                            rule=rule_map[
+                                                listing_rule.promotion_rule_id
+                                            ],
+                                            variant_listing_promotion_rule=listing_rule,
+                                            promotion=rule_id_to_promotion_map[
+                                                listing_rule.promotion_rule_id
+                                            ],
+                                            rule_translation=rule_id_to_rule_translation[
+                                                listing_rule.promotion_rule_id
+                                            ],
+                                            promotion_translation=rule_id_to_promotion_translation[
+                                                listing_rule.promotion_rule_id
+                                            ],
+                                        )
+                                        for listing_rule in listing_promotion_rules
+                                    ]
 
-                            return [rules_info_map[key] for key in keys]
+                                return [rules_info_map[key] for key in keys]
 
-                        return (
-                            PromotionTranslationByIdAndLanguageCodeLoader(self.context)
-                            .load_many(promotion_ids_language_codes)
-                            .then(with_promotion_translations)
+                            return (
+                                PromotionTranslationByIdAndLanguageCodeLoader(
+                                    self.context
+                                )
+                                .load_many(promotion_ids_language_codes)
+                                .then(with_promotion_translations)
+                            )
+
+                        promotion_rules = PromotionRuleByIdLoader(
+                            self.context
+                        ).load_many(rule_ids)
+                        promotions = PromotionByRuleIdLoader(self.context).load_many(
+                            rule_ids
                         )
 
-                    promotion_rules = PromotionRuleByIdLoader(self.context).load_many(
-                        rule_ids
-                    )
-                    promotions = PromotionByRuleIdLoader(self.context).load_many(
-                        rule_ids
-                    )
+                        rules_translations = (
+                            PromotionRuleTranslationByIdAndLanguageCodeLoader(
+                                self.context
+                            ).load_many(rule_ids_language_codes)
+                        )
+                        return Promise.all(
+                            [promotion_rules, promotions, rules_translations]
+                        ).then(with_promotion_rules)
 
-                    rules_translations = (
-                        PromotionRuleTranslationByIdAndLanguageCodeLoader(
+                    channel_listing_ids = [
+                        listing.id for listing in channel_listings if listing
+                    ]
+                    return (
+                        VariantChannelListingPromotionRuleByListingIdLoader(
                             self.context
-                        ).load_many(rule_ids_language_codes)
+                        )
+                        .load_many(channel_listing_ids)
+                        .then(with_channel_listing_promotion_rules)
                     )
-                    return Promise.all(
-                        [promotion_rules, promotions, rules_translations]
-                    ).then(with_promotion_rules)
 
-                channel_listing_ids = [
-                    listing.id for listing in channel_listings if listing
+                variant_ids_channel_ids = [
+                    (line.variant_id, channel_id)
+                    for line, channel_id in zip(checkout_lines, channel_pks)
                 ]
+                language_codes = [checkout.language_code for checkout in checkouts]
+
                 return (
-                    VariantChannelListingPromotionRuleByListingIdLoader(self.context)
-                    .load_many(channel_listing_ids)
-                    .then(with_channel_listing_promotion_rules)
+                    VariantChannelListingByVariantIdAndChannelIdLoader(self.context)
+                    .load_many(variant_ids_channel_ids)
+                    .then(with_channel_listings)
                 )
 
-            variant_ids_channel_ids = []
-            language_codes = []
-            for channel_id, lines, checkout in zip(
-                channel_pks, checkout_lines, checkouts
-            ):
-                variant_ids_channel_ids.extend(
-                    [(line.variant_id, channel_id) for line in lines]
-                )
-                language_codes.extend([checkout.language_code for line in lines])
-
+            checkout_tokens = [line.checkout_id for line in checkout_lines]
             return (
-                VariantChannelListingByVariantIdAndChannelIdLoader(self.context)
-                .load_many(variant_ids_channel_ids)
-                .then(with_channel_listings)
+                CheckoutByTokenLoader(self.context)
+                .load_many(checkout_tokens)
+                .then(with_checkouts)
             )
 
-        checkouts = CheckoutByTokenLoader(self.context).load_many(keys)
-        checkout_lines = CheckoutLinesByCheckoutTokenLoader(self.context).load_many(
-            keys
+        return (
+            CheckoutLineByIdLoader(self.context)
+            .load_many(keys)
+            .then(with_checkout_lines)
         )
-        return Promise.all([checkouts, checkout_lines]).then(with_checkout_lines)
 
 
 class CheckoutInfoByCheckoutTokenLoader(DataLoader[str, CheckoutInfo]):

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -412,7 +412,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(64):
+    with django_assert_num_queries(63):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 1
@@ -430,7 +430,7 @@ def test_create_checkout_with_reservations(
         }
     }
 
-    with django_assert_num_queries(64):
+    with django_assert_num_queries(63):
         response = api_client.post_graphql(query, variables)
         assert get_graphql_content(response)["data"]["checkoutCreate"]
         assert Checkout.objects.first().lines.count() == 10
@@ -681,7 +681,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-    with django_assert_num_queries(78):
+    with django_assert_num_queries(77):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -695,7 +695,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(78):
+    with django_assert_num_queries(77):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],
@@ -940,7 +940,7 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(77):
+    with django_assert_num_queries(76):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -953,7 +953,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(77):
+    with django_assert_num_queries(76):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1663,6 +1663,75 @@ def test_checkout_prices_with_sales(
     assert line_total_price.gross.amount < undiscounted_total_price
 
 
+def test_checkout_prices_with_promotion(
+    user_api_client, checkout_with_item_on_promotion
+):
+    # given
+    query = QUERY_CHECKOUT_PRICES
+    checkout = checkout_with_item_on_promotion
+    variables = {"id": to_global_id_or_none(checkout)}
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    # when
+    response = user_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkout"]
+
+    # then
+    assert data["token"] == str(checkout.token)
+    assert len(data["lines"]) == checkout.lines.count()
+
+    checkout.refresh_from_db()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    total = calculations.checkout_total(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=checkout.shipping_address,
+    )
+    assert data["totalPrice"]["gross"]["amount"] == (total.gross.amount)
+    subtotal = calculations.checkout_subtotal(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=checkout.shipping_address,
+    )
+    assert data["subtotalPrice"]["gross"]["amount"] == (subtotal.gross.amount)
+    line_info = lines[0]
+    assert line_info.line.quantity > 0
+    line_total_price = calculations.checkout_line_total(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        checkout_line_info=line_info,
+    )
+    assert data["lines"][0]["unitPrice"]["gross"]["amount"] == round(
+        line_total_price.gross.amount / line_info.line.quantity, 2
+    )
+    assert (
+        data["lines"][0]["totalPrice"]["gross"]["amount"]
+        == line_total_price.gross.amount
+    )
+    undiscounted_unit_price = line_info.variant.get_base_price(
+        line_info.channel_listing,
+        line_info.line.price_override,
+    )
+    undiscounted_total_price = undiscounted_unit_price.amount * line_info.line.quantity
+    assert (
+        data["lines"][0]["undiscountedUnitPrice"]["amount"]
+        == undiscounted_unit_price.amount
+    )
+    assert (
+        data["lines"][0]["undiscountedTotalPrice"]["amount"] == undiscounted_total_price
+    )
+    assert line_total_price.gross.amount < undiscounted_total_price
+
+
 def test_checkout_display_gross_prices_use_default(user_api_client, checkout_with_item):
     # given
     variables = {"id": to_global_id_or_none(checkout_with_item)}

--- a/saleor/graphql/discount/dataloaders.py
+++ b/saleor/graphql/discount/dataloaders.py
@@ -328,7 +328,5 @@ class PromotionByRuleIdLoader(DataLoader):
             .filter(Exists(rules.filter(promotion_id=OuterRef("id"))))
             .in_bulk()
         )
-        promotion_map = defaultdict(list)
-        for rule in rules:
-            promotion_map[rule.id].append(promotions.get(rule.promotion_id))
-        return [promotion_map.get(rule_id, []) for rule_id in keys]
+        promotion_map = {rule.id: promotions.get(rule.promotion_id) for rule in rules}
+        return [promotion_map.get(rule_id) for rule_id in keys]


### PR DESCRIPTION
Fix `VariantPromotionRuleInfoByCheckoutLineIdLoader` data loader, add tests for checkout price recalculations with promotions.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
