### PR TITLE
Add `ACCOUNT_DELETED` webhook event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ Shipping methods can be removed by the user after it has been assigned to a chec
 
 - Add `ACCOUNT_CONFIRMED` webhook - #13471, by @Air-t
   - Called when user confirm an account with `confirmAccount` mutation.
+- Add `ACCOUNT_DELETED` webhook - #13471, by @Air-t
+  - Called after account deletion is confirmed with `accountDelete` mutation.
 
 ### Other changes
 - Add possibility to log without confirming email - #13059 by @kadewu

--- a/saleor/graphql/account/mutations/account/account_delete.py
+++ b/saleor/graphql/account/mutations/account/account_delete.py
@@ -7,10 +7,13 @@ from .....account import models
 from .....account.error_codes import AccountErrorCode
 from .....core.tokens import account_delete_token_generator
 from .....permission.auth_filters import AuthorizationFilters
+from .....webhook.event_types import WebhookEventAsyncType
 from ....core import ResolveInfo
 from ....core.doc_category import DOC_CATEGORY_USERS
 from ....core.mutations import ModelDeleteMutation
 from ....core.types import AccountError
+from ....core.utils import WebhookEventInfo
+from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import User
 from ..base import INVALID_TOKEN
 
@@ -33,6 +36,12 @@ class AccountDelete(ModelDeleteMutation):
         error_type_class = AccountError
         error_type_field = "account_errors"
         permissions = (AuthorizationFilters.AUTHENTICATED_USER,)
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.ACCOUNT_DELETED,
+                description="Account was deleted.",
+            ),
+        ]
 
     @classmethod
     def clean_instance(cls, info: ResolveInfo, instance):
@@ -66,4 +75,11 @@ class AccountDelete(ModelDeleteMutation):
         # After the instance is deleted, set its ID to the original database's
         # ID so that the success response contains ID of the deleted object.
         user.id = db_id
+        cls.post_save_action(info, user, None)
+
         return cls.success_response(user)
+
+    @classmethod
+    def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
+        manager = get_plugin_manager_promise(info.context).get()
+        cls.call_event(manager.account_deleted, instance)

--- a/saleor/graphql/account/tests/mutations/account/test_account_delete.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_delete.py
@@ -23,8 +23,14 @@ ACCOUNT_DELETE_MUTATION = """
 
 
 @patch("saleor.core.tasks.delete_from_storage_task.delay")
+@patch("saleor.plugins.manager.PluginsManager.account_deleted")
 @freeze_time("2018-05-31 12:00:01")
-def test_account_delete(delete_from_storage_task_mock, user_api_client, media_root):
+def test_account_delete(
+    mocked_account_deleted,
+    delete_from_storage_task_mock,
+    user_api_client,
+    media_root,
+):
     # given
     thumbnail_mock = MagicMock(spec=File)
     thumbnail_mock.name = "image.jpg"
@@ -54,6 +60,7 @@ def test_account_delete(delete_from_storage_task_mock, user_api_client, media_ro
     # ensure all related thumbnails have been deleted
     assert not Thumbnail.objects.filter(user_id=user_id).exists()
     delete_from_storage_task_mock.assert_called_once_with(img_path)
+    mocked_account_deleted.assert_called_once_with(user)
 
 
 @freeze_time("2018-05-31 12:00:01")

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1725,15 +1725,14 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   """Account email change is requested."""
   ACCOUNT_CHANGE_EMAIL_REQUESTED
 
-  """
-  An account is confirmed.
-  
-  Added in Saleor 3.15.
-  """
+  """An account is confirmed."""
   ACCOUNT_CONFIRMED
 
   """An account delete is requested."""
   ACCOUNT_DELETE_REQUESTED
+
+  """An account is deleted."""
+  ACCOUNT_DELETED
 
   """A new address created."""
   ADDRESS_CREATED
@@ -1795,11 +1794,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   """A channel status is changed."""
   CHANNEL_STATUS_CHANGED
 
-  """
-  A channel metadata is updated.
-  
-  Added in Saleor 3.15.
-  """
+  """A channel metadata is updated."""
   CHANNEL_METADATA_UPDATED
 
   """A new gift card created."""
@@ -2383,15 +2378,14 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   """Account email change is requested."""
   ACCOUNT_CHANGE_EMAIL_REQUESTED
 
-  """
-  An account is confirmed.
-  
-  Added in Saleor 3.15.
-  """
+  """An account is confirmed."""
   ACCOUNT_CONFIRMED
 
   """An account delete is requested."""
   ACCOUNT_DELETE_REQUESTED
+
+  """An account is deleted."""
+  ACCOUNT_DELETED
 
   """A new address created."""
   ADDRESS_CREATED
@@ -2453,11 +2447,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   """A channel status is changed."""
   CHANNEL_STATUS_CHANGED
 
-  """
-  A channel metadata is updated.
-  
-  Added in Saleor 3.15.
-  """
+  """A channel metadata is updated."""
   CHANNEL_METADATA_UPDATED
 
   """A new gift card created."""
@@ -3398,6 +3388,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   ACCOUNT_CHANGE_EMAIL_REQUESTED
   ACCOUNT_CONFIRMED
   ACCOUNT_DELETE_REQUESTED
+  ACCOUNT_DELETED
   ADDRESS_CREATED
   ADDRESS_UPDATED
   ADDRESS_DELETED
@@ -18116,13 +18107,16 @@ type Mutation {
   Remove user account. 
   
   Requires one of the following permissions: AUTHENTICATED_USER.
+  
+  Triggers the following webhook events:
+  - ACCOUNT_DELETED (async): Account was deleted.
   """
   accountDelete(
     """
     A one-time token required to remove account. Sent by email using AccountRequestDeletion mutation.
     """
     token: String!
-  ): AccountDelete @doc(category: "Users")
+  ): AccountDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ACCOUNT_DELETED], syncEvents: [])
 
   """
   Creates user address. 
@@ -28366,8 +28360,11 @@ type AccountRequestDeletion @doc(category: "Users") @webhookEventsInfo(asyncEven
 Remove user account. 
 
 Requires one of the following permissions: AUTHENTICATED_USER.
+
+Triggers the following webhook events:
+- ACCOUNT_DELETED (async): Account was deleted.
 """
