### PR TITLE
Add notify user flag to fullfilment updated webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ Shipping methods can be removed by the user after it has been assigned to a chec
   - Called after `requestPasswordReset` or `customerCreate` mutation.
 - Add `STAFF_SET_PASSWORD_REQUESTED` webhook - #13486, by @Air-t
   - Called after `requestPasswordReset` or `customerCreate` mutation for staff users.
+- Add `NOTIFY_CUSTOMER` flag to `FulfillmentCreated` type - #13620, by @Air-t
+  - Informs apps if customer should be notified when fulfillment is created.
 
 ### Other changes
 - Add possibility to log without confirming email - #13059 by @kadewu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ Shipping methods can be removed by the user after it has been assigned to a chec
   - Called after `requestPasswordReset` or `customerCreate` mutation for staff users.
 - Add `NOTIFY_CUSTOMER` flag to `FulfillmentCreated` type - #13620, by @Air-t
   - Informs apps if customer should be notified when fulfillment is created.
+- Add `FULFILLMENT_UPDATED` webhook event - #13630, by @Air-t
+  - Informs apps if customer should be notified when fulfillment is updated.
 
 ### Other changes
 - Add possibility to log without confirming email - #13059 by @kadewu

--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -11,13 +11,14 @@ from ....order import models as order_models
 from ....order.actions import OrderFulfillmentLineInfo, create_fulfillments
 from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_36
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import BaseInputObjectType, NonNullList, OrderError
-from ...core.utils import get_duplicated_values
+from ...core.utils import WebhookEventInfo, get_duplicated_values
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ...warehouse.types import Warehouse
@@ -105,6 +106,16 @@ class OrderFulfill(BaseMutation):
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.FULFILLMENT_CREATED,
+                description="Fulfillment tracking number is created.",
+            ),
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.ORDER_FULFILLED,
+                description="Order is fulfilled.",
+            ),
+        ]
 
     @classmethod
     def clean_lines(cls, order_lines, quantities_for_lines):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1919,6 +1919,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
 
   """A new fulfillment is created."""
   FULFILLMENT_CREATED
+  FULFILLMENT_UPDATED
 
   """A fulfillment is cancelled."""
   FULFILLMENT_CANCELED
@@ -2581,6 +2582,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
 
   """A new fulfillment is created."""
   FULFILLMENT_CREATED
+  FULFILLMENT_UPDATED
 
   """A fulfillment is cancelled."""
   FULFILLMENT_CANCELED
@@ -3455,6 +3457,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   ORDER_METADATA_UPDATED
   ORDER_BULK_CREATED
   FULFILLMENT_CREATED
+  FULFILLMENT_UPDATED
   FULFILLMENT_CANCELED
   FULFILLMENT_APPROVED
   FULFILLMENT_METADATA_UPDATED
