### PR TITLE
[Programmatic payments] storedPaymentMethods field in `Checkout` and `User` type

### DIFF
--- a/saleor/graphql/account/tests/queries/test_me.py
+++ b/saleor/graphql/account/tests/queries/test_me.py
@@ -1,6 +1,17 @@
+from decimal import Decimal
+
 import graphene
+import mock
+from prices import Money
 
 from .....order.models import FulfillmentStatus
+from .....payment.interface import (
+    ListStoredPaymentMethodsRequestData,
+    PaymentGateway,
+    PaymentMethodCreditCardInfo,
+    PaymentMethodData,
+)
+from ....payment.enums import TokenizedPaymentFlowEnum
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 ME_QUERY = """
@@ -271,3 +282,216 @@ def test_me_with_cancelled_fulfillments(
     fulfillments = order["fulfillments"]
     assert len(fulfillments) == 1
     assert fulfillments[0]["status"] == FulfillmentStatus.FULFILLED.upper()
+
+
+QUERY_ME_WITH_STORED_PAYMENT_METHODS = """
+query Me($channel: String!, $amount:PositiveDecimal) {
+  me{
+    storedPaymentMethods(channel: $channel, amount: $amount){
+      id
+      gateway{
+        name
+        id
+        config{
+          field
+          value
+        }
+        currencies
+      }
+      paymentMethodId
+      creditCardInfo{
+        brand
+        firstDigits
+        lastDigits
+        expMonth
+        expYear
+      }
+      supportedPaymentFlows
+      type
+      name
+      data
+    }
+  }
+}
+"""
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.list_stored_payment_methods")
+def test_me_query_stored_payment_methods_with_provided_amount(
+    mocked_list_stored_payment_methods, user_api_client, channel_USD, customer_user
+):
+    # given
+    payment_method_id = "app:payment-method-id"
+    external_id = "payment-method-id"
+    supported_payment_flow = TokenizedPaymentFlowEnum.INTERACTIVE
+    payment_method_type = "credit-card"
+    payment_method_name = "Payment method name"
+    payment_method_data = {"additional_data": "value"}
+
+    payment_gateway_id = "gateway-id"
+    payment_gateway_name = "gateway-name"
+
+    credit_card_brand = "brand"
+    credit_card_first_digits = "123"
+    credit_card_last_digits = "456"
+    credit_card_exp_month = 1
+    credit_card_exp_year = 2021
+
+    requested_amount = Decimal("100.00")
+
+    mocked_list_stored_payment_methods.return_value = [
+        PaymentMethodData(
+            id=payment_method_id,
+            external_id=external_id,
+            supported_payment_flows=[supported_payment_flow.value],
+            type=payment_method_type,
+            credit_card_info=PaymentMethodCreditCardInfo(
+                brand=credit_card_brand,
+                first_digits=credit_card_first_digits,
+                last_digits=credit_card_last_digits,
+                exp_month=credit_card_exp_month,
+                exp_year=credit_card_exp_year,
+            ),
+            name=payment_method_name,
+            data=payment_method_data,
+            gateway=PaymentGateway(
+                id=payment_gateway_id,
+                name=payment_gateway_name,
+                currencies=[channel_USD.currency_code],
+                config=[],
+            ),
+        )
+    ]
+
+    request_data = ListStoredPaymentMethodsRequestData(
+        user=user_api_client.user,
+        channel=channel_USD,
+        amount=Money(requested_amount, channel_USD.currency_code),
+    )
+
+    query = QUERY_ME_WITH_STORED_PAYMENT_METHODS
+
+    # when
+    response = user_api_client.post_graphql(
+        query, variables={"channel": channel_USD.slug, "amount": requested_amount}
+    )
+
+    # then
+    mocked_list_stored_payment_methods.assert_called_once_with(request_data)
+    content = get_graphql_content(response)
+
+    data = content["data"]["me"]
+    assert data["storedPaymentMethods"] == [
+        {
+            "id": payment_method_id,
+            "gateway": {
+                "name": payment_gateway_name,
+                "id": payment_gateway_id,
+                "config": [],
+                "currencies": [channel_USD.currency_code],
+            },
+            "paymentMethodId": external_id,
+            "creditCardInfo": {
+                "brand": credit_card_brand,
+                "firstDigits": credit_card_first_digits,
+                "lastDigits": credit_card_last_digits,
+                "expMonth": credit_card_exp_month,
+                "expYear": credit_card_exp_year,
+            },
+            "supportedPaymentFlows": [supported_payment_flow.name],
+            "type": payment_method_type,
+            "name": payment_method_name,
+            "data": payment_method_data,
+        }
+    ]
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.list_stored_payment_methods")
+def test_me_query_stored_payment_methods_without_provided_amount(
+    mocked_list_stored_payment_methods, user_api_client, channel_USD, customer_user
+):
+    # given
+    payment_method_id = "app:payment-method-id"
+    external_id = "payment-method-id"
+    supported_payment_flow = TokenizedPaymentFlowEnum.INTERACTIVE
+    payment_method_type = "credit-card"
+    payment_method_name = "Payment method name"
+    payment_method_data = {"additional_data": "value"}
+
+    payment_gateway_id = "gateway-id"
+    payment_gateway_name = "gateway-name"
+
+    credit_card_brand = "brand"
+    credit_card_first_digits = "123"
+    credit_card_last_digits = "456"
+    credit_card_exp_month = 1
+    credit_card_exp_year = 2021
+
+    mocked_list_stored_payment_methods.return_value = [
+        PaymentMethodData(
+            id=payment_method_id,
+            external_id=external_id,
+            supported_payment_flows=[supported_payment_flow.value],
+            type=payment_method_type,
+            credit_card_info=PaymentMethodCreditCardInfo(
+                brand=credit_card_brand,
+                first_digits=credit_card_first_digits,
+                last_digits=credit_card_last_digits,
+                exp_month=credit_card_exp_month,
+                exp_year=credit_card_exp_year,
+            ),
+            name=payment_method_name,
+            data=payment_method_data,
+            gateway=PaymentGateway(
+                id=payment_gateway_id,
+                name=payment_gateway_name,
+                currencies=[channel_USD.currency_code],
+                config=[],
+            ),
+        )
+    ]
+
+    request_data = ListStoredPaymentMethodsRequestData(
+        user=user_api_client.user,
+        channel=channel_USD,
+        amount=Money(Decimal("0"), channel_USD.currency_code),
+    )
+
+    query = QUERY_ME_WITH_STORED_PAYMENT_METHODS
+
+    # when
+    response = user_api_client.post_graphql(
+        query,
+        variables={
+            "channel": channel_USD.slug,
+        },
+    )
+
+    # then
+    mocked_list_stored_payment_methods.assert_called_once_with(request_data)
+    content = get_graphql_content(response)
+
+    data = content["data"]["me"]
+    assert data["storedPaymentMethods"] == [
+        {
+            "id": payment_method_id,
+            "gateway": {
+                "name": payment_gateway_name,
+                "id": payment_gateway_id,
+                "config": [],
+                "currencies": [channel_USD.currency_code],
+            },
+            "paymentMethodId": external_id,
+            "creditCardInfo": {
+                "brand": credit_card_brand,
+                "firstDigits": credit_card_first_digits,
+                "lastDigits": credit_card_last_digits,
+                "expMonth": credit_card_exp_month,
+                "expYear": credit_card_exp_year,
+            },
+            "supportedPaymentFlows": [supported_payment_flow.name],
+            "type": payment_method_type,
+            "name": payment_method_name,
+            "data": payment_method_data,
+        }
+    ]

--- a/saleor/graphql/account/tests/queries/test_user.py
+++ b/saleor/graphql/account/tests/queries/test_user.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import graphene
+import mock
 import pytest
 from django.core.files import File
 
@@ -1277,3 +1278,63 @@ def test_unauthenticated_query_user_by_email_for_federation(api_client, customer
     )
     content = get_graphql_content(response)
     assert content["data"]["_entities"] == [None]
+
+
+USER_QUERY_WITH_STORED_PAYMENT_METHODS = """
+query User($id: ID, $channel: String!) {
+  user(id: $id) {
+    storedPaymentMethods(channel: $channel){
+      id
+      gateway{
+        name
+        id
+        config{
+          field
+          value
+        }
+        currencies
+      }
+      paymentMethodId
+      creditCardInfo{
+        brand
+        firstDigits
+        lastDigits
+        expMonth
+        expYear
+      }
+      supportedPaymentFlows
+      type
+      name
+      data
+    }
+  }
+}
+"""
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.list_stored_payment_methods")
+def test_query_customer_stored_payment_methods(
+    mocked_list_stored_payment_methods,
+    staff_api_client,
+    permission_manage_users,
+    customer_user,
+    channel_USD,
+):
+    query = USER_QUERY_WITH_STORED_PAYMENT_METHODS
+    staff_api_client.user.user_permissions.add(permission_manage_users)
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables={
+            "channel": channel_USD.slug,
+            "id": graphene.Node.to_global_id("User", customer_user.pk),
+        },
+    )
+
+    # then
+    assert not mocked_list_stored_payment_methods.called
+
+    content = get_graphql_content(response)
+
+    assert content["data"]["user"]["storedPaymentMethods"] == []

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -393,7 +393,10 @@ class User(ModelObjectType[models.User]):
     )
     stored_payment_sources = NonNullList(
         "saleor.graphql.payment.types.PaymentSource",
-        description="List of stored payment sources.",
+        description=(
+            "List of stored payment sources. The field returns a list of payment "
+            "sources stored for payment plugins."
+        ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
@@ -425,15 +428,21 @@ class User(ModelObjectType[models.User]):
         StoredPaymentMethod,
         description=(
             "Returns a list of user's stored payment methods that can be used in "
-            "provided channel. When `amount` is not provided, 0 will be used as "
-            "default value." + ADDED_IN_315 + PREVIEW_FEATURE
+            "provided channel. The field returns a list of stored payment methods by "
+            "payment apps. When `amount` is not provided, 0 will be used as default "
+            "value." + ADDED_IN_315 + PREVIEW_FEATURE
         ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned.",
             required=True,
         ),
         amount=PositiveDecimal(
-            description="Amount that will be used to fetch stored payment methods."
+            description=(
+                "Amount that will be used to fetch stored payment methods."
+                "The provided amount will be sent to the payment app. The payment app "
+                "will use the amount to fetch all available stored payment methods for "
+                "the requested amount."
+            )
         ),
     )
 

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -1,16 +1,19 @@
 import uuid
+from decimal import Decimal
 from functools import partial
 from typing import List, Optional, cast
 
 import graphene
 from django.contrib.auth import get_user_model
 from graphene import relay
+from prices import Money
 from promise import Promise
 
 from ...account import models
 from ...checkout.utils import get_user_checkout
 from ...core.exceptions import PermissionDenied
 from ...order import OrderStatus
+from ...payment.interface import ListStoredPaymentMethodsRequestData
 from ...permission.auth_filters import AuthorizationFilters
 from ...permission.enums import AccountPermissions, AppPermission, OrderPermissions
 from ...thumbnail.utils import (
@@ -21,6 +24,7 @@ from ...thumbnail.utils import (
 from ..account.utils import check_is_owner_or_has_one_of_perms
 from ..app.dataloaders import AppByIdLoader, get_app_promise
 from ..app.types import App
+from ..channel.dataloaders import ChannelBySlugLoader
 from ..channel.types import Channel
 from ..checkout.dataloaders import CheckoutByUserAndChannelLoader, CheckoutByUserLoader
 from ..checkout.types import Checkout, CheckoutCountableConnection
@@ -30,6 +34,7 @@ from ..core.descriptions import (
     ADDED_IN_38,
     ADDED_IN_310,
     ADDED_IN_314,
+    ADDED_IN_315,
     DEPRECATED_IN_3X_FIELD,
     PREVIEW_FEATURE,
 )
@@ -37,7 +42,7 @@ from ..core.doc_category import DOC_CATEGORY_USERS
 from ..core.enums import LanguageCodeEnum
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.fields import ConnectionField, PermissionsField
-from ..core.scalars import UUID
+from ..core.scalars import UUID, PositiveDecimal
 from ..core.tracing import traced_resolver
 from ..core.types import (
     BaseInputObjectType,
@@ -53,6 +58,7 @@ from ..core.utils import from_global_id_or_error, str_to_enum, to_global_id_or_n
 from ..giftcard.dataloaders import GiftCardsByUserLoader
 from ..meta.types import ObjectWithMetadata
 from ..order.dataloaders import OrderLineByIdLoader, OrdersByUserLoader
+from ..payment.types import StoredPaymentMethod
 from ..plugins.dataloaders import get_plugin_manager_promise
 from ..utils import format_permissions_for_display, get_user_or_app_from_context
 from .dataloaders import (
@@ -415,6 +421,21 @@ class User(ModelObjectType[models.User]):
         required=True,
         description="The data when the user last update the account information.",
     )
+    stored_payment_methods = NonNullList(
+        StoredPaymentMethod,
+        description=(
+            "Returns a list of user's stored payment methods that can be used in "
+            "provided channel. When `amount` is not provided, 0 will be used as "
+            "default value." + ADDED_IN_315 + PREVIEW_FEATURE
+        ),
+        channel=graphene.String(
+            description="Slug of a channel for which the data should be returned.",
+            required=True,
+        ),
+        amount=PositiveDecimal(
+            description="Amount that will be used to fetch stored payment methods."
+        ),
+    )
 
     class Meta:
         description = "Represents user data."
@@ -653,6 +674,33 @@ class User(ModelObjectType[models.User]):
             else:
                 results.append(users_by_email.get(root.email))
         return results
+
+    @staticmethod
+    def resolve_stored_payment_methods(
+        root: models.User,
+        info: ResolveInfo,
+        channel: str,
+        amount: Optional[Decimal] = None,
+    ):
+        requestor = get_user_or_app_from_context(info.context)
+        if not requestor or requestor.id != root.id:
+            return []
+
+        def get_stored_payment_methods(data):
+            channel_obj, manager = data
+            request_data = ListStoredPaymentMethodsRequestData(
+                user=root,
+                channel=channel_obj,
+                amount=Money(amount or Decimal(0), channel_obj.currency_code),
+            )
+            return manager.list_stored_payment_methods(request_data)
+
+        return Promise.all(
+            [
+                ChannelBySlugLoader(info.context).load(channel),
+                get_plugin_manager_promise(info.context),
+            ]
+        ).then(get_stored_payment_methods)
 
 
 class UserCountableConnection(CountableConnection):

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -24,6 +24,12 @@ from ....core.prices import quantize_price
 from ....discount import DiscountValueType, VoucherType
 from ....discount.utils import generate_sale_discount_objects_for_checkout
 from ....payment import TransactionAction
+from ....payment.interface import (
+    ListStoredPaymentMethodsRequestData,
+    PaymentGateway,
+    PaymentMethodCreditCardInfo,
+    PaymentMethodData,
+)
 from ....plugins.manager import get_plugins_manager
 from ....plugins.tests.sample_plugins import ActiveDummyPaymentGateway
 from ....product.models import ProductVariant
@@ -33,6 +39,7 @@ from ....tests.utils import dummy_editorjs
 from ....warehouse import WarehouseClickAndCollectOption
 from ....warehouse.models import PreorderReservation, Reservation, Stock, Warehouse
 from ...core.utils import to_global_id_or_none
+from ...payment.enums import TokenizedPaymentFlowEnum
 from ...tests.utils import assert_no_permission, get_graphql_content
 from ..enums import CheckoutAuthorizeStatusEnum, CheckoutChargeStatusEnum
 from ..mutations.utils import (
@@ -2381,3 +2388,352 @@ def test_checkout_balance(
         + transaction.charge_pending_value
         - checkout_with_prices.total.gross.amount
     )
+
+
+QUERY_CHECKOUT_STORED_PAYMENT_METHODS = """
+query getCheckout($id: ID, $amount: PositiveDecimal) {
+  checkout(id: $id) {
+    storedPaymentMethods(amount: $amount){
+      id
+      gateway{
+        name
+        id
+        config{
+          field
+          value
+        }
+        currencies
+      }
+      paymentMethodId
+      creditCardInfo{
+        brand
+        firstDigits
+        lastDigits
+        expMonth
+        expYear
+      }
+      supportedPaymentFlows
+      type
+      name
+      data
+    }
+  }
+}
+"""
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.list_stored_payment_methods")
+def test_checkout_with_stored_payment_methods_empty_response(
+    mocked_list_stored_payment_methods,
+    user_api_client,
+    checkout_with_prices,
+):
+    # given
+    checkout_with_prices.user = user_api_client.user
+    checkout_with_prices.save(update_fields=["user"])
+
+    mocked_list_stored_payment_methods.return_value = []
+    query = QUERY_CHECKOUT_STORED_PAYMENT_METHODS
+    variables = {"id": to_global_id_or_none(checkout_with_prices)}
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout_with_prices)
+    checkout_info = fetch_checkout_info(checkout_with_prices, lines, manager)
+
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=checkout_with_prices.shipping_address,
+    )
+
+    request_data = ListStoredPaymentMethodsRequestData(
+        user=checkout_with_prices.user,
+        channel=checkout_with_prices.channel,
+        amount=total.gross,
+    )
+
+    # when
+    response = user_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    mocked_list_stored_payment_methods.assert_called_once_with(request_data)
+    assert content["data"]["checkout"]["storedPaymentMethods"] == []
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.list_stored_payment_methods")
+def test_checkout_with_stored_payment_methods(
+    mocked_list_stored_payment_methods,
+    user_api_client,
+    checkout_with_prices,
+):
+    # given
+    checkout_with_prices.user = user_api_client.user
+    checkout_with_prices.save(update_fields=["user"])
+
+    payment_method_id = "app:payment-method-id"
+    external_id = "payment-method-id"
+    supported_payment_flow = TokenizedPaymentFlowEnum.INTERACTIVE
+    payment_method_type = "credit-card"
+    payment_method_name = "Payment method name"
+    payment_method_data = {"additional_data": "value"}
+
+    payment_gateway_id = "gateway-id"
+    payment_gateway_name = "gateway-name"
+
+    credit_card_brand = "brand"
+    credit_card_first_digits = "123"
+    credit_card_last_digits = "456"
+    credit_card_exp_month = 1
+    credit_card_exp_year = 2021
+
+    mocked_list_stored_payment_methods.return_value = [
+        PaymentMethodData(
+            id=payment_method_id,
+            external_id=external_id,
+            supported_payment_flows=[supported_payment_flow.value],
+            type=payment_method_type,
+            credit_card_info=PaymentMethodCreditCardInfo(
+                brand=credit_card_brand,
+                first_digits=credit_card_first_digits,
+                last_digits=credit_card_last_digits,
+                exp_month=credit_card_exp_month,
+                exp_year=credit_card_exp_year,
+            ),
+            name=payment_method_name,
+            data=payment_method_data,
+            gateway=PaymentGateway(
+                id=payment_gateway_id,
+                name=payment_gateway_name,
+                currencies=[checkout_with_prices.currency],
+                config=[],
+            ),
+        )
+    ]
+
+    query = QUERY_CHECKOUT_STORED_PAYMENT_METHODS
+    variables = {"id": to_global_id_or_none(checkout_with_prices)}
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout_with_prices)
+    checkout_info = fetch_checkout_info(checkout_with_prices, lines, manager)
+
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=checkout_with_prices.shipping_address,
+    )
+
+    request_data = ListStoredPaymentMethodsRequestData(
+        user=checkout_with_prices.user,
+        channel=checkout_with_prices.channel,
+        amount=total.gross,
+    )
+
+    # when
+    response = user_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    mocked_list_stored_payment_methods.assert_called_once_with(request_data)
+    assert content["data"]["checkout"]["storedPaymentMethods"] == [
+        {
+            "id": payment_method_id,
+            "gateway": {
+                "name": payment_gateway_name,
+                "id": payment_gateway_id,
+                "config": [],
+                "currencies": [checkout_with_prices.currency],
+            },
+            "paymentMethodId": external_id,
+            "creditCardInfo": {
+                "brand": credit_card_brand,
+                "firstDigits": credit_card_first_digits,
+                "lastDigits": credit_card_last_digits,
+                "expMonth": credit_card_exp_month,
+                "expYear": credit_card_exp_year,
+            },
+            "supportedPaymentFlows": [supported_payment_flow.name],
+            "type": payment_method_type,
+            "name": payment_method_name,
+            "data": payment_method_data,
+        }
+    ]
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.list_stored_payment_methods")
+def test_checkout_with_stored_payment_methods_with_provided_amount(
+    mocked_list_stored_payment_methods,
+    user_api_client,
+    checkout_with_prices,
+):
+    # given
+    checkout_with_prices.user = user_api_client.user
+    checkout_with_prices.save(update_fields=["user"])
+
+    payment_method_id = "app:payment-method-id"
+    external_id = "payment-method-id"
+    supported_payment_flow = TokenizedPaymentFlowEnum.INTERACTIVE
+    payment_method_type = "credit-card"
+    payment_method_name = "Payment method name"
+    payment_method_data = {"additional_data": "value"}
+
+    payment_gateway_id = "gateway-id"
+    payment_gateway_name = "gateway-name"
+
+    credit_card_brand = "brand"
+    credit_card_first_digits = "123"
+    credit_card_last_digits = "456"
+    credit_card_exp_month = 1
+    credit_card_exp_year = 2021
+
+    requested_amount = Decimal("100.00")
+
+    mocked_list_stored_payment_methods.return_value = [
+        PaymentMethodData(
+            id=payment_method_id,
+            external_id=external_id,
+            supported_payment_flows=[supported_payment_flow.value],
+            type=payment_method_type,
+            credit_card_info=PaymentMethodCreditCardInfo(
+                brand=credit_card_brand,
+                first_digits=credit_card_first_digits,
+                last_digits=credit_card_last_digits,
+                exp_month=credit_card_exp_month,
+                exp_year=credit_card_exp_year,
+            ),
+            name=payment_method_name,
+            data=payment_method_data,
+            gateway=PaymentGateway(
+                id=payment_gateway_id,
+                name=payment_gateway_name,
+                currencies=[checkout_with_prices.currency],
+                config=[],
+            ),
+        )
+    ]
+
+    query = QUERY_CHECKOUT_STORED_PAYMENT_METHODS
+    variables = {
+        "id": to_global_id_or_none(checkout_with_prices),
+        "amount": requested_amount,
+    }
+
+    request_data = ListStoredPaymentMethodsRequestData(
+        user=checkout_with_prices.user,
+        channel=checkout_with_prices.channel,
+        amount=Money(requested_amount, checkout_with_prices.currency),
+    )
+
+    # when
+    response = user_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    mocked_list_stored_payment_methods.assert_called_once_with(request_data)
+    assert content["data"]["checkout"]["storedPaymentMethods"] == [
+        {
+            "id": payment_method_id,
+            "gateway": {
+                "name": payment_gateway_name,
+                "id": payment_gateway_id,
+                "config": [],
+                "currencies": [checkout_with_prices.currency],
+            },
+            "paymentMethodId": external_id,
+            "creditCardInfo": {
+                "brand": credit_card_brand,
+                "firstDigits": credit_card_first_digits,
+                "lastDigits": credit_card_last_digits,
+                "expMonth": credit_card_exp_month,
+                "expYear": credit_card_exp_year,
+            },
+            "supportedPaymentFlows": [supported_payment_flow.name],
+            "type": payment_method_type,
+            "name": payment_method_name,
+            "data": payment_method_data,
+        }
+    ]
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.list_stored_payment_methods")
+def test_checkout_with_stored_payment_methods_requested_by_staff_user(
+    mocked_list_stored_payment_methods,
+    staff_api_client,
+    checkout_with_prices,
+    customer_user2,
+    permission_manage_checkouts,
+    permission_manage_users,
+):
+    # given
+    checkout_with_prices.user = customer_user2
+    checkout_with_prices.save(update_fields=["user"])
+
+    staff_api_client.user.user_permissions.add(permission_manage_checkouts)
+
+    mocked_list_stored_payment_methods.return_value = []
+    query = QUERY_CHECKOUT_STORED_PAYMENT_METHODS
+    variables = {"id": to_global_id_or_none(checkout_with_prices)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    assert customer_user2 != staff_api_client.user
+
+    content = get_graphql_content(response)
+
+    assert not mocked_list_stored_payment_methods.called
+    assert content["data"]["checkout"]["storedPaymentMethods"] == []
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.list_stored_payment_methods")
+def test_checkout_with_stored_payment_methods_requested_by_app(
+    mocked_list_stored_payment_methods,
+    app_api_client,
+    checkout_with_prices,
+    customer_user2,
+    permission_manage_checkouts,
+    permission_manage_users,
+):
+    # given
+    app = app_api_client.app
+    app.permissions.add(
+        permission_manage_checkouts,
+        permission_manage_users,
+    )
+    checkout_with_prices.user = customer_user2
+    checkout_with_prices.save(update_fields=["user"])
+
+    mocked_list_stored_payment_methods.return_value = []
+    query = QUERY_CHECKOUT_STORED_PAYMENT_METHODS
+    variables = {"id": to_global_id_or_none(checkout_with_prices)}
+
+    # when
+    response = app_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    assert not mocked_list_stored_payment_methods.called
+    assert content["data"]["checkout"]["storedPaymentMethods"] == []

--- a/saleor/graphql/payment/enums.py
+++ b/saleor/graphql/payment/enums.py
@@ -1,6 +1,7 @@
 from ...payment import (
     ChargeStatus,
     StorePaymentMethod,
+    TokenizedPaymentFlow,
     TransactionAction,
     TransactionEventType,
     TransactionKind,
@@ -73,3 +74,9 @@ StorePaymentMethodEnum = to_enum(
     StorePaymentMethod, type_name="StorePaymentMethodEnum", description=description
 )
 StorePaymentMethodEnum.doc_category = DOC_CATEGORY_PAYMENTS
+
+TokenizedPaymentFlowEnum = to_enum(
+    TokenizedPaymentFlow,
+    type_name="TokenizedPaymentFlowEnum",
+    description=TokenizedPaymentFlow.__doc__,
+)

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -7,6 +7,7 @@ from graphene import relay
 
 from ...core.exceptions import PermissionDenied
 from ...payment import models
+from ...payment.interface import PaymentMethodData
 from ...permission.enums import OrderPermissions
 from ..account.dataloaders import UserByUserIdLoader
 from ..app.dataloaders import AppByIdLoader, AppsByAppIdentifierLoader
@@ -18,10 +19,12 @@ from ..core.descriptions import (
     ADDED_IN_34,
     ADDED_IN_36,
     ADDED_IN_313,
+    ADDED_IN_315,
     PREVIEW_FEATURE,
 )
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.fields import JSONString, PermissionsField
+from ..core.scalars import JSON
 from ..core.tracing import traced_resolver
 from ..core.types import BaseObjectType, ModelObjectType, Money, NonNullList
 from ..meta.permissions import public_payment_permissions
@@ -36,6 +39,7 @@ from .dataloaders import (
 from .enums import (
     OrderAction,
     PaymentChargeStatusEnum,
+    TokenizedPaymentFlowEnum,
     TransactionActionEnum,
     TransactionEventTypeEnum,
     TransactionKindEnum,
@@ -547,3 +551,87 @@ class TransactionItem(ModelObjectType[models.TransactionItem]):
             return model.objects.get(lookup)
         except model.DoesNotExist:
             return None
+
+
+class GatewayConfigLine(BaseObjectType):
+    field = graphene.String(required=True, description="Gateway config key.")
+    value = graphene.String(description="Gateway config value for key.")
+
+    class Meta:
+        description = "Payment gateway client configuration key and value pair."
+        doc_category = DOC_CATEGORY_PAYMENTS
+
+
+class PaymentGateway(BaseObjectType):
+    name = graphene.String(required=True, description="Payment gateway name.")
+    id = graphene.ID(required=True, description="Payment gateway ID.")
+    config = NonNullList(
+        GatewayConfigLine,
+        required=True,
+        description="Payment gateway client configuration.",
+    )
+    currencies = NonNullList(
+        graphene.String,
+        required=True,
+        description="Payment gateway supported currencies.",
+    )
+
+    class Meta:
+        description = (
+            "Available payment gateway backend with configuration "
+            "necessary to setup client."
+        )
+        doc_category = DOC_CATEGORY_PAYMENTS
+
+
+class StoredPaymentMethod(BaseObjectType):
+    id = graphene.ID(required=True, description="Stored payment method ID.")
+
+    gateway = graphene.Field(
+        PaymentGateway,
+        required=True,
+        description="Payment gateway that stores this payment method.",
+    )
+    payment_method_id = graphene.String(
+        description=(
+            "ID of stored payment method used to make payment actions. "
+            "Note: method ID is unique only within the payment gateway."
+        ),
+        required=True,
+    )
+
+    credit_card_info = graphene.Field(
+        CreditCard,
+        required=False,
+        description="Stored credit card details if available.",
+    )
+
+    supported_payment_flows = graphene.Field(NonNullList(TokenizedPaymentFlowEnum))
+
+    type = graphene.String(
+        required=True,
+        description="Type of the payment method. Example: credit card, wallet, etc.",
+    )
+    name = graphene.String(
+        description=(
+            "Payment method name. Example: last 4 digits of credit card, obfuscated "
+            "email, etc."
+        )
+    )
+    data = graphene.Field(
+        JSON,
+        description=(
+            "JSON data returned by Payment Provider app for this payment method."
+        ),
+    )
+
+    class Meta:
+        description = (
+            "Represents a payment method stored for user (tokenized) in payment "
+            "gateway." + ADDED_IN_315 + PREVIEW_FEATURE
+        )
+        doc_category = DOC_CATEGORY_PAYMENTS
+
+    @staticmethod
+    def resolve_payment_method_id(root: PaymentMethodData, _info: ResolveInfo):
+        return root.external_id

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9762,7 +9762,9 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   """
   events: [CustomerEvent!]
 
