### PR TITLE
Mark ANY webhook event type as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Shipping methods can be removed by the user after it has been assigned to a chec
 - Add `ProductBulkTranslate` mutation - #13329 by @SzymJ
 - Add `ProductVariantBulkTranslate` mutation - #13329 by @SzymJ
 - Add `AttributeBulkCreate` mutation - #13398 by @SzymJ
+- Deprecate `WebhookEventTypeAsyncEnum.ANY_EVENTS` and `WebhookEventTypeEnum.ANY_EVENTS`; instead listeners should subscribe to specific webhook events -  #13452 by @maarcingebala
 
 ### Saleor Apps
 

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -6,6 +6,11 @@ DEPRECATED_IN_3X_FIELD = "This field will be removed in Saleor 4.0."
 # deprecation message needs to be included in the field description.
 DEPRECATED_IN_3X_INPUT = "\n\nDEPRECATED: this field will be removed in Saleor 4.0."
 
+# Deprecation message for enum values.
+DEPRECATED_IN_3X_ENUM_VALUE = (
+    "\n\nDEPRECATED: this value will be removed in Saleor 4.0."
+)
+
 DEPRECATED_IN_3X_MUTATION = (
     "\n\nDEPRECATED: this mutation will be removed in Saleor 4.0."
 )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1712,7 +1712,11 @@ type WebhookEvent @doc(category: "Webhooks") {
 
 """Enum determining type of webhook."""
 enum WebhookEventTypeEnum @doc(category: "Webhooks") {
-  """All the events."""
+  """
+  All the events.
+  
+  DEPRECATED: this value will be removed in Saleor 4.0.
+  """
   ANY_EVENTS
 
   """An account confirmation is requested."""
@@ -2352,7 +2356,11 @@ type WebhookEventAsync @doc(category: "Webhooks") {
 
 """Enum determining type of webhook."""
 enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
-  """All the events."""
+  """
+  All the events.
+  
+  DEPRECATED: this value will be removed in Saleor 4.0.
+  """
   ANY_EVENTS
 
   """An account confirmation is requested."""

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -8,6 +8,7 @@ from ..core.descriptions import (
     ADDED_IN_313,
     ADDED_IN_314,
     ADDED_IN_315,
+    DEPRECATED_IN_3X_ENUM_VALUE,
     PREVIEW_FEATURE,
 )
 from ..core.doc_category import DOC_CATEGORY_WEBHOOKS
@@ -204,7 +205,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.VOUCHER_METADATA_UPDATED: (
         "A voucher metadata is updated." + ADDED_IN_38
     ),
-    WebhookEventAsyncType.ANY: "All the events.",
+    WebhookEventAsyncType.ANY: "All the events." + DEPRECATED_IN_3X_ENUM_VALUE,
     WebhookEventAsyncType.OBSERVABILITY: "An observability event is created.",
     WebhookEventAsyncType.THUMBNAIL_CREATED: "A thumbnail is created." + ADDED_IN_312,
     WebhookEventAsyncType.SHOP_METADATA_UPDATED: "Shop metadata is updated."


### PR DESCRIPTION
`ANY` webhook event type shouldn't be used, instead listeners should subscribe to specific events they want to receive updates about.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [x] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
