### PR TITLE
fix annotate_quantities qs manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Saleor Apps
 
 ### Other changes
+- Fix error in variant available stock calculation - 13593 by @awaisdar001
 
 # 3.15.0 [Unreleased]
 
@@ -163,7 +164,6 @@ Shipping methods can be removed by the user after it has been assigned to a chec
 - Fix seo field to accept null value - #13512 by @ssuraliya
 - Add missing descriptions to payment module - #13546 by @devilsautumn
 - Fix `NOTIFY_USER` allow to create webhook with only one event - #13584 by @Air-t
-- Fix error in variant available stock calculation - 13593 by @awaisdar001
 
 # 3.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ Shipping methods can be removed by the user after it has been assigned to a chec
 - Fix seo field to accept null value - #13512 by @ssuraliya
 - Add missing descriptions to payment module - #13546 by @devilsautumn
 - Fix `NOTIFY_USER` allow to create webhook with only one event - #13584 by @Air-t
+- Fix error in variant available stock calculation - 13593 by @awaisdar001
 
 # 3.14.0
 

--- a/saleor/product/tests/test_managers.py
+++ b/saleor/product/tests/test_managers.py
@@ -1,0 +1,60 @@
+from saleor.product.models import ProductVariant
+
+
+def test_available_quantity_with_no_allocations(variant, allocations):
+    stocks = variant.stocks.first()
+    stocks.allocations.all().delete()
+    assert stocks.quantity == 15
+
+    assert stocks.allocations.count() == 0
+    # No allocations have been made, so available_quantity should be equal to quantity
+    instance = ProductVariant.objects.annotate_quantities().get(pk=variant.pk)
+    assert instance.available_quantity == 15
+
+
+def test_available_quantity_with_allocations(variant, allocations):
+    stocks = variant.stocks.first()
+
+    allocation_quantity = sum(
+        allocation.quantity_allocated for allocation in stocks.allocations.all()
+    )
+    assert stocks.allocations.count() == 3
+    assert stocks.quantity == 15
+    assert allocation_quantity == 7
+
+    #  Available quantity should be quantity - quantity_allocated
+    instance = ProductVariant.objects.annotate_quantities().get(pk=variant.pk)
+    assert instance.available_quantity == 15 - 7
+
+
+def test_available_quantity_with_allocations_quantity_zero(variant, allocations):
+    stocks = variant.stocks.first()
+    stocks.allocations.update(quantity_allocated=0)
+
+    assert stocks.allocations.count() == 3
+    assert stocks.quantity == 15
+
+    # Allocations have been cleared, so available_quantity should be equal to quantity
+    instance = ProductVariant.objects.annotate_quantities().get(pk=variant.pk)
+    assert instance.available_quantity == 15
+
+
+def test_available_quantity_with_insufficient_stock(variant, allocations):
+    stocks = variant.stocks.first()
+    stocks.allocations.update(quantity_allocated=100)
+
+    assert stocks.allocations.count() == 3
+    assert stocks.quantity == 15
+
+    # Allocations are greater than available quantity, so available_quantity should
+    # be negative.
+    instance = ProductVariant.objects.annotate_quantities().get(pk=variant.pk)
+    assert instance.available_quantity == 15 - 300
+
+
+def test_available_quantity_with_no_stock(variant):
+    # Delete the stocks to simulate a product variant with no available stock
+    variant.stocks.all().delete()
+
+    instance = ProductVariant.objects.annotate_quantities().get(pk=variant.pk)
+    assert instance.available_quantity == 0


### PR DESCRIPTION
This pull request aims to address a critical bug in the `annotate_quantities` method of the `ProductVariant` model. The existing implementation incorrectly sums the `quantity_allocated` field across multiple allocations for a given stock, leading to inaccurate calculations of the `quantity`. Additionally, it introduces a new field `available_quantity` to the `ProductVariant` model, providing a more accurate representation of the quantity available for a specific product variant.

# Bug Fix and Scenario:


The existing implementation of the `annotate_quantities` method simply sums the `quantity_allocated` field from all related allocations using Sum("stocks__allocations__quantity_allocated"). However, in scenarios where a stock has multiple allocations, this approach leads to a flawed summing of quantities. Consider the following test case. 
```
def test_available_quantity_with_allocations_quantity_zero(variant, allocations):
    stocks = variant.stocks.first()
    stocks.allocations.update(quantity_allocated=0)

    assert stocks.allocations.count() == 3
    assert stocks.quantity == 15

    # Allocations have been cleared, so available_quantity should be equal to quantity
    instance = ProductVariant.objects.annotate_quantities().get(pk=variant.pk)
    assert instance.quantity == 15 # <<< this becomes 45. which is 15 (actual quantity * 3 allocation instances). 

    assert instance.available_quantity == 15 # this is the new field being introduced. 
```

# Proposed Solution:

To resolve this issue, we've introduced a new and more robust approach to calculating the `quantity` and `available_quantity`. We now use a `Subquery` expression to efficiently retrieve the total `quantity_allocated` for a specific product variant's stock, and then use a `Case` expression to accurately calculate the `quantity` and `available_quantity`.


# Additional Changes:

With the addition of the `available_quantity` field, clients can now access this field directly from the ProductVariant instances to obtain the accurate quantity available for the respective product variant.

# Testing:

To ensure the accuracy of the changes, new test cases have been added to cover various scenarios with multiple allocations and varying `quantity_allocated` values. 

These tests have been executed successfully.

# Impact
This pull request not only fixes a critical bug but also enhances the accuracy and reliability of the annotate_quantities method. It introduces the new available_quantity field to provide a more informative representation of the product variant's stock status, making it easier for clients to access and utilize this crucial information.

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [x] The changes are covered by test cases
