### PR TITLE
[TEST] Adding test for creating checkout from order core 0104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ Shipping methods can be removed by the user after it has been assigned to a chec
 - Add `ProductVariantBulkTranslate` mutation - #13329 by @SzymJ
 - Add `AttributeBulkCreate` mutation - #13398 by @SzymJ
 - Deprecate `WebhookEventTypeAsyncEnum.ANY_EVENTS` and `WebhookEventTypeEnum.ANY_EVENTS`; instead listeners should subscribe to specific webhook events -  #13452 by @maarcingebala
+- Add ability to update `warehouse` address with `MANAGE_PRODUCTS` permissions: - #13248 by @Air-t
+- Add ability to update `site` address with `MANAGE_SETTINGS` permissions: - #13248 by @Air-t
+- Add the ability to set address public metadata in the following mutations: - #13248 by @Air-t
+  - `accountUpdate`, `accountAddressCreate`, `accountAddressUpdate`, `addressCreate`, `AccountAddressUpdate`,
+  - `checkoutShippingAddressUpdate`, `checkoutBillingAddressUpdate`, `shopAddressUpdate`, `warehouseUpdate`
+  - Add `metadata` to `AddressInput` field
 
 ### Saleor Apps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4476,9 +4476,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7769,9 +7769,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true
     },
     "wrap-ansi": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -361,17 +361,17 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.28.3"
+version = "1.28.7"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.28.3-py3-none-any.whl", hash = "sha256:34f07b3fc2503240c0f58114cf3afea91295c7996d084991b78a278a56157c48"},
-    {file = "boto3-1.28.3.tar.gz", hash = "sha256:610369a7f984b58973c097ea649ec81976c04565d39a2d6d3edc280d23b0cb87"},
+    {file = "boto3-1.28.7-py3-none-any.whl", hash = "sha256:46803b8ae114ff139f2a87fcb5d2f5a5728f6c96fe3a2b9416a8fcbe761423ae"},
+    {file = "boto3-1.28.7.tar.gz", hash = "sha256:ef6a465d3b25b89bcd00ff69675b33917166145e544735dcb9978091f5b0b752"},
 ]
 
 [package.dependencies]
-botocore = ">=1.31.3,<1.32.0"
+botocore = ">=1.31.7,<1.32.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -380,13 +380,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.31.3"
+version = "1.31.7"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.31.3-py3-none-any.whl", hash = "sha256:2aa27c75e62bfcf7900cb85283228fcb7df0fa1bdc2ae76dcee90788dd444934"},
-    {file = "botocore-1.31.3.tar.gz", hash = "sha256:744ce853cadc7ae87ba42ef6828194ddec97d606dd4d08b4dfe3d96d5001eb0c"},
+    {file = "botocore-1.31.7-py3-none-any.whl", hash = "sha256:f211ef5714bec8ae24b3fe737b8689611ef4d0dbea0ab46ef8328e112dd10ada"},
+    {file = "botocore-1.31.7.tar.gz", hash = "sha256:f4473f66c153c262b8262404d737f4249366daf00fb068b495577a24b830ebcb"},
 ]
 
 [package.dependencies]
@@ -395,7 +395,7 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
-crt = ["awscrt (==0.16.9)"]
+crt = ["awscrt (==0.16.26)"]
 
 [[package]]
 name = "braintree"
@@ -4873,4 +4873,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.9"
-content-hash = "267b99ff2a19dfab5486f09dfb7275035537ab3dbf778300905e285e034a99ac"
+content-hash = "6e2922fd395bb4319e0c051798ba8f8e84dcff4000e5e6ed6d52c817c65ab811"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.saleor.io/"
   [tool.poetry.dependencies]
   python = "~3.9"
   babel = ">=2.8,<2.13"
-  boto3 = "^1.26"
+  boto3 = "^1.28"
   braintree = ">=4.2,<4.21"
   dj-database-url = "^2"
   dj-email-url = "^1"

--- a/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
+++ b/saleor/graphql/account/bulk_mutations/customer_bulk_update.py
@@ -358,6 +358,8 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
     @classmethod
     def update_address(cls, info, instance, data, field):
         address = getattr(instance, field) or models.Address()
+        address_metadata = data.pop("metadata", list())
+        cls.update_metadata(address, address_metadata)
         address = cls.construct_instance(address, data)
         cls.clean_instance(info, address)
         return address
@@ -507,6 +509,7 @@ class CustomerBulkUpdate(BaseMutation, I18nMixin):
                 "country",
                 "country_area",
                 "phone",
+                "metadata",
             ],
         )
 

--- a/saleor/graphql/account/mixins.py
+++ b/saleor/graphql/account/mixins.py
@@ -1,0 +1,5 @@
+class AddressMetadataMixin:
+    @classmethod
+    def construct_instance(cls, instance, cleaned_data):
+        cls.update_metadata(instance, cleaned_data.pop("metadata", list()))  # type: ignore[attr-defined] # noqa: E501
+        return super().construct_instance(instance, cleaned_data)  # type: ignore[misc] # noqa: E501

--- a/saleor/graphql/account/mutations/account/account_address_create.py
+++ b/saleor/graphql/account/mutations/account/account_address_create.py
@@ -17,10 +17,11 @@ from ....core.utils import WebhookEventInfo
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...enums import AddressTypeEnum
 from ...i18n import I18nMixin
+from ...mixins import AddressMetadataMixin
 from ...types import Address, AddressInput, User
 
 
-class AccountAddressCreate(ModelMutation, I18nMixin):
+class AccountAddressCreate(AddressMetadataMixin, ModelMutation, I18nMixin):
     user = graphene.Field(
         User, description="A user instance for which the address was created."
     )

--- a/saleor/graphql/account/mutations/account/account_address_update.py
+++ b/saleor/graphql/account/mutations/account/account_address_update.py
@@ -3,11 +3,12 @@ from .....webhook.event_types import WebhookEventAsyncType
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.types import AccountError
 from ....core.utils import WebhookEventInfo
+from ...mixins import AddressMetadataMixin
 from ...types import Address
 from ..base import BaseAddressUpdate
 
 
