### PR TITLE
Fix resolving order by non-existing external reference

### DIFF
--- a/saleor/graphql/core/utils/__init__.py
+++ b/saleor/graphql/core/utils/__init__.py
@@ -122,7 +122,7 @@ def raise_validation_error(field=None, message=None, code=None):
 
 
 def ext_ref_to_global_id_or_error(model, external_reference):
-    """Convert external reference to graphen global id."""
+    """Convert external reference to global id."""
     internal_id = (
         model.objects.filter(external_reference=external_reference)
         .values_list("id", flat=True)

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 import graphene
+from django.core.exceptions import ValidationError
 from graphql import GraphQLError
 
 from ...order import models
@@ -161,7 +162,10 @@ class OrderQueries(graphene.ObjectType):
             "id", id, "external_reference", external_reference
         )
         if not id:
-            id = ext_ref_to_global_id_or_error(models.Order, external_reference)
+            try:
+                id = ext_ref_to_global_id_or_error(models.Order, external_reference)
+            except ValidationError:
+                return None
         _, id = from_global_id_or_error(id, Order)
         return resolve_order(info, id)
 

--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -1125,6 +1125,24 @@ def test_query_order_by_external_reference(user_api_client, order):
     assert data["id"] == graphene.Node.to_global_id("Order", order.id)
 
 
+@pytest.mark.parametrize("external_reference", ['" "', "not-existing"])
+def test_query_order_by_not_existing_external_reference(
+    external_reference, user_api_client, order
+):
+    # given
+    query = QUERY_ORDER_BY_EXTERNAL_REFERENCE
+    order.external_reference = "test-ext-ref"
+    order.save(update_fields=["external_reference"])
+    variables = {"externalReference": external_reference}
+
+    # when
+    response = user_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["order"] is None
+
+
 def test_query_order_by_external_reference_and_id(user_api_client, order):
     # given
     query = QUERY_ORDER_BY_EXTERNAL_REFERENCE


### PR DESCRIPTION
Fixes https://saleor.sentry.io/issues/4171387180/?project=6417854

Before if would crash with unhandled ValidationError:
```json
{
  "errors": [
    {
      "message": "{'externalReference': ['Couldn\\'t resolve to a node: \" \"']}",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "order"
      ],
      "extensions": {
        "exception": {
          "code": "ValidationError",
          "stacktrace": [
            "Traceback (most recent call last):",
            "  File \"/Users/marcin/.pyenv/versions/3.9.1/envs/saleor/lib/python3.9/site-packages/graphql/execution/executor.py\", line 452, in resolve_or_error",
            "    return executor.execute(resolve_fn, source, info, **args)",
            "  File \"/Users/marcin/.pyenv/versions/3.9.1/envs/saleor/lib/python3.9/site-packages/graphql/execution/executors/sync.py\", line 16, in execute",
            "    return fn(*args, **kwargs)",
            "  File \"/Users/marcin/mirumee/saleor-platform/saleor/saleor/graphql/order/schema.py\", line 164, in resolve_order",
            "    id = ext_ref_to_global_id_or_error(models.Order, external_reference)",
            "  File \"/Users/marcin/mirumee/saleor-platform/saleor/saleor/graphql/core/utils/__init__.py\", line 134, in ext_ref_to_global_id_or_error",
            "    raise_validation_error(",
            "  File \"/Users/marcin/mirumee/saleor-platform/saleor/saleor/graphql/core/utils/__init__.py\", line 121, in raise_validation_error",
            "    raise ValidationError({field: ValidationError(message, code=code)})",
            "django.core.exceptions.ValidationError: {'externalReference': ['Couldn\\'t resolve to a node: \" \"']}"
          ]
        }
      }
    }
  ],
  "data": {
    "order": null
  },
}
```

With this PR it will just return `null`:
```json
{
  "data": {
    "order": null
  }
}
```

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
