### PR TITLE
Upgrade certifi to latest version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -613,14 +613,14 @@ zstd = ["zstandard"]
 
 [[package]]
 name = "certifi"
-version = "2022.12.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
-    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 
 [[package]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ brotlicffi==1.0.9.2 ; platform_python_implementation != "CPython" and python_ver
 cachetools==5.2.0 ; python_version >= "3.9" and python_version < "3.10"
 celery==5.2.7 ; python_version >= "3.9" and python_version < "3.10"
 celery[redis]==5.2.7 ; python_version >= "3.9" and python_version < "3.10"
-certifi==2022.12.7 ; python_version >= "3.9" and python_version < "3.10"
+certifi==2023.7.22 ; python_version >= "3.9" and python_version < "3.10"
 cffi==1.15.1 ; python_version >= "3.9" and python_version < "3.10"
 charset-normalizer==2.1.1 ; python_version >= "3.9" and python_version < "3.10"
 click-didyoumean==0.3.0 ; python_version >= "3.9" and python_version < "3.10"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@ brotlicffi==1.0.9.2 ; platform_python_implementation != "CPython" and python_ver
 cachetools==5.2.0 ; python_version >= "3.9" and python_version < "3.10"
 celery==5.2.7 ; python_version >= "3.9" and python_version < "3.10"
 celery[redis]==5.2.7 ; python_version >= "3.9" and python_version < "3.10"
-certifi==2022.12.7 ; python_version >= "3.9" and python_version < "3.10"
+certifi==2023.7.22 ; python_version >= "3.9" and python_version < "3.10"
 cffi==1.15.1 ; python_version >= "3.9" and python_version < "3.10"
 cfgv==3.3.1 ; python_version >= "3.9" and python_version < "3.10"
 charset-normalizer==2.1.1 ; python_version >= "3.9" and python_version < "3.10"


### PR DESCRIPTION
Fixes CVE-2023-37920 -- Certifi 2023.07.22 removes root certificates from "e-Tugra" from the root store..