-  """List of stored payment sources."""
+  """
+  List of stored payment sources. The field returns a list of payment sources stored for payment plugins.
+  """
   storedPaymentSources(
     """Slug of a channel for which the data should be returned."""
     channel: String
@@ -9794,7 +9796,7 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   updatedAt: DateTime!
 
   """
-  Returns a list of user's stored payment methods that can be used in provided channel. When `amount` is not provided, 0 will be used as default value.
+  Returns a list of user's stored payment methods that can be used in provided channel. The field returns a list of stored payment methods by payment apps. When `amount` is not provided, 0 will be used as default value.
   
   Added in Saleor 3.15.
   
@@ -9804,7 +9806,9 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
     """Slug of a channel for which the data should be returned."""
     channel: String!
 
-    """Amount that will be used to fetch stored payment methods."""
+    """
+    Amount that will be used to fetch stored payment methods.The provided amount will be sent to the payment app. The payment app will use the amount to fetch all available stored payment methods for the requested amount.
+    """
     amount: PositiveDecimal
   ): [StoredPaymentMethod!]
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9792,6 +9792,21 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
 
   """The data when the user last update the account information."""
   updatedAt: DateTime!
+
+  """
+  Returns a list of user's stored payment methods that can be used in provided channel. When `amount` is not provided, 0 will be used as default value.
+  
+  Added in Saleor 3.15.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  storedPaymentMethods(
+    """Slug of a channel for which the data should be returned."""
+    channel: String!
+
+    """Amount that will be used to fetch stored payment methods."""
+    amount: PositiveDecimal
+  ): [StoredPaymentMethod!]
 }
 
 """Checkout object."""
