### PR TITLE
fix clean seo data error when null is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ Shipping methods can be removed by the user after it has been assigned to a chec
 - Fix error handling in the permission check for `Query.webhook` - #13378 by @patrys
 - Add missing descriptions to Translation module. - #13410 by @Smit-Parmar
 - Add missing descriptions to menu module - #13409 by @devilsautumn
+- Fix seo field to accept null value - #13512 by @ssuraliya
 
 # 3.14.0
 

--- a/saleor/graphql/core/tests/test_validators.py
+++ b/saleor/graphql/core/tests/test_validators.py
@@ -101,6 +101,12 @@ def test_clean_seo_fields():
     assert data["seo_description"] == description
 
 
+def test_clean_seo_fields_accepts_null():
+    data = {"seo": None}
+    clean_seo_fields(data)
+    assert not data
+
+
 @pytest.mark.parametrize(
     "cleaned_input",
     [

--- a/saleor/graphql/core/validators/__init__.py
+++ b/saleor/graphql/core/validators/__init__.py
@@ -178,11 +178,12 @@ def clean_seo_fields(data):
     """Extract and assign seo fields to given dictionary."""
     seo_fields = data.pop("seo", {})
 
-    if "title" in seo_fields:
-        data["seo_title"] = seo_fields["title"]
+    if seo_fields:
+        if "title" in seo_fields:
+            data["seo_title"] = seo_fields["title"]
 
-    if "description" in seo_fields:
-        data["seo_description"] = seo_fields["description"]
+        if "description" in seo_fields:
+            data["seo_description"] = seo_fields["description"]
 
 
 def validate_required_string_field(cleaned_input, field_name: str):


### PR DESCRIPTION
I want to merge this change because fix clean seo data error when null is passed as seo value.

Fixes #13512 .

clean_seo_fields method in graphql>core>validators threw an error 'seo' parameter was passed as 'None'. Fixed it by applying a 
null check.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [x] The changes are covered by test cases
