### PR TITLE
Fix using search argument with sorting by RANK

### DIFF
--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -143,7 +143,9 @@ from .types import (
 
 
 def search_string_in_kwargs(kwargs: dict) -> bool:
-    return bool(kwargs.get("filter", {}).get("search", "").strip())
+    return bool(kwargs.get("filter", {}).get("search", "").strip()) or bool(
+        kwargs.get("search", "").strip()
+    )
 
 
 def sort_field_from_kwargs(kwargs: dict) -> Optional[List[str]]:
@@ -434,14 +436,15 @@ class ProductQueries(graphene.ObjectType):
 
     @staticmethod
     @traced_resolver
-    def resolve_products(
-        _root, info: ResolveInfo, *, channel=None, search=None, **kwargs
-    ):
+    def resolve_products(_root, info: ResolveInfo, *, channel=None, **kwargs):
         if sort_field_from_kwargs(kwargs) == ProductOrderField.RANK:
             # sort by RANK can be used only with search filter
             if not search_string_in_kwargs(kwargs):
                 raise GraphQLError(
-                    "Sorting by RANK is available only when using a search filter."
+                    (
+                        "Sorting by RANK is available only when using a search filter "
+                        "or search argument."
+                    )
                 )
         if search_string_in_kwargs(kwargs) and not sort_field_from_kwargs(kwargs):
             # default to sorting by RANK if search is used
@@ -451,6 +454,7 @@ class ProductQueries(graphene.ObjectType):
                 {"direction": "-", "field": ["search_rank", "id"]}
             )
 
+        search = kwargs.get("search")
         requestor = get_user_or_app_from_context(info.context)
         has_required_permissions = has_one_of_permissions(
             requestor, ALL_PRODUCTS_PERMISSIONS


### PR DESCRIPTION
I want to merge this change because it fixes using `search` argument with sorting by `RANK`.

Port of #13617
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
