### PR TITLE
[TEST] Adding test for creating checkout from order core 0104

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
@@ -1,0 +1,162 @@
+import pytest
+
+from ..channel.utils import create_channel
+from ..orders.utils.draft_order import draft_order_create
+from ..orders.utils.order_lines import order_lines_create
+from ..product.utils import (
+    create_category,
+    create_product,
+    create_product_channel_listing,
+    create_product_type,
+    create_product_variant,
+    create_product_variant_channel_listing,
+)
+from ..shipping_zone.utils import (
+    create_shipping_method,
+    create_shipping_method_channel_listing,
+    create_shipping_zone,
+)
+from ..utils import assign_permissions
+from ..warehouse.utils import create_warehouse
+from .utils import checkout_create_from_order
+
+
+def prepare_product(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_shipping,
+    permission_manage_product_types_and_attributes,
+    permission_manage_orders,
+    permission_manage_checkouts,
+    channel_slug,
+):
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_checkouts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    warehouse_data = create_warehouse(e2e_staff_api_client)
+    warehouse_id = warehouse_data["id"]
+
+    warehouse_ids = [warehouse_id]
+    channel_data = create_channel(
+        e2e_staff_api_client, slug=channel_slug, warehouse_ids=warehouse_ids
+    )
+    channel_id = channel_data["id"]
+
+    channel_ids = [channel_id]
+    shipping_zone_data = create_shipping_zone(
+        e2e_staff_api_client,
+        warehouse_ids=warehouse_ids,
+        channel_ids=channel_ids,
+    )
+    shipping_zone_id = shipping_zone_data["id"]
+
+    shipping_method_data = create_shipping_method(
+        e2e_staff_api_client, shipping_zone_id
+    )
+    shipping_method_id = shipping_method_data["id"]
+
+    create_shipping_method_channel_listing(
+        e2e_staff_api_client, shipping_method_id, channel_id
+    )
+
+    product_type_data = create_product_type(
+        e2e_staff_api_client,
+    )
+    product_type_id = product_type_data["id"]
+
+    category_data = create_category(e2e_staff_api_client)
+    category_id = category_data["id"]
+
+    product_data = create_product(e2e_staff_api_client, product_type_id, category_id)
+    product_id = product_data["id"]
+
+    create_product_channel_listing(e2e_staff_api_client, product_id, channel_id)
+
+    stocks = [
+        {
+            "warehouse": warehouse_id,
+            "quantity": 5,
+        }
+    ]
+    product_variant_data = create_product_variant(
+        e2e_staff_api_client,
+        product_id,
+        stocks=stocks,
+    )
+    product_variant_id = product_variant_data["id"]
+
+    create_product_variant_channel_listing(
+        e2e_staff_api_client,
+        product_variant_id,
+        channel_id,
+    )
+
+    return channel_id, product_variant_id
+
+
+@pytest.mark.e2e
+def test_checkout_create_from_order_core_0104(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+    permission_manage_checkouts,
+):
+    # Before
+    channel_id, variant_id = prepare_product(
+        e2e_staff_api_client,
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_product_types_and_attributes,
+        permission_manage_shipping,
+        permission_manage_orders,
+        permission_manage_checkouts,
+        channel_slug="test",
+    )
+    # Step 1 - Create draft order
+    data = draft_order_create(
+        e2e_staff_api_client,
+        channel_id,
+    )
+
+    order_id = data["order"]["id"]
+    errors = data["errors"]
+
+    assert errors == []
+    assert order_id is not None
+
+    order_lines = [{"variantId": variant_id, "quantity": 1, "price": 100}]
+    order_data = order_lines_create(e2e_staff_api_client, order_id, order_lines)
+    assert order_data is not None
+    order_product_variant_id = order_data["order"]["lines"][0]["variant"]
+    order_product_quantity = order_data["order"]["lines"][0]["quantity"]
+    assert order_product_quantity is not None
+    assert order_product_variant_id is not None
+
+    # # Step 2 - Create checkout from order
+    checkout_data = checkout_create_from_order(e2e_staff_api_client, order_id)
+    checkout_id = checkout_data["checkout"]["id"]
+    assert checkout_id is not None
+    errors = checkout_data["errors"]
+    assert errors == []
+    checkout_lines = checkout_data["checkout"]["lines"]
+    assert checkout_lines != []
+
+    checkout_product_variant_id = checkout_lines[0]["variant"]["id"]
+    checkout_product_quantity = checkout_lines[0]["quantity"]
+    assert checkout_product_variant_id is not None
+    assert checkout_product_quantity is not None
+    order_product_variant_id_value = order_product_variant_id["id"]
+
+    assert checkout_product_variant_id == order_product_variant_id_value
+    assert checkout_product_quantity == order_product_quantity