@@ -10044,6 +10059,18 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   - CHECKOUT_CALCULATE_TAXES (sync): Optionally triggered when checkout prices are expired.
   """
   chargeStatus: CheckoutChargeStatusEnum! @webhookEventsInfo(asyncEvents: [], syncEvents: [CHECKOUT_CALCULATE_TAXES])
+
+  """
+  List of user's stored payment methods that can be used in this checkout session. It uses the channel that the checkout was created in. When `amount` is not provided, `checkout.total` will be used as a default value.
+  
+  Added in Saleor 3.15.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  storedPaymentMethods(
+    """Amount that will be used to fetch stored payment methods."""
+    amount: PositiveDecimal
+  ): [StoredPaymentMethod!]
 }
 
 """
@@ -12007,6 +12034,54 @@ enum CheckoutChargeStatusEnum @doc(category: "Checkout") {
   FULL
   OVERCHARGED
 }
+
+"""
+Represents a payment method stored for user (tokenized) in payment gateway.
+
+Added in Saleor 3.15.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type StoredPaymentMethod @doc(category: "Payments") {
+  """Stored payment method ID."""
+  id: ID!
+
+  """Payment gateway that stores this payment method."""
+  gateway: PaymentGateway!
+
+  """
+  ID of stored payment method used to make payment actions. Note: method ID is unique only within the payment gateway.
+  """
+  paymentMethodId: String!
+
+  """Stored credit card details if available."""
+  creditCardInfo: CreditCard
+  supportedPaymentFlows: [TokenizedPaymentFlowEnum!]
+
+  """Type of the payment method. Example: credit card, wallet, etc."""
+  type: String!
+
+  """
+  Payment method name. Example: last 4 digits of credit card, obfuscated email, etc.
+  """
+  name: String
+
+  """JSON data returned by Payment Provider app for this payment method."""
+  data: JSON
+}
+
+"""
+Represents possible tokenized payment flows that can be used to process payment.
+
+    The following flows are possible:
+    INTERACTIVE - Payment method can be used for 1 click checkout - it's prefilled in
+    checkout form (might require additional authentication from user)
+"""
+enum TokenizedPaymentFlowEnum {
+  INTERACTIVE
+}
+
+scalar JSON
 
 type CheckoutCountableConnection @doc(category: "Checkout") {
   """Pagination data for this connection."""
@@ -22483,8 +22558,6 @@ type PaymentGatewayConfig @doc(category: "Payments") {
   data: JSON
   errors: [PaymentGatewayConfigError!]
 }
-
-scalar JSON
 
 type PaymentGatewayConfigError @doc(category: "Payments") {
   """

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -14,7 +14,6 @@ from ...permission.auth_filters import AuthorizationFilters
 from ...permission.enums import SitePermissions, get_permissions
 from ...site import models as site_models
 from ..account.types import Address, AddressInput, StaffNotificationRecipient
-from ..checkout.types import PaymentGateway
 from ..core import ResolveInfo
 from ..core.descriptions import (
     ADDED_IN_31,
@@ -42,6 +41,7 @@ from ..core.types import (
 )
 from ..core.utils import str_to_enum
 from ..meta.types import ObjectWithMetadata
+from ..payment.types import PaymentGateway
 from ..plugins.dataloaders import plugin_manager_promise_callback
 from ..shipping.types import ShippingMethod
 from ..site.dataloaders import get_site_promise, load_site_callback


### PR DESCRIPTION
I want to merge this change because it adds a new field to `Checkout` and `User` type. The field  returns a list of stored payment methods fetched by `list-stored-payment-methods` webhook. 
More details: https://github.com/saleor/saleor/issues/13384

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
