### PR TITLE
Add permission checking based on Attribute.type

### DIFF
--- a/saleor/graphql/attribute/mutations/attribute_value_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_create.py
@@ -11,11 +11,13 @@ from ...core.types import AttributeError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Attribute, AttributeValue
 from .attribute_create import AttributeValueCreateInput
-from .mixins import AttributeMixin
+from .mixins import AttributeMixin, AttributePermissionValidationMixin
 from .validators import validate_value_is_unique
 
 
-class AttributeValueCreate(AttributeMixin, ModelMutation):
+class AttributeValueCreate(
+    AttributeMixin, ModelMutation, AttributePermissionValidationMixin
+):
     ATTRIBUTE_VALUES_FIELD = "input"
 
     attribute = graphene.Field(Attribute, description="The updated attribute.")
@@ -78,6 +80,7 @@ class AttributeValueCreate(AttributeMixin, ModelMutation):
     @classmethod
     def perform_mutation(cls, _root, info, attribute_id, input):
         attribute = cls.get_node_or_error(info, attribute_id, only_type=Attribute)
+        cls.check_permissions_for_attribute(attribute, info)
         instance = models.AttributeValue(attribute=attribute)
         cleaned_input = cls.clean_input(info, instance, input)
         instance = cls.construct_instance(instance, cleaned_input)

--- a/saleor/graphql/attribute/mutations/attribute_value_delete.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_delete.py
@@ -8,9 +8,10 @@ from ...core.mutations import ModelDeleteMutation
 from ...core.types import AttributeError
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Attribute, AttributeValue
+from .mixins import AttributePermissionValidationMixin
 
 
-class AttributeValueDelete(ModelDeleteMutation):
+class AttributeValueDelete(ModelDeleteMutation, AttributePermissionValidationMixin):
     attribute = graphene.Field(Attribute, description="The updated attribute.")
 
     class Arguments:
@@ -28,6 +29,7 @@ class AttributeValueDelete(ModelDeleteMutation):
     def perform_mutation(cls, _root, info, **data):
         node_id = data.get("id")
         instance = cls.get_node_or_error(info, node_id, only_type=AttributeValue)
