### PR TITLE
Fix how multiple giftcards are applied

### DIFF
--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -188,8 +188,7 @@ def test_create_order_with_many_gift_cards_worth_more_than_total(
     gift_cards_balance_before_order = (
         gift_card_1.current_balance.amount + gift_card_2.current_balance.amount
     )
-    checkout.gift_cards.add(gift_card_2)
-    checkout.gift_cards.add(gift_card_1)
+    checkout.gift_cards.add(gift_card_2, gift_card_1)
     checkout.save()
     checkout_lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, checkout_lines, manager)
@@ -207,7 +206,7 @@ def test_create_order_with_many_gift_cards_worth_more_than_total(
     zero_price = zero_money(gift_card.currency)
 
     # then
-    assert order.gift_cards.count() > 0
+    assert order.gift_cards.count() == 2
     assert gift_card_1.current_balance == zero_price
     assert gift_card_2.current_balance.amount == gift_card_2_balance_halved
     assert price_without_gift_card.gross.amount == (

--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -151,6 +151,76 @@ def test_create_order_with_gift_card_partial_use(
     )
 
 
+def test_create_order_with_many_gift_cards_worth_more_than_total(
+    checkout_with_items_and_shipping,
+    gift_card_created_by_staff,
+    gift_card,
+    customer_user,
+    shipping_method,
+    app,
+):
+    # given
+    gift_card_1 = gift_card_created_by_staff
+    gift_card_2 = gift_card
+    checkout = checkout_with_items_and_shipping
+    checkout.user = customer_user
+    checkout.save()
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    price_without_gift_card = calculations.checkout_total(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=checkout.shipping_address,
+    )
+    gift_card_2_old_balance = gift_card_2.current_balance.amount
+    gift_card_2_balance_halved = gift_card_2_old_balance / 2
+    gift_card_2_new_balance = (
+        price_without_gift_card.gross.amount - gift_card_2_balance_halved
+    )
+
+    gift_card_2.current_balance_amount = gift_card_2_new_balance
+    gift_card_2.initial_balance_amount = gift_card_2_new_balance
+    gift_card_2.save()
+    gift_cards_balance_before_order = (
+        gift_card_1.current_balance.amount + gift_card_2.current_balance.amount
+    )
+    checkout.gift_cards.add(gift_card_2)
+    checkout.gift_cards.add(gift_card_1)
+    checkout.save()
+    checkout_lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, checkout_lines, manager)
+
+    # when
+    order = create_order_from_checkout(
+        checkout_info=checkout_info,
+        manager=manager,
+        user=None,
+        app=app,
+        tracking_code="tracking_code",
+    )
+    gift_card_1.refresh_from_db()
+    gift_card_2.refresh_from_db()
+    zero_price = zero_money(gift_card.currency)
+
+    # then
+    assert order.gift_cards.count() > 0
+    assert gift_card_1.current_balance == zero_price
+    assert gift_card_2.current_balance.amount == gift_card_2_balance_halved
+    assert price_without_gift_card.gross.amount == (
+        gift_cards_balance_before_order - gift_card_2_balance_halved
+    )
+    assert GiftCardEvent.objects.filter(
+        gift_card=gift_card_created_by_staff, type=GiftCardEvents.USED_IN_ORDER
+    )
+    assert GiftCardEvent.objects.filter(
+        gift_card=gift_card, type=GiftCardEvents.USED_IN_ORDER
+    )
+
+
 def test_create_order_with_many_gift_cards(
     checkout_with_item,
     gift_card_created_by_staff,

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -306,7 +306,7 @@ def test_add_gift_cards_to_order(
 
     # when
     add_gift_cards_to_order(
-        checkout_info, order, Money(20, gift_card.currency), staff_user, None
+        checkout_info, order, Money(30, gift_card.currency), staff_user, None
     )
 
     # then
@@ -347,6 +347,34 @@ def test_add_gift_cards_to_order(
     }
 
 
+def test_add_gift_cards_to_order_with_more_than_total(
+    checkout_with_item, gift_card, gift_card_expiry_date, order, staff_user
+):
+    # given
+    checkout = checkout_with_item
+    checkout.user = staff_user
+    checkout.gift_cards.add(gift_card_expiry_date)
+    checkout.gift_cards.add(gift_card)
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    # when
+    add_gift_cards_to_order(
+        checkout_info, order, Money(25, gift_card.currency), staff_user, None
+    )
+
+    # then
+    gift_card.refresh_from_db()
+    gift_card_expiry_date.refresh_from_db()
+    assert gift_card.current_balance_amount == Decimal(5)
+    assert gift_card_expiry_date.current_balance_amount == 0
+    assert gift_card.used_by == staff_user
+    assert gift_card.used_by_email == staff_user.email
+    assert gift_card_expiry_date.used_by == staff_user
+    assert gift_card_expiry_date.used_by_email == staff_user.email
+
+
 def test_add_gift_cards_to_order_no_checkout_user(
     checkout_with_item, gift_card, gift_card_expiry_date, order, staff_user
 ):
@@ -363,7 +391,7 @@ def test_add_gift_cards_to_order_no_checkout_user(
 
     # when
     add_gift_cards_to_order(
-        checkout_info, order, Money(20, gift_card.currency), staff_user, None
+        checkout_info, order, Money(30, gift_card.currency), staff_user, None
     )
 
     # then

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -353,8 +353,7 @@ def test_add_gift_cards_to_order_with_more_than_total(
     # given
     checkout = checkout_with_item
     checkout.user = staff_user
-    checkout.gift_cards.add(gift_card_expiry_date)
-    checkout.gift_cards.add(gift_card)
+    checkout.gift_cards.add(gift_card_expiry_date, gift_card)
     manager = get_plugins_manager()
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -431,7 +431,7 @@ def update_gift_card_balance(
     gift_card: GiftCard,
     total_price_left: Money,
     balance_data: List[Tuple[GiftCard, float]],
-):
+) -> Money:
     previous_balance = gift_card.current_balance
     if total_price_left < gift_card.current_balance:
         gift_card.current_balance = gift_card.current_balance - total_price_left

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -407,7 +407,9 @@ def add_gift_cards_to_order(
         if total_price_left > zero_money(total_price_left.currency):
             order_gift_cards.append(gift_card)
 
-            update_gift_card_balance(gift_card, total_price_left, balance_data)
+            total_price_left = update_gift_card_balance(
+                gift_card, total_price_left, balance_data
+            )
 
             set_gift_card_user(gift_card, used_by_user, used_by_email)
 
@@ -438,6 +440,7 @@ def update_gift_card_balance(
         total_price_left = total_price_left - gift_card.current_balance
         gift_card.current_balance_amount = 0
     balance_data.append((gift_card, previous_balance.amount))
+    return total_price_left
 
 
 def set_gift_card_user(


### PR DESCRIPTION
I want to merge this change because it fixes [#13640](https://github.com/saleor/saleor/issues/13640) 
Multiple gift cards, that have overall balance bigger than total price, were both used up instead of having remaining change in giftcard. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
