### PR TITLE
Add `ACCOUNT_SET_PASSWORD_REQUESTED` webhook event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ Shipping methods can be removed by the user after it has been assigned to a chec
   - Called after account deletion is confirmed with `accountDelete` mutation.
 - Add `ACCOUNT_EMAIL_CHANGED` webhook - #13537, by @Air-t
   - Called when `confirmEmailChange` mutation is triggered.
+- Add `ACCOUNT_SET_PASSWORD_REQUESTED` webhook - #13486, by @Air-t
+  - Called after `requestPasswordReset` or `customerCreate` mutation.
 
 ### Other changes
 - Add possibility to log without confirming email - #13059 by @kadewu

--- a/saleor/graphql/account/mutations/authentication/request_password_reset.py
+++ b/saleor/graphql/account/mutations/authentication/request_password_reset.py
@@ -1,12 +1,15 @@
+from urllib.parse import urlencode
+
 import graphene
 from django.conf import settings
+from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
 from .....account.error_codes import AccountErrorCode
 from .....account.notifications import send_password_reset_notification
 from .....account.utils import retrieve_user_by_email
-from .....core.utils.url import validate_storefront_url
+from .....core.utils.url import prepare_url, validate_storefront_url
 from .....webhook.event_types import WebhookEventAsyncType
 from ....channel.utils import clean_channel, validate_channel
 from ....core import ResolveInfo
@@ -47,7 +50,11 @@ class RequestPasswordReset(BaseMutation):
             WebhookEventInfo(
                 type=WebhookEventAsyncType.NOTIFY_USER,
                 description="A notification for password reset.",
-            )
+            ),
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.ACCOUNT_SET_PASSWORD_REQUESTED,
+                description="Setting a new password for the account is requested.",
+            ),
         ]
 
     @classmethod
@@ -99,8 +106,10 @@ class RequestPasswordReset(BaseMutation):
     def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
         email = data["email"]
         redirect_url = data["redirect_url"]
-        channel_slug = data.get("channel")
         user = cls.clean_user(email, redirect_url, info)
+        channel_slug = data.get("channel")
+        token = default_token_generator.make_token(user)
+        params = urlencode({"email": user.email, "token": token})
 
         if not user.is_staff:
             channel_slug = clean_channel(
@@ -110,6 +119,7 @@ class RequestPasswordReset(BaseMutation):
             channel_slug = validate_channel(
                 channel_slug, error_class=AccountErrorCode
             ).slug
+
         manager = get_plugin_manager_promise(info.context).get()
         send_password_reset_notification(
             redirect_url,
@@ -118,6 +128,14 @@ class RequestPasswordReset(BaseMutation):
             channel_slug=channel_slug,
             staff=user.is_staff,
         )
+        cls.call_event(
+            manager.account_set_password_requested,
+            user,
+            channel_slug,
+            token,
+            prepare_url(params, redirect_url),
+        )
         user.last_password_reset_request = timezone.now()
         user.save(update_fields=["last_password_reset_request"])
+
         return RequestPasswordReset()

--- a/saleor/graphql/account/mutations/staff/customer_create.py
+++ b/saleor/graphql/account/mutations/staff/customer_create.py
@@ -33,4 +33,8 @@ class CustomerCreate(BaseCustomerCreate):
                 type=WebhookEventAsyncType.NOTIFY_USER,
                 description="A notification for setting the password.",
             ),
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.ACCOUNT_SET_PASSWORD_REQUESTED,
+                description="Setting a new password for the account is requested.",
+            ),
         ]

