### PR TITLE
Refactor sale_delete mutation.

### DIFF
--- a/saleor/discount/migrations/0045_promotion_promotionrule.py
+++ b/saleor/discount/migrations/0045_promotion_promotionrule.py
@@ -100,7 +100,7 @@ class Migration(migrations.Migration):
                         sanitizer=saleor.core.utils.editorjs.clean_editor_js,
                     ),
                 ),
-                ("catalogue_predicate", models.JSONField(blank=True)),
+                ("catalogue_predicate", models.JSONField(blank=True, default=dict)),
                 (
                     "reward_value_type",
                     models.CharField(

--- a/saleor/discount/migrations/0045_promotion_promotionrule.py
+++ b/saleor/discount/migrations/0045_promotion_promotionrule.py
@@ -84,7 +84,14 @@ class Migration(migrations.Migration):
                         unique=True,
                     ),
                 ),
-                ("name", models.CharField(max_length=255)),
+                (
+                    "name",
+                    models.CharField(
+                        max_length=255,
+                        blank=True,
+                        null=True,
+                    ),
+                ),
                 (
                     "description",
                     saleor.core.db.fields.SanitizedJSONField(
@@ -93,7 +100,7 @@ class Migration(migrations.Migration):
                         sanitizer=saleor.core.utils.editorjs.clean_editor_js,
                     ),
                 ),
-                ("catalogue_predicate", models.JSONField()),
+                ("catalogue_predicate", models.JSONField(blank=True)),
                 (
                     "reward_value_type",
                     models.CharField(

--- a/saleor/discount/migrations/0049_migrate_sales_to_promotions.py
+++ b/saleor/discount/migrations/0049_migrate_sales_to_promotions.py
@@ -101,6 +101,7 @@ def convert_sale_into_promotion(Promotion, sale):
         updated_at=sale.updated_at,
         metadata=sale.metadata,
         private_metadata=sale.private_metadata,
+        last_notification_scheduled_at=sale.notification_sent_datetime,
     )
 
 
@@ -108,7 +109,6 @@ def create_promotion_rule(
     PromotionRule, sale, promotion, discount_value=None, old_channel_listing_id=None
 ):
     return PromotionRule(
-        name="",
         promotion=promotion,
         catalogue_predicate=create_catalogue_predicate_from_sale(sale),
         reward_value_type=sale.type,

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -428,7 +428,7 @@ class PromotionRule(models.Model):
         Promotion, on_delete=models.CASCADE, related_name="rules"
     )
     channels = models.ManyToManyField(Channel)
-    catalogue_predicate = models.JSONField(blank=True)
+    catalogue_predicate = models.JSONField(blank=True, default=dict)
     reward_value_type = models.CharField(
         max_length=255, choices=RewardValueType.CHOICES, blank=True, null=True
     )

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -422,13 +422,13 @@ class PromotionTranslation(Translation):
 
 class PromotionRule(models.Model):
     id = models.UUIDField(primary_key=True, editable=False, unique=True, default=uuid4)
-    name = models.CharField(max_length=255)
+    name = models.CharField(max_length=255, blank=True, null=True)
     description = SanitizedJSONField(blank=True, null=True, sanitizer=clean_editor_js)
     promotion = models.ForeignKey(
         Promotion, on_delete=models.CASCADE, related_name="rules"
     )
     channels = models.ManyToManyField(Channel)
-    catalogue_predicate = models.JSONField()
+    catalogue_predicate = models.JSONField(blank=True)
     reward_value_type = models.CharField(
         max_length=255, choices=RewardValueType.CHOICES, blank=True, null=True
     )

--- a/saleor/discount/sale_converter.py
+++ b/saleor/discount/sale_converter.py
@@ -85,6 +85,7 @@ def _convert_sale_into_promotion(sale):
         updated_at=sale.updated_at,
         metadata=sale.metadata,
         private_metadata=sale.private_metadata,
+        last_notification_scheduled_at=sale.notification_sent_datetime,
     )
 
 
