### PR TITLE
Clean up with naming in structures used in transaction API

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
@@ -118,7 +118,7 @@ class TransactionInitialize(TransactionSessionBase):
         app = cls.clean_app_from_payment_gateway(payment_gateway_data)
         transaction, event, data = handle_transaction_initialize_session(
             source_object=source_object,
-            payment_gateway=payment_gateway_data,
+            payment_gateway_data=payment_gateway_data,
             amount=amount,
             action=action,
             app=app,

--- a/saleor/graphql/payment/mutations/transaction/transaction_process.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_process.py
@@ -172,7 +172,7 @@ class TransactionProcess(BaseMutation):
         event, data = handle_transaction_process_session(
             transaction_item=transaction_item,
             source_object=source_object,
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=app_identifier, data=data
             ),
             app=app,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -13,6 +13,7 @@ from .....payment.interface import (
     PaymentGatewayData,
     TransactionProcessActionData,
     TransactionSessionData,
+    TransactionSessionResult,
 )
 from ....channel.enums import TransactionFlowStrategyEnum
 from ....core.enums import TransactionInitializeErrorCode
@@ -166,7 +167,7 @@ def _assert_fields(
                 amount=expected_amount,
                 currency=source_object.currency,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=app_identifier, data=None, error=None
             ),
         )
