### PR TITLE
Add `notify_customer` flag to `FulfillmentApproved` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ in 3.17. Use `PaymentSettings.defaultTransactionFlowStrategy` instead.
 - Add `STORED_PAYMENT_METHOD_DELETE_REQUESTED` webhook event - #13660 by @korycins
 - Add `NOTIFY_CUSTOMER` flag to `FulfillmentCreated` type - #13620, by @Air-t
   - Inform apps if customer should be notified when fulfillment is created.
+- Add `NOTIFY_CUSTOMER` flag to `FulfillmentApproved` type - #13637, by @Air-t
+  - Inform apps if customer should be notified when fulfillment is approved.
 
 ### Other changes
 - Fix error in variant available stock calculation - 13593 by @awaisdar001

--- a/saleor/graphql/order/mutations/fulfillment_approve.py
+++ b/saleor/graphql/order/mutations/fulfillment_approve.py
@@ -9,12 +9,14 @@ from ....order import FulfillmentStatus
 from ....order.actions import approve_fulfillment
 from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_31
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
+from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ...site.dataloaders import get_site_promise
 from ..types import Fulfillment, Order
@@ -41,6 +43,12 @@ class FulfillmentApprove(BaseMutation):
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.FULFILLMENT_APPROVED,
+                description="Fulfillment is approved.",
+            ),
+        ]
 
     @classmethod
     def clean_input(cls, info: ResolveInfo, fulfillment):

