### PR TITLE
Fix webhook calls triggered by transactionRequestAction mutation

### DIFF
--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
@@ -78,7 +78,7 @@ def test_trigger_webhook_sync_with_subscription(
 
     # then
     assert json.loads(event_delivery.payload.payload) == expected_payment_payload
-    mock_request.assert_called_once_with(payment_app, event_delivery)
+    mock_request.assert_called_once_with(event_delivery)
 
 
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")

--- a/saleor/plugins/webhook/tests/test_payment_gateway_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_gateway_initialize_session_webhook.py
@@ -82,7 +82,7 @@ def _assert_fields(payload, webhook, expected_data, response, mock_request):
     )
     assert delivery.payload == event_payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook.app, delivery)
+    mock_request.assert_called_once_with(delivery)
     assert response == [
         PaymentGatewayData(app_identifier=webhook_app.identifier, data=expected_data)
     ]

--- a/saleor/plugins/webhook/tests/test_payment_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook.py
@@ -55,7 +55,7 @@ def test_trigger_webhook_sync(mock_request, payment_app):
         WebhookEventSyncType.PAYMENT_CAPTURE, data, payment_app.webhooks.first()
     )
     event_delivery = EventDelivery.objects.first()
-    mock_request.assert_called_once_with(payment_app, event_delivery)
+    mock_request.assert_called_once_with(event_delivery)
 
 
 @mock.patch("saleor.plugins.webhook.tasks.create_delivery_for_subscription_sync_event")
@@ -76,7 +76,7 @@ def test_trigger_webhook_sync_with_subscription(
         payment_app.webhooks.first(),
         payment,
     )
-    mock_request.assert_called_once_with(payment_app, fake_delivery)
+    mock_request.assert_called_once_with(fake_delivery)
 
 
 @mock.patch("saleor.plugins.webhook.tasks.observability.report_event_delivery_attempt")
