### PR TITLE
[Programmatic payments] Drop `amount` field from `storedPaymentMethods`

### DIFF
--- a/saleor/graphql/account/tests/queries/test_me.py
+++ b/saleor/graphql/account/tests/queries/test_me.py
@@ -1,8 +1,5 @@
-from decimal import Decimal
-
 import graphene
 import mock
-from prices import Money
 
 from .....order.models import FulfillmentStatus
 from .....payment.interface import (
@@ -285,9 +282,9 @@ def test_me_with_cancelled_fulfillments(
 
 
 QUERY_ME_WITH_STORED_PAYMENT_METHODS = """
-query Me($channel: String!, $amount:PositiveDecimal) {
+query Me($channel: String!) {
   me{
-    storedPaymentMethods(channel: $channel, amount: $amount){
+    storedPaymentMethods(channel: $channel){
       id
       gateway{
         name
@@ -317,97 +314,7 @@ query Me($channel: String!, $amount:PositiveDecimal) {
 
 
 @mock.patch("saleor.plugins.manager.PluginsManager.list_stored_payment_methods")
-def test_me_query_stored_payment_methods_with_provided_amount(
-    mocked_list_stored_payment_methods, user_api_client, channel_USD, customer_user
-):
-    # given
-    payment_method_id = "app:payment-method-id"
-    external_id = "payment-method-id"
-    supported_payment_flow = TokenizedPaymentFlowEnum.INTERACTIVE
-    payment_method_type = "credit-card"
-    payment_method_name = "Payment method name"
-    payment_method_data = {"additional_data": "value"}
-
-    payment_gateway_id = "gateway-id"
-    payment_gateway_name = "gateway-name"
-
-    credit_card_brand = "brand"
-    credit_card_first_digits = "123"
-    credit_card_last_digits = "456"
-    credit_card_exp_month = 1
-    credit_card_exp_year = 2021
-
-    requested_amount = Decimal("100.00")
-
-    mocked_list_stored_payment_methods.return_value = [
-        PaymentMethodData(
-            id=payment_method_id,
-            external_id=external_id,
-            supported_payment_flows=[supported_payment_flow.value],
-            type=payment_method_type,
-            credit_card_info=PaymentMethodCreditCardInfo(
-                brand=credit_card_brand,
-                first_digits=credit_card_first_digits,
-                last_digits=credit_card_last_digits,
-                exp_month=credit_card_exp_month,
-                exp_year=credit_card_exp_year,
-            ),
-            name=payment_method_name,
-            data=payment_method_data,
-            gateway=PaymentGateway(
-                id=payment_gateway_id,
-                name=payment_gateway_name,
-                currencies=[channel_USD.currency_code],
-                config=[],
-            ),
-        )
-    ]
-
-    request_data = ListStoredPaymentMethodsRequestData(
-        user=user_api_client.user,
-        channel=channel_USD,
-        amount=Money(requested_amount, channel_USD.currency_code),
-    )
-
-    query = QUERY_ME_WITH_STORED_PAYMENT_METHODS
-
-    # when
-    response = user_api_client.post_graphql(
-        query, variables={"channel": channel_USD.slug, "amount": requested_amount}
-    )
-
-    # then
-    mocked_list_stored_payment_methods.assert_called_once_with(request_data)
-    content = get_graphql_content(response)
-
-    data = content["data"]["me"]
-    assert data["storedPaymentMethods"] == [
-        {
-            "id": payment_method_id,
-            "gateway": {
-                "name": payment_gateway_name,
-                "id": payment_gateway_id,
-                "config": [],
-                "currencies": [channel_USD.currency_code],
-            },
-            "paymentMethodId": external_id,
-            "creditCardInfo": {
-                "brand": credit_card_brand,
-                "firstDigits": credit_card_first_digits,
-                "lastDigits": credit_card_last_digits,
-                "expMonth": credit_card_exp_month,
-                "expYear": credit_card_exp_year,
-            },
-            "supportedPaymentFlows": [supported_payment_flow.name],
-            "type": payment_method_type,
-            "name": payment_method_name,
-            "data": payment_method_data,
-        }
-    ]
-
-
-@mock.patch("saleor.plugins.manager.PluginsManager.list_stored_payment_methods")
-def test_me_query_stored_payment_methods_without_provided_amount(
+def test_me_query_stored_payment_methods(
     mocked_list_stored_payment_methods, user_api_client, channel_USD, customer_user
 ):
     # given
@@ -454,7 +361,6 @@ def test_me_query_stored_payment_methods_without_provided_amount(
     request_data = ListStoredPaymentMethodsRequestData(
         user=user_api_client.user,
         channel=channel_USD,
-        amount=Money(Decimal("0"), channel_USD.currency_code),
     )
 
     query = QUERY_ME_WITH_STORED_PAYMENT_METHODS

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -1,12 +1,10 @@
 import uuid
-from decimal import Decimal
 from functools import partial
 from typing import List, Optional, cast
 
 import graphene
 from django.contrib.auth import get_user_model
 from graphene import relay
-from prices import Money
 from promise import Promise
 
 from ...account import models
@@ -42,7 +40,7 @@ from ..core.doc_category import DOC_CATEGORY_USERS
 from ..core.enums import LanguageCodeEnum
 from ..core.federation import federated_entity, resolve_federation_references
 from ..core.fields import ConnectionField, PermissionsField
-from ..core.scalars import UUID, PositiveDecimal
+from ..core.scalars import UUID
 from ..core.tracing import traced_resolver
 from ..core.types import (
     BaseInputObjectType,
@@ -436,14 +434,6 @@ class User(ModelObjectType[models.User]):
             description="Slug of a channel for which the data should be returned.",
             required=True,
         ),
-        amount=PositiveDecimal(
-            description=(
-                "Amount that will be used to fetch stored payment methods."
-                "The provided amount will be sent to the payment app. The payment app "
-                "will use the amount to fetch all available stored payment methods for "
-                "the requested amount."
-            )
-        ),
     )
 
     class Meta:
@@ -689,7 +679,6 @@ class User(ModelObjectType[models.User]):
         root: models.User,
         info: ResolveInfo,
         channel: str,
-        amount: Optional[Decimal] = None,
     ):
         requestor = get_user_or_app_from_context(info.context)
         if not requestor or requestor.id != root.id:
@@ -700,7 +689,6 @@ class User(ModelObjectType[models.User]):
             request_data = ListStoredPaymentMethodsRequestData(
                 user=root,
                 channel=channel_obj,
-                amount=Money(amount or Decimal(0), channel_obj.currency_code),
             )
             return manager.list_stored_payment_methods(request_data)
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -9805,11 +9805,6 @@ type User implements Node & ObjectWithMetadata @doc(category: "Users") {
   storedPaymentMethods(
     """Slug of a channel for which the data should be returned."""
     channel: String!
-
-    """
-    Amount that will be used to fetch stored payment methods.The provided amount will be sent to the payment app. The payment app will use the amount to fetch all available stored payment methods for the requested amount.
-    """
-    amount: PositiveDecimal
   ): [StoredPaymentMethod!]
 }
 
@@ -32177,11 +32172,6 @@ type ListStoredPaymentMethods implements Event @doc(category: "Payments") {
   Channel in context which was used to fetch the list of payment methods.
   """
   channel: Channel!
-
-  """
-  Amount that the payment method must support. If not provided by the user, 0 will be used as default value.
-  """
-  value: Money
 }
 
 """_Any value scalar as defined by Federation spec."""

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -58,7 +58,7 @@ from ..core.doc_category import (
     DOC_CATEGORY_TAXES,
 )
 from ..core.scalars import JSON, PositiveDecimal
-from ..core.types import Money, NonNullList, SubscriptionObjectType
+from ..core.types import NonNullList, SubscriptionObjectType
 from ..core.types.order_or_checkout import OrderOrCheckout
 from ..order.dataloaders import OrderByIdLoader
 from ..order.types import Order, OrderGrantedRefund
@@ -1757,13 +1757,6 @@ class ListStoredPaymentMethods(SubscriptionObjectType):
         ),
         required=True,
     )