-type AccountDelete @doc(category: "Users") {
+type AccountDelete @doc(category: "Users") @webhookEventsInfo(asyncEvents: [ACCOUNT_DELETED], syncEvents: []) {
   accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
@@ -29169,7 +29166,7 @@ Event sent when account is confirmed.
 
 Added in Saleor 3.15.
 """
-type AccountConfirmed implements Event @doc(category: "Users") {
+type AccountConfirmed implements Event {
   """Time of the event."""
   issuedAt: DateTime
 
@@ -29204,6 +29201,40 @@ Event sent when account delete is requested.
 Added in Saleor 3.15.
 """
 type AccountDeleteRequested implements Event @doc(category: "Users") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The URL to redirect the user after he accepts the request."""
+  redirectUrl: String
+
+  """The user the event relates to."""
+  user: User
+
+  """The channel data."""
+  channel: Channel
+
+  """The token required to confirm request."""
+  token: String
+
+  """Shop data."""
+  shop: Shop
+}
+
+"""
+Event sent when account is deleted.
+
+Added in Saleor 3.15.
+"""
+type AccountDeleted implements Event {
   """Time of the event."""
   issuedAt: DateTime
 

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -41,8 +41,9 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED: (
         "Account email change is requested."
     ),
-    WebhookEventAsyncType.ACCOUNT_CONFIRMED: "An account is confirmed." + ADDED_IN_315,
+    WebhookEventAsyncType.ACCOUNT_CONFIRMED: "An account is confirmed.",
     WebhookEventAsyncType.ACCOUNT_DELETE_REQUESTED: "An account delete is requested.",
+    WebhookEventAsyncType.ACCOUNT_DELETED: "An account is deleted.",
     WebhookEventAsyncType.ADDRESS_CREATED: "A new address created.",
     WebhookEventAsyncType.ADDRESS_UPDATED: "An address updated.",
     WebhookEventAsyncType.ADDRESS_DELETED: "An address deleted.",
@@ -63,8 +64,7 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.CHANNEL_UPDATED: "A channel is updated.",
     WebhookEventAsyncType.CHANNEL_DELETED: "A channel is deleted.",
     WebhookEventAsyncType.CHANNEL_STATUS_CHANGED: "A channel status is changed.",
-    WebhookEventAsyncType.CHANNEL_METADATA_UPDATED: "A channel metadata is updated."
-    + ADDED_IN_315,
+    WebhookEventAsyncType.CHANNEL_METADATA_UPDATED: "A channel metadata is updated.",
     WebhookEventAsyncType.CHECKOUT_CREATED: "A new checkout is created.",
     WebhookEventAsyncType.CHECKOUT_UPDATED: checkout_updated_event_enum_description,
     WebhookEventAsyncType.CHECKOUT_METADATA_UPDATED: (

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -177,7 +177,7 @@ class AccountOperationBase(AbstractType):
 
 class AccountConfirmed(SubscriptionObjectType, AccountOperationBase):
     class Meta:
-        root_type = "User"
+        root_type = None
         enable_dry_run = False
         interfaces = (Event,)
         description = "Event sent when account is confirmed." + ADDED_IN_315
@@ -220,6 +220,14 @@ class AccountDeleteRequested(SubscriptionObjectType, AccountOperationBase):
         enable_dry_run = False
         interfaces = (Event,)
         description = "Event sent when account delete is requested." + ADDED_IN_315
+
+
+class AccountDeleted(SubscriptionObjectType, AccountOperationBase):
+    class Meta:
+        root_type = None
+        enable_dry_run = False
+        interfaces = (Event,)
+        description = "Event sent when account is deleted." + ADDED_IN_315
 
 
 class AddressBase(AbstractType):
@@ -2143,6 +2151,7 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED: AccountChangeEmailRequested,
     WebhookEventAsyncType.ACCOUNT_CONFIRMED: AccountConfirmed,
     WebhookEventAsyncType.ACCOUNT_DELETE_REQUESTED: AccountDeleteRequested,
+    WebhookEventAsyncType.ACCOUNT_DELETED: AccountDeleted,
     WebhookEventAsyncType.ADDRESS_CREATED: AddressCreated,
     WebhookEventAsyncType.ADDRESS_UPDATED: AddressUpdated,
     WebhookEventAsyncType.ADDRESS_DELETED: AddressDeleted,

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -171,6 +171,12 @@ class BasePlugin:
     # change email is requested.
     account_change_email_requested: Callable[["User", str, str, str, str, None], None]
 
+    # Trigger when account delete is confirmed.
+    #
+    # Overwrite this method if you need to trigger specific logic after an account
+    # delete is confirmed.
+    account_deleted: Callable[["User", None], None]
+
     # Trigger when account delete is requested.
     #
     # Overwrite this method if you need to trigger specific logic after an account

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1101,6 +1101,10 @@ class PluginsManager(PaymentInterface):
             redirect_url=redirect_url,
         )
 
+    def account_deleted(self, user: "User"):
+        default_value = None
+        return self.__run_method_on_plugins("account_deleted", default_value, user)
+
     def address_created(self, address: "Address"):
         default_value = None
         return self.__run_method_on_plugins("address_created", default_value, address)

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -257,6 +257,14 @@ class WebhookPlugin(BasePlugin):
             redirect_url,
         )
 
+    def account_deleted(self, user: "User", previous_value: None) -> None:
+        if not self.active:
+            return previous_value
+        self._trigger_account_event(
+            WebhookEventAsyncType.ACCOUNT_DELETED,
+            user,
+        )
+
     def _trigger_address_event(self, event_type, address):
         if webhooks := get_webhooks_for_event(event_type):
             payload = self._serialize_payload(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -53,6 +53,14 @@ def subscription_account_delete_requested_webhook(subscription_webhook):
 
 
 @pytest.fixture
+def subscription_account_deleted_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.ACCOUNT_DELETED,
+        WebhookEventAsyncType.ACCOUNT_DELETED,
+    )
+
+
+@pytest.fixture
 def subscription_address_created_webhook(subscription_webhook):
     return subscription_webhook(
         queries.ADDRESS_CREATED, WebhookEventAsyncType.ADDRESS_CREATED

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -99,6 +99,21 @@ ACCOUNT_DELETE_REQUESTED = (
 """
 )
 
+ACCOUNT_DELETED = (
+    fragments.CUSTOMER_DETAILS
+    + """
+    subscription{
+      event{
+        ...on AccountDeleted{
+          user{
+            ...CustomerDetails
+          }
+        }
+      }
+    }
+"""
+)
+
 
 ADDRESS_CREATED = (
     fragments.ADDRESS_DETAILS

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -188,6 +188,24 @@ def test_account_delete_requested(
     assert deliveries[0].webhook == webhooks[0]
 
 
+def test_account_deleted_confirmed(customer_user, subscription_account_deleted_webhook):
+    # given
+    webhooks = [subscription_account_deleted_webhook]
+    event_type = WebhookEventAsyncType.ACCOUNT_DELETED
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, {"user": customer_user}, webhooks
+    )
+
+    # then
+    expected_payload = generate_account_events_payload(customer_user)
+
+    assert deliveries[0].payload.payload == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
 def test_address_created(address, subscription_address_created_webhook):
     # given
     webhooks = [subscription_address_created_webhook]

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -6330,6 +6330,7 @@ def webhook_app(
     permission_manage_products,
     permission_manage_staff,
     permission_manage_orders,
+    permission_manage_users,
 ):
     app = App.objects.create(name="Webhook app", is_active=True)
     app.permissions.add(permission_manage_shipping)
@@ -6339,6 +6340,7 @@ def webhook_app(
     app.permissions.add(permission_manage_products)
     app.permissions.add(permission_manage_staff)
     app.permissions.add(permission_manage_orders)
+    app.permissions.add(permission_manage_users)
     return app
 
 

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -26,6 +26,7 @@ class WebhookEventAsyncType:
     ACCOUNT_CHANGE_EMAIL_REQUESTED = "account_change_email_requested"
     ACCOUNT_CONFIRMED = "account_confirmed"
     ACCOUNT_DELETE_REQUESTED = "account_delete_requested"
+    ACCOUNT_DELETED = "account_deleted"
 
     ADDRESS_CREATED = "address_created"
     ADDRESS_UPDATED = "address_updated"
@@ -195,6 +196,10 @@ class WebhookEventAsyncType:
         },
         ACCOUNT_DELETE_REQUESTED: {
             "name": "Account delete requested",
+            "permission": AccountPermissions.MANAGE_USERS,
+        },
+        ACCOUNT_DELETED: {
+            "name": "Account delete confirmed",
             "permission": AccountPermissions.MANAGE_USERS,
         },
         ADDRESS_CREATED: {


### PR DESCRIPTION
Adds `ACCOUNT_DELETED` event sent after `accountDelete` mutation.

Resolves https://github.com/saleor/saleor/issues/13473

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
