### PR TITLE
[Programmatic payments] webhook: stored payment method request delete

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -32205,6 +32205,9 @@ type StoredPaymentMethodRequestDelete implements Event @doc(category: "Payments"
   The ID of the payment method that should be deleted by the payment gateway.
   """
   paymentMethodId: String!
+
+  """Channel related to delete request."""
+  channel: Channel!
 }
 
 """_Any value scalar as defined by Federation spec."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2254,6 +2254,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   TRANSACTION_INITIALIZE_SESSION
   TRANSACTION_PROCESS_SESSION
   LIST_STORED_PAYMENT_METHODS
+  PAYMENT_METHOD_REQUEST_DELETE
 }
 
 """Synchronous webhook event."""
@@ -2341,6 +2342,7 @@ enum WebhookEventTypeSyncEnum @doc(category: "Webhooks") {
   TRANSACTION_INITIALIZE_SESSION
   TRANSACTION_PROCESS_SESSION
   LIST_STORED_PAYMENT_METHODS
+  PAYMENT_METHOD_REQUEST_DELETE
 }
 
 """Asynchronous webhook event."""
@@ -32172,6 +32174,37 @@ type ListStoredPaymentMethods implements Event @doc(category: "Payments") {
   Channel in context which was used to fetch the list of payment methods.
   """
   channel: Channel!
+}
+
+"""
+Event sent when user requests to delete a payment method.
+
+Added in Saleor 3.15.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type PaymentMethodRequestDelete implements Event @doc(category: "Payments") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """
+  The user for which the app should proceed with payment method delete request.
+  """
+  user: User!
+
+  """
+  The ID of the payment method that should be deleted by the payment gateway.
+  """
+  paymentMethodId: String!
 }
 
 """_Any value scalar as defined by Federation spec."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2254,7 +2254,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   TRANSACTION_INITIALIZE_SESSION
   TRANSACTION_PROCESS_SESSION
   LIST_STORED_PAYMENT_METHODS
-  PAYMENT_METHOD_REQUEST_DELETE
+  STORED_PAYMENT_METHOD_REQUEST_DELETE
 }
 
 """Synchronous webhook event."""
@@ -2342,7 +2342,7 @@ enum WebhookEventTypeSyncEnum @doc(category: "Webhooks") {
   TRANSACTION_INITIALIZE_SESSION
   TRANSACTION_PROCESS_SESSION
   LIST_STORED_PAYMENT_METHODS
-  PAYMENT_METHOD_REQUEST_DELETE
+  STORED_PAYMENT_METHOD_REQUEST_DELETE
 }
 
 """Asynchronous webhook event."""
@@ -32183,7 +32183,7 @@ Added in Saleor 3.15.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
-type PaymentMethodRequestDelete implements Event @doc(category: "Payments") {
+type StoredPaymentMethodRequestDelete implements Event @doc(category: "Payments") {
   """Time of the event."""
   issuedAt: DateTime
 

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1824,6 +1824,12 @@ class StoredPaymentMethodRequestDelete(SubscriptionObjectType):
         required=True,
     )
 
+    channel = graphene.Field(
+        "saleor.graphql.channel.types.Channel",
+        description=("Channel related to delete request."),
+        required=True,
+    )
+
     class Meta:
         root_type = None
         enable_dry_run = False
@@ -1848,6 +1854,13 @@ class StoredPaymentMethodRequestDelete(SubscriptionObjectType):
     ):
         _, payment_method_data = root
         return payment_method_data.payment_method_id
+
+    @classmethod
+    def resolve_channel(
+        cls, root: tuple[str, StoredPaymentMethodRequestDeleteData], _info: ResolveInfo
+    ):
+        _, payment_method_data = root
+        return payment_method_data.channel
 
 
 class TranslationTypes(Union):

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -15,6 +15,7 @@ from ...order.utils import get_all_shipping_methods_for_order
 from ...page.models import PageTranslation
 from ...payment.interface import (
     ListStoredPaymentMethodsRequestData,
+    PaymentMethodRequestDeleteData,
     TransactionActionData,
     TransactionSessionData,
 )
@@ -1805,6 +1806,50 @@ class TransactionItemMetadataUpdated(SubscriptionObjectType):
         return transaction_item
 
 
+class PaymentMethodRequestDelete(SubscriptionObjectType):
+    user = graphene.Field(
+        UserType,
+        description=(
+            "The user for which the app should proceed with payment method delete "
+            "request."
+        ),
+        required=True,
+    )
+    payment_method_id = graphene.Field(
+        graphene.String,
+        description=(
+            "The ID of the payment method that should be deleted by the payment "
+            "gateway."
+        ),
+        required=True,
+    )
+
+    class Meta:
+        root_type = None
+        enable_dry_run = False
+        interfaces = (Event,)
+        description = (
+            "Event sent when user requests to delete a payment method."
+            + ADDED_IN_315
+            + PREVIEW_FEATURE
+        )
+        doc_category = DOC_CATEGORY_PAYMENTS
+
+    @classmethod
+    def resolve_user(
+        cls, root: tuple[str, PaymentMethodRequestDeleteData], _info: ResolveInfo
+    ):
+        _, payment_method_data = root
+        return payment_method_data.user
+
+    @classmethod
+    def resolve_payment_method_id(
+        cls, root: tuple[str, PaymentMethodRequestDeleteData], _info: ResolveInfo
+    ):
+        _, payment_method_data = root
+        return payment_method_data.payment_method_id
+
+
 class TranslationTypes(Union):
     class Meta:
         types = tuple(TRANSLATIONS_TYPES_MAP.values())
@@ -2318,4 +2363,5 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventSyncType.TRANSACTION_PROCESS_SESSION: TransactionProcessSession,
     WebhookEventAsyncType.SHOP_METADATA_UPDATED: ShopMetadataUpdated,
     WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS: ListStoredPaymentMethods,
+    WebhookEventSyncType.PAYMENT_METHOD_REQUEST_DELETE: PaymentMethodRequestDelete,
 }

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -15,7 +15,7 @@ from ...order.utils import get_all_shipping_methods_for_order
 from ...page.models import PageTranslation
 from ...payment.interface import (
     ListStoredPaymentMethodsRequestData,
-    PaymentMethodRequestDeleteData,
+    StoredPaymentMethodRequestDeleteData,
     TransactionActionData,
     TransactionSessionData,
 )
@@ -1806,7 +1806,7 @@ class TransactionItemMetadataUpdated(SubscriptionObjectType):
         return transaction_item
 
 
-class PaymentMethodRequestDelete(SubscriptionObjectType):
+class StoredPaymentMethodRequestDelete(SubscriptionObjectType):
     user = graphene.Field(
         UserType,
         description=(
@@ -1837,14 +1837,14 @@ class PaymentMethodRequestDelete(SubscriptionObjectType):
 
     @classmethod
     def resolve_user(
-        cls, root: tuple[str, PaymentMethodRequestDeleteData], _info: ResolveInfo
+        cls, root: tuple[str, StoredPaymentMethodRequestDeleteData], _info: ResolveInfo
     ):
         _, payment_method_data = root
         return payment_method_data.user
 
     @classmethod
     def resolve_payment_method_id(
-        cls, root: tuple[str, PaymentMethodRequestDeleteData], _info: ResolveInfo
+        cls, root: tuple[str, StoredPaymentMethodRequestDeleteData], _info: ResolveInfo
     ):
         _, payment_method_data = root
         return payment_method_data.payment_method_id
@@ -2363,5 +2363,7 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventSyncType.TRANSACTION_PROCESS_SESSION: TransactionProcessSession,
     WebhookEventAsyncType.SHOP_METADATA_UPDATED: ShopMetadataUpdated,
     WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS: ListStoredPaymentMethods,
-    WebhookEventSyncType.PAYMENT_METHOD_REQUEST_DELETE: PaymentMethodRequestDelete,
+    WebhookEventSyncType.STORED_PAYMENT_METHOD_REQUEST_DELETE: (
+        StoredPaymentMethodRequestDelete
+    ),
 }

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1826,7 +1826,7 @@ class StoredPaymentMethodRequestDelete(SubscriptionObjectType):
 
     channel = graphene.Field(
         "saleor.graphql.channel.types.Channel",
-        description=("Channel related to delete request."),
+        description="Channel related to delete request.",
         required=True,
     )
 

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -34,6 +34,7 @@ class StoredPaymentMethodRequestDeleteData:
 
     payment_method_id: str
     user: "User"
+    channel: "Channel"
 
 
 @dataclass

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -21,7 +21,7 @@ JSONType = Union[Dict[str, JSONValue], List[JSONValue]]
 
 
 @dataclass
-class PaymentMethodRequestDeleteResponseData:
+class StoredPaymentMethodRequestDeleteResponseData:
     """Dataclass for storing the response information from payment app."""
 
     success: bool
@@ -29,7 +29,7 @@ class PaymentMethodRequestDeleteResponseData:
 
 
 @dataclass
-class PaymentMethodRequestDeleteData:
+class StoredPaymentMethodRequestDeleteData:
     """Dataclass for storing the request information for payment app."""
 
     payment_method_id: str

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -21,6 +21,22 @@ JSONType = Union[Dict[str, JSONValue], List[JSONValue]]
 
 
 @dataclass
+class PaymentMethodRequestDeleteResponseData:
+    """Dataclass for storing the response information from payment app."""
+
+    success: bool
+    message: Optional[str] = None
+
+
+@dataclass
+class PaymentMethodRequestDeleteData:
+    """Dataclass for storing the request information for payment app."""
+
+    payment_method_id: str
+    user: "User"
+
+
+@dataclass
 class PaymentGateway:
     """Dataclass for storing information about a payment gateway."""
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -33,6 +33,8 @@ from ..payment.interface import (
     PaymentData,
     PaymentGateway,
     PaymentMethodData,
+    PaymentMethodRequestDeleteData,
+    PaymentMethodRequestDeleteResponseData,
     TransactionActionData,
 )
 from ..thumbnail.models import Thumbnail
@@ -655,6 +657,14 @@ class BasePlugin:
     list_stored_payment_methods: Callable[
         ["ListStoredPaymentMethodsRequestData", list["PaymentMethodData"]],
         list["PaymentMethodData"],
+    ]
+
+    payment_method_request_delete: Callable[
+        [
+            "PaymentMethodRequestDeleteData",
+            "PaymentMethodRequestDeleteResponseData",
+        ],
+        "PaymentMethodRequestDeleteResponseData",
     ]
 
     # Trigger when menu is created.

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -33,8 +33,8 @@ from ..payment.interface import (
     PaymentData,
     PaymentGateway,
     PaymentMethodData,
-    PaymentMethodRequestDeleteData,
-    PaymentMethodRequestDeleteResponseData,
+    StoredPaymentMethodRequestDeleteData,
+    StoredPaymentMethodRequestDeleteResponseData,
     TransactionActionData,
 )
 from ..thumbnail.models import Thumbnail
@@ -659,12 +659,12 @@ class BasePlugin:
         list["PaymentMethodData"],
     ]
 
-    payment_method_request_delete: Callable[
+    stored_payment_method_request_delete: Callable[
         [
-            "PaymentMethodRequestDeleteData",
-            "PaymentMethodRequestDeleteResponseData",
+            "StoredPaymentMethodRequestDeleteData",
+            "StoredPaymentMethodRequestDeleteResponseData",
         ],
-        "PaymentMethodRequestDeleteResponseData",
+        "StoredPaymentMethodRequestDeleteResponseData",
     ]
 
     # Trigger when menu is created.

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -32,6 +32,21 @@ from ..core.taxes import TaxData, TaxType, zero_money, zero_taxed_money
 from ..graphql.core import ResolveInfo, SaleorContext
 from ..order import base_calculations as base_order_calculations
 from ..order.interface import OrderTaxedPricesData
+from ..payment.interface import (
+    CustomerSource,
+    GatewayResponse,
+    InitializedPaymentResponse,
+    ListStoredPaymentMethodsRequestData,
+    PaymentData,
+    PaymentGateway,
+    PaymentGatewayData,
+    PaymentMethodData,
+    PaymentMethodRequestDeleteData,
+    PaymentMethodRequestDeleteResponseData,
+    TokenConfig,
+    TransactionActionData,
+    TransactionSessionData,
+)
 from ..tax.utils import calculate_tax_rate
 from .base_plugin import ExcludedShippingMethod, ExternalAccessTokens
 from .models import PluginConfiguration
@@ -49,19 +64,6 @@ if TYPE_CHECKING:
     from ..menu.models import Menu, MenuItem
     from ..order.models import Fulfillment, Order, OrderLine
     from ..page.models import Page, PageType
-    from ..payment.interface import (
-        CustomerSource,
-        GatewayResponse,
-        InitializedPaymentResponse,
-        ListStoredPaymentMethodsRequestData,
-        PaymentData,
-        PaymentGateway,
-        PaymentGatewayData,
-        PaymentMethodData,
-        TokenConfig,
-        TransactionActionData,
-        TransactionSessionData,
-    )
     from ..payment.models import TransactionItem
     from ..product.models import (
         Category,
@@ -1481,6 +1483,20 @@ class PluginsManager(PaymentInterface):
             default_value,
             list_stored_payment_methods_data,
         )
+
+    def payment_method_request_delete(
+        self,
+        request_delete_data: "PaymentMethodRequestDeleteData",
+    ) -> "PaymentMethodRequestDeleteResponseData":
+        default_response = PaymentMethodRequestDeleteResponseData(
+            success=False, message="Payment method request delete failed to deliver."
+        )
+        response = self.__run_method_on_plugins(
+            "payment_method_request_delete",
+            default_response,
+            request_delete_data,
+        )
+        return response
 
     def translation_created(self, translation: "Translation"):
         default_value = None

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -41,8 +41,8 @@ from ..payment.interface import (
     PaymentGateway,
     PaymentGatewayData,
     PaymentMethodData,
-    PaymentMethodRequestDeleteData,
-    PaymentMethodRequestDeleteResponseData,
+    StoredPaymentMethodRequestDeleteData,
+    StoredPaymentMethodRequestDeleteResponseData,
     TokenConfig,
     TransactionActionData,
     TransactionSessionData,
@@ -1484,15 +1484,15 @@ class PluginsManager(PaymentInterface):
             list_stored_payment_methods_data,
         )
 
-    def payment_method_request_delete(
+    def stored_payment_method_request_delete(
         self,
-        request_delete_data: "PaymentMethodRequestDeleteData",
-    ) -> "PaymentMethodRequestDeleteResponseData":
-        default_response = PaymentMethodRequestDeleteResponseData(
+        request_delete_data: "StoredPaymentMethodRequestDeleteData",
+    ) -> "StoredPaymentMethodRequestDeleteResponseData":
+        default_response = StoredPaymentMethodRequestDeleteResponseData(
             success=False, message="Payment method request delete failed to deliver."
         )
         response = self.__run_method_on_plugins(
-            "payment_method_request_delete",
+            "stored_payment_method_request_delete",
             default_response,
             request_delete_data,
         )

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -345,7 +345,7 @@ class PluginSample(BasePlugin):
     ):
         return []
 
-    def payment_method_request_delete(self, request_delete_data, previous_value):
+    def stored_payment_method_request_delete(self, request_delete_data, previous_value):
         return previous_value
 
 

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -345,6 +345,9 @@ class PluginSample(BasePlugin):
     ):
         return []
 
+    def payment_method_request_delete(self, request_delete_data, previous_value):
+        return previous_value
+
 
 class ChannelPluginSample(PluginSample):
     PLUGIN_ID = "channel.plugin.sample"

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -21,6 +21,8 @@ from ...payment.interface import (
     ListStoredPaymentMethodsRequestData,
     PaymentGateway,
     PaymentGatewayData,
+    PaymentMethodRequestDeleteData,
+    PaymentMethodRequestDeleteResponseData,
     TransactionProcessActionData,
     TransactionSessionData,
 )
@@ -1355,3 +1357,30 @@ def test_list_stored_payment_methods(
 
     # then
     mocked_list_stored_payment_methods.assert_called_once()
+
+
+@patch("saleor.plugins.tests.sample_plugins.PluginSample.payment_method_request_delete")
+def test_payment_method_request_delete(
+    mocked_payment_method_request_delete, customer_user
+):
+    # given
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+        "saleor.plugins.tests.sample_plugins.PluginInactive",
+    ]
+    manager = PluginsManager(plugins=plugins)
+    request_delete_data = PaymentMethodRequestDeleteData(
+        user=customer_user,
+        payment_method_id="123",
+    )
+    previous_response = PaymentMethodRequestDeleteResponseData(
+        success=False, message="Payment method request delete failed to deliver."
+    )
+
+    # when
+    manager.payment_method_request_delete(request_delete_data=request_delete_data)
+
+    # then
+    mocked_payment_method_request_delete.assert_called_once_with(
+        request_delete_data, previous_value=previous_response
+    )

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -21,8 +21,8 @@ from ...payment.interface import (
     ListStoredPaymentMethodsRequestData,
     PaymentGateway,
     PaymentGatewayData,
-    PaymentMethodRequestDeleteData,
-    PaymentMethodRequestDeleteResponseData,
+    StoredPaymentMethodRequestDeleteData,
+    StoredPaymentMethodRequestDeleteResponseData,
     TransactionProcessActionData,
     TransactionSessionData,
 )
@@ -1359,9 +1359,11 @@ def test_list_stored_payment_methods(
     mocked_list_stored_payment_methods.assert_called_once()
 
 
-@patch("saleor.plugins.tests.sample_plugins.PluginSample.payment_method_request_delete")
-def test_payment_method_request_delete(
-    mocked_payment_method_request_delete, customer_user
+@patch(
+    "saleor.plugins.tests.sample_plugins.PluginSample.stored_payment_method_request_delete"
+)
+def test_stored_payment_method_request_delete(
+    mocked_stored_payment_method_request_delete, customer_user
 ):
     # given
     plugins = [
@@ -1369,18 +1371,20 @@ def test_payment_method_request_delete(
         "saleor.plugins.tests.sample_plugins.PluginInactive",
     ]
     manager = PluginsManager(plugins=plugins)
-    request_delete_data = PaymentMethodRequestDeleteData(
+    request_delete_data = StoredPaymentMethodRequestDeleteData(
         user=customer_user,
         payment_method_id="123",
     )
-    previous_response = PaymentMethodRequestDeleteResponseData(
+    previous_response = StoredPaymentMethodRequestDeleteResponseData(
         success=False, message="Payment method request delete failed to deliver."
     )
 
     # when
-    manager.payment_method_request_delete(request_delete_data=request_delete_data)
+    manager.stored_payment_method_request_delete(
+        request_delete_data=request_delete_data
+    )
 
     # then
-    mocked_payment_method_request_delete.assert_called_once_with(
+    mocked_stored_payment_method_request_delete.assert_called_once_with(
         request_delete_data, previous_value=previous_response
     )

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1363,7 +1363,7 @@ def test_list_stored_payment_methods(
     "saleor.plugins.tests.sample_plugins.PluginSample.stored_payment_method_request_delete"
 )
 def test_stored_payment_method_request_delete(
-    mocked_stored_payment_method_request_delete, customer_user
+    mocked_stored_payment_method_request_delete, customer_user, channel_USD
 ):
     # given
     plugins = [
@@ -1372,8 +1372,7 @@ def test_stored_payment_method_request_delete(
     ]
     manager = PluginsManager(plugins=plugins)
     request_delete_data = StoredPaymentMethodRequestDeleteData(
-        user=customer_user,
-        payment_method_id="123",
+        user=customer_user, payment_method_id="123", channel=channel_USD
     )
     previous_response = StoredPaymentMethodRequestDeleteResponseData(
         success=False, message="Payment method request delete failed to deliver."

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1580,6 +1580,7 @@ class WebhookPlugin(BasePlugin):
                 "user_id": graphene.Node.to_global_id(
                     "User", request_delete_data.user.id
                 ),
+                "channel_slug": request_delete_data.channel.slug,
             }
         )
 
@@ -1590,6 +1591,7 @@ class WebhookPlugin(BasePlugin):
             subscribable_object=StoredPaymentMethodRequestDeleteData(
                 payment_method_id=app_data.name,
                 user=request_delete_data.user,
+                channel=request_delete_data.channel,
             ),
             timeout=WEBHOOK_SYNC_TIMEOUT,
         )

--- a/saleor/plugins/webhook/stored_payment_methods.py
+++ b/saleor/plugins/webhook/stored_payment_methods.py
@@ -7,6 +7,7 @@ from ...payment.interface import (
     PaymentGateway,
     PaymentMethodCreditCardInfo,
     PaymentMethodData,
+    PaymentMethodRequestDeleteResponseData,
 )
 from .utils import to_payment_app_id
 
@@ -137,3 +138,13 @@ def get_list_stored_payment_methods_from_response(
         ):
             payment_methods.append(parsed_payment_method)
     return payment_methods
+
+
+def get_response_for_payment_method_request_delete(
+    response_data: Optional[dict],
+) -> "PaymentMethodRequestDeleteResponseData":
+    response_data = response_data or {"message": "Failed to delivery request."}
+    return PaymentMethodRequestDeleteResponseData(
+        success=response_data.get("success", False),
+        message=response_data.get("message", None),
+    )

--- a/saleor/plugins/webhook/stored_payment_methods.py
+++ b/saleor/plugins/webhook/stored_payment_methods.py
@@ -7,7 +7,7 @@ from ...payment.interface import (
     PaymentGateway,
     PaymentMethodCreditCardInfo,
     PaymentMethodData,
-    PaymentMethodRequestDeleteResponseData,
+    StoredPaymentMethodRequestDeleteResponseData,
 )
 from .utils import to_payment_app_id
 
@@ -140,11 +140,11 @@ def get_list_stored_payment_methods_from_response(
     return payment_methods
 
 
-def get_response_for_payment_method_request_delete(
+def get_response_for_stored_payment_method_request_delete(
     response_data: Optional[dict],
-) -> "PaymentMethodRequestDeleteResponseData":
+) -> "StoredPaymentMethodRequestDeleteResponseData":
     response_data = response_data or {"message": "Failed to delivery request."}
-    return PaymentMethodRequestDeleteResponseData(
+    return StoredPaymentMethodRequestDeleteResponseData(
         success=response_data.get("success", False),
         message=response_data.get("message", None),
     )

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_list_payment_methods.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_list_payment_methods.py
@@ -24,7 +24,6 @@ subscription {
 
 def test_list_stored_payment_methods(
     list_stored_payment_methods_app,
-    webhook_list_stored_payment_methods_response,
     channel_USD,
     customer_user,
 ):

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_request_delete.py
@@ -2,14 +2,14 @@ import json
 
 import graphene
 
-from .....payment.interface import PaymentMethodRequestDeleteData
+from .....payment.interface import StoredPaymentMethodRequestDeleteData
 from .....webhook.event_types import WebhookEventSyncType
 from ...tasks import create_deliveries_for_subscriptions
 
-PAYMENT_METHOD_REQUEST_DELETE = """
+STORED_PAYMENT_METHOD_REQUEST_DELETE = """
 subscription {
   event {
-    ... on PaymentMethodRequestDelete{
+    ... on StoredPaymentMethodRequestDelete{
       user{
         id
       }
@@ -20,22 +20,22 @@ subscription {
 """
 
 
