### PR TITLE
Fix using search argument with sorting by RANK

### DIFF
--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -453,9 +453,12 @@ class ProductQueries(graphene.ObjectType):
     ):
         if sort_field_from_kwargs(kwargs) == ProductOrderField.RANK:
             # sort by RANK can be used only with search filter
-            if not search_string_in_kwargs(kwargs):
+            if not search_string_in_kwargs(kwargs) and not search:
                 raise GraphQLError(
-                    "Sorting by RANK is available only when using a search filter."
+                    (
+                        "Sorting by RANK is available only when using a search filter "
+                        "or search argument."
+                    )
                 )
         if search_string_in_kwargs(kwargs) and not sort_field_from_kwargs(kwargs):
             # default to sorting by RANK if search is used


### PR DESCRIPTION
I want to merge this change because it fixes using `search` argument with sorting by `RANK`.

Fix for #13557

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