@@ -15743,6 +15746,10 @@ type Mutation {
   Updates a fulfillment for an order. 
   
   Requires one of the following permissions: MANAGE_ORDERS.
+  
+  Triggers the following webhook events:
+  - FULFILLMENT_UPDATED (async): Fulfillment tracking number is updated.
+  - ORDER_FULFILLMENT_UPDATE (sync): Fulfillment tracking number is updated.
   """
   orderFulfillmentUpdateTracking(
     """ID of a fulfillment to update."""
@@ -15750,7 +15757,7 @@ type Mutation {
 
     """Fields required to update a fulfillment."""
     input: FulfillmentUpdateTrackingInput!
-  ): FulfillmentUpdateTracking @doc(category: "Orders")
+  ): FulfillmentUpdateTracking @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_UPDATED], syncEvents: [])
 
   """
   Refund products. 
@@ -23612,8 +23619,12 @@ type FulfillmentApprove @doc(category: "Orders") {
 Updates a fulfillment for an order. 
 
 Requires one of the following permissions: MANAGE_ORDERS.
+
+Triggers the following webhook events:
+- FULFILLMENT_UPDATED (async): Fulfillment tracking number is updated.
+- ORDER_FULFILLMENT_UPDATE (sync): Fulfillment tracking number is updated.
 """
-type FulfillmentUpdateTracking @doc(category: "Orders") {
+type FulfillmentUpdateTracking @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_UPDATED], syncEvents: []) {
   """A fulfillment with updated tracking."""
   fulfillment: Fulfillment
 
@@ -31131,6 +31142,38 @@ Event sent when new fulfillment is created.
 Added in Saleor 3.4.
 """
 type FulfillmentCreated implements Event @doc(category: "Orders") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The fulfillment the event relates to."""
+  fulfillment: Fulfillment
+
+  """The order the fulfillment belongs to."""
+  order: Order
+
+  """
+  If true, send an email notification to the customer.
+  
+  Added in Saleor 3.15.
+  """
+  notifyCustomer: Boolean!
+}
+
+"""
+Event sent when new fulfillment is updated.
+
+Added in Saleor 3.15.
+"""
+type FulfillmentUpdated implements Event @doc(category: "Orders") {
   """Time of the event."""
   issuedAt: DateTime
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15695,6 +15695,10 @@ type Mutation {
   Creates new fulfillments for an order. 
   
   Requires one of the following permissions: MANAGE_ORDERS.
+  
+  Triggers the following webhook events:
+  - FULFILLMENT_CREATED (async): Fulfillment tracking number is created.
+  - ORDER_FULFILLED (async): Order is fulfilled.
   """
   orderFulfill(
     """Fields required to create a fulfillment."""
@@ -15702,7 +15706,7 @@ type Mutation {
 
     """ID of the order to be fulfilled."""
     order: ID
-  ): OrderFulfill @doc(category: "Orders")
+  ): OrderFulfill @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_CREATED, ORDER_FULFILLED], syncEvents: [])
 
   """
   Cancels existing fulfillment and optionally restocks items. 
@@ -23516,8 +23520,12 @@ type OrderConfirm @doc(category: "Orders") {
 Creates new fulfillments for an order. 
 
 Requires one of the following permissions: MANAGE_ORDERS.
+
+Triggers the following webhook events:
+- FULFILLMENT_CREATED (async): Fulfillment tracking number is created.
+- ORDER_FULFILLED (async): Order is fulfilled.
 """