-def test_payment_method_request_delete(
-    payment_method_request_delete_app, customer_user
+def test_stored_payment_method_request_delete(
+    stored_payment_method_request_delete_app, customer_user
 ):
     # given
-    webhook = payment_method_request_delete_app.webhooks.first()
-    webhook.subscription_query = PAYMENT_METHOD_REQUEST_DELETE
+    webhook = stored_payment_method_request_delete_app.webhooks.first()
+    webhook.subscription_query = STORED_PAYMENT_METHOD_REQUEST_DELETE
     webhook.save()
 
     payment_method_id = "123"
 
-    request_delete_data = PaymentMethodRequestDeleteData(
+    request_delete_data = StoredPaymentMethodRequestDeleteData(
         user=customer_user,
         payment_method_id=payment_method_id,
     )
 
-    event_type = WebhookEventSyncType.PAYMENT_METHOD_REQUEST_DELETE
+    event_type = WebhookEventSyncType.STORED_PAYMENT_METHOD_REQUEST_DELETE
 
     # when
     delivery = create_deliveries_for_subscriptions(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_request_delete.py
@@ -1,0 +1,51 @@
+import json
+
+import graphene
+
+from .....payment.interface import PaymentMethodRequestDeleteData
+from .....webhook.event_types import WebhookEventSyncType
+from ...tasks import create_deliveries_for_subscriptions
+
+PAYMENT_METHOD_REQUEST_DELETE = """
+subscription {
+  event {
+    ... on PaymentMethodRequestDelete{
+      user{
+        id
+      }
+      paymentMethodId
+    }
+  }
+}
+"""
+
+
+def test_payment_method_request_delete(
+    payment_method_request_delete_app, customer_user
+):
+    # given
+    webhook = payment_method_request_delete_app.webhooks.first()
+    webhook.subscription_query = PAYMENT_METHOD_REQUEST_DELETE
+    webhook.save()
+
+    payment_method_id = "123"
+
+    request_delete_data = PaymentMethodRequestDeleteData(
+        user=customer_user,
+        payment_method_id=payment_method_id,
+    )
+
+    event_type = WebhookEventSyncType.PAYMENT_METHOD_REQUEST_DELETE
+
+    # when
+    delivery = create_deliveries_for_subscriptions(
+        event_type, request_delete_data, [webhook]
+    )[0]
+
+    # then
+    assert delivery.payload
+    assert delivery.payload.payload
+    assert json.loads(delivery.payload.payload) == {
+        "paymentMethodId": payment_method_id,
+        "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
+    }

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_request_delete.py
@@ -14,6 +14,9 @@ subscription {
         id
       }
       paymentMethodId
+      channel{
+        id
+      }
     }
   }
 }