-class AccountAddressUpdate(BaseAddressUpdate):
+class AccountAddressUpdate(AddressMetadataMixin, BaseAddressUpdate):
     class Meta:
         auto_permission_message = False
         description = (

--- a/saleor/graphql/account/mutations/account/account_update.py
+++ b/saleor/graphql/account/mutations/account/account_update.py
@@ -5,6 +5,7 @@ import graphene
 from .....account import models
 from .....permission.auth_filters import AuthorizationFilters
 from .....webhook.event_types import WebhookEventAsyncType
+from ....account.mixins import AddressMetadataMixin
 from ....core import ResolveInfo
 from ....core.descriptions import ADDED_IN_314
 from ....core.doc_category import DOC_CATEGORY_USERS
@@ -34,7 +35,7 @@ class AccountInput(AccountBaseInput):
         doc_category = DOC_CATEGORY_USERS
 
 
-class AccountUpdate(BaseCustomerCreate):
+class AccountUpdate(AddressMetadataMixin, BaseCustomerCreate):
     class Arguments:
         input = AccountInput(
             description="Fields required to update the account of the logged-in user.",

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -89,6 +89,7 @@ class BaseAddressUpdate(ModelMutation, I18nMixin):
         cleaned_input = cls.clean_input(
             info=info, instance=instance, data=data.get("input")
         )
+        cls.update_metadata(instance, cleaned_input.pop("metadata", list()))
         address = cls.validate_address(cleaned_input, instance=instance)
         cls.clean_instance(info, address)
         cls.save(info, address, cleaned_input)
@@ -253,21 +254,25 @@ class BaseCustomerCreate(ModelMutation, I18nMixin):
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
 
         if shipping_address_data:
+            address_metadata = shipping_address_data.pop("metadata", list())
             shipping_address = cls.validate_address(
                 shipping_address_data,
                 address_type=AddressType.SHIPPING,
                 instance=getattr(instance, SHIPPING_ADDRESS_FIELD),
                 info=info,
             )
+            cls.update_metadata(shipping_address, address_metadata)
             cleaned_input[SHIPPING_ADDRESS_FIELD] = shipping_address
 
         if billing_address_data:
+            address_metadata = billing_address_data.pop("metadata", list())
             billing_address = cls.validate_address(
                 billing_address_data,
                 address_type=AddressType.BILLING,
                 instance=getattr(instance, BILLING_ADDRESS_FIELD),
                 info=info,
             )
+            cls.update_metadata(billing_address, address_metadata)
             cleaned_input[BILLING_ADDRESS_FIELD] = billing_address
 
         if cleaned_input.get("redirect_url"):

--- a/saleor/graphql/account/mutations/staff/address_create.py
+++ b/saleor/graphql/account/mutations/staff/address_create.py
@@ -8,6 +8,7 @@ from .....account.utils import (
 from .....core.tracing import traced_atomic_transaction
 from .....permission.enums import AccountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
+from ....account.mixins import AddressMetadataMixin
 from ....account.types import Address, AddressInput, User
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
@@ -18,7 +19,7 @@ from ....plugins.dataloaders import get_plugin_manager_promise
 from ...i18n import I18nMixin
 
 
-class AddressCreate(ModelMutation, I18nMixin):
+class AddressCreate(AddressMetadataMixin, ModelMutation, I18nMixin):
     user = graphene.Field(
         User, description="A user instance for which the address was created."
     )

--- a/saleor/graphql/account/mutations/staff/address_update.py
+++ b/saleor/graphql/account/mutations/staff/address_update.py
@@ -5,10 +5,11 @@ from ....account.types import Address
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.types import AccountError
 from ....core.utils import WebhookEventInfo
+from ...mixins import AddressMetadataMixin
 from ..base import BaseAddressUpdate
 
 
-class AddressUpdate(BaseAddressUpdate):
+class AddressUpdate(AddressMetadataMixin, BaseAddressUpdate):
     class Meta:
         description = "Updates an address."
         doc_category = DOC_CATEGORY_USERS

--- a/saleor/graphql/account/tests/mutations/account/test_account_address_update.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_address_update.py
@@ -13,6 +13,10 @@ ACCOUNT_ADDRESS_UPDATE_MUTATION = """
         accountAddressUpdate(id: $addressId, input: $address) {
             address {
                 city
+                metadata {
+                    key
+                    value
+                }
             }
             user {
                 id
@@ -39,9 +43,11 @@ def test_customer_update_own_address(
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content["data"]["accountAddressUpdate"]
+    assert data["address"]["metadata"] == [{"key": "public", "value": "public_value"}]
     assert data["address"]["city"] == address_data["city"].upper()
     address_obj.refresh_from_db()
     assert address_obj.city == address_data["city"].upper()
+    assert address_obj.metadata == {"public": "public_value"}
     user.refresh_from_db()
     assert generate_address_search_document_value(address_obj) in user.search_document
 

--- a/saleor/graphql/account/tests/mutations/account/test_account_update.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_update.py
@@ -36,9 +36,17 @@ ACCOUNT_UPDATE_QUERY = """
                 email
                 defaultBillingAddress {
                     id
+                    metadata {
+                        key
+                        value
+                    }
                 }
                 defaultShippingAddress {
                     id
+                    metadata {
+                        key
+                        value
+                    }
                 }
                 languageCode
                 metadata {
@@ -91,6 +99,7 @@ def test_logged_customer_update_addresses(user_api_client, graphql_address_data)
     # instances weren't created, but the existing ones got updated
     user = user_api_client.user
     new_first_name = graphql_address_data["firstName"]
+    metadata = graphql_address_data["metadata"]
     assert user.default_billing_address
     assert user.default_shipping_address
     assert user.default_billing_address.first_name != new_first_name
@@ -104,6 +113,9 @@ def test_logged_customer_update_addresses(user_api_client, graphql_address_data)
     data = content["data"][mutation_name]
     assert not data["errors"]
 
+    assert data["user"]["defaultShippingAddress"]["metadata"] == metadata
+    assert data["user"]["defaultBillingAddress"]["metadata"] == metadata
+
     # check that existing instances are updated
     billing_address_pk = user.default_billing_address.pk
     shipping_address_pk = user.default_shipping_address.pk
@@ -114,6 +126,9 @@ def test_logged_customer_update_addresses(user_api_client, graphql_address_data)
     assert user.default_billing_address.first_name == new_first_name
     assert user.default_shipping_address.first_name == new_first_name
     assert user.search_document
+
+    assert user.default_billing_address.metadata == {"public": "public_value"}
+    assert user.default_shipping_address.metadata == {"public": "public_value"}
 
 
 def test_logged_customer_update_addresses_invalid_shipping_address(

--- a/saleor/graphql/account/tests/mutations/staff/test_address_create.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_address_create.py
@@ -23,6 +23,10 @@ ADDRESS_CREATE_MUTATION = """
                 country {
                     code
                 }
+                metadata {
+                    key
+                    value
+                }
             }
             user {
                 id
@@ -50,7 +54,10 @@ def test_create_address_mutation(
     data = content["data"]["addressCreate"]
     assert data["address"]["city"] == "DUMMY"
     assert data["address"]["country"]["code"] == "PL"
+    assert data["address"]["metadata"] == [{"key": "public", "value": "public_value"}]
     address_obj = Address.objects.get(city="DUMMY")
+
+    assert address_obj.metadata == {"public": "public_value"}
     assert address_obj.user_addresses.first() == customer_user
     assert data["user"]["id"] == user_id
 

--- a/saleor/graphql/account/tests/mutations/staff/test_address_update.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_address_update.py
@@ -13,6 +13,10 @@ ADDRESS_UPDATE_MUTATION = """
         addressUpdate(id: $addressId, input: $address) {
             address {
                 city
+                metadata {
+                    key
+                    value
+                }
             }
             user {
                 id
@@ -37,6 +41,7 @@ def test_address_update_mutation(
     )
     content = get_graphql_content(response)
     data = content["data"]["addressUpdate"]
+    assert data["address"]["metadata"] == [{"key": "public", "value": "public_value"}]
     assert data["address"]["city"] == graphql_address_data["city"].upper()
     address_obj.refresh_from_db()
     assert address_obj.city == graphql_address_data["city"].upper()

--- a/saleor/graphql/account/tests/mutations/staff/test_customer_update.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_customer_update.py
@@ -31,9 +31,17 @@ CUSTOMER_UPDATE_MUTATION = """
                 lastName
                 defaultBillingAddress {
                     id
+                    metadata {
+                        key
+                        value
+                    }
                 }
                 defaultShippingAddress {
                     id
+                    metadata {
+                        key
+                        value
+                    }
                 }
                 languageCode
                 isActive
@@ -78,14 +86,14 @@ def test_customer_update(
     note = "Test update note"
     external_reference = "test-ext-ref"
     address_data = convert_dict_keys_to_camel_case(address.as_data())
-    address_data.pop("metadata")
+    metadata = [{"key": "test key", "value": "test value"}]
+    private_metadata = [{"key": "private test key", "value": "private test value"}]
+    address_data["metadata"] = metadata
+    stored_metadata = {"test key": "test value"}
     address_data.pop("privateMetadata")
 
     new_street_address = "Updated street address"
     address_data["streetAddress1"] = new_street_address
-
-    metadata = {"key": "test key", "value": "test value"}
-    private_metadata = {"key": "private test key", "value": "private test value"}
 
     variables = {
         "id": user_id,
@@ -98,8 +106,8 @@ def test_customer_update(
             "defaultBillingAddress": address_data,
             "defaultShippingAddress": address_data,
             "languageCode": "PL",
-            "metadata": [metadata],
-            "privateMetadata": [private_metadata],
+            "metadata": metadata,
+            "privateMetadata": private_metadata,
         },
     }
 
@@ -119,8 +127,10 @@ def test_customer_update(
     assert data["user"]["languageCode"] == "PL"
     assert data["user"]["externalReference"] == external_reference
     assert not data["user"]["isActive"]
-    assert metadata in data["user"]["metadata"]
-    assert private_metadata in data["user"]["privateMetadata"]
+    assert metadata[0] in data["user"]["metadata"]
+    assert private_metadata[0] in data["user"]["privateMetadata"]
+    assert data["user"]["defaultShippingAddress"]["metadata"] == metadata
+    assert data["user"]["defaultBillingAddress"]["metadata"] == metadata
 
     customer_user.refresh_from_db()
 
@@ -132,9 +142,11 @@ def test_customer_update(
     assert billing_address.pk == billing_address_pk
     assert shipping_address.pk == shipping_address_pk
 
+    assert billing_address.metadata == stored_metadata
+    assert billing_address.metadata == stored_metadata
+
     assert billing_address.street_address_1 == new_street_address
     assert shipping_address.street_address_1 == new_street_address
-
     (
         name_changed_event,
         deactivated_event,

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -10,6 +10,7 @@ from promise import Promise
 from ...account import models
 from ...checkout.utils import get_user_checkout
 from ...core.exceptions import PermissionDenied
+from ...graphql.meta.inputs import MetadataInput
 from ...order import OrderStatus
 from ...permission.auth_filters import AuthorizationFilters
 from ...permission.enums import AccountPermissions, AppPermission, OrderPermissions
@@ -84,6 +85,12 @@ class AddressInput(BaseInputObjectType):
             "Phone numbers are validated with Google's "
             "[libphonenumber](https://github.com/google/libphonenumber) library."
         )
+    )
+
+    metadata = graphene.List(
+        graphene.NonNull(MetadataInput),
+        description="Address public metadata." + ADDED_IN_315,
+        required=False,
     )
 
 

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -283,9 +283,22 @@ class CheckoutCreate(ModelMutation, I18nMixin):
 
         cleaned_input["channel"] = channel
         cleaned_input["currency"] = channel.currency_code
-
+        shipping_address_metadata = (
+            data.get("shipping_address", {}).pop("metadata", list())
+            if data.get("shipping_address")
+            else None
+        )
+        billing_address_metadata = (
+            data.get("billing_address", {}).pop("metadata", list())
+            if data.get("billing_address")
+            else None
+        )
         shipping_address = cls.retrieve_shipping_address(user, data)
         billing_address = cls.retrieve_billing_address(user, data)
+        if shipping_address:
+            cls.update_metadata(shipping_address, shipping_address_metadata)
+        if billing_address:
+            cls.update_metadata(billing_address, billing_address_metadata)
 
         country = get_active_country(
             channel,

--- a/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_shipping_address_update.py
@@ -16,6 +16,7 @@ from ....checkout.utils import (
     is_shipping_required,
 )
 from ....core.tracing import traced_atomic_transaction
+from ....graphql.account.mixins import AddressMetadataMixin
 from ....warehouse.reservations import is_reservation_enabled
 from ....webhook.event_types import WebhookEventAsyncType
 from ...account.i18n import I18nMixin
@@ -41,7 +42,7 @@ if TYPE_CHECKING:
     from ....checkout.fetch import DeliveryMethodBase
 
 
-class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
+class CheckoutShippingAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixin):
     checkout = graphene.Field(Checkout, description="An updated checkout.")
 
     class Arguments:

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_create.py
@@ -11,38 +11,70 @@ def test_checkout_create(api_client, stock, graphql_address_data, channel_USD):
         checkoutCreate(input: $checkoutInput) {
             created
             checkout {
-            id
-            token
-            email
-            quantity
+                id
+                token
+                email
+                quantity
+                shippingAddress {
+                    metadata {
+                        key
+                        value
+                    }
+                }
+                billingAddress {
+                    metadata {
+                        key
+                        value
+                    }
+                }
             lines {
                 quantity
             }
             }
             errors {
-            field
-            message
-            code
-            variants
-            addressType
+                field
+                message
+                code
+                variants
+                addressType
             }
         }
-        }
+    }
     """
+    # given
     variant = stock.product_variant
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
     test_email = "test@example.com"
-    shipping_address = graphql_address_data
+    address = graphql_address_data
     variables = {
         "checkoutInput": {
             "channel": channel_USD.slug,
             "lines": [{"quantity": 1, "variantId": variant_id}],
             "email": test_email,
-            "shippingAddress": shipping_address,
+            "shippingAddress": address,
+            "billingAddress": address,
         }
     }
     assert not Checkout.objects.exists()
+
+    # when
     response = api_client.post_graphql(query, variables)
     content = get_graphql_content(response)["data"]["checkoutCreate"]
+
+    # then
+    stored_metadata = {"public": "public_value"}
+    assert (
+        content["checkout"]["shippingAddress"]["metadata"]
+        == graphql_address_data["metadata"]
+    )
+    assert (
+        content["checkout"]["billingAddress"]["metadata"]
+        == graphql_address_data["metadata"]
+    )
+
+    checkout = Checkout.objects.get(email=test_email)
+
+    assert checkout.billing_address.metadata == stored_metadata
+    assert checkout.shipping_address.metadata == stored_metadata
 
     assert content["created"] is True

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_billing_address_update.py
@@ -173,7 +173,6 @@ def test_checkout_billing_address_update(
     }
     """
     billing_address = graphql_address_data
-
     variables = {
         "id": to_global_id_or_none(checkout_with_item),
         "billingAddress": billing_address,
@@ -184,6 +183,7 @@ def test_checkout_billing_address_update(
     data = content["data"]["checkoutBillingAddressUpdate"]
     assert not data["errors"]
     checkout.refresh_from_db()
+    assert checkout.billing_address.metadata == {"public": "public_value"}
     assert checkout.billing_address is not None
     assert checkout.billing_address.first_name == billing_address["firstName"]
     assert checkout.billing_address.last_name == billing_address["lastName"]

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_create.py
@@ -495,13 +495,20 @@ def test_checkout_create(api_client, stock, graphql_address_data, channel_USD):
     variant = stock.product_variant
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
     test_email = "test@example.com"
-    shipping_address = graphql_address_data
+    billing_metadata = [{"key": "billing", "value": "billing_value"}]
+    shipping_metadata = [{"key": "shipping", "value": "shipping_value"}]
+    shipping_address_data = graphql_address_data.copy()
+    billing_address_data = graphql_address_data.copy()
+    shipping_address_data["metadata"] = shipping_metadata
+    billing_address_data["metadata"] = billing_metadata
+
     variables = {
         "checkoutInput": {
             "channel": channel_USD.slug,
             "lines": [{"quantity": 1, "variantId": variant_id}],
             "email": test_email,
-            "shippingAddress": shipping_address,
+            "shippingAddress": shipping_address_data,
+            "billingAddress": billing_address_data,
         }
     }
     assert not Checkout.objects.exists()
@@ -517,20 +524,27 @@ def test_checkout_create(api_client, stock, graphql_address_data, channel_USD):
     assert checkout_line.variant == variant
     assert checkout_line.quantity == 1
     assert new_checkout.shipping_address is not None
-    assert new_checkout.shipping_address.first_name == shipping_address["firstName"]
-    assert new_checkout.shipping_address.last_name == shipping_address["lastName"]
+    assert (
+        new_checkout.shipping_address.first_name == shipping_address_data["firstName"]
+    )
+    assert new_checkout.shipping_address.last_name == shipping_address_data["lastName"]
     assert (
         new_checkout.shipping_address.street_address_1
-        == shipping_address["streetAddress1"]
+        == shipping_address_data["streetAddress1"]
     )
     assert (
         new_checkout.shipping_address.street_address_2
-        == shipping_address["streetAddress2"]
+        == shipping_address_data["streetAddress2"]
     )
-    assert new_checkout.shipping_address.postal_code == shipping_address["postalCode"]
-    assert new_checkout.shipping_address.country == shipping_address["country"]
-    assert new_checkout.shipping_address.city == shipping_address["city"].upper()
+    assert (
+        new_checkout.shipping_address.postal_code == shipping_address_data["postalCode"]
+    )
+    assert new_checkout.shipping_address.country == shipping_address_data["country"]
+    assert new_checkout.shipping_address.city == shipping_address_data["city"].upper()
     assert not Reservation.objects.exists()
+
+    assert new_checkout.shipping_address.metadata == {"shipping": "shipping_value"}
+    assert new_checkout.billing_address.metadata == {"billing": "billing_value"}
 
 
 def test_checkout_create_with_custom_price(

--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -288,7 +288,7 @@ INTROSPECTION_RESULT = {"__schema": {"queryType": {"name": "Query"}}}
 
 @mock.patch("saleor.graphql.views.cache.set")
 @mock.patch("saleor.graphql.views.cache.get")
-@override_settings(DEBUG=False)
+@override_settings(DEBUG=False, OBSERVABILITY_REPORT_ALL_API_CALLS=False)
 def test_introspection_query_is_cached(cache_get_mock, cache_set_mock, api_client):
     cache_get_mock.return_value = None
     cache_key = generate_cache_key(INTROSPECTION_QUERY)
@@ -303,7 +303,7 @@ def test_introspection_query_is_cached(cache_get_mock, cache_set_mock, api_clien
 
 @mock.patch("saleor.graphql.views.cache.set")
 @mock.patch("saleor.graphql.views.cache.get")
-@override_settings(DEBUG=False)
+@override_settings(DEBUG=False, OBSERVABILITY_REPORT_ALL_API_CALLS=False)
 def test_introspection_query_is_cached_only_once(
     cache_get_mock, cache_set_mock, api_client
 ):
@@ -318,7 +318,7 @@ def test_introspection_query_is_cached_only_once(
 
 @mock.patch("saleor.graphql.views.cache.set")
 @mock.patch("saleor.graphql.views.cache.get")
-@override_settings(DEBUG=True)
+@override_settings(DEBUG=True, OBSERVABILITY_REPORT_ALL_API_CALLS=False)
 def test_introspection_query_is_not_cached_in_debug_mode(
     cache_get_mock, cache_set_mock, api_client
 ):

--- a/saleor/graphql/meta/mutations/delete_metadata.py
+++ b/saleor/graphql/meta/mutations/delete_metadata.py
@@ -40,5 +40,5 @@ class DeleteMetadata(BaseMetadataMutation):
             meta_instance = get_valid_metadata_instance(instance)
             for key in keys:
                 meta_instance.delete_value_from_metadata(key)
-            save_instance(meta_instance, "metadata")
+            save_instance(meta_instance, ["metadata"])
         return cls.success_response(instance)

--- a/saleor/graphql/meta/mutations/delete_private_metadata.py
+++ b/saleor/graphql/meta/mutations/delete_private_metadata.py
@@ -40,5 +40,5 @@ class DeletePrivateMetadata(BaseMetadataMutation):
             meta_instance = get_valid_metadata_instance(instance)
             for key in keys:
                 meta_instance.delete_value_from_private_metadata(key)
-            save_instance(meta_instance, "private_metadata")
+            save_instance(meta_instance, ["private_metadata"])
         return cls.success_response(instance)

--- a/saleor/graphql/meta/mutations/update_metadata.py
+++ b/saleor/graphql/meta/mutations/update_metadata.py
@@ -42,6 +42,6 @@ class UpdateMetadata(BaseMetadataMutation):
             cls.validate_metadata_keys(input)
             items = {data.key: data.value for data in input}
             meta_instance.store_value_in_metadata(items=items)
-            save_instance(meta_instance, "metadata")
+            save_instance(meta_instance, ["metadata"])
 
         return cls.success_response(instance)

--- a/saleor/graphql/meta/mutations/update_private_metadata.py
+++ b/saleor/graphql/meta/mutations/update_private_metadata.py
@@ -38,5 +38,5 @@ class UpdatePrivateMetadata(BaseMetadataMutation):
             cls.validate_metadata_keys(metadata_list)
             items = {data.key: data.value for data in metadata_list}
             meta_instance.store_value_in_private_metadata(items=items)
-            save_instance(meta_instance, "private_metadata")
+            save_instance(meta_instance, ["private_metadata"])
         return cls.success_response(instance)

--- a/saleor/graphql/meta/mutations/utils.py
+++ b/saleor/graphql/meta/mutations/utils.py
@@ -18,17 +18,15 @@ def get_valid_metadata_instance(instance) -> ModelWithMetadata:
     return instance
 
 
-def save_instance(instance, metadata_field: str):
-    fields = [metadata_field]
-
+def save_instance(instance, metadata_fields: list):
     try:
         if bool(instance._meta.get_field("updated_at")):
-            fields.append("updated_at")
+            metadata_fields.append("updated_at")
     except FieldDoesNotExist:
         pass
 
     try:
-        instance.save(update_fields=fields)
+        instance.save(update_fields=metadata_fields)
     except DatabaseError:
         msg = "Cannot update metadata for instance. Updating not existing object."
         raise ValidationError(

--- a/saleor/graphql/meta/permissions.py
+++ b/saleor/graphql/meta/permissions.py
@@ -108,14 +108,12 @@ def public_address_permissions(
 
     if address.user_addresses.filter(Exists(staff_users.filter(id=OuterRef("id")))):
         return [AccountPermissions.MANAGE_STAFF]
-
-    if (
-        warehouse_models.Warehouse.objects.filter(address_id=address.id).exists()
-        or site_models.SiteSettings.objects.filter(
-            company_address_id=address.id
-        ).exists()
-    ):
-        raise PermissionDenied()
+    elif warehouse_models.Warehouse.objects.filter(address_id=address.id).exists():
+        return [ProductPermissions.MANAGE_PRODUCTS]
+    elif site_models.SiteSettings.objects.filter(
+        company_address_id=address.id
+    ).exists():
+        return [SitePermissions.MANAGE_SETTINGS]
 
     return [AccountPermissions.MANAGE_USERS]
 

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -21,6 +21,7 @@ from ....order.utils import (
 from ....permission.enums import OrderPermissions
 from ....shipping.utils import convert_to_shipping_method_data
 from ...account.i18n import I18nMixin
+from ...account.mixins import AddressMetadataMixin
 from ...account.types import AddressInput
 from ...app.dataloaders import get_app_promise
 from ...channel.types import Channel
@@ -130,7 +131,10 @@ class DraftOrderCreateInput(DraftOrderInput):
 
 
 class DraftOrderCreate(
-    ModelWithRestrictedChannelAccessMutation, ShippingMethodUpdateMixin, I18nMixin
+    AddressMetadataMixin,
+    ModelWithRestrictedChannelAccessMutation,
+    ShippingMethodUpdateMixin,
+    I18nMixin,
 ):
     class Arguments:
         input = DraftOrderCreateInput(

--- a/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
@@ -118,7 +118,7 @@ class TransactionInitialize(TransactionSessionBase):
         app = cls.clean_app_from_payment_gateway(payment_gateway_data)
         transaction, event, data = handle_transaction_initialize_session(
             source_object=source_object,
-            payment_gateway=payment_gateway_data,
+            payment_gateway_data=payment_gateway_data,
             amount=amount,
             action=action,
             app=app,

--- a/saleor/graphql/payment/mutations/transaction/transaction_process.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_process.py
@@ -172,7 +172,7 @@ class TransactionProcess(BaseMutation):
         event, data = handle_transaction_process_session(
             transaction_item=transaction_item,
             source_object=source_object,
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=app_identifier, data=data
             ),
             app=app,

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -13,6 +13,7 @@ from .....payment.interface import (
     PaymentGatewayData,
     TransactionProcessActionData,
     TransactionSessionData,
+    TransactionSessionResult,
 )
 from ....channel.enums import TransactionFlowStrategyEnum
 from ....core.enums import TransactionInitializeErrorCode
@@ -166,7 +167,7 @@ def _assert_fields(
                 amount=expected_amount,
                 currency=source_object.currency,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=app_identifier, data=None, error=None
             ),
         )
@@ -192,8 +193,8 @@ def test_for_checkout_without_payment_gateway_data(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = "CHARGE_SUCCESS"
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -243,8 +244,8 @@ def test_for_order_without_payment_gateway_data(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = "CHARGE_SUCCESS"
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -294,8 +295,8 @@ def test_checkout_with_pending_amount(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -346,8 +347,8 @@ def test_order_with_pending_amount(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -399,8 +400,8 @@ def test_checkout_with_action_required_response(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -449,8 +450,8 @@ def test_order_with_action_required_response(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -499,8 +500,8 @@ def test_checkout_with_action_required_response_and_missing_psp_reference(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     del expected_response["pspReference"]
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -548,8 +549,8 @@ def test_order_with_action_required_response_and_missing_psp_reference(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     del expected_response["pspReference"]
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -603,8 +604,8 @@ def test_checkout_when_amount_is_not_provided(
     expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -654,8 +655,8 @@ def test_order_when_amount_is_not_provided(
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["amount"] = str(order.total_gross_amount)
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -716,8 +717,8 @@ def test_order_with_transaction_when_amount_is_not_provided(
         order.total_gross_amount - expected_charged_amount
     )
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -784,8 +785,8 @@ def test_checkout_with_transaction_when_amount_is_not_provided(
         checkout.total_gross_amount - expected_charged_amount
     )
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -844,8 +845,8 @@ def test_app_with_action_field_and_handle_payments(
     expected_response["amount"] = str(checkout.total_gross_amount)
     expected_response["pspReference"] = expected_psp_reference
     del expected_response["data"]
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -901,8 +902,8 @@ def test_uses_default_channel_action(
     expected_response = transaction_session_response.copy()
     expected_response["result"] = "CHARGE_SUCCESS"
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -962,8 +963,8 @@ def test_app_with_action_field(
         checkout.total_gross_amount - expected_charged_amount
     )
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -1155,8 +1156,8 @@ def test_checkout_fully_paid(
     expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
     expected_response["result"] = result.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_initialize.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {

--- a/saleor/graphql/payment/tests/mutations/test_transaction_process.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_process.py
@@ -14,6 +14,7 @@ from .....payment.interface import (
     PaymentGatewayData,
     TransactionProcessActionData,
     TransactionSessionData,
+    TransactionSessionResult,
 )
 from .....payment.models import TransactionEvent
 from ....core.enums import TransactionProcessErrorCode
@@ -165,7 +166,7 @@ def _assert_fields(
                 amount=expected_amount,
                 currency=source_object.currency,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=app_identifier, data=data, error=None
             ),
         )
@@ -205,8 +206,8 @@ def test_for_checkout_without_data(
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
     del expected_response["data"]
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -266,8 +267,8 @@ def test_for_order_without_data(
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
     del expected_response["data"]
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -325,8 +326,8 @@ def test_for_checkout_with_data(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
     expected_data = {"some": "json-data"}
     variables = {
@@ -386,8 +387,8 @@ def test_for_order_with_data(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_SUCCESS.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     expected_data = {"some": "json-data"}
@@ -447,8 +448,8 @@ def test_checkout_with_pending_amount(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -507,8 +508,8 @@ def test_order_with_pending_amount(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -566,8 +567,8 @@ def test_checkout_with_action_required_response(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -624,8 +625,8 @@ def test_order_with_action_required_response(
     expected_response["amount"] = expected_amount
     expected_response["result"] = TransactionEventType.CHARGE_ACTION_REQUIRED.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {
@@ -878,8 +879,8 @@ def test_checkout_fully_paid(
     expected_response["amount"] = str(checkout_info.checkout.total_gross_amount)
     expected_response["result"] = result.upper()
     expected_response["pspReference"] = expected_psp_reference
-    mocked_process.return_value = PaymentGatewayData(
-        app_identifier=expected_app_identifier, data=expected_response
+    mocked_process.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
     )
 
     variables = {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7331,6 +7331,21 @@ input AddressInput {
   Phone numbers are validated with Google's [libphonenumber](https://github.com/google/libphonenumber) library.
   """
   phone: String
+
+  """
+  Address public metadata.
+  
+  Added in Saleor 3.15.
+  """
+  metadata: [MetadataInput!]
+}
+
+input MetadataInput {
+  """Key of a metadata item."""
+  key: String!
+
+  """Value of a metadata item."""
+  value: String!
 }
 
 """Represents a custom attribute."""
@@ -19391,14 +19406,6 @@ input ShopSettingsInput {
   DEPRECATED: this field will be removed in Saleor 4.0. To enable taxes for a shipping method, assign a tax class to the shipping method with `shippingPriceCreate` or `shippingPriceUpdate` mutations.
   """
   chargeTaxesOnShipping: Boolean
-}
-
-input MetadataInput {
-  """Key of a metadata item."""
-  key: String!
-
-  """Value of a metadata item."""
-  value: String!
 }
 
 """

--- a/saleor/graphql/shop/mutations/shop_address_update.py
+++ b/saleor/graphql/shop/mutations/shop_address_update.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ....account import models as account_models
+from ....graphql.account.mixins import AddressMetadataMixin
 from ....permission.enums import SitePermissions
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
@@ -12,7 +13,7 @@ from ...site.dataloaders import get_site_promise
 from ..types import Shop
 
 
-class ShopAddressUpdate(BaseMutation, I18nMixin):
+class ShopAddressUpdate(AddressMetadataMixin, BaseMutation, I18nMixin):
     shop = graphene.Field(Shop, description="Updated shop.")
 
     class Arguments:

--- a/saleor/graphql/shop/tests/mutations/test_shop_address_update.py
+++ b/saleor/graphql/shop/tests/mutations/test_shop_address_update.py
@@ -26,6 +26,7 @@ def test_mutation_update_company_address(
             "city": address.city,
             "country": address.country.code,
             "postalCode": address.postal_code,
+            "metadata": [{"key": "meta", "value": "data"}],
         }
     }
 
@@ -45,6 +46,7 @@ def test_mutation_update_company_address(
     assert site_settings.company_address.street_address_1 == address.street_address_1
     assert site_settings.company_address.city == address.city
     assert site_settings.company_address.country.code == address.country.code
+    assert site_settings.company_address.metadata == {"meta": "data"}
 
 
 def test_mutation_update_company_address_remove_address(

--- a/saleor/graphql/warehouse/mutations/warehouse_create.py
+++ b/saleor/graphql/warehouse/mutations/warehouse_create.py
@@ -1,6 +1,7 @@
 from ....permission.enums import ProductPermissions
 from ....warehouse import models
 from ...account.i18n import I18nMixin
+from ...account.mixins import AddressMetadataMixin
 from ...core import ResolveInfo
 from ...core.mutations import ModelMutation
 from ...core.types import WarehouseError
@@ -9,7 +10,7 @@ from ..types import Warehouse, WarehouseCreateInput
 from .base import WarehouseMixin
 
 
-class WarehouseCreate(WarehouseMixin, ModelMutation, I18nMixin):
+class WarehouseCreate(AddressMetadataMixin, WarehouseMixin, ModelMutation, I18nMixin):
     class Arguments:
         input = WarehouseCreateInput(
             required=True, description="Fields required to create warehouse."
@@ -25,7 +26,13 @@ class WarehouseCreate(WarehouseMixin, ModelMutation, I18nMixin):
 
     @classmethod
     def prepare_address(cls, cleaned_data, *args):
+        address_data = cleaned_data.get("address")
+        address_metadata = list()
+        if address_data:
+            address_metadata = address_data.pop("metadata", list())
         address_form = cls.validate_address_form(cleaned_data["address"])
+        if address_metadata:
+            cls.update_metadata(address_form.instance, address_metadata)
         return address_form.save()
 
     @classmethod

--- a/saleor/graphql/warehouse/mutations/warehouse_update.py
+++ b/saleor/graphql/warehouse/mutations/warehouse_update.py
@@ -29,10 +29,15 @@ class WarehouseUpdate(WarehouseMixin, ModelMutation, I18nMixin):
     @classmethod
     def prepare_address(cls, cleaned_data, instance):
         address_data = cleaned_data.get("address")
+        address_metadata = list()
+        if address_data:
+            address_metadata = address_data.pop("metadata", list())
         address = instance.address
         if address_data is None:
             return address
         address_form = cls.validate_address_form(address_data, instance=address)
+        if address_metadata:
+            cls.update_metadata(address, address_metadata)
         return address_form.save()
 
     @classmethod

--- a/saleor/graphql/warehouse/tests/mutations/test_warehouse_update.py
+++ b/saleor/graphql/warehouse/tests/mutations/test_warehouse_update.py
@@ -32,6 +32,10 @@ mutation updateWarehouse($input: WarehouseUpdateInput!, $id: ID!) {
                 id
                 streetAddress1
                 streetAddress2
+                metadata {
+                    key
+                    value
+                }
             }
         }
     }
@@ -40,7 +44,7 @@ mutation updateWarehouse($input: WarehouseUpdateInput!, $id: ID!) {
 
 
 def test_mutation_update_warehouse(
-    staff_api_client, warehouse, permission_manage_products
+    staff_api_client, warehouse, permission_manage_products, graphql_address_data
 ):
     # given
     warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.id)
@@ -49,18 +53,29 @@ def test_mutation_update_warehouse(
     external_reference = "test-ext-ref"
     variables = {
         "id": warehouse_id,
-        "input": {"name": "New name", "externalReference": external_reference},
+        "input": {
+            "name": "New name",
+            "externalReference": external_reference,
+            "address": graphql_address_data,
+        },
     }
 
     # when
-    staff_api_client.post_graphql(
+    response = staff_api_client.post_graphql(
         MUTATION_UPDATE_WAREHOUSE,
         variables=variables,
         permissions=[permission_manage_products],
     )
+    content = get_graphql_content(response)
 
     # then
     warehouse.refresh_from_db()
+    warehouse_data = content["data"]["updateWarehouse"]["warehouse"]
+
+    assert warehouse_data["address"]["metadata"] == [
+        {"key": "public", "value": "public_value"}
+    ]
+    assert warehouse.address.metadata == {"public": "public_value"}
     assert not (warehouse.name == warehouse_old_name)
     assert warehouse.name == "New name"
     assert warehouse.slug == warehouse_slug

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1695,7 +1695,7 @@ class TransactionSessionBase(SubscriptionObjectType, AbstractType):
     @classmethod
     def resolve_data(cls, root: tuple[str, TransactionSessionData], _info: ResolveInfo):
         _, transaction_session_data = root
-        return transaction_session_data.payment_gateway.data
+        return transaction_session_data.payment_gateway_data.data
 
     @classmethod
     def resolve_merchant_reference(

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -73,7 +73,14 @@ class TransactionSessionData:
     transaction: "TransactionItem"
     source_object: Union["Checkout", "Order"]
     action: TransactionProcessActionData
-    payment_gateway: PaymentGatewayData
+    payment_gateway_data: PaymentGatewayData
+
+
+@dataclass
+class TransactionSessionResult:
+    app_identifier: str
+    response: Optional[Dict[Any, Any]] = None
+    error: Optional[str] = None
 
 
 @dataclass

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1432,7 +1432,7 @@ def create_transaction_for_order(
 
 def handle_transaction_initialize_session(
     source_object: Union[Checkout, Order],
-    payment_gateway: PaymentGatewayData,
+    payment_gateway_data: PaymentGatewayData,
     amount: Decimal,
     action: str,
     app: App,
@@ -1444,7 +1444,7 @@ def handle_transaction_initialize_session(
     session_data = TransactionSessionData(
         transaction=transaction_item,
         source_object=source_object,
-        payment_gateway=payment_gateway,
+        payment_gateway_data=payment_gateway_data,
         action=TransactionProcessActionData(
             action_type=action, currency=source_object.currency, amount=amount
         ),
@@ -1458,9 +1458,9 @@ def handle_transaction_initialize_session(
         currency=transaction_item.currency,
         amount_value=amount,
     )
-    response = manager.transaction_initialize_session(session_data)
+    result = manager.transaction_initialize_session(session_data)
 
-    response_data = response.data if response else None
+    response_data = result.response if result else None
 
     created_event = create_transaction_event_for_transaction_session(
         request_event,
@@ -1475,7 +1475,7 @@ def handle_transaction_initialize_session(
 def handle_transaction_process_session(
     transaction_item: TransactionItem,
     source_object: Union[Checkout, Order],
-    payment_gateway: PaymentGatewayData,
+    payment_gateway_data: PaymentGatewayData,
     action: str,
     app: App,
     manager: PluginsManager,
@@ -1484,7 +1484,7 @@ def handle_transaction_process_session(
     session_data = TransactionSessionData(
         transaction=transaction_item,
         source_object=source_object,
-        payment_gateway=payment_gateway,
+        payment_gateway_data=payment_gateway_data,
         action=TransactionProcessActionData(
             action_type=action,
             currency=source_object.currency,
@@ -1492,9 +1492,9 @@ def handle_transaction_process_session(
         ),
     )
 
-    response = manager.transaction_process_session(session_data)
+    result = manager.transaction_process_session(session_data)
 
-    response_data = response.data if response else None
+    response_data = result.response if result else None
 
     created_event = create_transaction_event_for_transaction_session(
         request_event,

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -32,6 +32,7 @@ from ..payment.interface import (
     PaymentData,
     PaymentGateway,
     TransactionActionData,
+    TransactionSessionResult,
 )
 from ..thumbnail.models import Thumbnail
 from .models import PluginConfiguration
@@ -849,11 +850,11 @@ class BasePlugin:
     ]
 
     transaction_initialize_session: Callable[
-        ["TransactionSessionData", None], "PaymentGatewayData"
+        ["TransactionSessionData", None], "TransactionSessionResult"
     ]
 
     transaction_process_session: Callable[
-        ["TransactionSessionData", None], "PaymentGatewayData"
+        ["TransactionSessionData", None], "TransactionSessionResult"
     ]
 
     # Trigger when transaction item metadata is updated.

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
         TokenConfig,
         TransactionActionData,
         TransactionSessionData,
+        TransactionSessionResult,
     )
     from ..payment.models import TransactionItem
     from ..product.models import (
@@ -1024,7 +1025,7 @@ class PluginsManager(PaymentInterface):
     def transaction_initialize_session(
         self,
         transaction_session_data: "TransactionSessionData",
-    ) -> "PaymentGatewayData":
+    ) -> "TransactionSessionResult":
         default_value = None
         return self.__run_method_on_plugins(
             "transaction_initialize_session",
@@ -1036,7 +1037,7 @@ class PluginsManager(PaymentInterface):
     def transaction_process_session(
         self,
         transaction_session_data: "TransactionSessionData",
-    ) -> "PaymentGatewayData":
+    ) -> "TransactionSessionResult":
         default_value = None
         return self.__run_method_on_plugins(
             "transaction_process_session",

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -20,7 +20,11 @@ from prices import Money, TaxedMoney
 from ...account.models import User
 from ...core.taxes import TaxData, TaxLineData, TaxType
 from ...order.interface import OrderTaxedPricesData
-from ...payment.interface import PaymentGatewayData, TransactionSessionData
+from ...payment.interface import (
+    PaymentGatewayData,
+    TransactionSessionData,
+    TransactionSessionResult,
+)
 from ..base_plugin import BasePlugin, ConfigurationTypeField, ExternalAccessTokens
 
 if TYPE_CHECKING:
@@ -317,14 +321,18 @@ class PluginSample(BasePlugin):
         transaction_session_data: "TransactionSessionData",
         previous_value: Any,
     ):
-        return PaymentGatewayData(app_identifier="123", data=None, error="Some error")
+        return TransactionSessionResult(
+            app_identifier="123", response=None, error="Some error"
+        )
 
     def transaction_process_session(
         self,
         transaction_session_data: "TransactionSessionData",
         previous_value: Any,
     ):
-        return PaymentGatewayData(app_identifier="321", data=None, error="Some error")
+        return TransactionSessionResult(
+            app_identifier="321", response=None, error="Some error"
+        )
 
     def checkout_fully_paid(self, checkout):
         return None

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -22,6 +22,7 @@ from ...payment.interface import (
     PaymentGatewayData,
     TransactionProcessActionData,
     TransactionSessionData,
+    TransactionSessionResult,
 )
 from ...product.models import Product
 from ..base_plugin import ExternalAccessTokens
@@ -1211,7 +1212,7 @@ def test_manager_transaction_initialize_session(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=None, error=None
         ),
     )
@@ -1221,7 +1222,7 @@ def test_manager_transaction_initialize_session(
     )
 
     # then
-    assert isinstance(response, PaymentGatewayData)
+    assert isinstance(response, TransactionSessionResult)
 
 
 def test_manager_transaction_process_session(
@@ -1252,7 +1253,7 @@ def test_manager_transaction_process_session(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=None, error=None
         ),
     )
@@ -1262,7 +1263,7 @@ def test_manager_transaction_process_session(
     )
 
     # then
-    assert isinstance(response, PaymentGatewayData)
+    assert isinstance(response, TransactionSessionResult)
 
 
 @patch("saleor.plugins.tests.sample_plugins.PluginSample.checkout_fully_paid")

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_initialize_session.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_initialize_session.py
@@ -75,7 +75,7 @@ def test_transaction_initialize_session_checkout_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -140,7 +140,7 @@ def test_transaction_initialize_session_checkout_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -204,7 +204,7 @@ def test_transaction_initialize_session_order_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -268,7 +268,7 @@ def test_transaction_initialize_session_order_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_process_session.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_process_session.py
@@ -75,7 +75,7 @@ def test_transaction_process_session_checkout_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -140,7 +140,7 @@ def test_transaction_process_session_checkout_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -204,7 +204,7 @@ def test_transaction_process_session_order_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )
@@ -268,7 +268,7 @@ def test_transaction_process_session_order_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
-        payment_gateway=PaymentGatewayData(
+        payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
     )

--- a/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
@@ -12,6 +12,7 @@ from ....payment.interface import (
     PaymentGatewayData,
     TransactionProcessActionData,
     TransactionSessionData,
+    TransactionSessionResult,
 )
 from ....webhook.event_types import WebhookEventSyncType
 from ....webhook.models import Webhook
@@ -111,8 +112,8 @@ def _assert_fields(payload, webhook, expected_response, response, mock_request):
     assert delivery.payload == event_payload
     assert delivery.webhook == webhook
     mock_request.assert_called_once_with(webhook_app, delivery)
-    assert response == PaymentGatewayData(
-        app_identifier=webhook_app.identifier, data=expected_response, error=None
+    assert response == TransactionSessionResult(
+        app_identifier=webhook_app.identifier, response=expected_response, error=None
     )
 
 
@@ -162,7 +163,7 @@ def test_transaction_initialize_checkout_without_request_data_and_static_payload
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -230,7 +231,7 @@ def test_transaction_initialize_checkout_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -298,7 +299,7 @@ def test_transaction_initialize_checkout_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -367,7 +368,7 @@ def test_transaction_initialize_checkout_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -436,7 +437,7 @@ def test_transaction_initialize_session_skips_app_without_identifier(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -447,8 +448,8 @@ def test_transaction_initialize_session_skips_app_without_identifier(
     assert not EventPayload.objects.first()
     assert not EventDelivery.objects.first()
     assert not mock_request.called
-    assert response == PaymentGatewayData(
-        app_identifier="", data=None, error="Missing app identifier"
+    assert response == TransactionSessionResult(
+        app_identifier="", response=None, error="Missing app identifier"
     )
 
 
@@ -498,7 +499,7 @@ def test_transaction_initialize_order_without_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -566,7 +567,7 @@ def test_transaction_initialize_order_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -634,7 +635,7 @@ def test_transaction_initialize_order_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -703,7 +704,7 @@ def test_transaction_initialize_order_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),

--- a/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
@@ -12,6 +12,7 @@ from ....payment.interface import (
     PaymentGatewayData,
     TransactionProcessActionData,
     TransactionSessionData,
+    TransactionSessionResult,
 )
 from ....webhook.event_types import WebhookEventSyncType
 from ....webhook.models import Webhook
@@ -111,8 +112,8 @@ def _assert_fields(payload, webhook, expected_response, response, mock_request):
     assert delivery.payload == event_payload
     assert delivery.webhook == webhook
     mock_request.assert_called_once_with(webhook_app, delivery)
-    assert response == PaymentGatewayData(
-        app_identifier=webhook_app.identifier, data=expected_response, error=None
+    assert response == TransactionSessionResult(
+        app_identifier=webhook_app.identifier, response=expected_response, error=None
     )
 
 
@@ -162,7 +163,7 @@ def test_transaction_process_checkout_without_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -230,7 +231,7 @@ def test_transaction_process_checkout_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -298,7 +299,7 @@ def test_transaction_process_checkout_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -367,7 +368,7 @@ def test_transaction_process_checkout_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -436,7 +437,7 @@ def test_transaction_process_session_skips_app_without_identifier(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -447,8 +448,8 @@ def test_transaction_process_session_skips_app_without_identifier(
     assert not EventPayload.objects.first()
     assert not EventDelivery.objects.first()
     assert not mock_request.called
-    assert response == PaymentGatewayData(
-        app_identifier="", data=None, error="Missing app identifier"
+    assert response == TransactionSessionResult(
+        app_identifier="", response=None, error="Missing app identifier"
     )
 
 
@@ -498,7 +499,7 @@ def test_transaction_process_order_without_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -566,7 +567,7 @@ def test_transaction_process_order_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),
@@ -634,7 +635,7 @@ def test_transaction_process_order_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
         ),
@@ -703,7 +704,7 @@ def test_transaction_process_order_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
-            payment_gateway=PaymentGatewayData(
+            payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
         ),

--- a/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
@@ -1,0 +1,162 @@
+import pytest
+
+from ..channel.utils import create_channel
+from ..orders.utils.draft_order import draft_order_create
+from ..orders.utils.order_lines import order_lines_create
+from ..product.utils import (
+    create_category,
+    create_product,
+    create_product_channel_listing,
+    create_product_type,
+    create_product_variant,
+    create_product_variant_channel_listing,
+)
+from ..shipping_zone.utils import (
+    create_shipping_method,
+    create_shipping_method_channel_listing,
+    create_shipping_zone,
+)
+from ..utils import assign_permissions
+from ..warehouse.utils import create_warehouse
+from .utils import checkout_create_from_order
+
+
+def prepare_product(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_shipping,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+    permission_manage_checkouts,
+    channel_slug,
+):
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_checkouts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    warehouse_data = create_warehouse(e2e_staff_api_client)
+    warehouse_id = warehouse_data["id"]
+
+    warehouse_ids = [warehouse_id]
+    channel_data = create_channel(
+        e2e_staff_api_client, slug=channel_slug, warehouse_ids=warehouse_ids
+    )
+    channel_id = channel_data["id"]
+
+    channel_ids = [channel_id]
+    shipping_zone_data = create_shipping_zone(
+        e2e_staff_api_client,
+        warehouse_ids=warehouse_ids,
+        channel_ids=channel_ids,
+    )
+    shipping_zone_id = shipping_zone_data["id"]
+
+    shipping_method_data = create_shipping_method(
+        e2e_staff_api_client, shipping_zone_id
+    )
+    shipping_method_id = shipping_method_data["id"]
+
+    create_shipping_method_channel_listing(
+        e2e_staff_api_client, shipping_method_id, channel_id
+    )
+
+    product_type_data = create_product_type(
+        e2e_staff_api_client,
+    )
+    product_type_id = product_type_data["id"]
+
+    category_data = create_category(e2e_staff_api_client)
+    category_id = category_data["id"]
+
+    product_data = create_product(e2e_staff_api_client, product_type_id, category_id)
+    product_id = product_data["id"]
+
+    create_product_channel_listing(e2e_staff_api_client, product_id, channel_id)
+
+    stocks = [
+        {
+            "warehouse": warehouse_id,
+            "quantity": 5,
+        }
+    ]
+    product_variant_data = create_product_variant(
+        e2e_staff_api_client,
+        product_id,
+        stocks=stocks,
+    )
+    product_variant_id = product_variant_data["id"]
+
+    create_product_variant_channel_listing(
+        e2e_staff_api_client,
+        product_variant_id,
+        channel_id,
+    )
+
+    return channel_id, product_variant_id
+
+
+@pytest.mark.e2e
+def test_checkout_create_from_order_core_0104(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+    permission_manage_checkouts,
+):
+    # Before
+    channel_id, variant_id = prepare_product(
+        e2e_staff_api_client,
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_product_types_and_attributes,
+        permission_manage_shipping,
+        permission_manage_orders,
+        permission_manage_checkouts,
+        channel_slug="test",
+    )
+    # Step 1 - Create draft order
+    data = draft_order_create(
+        e2e_staff_api_client,
+        channel_id,
+    )
+
+    order_id = data["order"]["id"]
+    errors = data["errors"]
+
+    assert errors == []
+    assert order_id is not None
+
+    order_lines = [{"variantId": variant_id, "quantity": 1, "price": 100}]
+    order_data = order_lines_create(e2e_staff_api_client, order_id, order_lines)
+    assert order_data is not None
+    order_product_variant_id = order_data["order"]["lines"][0]["variant"]
+    order_product_quantity = order_data["order"]["lines"][0]["quantity"]
+    assert order_product_quantity is not None
+    assert order_product_variant_id is not None
+
+    # # Step 2 - Create checkout from order
+    checkout_data = checkout_create_from_order(e2e_staff_api_client, order_id)
+    checkout_id = checkout_data["checkout"]["id"]
+    assert checkout_id is not None
+    errors = checkout_data["errors"]
+    assert errors == []
+    checkout_lines = checkout_data["checkout"]["lines"]
+    assert checkout_lines != []
+
+    checkout_product_variant_id = checkout_lines[0]["variant"]["id"]
+    checkout_product_quantity = checkout_lines[0]["quantity"]
+    assert checkout_product_variant_id is not None
+    assert checkout_product_quantity is not None
+    order_product_variant_id_value = order_product_variant_id["id"]
+
+    assert checkout_product_variant_id == order_product_variant_id_value
+    assert checkout_product_quantity == order_product_quantity

--- a/saleor/tests/e2e/checkout/utils/__init__.py
+++ b/saleor/tests/e2e/checkout/utils/__init__.py
@@ -1,7 +1,10 @@
+from ...orders.utils.draft_order import draft_order_create
+from ...orders.utils.order_lines import order_lines_create
 from ...product.utils.product_channel_listing import raw_create_product_channel_listing
 from .checkout_billing_address_update import checkout_billing_address_update
 from .checkout_complete import checkout_complete
 from .checkout_create import checkout_create, raw_checkout_create
+from .checkout_create_from_order import checkout_create_from_order
 from .checkout_delivery_method_update import checkout_delivery_method_update
 from .checkout_lines_update import checkout_lines_update
 from .checkout_payment_create import (
@@ -21,4 +24,7 @@ __all__ = [
     "checkout_shipping_address_update",
     "raw_checkout_dummy_payment_create",
     "checkout_lines_update",
+    "draft_order_create",
+    "order_lines_create",
+    "checkout_create_from_order",
 ]

--- a/saleor/tests/e2e/checkout/utils/checkout_create_from_order.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_create_from_order.py
@@ -1,0 +1,125 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+CHECKOUT_CREATE_FROM_ORDER_MUTATION = """
+mutation CheckoutCreateFromOrder( $id: ID!){
+  checkoutCreateFromOrder(id: $id){
+    errors{
+      field
+      message
+      code
+    }
+    unavailableVariants{
+      lineId
+      variantId
+      code
+      message
+    }
+    checkout{
+      id
+      email
+      totalPrice{
+          gross{
+            amount
+            currency
+          }
+          net{
+            amount
+            currency
+          }
+          tax{
+            amount
+            currency
+          }
+        }
+      user{
+        id
+      }
+      lines{
+        variant{
+          id
+          name
+          product{
+            id
+            name
+          }
+        }
+        quantity
+        totalPrice{
+          gross{
+            amount
+            currency
+          }
+          net{
+            amount
+            currency
+          }
+          tax{
+            amount
+            currency
+          }
+        }
+      }
+      metadata{
+        key
+        value
+      }
+      shippingPrice{
+          gross{
+            amount
+            currency
+          }
+          net{
+            amount
+            currency
+          }
+          tax{
+            amount
+            currency
+          }
+        }
+      shippingAddress{
+        country{
+          code
+        }
+        countryArea
+        streetAddress1
+        streetAddress2
+        postalCode
+        city
+        firstName
+        lastName
+      }
+      billingAddress{
+        country{
+          code
+        }
+        countryArea
+        streetAddress1
+        streetAddress2
+        postalCode
+        city
+        firstName
+        lastName
+      }
+      shippingMethods{
+        id
+        name
+      }
+    }
+  }
+}
+"""
+
+
+def checkout_create_from_order(api_client, order_id):
+    variables = {"id": order_id}
+
+    response = api_client.post_graphql(
+        CHECKOUT_CREATE_FROM_ORDER_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    checkout_data = content["data"]["checkoutCreateFromOrder"]
+
+    return checkout_data

--- a/saleor/tests/e2e/orders/__init__.py
+++ b/saleor/tests/e2e/orders/__init__.py
@@ -1,0 +1,7 @@
+from .utils.draft_order import draft_order_create
+from .utils.order_lines import order_lines_create
+
+__all__ = [
+    "draft_order_create",
+    "order_lines_create",
+]

--- a/saleor/tests/e2e/orders/utils/draft_order.py
+++ b/saleor/tests/e2e/orders/utils/draft_order.py
@@ -1,0 +1,35 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+DRAFT_ORDER_CREATE_MUTATION = """
+mutation OrderDraftCreate($input: DraftOrderCreateInput!){
+  draftOrderCreate(input: $input){
+    errors{
+        message
+        field}
+    order{
+        id
+        }
+    }
+}
+"""
+
+
+def draft_order_create(
+    api_client,
+    channel_id,
+):
+    variables = {
+        "input": {
+            "channelId": channel_id,
+        }
+    }
+
+    response = api_client.post_graphql(
+        DRAFT_ORDER_CREATE_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["draftOrderCreate"]
+
+    return data

--- a/saleor/tests/e2e/orders/utils/order_lines.py
+++ b/saleor/tests/e2e/orders/utils/order_lines.py
@@ -1,0 +1,33 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+ORDER_LINES_CREATE_MUTATION = """
+mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]! ){
+  orderLinesCreate(id: $id input: $input, ) {
+    order {
+      lines {
+        quantity
+        variant {
+          id
+        }
+      }
+    }
+    errors {
+      field
+      message
+    }
+  }
+}
+"""
+
+
+def order_lines_create(
+    api_client,
+    order_id,
+    input,
+):
+    variables = {"id": order_id, "input": input}
+
+    response = api_client.post_graphql(ORDER_LINES_CREATE_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    return content["data"]["orderLinesCreate"]

--- a/saleor/tests/e2e/utils.py
+++ b/saleor/tests/e2e/utils.py
@@ -1,3 +1,4 @@
+from ...account.models import Group
 from ...graphql.tests.utils import get_graphql_content  # noqa: F401
 from ...graphql.tests.utils import get_multipart_request_body  # noqa: F401
 
@@ -5,4 +6,9 @@ from ...graphql.tests.utils import get_multipart_request_body  # noqa: F401
 def assign_permissions(api_client, permissions):
     user = api_client.user
     if user:
-        user.user_permissions.add(*permissions)
+        group = Group.objects.create(
+            name="admins",
+            restricted_access_to_channels=False,
+        )
+        group.permissions.add(*permissions)
+        user.groups.add(group)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -833,6 +833,7 @@ def graphql_address_data():
         "city": "Wrocław",
         "countryArea": "",
         "phone": "+48321321888",
+        "metadata": [{"key": "public", "value": "public_value"}],
     }
 
 


### PR DESCRIPTION
I want to merge this change because it adds a test for creating checkout from order core 0104

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