@@ -126,7 +127,6 @@ def _create_promotion_rule(
     sale, promotion, discount_value=None, old_channel_listing_id=None
 ):
     return PromotionRule(
-        name="",
         promotion=promotion,
         catalogue_predicate=_create_catalogue_predicate_from_sale(sale),
         reward_value_type=sale.type,

--- a/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
@@ -57,7 +57,7 @@ class SaleAddCatalogues(SaleBaseCatalogueMutation):
 
             def sale_update_event():
                 return manager.sale_updated(
-                    sale,
+                    sale,  # type: ignore # will be handled in separate PR
                     previous_catalogue=previous_cat_converted,
                     current_catalogue=current_cat_converted,
                 )

--- a/saleor/graphql/discount/mutations/sale/sale_delete.py
+++ b/saleor/graphql/discount/mutations/sale/sale_delete.py
@@ -2,19 +2,22 @@ import graphene
 
 from .....core.tracing import traced_atomic_transaction
 from .....discount import models
-from .....discount.utils import fetch_catalogue_info
 from .....graphql.core.mutations import ModelDeleteMutation
 from .....permission.enums import DiscountPermissions
-from .....product.tasks import update_products_discounted_prices_of_catalogues_task
+from .....product.tasks import update_products_discounted_prices_for_promotion_task
 from .....webhook.event_types import WebhookEventAsyncType
 from ....channel import ChannelContext
 from ....core import ResolveInfo
 from ....core.descriptions import DEPRECATED_IN_3X_MUTATION
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.types import DiscountError
 from ....core.utils import WebhookEventInfo
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import Sale
-from ..utils import convert_catalogue_info_to_global_ids
+from ...utils import (
+    convert_migrated_sale_predicate_to_catalogue_info,
+    get_products_for_rule,
+)
 
 
 class SaleDelete(ModelDeleteMutation):
@@ -27,8 +30,10 @@ class SaleDelete(ModelDeleteMutation):
             + DEPRECATED_IN_3X_MUTATION
             + " Use `promotionDelete` mutation instead."
         )
-        model = models.Sale
+        model = models.Promotion
         object_type = Sale
+        return_field_name = "sale"
+        doc_category = DOC_CATEGORY_DISCOUNTS
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
         error_type_class = DiscountError
         error_type_field = "discount_errors"
@@ -43,22 +48,28 @@ class SaleDelete(ModelDeleteMutation):
     def perform_mutation(  # type: ignore[override]
         cls, root, info: ResolveInfo, /, *, id: str
     ):
-        instance = cls.get_node_or_error(info, id, only_type=Sale)
-        previous_catalogue = fetch_catalogue_info(instance)
-        manager = get_plugin_manager_promise(info.context).get()
+        object_id = cls.get_global_id_or_error(id, "Sale")
+        promotion = models.Promotion.objects.get(old_sale_id=object_id)
+        promotion_id = promotion.id
+        rule = promotion.rules.first()
+        assert rule
+        previous_predicate = rule.catalogue_predicate
+        previous_catalogue = convert_migrated_sale_predicate_to_catalogue_info(
+            previous_predicate
+        )
+        products = get_products_for_rule(rule)
+        product_ids = set(products.values_list("id", flat=True))
         with traced_atomic_transaction():
