### PR TITLE
Add taxes to undiscounted order prices

### DIFF
--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -4,10 +4,11 @@ from unittest import mock
 import before_after
 import pytest
 from django.test import override_settings
-from prices import TaxedMoney
+from prices import Money, TaxedMoney
 
 from ...checkout.models import Checkout, CheckoutLine
 from ...core.exceptions import InsufficientStock
+from ...core.prices import quantize_price
 from ...core.taxes import zero_money, zero_taxed_money
 from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCard, GiftCardEvent
@@ -623,6 +624,61 @@ def test_create_order_from_checkout_store_shipping_prices(
     )
 
 
+def test_create_order_from_checkout_valid_undiscounted_prices(
+    checkout_with_items_and_shipping, shipping_method, customer_user, app
+):
+    # given
+    checkout = checkout_with_items_and_shipping
+    tc = checkout.channel.tax_configuration
+    tc.country_exceptions.all().delete()
+    tc.tax_calculation_strategy = "FLAT_RATES"
+    tc.prices_entered_with_tax = False
+    tc.save()
+    line = checkout.lines.first()
+    product = line.variant.product
+    product.tax_class.country_rates.update_or_create(
+        country=checkout.shipping_address.country.code, defaults={"rate": 7.75}
+    )
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+
+    checkout_info = fetch_checkout_info(checkout, lines, manager, [])
+
+    # when
+    order = create_order_from_checkout(
+        checkout_info=checkout_info,
+        manager=manager,
+        user=None,
+        app=app,
+        tracking_code="tracking_code",
+    )
+
+    # then
+    for line in order.lines.all():
+        expected_gross = quantize_price(
+            Money((line.base_unit_price.amount * (1 + line.tax_rate)), line.currency),
+            line.currency,
+        )
+        expected_undiscounted_unit_price = TaxedMoney(
+            net=line.base_unit_price,
+            gross=expected_gross,
+        )
+
+        assert line.undiscounted_unit_price == expected_undiscounted_unit_price
+        expected_total_gross = quantize_price(
+            Money(
+                (line.base_unit_price.amount * (1 + line.tax_rate)) * line.quantity,
+                line.currency,
+            ),
+            line.currency,
+        )
+        expected_undiscounted_total_price = TaxedMoney(
+            net=line.base_unit_price * line.quantity,
+            gross=expected_total_gross,
+        )
+        assert line.undiscounted_total_price == expected_undiscounted_total_price
+
+
 def test_create_order_from_store_shipping_prices_with_free_shipping_voucher(
     checkout_with_voucher_free_shipping,
     shipping_method,
@@ -739,3 +795,58 @@ def test_note_in_created_order_checkout_deleted_in_the_meantime(
 
     # then
     assert order is None
+
+
+@mock.patch("saleor.checkout.calculations.checkout_line_total")
+@mock.patch("saleor.checkout.calculations.checkout_line_unit_price")
+def test_create_order_from_checkout_update_undiscounted_prices_match(
+    mock_unit,
+    mock_total,
+    checkout_with_items_and_shipping,
+    shipping_method,
+    customer_user,
+    app,
+):
+    # given
+    checkout = checkout_with_items_and_shipping
+    tc = checkout.channel.tax_configuration
+    tc.country_exceptions.all().delete()
+    tc.tax_calculation_strategy = "TAX_APP"
+    tc.prices_entered_with_tax = False
+    tc.save()
+
+    # mock tax app returning different prices than local calculations
+    expected_price = TaxedMoney(
+        net=Money("35.000", "USD"),
+        gross=Money("37.720", "USD"),
+    )
+    mock_unit.return_value = expected_price
+    mock_total.return_value = expected_price
+
+    manager = get_plugins_manager()
+    country_code = checkout.shipping_address.country.code
+    line = checkout.lines.first()
+    line.quantity = 1
+    line.save()
+    product = line.variant.product
+    channel_listing = line.variant.channel_listings.first()
+
+    channel_listing.price = Money("35.000", "USD")
+    channel_listing.save()
+    product.tax_class.country_rates.update_or_create(
+        country=country_code, defaults={"rate": 7.75}
+    )
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager, [])
+
+    # when
+    order = create_order_from_checkout(
+        checkout_info=checkout_info,
+        manager=manager,
+        user=None,
+        app=app,
+        tracking_code="tracking_code",
+    )
+    line = order.lines.first()
+    assert line.unit_price == line.undiscounted_unit_price
+    assert line.total_price == line.undiscounted_total_price

--- a/saleor/checkout/tests/test_utils.py
+++ b/saleor/checkout/tests/test_utils.py
@@ -1,0 +1,52 @@
+from decimal import Decimal
+
+import pytest
+from prices import Money, TaxedMoney
+
+from ..utils import get_taxed_undiscounted_price
+
+BASE = Money("35.00", "USD")
+
+
+@pytest.mark.parametrize(
+    "price, tax_rate, prices_entered_with_tax, result",
+    [
+        # result should not be calculated but taken from price
+        (
+            TaxedMoney(gross=Money("43.74", "USD"), net=BASE),
+            Decimal(0.25),
+            False,
+            TaxedMoney(gross=Money("43.74", "USD"), net=BASE),
+        ),
+        # result should be calculated and different from price
+        (
+            TaxedMoney(gross=Money("43.74", "USD"), net=Money("36.00", "USD")),
+            Decimal(0.25),
+            False,
+            TaxedMoney(gross=Money("43.75", "USD"), net=BASE),
+        ),
+        # result should not be calculated and taken from price
+        (
+            TaxedMoney(gross=BASE, net=Money("26.26", "USD")),
+            Decimal(0.25),
+            True,
+            TaxedMoney(gross=BASE, net=Money("26.26", "USD")),
+        ),
+        # result should be calculated and different from price
+        (
+            TaxedMoney(gross=Money("36.00", "USD"), net=Money("26.26", "USD")),
+            Decimal(0.25),
+            True,
+            TaxedMoney(gross=BASE, net=Money("28.00", "USD")),
+        ),
+    ],
+)
+def test_get_taxed_undiscounted_price(price, tax_rate, prices_entered_with_tax, result):
+    result_price = get_taxed_undiscounted_price(
+        undiscounted_base_price=BASE,
+        price=price,
+        tax_rate=tax_rate,
+        prices_entered_with_tax=prices_entered_with_tax,
+    )
+
+    assert result_price == result

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -5,10 +5,11 @@ from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union, cast
 import graphene
 from django.core.exceptions import ValidationError
 from django.utils import timezone
-from prices import Money
+from prices import Money, TaxedMoney
 
 from ..account.models import User
 from ..core.exceptions import ProductNotPublished
+from ..core.prices import quantize_price
 from ..core.taxes import zero_taxed_money
 from ..core.utils.promo_code import (
     InvalidPromoCode,
@@ -31,6 +32,7 @@ from ..product import models as product_models
 from ..shipping.interface import ShippingMethodData
 from ..shipping.models import ShippingMethod, ShippingMethodChannelListing
 from ..shipping.utils import convert_to_shipping_method_data
+from ..tax.calculations import calculate_flat_rate_tax
 from ..warehouse.availability import check_stock_and_preorder_quantity
 from ..warehouse.models import Warehouse
 from ..warehouse.reservations import reserve_stocks_and_preorders
@@ -954,3 +956,27 @@ def get_checkout_metadata(checkout: "Checkout"):
         return checkout.metadata_storage
     else:
         return CheckoutMetadata(checkout=checkout)
+
+
+def get_taxed_undiscounted_price(
+    undiscounted_base_price: "Money",
+    price: "TaxedMoney",
+    tax_rate: "Decimal",
+    prices_entered_with_tax: bool,
+):
+    """Apply taxes to undiscounted base price.
+
+    This function also prevents rounding difference between prices from tax-app and
+    local calculations based on tax_rate that might occur in orders without discounts.
+    """
+    price_to_compare = price.gross if prices_entered_with_tax else price.net
+    if undiscounted_base_price == price_to_compare:
+        return price
+    return quantize_price(
+        calculate_flat_rate_tax(
+            money=undiscounted_base_price,
+            tax_rate=tax_rate * 100,
+            prices_entered_with_tax=prices_entered_with_tax,
+        ),
+        undiscounted_base_price.currency,
+    )

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -982,7 +982,6 @@ def test_checkout_with_voucher_complete(
     assert order_id == graphene.Node.to_global_id("Order", order.id)
     assert order.metadata == checkout.metadata_storage.metadata
     assert order.private_metadata == checkout.metadata_storage.private_metadata
-
     assert order.total == total
     assert order.undiscounted_total == total + discount_amount
 

--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -101,6 +101,9 @@ query OrdersQuery {
                         gross{
                             amount
                         }
+                        net{
+                            amount
+                        }
                     }
                 }
                 discounts{
@@ -926,8 +929,13 @@ def test_order_line_discount_query(
     unit_discount_amount = quantize_price(
         Decimal(line_with_discount["unitDiscount"]["amount"]), currency=order.currency
     )
-    undiscounted_unit_price = quantize_price(
+
+    undiscounted_unit_price_gross = quantize_price(
         Decimal(line_with_discount["undiscountedUnitPrice"]["gross"]["amount"]),
+        currency=order.currency,
+    )
+    undiscounted_unit_price_net = quantize_price(
+        Decimal(line_with_discount["undiscountedUnitPrice"]["net"]["amount"]),
         currency=order.currency,
     )
 
@@ -937,13 +945,21 @@ def test_order_line_discount_query(
     expected_unit_discount_amount = quantize_price(
         line.unit_discount.amount, currency=order.currency
     )
-    expected_undiscounted_unit_price = quantize_price(
+    expected_undiscounted_unit_price_gross = quantize_price(
         line.undiscounted_unit_price.gross.amount, currency=order.currency
+    )
+    expected_calculated_gross = quantize_price(
+        line.undiscounted_unit_price.net.amount * (line.tax_rate + 1), line.currency
+    )
+    expected_undiscounted_unit_price_net = quantize_price(
+        line.undiscounted_unit_price.net.amount, currency=order.currency
     )
 
     assert unit_gross_amount == expected_unit_price_gross_amount
     assert unit_discount_amount == expected_unit_discount_amount
-    assert undiscounted_unit_price == expected_undiscounted_unit_price
+    assert undiscounted_unit_price_gross == expected_undiscounted_unit_price_gross
+    assert undiscounted_unit_price_net == expected_undiscounted_unit_price_net
+    assert undiscounted_unit_price_gross == expected_calculated_gross
 
 
 def test_order_query_in_pln_channel(

--- a/saleor/graphql/order/tests/queries/test_order_line.py
+++ b/saleor/graphql/order/tests/queries/test_order_line.py
@@ -1,9 +1,13 @@
-from unittest.mock import MagicMock
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
 
 import graphene
 from django.core.files import File
-from prices import Money
+from prices import Money, TaxedMoney
 
+from .....core.prices import quantize_price
+from .....order import OrderStatus
+from .....order.interface import OrderTaxedPricesData
 from .....thumbnail.models import Thumbnail
 from .....warehouse.models import Stock
 from ....core.enums import ThumbnailFormatEnum
@@ -626,3 +630,117 @@ def test_order_line_tax_class_query_by_app(
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
     assert order_data["lines"][0]["taxClass"]["id"]
+
+
+UNDISCOUNTED_PRICE_QUERY = """
+        query OrdersQuery {
+            orders(first: 1) {
+                edges {
+                    node {
+                        lines {
+                            undiscountedUnitPrice {
+                                net {
+                                    amount
+                                }
+                                gross {
+                                    amount
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+"""
+
+
+@patch("saleor.plugins.manager.PluginsManager.calculate_order_line_unit")
+def test_order_query_undiscounted_prices_taxed(
+    mocked_calculate_order_line_unit,
+    staff_api_client,
+    permission_group_all_perms_all_channels,
+    fulfilled_order,
+):
+    # given
+
+    order = fulfilled_order
+    query = UNDISCOUNTED_PRICE_QUERY
+    order.status = OrderStatus.UNCONFIRMED
+    order.should_refresh_prices = True
+    order.save(update_fields=["status", "should_refresh_prices"])
+    tc = order.channel.tax_configuration
+    tc.prices_entered_with_tax = False
+    tc.save(update_fields=["prices_entered_with_tax"])
+    line = order.lines.first()
+    tax_rate = line.tax_rate
+    permission_group_all_perms_all_channels.user_set.add(staff_api_client.user)
+
+    line_undiscounted_price = TaxedMoney(
+        line.undiscounted_base_unit_price,
+        line.undiscounted_base_unit_price * (1 + tax_rate),
+    )
+    mocked_calculate_order_line_unit.return_value = OrderTaxedPricesData(
+        undiscounted_price=line_undiscounted_price,
+        price_with_discounts=line_undiscounted_price,
+    )
+
+    # set gross the same as net as to make sure prices were recalculated
+    line.undiscounted_unit_price_gross_amount = line.undiscounted_unit_price_net_amount
+    line.save(update_fields=["undiscounted_unit_price_gross_amount"])
+
+    # when
+    response = staff_api_client.post_graphql(query)
+
+    # then
+
+    content = get_graphql_content(response)
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+    first_order_data_line_price = order_data["lines"][0]["undiscountedUnitPrice"]
+    assert first_order_data_line_price["net"]["amount"] == line.unit_price.net.amount
+
+    expected_gross = quantize_price(
+        line.unit_price.net.amount * (tax_rate + 1), line.currency
+    )
+    result_gross = quantize_price(
+        Decimal(first_order_data_line_price["gross"]["amount"]), line.currency
+    )
+    assert result_gross == expected_gross
+
+
+def test_order_query_undiscounted_prices_no_tax(
+    staff_api_client, permission_group_all_perms_all_channels, order_with_lines
+):
+    # given
+    order = order_with_lines
+    query = UNDISCOUNTED_PRICE_QUERY
+    order.status = OrderStatus.UNCONFIRMED
+    order.should_refresh_prices = True
+    order.save(update_fields=["status", "should_refresh_prices"])
+    tc = order.channel.tax_configuration
+    tc.country_exceptions.all().delete()
+    tc.prices_entered_with_tax = False
+    tc.tax_calculation_strategy = None
+    tc.charge_taxes = False
+    tc.save(
+        update_fields=[
+            "prices_entered_with_tax",
+            "tax_calculation_strategy",
+            "charge_taxes",
+        ]
+    )
+
+    line = order.lines.first()
+    line.undiscounted_unit_price_gross_amount = line.undiscounted_unit_price_net_amount
+    line.tax_rate = Decimal(0)
+    line.save()
+
+    permission_group_all_perms_all_channels.user_set.add(staff_api_client.user)
+    # when
+    response = staff_api_client.post_graphql(query)
+
+    # then
+    content = get_graphql_content(response)
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+    first_order_data_line_price = order_data["lines"][0]["undiscountedUnitPrice"]
+    assert first_order_data_line_price["net"]["amount"] == line.unit_price.net.amount
+    assert first_order_data_line_price["gross"]["amount"] == line.unit_price.net.amount

--- a/saleor/order/migrations/170_recalculate_undiscounted_prices.py
+++ b/saleor/order/migrations/170_recalculate_undiscounted_prices.py
@@ -1,0 +1,47 @@
+from django.db import migrations
+from django.apps import apps as registry
+from django.db.models.signals import post_migrate
+
+from .tasks.saleor3_14 import recalculate_undiscounted_prices
+from django.db.models import Q, F
+
+
+def recalculate_undiscounted_prices_for_order(apps, _schema_editor):
+    def on_migrations_complete(sender=None, **kwargs):
+        recalculate_undiscounted_prices.delay()
+
+    # Make sure that there are OrderLines that needs to be updated
+    # to prevent running unneeded task
+    OrderLine = apps.get_model("order", "OrderLine")
+    if not OrderLine.objects.filter(
+        (
+            Q(
+                undiscounted_unit_price_net_amount=F(
+                    "undiscounted_unit_price_gross_amount"
+                )
+            )
+            | Q(
+                undiscounted_total_price_net_amount=F(
+                    "undiscounted_total_price_gross_amount"
+                )
+            )
+        )
+        & Q(tax_rate__gt=0)
+    ):
+        return
+
+    sender = registry.get_app_config("order")
+    post_migrate.connect(on_migrations_complete, weak=False, sender=sender)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("order", "0169_alter_order_options"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            recalculate_undiscounted_prices_for_order,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/saleor/order/migrations/tasks/saleor3_14.py
+++ b/saleor/order/migrations/tasks/saleor3_14.py
@@ -1,11 +1,22 @@
 from django.utils import timezone
 
-from ....celeryconf import app
 from ... import OrderStatus
-from ...models import Order
+from decimal import Decimal
+from celery.utils.log import get_task_logger
+from django.db.models import Q, F
+
+from ....core.prices import quantize_price
+from ....tax.models import TaxConfiguration
+from ....channel.models import Channel
+from ....order.models import OrderLine, Order
+from ....celeryconf import app
+
+task_logger = get_task_logger(__name__)
 
 # Batch size of size 5000 is about 5MB memory usage in task
 BATCH_SIZE = 5000
+
+LINE_BATCH = 500
 
 
 @app.task
@@ -15,3 +26,131 @@ def order_propagate_expired_at_task():
     if order_ids:
         Order.objects.filter(id__in=order_ids).update(expired_at=timezone.now())
         order_propagate_expired_at_task.delay()
+
+
+def add_taxes_to_price(price, tax_rate, prices_entered_with_tax):
+    tax_rate = Decimal(1 + tax_rate)
+
+    if prices_entered_with_tax:
+        net_amount = price / tax_rate
+        gross_amount = price
+    else:
+        net_amount = price
+        gross_amount = price * tax_rate
+
+    return net_amount, gross_amount
+
+
+def update_fields_for_line(
+    field_name, line, tax_rate, prices_entered_with_tax, lines_to_update
+):
+    line_net = getattr(line, f"{field_name}_net_amount")
+    line_gross = getattr(line, f"{field_name}_gross_amount")
+    if line_net == line_gross and all([line_net != 0, line_gross != 0]):
+        line_net, line_gross = add_taxes_to_price(
+            line_net, tax_rate, prices_entered_with_tax
+        )
+        setattr(
+            line, f"{field_name}_net_amount", quantize_price(line_net, line.currency)
+        )
+        setattr(
+            line,
+            f"{field_name}_gross_amount",
+            quantize_price(line_gross, line.currency),
+        )
+        lines_to_update.add(line)
+
+
+def recalculate_tax_for_prices(
+    line, prices_entered_with_tax, tax_rate, lines_to_update
+):
+    for field in ["undiscounted_unit_price", "undiscounted_total_price"]:
+        update_fields_for_line(
+            field, line, tax_rate, prices_entered_with_tax, lines_to_update
+        )
+
+
+def get_order_prices_entered_with_tax_mapping(
+    order_lines, order_model, channel_model, tax_configuration
+):
+    orders = order_model.objects.filter(id__in=order_lines.values("order_id"))
+    channels = channel_model.objects.filter(id__in=orders.values("channel_id"))
+    tax_configurations = tax_configuration.objects.filter(
+        id__in=channels.values("tax_configuration__id")
+    )
+    tax_conf_to_prices_entered_with_taxes = {
+        tc_id: price_entered_with_taxes
+        for tc_id, price_entered_with_taxes in tax_configurations.values_list(
+            "id", "prices_entered_with_tax"
+        )
+    }
+
+    channel_to_prices_entered_with_taxes = dict()
+    for channel_id, tax_conf_id in channels.values_list("id", "tax_configuration__id"):
+        channel_to_prices_entered_with_taxes[
+            channel_id
+        ] = tax_conf_to_prices_entered_with_taxes[tax_conf_id]
+
+    order_to_prices_entered_with_taxes = dict()
+    for order_id, channel_id in orders.values_list("id", "channel__id"):
+        order_to_prices_entered_with_taxes[
+            order_id
+        ] = channel_to_prices_entered_with_taxes[channel_id]
+
+    return order_to_prices_entered_with_taxes
+
+
+@app.task
+def recalculate_undiscounted_prices():
+    order_lines = (
+        OrderLine.objects.filter(
+            (
+                Q(
+                    undiscounted_unit_price_net_amount=F(
+                        "undiscounted_unit_price_gross_amount"
+                    )
+                )
+                | Q(
+                    undiscounted_total_price_net_amount=F(
+                        "undiscounted_total_price_gross_amount"
+                    )
+                )
+            )
+            & Q(tax_rate__gt=0)
+        )
+        .prefetch_related("order_id")
+        .order_by("-created_at")[:LINE_BATCH]
+    )
+
+    if not order_lines:
+        task_logger.info("No order lines to update.")
+        return
+
+    order_to_prices_with_tax_map = get_order_prices_entered_with_tax_mapping(
+        order_lines,
+        order_model=Order,
+        channel_model=Channel,
+        tax_configuration=TaxConfiguration,
+    )
+
+    lines_to_update = set()
+    for line in order_lines:
+        prices_entered_with_tax = order_to_prices_with_tax_map[line.order.id]
+        tax_rate = line.tax_rate
+        if tax_rate > 0:
+            recalculate_tax_for_prices(
+                line, prices_entered_with_tax, tax_rate, lines_to_update
+            )
+
+    if lines_to_update:
+        OrderLine.objects.bulk_update(
+            list(lines_to_update),
+            [
+                "undiscounted_unit_price_gross_amount",
+                "undiscounted_unit_price_net_amount",
+                "undiscounted_total_price_gross_amount",
+                "undiscounted_total_price_net_amount",
+            ],
+        )
+
+        recalculate_undiscounted_prices.delay()

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -448,7 +448,7 @@ class PluginsManager(PaymentInterface):
             default_value * quantity,
         )
         default_taxed_value = TaxedMoney(
-            net=total_value / quantity, gross=default_value
+            net=total_value / quantity, gross=total_value / quantity
         )
         unit_price = self.__run_method_on_plugins(
             "calculate_checkout_line_unit_price",


### PR DESCRIPTION
I want to merge this change because it is a port of #12284 but we decided to release it for Saleor `3.14` and up instead of `3.9` so it needed some extra adjustments. 

All the comments from the old PR are addressed, but It still needs a review since the base is different. 


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