--- a/saleor/graphql/account/tests/mutations/authentication/test_request_password_reset.py
+++ b/saleor/graphql/account/tests/mutations/authentication/test_request_password_reset.py
@@ -30,7 +30,9 @@ REQUEST_PASSWORD_RESET_MUTATION = """
 
 @freeze_time("2018-05-31 12:00:01")
 @patch("saleor.plugins.manager.PluginsManager.notify")
+@patch("saleor.plugins.manager.PluginsManager.account_set_password_requested")
 def test_account_reset_password(
+    mocked_account_set_password_requested,
     mocked_notify,
     user_api_client,
     customer_user,
@@ -68,6 +70,10 @@ def test_account_reset_password(
     user = user_api_client.user
     user.refresh_from_db()
     assert user.last_password_reset_request == timezone.now()
+
+    mocked_account_set_password_requested.assert_called_once_with(
+        user, channel_PLN.slug, token, reset_url
+    )
 
 
 @freeze_time("2018-05-31 12:00:01")

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1728,6 +1728,9 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   """An account email was changed"""
   ACCOUNT_EMAIL_CHANGED
 
+  """Setting a new password for the account is requested."""
+  ACCOUNT_SET_PASSWORD_REQUESTED
+
   """An account is confirmed."""
   ACCOUNT_CONFIRMED
 
@@ -2383,6 +2386,9 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """An account email was changed"""
   ACCOUNT_EMAIL_CHANGED
+
+  """Setting a new password for the account is requested."""
+  ACCOUNT_SET_PASSWORD_REQUESTED
 
   """An account is confirmed."""
   ACCOUNT_CONFIRMED
@@ -3393,6 +3399,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   ACCOUNT_CONFIRMATION_REQUESTED
   ACCOUNT_CHANGE_EMAIL_REQUESTED
   ACCOUNT_EMAIL_CHANGED
+  ACCOUNT_SET_PASSWORD_REQUESTED
   ACCOUNT_CONFIRMED
   ACCOUNT_DELETE_REQUESTED
   ACCOUNT_DELETED
@@ -17900,6 +17907,7 @@ type Mutation {
   
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for password reset.
+  - ACCOUNT_SET_PASSWORD_REQUESTED (async): Setting a new password for the account is requested.
   """
   requestPasswordReset(
     """
@@ -17914,7 +17922,7 @@ type Mutation {
     URL of a view where users should be redirected to reset the password. URL in RFC 1808 format.
     """
     redirectUrl: String!
-  ): RequestPasswordReset @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER], syncEvents: [])
+  ): RequestPasswordReset @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, ACCOUNT_SET_PASSWORD_REQUESTED], syncEvents: [])
 
   """
   Sends a notification confirmation.
@@ -18219,11 +18227,12 @@ type Mutation {
   - CUSTOMER_CREATED (async): A new customer account was created.
   - CUSTOMER_METADATA_UPDATED (async): Optionally called when customer's metadata was updated.
   - NOTIFY_USER (async): A notification for setting the password.
+  - ACCOUNT_SET_PASSWORD_REQUESTED (async): Setting a new password for the account is requested.
   """
   customerCreate(
     """Fields required to create a customer."""
     input: UserCreateInput!
-  ): CustomerCreate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_CREATED, CUSTOMER_METADATA_UPDATED, NOTIFY_USER], syncEvents: [])
+  ): CustomerCreate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_CREATED, CUSTOMER_METADATA_UPDATED, NOTIFY_USER, ACCOUNT_SET_PASSWORD_REQUESTED], syncEvents: [])
 
   """
   Updates an existing customer. 
@@ -28107,8 +28116,9 @@ Sends an email with the account password modification link.
 
 Triggers the following webhook events:
 - NOTIFY_USER (async): A notification for password reset.
+- ACCOUNT_SET_PASSWORD_REQUESTED (async): Setting a new password for the account is requested.
 """
