### PR TITLE
Observability settings shouldn't cause errors in tests for introspection caching

### DIFF
--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -288,7 +288,7 @@ INTROSPECTION_RESULT = {"__schema": {"queryType": {"name": "Query"}}}
 
 @mock.patch("saleor.graphql.views.cache.set")
 @mock.patch("saleor.graphql.views.cache.get")
-@override_settings(DEBUG=False)
+@override_settings(DEBUG=False, OBSERVABILITY_REPORT_ALL_API_CALLS=False)
 def test_introspection_query_is_cached(cache_get_mock, cache_set_mock, api_client):
     cache_get_mock.return_value = None
     cache_key = generate_cache_key(INTROSPECTION_QUERY)
@@ -303,7 +303,7 @@ def test_introspection_query_is_cached(cache_get_mock, cache_set_mock, api_clien
 
 @mock.patch("saleor.graphql.views.cache.set")
 @mock.patch("saleor.graphql.views.cache.get")
-@override_settings(DEBUG=False)
+@override_settings(DEBUG=False, OBSERVABILITY_REPORT_ALL_API_CALLS=False)
 def test_introspection_query_is_cached_only_once(
     cache_get_mock, cache_set_mock, api_client
 ):
@@ -318,7 +318,7 @@ def test_introspection_query_is_cached_only_once(
 
 @mock.patch("saleor.graphql.views.cache.set")
 @mock.patch("saleor.graphql.views.cache.get")
-@override_settings(DEBUG=True)
+@override_settings(DEBUG=True, OBSERVABILITY_REPORT_ALL_API_CALLS=False)
 def test_introspection_query_is_not_cached_in_debug_mode(
     cache_get_mock, cache_set_mock, api_client
 ):


### PR DESCRIPTION
I want to merge this change because observability settings shouldn't cause errors in tests for introspection caching.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