@@ -192,8 +193,8 @@ def test_for_checkout_without_payment_gateway_data(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = "CHARGE_SUCCESS"
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -243,8 +244,8 @@ def test_for_order_without_payment_gateway_data(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = "CHARGE_SUCCESS"
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -294,8 +295,8 @@ def test_checkout_with_pending_amount(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -346,8 +347,8 @@ def test_order_with_pending_amount(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -399,8 +400,8 @@ def test_checkout_with_action_required_response(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -449,8 +450,8 @@ def test_order_with_action_required_response(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -499,8 +500,8 @@ def test_checkout_with_action_required_response_and_missing_psp_reference(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     del expected_response["pspReference"]
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -548,8 +549,8 @@ def test_order_with_action_required_response_and_missing_psp_reference(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     del expected_response["pspReference"]
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -603,8 +604,8 @@ def test_checkout_when_amount_is_not_provided(
     expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -654,8 +655,8 @@ def test_order_when_amount_is_not_provided(
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["amount"] = str(order.total_gross_amount)
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -716,8 +717,8 @@ def test_order_with_transaction_when_amount_is_not_provided(
         order.total_gross_amount - expected_charged_amount
     )
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -784,8 +785,8 @@ def test_checkout_with_transaction_when_amount_is_not_provided(
         checkout.total_gross_amount - expected_charged_amount
     )
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -844,8 +845,8 @@ def test_app_with_action_field_and_handle_payments(
     expected_response["amount"] = str(checkout.total_gross_amount)
     expected_response["pspReference"] = expected_psp_reference
     del expected_response["data"]
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -901,8 +902,8 @@ def test_uses_default_channel_action(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = "CHARGE_SUCCESS"
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -962,8 +963,8 @@ def test_app_with_action_field(
         checkout.total_gross_amount - expected_charged_amount
     )
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -1155,8 +1156,8 @@ def test_checkout_fully_paid(
     expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
     expected_response["result"] = result.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -14,6 +14,7 @@ from .....payment.interface import (
     PaymentGatewayData,
     TransactionProcessActionData,
     TransactionSessionData,
+    TransactionSessionResult,
 )
 from .....payment.models import TransactionEvent
 from ....core.enums import TransactionProcessErrorCode
@@ -165,7 +166,7 @@ def _assert_fields(
                 amount=expected_amount,
                 currency=source_object.currency,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=app_identifier, data=data, error=None
             ),
         )
@@ -205,8 +206,8 @@ def test_for_checkout_without_data(
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
     del expected_response["data"]
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -266,8 +267,8 @@ def test_for_order_without_data(
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
     del expected_response["data"]
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -325,8 +326,8 @@ def test_for_checkout_with_data(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
     expected_data = {"some": "json-data"}
     variables = {
@@ -386,8 +387,8 @@ def test_for_order_with_data(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     expected_data = {"some": "json-data"}
@@ -447,8 +448,8 @@ def test_checkout_with_pending_amount(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -507,8 +508,8 @@ def test_order_with_pending_amount(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -566,8 +567,8 @@ def test_checkout_with_action_required_response(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -624,8 +625,8 @@ def test_order_with_action_required_response(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -878,8 +879,8 @@ def test_checkout_fully_paid(
     expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
     expected_response["result"] = result.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1695,7 +1695,7 @@ class TransactionSessionBase(SubscriptionObjectType, AbstractType):
     @classmethod
     def resolve_data(cls, root: tuple[str, TransactionSessionData], _info: ResolveInfo):
         _, transaction_session_data = root
-        return transaction_session_data.payment_gateway.data
+        return transaction_session_data.payment_gateway_data.data
 
     @classmethod
     def resolve_merchant_reference(

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -73,7 +73,14 @@ class TransactionSessionData:
     transaction: "TransactionItem"
     source_object: Union["Checkout", "Order"]
     action: TransactionProcessActionData
-    payment_gateway: PaymentGatewayData
+    payment_gateway_data: PaymentGatewayData
+
+
+@dataclass
+class TransactionSessionResult:
+    app_identifier: str
+    response: Optional[Dict[Any, Any]] = None
+    error: Optional[str] = None
 
 
 @dataclass

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1422,7 +1422,7 @@ def create_transaction_for_order(
 
 def handle_transaction_initialize_session(
     source_object: Union[Checkout, Order],
-    payment_gateway: PaymentGatewayData,
+    payment_gateway_data: PaymentGatewayData,
     amount: Decimal,
     action: str,
     app: App,
@@ -1434,7 +1434,7 @@ def handle_transaction_initialize_session(
     session_data = TransactionSessionData(
         transaction=transaction_item,
         source_object=source_object,
-        payment_gateway=payment_gateway,
+        payment_gateway_data=payment_gateway_data,
         action=TransactionProcessActionData(
             action_type=action, currency=source_object.currency, amount=amount
         ),
@@ -1448,9 +1448,9 @@ def handle_transaction_initialize_session(
         currency=transaction_item.currency,
         amount_value=amount,
     )
-    response = manager.transaction_initialize_session(session_data)
+    result = manager.transaction_initialize_session(session_data)
 
-    response_data = response.data if response else None
+    response_data = result.response if result else None
 
     created_event = create_transaction_event_for_transaction_session(
         request_event,
@@ -1465,7 +1465,7 @@ def handle_transaction_initialize_session(
 def handle_transaction_process_session(
     transaction_item: TransactionItem,
     source_object: Union[Checkout, Order],
-    payment_gateway: PaymentGatewayData,
+    payment_gateway_data: PaymentGatewayData,
     action: str,
     app: App,
     manager: PluginsManager,
@@ -1474,7 +1474,7 @@ def handle_transaction_process_session(
     session_data = TransactionSessionData(
         transaction=transaction_item,
         source_object=source_object,
-        payment_gateway=payment_gateway,
+        payment_gateway_data=payment_gateway_data,
         action=TransactionProcessActionData(
             action_type=action,
             currency=source_object.currency,
@@ -1482,9 +1482,9 @@ def handle_transaction_process_session(
         ),
     )
 
-    response = manager.transaction_process_session(session_data)
+    result = manager.transaction_process_session(session_data)
 
-    response_data = response.data if response else None
+    response_data = result.response if result else None
 
     created_event = create_transaction_event_for_transaction_session(
         request_event,

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -32,6 +32,7 @@ from ..payment.interface import (
     PaymentData,
     PaymentGateway,
     TransactionActionData,
+    TransactionSessionResult,
 )
 from ..thumbnail.models import Thumbnail
 from .models import PluginConfiguration
@@ -849,11 +850,11 @@ class BasePlugin:
     ]
 
     transaction_initialize_session: Callable[
-        ["TransactionSessionData", None], "PaymentGatewayData"
+        ["TransactionSessionData", None], "TransactionSessionResult"
     ]
 
     transaction_process_session: Callable[
-        ["TransactionSessionData", None], "PaymentGatewayData"
+        ["TransactionSessionData", None], "TransactionSessionResult"
     ]
 
     # Trigger when transaction item metadata is updated.

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
         TokenConfig,
         TransactionActionData,
         TransactionSessionData,
+        TransactionSessionResult,
     )
     from ..payment.models import TransactionItem
     from ..product.models import (
@@ -1024,7 +1025,7 @@ class PluginsManager(PaymentInterface):
     def transaction_initialize_session(
         self,
         transaction_session_data: "TransactionSessionData",
-    ) -> "PaymentGatewayData":
+    ) -> "TransactionSessionResult":
         default_value = None
         return self.__run_method_on_plugins(
             "transaction_initialize_session",
@@ -1036,7 +1037,7 @@ class PluginsManager(PaymentInterface):
     def transaction_process_session(
         self,
         transaction_session_data: "TransactionSessionData",
-    ) -> "PaymentGatewayData":
+    ) -> "TransactionSessionResult":
         default_value = None
         return self.__run_method_on_plugins(
             "transaction_process_session",

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -20,7 +20,11 @@ from prices import Money, TaxedMoney
 from ...account.models import User
 from ...core.taxes import TaxData, TaxLineData, TaxType
 from ...order.interface import OrderTaxedPricesData
-from ...payment.interface import PaymentGatewayData, TransactionSessionData
+from ...payment.interface import (
+    PaymentGatewayData,
+    TransactionSessionData,
+    TransactionSessionResult,
+)
 from ..base_plugin import BasePlugin, ConfigurationTypeField, ExternalAccessTokens
 
 if TYPE_CHECKING:
@@ -317,14 +321,18 @@ class PluginSample(BasePlugin):
         transaction_session_data: "TransactionSessionData",
         previous_value: Any,
     ):
-        return PaymentGatewayData(app_identifier="123", data=None, error="Some error")
+        return TransactionSessionResult(
+            app_identifier="123", response=None, error="Some error"
+        )
 
     def transaction_process_session(
         self,
         transaction_session_data: "TransactionSessionData",
         previous_value: Any,
     ):
-        return PaymentGatewayData(app_identifier="321", data=None, error="Some error")
+        return TransactionSessionResult(
+            app_identifier="321", response=None, error="Some error"
+        )
 
     def checkout_fully_paid(self, checkout):
         return None

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -22,6 +22,7 @@ from ...payment.interface import (
     PaymentGatewayData,
     TransactionProcessActionData,
     TransactionSessionData,
+    TransactionSessionResult,
 )
 from ...product.models import Product
 from ..base_plugin import ExternalAccessTokens
@@ -1211,7 +1212,7 @@ def test_manager_transaction_initialize_session(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=None, error=None
         ),
     )
@@ -1221,7 +1222,7 @@ def test_manager_transaction_initialize_session(
     )
 
     # then
-    assert isinstance(response, PaymentGatewayData)
+    assert isinstance(response, TransactionSessionResult)
 
 
 def test_manager_transaction_process_session(
@@ -1252,7 +1253,7 @@ def test_manager_transaction_process_session(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=None, error=None
         ),
     )
@@ -1262,7 +1263,7 @@ def test_manager_transaction_process_session(
     )
 
     # then
-    assert isinstance(response, PaymentGatewayData)
+    assert isinstance(response, TransactionSessionResult)
 
 
 @patch("saleor.plugins.tests.sample_plugins.PluginSample.checkout_fully_paid")

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_initialize_session.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_initialize_session.py
@@ -75,7 +75,7 @@ def test_transaction_initialize_session_checkout_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -140,7 +140,7 @@ def test_transaction_initialize_session_checkout_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -204,7 +204,7 @@ def test_transaction_initialize_session_order_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -268,7 +268,7 @@ def test_transaction_initialize_session_order_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_process_session.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_process_session.py
@@ -75,7 +75,7 @@ def test_transaction_process_session_checkout_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -140,7 +140,7 @@ def test_transaction_process_session_checkout_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -204,7 +204,7 @@ def test_transaction_process_session_order_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -268,7 +268,7 @@ def test_transaction_process_session_order_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )

--- a/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
@@ -12,6 +12,7 @@ from ....payment.interface import (
     PaymentGatewayData,
     TransactionProcessActionData,
     TransactionSessionData,
+    TransactionSessionResult,
 )
 from ....webhook.event_types import WebhookEventSyncType
 from ....webhook.models import Webhook
@@ -111,8 +112,8 @@ def _assert_fields(payload, webhook, expected_response, response, mock_request):
     assert delivery.payload == event_payload
     assert delivery.webhook == webhook
     mock_request.assert_called_once_with(webhook_app, delivery)
-    assert response == PaymentGatewayData(
-        app_identifier=webhook_app.identifier, data=expected_response, error=None
+    assert response == TransactionSessionResult(
+        app_identifier=webhook_app.identifier, response=expected_response, error=None
     )
 
 
@@ -162,7 +163,7 @@ def test_transaction_initialize_checkout_without_request_data_and_static_payload
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -230,7 +231,7 @@ def test_transaction_initialize_checkout_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -298,7 +299,7 @@ def test_transaction_initialize_checkout_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -367,7 +368,7 @@ def test_transaction_initialize_checkout_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -436,7 +437,7 @@ def test_transaction_initialize_session_skips_app_without_identifier(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -447,8 +448,8 @@ def test_transaction_initialize_session_skips_app_without_identifier(
     assert not EventPayload.objects.first()
     assert not EventDelivery.objects.first()
     assert not mock_request.called
-    assert response == PaymentGatewayData(
-        app_identifier="", data=None, error="Missing app identifier"
+    assert response == TransactionSessionResult(
+        app_identifier="", response=None, error="Missing app identifier"
     )
 
 
@@ -498,7 +499,7 @@ def test_transaction_initialize_order_without_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -566,7 +567,7 @@ def test_transaction_initialize_order_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -634,7 +635,7 @@ def test_transaction_initialize_order_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -703,7 +704,7 @@ def test_transaction_initialize_order_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),

--- a/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
@@ -12,6 +12,7 @@ from ....payment.interface import (
     PaymentGatewayData,
     TransactionProcessActionData,
     TransactionSessionData,
+    TransactionSessionResult,
 )
 from ....webhook.event_types import WebhookEventSyncType
 from ....webhook.models import Webhook
@@ -111,8 +112,8 @@ def _assert_fields(payload, webhook, expected_response, response, mock_request):
     assert delivery.payload == event_payload
     assert delivery.webhook == webhook
     mock_request.assert_called_once_with(webhook_app, delivery)
-    assert response == PaymentGatewayData(
-        app_identifier=webhook_app.identifier, data=expected_response, error=None
+    assert response == TransactionSessionResult(
+        app_identifier=webhook_app.identifier, response=expected_response, error=None
     )
 
 
@@ -162,7 +163,7 @@ def test_transaction_process_checkout_without_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -230,7 +231,7 @@ def test_transaction_process_checkout_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -298,7 +299,7 @@ def test_transaction_process_checkout_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -367,7 +368,7 @@ def test_transaction_process_checkout_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -436,7 +437,7 @@ def test_transaction_process_session_skips_app_without_identifier(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -447,8 +448,8 @@ def test_transaction_process_session_skips_app_without_identifier(
     assert not EventPayload.objects.first()
     assert not EventDelivery.objects.first()
     assert not mock_request.called
-    assert response == PaymentGatewayData(
-        app_identifier="", data=None, error="Missing app identifier"
+    assert response == TransactionSessionResult(
+        app_identifier="", response=None, error="Missing app identifier"
     )
 
 
@@ -498,7 +499,7 @@ def test_transaction_process_order_without_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -566,7 +567,7 @@ def test_transaction_process_order_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -634,7 +635,7 @@ def test_transaction_process_order_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -703,7 +704,7 @@ def test_transaction_process_order_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),


### PR DESCRIPTION
I want to merge this change because the transaction flow was using the data class that wasn't related to the flow. Leaving it in its current form would be misleading to anyone not familiar with the flow. The PR adds a separate dataclass for session-action-result, and cleans up the names used in the flow, to be more readable

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