--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -115,6 +115,10 @@ class OrderFulfill(BaseMutation):
                 type=WebhookEventAsyncType.ORDER_FULFILLED,
                 description="Order is fulfilled.",
             ),
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.FULFILLMENT_APPROVED,
+                description="A fulfillment is approved.",
+            ),
         ]
 
     @classmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15913,6 +15913,7 @@ type Mutation {
   Triggers the following webhook events:
   - FULFILLMENT_CREATED (async): A new fulfillment is created.
   - ORDER_FULFILLED (async): Order is fulfilled.
+  - FULFILLMENT_APPROVED (async): A fulfillment is approved.
   """
   orderFulfill(
     """Fields required to create a fulfillment."""
@@ -15920,7 +15921,7 @@ type Mutation {
 
     """ID of the order to be fulfilled."""
     order: ID
-  ): OrderFulfill @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_CREATED, ORDER_FULFILLED], syncEvents: [])
+  ): OrderFulfill @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_CREATED, ORDER_FULFILLED, FULFILLMENT_APPROVED], syncEvents: [])
 
   """
   Cancels existing fulfillment and optionally restocks items. 
@@ -15941,6 +15942,9 @@ type Mutation {
   Added in Saleor 3.1. 
   
   Requires one of the following permissions: MANAGE_ORDERS.
+  
+  Triggers the following webhook events:
+  - FULFILLMENT_APPROVED (async): Fulfillment is approved.
   """
   orderFulfillmentApprove(
     """True if stock could be exceeded."""
@@ -15951,7 +15955,7 @@ type Mutation {
 
     """True if confirmation email should be send."""
     notifyCustomer: Boolean!
-  ): FulfillmentApprove @doc(category: "Orders")
+  ): FulfillmentApprove @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_APPROVED], syncEvents: [])
 
   """
   Updates a fulfillment for an order. 
@@ -23781,8 +23785,9 @@ Requires one of the following permissions: MANAGE_ORDERS.
 Triggers the following webhook events:
 - FULFILLMENT_CREATED (async): A new fulfillment is created.
 - ORDER_FULFILLED (async): Order is fulfilled.
+- FULFILLMENT_APPROVED (async): A fulfillment is approved.
 """
-type OrderFulfill @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_CREATED, ORDER_FULFILLED], syncEvents: []) {
+type OrderFulfill @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_CREATED, ORDER_FULFILLED, FULFILLMENT_APPROVED], syncEvents: []) {
   """List of created fulfillments."""
   fulfillments: [Fulfillment!]
 
@@ -23854,8 +23859,11 @@ Approve existing fulfillment.
 Added in Saleor 3.1. 
 
 Requires one of the following permissions: MANAGE_ORDERS.
+
+Triggers the following webhook events:
+- FULFILLMENT_APPROVED (async): Fulfillment is approved.
 """
-type FulfillmentApprove @doc(category: "Orders") {
+type FulfillmentApprove @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_APPROVED], syncEvents: []) {
   """An approved fulfillment."""
   fulfillment: Fulfillment
 
@@ -31469,7 +31477,7 @@ type FulfillmentCreated implements Event @doc(category: "Orders") {
   order: Order
 
   """
-  If true, send an email notification to the customer.
+  If true, the app should send a notification to the customer.
   
   Added in Saleor 3.16.
   """
@@ -31524,6 +31532,13 @@ type FulfillmentApproved implements Event @doc(category: "Orders") {
 
   """The order the fulfillment belongs to."""
   order: Order
+
+  """
+  If true, send a notification to the customer.
+  
+  Added in Saleor 3.16.
+  """
+  notifyCustomer: Boolean!
 }
 
 """

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1165,7 +1165,8 @@ class FulfillmentBase(AbstractType):
 class FulfillmentCreated(SubscriptionObjectType, FulfillmentBase):
     notify_customer = graphene.Boolean(
         description=(
-            "If true, send an email notification to the customer." + ADDED_IN_316
+            "If true, the app should send a notification to the customer."
+            + ADDED_IN_316
         ),
         required=True,
     )
@@ -1202,11 +1203,32 @@ class FulfillmentCanceled(SubscriptionObjectType, FulfillmentBase):
 
 
 class FulfillmentApproved(SubscriptionObjectType, FulfillmentBase):
+    notify_customer = graphene.Boolean(
+        description="If true, send a notification to the customer." + ADDED_IN_316,
+        required=True,
+    )
+
     class Meta:
+        doc_category = DOC_CATEGORY_ORDERS
         root_type = "Fulfillment"
-        enable_dry_run = True
+        enable_dry_run = False
         interfaces = (Event,)
         description = "Event sent when fulfillment is approved." + ADDED_IN_37
+
+    @staticmethod
+    def resolve_fulfillment(root, info: ResolveInfo):
+        _, data = root
+        return data["fulfillment"]
+
+    @staticmethod
+    def resolve_order(root, info: ResolveInfo):
+        _, data = root
+        return data["fulfillment"].order
+
+    @staticmethod
+    def resolve_notify_customer(root, _info: ResolveInfo):
+        _, data = root
+        return data["notify_customer"]
 
 
 class FulfillmentMetadataUpdated(SubscriptionObjectType, FulfillmentBase):

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
@@ -273,7 +273,6 @@ def async_subscription_webhooks_with_root_objects(
     subscription_invoice_deleted_webhook,
     subscription_invoice_sent_webhook,
     subscription_fulfillment_canceled_webhook,
-    subscription_fulfillment_approved_webhook,
     subscription_fulfillment_metadata_updated_webhook,
     subscription_customer_created_webhook,
     subscription_customer_updated_webhook,
@@ -469,10 +468,6 @@ def async_subscription_webhooks_with_root_objects(
         events.INVOICE_SENT: [subscription_invoice_sent_webhook, invoice],
         events.FULFILLMENT_CANCELED: [
             subscription_fulfillment_canceled_webhook,
-            fulfillment,
-        ],
-        events.FULFILLMENT_APPROVED: [
-            subscription_fulfillment_approved_webhook,
             fulfillment,
         ],
         events.FULFILLMENT_METADATA_UPDATED: [

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -563,7 +563,7 @@ def approve_fulfillment(
         update_order_status(order)
 
         call_event(manager.order_updated, order)
-        call_event(manager.fulfillment_approved, fulfillment)
+        call_event(manager.fulfillment_approved, fulfillment, notify_customer)
         if order.status == OrderStatus.FULFILLED:
             call_event(manager.order_fulfilled, order)
 

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -875,13 +875,16 @@ class PluginsManager(PaymentInterface):
             channel_slug=fulfillment.order.channel.slug,
         )
 
-    def fulfillment_approved(self, fulfillment: "Fulfillment"):
+    def fulfillment_approved(
+        self, fulfillment: "Fulfillment", notify_customer: Optional[bool] = True
+    ):
         default_value = None
         return self.__run_method_on_plugins(
             "fulfillment_approved",
             default_value,
             fulfillment,
             channel_slug=fulfillment.order.channel.slug,
+            notify_customer=notify_customer,
         )
 
     def fulfillment_metadata_updated(self, fulfillment: "Fulfillment"):

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -958,14 +958,26 @@ class WebhookPlugin(BasePlugin):
                 fulfillment_data, event_type, webhooks, fulfillment, self.requestor
             )
 
-    def fulfillment_approved(self, fulfillment: "Fulfillment", previous_value):
+    def fulfillment_approved(
+        self,
+        fulfillment: "Fulfillment",
+        notify_customer: Optional[bool] = True,
+        previous_value: Optional[Any] = None,
+    ):
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.FULFILLMENT_APPROVED
         if webhooks := get_webhooks_for_event(event_type):
             fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
             trigger_webhooks_async(
-                fulfillment_data, event_type, webhooks, fulfillment, self.requestor
+                fulfillment_data,
+                event_type,
+                webhooks,
+                {
+                    "fulfillment": fulfillment,
+                    "notify_customer": notify_customer,
+                },
+                self.requestor,
             )
 
     def fulfillment_metadata_updated(self, fulfillment: "Fulfillment", previous_value):

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1372,12 +1372,14 @@ FULFILLMENT_CANCELED = (
 """
 )
 
+
 FULFILLMENT_APPROVED = (
     fragments.FULFILLMENT_DETAILS
     + """
     subscription{
       event{
         ...on FulfillmentApproved{
+          notifyCustomer
           fulfillment{
             ...FulfillmentDetails
           }

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1691,13 +1691,22 @@ def test_fulfillment_approved(fulfillment, subscription_fulfillment_approved_web
     # given
     webhooks = [subscription_fulfillment_approved_webhook]
     event_type = WebhookEventAsyncType.FULFILLMENT_APPROVED
-    expected_payload = generate_fulfillment_payload(fulfillment)
+    expected_payload = generate_fulfillment_payload(
+        fulfillment, add_notify_customer_field=True
+    )
 
     # when
-    deliveries = create_deliveries_for_subscriptions(event_type, fulfillment, webhooks)
+    deliveries = create_deliveries_for_subscriptions(
+        event_type,
+        {
+            "fulfillment": fulfillment,
+            "notify_customer": True,
+        },
+        webhooks,
+    )
 
     # then
-    assert deliveries[0].payload.payload == json.dumps(expected_payload)
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
 


### PR DESCRIPTION
I want to merge this change because it allows to determine if customer should be informed when fulfilment is approved

Resolves https://github.com/saleor/saleor/issues/13561

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
