### PR TITLE
Fix `NOTIFY_USER` with another event issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,8 @@ Shipping methods can be removed by the user after it has been assigned to a chec
 - Add missing descriptions to page module - #13536 by @devilsautumn
 - Fix seo field to accept null value - #13512 by @ssuraliya
 - Add missing descriptions to payment module - #13546 by @devilsautumn
+- Fix `NOTIFY_USER` allow to create webhook with only one event - #13584 by @Air-t
+
 
 # 3.14.0
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -18549,6 +18549,7 @@ enum WebhookErrorCode @doc(category: "Webhooks") {
   UNABLE_TO_PARSE
   MISSING_EVENT
   INVALID_CUSTOM_HEADERS
+  INVALID_NOTIFY_WITH_SUBSCRIPTION
 }
 
 input WebhookCreateInput @doc(category: "Webhooks") {

--- a/saleor/graphql/webhook/mixins.py
+++ b/saleor/graphql/webhook/mixins.py
@@ -1,0 +1,21 @@
+from django.core.exceptions import ValidationError
+
+from ...webhook.error_codes import WebhookErrorCode
+from ...webhook.event_types import WebhookEventAsyncType
+
+
+class NotifyUserEventValidationMixin:
+    @classmethod
+    def validate_events(cls, events):
+        # NOTIFY_USER needs to be the only one event registered per webhook.
+        # This solves issue temporarily. NOTIFY_USER will be deprecated in the future.
+        if WebhookEventAsyncType.NOTIFY_USER in events and len(events) > 1:
+            raise ValidationError(
+                {
+                    "async_events": ValidationError(
+                        "The NOTIFY_USER webhook cannot be combined with other events.",
+                        code=WebhookErrorCode.INVALID_NOTIFY_WITH_SUBSCRIPTION.value,
+                    )
+                }
+            )
+        return events

--- a/saleor/webhook/error_codes.py
+++ b/saleor/webhook/error_codes.py
@@ -13,6 +13,7 @@ class WebhookErrorCode(Enum):
     UNABLE_TO_PARSE = "unable_to_parse"
     MISSING_EVENT = "missing_event"
     INVALID_CUSTOM_HEADERS = "invalid_custom_headers"
+    INVALID_NOTIFY_WITH_SUBSCRIPTION = "invalid_notify_with_subscription"
 
 
 class WebhookDryRunErrorCode(Enum):


### PR DESCRIPTION
* This fixes the issue when too `NOTIFY_USER` event is added
* with any other event to the same webhook. In this case
* `NOTIFY_USER` will not be triggered. Fix prevents to save
* multiple events along with `NOTIFY_USER` event.

Resolves https://github.com/saleor/saleor/issues/13577

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