@@ -21,7 +24,7 @@ subscription {
 
 
 def test_stored_payment_method_request_delete(
-    stored_payment_method_request_delete_app, customer_user
+    stored_payment_method_request_delete_app, customer_user, channel_USD
 ):
     # given
     webhook = stored_payment_method_request_delete_app.webhooks.first()
@@ -31,8 +34,7 @@ def test_stored_payment_method_request_delete(
     payment_method_id = "123"
 
     request_delete_data = StoredPaymentMethodRequestDeleteData(
-        user=customer_user,
-        payment_method_id=payment_method_id,
+        user=customer_user, payment_method_id=payment_method_id, channel=channel_USD
     )
 
     event_type = WebhookEventSyncType.STORED_PAYMENT_METHOD_REQUEST_DELETE
@@ -48,4 +50,5 @@ def test_stored_payment_method_request_delete(
     assert json.loads(delivery.payload.payload) == {
         "paymentMethodId": payment_method_id,
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
+        "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
     }

--- a/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
+++ b/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
@@ -1,12 +1,13 @@
 import graphene
 import mock
+import pytest
 
 from ....core.models import EventDelivery
 from ....payment.interface import ListStoredPaymentMethodsRequestData
 from ....settings import WEBHOOK_SYNC_TIMEOUT
 from ....webhook.event_types import WebhookEventSyncType
 from ..const import WEBHOOK_CACHE_DEFAULT_TIMEOUT
-from ..list_stored_payment_methods import get_list_stored_payment_methods_from_response
+from ..stored_payment_methods import get_list_stored_payment_methods_from_response
 from ..utils import generate_cache_key_for_webhook
 
 LIST_STORED_PAYMENT_METHODS = """
@@ -23,6 +24,28 @@ subscription {
   }
 }
 """
+
+
+@pytest.fixture
+def webhook_list_stored_payment_methods_response():
+    return {
+        "paymentMethods": [
+            {
+                "id": "method-1",
+                "supportedPaymentFlows": ["INTERACTIVE"],
+                "type": "Credit Card",
+                "creditCardInfo": {
+                    "brand": "visa",
+                    "lastDigits": "1234",
+                    "expMonth": 1,
+                    "expYear": 2023,
+                    "firstDigits": "123456",
+                },
+                "name": "***1234",
+                "data": {"some": "data"},
+            }
+        ]
+    }
 
 
 @mock.patch("saleor.plugins.webhook.tasks.cache.set")

--- a/saleor/plugins/webhook/tests/test_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_request_delete.py
@@ -20,6 +20,9 @@ subscription {
         id
       }
       paymentMethodId
+      channel{
+        id
+      }
     }
   }
 }