+        cls.check_permissions_for_attribute(instance.attribute, info)
         product_ids = cls.get_product_ids_to_update(instance)
         response = super().perform_mutation(_root, info, **data)
         product_models.Product.objects.filter(id__in=product_ids).update(

--- a/saleor/graphql/attribute/mutations/attribute_value_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_update.py
@@ -64,6 +64,10 @@ class AttributeValueUpdate(AttributeValueCreate):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
+        attribute_value = cls.get_node_or_error(
+            info, data.get("id"), only_type=AttributeValue
+        )
+        cls.check_permissions_for_attribute(attribute_value.attribute, info)
         return super(AttributeValueCreate, cls).perform_mutation(_root, info, **data)
 
     @classmethod

--- a/saleor/graphql/attribute/mutations/mixins.py
+++ b/saleor/graphql/attribute/mutations/mixins.py
@@ -5,8 +5,11 @@ from text_unidecode import unidecode
 from ....attribute import ATTRIBUTE_PROPERTIES_CONFIGURATION, AttributeInputType
 from ....attribute import models as models
 from ....attribute.error_codes import AttributeErrorCode
+from ....core.exceptions import PermissionDenied
+from ....core.permissions import PagePermissions, ProductPermissions
 from ....core.utils import prepare_unique_slug
 from ...core.validators import validate_slug_and_generate_if_needed
+from ..enums import AttributeTypeEnum
 
 
 class AttributeMixin:
@@ -187,3 +190,14 @@ class AttributeMixin:
         values = cleaned_data.get(cls.ATTRIBUTE_VALUES_FIELD) or []
         for value in values:
             attribute.values.create(**value)
+
+
+class AttributePermissionValidationMixin:
+    @classmethod
+    def check_permissions_for_attribute(cls, attribute, info):
+        if attribute.type == AttributeTypeEnum.PRODUCT_TYPE.value:
+            permissions = (ProductPermissions.MANAGE_PRODUCTS,)
+        else:
+            permissions = (PagePermissions.MANAGE_PAGES,)
+        if not cls.check_permissions(info.context, permissions):
+            raise PermissionDenied(permissions=permissions)

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
@@ -389,3 +389,26 @@ def test_create_attribute_value_capitalized_name(
     data = content["data"]["attributeValueCreate"]
     assert not data["errors"]
     assert data["attributeValue"]["slug"] == "red-2"
+
+
+def test_create_attribute_value_for_attribute_type_pages_without_permission(
+    staff_api_client, page_attribute, permission_manage_products
+):
+    # given
+    query = CREATE_ATTRIBUTE_VALUE_MUTATION
+    attribute_id = graphene.Node.to_global_id("Attribute", page_attribute.id)
+    variables = {"name": "test name", "attributeId": attribute_id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    errors = content["errors"]
+    assert len(errors) == 1
+    assert (
+        errors[0]["message"]
+        == "You need one of the following permissions: MANAGE_PAGES"
+    )

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
@@ -392,11 +392,11 @@ def test_create_attribute_value_capitalized_name(
 
 
 def test_create_attribute_value_for_attribute_type_pages_without_permission(
-    staff_api_client, page_attribute, permission_manage_products
+    staff_api_client, size_page_attribute, permission_manage_products
 ):
     # given
     query = CREATE_ATTRIBUTE_VALUE_MUTATION
-    attribute_id = graphene.Node.to_global_id("Attribute", page_attribute.id)
+    attribute_id = graphene.Node.to_global_id("Attribute", size_page_attribute.id)
     variables = {"name": "test name", "attributeId": attribute_id}
 
     # when

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
@@ -260,14 +260,18 @@ def test_delete_attribute_value_product_search_document_updated_variant_attribut
 
 def test_delete_attribute_value_for_attribute_type_page_without_permission(
     staff_api_client,
-    page_attribute_value,
+    size_page_attribute,
     permission_manage_product_types_and_attributes,
     permission_manage_pages,
 ):
     # when
     response = staff_api_client.post_graphql(
         ATTRIBUTE_VALUE_DELETE_MUTATION,
-        {"id": graphene.Node.to_global_id("AttributeValue", page_attribute_value.id)},
+        {
+            "id": graphene.Node.to_global_id(
+                "AttributeValue", size_page_attribute.values.first().id
+            )
+        },
         permissions=[permission_manage_product_types_and_attributes],
     )
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -51,6 +51,7 @@ def test_update_attribute_value(
     staff_api_client,
     pink_attribute_value,
     permission_manage_product_types_and_attributes,
+    permission_manage_products,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
@@ -61,7 +62,12 @@ def test_update_attribute_value(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
 
     # then
@@ -79,6 +85,7 @@ def test_update_attribute_value_update_search_index_dirty_in_product(
     staff_api_client,
     product,
     permission_manage_product_types_and_attributes,
+    permission_manage_products,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
@@ -89,7 +96,12 @@ def test_update_attribute_value_update_search_index_dirty_in_product(
 
     # when
     staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
     product.refresh_from_db(fields=["search_index_dirty"])
 
@@ -108,6 +120,7 @@ def test_update_attribute_value_trigger_webhooks(
     pink_attribute_value,
     permission_manage_product_types_and_attributes,
     settings,
+    permission_manage_products,
 ):
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
@@ -122,7 +135,10 @@ def test_update_attribute_value_trigger_webhooks(
     response = staff_api_client.post_graphql(
         UPDATE_ATTRIBUTE_VALUE_MUTATION,
         variables,
-        permissions=[permission_manage_product_types_and_attributes],
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
     content = get_graphql_content(response)
     data = content["data"]["attributeValueUpdate"]
@@ -179,6 +195,7 @@ def test_update_attribute_value_name_not_unique(
     staff_api_client,
     pink_attribute_value,
     permission_manage_product_types_and_attributes,
+    permission_manage_products,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
@@ -190,7 +207,12 @@ def test_update_attribute_value_name_not_unique(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
 
     # then
@@ -205,6 +227,7 @@ def test_update_attribute_value_the_same_name_as_different_attribute_value(
     size_attribute,
     color_attribute,
     permission_manage_product_types_and_attributes,
+    permission_manage_products,
 ):
     """Ensure the attribute value with the same slug as value of different attribute
     can be set."""
@@ -220,7 +243,12 @@ def test_update_attribute_value_the_same_name_as_different_attribute_value(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
 
     # then
@@ -239,6 +267,7 @@ def test_update_attribute_value_product_search_document_updated(
     pink_attribute_value,
     permission_manage_product_types_and_attributes,
     product,
+    permission_manage_products,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
@@ -256,7 +285,12 @@ def test_update_attribute_value_product_search_document_updated(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
 
     # then
@@ -275,6 +309,7 @@ def test_update_attribute_value_product_search_document_updated_variant_attribut
     pink_attribute_value,
     permission_manage_product_types_and_attributes,
     variant,
+    permission_manage_products,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
@@ -293,7 +328,12 @@ def test_update_attribute_value_product_search_document_updated_variant_attribut
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
 
     # then
@@ -311,6 +351,7 @@ def test_update_swatch_attribute_value(
     staff_api_client,
     swatch_attribute,
     permission_manage_product_types_and_attributes,
+    permission_manage_products,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
@@ -321,7 +362,12 @@ def test_update_swatch_attribute_value(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
 
     # then
@@ -343,6 +389,7 @@ def test_update_swatch_attribute_value_clear_value(
     staff_api_client,
     swatch_attribute,
     permission_manage_product_types_and_attributes,
+    permission_manage_products,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
@@ -353,7 +400,12 @@ def test_update_swatch_attribute_value_clear_value(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
 
     # then
@@ -375,6 +427,7 @@ def test_update_swatch_attribute_value_clear_file_value(
     staff_api_client,
     swatch_attribute,
     permission_manage_product_types_and_attributes,
+    permission_manage_products,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
@@ -385,7 +438,12 @@ def test_update_swatch_attribute_value_clear_file_value(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
 
     # then
@@ -414,6 +472,7 @@ def test_update_attribute_value_invalid_input_data(
     staff_api_client,
     pink_attribute_value,
     permission_manage_product_types_and_attributes,
+    permission_manage_products,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
@@ -424,7 +483,12 @@ def test_update_attribute_value_invalid_input_data(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
 
     # then
@@ -441,6 +505,7 @@ def test_update_attribute_value_swatch_attr_value(
     staff_api_client,
     swatch_attribute,
     permission_manage_product_types_and_attributes,
+    permission_manage_products,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
@@ -451,7 +516,12 @@ def test_update_attribute_value_swatch_attr_value(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[
+            permission_manage_product_types_and_attributes,
+            permission_manage_products,
+        ],
     )
 
     # then
@@ -461,3 +531,28 @@ def test_update_attribute_value_swatch_attr_value(
     assert data["attributeValue"]["name"] == value.name
     assert data["attributeValue"]["slug"] == value.slug
     assert data["attributeValue"]["value"] == new_value
+
+
+def test_update_attribute_value_for_attribute_type_pages_without_permission(
+    staff_api_client,
+    page_attribute_value,
+    permission_manage_product_types_and_attributes,
+):
+    # given
+    query = UPDATE_ATTRIBUTE_VALUE_MUTATION
+    attribute_id = graphene.Node.to_global_id("AttributeValue", page_attribute_value.id)
+    variables = {"input": {"value": "test new value"}, "id": attribute_id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_product_types_and_attributes]
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    errors = content["errors"]
+    assert len(errors) == 1
+    assert (
+        errors[0]["message"]
+        == "You need one of the following permissions: MANAGE_PAGES"
+    )

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -535,12 +535,14 @@ def test_update_attribute_value_swatch_attr_value(
 
 def test_update_attribute_value_for_attribute_type_pages_without_permission(
     staff_api_client,
-    page_attribute_value,
+    size_page_attribute,
     permission_manage_product_types_and_attributes,
 ):
     # given
     query = UPDATE_ATTRIBUTE_VALUE_MUTATION
-    attribute_id = graphene.Node.to_global_id("AttributeValue", page_attribute_value.id)
+    attribute_id = graphene.Node.to_global_id(
+        "AttributeValue", size_page_attribute.values.first().id
+    )
     variables = {"input": {"value": "test new value"}, "id": attribute_id}
 
     # when

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1292,27 +1292,6 @@ def shipping_method_channel_PLN(shipping_zone, channel_PLN):
 
 
 @pytest.fixture
-def page_attribute(db):
-    attribute = Attribute.objects.create(
-        slug="page",
-        name="Page",
-        type=AttributeType.PAGE_TYPE,
-        input_type=AttributeInputType.SWATCH,
-        filterable_in_storefront=True,
-        filterable_in_dashboard=True,
-        available_in_grid=True,
-    )
-    return attribute
-
-
-@pytest.fixture
-def page_attribute_value(page_attribute):
-    return AttributeValue.objects.create(
-        attribute=page_attribute, name="Value", slug="value", value="test value"
-    )
-
-
-@pytest.fixture
 def color_attribute(db):
     attribute = Attribute.objects.create(
         slug="color",

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1292,6 +1292,27 @@ def shipping_method_channel_PLN(shipping_zone, channel_PLN):
 
 
 @pytest.fixture
+def page_attribute(db):
+    attribute = Attribute.objects.create(
+        slug="page",
+        name="Page",
+        type=AttributeType.PAGE_TYPE,
+        input_type=AttributeInputType.SWATCH,
+        filterable_in_storefront=True,
+        filterable_in_dashboard=True,
+        available_in_grid=True,
+    )
+    return attribute
+
+
+@pytest.fixture
+def page_attribute_value(page_attribute):
+    return AttributeValue.objects.create(
+        attribute=page_attribute, name="Value", slug="value", value="test value"
+    )
+
+
+@pytest.fixture
 def color_attribute(db):
     attribute = Attribute.objects.create(
         slug="color",


### PR DESCRIPTION
I want to merge this change because adds validation if user has permissions to create/update/delete AttributeValue based on Attribute.type.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