-type RequestPasswordReset @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER], syncEvents: []) {
+type RequestPasswordReset @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, ACCOUNT_SET_PASSWORD_REQUESTED], syncEvents: []) {
   accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
@@ -28471,8 +28481,9 @@ Triggers the following webhook events:
 - CUSTOMER_CREATED (async): A new customer account was created.
 - CUSTOMER_METADATA_UPDATED (async): Optionally called when customer's metadata was updated.
 - NOTIFY_USER (async): A notification for setting the password.
+- ACCOUNT_SET_PASSWORD_REQUESTED (async): Setting a new password for the account is requested.
 """
-type CustomerCreate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_CREATED, CUSTOMER_METADATA_UPDATED, NOTIFY_USER], syncEvents: []) {
+type CustomerCreate @doc(category: "Users") @webhookEventsInfo(asyncEvents: [CUSTOMER_CREATED, CUSTOMER_METADATA_UPDATED, NOTIFY_USER, ACCOUNT_SET_PASSWORD_REQUESTED], syncEvents: []) {
   accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
@@ -29225,6 +29236,40 @@ type AccountEmailChanged implements Event {
 
   """The new email address."""
   newEmail: String
+}
+
+"""
+Event sent when setting a new password is requested.
+
+Added in Saleor 3.15.
+"""
+type AccountSetPasswordRequested implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The URL to redirect the user after he accepts the request."""
+  redirectUrl: String
+
+  """The user the event relates to."""
+  user: User
+
+  """The channel data."""
+  channel: Channel
+
+  """The token required to confirm request."""
+  token: String
+
+  """Shop data."""
+  shop: Shop
 }
 
 """

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -42,6 +42,9 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED: (
         "An account email change is requested."
     ),
+    WebhookEventAsyncType.ACCOUNT_SET_PASSWORD_REQUESTED: (
+        "Setting a new password for the account is requested."
+    ),
     WebhookEventAsyncType.ACCOUNT_CONFIRMED: "An account is confirmed.",
     WebhookEventAsyncType.ACCOUNT_DELETE_REQUESTED: "An account delete is requested.",
     WebhookEventAsyncType.ACCOUNT_DELETED: "An account is deleted.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -226,6 +226,16 @@ class AccountEmailChanged(SubscriptionObjectType, AccountOperationBase):
         description = "Event sent when account email is changed." + ADDED_IN_315
 
 
+class AccountSetPasswordRequested(SubscriptionObjectType, AccountOperationBase):
+    class Meta:
+        root_type = None
+        enable_dry_run = False
+        interfaces = (Event,)
+        description = (
+            "Event sent when setting a new password is requested." + ADDED_IN_315
+        )
+
+
 class AccountDeleteRequested(SubscriptionObjectType, AccountOperationBase):
     class Meta:
         root_type = "User"
@@ -2162,6 +2172,7 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.ACCOUNT_CONFIRMATION_REQUESTED: AccountConfirmationRequested,
     WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED: AccountChangeEmailRequested,
     WebhookEventAsyncType.ACCOUNT_EMAIL_CHANGED: AccountEmailChanged,
+    WebhookEventAsyncType.ACCOUNT_SET_PASSWORD_REQUESTED: AccountSetPasswordRequested,
     WebhookEventAsyncType.ACCOUNT_CONFIRMED: AccountConfirmed,
     WebhookEventAsyncType.ACCOUNT_DELETE_REQUESTED: AccountDeleteRequested,
     WebhookEventAsyncType.ACCOUNT_DELETED: AccountDeleted,

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -171,6 +171,12 @@ class BasePlugin:
     # change email is requested.
     account_change_email_requested: Callable[["User", str, str, str, str, None], None]
 
+    # Trigger when account set password is requested.
+    #
+    # Overwrite this method if you need to trigger specific logic after an account
+    # set password is requested.
+    account_set_password_requested: Callable[["User", str, str, str, None], None]
+
     # Trigger when account delete is confirmed.
     #
     # Overwrite this method if you need to trigger specific logic after an account

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1099,6 +1099,23 @@ class PluginsManager(PaymentInterface):
             user,
         )
 
+    def account_set_password_requested(
+        self,
+        user: "User",
+        channel_slug: str,
+        token: str,
+        redirect_url: str,
+    ):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "account_set_password_requested",
+            default_value,
+            user,
+            channel_slug,
+            token=token,
+            redirect_url=redirect_url,
+        )
+
     def account_delete_requested(
         self, user: "User", channel_slug: str, token: str, redirect_url: str
     ):

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -251,6 +251,24 @@ class WebhookPlugin(BasePlugin):
             user,
         )
 
+    def account_set_password_requested(
+        self,
+        user: "User",
+        channel_slug: str,
+        token: str,
+        redirect_url: str,
+        previous_value: None,
+    ) -> None:
+        if not self.active:
+            return previous_value
+        self._trigger_account_request_event(
+            WebhookEventAsyncType.ACCOUNT_SET_PASSWORD_REQUESTED,
+            user,
+            channel_slug,
+            token,
+            redirect_url,
+        )
+
     def account_delete_requested(
         self,
         user: "User",

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -61,6 +61,14 @@ def subscription_account_delete_requested_webhook(subscription_webhook):
 
 
 @pytest.fixture
+def subscription_account_set_password_requested_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.ACCOUNT_SET_PASSWORD_REQUESTED,
+        WebhookEventAsyncType.ACCOUNT_SET_PASSWORD_REQUESTED,
+    )
+
+
+@pytest.fixture
 def subscription_account_deleted_webhook(subscription_webhook):
     return subscription_webhook(
         queries.ACCOUNT_DELETED,

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -115,6 +115,33 @@ ACCOUNT_DELETE_REQUESTED = (
 """
 )
 