-    value = graphene.Field(
-        Money,
-        description=(
-            "Amount that the payment method must support. If not provided by the user, "
-            "0 will be used as default value."
-        ),
-    )
 
     class Meta:
         root_type = None
@@ -1789,13 +1782,6 @@ class ListStoredPaymentMethods(SubscriptionObjectType):
     ):
         _, payment_method_data = root
         return payment_method_data.channel
-
-    @classmethod
-    def resolve_value(
-        cls, root: tuple[str, ListStoredPaymentMethodsRequestData], _info: ResolveInfo
-    ):
-        _, payment_method_data = root
-        return payment_method_data.amount
 
 
 class TransactionItemMetadataUpdated(SubscriptionObjectType):

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -5,8 +5,6 @@ from enum import Enum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
-from prices import Money
-
 from ..order import FulfillmentLineData
 from ..order.fetch import OrderLineInfo
 from ..payment.models import TransactionEvent, TransactionItem
@@ -36,7 +34,6 @@ class PaymentGateway:
 class ListStoredPaymentMethodsRequestData:
     channel: "Channel"
     user: "User"
-    amount: Money
 
 
 @dataclass

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1339,12 +1339,9 @@ def test_list_stored_payment_methods(
     mocked_list_stored_payment_methods, channel_USD, customer_user
 ):
     # given