--- a/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
@@ -123,7 +123,7 @@ def test_checkout_create_from_order_core_0104(
         permission_manage_checkouts,
         channel_slug="test",
     )
-    # Step 1 - Create draft order
+    # Step 1 - Create draft order and add order lines
     data = draft_order_create(
         e2e_staff_api_client,
         channel_id,

--- a/saleor/tests/e2e/checkout/utils/__init__.py
+++ b/saleor/tests/e2e/checkout/utils/__init__.py
@@ -1,7 +1,10 @@
+from ...orders.utils.draft_order import draft_order_create
+from ...orders.utils.order_lines import order_lines_create
 from ...product.utils.product_channel_listing import raw_create_product_channel_listing
 from .checkout_billing_address_update import checkout_billing_address_update
 from .checkout_complete import checkout_complete
 from .checkout_create import checkout_create, raw_checkout_create
+from .checkout_create_from_order import checkout_create_from_order
 from .checkout_delivery_method_update import checkout_delivery_method_update
 from .checkout_lines_update import checkout_lines_update
 from .checkout_payment_create import (
@@ -21,4 +24,7 @@ __all__ = [
     "checkout_shipping_address_update",
     "raw_checkout_dummy_payment_create",
     "checkout_lines_update",
+    "draft_order_create",
+    "order_lines_create",
+    "checkout_create_from_order",
 ]

--- a/saleor/tests/e2e/checkout/utils/checkout_create_from_order.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_create_from_order.py
@@ -1,0 +1,125 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+CHECKOUT_CREATE_FROM_ORDER_MUTATION = """
+mutation CheckoutCreateFromOrder( $id: ID!){
+  checkoutCreateFromOrder(id: $id){
+    errors{
+      field
+      message
+      code
+    }
+    unavailableVariants{
+      lineId
+      variantId
+      code
+      message
+    }
+    checkout{
+      id
+      email
+      totalPrice{
+          gross{
+            amount
+            currency
+          }
+          net{
+            amount
+            currency
+          }
+          tax{
+            amount
+            currency
+          }
+        }
+      user{
+        id
+      }
+      lines{
+        variant{
+          id
+          name
+          product{
+            id
+            name
+          }
+        }
+        quantity
+        totalPrice{
+          gross{
+            amount
+            currency
+          }
+          net{
+            amount
+            currency
+          }
+          tax{
+            amount
+            currency
+          }
+        }
+      }
+      metadata{
+        key
+        value
+      }
+      shippingPrice{
+          gross{
+            amount
+            currency
+          }
+          net{
+            amount
+            currency
+          }
+          tax{
+            amount
+            currency
+          }
+        }
+      shippingAddress{
+        country{
+          code
+        }
+        countryArea
+        streetAddress1
+        streetAddress2
+        postalCode
+        city
+        firstName
+        lastName
+      }
+      billingAddress{
+        country{
+          code
+        }
+        countryArea
+        streetAddress1
+        streetAddress2
+        postalCode
+        city
+        firstName
+        lastName
+      }
+      shippingMethods{
+        id
+        name
+      }
+    }
+  }
+}
+"""
+
+
+def checkout_create_from_order(api_client, order_id):
+    variables = {"id": order_id}
+
+    response = api_client.post_graphql(
+        CHECKOUT_CREATE_FROM_ORDER_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    checkout_data = content["data"]["checkoutCreateFromOrder"]
+
+    return checkout_data

--- a/saleor/tests/e2e/orders/__init__.py
+++ b/saleor/tests/e2e/orders/__init__.py
@@ -1,0 +1,7 @@
+from .utils.draft_order import draft_order_create
+from .utils.order_lines import order_lines_create
+
+__all__ = [
+    "draft_order_create",
+    "order_lines_create",
+]

--- a/saleor/tests/e2e/orders/utils/draft_order.py
+++ b/saleor/tests/e2e/orders/utils/draft_order.py
@@ -2,12 +2,13 @@ from saleor.graphql.tests.utils import get_graphql_content
 
 DRAFT_ORDER_CREATE_MUTATION = """
 mutation OrderDraftCreate($input: DraftOrderCreateInput!){
-  draftOrderCreate(input: $input){
-    errors{
-        message
-        field}
-    order{
-        id
+    draftOrderCreate(input: $input) {
+        errors {
+            message
+            field
+        }
+        order {
+            id
         }
     }
 }
@@ -31,5 +32,11 @@ def draft_order_create(
     content = get_graphql_content(response)
 
     data = content["data"]["draftOrderCreate"]
+
+    order_id = data["order"]["id"]
+    errors = data["errors"]
+
+    assert errors == []
+    assert order_id is not None
 
     return data

--- a/saleor/tests/e2e/orders/utils/draft_order.py
+++ b/saleor/tests/e2e/orders/utils/draft_order.py
@@ -1,0 +1,35 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+DRAFT_ORDER_CREATE_MUTATION = """
+mutation OrderDraftCreate($input: DraftOrderCreateInput!){
+  draftOrderCreate(input: $input){
+    errors{
+        message
+        field}
+    order{
+        id
+        }
+    }
+}
+"""
+
+
+def draft_order_create(
+    api_client,
+    channel_id,
+):
+    variables = {
+        "input": {
+            "channelId": channel_id,
+        }
+    }
+
+    response = api_client.post_graphql(
+        DRAFT_ORDER_CREATE_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["draftOrderCreate"]
+
+    return data

--- a/saleor/tests/e2e/orders/utils/order_lines.py
+++ b/saleor/tests/e2e/orders/utils/order_lines.py
@@ -1,0 +1,33 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+ORDER_LINES_CREATE_MUTATION = """
+mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]! ){
+  orderLinesCreate(id: $id input: $input, ) {
+    order {
+      lines {
+        quantity
+        variant {
+          id
+        }
+      }
+    }
+    errors {
+      field
+      message
+    }
+  }
+}
+"""
+
+
+def order_lines_create(
+    api_client,
+    order_id,
+    input,
+):
+    variables = {"id": order_id, "input": input}
+
+    response = api_client.post_graphql(ORDER_LINES_CREATE_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    return content["data"]["orderLinesCreate"]

--- a/saleor/tests/e2e/utils.py
+++ b/saleor/tests/e2e/utils.py
@@ -1,3 +1,4 @@
+from ...account.models import Group
 from ...graphql.tests.utils import get_graphql_content  # noqa: F401
 from ...graphql.tests.utils import get_multipart_request_body  # noqa: F401
 
@@ -5,4 +6,9 @@ from ...graphql.tests.utils import get_multipart_request_body  # noqa: F401
 def assign_permissions(api_client, permissions):
     user = api_client.user
     if user:
-        user.user_permissions.add(*permissions)
+        group = Group.objects.create(
+            name="admins",
+            restricted_access_to_channels=False,
+        )
+        group.permissions.add(*permissions)
+        user.groups.add(group)


### PR DESCRIPTION
I want to merge this change because it adds a test for creating checkout from order core 0104


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