-type OrderFulfill @doc(category: "Orders") {
+type OrderFulfill @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_CREATED, ORDER_FULFILLED], syncEvents: []) {
   """List of created fulfillments."""
   fulfillments: [Fulfillment!]
 
@@ -31140,6 +31148,13 @@ type FulfillmentCreated implements Event @doc(category: "Orders") {
 
   """The order the fulfillment belongs to."""
   order: Order
+
+  """
+  If true, send an email notification to the customer.
+  
+  Added in Saleor 3.15.
+  """
+  notifyCustomer: Boolean!
 }
 
 """

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1157,11 +1157,34 @@ class FulfillmentBase(AbstractType):
 
 
 class FulfillmentCreated(SubscriptionObjectType, FulfillmentBase):
+    notify_customer = graphene.Boolean(
+        description=(
+            "If true, send an email notification to the customer." + ADDED_IN_315
+        ),
+        required=True,
+    )
+
     class Meta:
-        root_type = "Fulfillment"
-        enable_dry_run = True
+        doc_category = DOC_CATEGORY_ORDERS
+        root_type = None
+        enable_dry_run = False
         interfaces = (Event,)
         description = "Event sent when new fulfillment is created." + ADDED_IN_34
+
+    @staticmethod
+    def resolve_fulfillment(root, info: ResolveInfo):
+        _, data = root
+        return data["fulfillment"]
+
+    @staticmethod
+    def resolve_order(root, info: ResolveInfo):
+        _, data = root
+        return data["order"]
+
+    @staticmethod
+    def resolve_notify_customer(root, _info: ResolveInfo):
+        _, data = root
+        return data["notify_customer"]
 
 
 class FulfillmentCanceled(SubscriptionObjectType, FulfillmentBase):

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1187,6 +1187,37 @@ class FulfillmentCreated(SubscriptionObjectType, FulfillmentBase):
         return data["notify_customer"]
 
 
+class FulfillmentUpdated(SubscriptionObjectType, FulfillmentBase):
+    notify_customer = graphene.Boolean(
+        description=(
+            "If true, send an email notification to the customer." + ADDED_IN_315
+        ),
+        required=True,
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_ORDERS
+        root_type = None
+        enable_dry_run = False
+        interfaces = (Event,)
+        description = "Event sent when new fulfillment is updated." + ADDED_IN_315
+
+    @staticmethod
+    def resolve_fulfillment(root, info: ResolveInfo):
+        _, data = root
+        return data["fulfillment"]
+
+    @staticmethod
+    def resolve_order(root, info: ResolveInfo):
+        _, data = root
+        return data["order"]
+
+    @staticmethod
+    def resolve_notify_customer(root, _info: ResolveInfo):
+        _, data = root
+        return data["notify_customer"]
+
+
 class FulfillmentCanceled(SubscriptionObjectType, FulfillmentBase):
     class Meta:
         root_type = "Fulfillment"
@@ -2282,6 +2313,7 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.INVOICE_DELETED: InvoiceDeleted,
     WebhookEventAsyncType.INVOICE_SENT: InvoiceSent,
     WebhookEventAsyncType.FULFILLMENT_CREATED: FulfillmentCreated,
+    WebhookEventAsyncType.FULFILLMENT_UPDATED: FulfillmentUpdated,
     WebhookEventAsyncType.FULFILLMENT_CANCELED: FulfillmentCanceled,
     WebhookEventAsyncType.FULFILLMENT_APPROVED: FulfillmentApproved,
     WebhookEventAsyncType.FULFILLMENT_METADATA_UPDATED: FulfillmentMetadataUpdated,

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
@@ -272,7 +272,6 @@ def async_subscription_webhooks_with_root_objects(
     subscription_invoice_requested_webhook,
     subscription_invoice_deleted_webhook,
     subscription_invoice_sent_webhook,
-    subscription_fulfillment_created_webhook,
     subscription_fulfillment_canceled_webhook,
     subscription_fulfillment_approved_webhook,
     subscription_fulfillment_metadata_updated_webhook,
@@ -468,10 +467,6 @@ def async_subscription_webhooks_with_root_objects(
         events.INVOICE_REQUESTED: [subscription_invoice_requested_webhook, invoice],
         events.INVOICE_DELETED: [subscription_invoice_deleted_webhook, invoice],
         events.INVOICE_SENT: [subscription_invoice_sent_webhook, invoice],
-        events.FULFILLMENT_CREATED: [
-            subscription_fulfillment_created_webhook,
-            fulfillment,
-        ],
         events.FULFILLMENT_CANCELED: [
             subscription_fulfillment_canceled_webhook,
             fulfillment,

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -299,7 +299,7 @@ def order_fulfilled(
         call_event(manager.order_updated, order)
 
         for fulfillment in fulfillments:
-            call_event(manager.fulfillment_created, fulfillment)
+            call_event(manager.fulfillment_created, fulfillment, notify_customer)
 
         if order.status == OrderStatus.FULFILLED:
             call_event(manager.order_fulfilled, order)

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -850,13 +850,16 @@ class PluginsManager(PaymentInterface):
         default_value = None
         return self.__run_method_on_plugins("order_bulk_created", default_value, orders)
 
-    def fulfillment_created(self, fulfillment: "Fulfillment"):
+    def fulfillment_created(
+        self, fulfillment: "Fulfillment", notify_customer: Optional[bool] = True
+    ):
         default_value = None
         return self.__run_method_on_plugins(
             "fulfillment_created",
             default_value,
             fulfillment,
             channel_slug=fulfillment.order.channel.slug,
+            notify_customer=notify_customer,
         )
 
     def fulfillment_canceled(self, fulfillment: "Fulfillment"):

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -862,6 +862,18 @@ class PluginsManager(PaymentInterface):
             notify_customer=notify_customer,
         )
 
+    def fulfillment_updated(
+        self, fulfillment: "Fulfillment", notify_customer: Optional[bool] = True
+    ):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "fulfillment_updated",
+            default_value,
+            fulfillment,
+            channel_slug=fulfillment.order.channel.slug,
+            notify_customer=notify_customer,
+        )
+
     def fulfillment_canceled(self, fulfillment: "Fulfillment"):
         default_value = None
         return self.__run_method_on_plugins(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -915,14 +915,23 @@ class WebhookPlugin(BasePlugin):
                 order_data, event_type, webhooks, order, self.requestor
             )
 
-    def fulfillment_created(self, fulfillment: "Fulfillment", previous_value):
+    def fulfillment_created(
+        self,
+        fulfillment: "Fulfillment",
+        notify_customer: Optional[bool] = True,
+        previous_value: Optional[Any] = None,
+    ):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.FULFILLMENT_CREATED
         if webhooks := get_webhooks_for_event(event_type):
             fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
             trigger_webhooks_async(
-                fulfillment_data, event_type, webhooks, fulfillment, self.requestor
+                fulfillment_data,
+                event_type,
+                webhooks,
+                {"notify_customer": notify_customer},
+                self.requestor,
             )
 
     def fulfillment_canceled(self, fulfillment: "Fulfillment", previous_value):

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -934,6 +934,25 @@ class WebhookPlugin(BasePlugin):
                 self.requestor,
             )
 
+    def fulfillment_updated(
+        self,
+        fulfillment: "Fulfillment",
+        notify_customer: Optional[bool] = True,
+        previous_value: Optional[Any] = None,
+    ):
+        if not self.active:
+            return previous_value
+        event_type = WebhookEventAsyncType.FULFILLMENT_UPDATED
+        if webhooks := get_webhooks_for_event(event_type):
+            fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
+            trigger_webhooks_async(
+                fulfillment_data,
+                event_type,
+                webhooks,
+                {"notify_customer": notify_customer},
+                self.requestor,
+            )
+
     def fulfillment_canceled(self, fulfillment: "Fulfillment", previous_value):
         if not self.active:
             return previous_value

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -105,7 +105,9 @@ def create_deliveries_for_subscriptions(
             subscribable_object=subscribable_object,
             subscription_query=webhook.subscription_query,
             request=initialize_request(
-                requestor, event_type in WebhookEventSyncType.ALL, event_type=event_type
+                requestor,
+                event_type in WebhookEventSyncType.ALL,
+                event_type=event_type,
             ),
             app=webhook.app,
         )
@@ -114,7 +116,6 @@ def create_deliveries_for_subscriptions(
                 "No payload was generated with subscription for event: %s" % event_type
             )
             continue
-
         event_payload = EventPayload(payload=json.dumps({**data}))
         event_payloads.append(event_payload)
         event_deliveries.append(
@@ -193,7 +194,6 @@ def trigger_webhooks_async(
     """
     regular_webhooks, subscription_webhooks = group_webhooks_by_subscription(webhooks)
     deliveries = []
-
     if regular_webhooks:
         payload = EventPayload.objects.create(payload=data)
         deliveries.extend(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -626,6 +626,14 @@ def subscription_fulfillment_created_webhook(subscription_webhook):
 
 
 @pytest.fixture
+def subscription_fulfillment_updated_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.FULFILLMENT_UPDATED,
+        WebhookEventAsyncType.FULFILLMENT_UPDATED,
+    )
+
+
+@pytest.fixture
 def subscription_fulfillment_canceled_webhook(subscription_webhook):
     return subscription_webhook(
         queries.FULFILLMENT_CANCELED,

--- a/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
@@ -111,9 +111,9 @@ def generate_fulfillment_lines_payload(fulfillment):
     ]
 
 
-def generate_fulfillment_payload(fulfillment):
+def generate_fulfillment_payload(fulfillment, add_notify_customer_field=False):
     fulfillment_id = graphene.Node.to_global_id("Fulfillment", fulfillment.pk)
-    return {
+    payload = {
         "fulfillment": {
             "id": fulfillment_id,
             "fulfillmentOrder": fulfillment.fulfillment_order,
@@ -125,6 +125,9 @@ def generate_fulfillment_payload(fulfillment):
             "id": graphene.Node.to_global_id("Order", fulfillment.order.pk),
         },
     }
+    if add_notify_customer_field:
+        payload["notifyCustomer"] = True
+    return payload
 
 
 def generate_address_payload(address):

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1341,6 +1341,7 @@ FULFILLMENT_CREATED = (
     subscription{
       event{
         ...on FulfillmentCreated{
+          notifyCustomer
           fulfillment{
             ...FulfillmentDetails
           }

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1354,6 +1354,26 @@ FULFILLMENT_CREATED = (
 """
 )
 
+
+FULFILLMENT_UPDATED = (
+    fragments.FULFILLMENT_DETAILS
+    + """
+    subscription{
+      event{
+        ...on FulfillmentUpdated{
+          notifyCustomer
+          fulfillment{
+            ...FulfillmentDetails
+          }
+          order{
+            id
+          }
+        }
+      }
+    }
+"""
+)
+
 FULFILLMENT_CANCELED = (
     fragments.FULFILLMENT_DETAILS
     + """

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1653,11 +1653,20 @@ def test_fulfillment_created(fulfillment, subscription_fulfillment_created_webho
     # given
     webhooks = [subscription_fulfillment_created_webhook]
     event_type = WebhookEventAsyncType.FULFILLMENT_CREATED
-    expected_payload = generate_fulfillment_payload(fulfillment)
+    expected_payload = generate_fulfillment_payload(
+        fulfillment, add_notify_customer_field=True
+    )
 
     # when
-    deliveries = create_deliveries_for_subscriptions(event_type, fulfillment, webhooks)
-
+    deliveries = create_deliveries_for_subscriptions(
+        event_type,
+        {
+            "order": fulfillment.order,
+            "fulfillment": fulfillment,
+            "notify_customer": True,
+        },
+        webhooks,
+    )
     # then
     assert json.loads(deliveries[0].payload.payload) == expected_payload
     assert len(deliveries) == len(webhooks)

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1673,6 +1673,31 @@ def test_fulfillment_created(fulfillment, subscription_fulfillment_created_webho
     assert deliveries[0].webhook == webhooks[0]
 
 
+def test_fulfillment_updated(fulfillment, subscription_fulfillment_updated_webhook):
+    # given
+    webhooks = [subscription_fulfillment_updated_webhook]
+    event_type = WebhookEventAsyncType.FULFILLMENT_UPDATED
+    expected_payload = generate_fulfillment_payload(
+        fulfillment, add_notify_customer_field=True
+    )
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type,
+        {
+            "order": fulfillment.order,
+            "fulfillment": fulfillment,
+            "notify_customer": True,
+        },
+        webhooks,
+    )
+
+    # then
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
 def test_fulfillment_canceled(fulfillment, subscription_fulfillment_canceled_webhook):
     # given
     webhooks = [subscription_fulfillment_canceled_webhook]

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -85,6 +85,7 @@ class WebhookEventAsyncType:
     ORDER_BULK_CREATED = "order_bulk_created"
 
     FULFILLMENT_CREATED = "fulfillment_created"
+    FULFILLMENT_UPDATED = "fulfillment_updated"
     FULFILLMENT_CANCELED = "fulfillment_canceled"
     FULFILLMENT_APPROVED = "fulfillment_approved"
     FULFILLMENT_METADATA_UPDATED = "fulfillment_metadata_updated"
@@ -395,6 +396,10 @@ class WebhookEventAsyncType:
         },
         FULFILLMENT_CREATED: {
             "name": "Fulfillment created",
+            "permission": OrderPermissions.MANAGE_ORDERS,
+        },
+        FULFILLMENT_UPDATED: {
+            "name": "Fulfillment updated",
             "permission": OrderPermissions.MANAGE_ORDERS,
         },
         FULFILLMENT_CANCELED: {


### PR DESCRIPTION
I want to merge this change because it adds missing `FULLFILMENT_UPDATED` updated event which replaces `NotifyEventType.ORDER_FULFILLMENT_UPDATE` event

Resolves: https://github.com/saleor/saleor/issues/13560

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