-    amount = Decimal(10)
-    currency = "USD"
     data = ListStoredPaymentMethodsRequestData(
         channel=channel_USD,
         user=customer_user,
-        amount=Money(amount, currency),
     )
 
     plugins = [

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1558,15 +1558,13 @@ class WebhookPlugin(BasePlugin):
             return previous_value
 
         event_type = WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS
-        currency = list_payment_method_data.amount.currency
+
         if webhooks := get_webhooks_for_event(event_type):
             payload_dict = {
                 "user_id": graphene.Node.to_global_id(
                     "User", list_payment_method_data.user.id
                 ),
                 "channel_slug": list_payment_method_data.channel.slug,
-                "currency": currency,
-                "amount": str(list_payment_method_data.amount.amount),
             }
             payload = self._serialize_payload(payload_dict)
             for webhook in webhooks:
@@ -1584,7 +1582,9 @@ class WebhookPlugin(BasePlugin):
                 if response_data:
                     previous_value.extend(
                         get_list_stored_payment_methods_from_response(
-                            webhook.app, response_data, currency
+                            webhook.app,
+                            response_data,
+                            list_payment_method_data.channel.currency_code,
                         )
                     )
         return previous_value

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_list_payment_methods.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_list_payment_methods.py
@@ -1,8 +1,6 @@
 import json
-from decimal import Decimal
 
 import graphene
-from prices import Money
 
 from .....payment.interface import ListStoredPaymentMethodsRequestData
 from .....webhook.event_types import WebhookEventSyncType
@@ -17,10 +15,6 @@ subscription {
       }
       channel{
         id
-      }
-      value{
-        amount
-        currency
       }
     }
   }
@@ -39,12 +33,9 @@ def test_list_stored_payment_methods(
     webhook.subscription_query = LIST_STORED_PAYMENT_METHODS
     webhook.save()
 
-    amount = 100.0
-    currency = "USD"
     data = ListStoredPaymentMethodsRequestData(
         channel=channel_USD,
         user=customer_user,
-        amount=Money(Decimal(amount), currency),
     )
 
     event_type = WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS
@@ -58,5 +49,4 @@ def test_list_stored_payment_methods(
     assert json.loads(delivery.payload.payload) == {
         "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
-        "value": {"amount": amount, "currency": currency},
     }

--- a/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
+++ b/saleor/plugins/webhook/tests/test_list_stored_payment_methods_webhook.py
@@ -1,8 +1,5 @@
-from decimal import Decimal
-
 import graphene
 import mock
-from prices import Money
 
 from ....core.models import EventDelivery
 from ....payment.interface import ListStoredPaymentMethodsRequestData
@@ -21,10 +18,6 @@ subscription {
       }
       channel{
         id
-      }
-      value{
-        amount
-        currency
       }
     }
   }
