### PR TITLE
Add preorder deallocation

### DIFF
--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -12,7 +12,10 @@ from ..core.utils.events import call_event
 from ..discount.models import Voucher, VoucherCustomer
 from ..payment.models import Payment, TransactionItem
 from ..plugins.manager import get_plugins_manager
-from ..warehouse.management import deallocate_stock_for_orders
+from ..warehouse.management import (
+    deallocate_preorders_for_orders,
+    deallocate_stock_for_orders,
+)
 from . import OrderEvents, OrderStatus
 from .models import Order, OrderEvent
 from .utils import invalidate_order_prices
@@ -115,6 +118,7 @@ def _expire_orders(manager, now):
         _bulk_release_voucher_usage(ids_batch)
         _order_expired_events(ids_batch)
         deallocate_stock_for_orders(ids_batch, manager)
+        deallocate_preorders_for_orders(ids_batch)
         _call_expired_order_events(ids_batch, manager)
 
 

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -901,3 +901,12 @@ def _get_stock_for_preorder_allocation(
     return (stock[0] if stock else None) or Stock(
         warehouse=warehouse, product_variant=product_variant, quantity=0
     )
+
+
+def deallocate_preorders_for_orders(orders_id):
+    lines = OrderLine.objects.filter(order_id__in=orders_id)
+    preorder_allocations = PreorderAllocation.objects.filter(
+        Exists(lines.filter(id=OuterRef("order_line_id")))
+    )
+    if preorder_allocations:
+        preorder_allocations.delete()


### PR DESCRIPTION
I want to merge this change because it adds missing pre-order deallocation to order expiring task.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