@@ -97,7 +97,7 @@ def test_send_webhook_request_sync_failed_attempt(
     mock_post().status_code = expected_data["status_code"]
     mock_post().elapsed = expected_data["duration"]
     # when
-    response_data = send_webhook_request_sync(app, event_delivery)
+    response_data = send_webhook_request_sync(event_delivery)
     attempt = EventDeliveryAttempt.objects.first()
 
     # then
@@ -130,7 +130,7 @@ def test_send_webhook_request_sync_successful_attempt(
     mock_post().status_code = expected_data["status_code"]
     mock_post().elapsed = expected_data["duration"]
     # when
-    response_data = send_webhook_request_sync(app, event_delivery)
+    response_data = send_webhook_request_sync(event_delivery)
 
     attempt = EventDeliveryAttempt.objects.first()
 
@@ -163,7 +163,7 @@ def test_send_webhook_request_sync_request_exception(
     )
 
     # when
-    response_data = send_webhook_request_sync(app, event_delivery)
+    response_data = send_webhook_request_sync(event_delivery)
     attempt = EventDeliveryAttempt.objects.first()
 
     # then
@@ -189,7 +189,7 @@ def test_send_webhook_request_sync_when_exception_with_response(
     mock_response.status_code = 302
     mock_post.side_effect = TooManyRedirects(response=mock_response)
     # when
-    send_webhook_request_sync(app, event_delivery)
+    send_webhook_request_sync(event_delivery)
     attempt = EventDeliveryAttempt.objects.first()
 
     # then
@@ -217,7 +217,7 @@ def test_send_webhook_request_sync_json_parsing_error(
     mock_post().status_code = expected_data["status_code"]
 
     # when
-    response_data = send_webhook_request_sync(app, event_delivery)
+    response_data = send_webhook_request_sync(event_delivery)
     attempt = EventDeliveryAttempt.objects.first()
 
     # then
@@ -237,7 +237,7 @@ def test_send_webhook_request_with_proper_timeout(mock_post, event_delivery, app
     mock_post().headers = {"header_key": "header_val"}
     mock_post().elapsed = datetime.timedelta(seconds=1)
     mock_post().status_code = 200
-    send_webhook_request_sync(app, event_delivery)
+    send_webhook_request_sync(event_delivery)
     assert mock_post.call_args.kwargs["timeout"] == settings.WEBHOOK_SYNC_TIMEOUT
 
 
@@ -253,7 +253,7 @@ def test_send_webhook_request_sync_invalid_scheme(webhook, app):
             payload=event_payload,
             webhook=webhook,
         )
-        send_webhook_request_sync(app, delivery)
+        send_webhook_request_sync(delivery)
 
 
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -518,7 +518,7 @@ def test_trigger_webhook_sync(mock_request, shipping_app):
         WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT, data, webhook
     )
     event_delivery = EventDelivery.objects.first()
-    mock_request.assert_called_once_with(shipping_app, event_delivery)
+    mock_request.assert_called_once_with(event_delivery)
 
 
 @mock.patch("saleor.plugins.webhook.shipping.cache.set")

--- a/saleor/plugins/webhook/tests/test_tasks.py
+++ b/saleor/plugins/webhook/tests/test_tasks.py
@@ -80,7 +80,7 @@ def test_trigger_transaction_request(
     assert generated_delivery.webhook == webhook
     assert generated_delivery.payload == generated_payload
 
-    mocked_task.assert_called_once_with(generated_delivery.id, app, event.id)
+    mocked_task.assert_called_once_with(generated_delivery.id, event.id)
 
 
 @freeze_time("2022-06-11 12:50")
@@ -158,7 +158,7 @@ def test_trigger_transaction_request_with_webhook_subscription(
 
     assert generated_delivery.payload == generated_payload
 
-    mocked_task.assert_called_once_with(generated_delivery.id, app, event.id)
+    mocked_task.assert_called_once_with(generated_delivery.id, event.id)
 
 
 @freeze_time("2022-06-11 12:50")
@@ -210,7 +210,7 @@ def test_handle_transaction_request_task_with_only_psp_reference(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, transaction_data.event.id)
 
     # then
     assert TransactionEvent.objects.count() == 1
@@ -277,7 +277,7 @@ def test_handle_transaction_request_task_with_server_error(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, transaction_data.event.id)
 
     # then
     assert mocked_webhook_retry.called
@@ -330,7 +330,7 @@ def test_handle_transaction_request_task_with_missing_psp_reference(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, transaction_data.event.id)
 
     # then
     assert (
@@ -413,7 +413,7 @@ def test_handle_transaction_request_task_with_missing_required_event_field(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, transaction_data.event.id)
 
     # then
     assert (
@@ -505,7 +505,7 @@ def test_handle_transaction_request_task_with_result_event(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, transaction_data.event.id)
 
     # then
     assert TransactionEvent.objects.all().count() == 2
@@ -596,7 +596,7 @@ def test_handle_transaction_request_task_with_only_required_fields_for_result_ev
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, transaction_data.event.id)
 
     # then
     assert TransactionEvent.objects.all().count() == 2
@@ -700,7 +700,7 @@ def test_handle_transaction_request_task_calls_recalculation_of_amounts(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, transaction_data.event.id)
 
     # then
     mocked_recalculation.assert_called_once_with(transaction, save=False)
@@ -764,7 +764,7 @@ def test_handle_transaction_request_task_with_available_actions(
     )
 
     # when
-    handle_transaction_request_task(delivery.id, app, transaction_data.event.id)
+    handle_transaction_request_task(delivery.id, transaction_data.event.id)
 
     # then
     assert TransactionEvent.objects.all().count() == 2

--- a/saleor/plugins/webhook/tests/test_tax_webhook.py
+++ b/saleor/plugins/webhook/tests/test_tax_webhook.py
@@ -63,7 +63,7 @@ def test_get_taxes_for_order(
     assert delivery.event_type == WebhookEventSyncType.ORDER_CALCULATE_TAXES
     assert delivery.payload == payload
     assert delivery.webhook == tax_order_webhook
-    mock_request.assert_called_once_with(tax_order_webhook.app, delivery)
+    mock_request.assert_called_once_with(delivery)
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)
 
@@ -181,7 +181,7 @@ def test_get_taxes_for_order_with_sync_subscription(
     assert delivery.event_type == WebhookEventSyncType.ORDER_CALCULATE_TAXES
     assert delivery.payload == payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook.app, delivery)
+    mock_request.assert_called_once_with(delivery)
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)
 
@@ -222,6 +222,6 @@ def test_get_taxes_for_checkout_with_sync_subscription(
     assert delivery.event_type == WebhookEventSyncType.CHECKOUT_CALCULATE_TAXES
     assert delivery.payload == payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook.app, delivery)
+    mock_request.assert_called_once_with(delivery)
     mock_fetch.assert_not_called()
     assert tax_data == parse_tax_data(tax_data_response)

--- a/saleor/plugins/webhook/tests/test_tax_webhook_tasks.py
+++ b/saleor/plugins/webhook/tests/test_tax_webhook_tasks.py
@@ -58,7 +58,7 @@ def test_trigger_tax_webhook_sync(
     assert delivery.event_type == event_type
     assert delivery.payload == payload
     assert delivery.webhook == tax_checkout_webhook
-    mock_request.assert_called_once_with(tax_checkout_webhook.app, delivery)
+    mock_request.assert_called_once_with(delivery)
     assert tax_data == parse_tax_data(tax_data_response)
 
 
@@ -86,7 +86,7 @@ def test_trigger_tax_webhook_sync_multiple_webhooks_first(
     assert delivery.event_type == event_type
     assert delivery.payload == payload
     assert delivery.webhook == successful_webhook
-    mock_request.assert_called_once_with(successful_webhook.app, delivery)
+    mock_request.assert_called_once_with(delivery)
     assert tax_data == parse_tax_data(tax_data_response)
 
 
@@ -116,7 +116,7 @@ def test_trigger_tax_webhook_sync_multiple_webhooks_last(
         assert delivery.event_type == event_type
         assert delivery.payload == payload
         assert delivery.webhook == webhook
-        assert call[0] == (webhook.app, delivery)
+        assert call[0] == (delivery,)
 
     assert mock_request.call_count == 3
     assert tax_data == parse_tax_data(tax_data_response)

--- a/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
@@ -110,7 +110,7 @@ def _assert_fields(payload, webhook, expected_response, response, mock_request):
     assert delivery.event_type == WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION
     assert delivery.payload == event_payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook_app, delivery)
+    mock_request.assert_called_once_with(delivery)
     assert response == PaymentGatewayData(
         app_identifier=webhook_app.identifier, data=expected_response, error=None
     )

--- a/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
@@ -110,7 +110,7 @@ def _assert_fields(payload, webhook, expected_response, response, mock_request):
     assert delivery.event_type == WebhookEventSyncType.TRANSACTION_PROCESS_SESSION
     assert delivery.payload == event_payload
     assert delivery.webhook == webhook
-    mock_request.assert_called_once_with(webhook_app, delivery)
+    mock_request.assert_called_once_with(delivery)
     assert response == PaymentGatewayData(
         app_identifier=webhook_app.identifier, data=expected_response, error=None
     )


### PR DESCRIPTION
I want to merge this change because it fixes `transactionRequestAction`  mutation. 
We added `app` object as an input to celery task. Celery worker is raising EncodeError - as can't serialize App object. 
The changes was introduced in https://github.com/saleor/saleor/pull/13223
Also I've reverted some part of the logic. There is no need to pass `app` in most of the functions. We already passing the `EventDelviery`. `EventDelivery` has a relation to webhook and app, so all details are already there (this is the way how we did that for async requests). 


Steps to reproduce:
- create an order (by checkout or draft)
- attach the transaction to the order as third-party app (app.identifier is required, to call transactionRequestAction)
- set `[CHARGE, CANCEL]` as  `availableActions` on transaction: [ref1](https://docs.saleor.io/docs/3.x/developer/payments#reporting-action-for-transaction), [ref2](https://docs.saleor.io/docs/3.x/developer/payments#creating-transaction)
- try to call `charge` or `cancel` button on dashboard side. It will return an InternalError (EncodeError)
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