-            response = super().perform_mutation(root, info, id=id)
-            cls.call_event(
-                lambda: manager.sale_deleted(
-                    instance, convert_catalogue_info_to_global_ids(previous_catalogue)
-                )
+            promotion.delete()
+            promotion.old_sale_id = object_id
+            promotion.id = promotion_id
+            response = cls.success_response(promotion)
+            response.sale = ChannelContext(node=promotion, channel_slug=None)
+
+            manager = get_plugin_manager_promise(info.context).get()
+            cls.call_event(manager.sale_deleted, promotion, previous_catalogue)
+            update_products_discounted_prices_for_promotion_task.delay(
+                list(product_ids)
             )
-            update_products_discounted_prices_of_catalogues_task.delay(
-                product_ids=list(previous_catalogue["products"]),
-                category_ids=list(previous_catalogue["categories"]),
-                collection_ids=list(previous_catalogue["collections"]),
-                variant_ids=list(previous_catalogue["variants"]),
-            )
-        response.sale = ChannelContext(node=instance, channel_slug=None)
 
         return response

--- a/saleor/graphql/discount/mutations/sale/sale_delete.py
+++ b/saleor/graphql/discount/mutations/sale/sale_delete.py
@@ -81,7 +81,7 @@ class SaleDelete(ModelDeleteMutation):
             raise_validation_error(
                 field="id",
                 message="Provided ID refers to Promotion model. "
-                "Please use 'promotionUpdate' mutation instead.",
+                "Please use 'promotionDelete' mutation instead.",
                 code=DiscountErrorCode.INVALID.value,
             )
         object_id = cls.get_global_id_or_error(id, "Sale")

--- a/saleor/graphql/discount/mutations/sale/sale_remove_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale/sale_remove_catalogues.py
@@ -50,7 +50,7 @@ class SaleRemoveCatalogues(SaleBaseCatalogueMutation):
             current_catalogue = fetch_catalogue_info(sale)
             cls.call_event(
                 lambda: manager.sale_updated(
-                    sale,
+                    sale,  # type: ignore # will be handled in separate PR
                     previous_catalogue=convert_catalogue_info_to_global_ids(
                         previous_catalogue
                     ),

--- a/saleor/graphql/discount/mutations/sale/sale_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_update.py
@@ -1,24 +1,36 @@
-from collections import defaultdict
 from datetime import datetime
+from typing import List
 
 import graphene
 import pytz
+from django.core.exceptions import ValidationError
 
 from .....core.tracing import traced_atomic_transaction
 from .....discount import models
-from .....discount.utils import CATALOGUE_FIELDS, fetch_catalogue_info
+from .....discount.error_codes import DiscountErrorCode
+from .....discount.sale_converter import create_catalogue_predicate
+from .....discount.utils import CATALOGUE_FIELDS
 from .....permission.enums import DiscountPermissions
-from .....product.tasks import update_products_discounted_prices_of_catalogues_task
+from .....product.tasks import update_products_discounted_prices_for_promotion_task
 from .....webhook.event_types import WebhookEventAsyncType
 from ....channel import ChannelContext
 from ....core import ResolveInfo
 from ....core.descriptions import DEPRECATED_IN_3X_MUTATION
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
 from ....core.types import DiscountError
-from ....core.utils import WebhookEventInfo
+from ....core.utils import (
+    WebhookEventInfo,
+    from_global_id_or_error,
+    raise_validation_error,
+)
+from ....core.validators import validate_end_is_after_start
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import Sale
-from ..utils import convert_catalogue_info_to_global_ids
+from ...utils import (
+    convert_migrated_sale_predicate_to_catalogue_info,
+    get_products_for_rule,
+)
 from .sale_create import SaleInput
 
 
@@ -35,11 +47,13 @@ class SaleUpdate(ModelMutation):
             + DEPRECATED_IN_3X_MUTATION
             + " Use `promotionUpdate` mutation instead."
         )
-        model = models.Sale
+        model = models.Promotion
         object_type = Sale
+        return_field_name = "sale"
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
         error_type_class = DiscountError
         error_type_field = "discount_errors"
+        doc_category = DOC_CATEGORY_DISCOUNTS
         webhook_events_info = [
             WebhookEventInfo(
                 type=WebhookEventAsyncType.SALE_UPDATED,
@@ -53,57 +67,152 @@ class SaleUpdate(ModelMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info: ResolveInfo, /, **data):
-        instance = cls.get_instance(info, **data)
-        previous_catalogue = fetch_catalogue_info(instance)
-        previous_end_date = instance.end_date
-        data = data.get("input")
-        manager = get_plugin_manager_promise(info.context).get()
-        cleaned_input = cls.clean_input(info, instance, data)
+        promotion = cls.get_instance(info, **data)
+        input = data.get("input")
+        cls.validate_dates(promotion, input)
+        rules = promotion.rules.all()
+        previous_predicate = rules[0].catalogue_predicate
+        previous_catalogue = convert_migrated_sale_predicate_to_catalogue_info(
+            previous_predicate
+        )
+        previous_end_date = promotion.end_date
+        previous_products = get_products_for_rule(rules[0])
+        previous_product_ids = set(previous_products.values_list("id", flat=True))
         with traced_atomic_transaction():
-            instance = cls.construct_instance(instance, cleaned_input)
-            cls.clean_instance(info, instance)
-            cls.save(info, instance, cleaned_input)
-            cls._save_m2m(info, instance, cleaned_input)
-            current_catalogue = fetch_catalogue_info(instance)
-            cls.send_sale_notifications(
-                manager,
-                instance,
-                cleaned_input,
+            cls.update_fields(promotion, rules, input)
+            cls.clean_instance(info, promotion)
+            promotion.save()
+            for rule in rules:
+                cls.clean_instance(info, rule)
+                rule.save()
+
+            cls.post_save_actions(
+                info,
+                input,
+                promotion,
                 previous_catalogue,
-                current_catalogue,
                 previous_end_date,
+                previous_product_ids,
             )
 
-            cls.update_products_discounted_prices(
-                cleaned_input, previous_catalogue, current_catalogue
+        return cls.success_response(ChannelContext(node=promotion, channel_slug=None))
+
+    @classmethod
+    def get_instance(cls, info: ResolveInfo, **data):
+        type, _id = from_global_id_or_error(data["id"], raise_error=False)
+        if type == "Promotion":
+            raise_validation_error(
+                field="id",
+                message="Provided ID refers to Promotion model. "
+                "Please use 'promotionUpdate' mutation instead.",
+                code=DiscountErrorCode.INVALID.value,
             )
-        return cls.success_response(ChannelContext(node=instance, channel_slug=None))
+        object_id = cls.get_global_id_or_error(data["id"], "Sale")
+        return models.Promotion.objects.get(old_sale_id=object_id)
+
+    @staticmethod
+    def validate_dates(instance, input):
+        start_date = input.get("start_date") or instance.start_date
+        end_date = input.get("end_date") or instance.end_date
+        try:
+            validate_end_is_after_start(start_date, end_date)
+        except ValidationError as error:
+            error.code = DiscountErrorCode.INVALID.value
+            raise ValidationError({"end_date": error})
+
+    @classmethod
+    def update_fields(
+        cls, promotion: models.Promotion, rules: List[models.PromotionRule], input
+    ):
+        if name := input.get("name"):
+            promotion.name = name
+        if start_date := input.get("start_date"):
+            promotion.start_date = start_date
+        if "end_date" in input.keys():
+            end_date = input.get("end_date")
+            promotion.end_date = end_date
+
+        # We need to make sure, that all rules have the same type and predicate
+        if type := input.get("type"):
+            for rule in rules:
+                rule.reward_value_type = type
+
+        if any([key in CATALOGUE_FIELDS for key in input.keys()]):
+            predicate = cls.create_predicate(input)
+            for rule in rules:
+                rule.catalogue_predicate = predicate
+
+    @staticmethod
+    def create_predicate(input):
+        collections = input.get("collections")
+        categories = input.get("categories")
+        products = input.get("products")
+        variants = input.get("variants")
+
+        return create_catalogue_predicate(collections, categories, products, variants)
+
+    @classmethod
+    def post_save_actions(
+        cls,
+        info,
+        input,
+        promotion,
+        previous_catalogue,
+        previous_end_date,
+        previous_product_ids,
+    ):
+        rule = promotion.rules.first()
+        current_predicate = rule.catalogue_predicate
+        current_catalogue = convert_migrated_sale_predicate_to_catalogue_info(
+            current_predicate
+        )
+        manager = get_plugin_manager_promise(info.context).get()
+        cls.send_sale_notifications(
+            manager,
+            promotion,
+            input,
+            previous_catalogue,
+            current_catalogue,
+            previous_end_date,
+        )
+
+        if any(
+            field in input.keys()
+            for field in [*CATALOGUE_FIELDS, "start_date", "end_date", "type"]
+        ):
+            products = get_products_for_rule(rule)
+            if (
+                product_ids := set(products.values_list("id", flat=True))
+                | previous_product_ids
+            ):
+                update_products_discounted_prices_for_promotion_task.delay(
+                    list(product_ids)
+                )
 
     @classmethod
     def send_sale_notifications(
         cls,
         manager,
         instance,
-        cleaned_input,
+        input,
         previous_catalogue,
         current_catalogue,
         previous_end_date,
     ):
-        current_catalogue = convert_catalogue_info_to_global_ids(current_catalogue)
         cls.call_event(
             manager.sale_updated,
             instance,
-            convert_catalogue_info_to_global_ids(previous_catalogue),
+            previous_catalogue,
             current_catalogue,
         )
 
         cls.send_sale_toggle_notification(
-            manager, instance, cleaned_input, current_catalogue, previous_end_date
+            manager, instance, input, current_catalogue, previous_end_date
         )
 
     @staticmethod
     def send_sale_toggle_notification(
-        manager, instance, clean_input, catalogue, previous_end_date
+        manager, instance, input, catalogue, previous_end_date
     ):
         """Send the notification about starting or ending sale if it wasn't sent yet.
 
@@ -113,9 +222,9 @@ class SaleUpdate(ModelMutation):
         """
         now = datetime.now(pytz.utc)
 
-        notification_date = instance.notification_sent_datetime
-        start_date = clean_input.get("start_date")
-        end_date = clean_input.get("end_date")
+        notification_date = instance.last_notification_scheduled_at
+        start_date = input.get("start_date")
+        end_date = input.get("end_date")
 
         if not start_date and not end_date:
             return
@@ -136,35 +245,5 @@ class SaleUpdate(ModelMutation):
 
         if send_notification:
             manager.sale_toggle(instance, catalogue)
-            instance.notification_sent_datetime = now
-            instance.save(update_fields=["notification_sent_datetime"])
-
-    @staticmethod
-    def update_products_discounted_prices(
-        cleaned_input, previous_catalogue, current_catalogue
-    ):
-        catalogues_to_recalculate = defaultdict(set)
-        for catalogue_field in CATALOGUE_FIELDS:
-            if any(
-                [
-                    field in cleaned_input
-                    for field in [
-                        catalogue_field,
-                        "start_date",
-                        "end_date",
-                        "type",
-                        "value",
-                    ]
-                ]
-            ):
-                catalogues_to_recalculate[catalogue_field] = previous_catalogue[
-                    catalogue_field
-                ].union(current_catalogue[catalogue_field])
-
-        if catalogues_to_recalculate:
-            update_products_discounted_prices_of_catalogues_task.delay(
-                product_ids=list(catalogues_to_recalculate["products"]),
-                category_ids=list(catalogues_to_recalculate["categories"]),
-                collection_ids=list(catalogues_to_recalculate["collections"]),
-                variant_ids=list(catalogues_to_recalculate["variants"]),
-            )
+            instance.last_notification_scheduled_at = now
+            instance.save(update_fields=["last_notification_scheduled_at"])

--- a/saleor/graphql/discount/tests/mutations/test_sale_delete.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_delete.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import graphene
 import pytest
 
+from .....discount.error_codes import DiscountErrorCode
 from .....discount.models import Promotion, PromotionRule
 from .....discount.sale_converter import convert_sales_to_promotions
 from .....discount.utils import fetch_catalogue_info
@@ -69,3 +70,41 @@ def test_sale_delete_mutation(
 
     deleted_webhook_mock.assert_called_once_with(promotion, previous_catalogue)
     update_products_discounted_prices_for_promotion_task_mock.assert_called_once()
+
+
+@patch(
+    "saleor.product.tasks.update_products_discounted_prices_for_promotion_task.delay"
+)
+@patch("saleor.plugins.manager.PluginsManager.sale_deleted")
+def test_sale_delete_mutation_with_promotion_id(
+    deleted_webhook_mock,
+    update_products_discounted_prices_for_promotion_task_mock,
+    staff_api_client,
+    sale,
+    permission_manage_discounts,
+):
+    # given
+    query = SALE_DELETE_MUTATION
+    convert_sales_to_promotions()
+    promotion = Promotion.objects.get(old_sale_id=sale.id)
+    variables = {"id": graphene.Node.to_global_id("Promotion", promotion.id)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_discounts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["saleDelete"]["sale"]
+    errors = content["data"]["saleDelete"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "id"
+    assert errors[0]["code"] == DiscountErrorCode.INVALID.name
+    assert errors[0]["message"] == (
+        "Provided ID refers to Promotion model. "
+        "Please use 'promotionUpdate' mutation instead."
+    )
+
+    deleted_webhook_mock.assert_not_called()
+    update_products_discounted_prices_for_promotion_task_mock.assert_not_called()

--- a/saleor/graphql/discount/tests/mutations/test_sale_delete.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_delete.py
@@ -103,7 +103,7 @@ def test_sale_delete_mutation_with_promotion_id(
     assert errors[0]["code"] == DiscountErrorCode.INVALID.name
     assert errors[0]["message"] == (
         "Provided ID refers to Promotion model. "
-        "Please use 'promotionUpdate' mutation instead."
+        "Please use 'promotionDelete' mutation instead."
     )
 
     deleted_webhook_mock.assert_not_called()

--- a/saleor/graphql/discount/types/promotions.py
+++ b/saleor/graphql/discount/types/promotions.py
@@ -59,7 +59,7 @@ class Promotion(ModelObjectType[models.Promotion]):
 
 class PromotionRule(ModelObjectType[models.PromotionRule]):
     id = graphene.GlobalID(required=True)
-    name = graphene.String(required=True, description="Name of the promotion rule.")
+    name = graphene.String(description="Name of the promotion rule.")
     description = JSON(description="Description of the promotion rule.")
     promotion = graphene.Field(
         Promotion, description="Promotion to which the rule belongs."

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -13634,7 +13634,7 @@ type PromotionRule implements Node @doc(category: "Discounts") {
   id: ID!
 
   """Name of the promotion rule."""
-  name: String!
+  name: String
 
   """Description of the promotion rule."""
   description: JSON

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -971,7 +971,7 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after
     # a sale is updated.
     sale_updated: Callable[
-        ["Sale", DefaultDict[str, Set[str]], DefaultDict[str, Set[str]], Any], Any
+        ["Promotion", DefaultDict[str, Set[str]], DefaultDict[str, Set[str]], Any], Any
     ]
 
     # Trigger when promotion is created.

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from ..core.middleware import Requestor
     from ..core.notify_events import NotifyEventType
     from ..core.taxes import TaxData, TaxType
-    from ..discount.models import Promotion, Sale, Voucher
+    from ..discount.models import Promotion, Voucher
     from ..giftcard.models import GiftCard
     from ..invoice.models import Invoice
     from ..menu.models import Menu, MenuItem
@@ -964,7 +964,7 @@ class BasePlugin:
     #
     # Overwrite this method if you need to trigger specific logic after
     # a sale is deleted.
-    sale_deleted: Callable[["Sale", DefaultDict[str, Set[str]], Any], Any]
+    sale_deleted: Callable[["Promotion", DefaultDict[str, Set[str]], Any], Any]
 
     # Trigger when sale is updated.
     #

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -743,7 +743,7 @@ class PluginsManager(PaymentInterface):
             "sale_deleted", default_value, sale, previous_catalogue
         )
 
-    def sale_updated(self, sale: "Sale", previous_catalogue, current_catalogue):
+    def sale_updated(self, sale: "Promotion", previous_catalogue, current_catalogue):
         default_value = None
         return self.__run_method_on_plugins(
             "sale_updated", default_value, sale, previous_catalogue, current_catalogue

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
     from ..checkout.models import Checkout
     from ..core.middleware import Requestor
-    from ..discount.models import Promotion, Sale, Voucher
+    from ..discount.models import Promotion, Voucher
     from ..giftcard.models import GiftCard
     from ..invoice.models import Invoice
     from ..menu.models import Menu, MenuItem
@@ -737,7 +737,7 @@ class PluginsManager(PaymentInterface):
             "sale_created", default_value, sale, current_catalogue
         )
 
-    def sale_deleted(self, sale: "Sale", previous_catalogue):
+    def sale_deleted(self, sale: "Promotion", previous_catalogue):
         default_value = None
         return self.__run_method_on_plugins(
             "sale_deleted", default_value, sale, previous_catalogue

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from ...checkout.fetch import CheckoutInfo, CheckoutLineInfo
     from ...checkout.models import Checkout
     from ...core.models import EventDelivery
-    from ...discount.models import Promotion, Sale
+    from ...discount.models import Promotion
     from ...order.models import Order, OrderLine
     from ...product.models import Product, ProductVariant
 
@@ -235,7 +235,7 @@ class PluginSample(BasePlugin):
 
     def sale_deleted(
         self,
-        sale: "Sale",
+        sale: "Promotion",
         previous_catalogue: DefaultDict[str, Set[str]],
         previous_value: Any,
     ):

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -226,7 +226,7 @@ class PluginSample(BasePlugin):
 
     def sale_updated(
         self,
-        sale: "Sale",
+        sale: "Promotion",
         previous_catalogue: DefaultDict[str, Set[str]],
         current_catalogue: DefaultDict[str, Set[str]],
         previous_value: Any,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -88,7 +88,7 @@ if TYPE_CHECKING:
     from ...account.models import Address, Group, User
     from ...attribute.models import Attribute, AttributeValue
     from ...channel.models import Channel
-    from ...discount.models import Promotion, Sale, Voucher
+    from ...discount.models import Promotion, Voucher
     from ...giftcard.models import GiftCard
     from ...invoice.models import Invoice
     from ...menu.models import Menu, MenuItem
@@ -760,7 +760,7 @@ class WebhookPlugin(BasePlugin):
 
     def sale_deleted(
         self,
-        sale: "Sale",
+        sale: "Promotion",
         previous_catalogue: DefaultDict[str, Set[str]],
         previous_value: Any,
     ) -> Any:

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -742,7 +742,7 @@ class WebhookPlugin(BasePlugin):
 
     def sale_updated(
         self,
-        sale: "Sale",
+        sale: "Promotion",
         previous_catalogue: DefaultDict[str, Set[str]],
         current_catalogue: DefaultDict[str, Set[str]],
         previous_value: Any,

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1500,10 +1500,9 @@ def test_sale_created(promotion_converted_from_sale, subscription_sale_created_w
     assert deliveries[0].webhook == webhooks[0]
 
 
-# TODO will be fixed in PR refactoring the mutation
-@pytest.mark.skip
-def test_sale_updated(sale, subscription_sale_updated_webhook):
+def test_sale_updated(promotion_converted_from_sale, subscription_sale_updated_webhook):
     # given
+    sale = promotion_converted_from_sale
     webhooks = [subscription_sale_updated_webhook]
     event_type = WebhookEventAsyncType.SALE_UPDATED
     expected_payload = generate_sale_payload(sale)

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1516,10 +1516,9 @@ def test_sale_updated(promotion_converted_from_sale, subscription_sale_updated_w
     assert deliveries[0].webhook == webhooks[0]
 
 
-# TODO will be fixed in PR refactoring the mutation
-@pytest.mark.skip
-def test_sale_deleted(sale, subscription_sale_deleted_webhook):
+def test_sale_deleted(promotion_converted_from_sale, subscription_sale_deleted_webhook):
     # given
+    sale = promotion_converted_from_sale
     webhooks = [subscription_sale_deleted_webhook]
     event_type = WebhookEventAsyncType.SALE_DELETED
     expected_payload = generate_sale_payload(sale)
@@ -1533,10 +1532,9 @@ def test_sale_deleted(sale, subscription_sale_deleted_webhook):
     assert deliveries[0].webhook == webhooks[0]
 
 
-# TODO will be fixed in PR refactoring the mutation
-@pytest.mark.skip
-def test_sale_toggle(sale, subscription_sale_toggle_webhook):
+def test_sale_toggle(promotion_converted_from_sale, subscription_sale_toggle_webhook):
     # given
+    sale = promotion_converted_from_sale
     webhooks = [subscription_sale_toggle_webhook]
     event_type = WebhookEventAsyncType.SALE_TOGGLE
     expected_payload = generate_sale_payload(sale)


### PR DESCRIPTION
I want to merge this change, because it makes `saleDelete` mutation compatible with new Promotion model.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
