### PR TITLE
Update last_login in auth flows

### DIFF
--- a/saleor/graphql/account/tests/mutations/test_external_refresh.py
+++ b/saleor/graphql/account/tests/mutations/test_external_refresh.py
@@ -1,6 +1,8 @@
 import json
 from unittest.mock import Mock, patch
 
+from freezegun import freeze_time
+
 from .....plugins.base_plugin import ExternalAccessTokens
 from ....tests.utils import get_graphql_content
 
@@ -33,6 +35,7 @@ def test_external_refresh_plugin_not_active(api_client, customer_user):
     assert data["user"] is None
 
 
+@freeze_time("2018-05-31 12:00:00")
 @patch("saleor.core.middleware.jwt_decode_with_exception_handler")
 def test_external_refresh(
     mock_refresh_token_middleware, api_client, customer_user, monkeypatch, rf
@@ -59,5 +62,8 @@ def test_external_refresh(
     assert data["refreshToken"] == expected_refresh_token
     assert data["csrfToken"] == expected_csrf_token
     assert data["user"]["email"] == customer_user.email
+    assert customer_user.last_login
+    last_login = customer_user.last_login.strftime("%Y-%m-%d %H:%M:%S")
+    assert last_login == "2018-05-31 12:00:00"
     assert mocked_plugin_fun.called
     assert mock_refresh_token_middleware.called

--- a/saleor/graphql/account/tests/mutations/test_token_refresh.py
+++ b/saleor/graphql/account/tests/mutations/test_token_refresh.py
@@ -58,6 +58,10 @@ def test_refresh_token_with_audience(api_client, customer_user, settings):
     assert payload["type"] == JWT_ACCESS_TYPE
     assert payload["token"] == customer_user.jwt_token_key
     assert payload["aud"] == token_audience
+    customer_user.refresh_from_db()
+    assert customer_user.last_login
+    last_login = customer_user.last_login.strftime("%Y-%m-%d %H:%M:%S")
+    assert last_login == "2020-03-18 12:00:00"
 
 
 @freeze_time("2020-03-18 12:00:00")

--- a/saleor/plugins/openid_connect/tests/test_utils.py
+++ b/saleor/plugins/openid_connect/tests/test_utils.py
@@ -1,7 +1,7 @@
 import json
 import time
 import warnings
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest import mock
 from unittest.mock import MagicMock, Mock
 
@@ -10,7 +10,7 @@ import pytz
 import requests
 from authlib.jose import JWTClaims
 from django.core.exceptions import ValidationError
-from django.utils.timezone import make_aware
+from django.utils import timezone
 from freezegun import freeze_time
 from requests import Response
 
@@ -317,7 +317,7 @@ def test_get_or_create_user_from_payload_with_last_login(customer_user, settings
     oauth_url = "https://saleor.io/oauth"
     sub_id = "oauth|1234"
 
-    customer_user.last_login = make_aware(
+    customer_user.last_login = timezone.make_aware(
         datetime.fromtimestamp(current_ts - 10), timezone=pytz.timezone("UTC")
     )
     customer_user.save()
@@ -329,11 +329,58 @@ def test_get_or_create_user_from_payload_with_last_login(customer_user, settings
     )
 
     customer_user.refresh_from_db()
-    assert customer_user.last_login == make_aware(
+    assert customer_user.last_login == timezone.make_aware(
         datetime.fromtimestamp(current_ts), timezone=pytz.timezone("UTC")
     )
     assert user_from_payload.email == customer_user.email
     assert user_from_payload.private_metadata[f"oidc-{oauth_url}"] == sub_id
+
+
+@freeze_time("2019-03-18 12:00:00")
+def test_get_or_create_user_from_payload_update_last_login(customer_user):
+    assert customer_user.last_login is None
+    oauth_url = "https://saleor.io/oauth"
+    sub_id = "oauth|1234"
+    get_or_create_user_from_payload(
+        payload={"sub": sub_id, "email": customer_user.email},
+        oauth_url=oauth_url,
+    )
+
+    customer_user.refresh_from_db()
+    assert customer_user.last_login
+    last_login = customer_user.last_login.strftime("%Y-%m-%d %H:%M:%S")
+    assert last_login == "2019-03-18 12:00:00"
+
+
+def test_get_or_create_user_from_payload_last_login_stays_same(customer_user):
+    last_login = timezone.now() - timedelta(minutes=14)
+    customer_user.last_login = last_login
+    customer_user.save()
+    oauth_url = "https://saleor.io/oauth"
+    sub_id = "oauth|1234"
+    get_or_create_user_from_payload(
+        payload={"sub": sub_id, "email": customer_user.email},
+        oauth_url=oauth_url,
+    )
+
+    customer_user.refresh_from_db()
+    assert customer_user.last_login == last_login
+
+
+def test_get_or_create_user_from_payload_last_login_modifies(customer_user):
+    last_login = timezone.now() - timedelta(minutes=16)
+    customer_user.last_login = last_login
+    customer_user.save()
+    oauth_url = "https://saleor.io/oauth"
+    sub_id = "oauth|1234"
+    get_or_create_user_from_payload(
+        payload={"sub": sub_id, "email": customer_user.email},
+        oauth_url=oauth_url,
+    )
+
+    customer_user.refresh_from_db()
+    assert customer_user.last_login
+    assert customer_user.last_login != last_login
 
 
 def test_jwt_token_without_expiration_claim(monkeypatch, decoded_access_token):

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -7,12 +7,13 @@ import requests
 from authlib.jose import JWTClaims, jwt
 from authlib.jose.errors import DecodeError, JoseError
 from authlib.oidc.core import CodeIDToken
+from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.db.models import QuerySet
-from django.utils.timezone import make_aware
+from django.utils import timezone
 from jwt import PyJWTError
 
 from ...account.models import Group, User
@@ -392,8 +393,16 @@ def _update_user_details(
         fields_to_save.append("email")
     if last_login:
         if not user.last_login or user.last_login.timestamp() < last_login:
-            login_time = make_aware(datetime.fromtimestamp(last_login))
+            login_time = timezone.make_aware(datetime.fromtimestamp(last_login))
             user.last_login = login_time
+            fields_to_save.append("last_login")
+    else:
+        if (
+            not user.last_login
+            or (timezone.now() - user.last_login).seconds
+            > settings.OAUTH_UPDATE_LAST_LOGIN_THRESHOLD
+        ):
+            user.last_login = timezone.now()
             fields_to_save.append("last_login")
 
     if fields_to_save:

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -834,3 +834,8 @@ WEBHOOK_CELERY_QUEUE_NAME = os.environ.get("WEBHOOK_CELERY_QUEUE_NAME", None)
 RESET_PASSWORD_LOCK_TIME = parse(
     os.environ.get("RESET_PASSWORD_LOCK_TIME", "15 minutes")
 )
+
+# Time threshold to update user last_login when performing requests with OAUTH token.
+OAUTH_UPDATE_LAST_LOGIN_THRESHOLD = parse(
+    os.environ.get("OAUTH_UPDATE_LAST_LOGIN_THRESHOLD", "15 minutes")
+)


### PR DESCRIPTION
I want to merge this change because it's a port of https://github.com/saleor/saleor/pull/13436.
It updates last_login on authentication flows across Saleor.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
