### PR TITLE
`transactionEventReport` assigns transaction.pspReference when empty

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1546,6 +1546,7 @@ class TransactionEventReport(ModelMutation):
     def update_transaction(
         cls,
         transaction: payment_models.TransactionItem,
+        transaction_event: payment_models.TransactionEvent,
         available_actions: Optional[list[str]] = None,
         app: Optional["App"] = None,
     ):
@@ -1559,6 +1560,20 @@ class TransactionEventReport(ModelMutation):
             "refund_pending_value",
             "cancel_pending_value",
         ]
+
+        if (
+            transaction_event.type
+            in [
+                TransactionEventType.AUTHORIZATION_REQUEST,
+                TransactionEventType.AUTHORIZATION_SUCCESS,
+                TransactionEventType.CHARGE_REQUEST,
+                TransactionEventType.CHARGE_SUCCESS,
+            ]
+            and not transaction.psp_reference
+        ):
+            transaction.psp_reference = transaction_event.psp_reference
+            fields_to_update.append("psp_reference")
+
         if available_actions is not None:
             transaction.available_actions = available_actions
             fields_to_update.append("available_actions")
@@ -1671,6 +1686,7 @@ class TransactionEventReport(ModelMutation):
             previous_charged_value = transaction.charged_value
             cls.update_transaction(
                 transaction,
+                transaction_event,
                 available_actions=available_actions,
                 app=app,
             )

--- a/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_event_report.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import graphene
+import pytest
 from django.utils import timezone
 
 from .....checkout import CheckoutAuthorizeStatus, CheckoutChargeStatus
@@ -24,6 +25,7 @@ fragment TransactionEventData on TransactionEventReport {
     transaction {
         id
         actions
+        pspReference
         events {
             id
         }
@@ -1600,3 +1602,67 @@ def test_transaction_event_report_by_app_assign_app_owner(
     assert transaction.app_identifier == app_api_client.app.identifier
     assert transaction.app == app_api_client.app
     assert transaction.user is None
+
+
+@pytest.mark.parametrize(
+    "transaction_psp_reference, expected_transaction_psp_reference",
+    [
+        (None, "psp_reference_from_event"),
+        ("", "psp_reference_from_event"),
+        ("psp_reference_from_transaction", "psp_reference_from_transaction"),
+    ],
+)
+def test_transaction_event_report_assign_transaction_psp_reference_if_missing(
+    transaction_psp_reference,
+    expected_transaction_psp_reference,
+    transaction_item_generator,
+    app_api_client,
+    permission_manage_payments,
+):
+    # given
+    transaction = transaction_item_generator(
+        authorized_value=Decimal("10"), psp_reference=transaction_psp_reference
+    )
+    amount = Decimal("11.00")
+    transaction_id = graphene.Node.to_global_id("TransactionItem", transaction.token)
+    variables = {
+        "id": transaction_id,
+        "type": TransactionEventTypeEnum.CHARGE_SUCCESS.name,
+        "amount": amount,
+        "pspReference": expected_transaction_psp_reference,
+    }
+    query = (
+        MUTATION_DATA_FRAGMENT
+        + """
+    mutation TransactionEventReport(
+        $id: ID!
+        $type: TransactionEventTypeEnum!
+        $amount: PositiveDecimal!
+        $pspReference: String!
+    ) {
+        transactionEventReport(
+            id: $id
+            type: $type
+            amount: $amount
+            pspReference: $pspReference
+        ) {
+            ...TransactionEventData
+        }
+    }
+    """
+    )
+    # when
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_payments]
+    )
+
+    # then
+    response = get_graphql_content(response)
+    transaction_report_data = response["data"]["transactionEventReport"]
+    transaction.refresh_from_db()
+
+    assert (
+        transaction_report_data["transaction"]["pspReference"]
+        == expected_transaction_psp_reference
+    )
+    assert transaction.psp_reference == expected_transaction_psp_reference


### PR DESCRIPTION
I want to merge this change because it is port of changes for #13612

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
