### PR TITLE
Use public key thumbprint as KID in JWKS.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable, unreleased changes to this project will be documented in this file.
 # 3.15.0 [Unreleased]
 
 ### Breaking changes
-- Use public key thumbprint as KID in JWKS.json #13442 by @cmiacz
 - Remove input and fields related to transaction API and deprecated in 3.13 - #13020 by @korycins
   - `WebhookEventTypeEnum.TRANSACTION_ACTION_REQUEST` - Use `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead.
   - `WebhookEventTypeAsyncEnum.TRANSACTION_ACTION_REQUEST` - Use `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead.
@@ -83,6 +82,7 @@ Shipping methods can be removed by the user after it has been assigned to a chec
   - Called when metadata is changed for the Shop object via the generic metadata API or the `shopSettingsUpdate` mutation.
 
 ### Other changes
+- Use public key thumbprint as KID in JWKS.json #13442 by @cmiacz
 - Add POC of Core API tests - #13034 by @fowczarek
 
 - Expand metric units to support more types of products. - #13043 by @FremahA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable, unreleased changes to this project will be documented in this file.
 # 3.15.0 [Unreleased]
 
 ### Breaking changes
+- Use public key thumbprint as KID in JWKS.json #13442 by @cmiacz
 - Remove input and fields related to transaction API and deprecated in 3.13 - #13020 by @korycins
   - `WebhookEventTypeEnum.TRANSACTION_ACTION_REQUEST` - Use `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead.
   - `WebhookEventTypeAsyncEnum.TRANSACTION_ACTION_REQUEST` - Use `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead.

--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -4,6 +4,7 @@ from os.path import exists, join
 from typing import Optional, Union, cast
 
 import jwt
+from authlib.jose import JsonWebKey
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from django.conf import settings
@@ -20,7 +21,6 @@ from .utils import build_absolute_uri
 logger = logging.getLogger(__name__)
 
 PUBLIC_KEY: Optional[rsa.RSAPublicKey] = None
-KID = "1"
 
 
 class JWTManagerBase:
@@ -56,6 +56,10 @@ class JWTManagerBase:
 
     @classmethod
     def get_jwks(cls) -> dict:
+        return NotImplemented
+
+    @classmethod
+    def get_key_id(cls) -> str:
         return NotImplemented
 
     @classmethod
@@ -138,8 +142,17 @@ class JWTManager(JWTManagerBase):
     @classmethod
     def get_jwks(cls) -> dict:
         jwk_dict = json.loads(RSAAlgorithm.to_jwk(cls.get_public_key()))
-        jwk_dict.update({"use": "sig", "kid": KID})
+        jwk_dict.update({"use": "sig", "kid": cls.get_key_id()})
         return {"keys": [jwk_dict]}
+
+    @classmethod
+    def get_key_id(cls) -> str:
+        public_key_pem = cls.get_public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        jwk = JsonWebKey.import_key(public_key_pem)
+        return jwk.thumbprint()
 
     @classmethod
     def encode(cls, payload):
@@ -147,7 +160,7 @@ class JWTManager(JWTManagerBase):
             payload,
             cls.get_private_key(),  # type: ignore[arg-type] # key is typed as str for all algos # noqa: E501
             algorithm="RS256",
-            headers={"kid": KID},
+            headers={"kid": cls.get_key_id()},
         )
 
     @classmethod
@@ -156,7 +169,7 @@ class JWTManager(JWTManagerBase):
             payload,
             key=cls.get_private_key(),  # type: ignore[arg-type] # key is typed as str for all algos # noqa: E501
             algorithm="RS256",
-            headers={"kid": KID},
+            headers={"kid": cls.get_key_id()},
             is_payload_detached=is_payload_detached,
         )
 

--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -148,7 +148,7 @@ class JWTManager(JWTManagerBase):
     @classmethod
     def get_key_id(cls) -> str:
         """Generate JWT key ID for the public key.
-        
+
         This generates a "thumbprint" as 'kid' field using RFC 7638 implementation
         based on the RSA public key.
         """

--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -147,6 +147,11 @@ class JWTManager(JWTManagerBase):
 
     @classmethod
     def get_key_id(cls) -> str:
+        """Generate JWT key ID for the public key.
+        
+        This generates a "thumbprint" as 'kid' field using RFC 7638 implementation
+        based on the RSA public key.
+        """
         public_key_pem = cls.get_public_key().public_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PublicFormat.SubjectPublicKeyInfo,


### PR DESCRIPTION
I want to merge this change because we have issues with key rotation.
It is expected that KID changes if we rotate RSA key for JWT. Right now we have hardcoded `KID: 1`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