@@ -38,6 +41,7 @@ def test_stored_payment_method_request_delete_with_static_payload(
     webhook_plugin,
     stored_payment_method_request_delete_app,
     webhook_stored_payment_method_request_delete_response,
+    channel_USD,
 ):
     # given
     mock_request.return_value = webhook_stored_payment_method_request_delete_response
@@ -51,6 +55,7 @@ def test_stored_payment_method_request_delete_with_static_payload(
         payment_method_id=to_payment_app_id(
             stored_payment_method_request_delete_app, payment_method_id
         ),
+        channel=channel_USD,
     )
 
     previous_value = StoredPaymentMethodRequestDeleteResponseData(
@@ -68,6 +73,7 @@ def test_stored_payment_method_request_delete_with_static_payload(
         {
             "payment_method_id": payment_method_id,
             "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+            "channel_slug": channel_USD.slug,
         }
     )
     mock_request.assert_called_once_with(
@@ -87,6 +93,7 @@ def test_stored_payment_method_request_delete_with_subscription_payload(
     webhook_plugin,
     stored_payment_method_request_delete_app,
     webhook_stored_payment_method_request_delete_response,
+    channel_USD,
 ):
     # given
     mock_request.return_value = webhook_stored_payment_method_request_delete_response
@@ -104,6 +111,7 @@ def test_stored_payment_method_request_delete_with_subscription_payload(
         payment_method_id=to_payment_app_id(
             stored_payment_method_request_delete_app, payment_method_id
         ),
+        channel=channel_USD,
     )
 
     previous_value = StoredPaymentMethodRequestDeleteResponseData(
@@ -121,6 +129,7 @@ def test_stored_payment_method_request_delete_with_subscription_payload(
         {
             "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
             "paymentMethodId": payment_method_id,
+            "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
         }
     )
     mock_request.assert_called_once_with(
@@ -140,6 +149,7 @@ def test_stored_payment_method_request_delete_missing_correct_response_from_webh
     webhook_plugin,
     stored_payment_method_request_delete_app,
     webhook_stored_payment_method_request_delete_response,
+    channel_USD,
 ):
     # given
     mock_request.return_value = None
@@ -157,6 +167,7 @@ def test_stored_payment_method_request_delete_missing_correct_response_from_webh
         payment_method_id=to_payment_app_id(
             stored_payment_method_request_delete_app, payment_method_id
         ),
+        channel=channel_USD,
     )
 
     previous_value = StoredPaymentMethodRequestDeleteResponseData(

--- a/saleor/plugins/webhook/tests/test_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_request_delete.py
@@ -6,16 +6,16 @@ import pytest
 
 from ....core.models import EventDelivery
 from ....payment.interface import (
-    PaymentMethodRequestDeleteData,
-    PaymentMethodRequestDeleteResponseData,
+    StoredPaymentMethodRequestDeleteData,
+    StoredPaymentMethodRequestDeleteResponseData,
 )
 from ....settings import WEBHOOK_SYNC_TIMEOUT
 from ..utils import to_payment_app_id
 
-PAYMENT_METHOD_REQUEST_DELETE = """
+STORED_PAYMENT_METHOD_REQUEST_DELETE = """
 subscription {
   event {
-    ... on PaymentMethodRequestDelete{
+    ... on StoredPaymentMethodRequestDelete{
       user{
         id
       }
@@ -27,38 +27,40 @@ subscription {
 
 
 @pytest.fixture
-def webhook_payment_method_request_delete_response():
+def webhook_stored_payment_method_request_delete_response():
     return {"success": True, "message": "Payment method deleted successfully"}
 
 
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
-def test_payment_method_request_delete_with_static_payload(
+def test_stored_payment_method_request_delete_with_static_payload(
     mock_request,
     customer_user,
     webhook_plugin,
-    payment_method_request_delete_app,
-    webhook_payment_method_request_delete_response,
+    stored_payment_method_request_delete_app,
+    webhook_stored_payment_method_request_delete_response,
 ):
     # given
-    mock_request.return_value = webhook_payment_method_request_delete_response
+    mock_request.return_value = webhook_stored_payment_method_request_delete_response
 
     plugin = webhook_plugin()
 
     payment_method_id = "123"
 
-    request_delete_data = PaymentMethodRequestDeleteData(
+    request_delete_data = StoredPaymentMethodRequestDeleteData(
         user=customer_user,
         payment_method_id=to_payment_app_id(
-            payment_method_request_delete_app, payment_method_id
+            stored_payment_method_request_delete_app, payment_method_id
         ),
     )
 
-    previous_value = PaymentMethodRequestDeleteResponseData(
+    previous_value = StoredPaymentMethodRequestDeleteResponseData(
         success=False, message="Payment method request delete failed to deliver."
     )
 
     # when
-    response = plugin.payment_method_request_delete(request_delete_data, previous_value)
+    response = plugin.stored_payment_method_request_delete(
+        request_delete_data, previous_value
+    )
 
     # then
     delivery = EventDelivery.objects.get()
@@ -69,46 +71,49 @@ def test_payment_method_request_delete_with_static_payload(
         }
     )
     mock_request.assert_called_once_with(
-        payment_method_request_delete_app, delivery, timeout=WEBHOOK_SYNC_TIMEOUT
+        stored_payment_method_request_delete_app, delivery, timeout=WEBHOOK_SYNC_TIMEOUT
     )
 
-    assert response == PaymentMethodRequestDeleteResponseData(
-        success=True, message=webhook_payment_method_request_delete_response["message"]
+    assert response == StoredPaymentMethodRequestDeleteResponseData(
+        success=True,
+        message=webhook_stored_payment_method_request_delete_response["message"],
     )
 
 
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
-def test_payment_method_request_delete_with_subscription_payload(
+def test_stored_payment_method_request_delete_with_subscription_payload(
     mock_request,
     customer_user,
     webhook_plugin,
-    payment_method_request_delete_app,
-    webhook_payment_method_request_delete_response,
+    stored_payment_method_request_delete_app,
+    webhook_stored_payment_method_request_delete_response,
 ):
     # given
-    mock_request.return_value = webhook_payment_method_request_delete_response
+    mock_request.return_value = webhook_stored_payment_method_request_delete_response
 
-    webhook = payment_method_request_delete_app.webhooks.first()
-    webhook.subscription_query = PAYMENT_METHOD_REQUEST_DELETE
+    webhook = stored_payment_method_request_delete_app.webhooks.first()
+    webhook.subscription_query = STORED_PAYMENT_METHOD_REQUEST_DELETE
     webhook.save()
 
     plugin = webhook_plugin()
 
     payment_method_id = "123"
 
-    request_delete_data = PaymentMethodRequestDeleteData(
+    request_delete_data = StoredPaymentMethodRequestDeleteData(
         user=customer_user,
         payment_method_id=to_payment_app_id(
-            payment_method_request_delete_app, payment_method_id
+            stored_payment_method_request_delete_app, payment_method_id
         ),
     )
 
-    previous_value = PaymentMethodRequestDeleteResponseData(
+    previous_value = StoredPaymentMethodRequestDeleteResponseData(
         success=False, message="Payment method request delete failed to deliver."
     )
 
     # when
-    response = plugin.payment_method_request_delete(request_delete_data, previous_value)
+    response = plugin.stored_payment_method_request_delete(
+        request_delete_data, previous_value
+    )
 
     # then
     delivery = EventDelivery.objects.get()
@@ -119,54 +124,57 @@ def test_payment_method_request_delete_with_subscription_payload(
         }
     )
     mock_request.assert_called_once_with(
-        payment_method_request_delete_app, delivery, timeout=WEBHOOK_SYNC_TIMEOUT
+        stored_payment_method_request_delete_app, delivery, timeout=WEBHOOK_SYNC_TIMEOUT
     )
 
-    assert response == PaymentMethodRequestDeleteResponseData(
-        success=True, message=webhook_payment_method_request_delete_response["message"]
+    assert response == StoredPaymentMethodRequestDeleteResponseData(
+        success=True,
+        message=webhook_stored_payment_method_request_delete_response["message"],
     )
 
 
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
-def test_payment_method_request_delete_missing_correct_response_from_webhook(
+def test_stored_payment_method_request_delete_missing_correct_response_from_webhook(
     mock_request,
     customer_user,
     webhook_plugin,
-    payment_method_request_delete_app,
-    webhook_payment_method_request_delete_response,
+    stored_payment_method_request_delete_app,
+    webhook_stored_payment_method_request_delete_response,
 ):
     # given
     mock_request.return_value = None
 
-    webhook = payment_method_request_delete_app.webhooks.first()
-    webhook.subscription_query = PAYMENT_METHOD_REQUEST_DELETE
+    webhook = stored_payment_method_request_delete_app.webhooks.first()
+    webhook.subscription_query = STORED_PAYMENT_METHOD_REQUEST_DELETE
     webhook.save()
 
     plugin = webhook_plugin()
 
     payment_method_id = "123"
 
-    request_delete_data = PaymentMethodRequestDeleteData(
+    request_delete_data = StoredPaymentMethodRequestDeleteData(
         user=customer_user,
         payment_method_id=to_payment_app_id(
-            payment_method_request_delete_app, payment_method_id
+            stored_payment_method_request_delete_app, payment_method_id
         ),
     )
 
-    previous_value = PaymentMethodRequestDeleteResponseData(
+    previous_value = StoredPaymentMethodRequestDeleteResponseData(
         success=False, message="Payment method request delete failed to deliver."
     )
 
     # when
-    response = plugin.payment_method_request_delete(request_delete_data, previous_value)
+    response = plugin.stored_payment_method_request_delete(
+        request_delete_data, previous_value
+    )
 
     # then
     delivery = EventDelivery.objects.get()
 
     mock_request.assert_called_once_with(
-        payment_method_request_delete_app, delivery, timeout=WEBHOOK_SYNC_TIMEOUT
+        stored_payment_method_request_delete_app, delivery, timeout=WEBHOOK_SYNC_TIMEOUT
     )
 
-    assert response == PaymentMethodRequestDeleteResponseData(
+    assert response == StoredPaymentMethodRequestDeleteResponseData(
         success=False, message="Failed to delivery request."
     )

--- a/saleor/plugins/webhook/tests/test_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_request_delete.py
@@ -1,0 +1,172 @@
+import json
+
+import graphene
+import mock
+import pytest
+
+from ....core.models import EventDelivery
+from ....payment.interface import (
+    PaymentMethodRequestDeleteData,
+    PaymentMethodRequestDeleteResponseData,
+)
+from ....settings import WEBHOOK_SYNC_TIMEOUT
+from ..utils import to_payment_app_id
+
+PAYMENT_METHOD_REQUEST_DELETE = """
+subscription {
+  event {
+    ... on PaymentMethodRequestDelete{
+      user{
+        id
+      }
+      paymentMethodId
+    }
+  }
+}
+"""
+
+
+@pytest.fixture
+def webhook_payment_method_request_delete_response():
+    return {"success": True, "message": "Payment method deleted successfully"}
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_payment_method_request_delete_with_static_payload(
+    mock_request,
+    customer_user,
+    webhook_plugin,
+    payment_method_request_delete_app,
+    webhook_payment_method_request_delete_response,
+):
+    # given
+    mock_request.return_value = webhook_payment_method_request_delete_response
+
+    plugin = webhook_plugin()
+
+    payment_method_id = "123"
+
+    request_delete_data = PaymentMethodRequestDeleteData(
+        user=customer_user,
+        payment_method_id=to_payment_app_id(
+            payment_method_request_delete_app, payment_method_id
+        ),
+    )
+
+    previous_value = PaymentMethodRequestDeleteResponseData(
+        success=False, message="Payment method request delete failed to deliver."
+    )
+
+    # when
+    response = plugin.payment_method_request_delete(request_delete_data, previous_value)
+
+    # then
+    delivery = EventDelivery.objects.get()
+    assert delivery.payload.payload == json.dumps(
+        {
+            "payment_method_id": payment_method_id,
+            "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+        }
+    )
+    mock_request.assert_called_once_with(
+        payment_method_request_delete_app, delivery, timeout=WEBHOOK_SYNC_TIMEOUT
+    )
+
+    assert response == PaymentMethodRequestDeleteResponseData(
+        success=True, message=webhook_payment_method_request_delete_response["message"]
+    )
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_payment_method_request_delete_with_subscription_payload(
+    mock_request,
+    customer_user,
+    webhook_plugin,
+    payment_method_request_delete_app,
+    webhook_payment_method_request_delete_response,
+):
+    # given
+    mock_request.return_value = webhook_payment_method_request_delete_response
+
+    webhook = payment_method_request_delete_app.webhooks.first()
+    webhook.subscription_query = PAYMENT_METHOD_REQUEST_DELETE
+    webhook.save()
+
+    plugin = webhook_plugin()
+
+    payment_method_id = "123"
+
+    request_delete_data = PaymentMethodRequestDeleteData(
+        user=customer_user,
+        payment_method_id=to_payment_app_id(
+            payment_method_request_delete_app, payment_method_id
+        ),
+    )
+
+    previous_value = PaymentMethodRequestDeleteResponseData(
+        success=False, message="Payment method request delete failed to deliver."
+    )
+
+    # when
+    response = plugin.payment_method_request_delete(request_delete_data, previous_value)
+
+    # then
+    delivery = EventDelivery.objects.get()
+    assert delivery.payload.payload == json.dumps(
+        {
+            "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
+            "paymentMethodId": payment_method_id,
+        }
+    )
+    mock_request.assert_called_once_with(
+        payment_method_request_delete_app, delivery, timeout=WEBHOOK_SYNC_TIMEOUT
+    )
+
+    assert response == PaymentMethodRequestDeleteResponseData(
+        success=True, message=webhook_payment_method_request_delete_response["message"]
+    )
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_payment_method_request_delete_missing_correct_response_from_webhook(
+    mock_request,
+    customer_user,
+    webhook_plugin,
+    payment_method_request_delete_app,
+    webhook_payment_method_request_delete_response,
+):
+    # given
+    mock_request.return_value = None
+
+    webhook = payment_method_request_delete_app.webhooks.first()
+    webhook.subscription_query = PAYMENT_METHOD_REQUEST_DELETE
+    webhook.save()
+
+    plugin = webhook_plugin()
+
+    payment_method_id = "123"
+
+    request_delete_data = PaymentMethodRequestDeleteData(
+        user=customer_user,
+        payment_method_id=to_payment_app_id(
+            payment_method_request_delete_app, payment_method_id
+        ),
+    )
+
+    previous_value = PaymentMethodRequestDeleteResponseData(
+        success=False, message="Payment method request delete failed to deliver."
+    )
+
+    # when
+    response = plugin.payment_method_request_delete(request_delete_data, previous_value)
+
+    # then
+    delivery = EventDelivery.objects.get()
+
+    mock_request.assert_called_once_with(
+        payment_method_request_delete_app, delivery, timeout=WEBHOOK_SYNC_TIMEOUT
+    )
+
+    assert response == PaymentMethodRequestDeleteResponseData(
+        success=False, message="Failed to delivery request."
+    )

--- a/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
@@ -6,11 +6,15 @@ import pytest
 
 from ....core.models import EventDelivery
 from ....payment.interface import (
+    ListStoredPaymentMethodsRequestData,
     StoredPaymentMethodRequestDeleteData,
     StoredPaymentMethodRequestDeleteResponseData,
 )
 from ....settings import WEBHOOK_SYNC_TIMEOUT
-from ..utils import to_payment_app_id
+from ....webhook.event_types import WebhookEventSyncType
+from ....webhook.models import Webhook
+from ..const import WEBHOOK_CACHE_DEFAULT_TIMEOUT
+from ..utils import generate_cache_key_for_webhook, to_payment_app_id
 
 STORED_PAYMENT_METHOD_REQUEST_DELETE = """
 subscription {
@@ -188,4 +192,112 @@ def test_stored_payment_method_request_delete_missing_correct_response_from_webh
 
     assert response == StoredPaymentMethodRequestDeleteResponseData(
         success=False, message="Failed to delivery request."
+    )
+
+
+@mock.patch("saleor.plugins.webhook.tasks.cache.delete")
+@mock.patch("saleor.plugins.webhook.tasks.cache.set")
+@mock.patch("saleor.plugins.webhook.tasks.cache.get")
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_stored_payment_method_request_delete_invalidates_cache_for_app(
+    mocked_request,
+    mocked_cache_get,
+    mocked_cache_set,
+    mocked_cache_delete,
+    customer_user,
+    webhook_plugin,
+    stored_payment_method_request_delete_app,
+    webhook_stored_payment_method_request_delete_response,
+    channel_USD,
+):
+    # given
+    mocked_cache_get.return_value = None
+
+    webhook = Webhook.objects.create(
+        name="list_stored_payment_methods",
+        app=stored_payment_method_request_delete_app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+    )
+    list_stored_payment_methods_response = {"paymentMethods": []}
+    mocked_request.side_effect = [
+        list_stored_payment_methods_response,
+        webhook_stored_payment_method_request_delete_response,
+    ]
+
+    webhook = stored_payment_method_request_delete_app.webhooks.first()
+    webhook.subscription_query = STORED_PAYMENT_METHOD_REQUEST_DELETE
+    webhook.save()
+
+    plugin = webhook_plugin()
+
+    payment_method_id = "123"
+
+    request_delete_data = StoredPaymentMethodRequestDeleteData(
+        user=customer_user,
+        payment_method_id=to_payment_app_id(
+            stored_payment_method_request_delete_app, payment_method_id
+        ),
+        channel=channel_USD,
+    )
+
+    previous_value = StoredPaymentMethodRequestDeleteResponseData(
+        success=False, message="Payment method request delete failed to deliver."
+    )
+
+    data = ListStoredPaymentMethodsRequestData(
+        channel=channel_USD,
+        user=customer_user,
+    )
+    expected_payload = {
+        "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+        "channel_slug": channel_USD.slug,
+    }
+    expected_cache_key = generate_cache_key_for_webhook(
+        expected_payload,
+        webhook.target_url,
+        WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+        stored_payment_method_request_delete_app.id,
+    )
+
+    # call mocked list_stored_payment_methods to call mocked cache logic
+    # this will make sure that we're deleting the same cache key as the one created
+    # in list_stored_payment_methods
+    plugin.list_stored_payment_methods(data, [])
+
+    mocked_cache_get.assert_called_once_with(expected_cache_key)
+    mocked_cache_set.assert_called_once_with(
+        expected_cache_key,
+        list_stored_payment_methods_response,
+        timeout=WEBHOOK_CACHE_DEFAULT_TIMEOUT,
+    )
+
+    # when
+    response = plugin.stored_payment_method_request_delete(
+        request_delete_data, previous_value
+    )
+
+    # then
+    delivery = EventDelivery.objects.filter(
+        event_type=WebhookEventSyncType.STORED_PAYMENT_METHOD_REQUEST_DELETE
+    ).first()
+    assert delivery.payload.payload == json.dumps(
+        {
+            "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
+            "paymentMethodId": payment_method_id,
+            "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
+        }
+    )
+    # delete the same cache key as created when fetching stored payment methods
+    mocked_cache_delete.assert_called_once_with(expected_cache_key)
+
+    mocked_request.assert_called_with(
+        stored_payment_method_request_delete_app, delivery, timeout=WEBHOOK_SYNC_TIMEOUT
+    )
+
+    assert response == StoredPaymentMethodRequestDeleteResponseData(
+        success=True,
+        message=webhook_stored_payment_method_request_delete_response["message"],
     )

--- a/saleor/plugins/webhook/tests/test_utils.py
+++ b/saleor/plugins/webhook/tests/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 
 from ....payment.interface import PaymentGateway
 from ....webhook.event_types import WebhookEventSyncType
-from ..list_stored_payment_methods import (
+from ..stored_payment_methods import (
     get_credit_card_info,
     get_list_stored_payment_methods_from_response,
     get_payment_method_from_response,

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -6461,7 +6461,7 @@ def list_stored_payment_methods_app(db, permission_manage_payments):
 
 
 @pytest.fixture
-def payment_method_request_delete_app(db, permission_manage_payments):
+def stored_payment_method_request_delete_app(db, permission_manage_payments):
     app = App.objects.create(
         name="Payment method request delete",
         is_active=True,
@@ -6471,12 +6471,12 @@ def payment_method_request_delete_app(db, permission_manage_payments):
     app.permissions.add(permission_manage_payments)
 
     webhook = Webhook.objects.create(
-        name="payment_method_request_delete",
+        name="stored_payment_method_request_delete",
         app=app,
         target_url="http://localhost:8000/endpoint/",
     )
     webhook.events.create(
-        event_type=WebhookEventSyncType.PAYMENT_METHOD_REQUEST_DELETE,
+        event_type=WebhookEventSyncType.STORED_PAYMENT_METHOD_REQUEST_DELETE,
     )
     return app
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -6461,6 +6461,27 @@ def list_stored_payment_methods_app(db, permission_manage_payments):
 
 
 @pytest.fixture
+def payment_method_request_delete_app(db, permission_manage_payments):
+    app = App.objects.create(
+        name="Payment method request delete",
+        is_active=True,
+        identifier="saleor.payment.app.payment.method.request.delete",
+    )
+    app.tokens.create(name="Default")
+    app.permissions.add(permission_manage_payments)
+
+    webhook = Webhook.objects.create(
+        name="payment_method_request_delete",
+        app=app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.PAYMENT_METHOD_REQUEST_DELETE,
+    )
+    return app
+
+
+@pytest.fixture
 def tax_app(db, permission_handle_taxes):
     app = App.objects.create(name="Tax App", is_active=True)
     app.permissions.add(permission_handle_taxes)
@@ -7203,28 +7224,6 @@ def event_attempt(event_delivery):
         response_headers=None,
         request_headers=None,
     )
-
-
-@pytest.fixture
-def webhook_list_stored_payment_methods_response():
-    return {
-        "paymentMethods": [
-            {
-                "id": "method-1",
-                "supportedPaymentFlows": ["INTERACTIVE"],
-                "type": "Credit Card",
-                "creditCardInfo": {
-                    "brand": "visa",
-                    "lastDigits": "1234",
-                    "expMonth": 1,
-                    "expYear": 2023,
-                    "firstDigits": "123456",
-                },
-                "name": "***1234",
-                "data": {"some": "data"},
-            }
-        ]
-    }
 
 
 @pytest.fixture

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -703,6 +703,7 @@ class WebhookEventSyncType:
     TRANSACTION_PROCESS_SESSION = "transaction_process_session"
 
     LIST_STORED_PAYMENT_METHODS = "list_stored_payment_methods"
+    PAYMENT_METHOD_REQUEST_DELETE = "payment_method_request_delete"
 
     EVENT_MAP: dict[str, dict[str, Any]] = {
         PAYMENT_LIST_GATEWAYS: {
@@ -779,6 +780,10 @@ class WebhookEventSyncType:
         },
         LIST_STORED_PAYMENT_METHODS: {
             "name": "List tokenized payment methods that can be used by the customer.",
+            "permission": PaymentPermissions.HANDLE_PAYMENTS,
+        },
+        PAYMENT_METHOD_REQUEST_DELETE: {
+            "name": "Request deletion of a tokenized payment method.",
             "permission": PaymentPermissions.HANDLE_PAYMENTS,
         },
     }

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -703,7 +703,7 @@ class WebhookEventSyncType:
     TRANSACTION_PROCESS_SESSION = "transaction_process_session"
 
     LIST_STORED_PAYMENT_METHODS = "list_stored_payment_methods"
-    PAYMENT_METHOD_REQUEST_DELETE = "payment_method_request_delete"
+    STORED_PAYMENT_METHOD_REQUEST_DELETE = "stored_payment_method_request_delete"
 
     EVENT_MAP: dict[str, dict[str, Any]] = {
         PAYMENT_LIST_GATEWAYS: {
@@ -782,7 +782,7 @@ class WebhookEventSyncType:
             "name": "List tokenized payment methods that can be used by the customer.",
             "permission": PaymentPermissions.HANDLE_PAYMENTS,
         },
-        PAYMENT_METHOD_REQUEST_DELETE: {
+        STORED_PAYMENT_METHOD_REQUEST_DELETE: {
             "name": "Request deletion of a tokenized payment method.",
             "permission": PaymentPermissions.HANDLE_PAYMENTS,
         },


### PR DESCRIPTION
I want to merge this change because it adds a new webhook for requesting a delete action
RFC: https://github.com/saleor/saleor/issues/13395

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
