### PR TITLE
Add fix for failing transaction webhooks with provided time field

### DIFF
--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
+import pytz
 from django.utils import timezone
 from freezegun import freeze_time
 
@@ -246,6 +247,53 @@ def test_parse_transaction_action_data_with_only_psp_reference():
 
     assert parsed_data.psp_reference == expected_psp_reference
     assert parsed_data.event is None
+
+
+@pytest.mark.parametrize(
+    "event_time, expected_datetime",
+    [
+        (
+            "2023-10-17T10:18:28.111Z",
+            datetime(2023, 10, 17, 10, 18, 28, 111000, tzinfo=pytz.UTC),
+        ),
+        ("2011-11-04", datetime(2011, 11, 4, 0, 0)),
+        ("2011-11-04T00:05:23", datetime(2011, 11, 4, 0, 5, 23)),
+        ("2011-11-04T00:05:23Z", datetime(2011, 11, 4, 0, 5, 23, tzinfo=pytz.UTC)),
+        ("20111104T000523", datetime(2011, 11, 4, 0, 5, 23)),
+        ("2011-W01-2T00:05:23.283", datetime(2011, 1, 4, 0, 5, 23, 283000)),
+        ("2011-11-04 00:05:23.283", datetime(2011, 11, 4, 0, 5, 23, 283000)),
+        (
+            "2011-11-04 00:05:23.283+00:00",
+            datetime(2011, 11, 4, 0, 5, 23, 283000, tzinfo=pytz.UTC),
+        ),
+        ("1994-11-05T13:15:30Z", datetime(1994, 11, 5, 13, 15, 30, tzinfo=pytz.UTC)),
+    ],
+)
+def test_parse_transaction_action_data_with_provided_time(
+    event_time, expected_datetime
+):
+    # given
+    expected_psp_reference = "psp:122:222"
+    event_amount = 12.00
+    event_type = TransactionEventType.CHARGE_SUCCESS
+    event_url = "http://localhost:3000/event/ref123"
+    event_cause = "No cause"
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+        "time": event_time,
+        "externalUrl": event_url,
+        "message": event_cause,
+    }
+
+    # when
+    parsed_data, error_msg = parse_transaction_action_data(
+        response_data, TransactionEventType.CHARGE_REQUEST
+    )
+    # then
+    assert parsed_data.event.time == expected_datetime
 
 
 def test_parse_transaction_action_data_with_event_all_fields_provided():

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Any, Dict, Optional, Union, cast, overload
 
 import graphene
+from aniso8601 import parse_datetime
 from babel.numbers import get_currency_precision
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import transaction
@@ -794,8 +795,17 @@ def parse_transaction_event_data(
                 datetime.fromisoformat(event_time_data) if event_time_data else None
             )
         except ValueError:
-            logger.warning(invalid_msg, "time", event_time_data)
-            error_field_msg.append(invalid_msg % ("time", event_time_data))
+            try:
+                # datetime.fromisoformat supports only formats of the objects that were
+                # created by date.isoformat() or datetime.isoformat(). It is fixed in
+                # 3.11
+                # This try except block can be removed after moving to python 3.11
+                # ref: https://docs.python.org/3/library/datetime.html#datetime.
+                # datetime.fromisoformat
+                parsed_event_data["time"] = parse_datetime(event_time_data)
+            except ValueError:
+                logger.warning(invalid_msg, "time", event_time_data)
+                error_field_msg.append(invalid_msg % ("time", event_time_data))
     else:
         parsed_event_data["time"] = timezone.now()
 


### PR DESCRIPTION
I want to merge this change because it is port of changes for https://github.com/saleor/saleor/pull/13440

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