+ACCOUNT_SET_PASSWORD_REQUESTED = (
+    fragments.CUSTOMER_DETAILS
+    + """
+    subscription{
+      event{
+        ...on AccountSetPasswordRequested{
+          user{
+            ...CustomerDetails
+          }
+          token
+          redirectUrl
+          channel{
+            slug
+            id
+          }
+          shop{
+            domain{
+                host
+                url
+            }
+          }
+        }
+      }
+    }
+"""
+)
+
 ACCOUNT_DELETED = (
     fragments.CUSTOMER_DETAILS
     + """

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -207,6 +207,35 @@ def test_account_delete_requested(
     assert deliveries[0].webhook == webhooks[0]
 
 
+def test_account_set_password_requested(
+    customer_user, channel_USD, subscription_account_set_password_requested_webhook
+):
+    # given
+    webhooks = [subscription_account_set_password_requested_webhook]
+    event_type = WebhookEventAsyncType.ACCOUNT_SET_PASSWORD_REQUESTED
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type,
+        {
+            "user": customer_user,
+            "channel_slug": channel_USD.slug,
+            "token": "token",
+            "redirect_url": "http://www.mirumee.com?token=token",
+        },
+        webhooks,
+    )
+
+    # then
+    expected_payload = generate_account_requested_events_payload(
+        customer_user, channel_USD
+    )
+
+    assert deliveries[0].payload.payload == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
 def test_account_deleted_confirmed(customer_user, subscription_account_deleted_webhook):
     # given
     webhooks = [subscription_account_deleted_webhook]

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -25,6 +25,7 @@ class WebhookEventAsyncType:
     ACCOUNT_CONFIRMATION_REQUESTED = "account_confirmation_requested"
     ACCOUNT_EMAIL_CHANGED = "account_email_changed"
     ACCOUNT_CHANGE_EMAIL_REQUESTED = "account_change_email_requested"
+    ACCOUNT_SET_PASSWORD_REQUESTED = "account_set_password_requested"
     ACCOUNT_CONFIRMED = "account_confirmed"
     ACCOUNT_DELETE_REQUESTED = "account_delete_requested"
     ACCOUNT_DELETED = "account_deleted"
@@ -193,6 +194,10 @@ class WebhookEventAsyncType:
         },
         ACCOUNT_EMAIL_CHANGED: {
             "name": "Account email changed",
+            "permission": AccountPermissions.MANAGE_USERS,
+        },
+        ACCOUNT_SET_PASSWORD_REQUESTED: {
+            "name": "Account set password requested",
             "permission": AccountPermissions.MANAGE_USERS,
         },
         ACCOUNT_CONFIRMED: {


### PR DESCRIPTION
Adds `ACCOUNT_SET_PASSWORD_REQUESTED` event sent after `requestPasswordReset` or `customerCreate` mutation.

Resolves https://github.com/saleor/saleor/issues/13486

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