@@ -51,18 +44,14 @@ def test_list_stored_payment_methods_with_static_payload(
     webhook = list_stored_payment_methods_app.webhooks.first()
 
     plugin = webhook_plugin()
-    amount = Decimal(100)
-    currency = "USD"
+
     data = ListStoredPaymentMethodsRequestData(
         channel=channel_USD,
         user=customer_user,
-        amount=Money(amount, currency),
     )
     expected_payload = {
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
-        "currency": currency,
-        "amount": str(amount),
     }
     expected_cache_key = generate_cache_key_for_webhook(
         expected_payload,
@@ -91,7 +80,7 @@ def test_list_stored_payment_methods_with_static_payload(
     assert response == get_list_stored_payment_methods_from_response(
         list_stored_payment_methods_app,
         webhook_list_stored_payment_methods_response,
-        currency,
+        channel_USD.currency_code,
     )
 
 
@@ -117,18 +106,14 @@ def test_list_stored_payment_methods_with_subscription_payload(
     webhook.save()
 
     plugin = webhook_plugin()
-    amount = Decimal(100)
-    currency = "USD"
+
     data = ListStoredPaymentMethodsRequestData(
         channel=channel_USD,
         user=customer_user,
-        amount=Money(amount, currency),
     )
     expected_payload = {
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
-        "currency": currency,
-        "amount": str(amount),
     }
     expected_cache_key = generate_cache_key_for_webhook(
         expected_payload,
@@ -157,7 +142,7 @@ def test_list_stored_payment_methods_with_subscription_payload(
     assert response == get_list_stored_payment_methods_from_response(
         list_stored_payment_methods_app,
         webhook_list_stored_payment_methods_response,
-        currency,
+        channel_USD.currency_code,
     )
 
 
@@ -183,18 +168,14 @@ def test_list_stored_payment_methods_uses_cache_if_available(
     webhook.save()
 
     plugin = webhook_plugin()
-    amount = Decimal(100)
-    currency = "USD"
+
     data = ListStoredPaymentMethodsRequestData(
         channel=channel_USD,
         user=customer_user,
-        amount=Money(amount, currency),
     )
     expected_payload = {
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
-        "currency": currency,
-        "amount": str(amount),
     }
     expected_cache_key = generate_cache_key_for_webhook(
         expected_payload,
@@ -215,7 +196,7 @@ def test_list_stored_payment_methods_uses_cache_if_available(
     assert response == get_list_stored_payment_methods_from_response(
         list_stored_payment_methods_app,
         webhook_list_stored_payment_methods_response,
-        currency,
+        channel_USD.currency_code,
     )
 
 
@@ -241,19 +222,14 @@ def test_list_stored_payment_methods_app_returns_incorrect_response(
     webhook.save()
 
     plugin = webhook_plugin()
-    amount = Decimal(100)
-    currency = "USD"
     data = ListStoredPaymentMethodsRequestData(
         channel=channel_USD,
         user=customer_user,
-        amount=Money(amount, currency),
     )
 
     expected_payload = {
         "user_id": graphene.Node.to_global_id("User", customer_user.pk),
         "channel_slug": channel_USD.slug,
-        "currency": currency,
-        "amount": str(amount),
     }
     expected_cache_key = generate_cache_key_for_webhook(
         expected_payload,


### PR DESCRIPTION
I want to merge this change because after deeper investigation we discovered that this field is not needed. 
Ref: https://github.com/saleor/saleor/issues/13384

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
