### PR TITLE
Extends AttributeValue Create/Update/Delete permission system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `enable_account_confirmation_by_email` to `SiteSettings` model and allow to update it via `shopSettingsUpdate` mutation - #12781 by @SzymJ
 - Add `brand` optional field with brand data (initially logo image) to `Manifest`, `AppInstallation` and `App` - #12361 by @przlada
 - Add `externalReference` field to `AttributeValueInput`, `BulkAttributeValueInput` and `AttributeValueSelectableTypeInput` - #12823 by @SzymJ
+- Extends `AttributeValue` Create/Update/Delete permission system - #13650 by @8r2y5
 
 ### Saleor Apps
 

--- a/saleor/graphql/attribute/constants.py
+++ b/saleor/graphql/attribute/constants.py
@@ -1,0 +1,42 @@
+from ...permission.enums import (
+    PagePermissions,
+    ProductPermissions,
+    ProductTypePermissions,
+)
+from .enums import AttributeTypeEnum
+from .utils import prepare_permission_text_for_description
+
+CREATE_PERMISSIONS_MAP = {
+    AttributeTypeEnum.PRODUCT_TYPE.value: (
+        ProductPermissions.MANAGE_PRODUCTS,
+        ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+    ),
+    AttributeTypeEnum.PAGE_TYPE.value: (
+        ProductPermissions.MANAGE_PRODUCTS,
+        PagePermissions.MANAGE_PAGES,
+        ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+    ),
+}
+CREATE_PRODUCT_TYPE_PERMISSIONS_TEXT = prepare_permission_text_for_description(
+    CREATE_PERMISSIONS_MAP[AttributeTypeEnum.PRODUCT_TYPE.value]
+)
+CREATE_PAGE_TYPE_PERMISSIONS_TEXT = prepare_permission_text_for_description(
+    CREATE_PERMISSIONS_MAP[AttributeTypeEnum.PAGE_TYPE.value]
+)
+
+UPDATE_DELETE_PERMISSIONS_MAP = {
+    AttributeTypeEnum.PRODUCT_TYPE.value: (
+        ProductPermissions.MANAGE_PRODUCTS,
+        ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+    ),
+    AttributeTypeEnum.PAGE_TYPE.value: (
+        PagePermissions.MANAGE_PAGES,
+        ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+    ),
+}
+UPDATE_DELETE_PRODUCT_TYPE_PERMISSIONS_TEXT = prepare_permission_text_for_description(
+    UPDATE_DELETE_PERMISSIONS_MAP[AttributeTypeEnum.PRODUCT_TYPE.value]
+)
+UPDATE_DELETE_PAGE_TYPE_PERMISSIONS_TEXT = prepare_permission_text_for_description(
+    UPDATE_DELETE_PERMISSIONS_MAP[AttributeTypeEnum.PAGE_TYPE.value]
+)

--- a/saleor/graphql/attribute/constants.py
+++ b/saleor/graphql/attribute/constants.py
@@ -4,39 +4,23 @@ from ...permission.enums import (
     ProductTypePermissions,
 )
 from .enums import AttributeTypeEnum
-from .utils import prepare_permission_text_for_description
 
-CREATE_PERMISSIONS_MAP = {
-    AttributeTypeEnum.PRODUCT_TYPE.value: (
-        ProductPermissions.MANAGE_PRODUCTS,
-        ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
-    ),
-    AttributeTypeEnum.PAGE_TYPE.value: (
-        ProductPermissions.MANAGE_PRODUCTS,
-        PagePermissions.MANAGE_PAGES,
-        ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
-    ),
+PERMISSIONS_MAP: dict = {
+    AttributeTypeEnum.PRODUCT_TYPE.value: {
+        "default": (
+            ProductPermissions.MANAGE_PRODUCTS,
+            ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+        )
+    },
+    AttributeTypeEnum.PAGE_TYPE.value: {
+        "default": (
+            PagePermissions.MANAGE_PAGES,
+            ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+        ),
+        "create": (
+            ProductPermissions.MANAGE_PRODUCTS,
+            PagePermissions.MANAGE_PAGES,
+            ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+        ),
+    },
 }
-CREATE_PRODUCT_TYPE_PERMISSIONS_TEXT = prepare_permission_text_for_description(
-    CREATE_PERMISSIONS_MAP[AttributeTypeEnum.PRODUCT_TYPE.value]
-)
-CREATE_PAGE_TYPE_PERMISSIONS_TEXT = prepare_permission_text_for_description(
-    CREATE_PERMISSIONS_MAP[AttributeTypeEnum.PAGE_TYPE.value]
-)
-
-UPDATE_DELETE_PERMISSIONS_MAP = {
-    AttributeTypeEnum.PRODUCT_TYPE.value: (
-        ProductPermissions.MANAGE_PRODUCTS,
-        ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
-    ),
-    AttributeTypeEnum.PAGE_TYPE.value: (
-        PagePermissions.MANAGE_PAGES,
-        ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
-    ),
-}
-UPDATE_DELETE_PRODUCT_TYPE_PERMISSIONS_TEXT = prepare_permission_text_for_description(
-    UPDATE_DELETE_PERMISSIONS_MAP[AttributeTypeEnum.PRODUCT_TYPE.value]
-)
-UPDATE_DELETE_PAGE_TYPE_PERMISSIONS_TEXT = prepare_permission_text_for_description(
-    UPDATE_DELETE_PERMISSIONS_MAP[AttributeTypeEnum.PAGE_TYPE.value]
-)

--- a/saleor/graphql/attribute/mutations/attribute_value_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_create.py
@@ -6,20 +6,18 @@ from django.core.exceptions import ValidationError
 from ....attribute import AttributeInputType
 from ....attribute import models as models
 from ....attribute.error_codes import AttributeErrorCode
-from ....core.exceptions import PermissionDenied
 from ....core.utils import generate_unique_slug
-from ....permission.enums import PagePermissions, ProductPermissions
-from ....permission.utils import (
-    has_one_of_permissions,
-    message_one_of_permissions_required,
-)
 from ...core import ResolveInfo
 from ...core.mutations import ModelMutation
 from ...core.types import AttributeError
 from ...plugins.dataloaders import get_plugin_manager_promise
-from ...utils import get_user_or_app_from_context
-from ..enums import AttributeTypeEnum
+from ..constants import (
+    CREATE_PAGE_TYPE_PERMISSIONS_TEXT,
+    CREATE_PERMISSIONS_MAP,
+    CREATE_PRODUCT_TYPE_PERMISSIONS_TEXT,
+)
 from ..types import Attribute, AttributeValue
+from ..utils import check_permissions_for_attribute
 from .attribute_create import AttributeValueCreateInput
 from .mixins import AttributeMixin
 from .validators import validate_value_is_unique
@@ -46,10 +44,13 @@ class AttributeValueCreate(AttributeMixin, ModelMutation):
         object_type = AttributeValue
         description = (
             "Creates a value for an attribute.\n\n"
-            "Depending on the attribute type, it requires different permissions to create:\n"
-            "`PRODUCT_TYPE` requires `MANAGE_PRODUCTS` permissions,\n"
-            "`PAGE_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PAGES` permissions.\n"
-            "DEPRECATED: it will be changed in 3.15."
+            "Depending on the attribute type, "
+            "it requires different permissions to create:\n"
+            f"`PRODUCT_TYPE` requires {CREATE_PRODUCT_TYPE_PERMISSIONS_TEXT} "
+            f"permissions,\n"
+            f"`PAGE_TYPE` requires {CREATE_PAGE_TYPE_PERMISSIONS_TEXT} permissions.\n"
+            "\n"
+            "DEPRECATED: those permissions will be changed in 4.0.\n"
         )
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
@@ -99,7 +100,7 @@ class AttributeValueCreate(AttributeMixin, ModelMutation):
     ):
         attribute = cls.get_node_or_error(info, attribute_id, only_type=Attribute)
         instance = models.AttributeValue(attribute=attribute)
-        cls._check_permissions_for_attribute(info.context, attribute)
+        check_permissions_for_attribute(info.context, attribute, CREATE_PERMISSIONS_MAP)
         cleaned_input = cls.clean_input(info, instance, input)
         instance = cls.construct_instance(instance, cleaned_input)
         cls.clean_instance(info, instance)
@@ -114,24 +115,3 @@ class AttributeValueCreate(AttributeMixin, ModelMutation):
         manager = get_plugin_manager_promise(info.context).get()
         cls.call_event(manager.attribute_value_created, instance)
         cls.call_event(manager.attribute_updated, instance.attribute)
-
-    @classmethod
-    def _check_permissions_for_attribute(cls, context, attribute):
-        if attribute.type == AttributeTypeEnum.PRODUCT_TYPE.value:
-            permissions = (ProductPermissions.MANAGE_PRODUCTS,)
-            if not cls.check_permissions(context, permissions):
-                raise PermissionDenied(permissions=permissions)
-
-        elif attribute.type == AttributeTypeEnum.PAGE_TYPE.value:
-            permissions = (
-                ProductPermissions.MANAGE_PRODUCTS,
-                PagePermissions.MANAGE_PAGES,
-            )
-            if not has_one_of_permissions(
-                get_user_or_app_from_context(context), permissions
-            ):
-                raise PermissionDenied(
-                    message=message_one_of_permissions_required(permissions).lstrip(
-                        "\n"
-                    )
-                )

--- a/saleor/graphql/attribute/mutations/attribute_value_create.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_create.py
@@ -11,11 +11,6 @@ from ...core import ResolveInfo
 from ...core.mutations import ModelMutation
 from ...core.types import AttributeError
 from ...plugins.dataloaders import get_plugin_manager_promise
-from ..constants import (
-    CREATE_PAGE_TYPE_PERMISSIONS_TEXT,
-    CREATE_PERMISSIONS_MAP,
-    CREATE_PRODUCT_TYPE_PERMISSIONS_TEXT,
-)
 from ..types import Attribute, AttributeValue
 from ..utils import check_permissions_for_attribute
 from .attribute_create import AttributeValueCreateInput
@@ -46,11 +41,14 @@ class AttributeValueCreate(AttributeMixin, ModelMutation):
             "Creates a value for an attribute.\n\n"
             "Depending on the attribute type, "
             "it requires different permissions to create:\n"
-            f"`PRODUCT_TYPE` requires {CREATE_PRODUCT_TYPE_PERMISSIONS_TEXT} "
-            f"permissions,\n"
-            f"`PAGE_TYPE` requires {CREATE_PAGE_TYPE_PERMISSIONS_TEXT} permissions.\n"
-            "\n"
-            "DEPRECATED: those permissions will be changed in 4.0.\n"
+            "-`PRODUCT_TYPE`: Requires one of the following permissions: "
+            "`MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.\n"
+            "-`PAGE_TYPE`: `MANAGE_PRODUCTS` or `MANAGE_PAGES` or "
+            "`MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.\n"
+            "\n\nDEPRECATED in Saleor 4.0, for attribute type:\n"
+            " - `PAGE_TYPE`, `MANAGE_PAGES` permission will be required,\n"
+            " - `PRODUCT_TYPE`, `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permission will "
+            "be required.\n"
         )
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
@@ -100,7 +98,7 @@ class AttributeValueCreate(AttributeMixin, ModelMutation):
     ):
         attribute = cls.get_node_or_error(info, attribute_id, only_type=Attribute)
         instance = models.AttributeValue(attribute=attribute)
-        check_permissions_for_attribute(info.context, attribute, CREATE_PERMISSIONS_MAP)
+        check_permissions_for_attribute(info.context, attribute, "create")
         cleaned_input = cls.clean_input(info, instance, input)
         instance = cls.construct_instance(instance, cleaned_input)
         cls.clean_instance(info, instance)

--- a/saleor/graphql/attribute/mutations/attribute_value_delete.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_delete.py
@@ -8,6 +8,11 @@ from ...core.descriptions import ADDED_IN_310
 from ...core.mutations import ModelDeleteMutation, ModelWithExtRefMutation
 from ...core.types import AttributeError
 from ...plugins.dataloaders import get_plugin_manager_promise
+from ..constants import (
+    UPDATE_DELETE_PAGE_TYPE_PERMISSIONS_TEXT,
+    UPDATE_DELETE_PERMISSIONS_MAP,
+    UPDATE_DELETE_PRODUCT_TYPE_PERMISSIONS_TEXT,
+)
 from ..types import Attribute, AttributeValue
 from ..utils import check_permissions_for_attribute
 
@@ -28,10 +33,13 @@ class AttributeValueDelete(ModelDeleteMutation, ModelWithExtRefMutation):
         object_type = AttributeValue
         description = (
             "Deletes a value of an attribute.\n\n"
-            "Depending on the attribute type, it requires different permissions to delete:\n"
-            "`PRODUCT_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,\n"
-            "`PAGE_TYPE` requires `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.\n"
-            "DEPRECATED: it will be changed in 3.15."
+            "Depending on the attribute type, "
+            "it requires different permissions to delete:\n"
+            "`PRODUCT_TYPE` requires "
+            f"{UPDATE_DELETE_PRODUCT_TYPE_PERMISSIONS_TEXT} permissions,\n"
+            f"`PAGE_TYPE` requires {UPDATE_DELETE_PAGE_TYPE_PERMISSIONS_TEXT} "
+            f"permissions.\n"
+            "DEPRECATED: those permissions will be changed in 4.0.\n"
         )
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
@@ -41,7 +49,9 @@ class AttributeValueDelete(ModelDeleteMutation, ModelWithExtRefMutation):
         cls, _root, info: ResolveInfo, /, *, external_reference=None, id=None
     ):
         instance = cls.get_instance(info, external_reference=external_reference, id=id)
-        check_permissions_for_attribute(info.context, instance.attribute)
+        check_permissions_for_attribute(
+            info.context, instance.attribute, UPDATE_DELETE_PERMISSIONS_MAP
+        )
         product_ids = cls.get_product_ids_to_update(instance)
         response = super().perform_mutation(
             _root, info, external_reference=external_reference, id=id

--- a/saleor/graphql/attribute/mutations/attribute_value_delete.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_delete.py
@@ -8,11 +8,6 @@ from ...core.descriptions import ADDED_IN_310
 from ...core.mutations import ModelDeleteMutation, ModelWithExtRefMutation
 from ...core.types import AttributeError
 from ...plugins.dataloaders import get_plugin_manager_promise
-from ..constants import (
-    UPDATE_DELETE_PAGE_TYPE_PERMISSIONS_TEXT,
-    UPDATE_DELETE_PERMISSIONS_MAP,
-    UPDATE_DELETE_PRODUCT_TYPE_PERMISSIONS_TEXT,
-)
 from ..types import Attribute, AttributeValue
 from ..utils import check_permissions_for_attribute
 
@@ -35,11 +30,14 @@ class AttributeValueDelete(ModelDeleteMutation, ModelWithExtRefMutation):
             "Deletes a value of an attribute.\n\n"
             "Depending on the attribute type, "
             "it requires different permissions to delete:\n"
-            "`PRODUCT_TYPE` requires "
-            f"{UPDATE_DELETE_PRODUCT_TYPE_PERMISSIONS_TEXT} permissions,\n"
-            f"`PAGE_TYPE` requires {UPDATE_DELETE_PAGE_TYPE_PERMISSIONS_TEXT} "
-            f"permissions.\n"
-            "DEPRECATED: those permissions will be changed in 4.0.\n"
+            "-`PRODUCT_TYPE`: Requires one of the following permissions: "
+            "`MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.\n"
+            "-`PAGE_TYPE`: `MANAGE_PRODUCTS` or `MANAGE_PAGES` or "
+            "`MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.\n"
+            "\n\nDEPRECATED in Saleor 4.0, for attribute type:\n"
+            " - `PAGE_TYPE`, `MANAGE_PAGES` permission will be required,\n"
+            " - `PRODUCT_TYPE`, `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permission will "
+            "be required.\n"
         )
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
@@ -49,9 +47,7 @@ class AttributeValueDelete(ModelDeleteMutation, ModelWithExtRefMutation):
         cls, _root, info: ResolveInfo, /, *, external_reference=None, id=None
     ):
         instance = cls.get_instance(info, external_reference=external_reference, id=id)
-        check_permissions_for_attribute(
-            info.context, instance.attribute, UPDATE_DELETE_PERMISSIONS_MAP
-        )
+        check_permissions_for_attribute(info.context, instance.attribute, "default")
         product_ids = cls.get_product_ids_to_update(instance)
         response = super().perform_mutation(
             _root, info, external_reference=external_reference, id=id

--- a/saleor/graphql/attribute/mutations/attribute_value_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_update.py
@@ -9,6 +9,11 @@ from ...core.descriptions import ADDED_IN_310
 from ...core.mutations import ModelWithExtRefMutation
 from ...core.types import AttributeError
 from ...plugins.dataloaders import get_plugin_manager_promise
+from ..constants import (
+    UPDATE_DELETE_PAGE_TYPE_PERMISSIONS_TEXT,
+    UPDATE_DELETE_PERMISSIONS_MAP,
+    UPDATE_DELETE_PRODUCT_TYPE_PERMISSIONS_TEXT,
+)
 from ..types import Attribute, AttributeValue
 from ..utils import check_permissions_for_attribute
 from .attribute_update import AttributeValueUpdateInput
@@ -57,10 +62,13 @@ class AttributeValueUpdate(AttributeValueCreate, ModelWithExtRefMutation):
         object_type = AttributeValue
         description = (
             "Updates value of an attribute.\n\n"
-            "Depending on the attribute type, it requires different permissions to update:\n"
-            "`PRODUCT_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,\n"
-            "`PAGE_TYPE` requires `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.\n"
-            "DEPRECATED: it will be changed in 3.15."
+            "Depending on the attribute type, "
+            "it requires different permissions to update:\n"
+            "`PRODUCT_TYPE` requires "
+            f"{UPDATE_DELETE_PRODUCT_TYPE_PERMISSIONS_TEXT} permissions,\n"
+            f"`PAGE_TYPE` requires {UPDATE_DELETE_PAGE_TYPE_PERMISSIONS_TEXT} "
+            f"permissions.\n"
+            "DEPRECATED: those permissions will be changed in 4.0.\n"
         )
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
@@ -78,7 +86,9 @@ class AttributeValueUpdate(AttributeValueCreate, ModelWithExtRefMutation):
     @classmethod
     def get_instance(cls, info, **data):
         instance = super().get_instance(info, **data)
-        check_permissions_for_attribute(info.context, instance.attribute)
+        check_permissions_for_attribute(
+            info.context, instance.attribute, UPDATE_DELETE_PERMISSIONS_MAP
+        )
         return instance
 
     @classmethod

--- a/saleor/graphql/attribute/mutations/attribute_value_update.py
+++ b/saleor/graphql/attribute/mutations/attribute_value_update.py
@@ -9,11 +9,6 @@ from ...core.descriptions import ADDED_IN_310
 from ...core.mutations import ModelWithExtRefMutation
 from ...core.types import AttributeError
 from ...plugins.dataloaders import get_plugin_manager_promise
-from ..constants import (
-    UPDATE_DELETE_PAGE_TYPE_PERMISSIONS_TEXT,
-    UPDATE_DELETE_PERMISSIONS_MAP,
-    UPDATE_DELETE_PRODUCT_TYPE_PERMISSIONS_TEXT,
-)
 from ..types import Attribute, AttributeValue
 from ..utils import check_permissions_for_attribute
 from .attribute_update import AttributeValueUpdateInput
@@ -64,11 +59,14 @@ class AttributeValueUpdate(AttributeValueCreate, ModelWithExtRefMutation):
             "Updates value of an attribute.\n\n"
             "Depending on the attribute type, "
             "it requires different permissions to update:\n"
-            "`PRODUCT_TYPE` requires "
-            f"{UPDATE_DELETE_PRODUCT_TYPE_PERMISSIONS_TEXT} permissions,\n"
-            f"`PAGE_TYPE` requires {UPDATE_DELETE_PAGE_TYPE_PERMISSIONS_TEXT} "
-            f"permissions.\n"
-            "DEPRECATED: those permissions will be changed in 4.0.\n"
+            "-`PRODUCT_TYPE`: Requires one of the following permissions: "
+            "`MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.\n"
+            "-`PAGE_TYPE`: `MANAGE_PRODUCTS` or `MANAGE_PAGES` or "
+            "`MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.\n"
+            "\n\nDEPRECATED in Saleor 4.0, for attribute type:\n"
+            " - `PAGE_TYPE`, `MANAGE_PAGES` permission will be required,\n"
+            " - `PRODUCT_TYPE`, `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permission will "
+            "be required.\n"
         )
         error_type_class = AttributeError
         error_type_field = "attribute_errors"
@@ -86,9 +84,7 @@ class AttributeValueUpdate(AttributeValueCreate, ModelWithExtRefMutation):
     @classmethod
     def get_instance(cls, info, **data):
         instance = super().get_instance(info, **data)
-        check_permissions_for_attribute(
-            info.context, instance.attribute, UPDATE_DELETE_PERMISSIONS_MAP
-        )
+        check_permissions_for_attribute(info.context, instance.attribute, "default")
         return instance
 
     @classmethod

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
@@ -450,8 +450,29 @@ def test_create_attribute_value_for_product_type_without_permissions(
     content = get_graphql_content(response, ignore_errors=True)
     assert (
         content["errors"][0]["message"]
-        == "You need one of the following permissions: MANAGE_PRODUCTS"
+        == "Requires one of the following permissions: MANAGE_PRODUCTS, "
+        "MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )
+
+
+def test_create_attribute_value_for_product_type_with_product_types_permission(
+    staff_api_client,
+    color_attribute,
+    permission_manage_product_types_and_attributes,
+):
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_ATTRIBUTE_VALUE_MUTATION,
+        {
+            "name": "test name",
+            "attributeId": graphene.Node.to_global_id("Attribute", color_attribute.id),
+        },
+        permissions=(permission_manage_product_types_and_attributes,),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["attributeValueCreate"]["errors"] == []
 
 
 def test_create_attribute_value_for_page_type_with_manage_products_permission(
@@ -469,6 +490,28 @@ def test_create_attribute_value_for_page_type_with_manage_products_permission(
             ),
         },
         permissions=(permission_manage_products,),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["attributeValueCreate"]["errors"] == []
+
+
+def test_create_attribute_value_for_page_type_with_manage_product_types_permission(
+    staff_api_client,
+    rich_text_attribute_page_type,
+    permission_manage_product_types_and_attributes,
+):
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_ATTRIBUTE_VALUE_MUTATION,
+        {
+            "name": "test name",
+            "attributeId": graphene.Node.to_global_id(
+                "Attribute", rich_text_attribute_page_type.id
+            ),
+        },
+        permissions=(permission_manage_product_types_and_attributes,),
     )
 
     # then
@@ -513,6 +556,6 @@ def test_create_attribute_value_for_page_type_without_permissions(
     # then
     content = get_graphql_content(response, ignore_errors=True)
     assert (
-        content["errors"][0]["message"]
-        == "Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_PAGES."
+        content["errors"][0]["message"] == "Requires one of the following permissions: "
+        "MANAGE_PRODUCTS, MANAGE_PAGES, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
@@ -450,7 +450,7 @@ def test_create_attribute_value_for_product_type_without_permissions(
     content = get_graphql_content(response, ignore_errors=True)
     assert (
         content["errors"][0]["message"]
-        == "Requires one of the following permissions: MANAGE_PRODUCTS, "
+        == "\n\nRequires one of the following permissions: MANAGE_PRODUCTS, "
         "MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )
 
@@ -555,7 +555,7 @@ def test_create_attribute_value_for_page_type_without_permissions(
 
     # then
     content = get_graphql_content(response, ignore_errors=True)
-    assert (
-        content["errors"][0]["message"] == "Requires one of the following permissions: "
+    assert content["errors"][0]["message"] == (
+        "\n\nRequires one of the following permissions: "
         "MANAGE_PRODUCTS, MANAGE_PAGES, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
@@ -335,8 +335,8 @@ def test_delete_record_for_product_type_without_permissions(
     # then
     content = get_graphql_content(response, ignore_errors=True)
     assert (
-        content["errors"][0]["message"]
-        == "Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
+        content["errors"][0]["message"] == "Requires one of the following permissions: "
+        "MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )
 
 
@@ -355,8 +355,8 @@ def test_delete_record_for_page_type_without_permissions(
     # then
     content = get_graphql_content(response, ignore_errors=True)
     assert (
-        content["errors"][0]["message"]
-        == "Requires one of the following permissions: MANAGE_PAGES, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
+        content["errors"][0]["message"] == "Requires one of the following permissions: "
+        "MANAGE_PAGES, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )
 
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
@@ -334,8 +334,8 @@ def test_delete_record_for_product_type_without_permissions(
 
     # then
     content = get_graphql_content(response, ignore_errors=True)
-    assert (
-        content["errors"][0]["message"] == "Requires one of the following permissions: "
+    assert content["errors"][0]["message"] == (
+        "\n\nRequires one of the following permissions: "
         "MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )
 
@@ -354,8 +354,8 @@ def test_delete_record_for_page_type_without_permissions(
 
     # then
     content = get_graphql_content(response, ignore_errors=True)
-    assert (
-        content["errors"][0]["message"] == "Requires one of the following permissions: "
+    assert content["errors"][0]["message"] == (
+        "\n\nRequires one of the following permissions: "
         "MANAGE_PAGES, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
@@ -281,7 +281,10 @@ def test_delete_attribute_value_by_both_id_and_external_reference(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[permission_manage_product_types_and_attributes],
+        check_no_permissions=False,
     )
     content = get_graphql_content(response)
 
@@ -305,10 +308,129 @@ def test_delete_attribute_value_by_external_reference_not_existing(
 
     # when
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_product_types_and_attributes]
+        query,
+        variables,
+        permissions=[permission_manage_product_types_and_attributes],
+        check_no_permissions=False,
     )
     content = get_graphql_content(response)
 
     # then
     errors = content["data"]["attributeValueDelete"]["errors"]
     assert errors[0]["message"] == f"Couldn't resolve to a node: {ext_ref}"
+
+
+def test_delete_record_for_product_type_without_permissions(
+    staff_api_client, swatch_attribute
+):
+    # given
+    value = swatch_attribute.values.first()
+    node_id = graphene.Node.to_global_id("AttributeValue", value.id)
+
+    # when
+    response = staff_api_client.post_graphql(
+        ATTRIBUTE_VALUE_DELETE_MUTATION, {"id": node_id}
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert (
+        content["errors"][0]["message"]
+        == "Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
+    )
+
+
+def test_delete_record_for_page_type_without_permissions(
+    staff_api_client, page_swatch_attribute
+):
+    # given
+    value = page_swatch_attribute.values.first()
+    node_id = graphene.Node.to_global_id("AttributeValue", value.id)
+
+    # when
+    response = staff_api_client.post_graphql(
+        ATTRIBUTE_VALUE_DELETE_MUTATION, {"id": node_id}
+    )
+
+    # then
+    content = get_graphql_content(response, ignore_errors=True)
+    assert (
+        content["errors"][0]["message"]
+        == "Requires one of the following permissions: MANAGE_PAGES, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
+    )
+
+
+def test_delete_record_for_product_type_with_manage_products(
+    staff_api_client, swatch_attribute, permission_manage_products
+):
+    # given
+    value = swatch_attribute.values.first()
+    node_id = graphene.Node.to_global_id("AttributeValue", value.id)
+
+    # when
+    response = staff_api_client.post_graphql(
+        ATTRIBUTE_VALUE_DELETE_MUTATION,
+        {"id": node_id},
+        permissions=[permission_manage_products],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert "errors" not in content["data"]["attributeValueDelete"]
+
+
+def test_delete_record_for_product_type_with_manage_product_types_and_attributes(
+    staff_api_client, swatch_attribute, permission_manage_product_types_and_attributes
+):
+    # given
+    value = swatch_attribute.values.first()
+    node_id = graphene.Node.to_global_id("AttributeValue", value.id)
+
+    # when
+    response = staff_api_client.post_graphql(
+        ATTRIBUTE_VALUE_DELETE_MUTATION,
+        {"id": node_id},
+        permissions=[permission_manage_product_types_and_attributes],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert "errors" not in content["data"]["attributeValueDelete"]
+
+
+def test_delete_record_for_page_type_with_permission_manage_pages(
+    staff_api_client, page_swatch_attribute, permission_manage_pages
+):
+    value = page_swatch_attribute.values.first()
+    node_id = graphene.Node.to_global_id("AttributeValue", value.id)
+
+    # when
+    response = staff_api_client.post_graphql(
+        ATTRIBUTE_VALUE_DELETE_MUTATION,
+        {"id": node_id},
+        permissions=[permission_manage_pages],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert "errors" not in content["data"]["attributeValueDelete"]
+
+
+def test_delete_record_for_page_type_with_manage_product_types_and_attributes(
+    staff_api_client,
+    page_swatch_attribute,
+    permission_manage_product_types_and_attributes,
+):
+    value = page_swatch_attribute.values.first()
+    node_id = graphene.Node.to_global_id("AttributeValue", value.id)
+
+    # when
+    response = staff_api_client.post_graphql(
+        ATTRIBUTE_VALUE_DELETE_MUTATION,
+        {"id": node_id},
+        permissions=[permission_manage_product_types_and_attributes],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert "errors" not in content["data"]["attributeValueDelete"]

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -639,7 +639,8 @@ def test_update_attribute_for_product_type_without_permissions(
     # then
     content = get_graphql_content(response, ignore_errors=True)
     assert (
-        content["errors"][0]["message"] == "Requires one of the following permissions: "
+        content["errors"][0]["message"]
+        == "\n\nRequires one of the following permissions: "
         "MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )
 
@@ -659,8 +660,8 @@ def test_update_attribute_for_page_type_without_permissions(
 
     # then
     content = get_graphql_content(response, ignore_errors=True)
-    assert (
-        content["errors"][0]["message"] == "Requires one of the following permissions: "
+    assert content["errors"][0]["message"] == (
+        "\n\nRequires one of the following permissions: "
         "MANAGE_PAGES, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -639,8 +639,8 @@ def test_update_attribute_for_product_type_without_permissions(
     # then
     content = get_graphql_content(response, ignore_errors=True)
     assert (
-        content["errors"][0]["message"]
-        == "Requires one of the following permissions: MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
+        content["errors"][0]["message"] == "Requires one of the following permissions: "
+        "MANAGE_PRODUCTS, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )
 
 
@@ -660,8 +660,8 @@ def test_update_attribute_for_page_type_without_permissions(
     # then
     content = get_graphql_content(response, ignore_errors=True)
     assert (
-        content["errors"][0]["message"]
-        == "Requires one of the following permissions: MANAGE_PAGES, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
+        content["errors"][0]["message"] == "Requires one of the following permissions: "
+        "MANAGE_PAGES, MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES."
     )
 
 

--- a/saleor/graphql/attribute/tests/test_utils.py
+++ b/saleor/graphql/attribute/tests/test_utils.py
@@ -6,16 +6,22 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from saleor.core.exceptions import PermissionDenied
-from saleor.permission.enums import ProductPermissions, ProductTypePermissions
+from saleor.permission.enums import (
+    PagePermissions,
+    ProductPermissions,
+    ProductTypePermissions,
+)
 
 from ....attribute import AttributeInputType
 from ....page.error_codes import PageErrorCode
 from ....product.error_codes import ProductErrorCode
+from ..constants import UPDATE_DELETE_PERMISSIONS_MAP
 from ..enums import AttributeTypeEnum
 from ..utils import (
     AttributeAssignmentMixin,
     AttrValuesForSelectableFieldInput,
     AttrValuesInput,
+    _validate_permissions_for_attribute,
     check_permissions_for_attribute,
     prepare_attribute_values,
     validate_attributes_input,
@@ -2174,67 +2180,109 @@ def test_check_permissions_for_attribute_unknown_type():
 
     # then
     with pytest.raises(RuntimeError, match="Unknown attribute type: test type"):
-        check_permissions_for_attribute(Mock(), mock_attribute)
+        check_permissions_for_attribute(Mock(), mock_attribute, {})
 
 
-@patch("saleor.graphql.attribute.utils.has_one_of_permissions")
-@patch("saleor.graphql.attribute.utils.get_user_or_app_from_context")
-@patch("saleor.graphql.attribute.utils.message_one_of_permissions_required")
-def test_check_permissions_for_attribute_product_type_have_permissions(
-    mock_message_one_of_permissions_required,
-    mock_get_user_or_app_from_context,
-    mock_has_one_of_permissions,
+@pytest.mark.parametrize(
+    "attribute_type, expected_permissions",
+    (
+        (
+            AttributeTypeEnum.PRODUCT_TYPE.value,
+            (
+                ProductPermissions.MANAGE_PRODUCTS,
+                ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+            ),
+        ),
+        (
+            AttributeTypeEnum.PAGE_TYPE.value,
+            (
+                PagePermissions.MANAGE_PAGES,
+                ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+            ),
+        ),
+    ),
+)
+@patch("saleor.graphql.attribute.utils._validate_permissions_for_attribute")
+def test_check_permissions_for_attribute_product_type_no_permissions(
+    mock__validate_permissions_for_attribute, attribute_type, expected_permissions
 ):
     # given
-    mock_has_one_of_permissions.return_value = True
-    mock_get_user_or_app_from_context.return_value = "test user"
-    mock_context = Mock()
-    mock_attribute = Mock(type=AttributeTypeEnum.PRODUCT_TYPE.value)
+    mock_attribute = Mock(type=attribute_type)
 
     # when
-    check_permissions_for_attribute(mock_context, mock_attribute)
+    check_permissions_for_attribute(
+        "test context", mock_attribute, UPDATE_DELETE_PERMISSIONS_MAP
+    )
 
     # then
-    mock_get_user_or_app_from_context.assert_called_once_with(mock_context)
-    mock_has_one_of_permissions.assert_called_once_with(
-        "test user",
-        (
-            ProductPermissions.MANAGE_PRODUCTS,
-            ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
-        ),
+    mock__validate_permissions_for_attribute.assert_called_once_with(
+        "test context", expected_permissions
     )
+
+
+@patch("saleor.graphql.attribute.utils.message_one_of_permissions_required")
+@patch("saleor.graphql.attribute.utils.has_one_of_permissions")
+@patch("saleor.graphql.attribute.utils.get_user_or_app_from_context")
+def test__validate_permissions_for_attribute_empty_permissions(
+    mock_get_user_or_app_from_context,
+    mock_has_one_of_permissions,
+    mock_message_one_of_permissions_required,
+):
+    # when
+    _validate_permissions_for_attribute("text context", [])
+
+    # then
+    mock_get_user_or_app_from_context.assert_not_called()
+    mock_has_one_of_permissions.assert_not_called()
     mock_message_one_of_permissions_required.assert_not_called()
 
 
+@patch("saleor.graphql.attribute.utils.message_one_of_permissions_required")
 @patch("saleor.graphql.attribute.utils.has_one_of_permissions")
 @patch("saleor.graphql.attribute.utils.get_user_or_app_from_context")
-@patch("saleor.graphql.attribute.utils.message_one_of_permissions_required")
-def test_check_permissions_for_attribute_product_type_no_permissions(
-    mock_message_one_of_permissions_required,
+def test__validate_permissions_for_attribute_requestor_has_no_permissions(
     mock_get_user_or_app_from_context,
     mock_has_one_of_permissions,
+    mock_message_one_of_permissions_required,
 ):
     # given
-    expected_permissions = (
-        ProductPermissions.MANAGE_PRODUCTS,
-        ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
-    )
+    mock_get_user_or_app_from_context.return_value = "test user or app"
     mock_has_one_of_permissions.return_value = False
-    mock_get_user_or_app_from_context.return_value = "test user"
-    mock_context = Mock()
-    mock_attribute = Mock(type=AttributeTypeEnum.PRODUCT_TYPE.value)
 
     # when
     with pytest.raises(PermissionDenied):
-        check_permissions_for_attribute(mock_context, mock_attribute)
+        _validate_permissions_for_attribute("text context", "test permissions")
 
     # then
-    mock_get_user_or_app_from_context.assert_called_once_with(mock_context)
+    mock_get_user_or_app_from_context.assert_called_once_with("text context")
     mock_has_one_of_permissions.assert_called_once_with(
-        "test user", expected_permissions
+        "test user or app", "test permissions"
     )
     assert mock_message_one_of_permissions_required.mock_calls == [
-        call(expected_permissions),
+        call("test permissions"),
         call().lstrip("\n"),
         call().lstrip().__bool__(),
     ]
+
+
+@patch("saleor.graphql.attribute.utils.message_one_of_permissions_required")
+@patch("saleor.graphql.attribute.utils.has_one_of_permissions")
+@patch("saleor.graphql.attribute.utils.get_user_or_app_from_context")
+def test__validate_permissions_for_attribute_requestor_has_permissions(
+    mock_get_user_or_app_from_context,
+    mock_has_one_of_permissions,
+    mock_message_one_of_permissions_required,
+):
+    # given
+    mock_get_user_or_app_from_context.return_value = "test user or app"
+    mock_has_one_of_permissions.return_value = True
+
+    # when
+    _validate_permissions_for_attribute("text context", "test permissions")
+
+    # then
+    mock_get_user_or_app_from_context.assert_called_once_with("text context")
+    mock_has_one_of_permissions.assert_called_once_with(
+        "test user or app", "test permissions"
+    )
+    mock_message_one_of_permissions_required.assert_not_called()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16557,10 +16557,13 @@ type Mutation {
   Creates a value for an attribute.
   
   Depending on the attribute type, it requires different permissions to create:
-  `PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
-  `PAGE_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+  -`PRODUCT_TYPE`: Requires one of the following permissions: `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
+  -`PAGE_TYPE`: `MANAGE_PRODUCTS` or `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
   
-  DEPRECATED: those permissions will be changed in 4.0.
+  
+  DEPRECATED in Saleor 4.0, for attribute type:
+   - `PAGE_TYPE`, `MANAGE_PAGES` permission will be required,
+   - `PRODUCT_TYPE`, `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permission will be required.
   """
   attributeValueCreate(
     """Attribute to which value will be assigned."""
@@ -16574,9 +16577,13 @@ type Mutation {
   Deletes a value of an attribute.
   
   Depending on the attribute type, it requires different permissions to delete:
-  `PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
-  `PAGE_TYPE` requires `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
-  DEPRECATED: those permissions will be changed in 4.0.
+  -`PRODUCT_TYPE`: Requires one of the following permissions: `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
+  -`PAGE_TYPE`: `MANAGE_PRODUCTS` or `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
+  
+  
+  DEPRECATED in Saleor 4.0, for attribute type:
+   - `PAGE_TYPE`, `MANAGE_PAGES` permission will be required,
+   - `PRODUCT_TYPE`, `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permission will be required.
   """
   attributeValueDelete(
     """
@@ -16594,9 +16601,13 @@ type Mutation {
   Updates value of an attribute.
   
   Depending on the attribute type, it requires different permissions to update:
-  `PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
-  `PAGE_TYPE` requires `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
-  DEPRECATED: those permissions will be changed in 4.0.
+  -`PRODUCT_TYPE`: Requires one of the following permissions: `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
+  -`PAGE_TYPE`: `MANAGE_PRODUCTS` or `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
+  
+  
+  DEPRECATED in Saleor 4.0, for attribute type:
+   - `PAGE_TYPE`, `MANAGE_PAGES` permission will be required,
+   - `PRODUCT_TYPE`, `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permission will be required.
   """
   attributeValueUpdate(
     """
@@ -25480,10 +25491,13 @@ type AttributeValueBulkDelete @doc(category: "Attributes") {
 Creates a value for an attribute.
 
 Depending on the attribute type, it requires different permissions to create:
-`PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
-`PAGE_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+-`PRODUCT_TYPE`: Requires one of the following permissions: `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
+-`PAGE_TYPE`: `MANAGE_PRODUCTS` or `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
 
-DEPRECATED: those permissions will be changed in 4.0.
+
+DEPRECATED in Saleor 4.0, for attribute type:
+ - `PAGE_TYPE`, `MANAGE_PAGES` permission will be required,
+ - `PRODUCT_TYPE`, `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permission will be required.
 """
 type AttributeValueCreate @doc(category: "Attributes") {
   """The updated attribute."""
@@ -25497,9 +25511,13 @@ type AttributeValueCreate @doc(category: "Attributes") {
 Deletes a value of an attribute.
 
 Depending on the attribute type, it requires different permissions to delete:
-`PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
-`PAGE_TYPE` requires `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
-DEPRECATED: those permissions will be changed in 4.0.
+-`PRODUCT_TYPE`: Requires one of the following permissions: `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
+-`PAGE_TYPE`: `MANAGE_PRODUCTS` or `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
+
+
+DEPRECATED in Saleor 4.0, for attribute type:
+ - `PAGE_TYPE`, `MANAGE_PAGES` permission will be required,
+ - `PRODUCT_TYPE`, `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permission will be required.
 """
 type AttributeValueDelete @doc(category: "Attributes") {
   """The updated attribute."""
@@ -25513,9 +25531,13 @@ type AttributeValueDelete @doc(category: "Attributes") {
 Updates value of an attribute.
 
 Depending on the attribute type, it requires different permissions to update:
-`PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
-`PAGE_TYPE` requires `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
-DEPRECATED: those permissions will be changed in 4.0.
+-`PRODUCT_TYPE`: Requires one of the following permissions: `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
+-`PAGE_TYPE`: `MANAGE_PRODUCTS` or `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
+
+
+DEPRECATED in Saleor 4.0, for attribute type:
+ - `PAGE_TYPE`, `MANAGE_PAGES` permission will be required,
+ - `PRODUCT_TYPE`, `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permission will be required.
 """
 type AttributeValueUpdate @doc(category: "Attributes") {
   """The updated attribute."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16554,9 +16554,12 @@ type Mutation {
   ): AttributeValueBulkDelete @doc(category: "Attributes")
 
   """
-  Creates a value for an attribute. 
+  Creates a value for an attribute.
   
-  Requires one of the following permissions: MANAGE_PRODUCTS.
+  Depending on the attribute type, it requires different permissions to create:
+  `PRODUCT_TYPE` requires `MANAGE_PRODUCTS` permissions,
+  `PAGE_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PAGES` permissions.
+  DEPRECATED: it will be changed in 3.15.
   """
   attributeValueCreate(
     """Attribute to which value will be assigned."""
@@ -16567,9 +16570,12 @@ type Mutation {
   ): AttributeValueCreate @doc(category: "Attributes")
 
   """
-  Deletes a value of an attribute. 
+  Deletes a value of an attribute.
   
-  Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Depending on the attribute type, it requires different permissions to delete:
+  `PRODUCT_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
+  `PAGE_TYPE` requires `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+  DEPRECATED: it will be changed in 3.15.
   """
   attributeValueDelete(
     """
@@ -16584,9 +16590,12 @@ type Mutation {
   ): AttributeValueDelete @doc(category: "Attributes")
 
   """
-  Updates value of an attribute. 
+  Updates value of an attribute.
   
-  Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+  Depending on the attribute type, it requires different permissions to update:
+  `PRODUCT_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
+  `PAGE_TYPE` requires `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+  DEPRECATED: it will be changed in 3.15.
   """
   attributeValueUpdate(
     """
@@ -25467,9 +25476,12 @@ type AttributeValueBulkDelete @doc(category: "Attributes") {
 }
 
 """
-Creates a value for an attribute. 
+Creates a value for an attribute.
 
-Requires one of the following permissions: MANAGE_PRODUCTS.
+Depending on the attribute type, it requires different permissions to create:
+`PRODUCT_TYPE` requires `MANAGE_PRODUCTS` permissions,
+`PAGE_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PAGES` permissions.
+DEPRECATED: it will be changed in 3.15.
 """
 type AttributeValueCreate @doc(category: "Attributes") {
   """The updated attribute."""
@@ -25480,9 +25492,12 @@ type AttributeValueCreate @doc(category: "Attributes") {
 }
 
 """
-Deletes a value of an attribute. 
+Deletes a value of an attribute.
 
-Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+Depending on the attribute type, it requires different permissions to delete:
+`PRODUCT_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
+`PAGE_TYPE` requires `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+DEPRECATED: it will be changed in 3.15.
 """
 type AttributeValueDelete @doc(category: "Attributes") {
   """The updated attribute."""
@@ -25493,9 +25508,12 @@ type AttributeValueDelete @doc(category: "Attributes") {
 }
 
 """
-Updates value of an attribute. 
+Updates value of an attribute.
 
-Requires one of the following permissions: MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES.
+Depending on the attribute type, it requires different permissions to update:
+`PRODUCT_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
+`PAGE_TYPE` requires `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+DEPRECATED: it will be changed in 3.15.
 """
 type AttributeValueUpdate @doc(category: "Attributes") {
   """The updated attribute."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -16557,9 +16557,10 @@ type Mutation {
   Creates a value for an attribute.
   
   Depending on the attribute type, it requires different permissions to create:
-  `PRODUCT_TYPE` requires `MANAGE_PRODUCTS` permissions,
-  `PAGE_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PAGES` permissions.
-  DEPRECATED: it will be changed in 3.15.
+  `PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
+  `PAGE_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+  
+  DEPRECATED: those permissions will be changed in 4.0.
   """
   attributeValueCreate(
     """Attribute to which value will be assigned."""
@@ -16573,9 +16574,9 @@ type Mutation {
   Deletes a value of an attribute.
   
   Depending on the attribute type, it requires different permissions to delete:
-  `PRODUCT_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
-  `PAGE_TYPE` requires `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
-  DEPRECATED: it will be changed in 3.15.
+  `PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
+  `PAGE_TYPE` requires `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+  DEPRECATED: those permissions will be changed in 4.0.
   """
   attributeValueDelete(
     """
@@ -16593,9 +16594,9 @@ type Mutation {
   Updates value of an attribute.
   
   Depending on the attribute type, it requires different permissions to update:
-  `PRODUCT_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
-  `PAGE_TYPE` requires `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
-  DEPRECATED: it will be changed in 3.15.
+  `PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
+  `PAGE_TYPE` requires `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+  DEPRECATED: those permissions will be changed in 4.0.
   """
   attributeValueUpdate(
     """
@@ -25479,9 +25480,10 @@ type AttributeValueBulkDelete @doc(category: "Attributes") {
 Creates a value for an attribute.
 
 Depending on the attribute type, it requires different permissions to create:
-`PRODUCT_TYPE` requires `MANAGE_PRODUCTS` permissions,
-`PAGE_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PAGES` permissions.
-DEPRECATED: it will be changed in 3.15.
+`PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
+`PAGE_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+
+DEPRECATED: those permissions will be changed in 4.0.
 """
 type AttributeValueCreate @doc(category: "Attributes") {
   """The updated attribute."""
@@ -25495,9 +25497,9 @@ type AttributeValueCreate @doc(category: "Attributes") {
 Deletes a value of an attribute.
 
 Depending on the attribute type, it requires different permissions to delete:
-`PRODUCT_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
-`PAGE_TYPE` requires `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
-DEPRECATED: it will be changed in 3.15.
+`PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
+`PAGE_TYPE` requires `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+DEPRECATED: those permissions will be changed in 4.0.
 """
 type AttributeValueDelete @doc(category: "Attributes") {
   """The updated attribute."""
@@ -25511,9 +25513,9 @@ type AttributeValueDelete @doc(category: "Attributes") {
 Updates value of an attribute.
 
 Depending on the attribute type, it requires different permissions to update:
-`PRODUCT_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
-`PAGE_TYPE` requires `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
-DEPRECATED: it will be changed in 3.15.
+`PRODUCT_TYPE` requires `ProductPermissions.MANAGE_PRODUCTS` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
+`PAGE_TYPE` requires `PagePermissions.MANAGE_PAGES` or `ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
+DEPRECATED: those permissions will be changed in 4.0.
 """
 type AttributeValueUpdate @doc(category: "Attributes") {
   """The updated attribute."""

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1839,6 +1839,23 @@ def swatch_attribute(db):
 
 
 @pytest.fixture
+def page_swatch_attribute(db):
+    attribute = Attribute.objects.create(
+        slug="T-shirt color",
+        name="t-shirt-color",
+        type=AttributeType.PAGE_TYPE,
+        input_type=AttributeInputType.SWATCH,
+        filterable_in_storefront=True,
+        filterable_in_dashboard=True,
+        available_in_grid=True,
+    )
+    AttributeValue.objects.create(
+        attribute=attribute, name="Blue", slug="blue", value="#0000ff"
+    )
+    return attribute
+
+
+@pytest.fixture
 def product_type_page_reference_attribute(db):
     return Attribute.objects.create(
         slug="page-reference",


### PR DESCRIPTION
I want to merge this change because it extends AttributeValue Create/Update/Delete permission system.

### Summary
To create AttributeValue for Attribute Type:
 - `PRODUCT_TYPE` requires, `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
   - Previously it required only `MANAGE_PRODUCT`.
 - `PAGE_TYPE` requires, `MANAGE_PRODUCT` or `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions. 
   - Previously it required only `MANAGE_PRODUCT`.
 
To update/delete AttributeValue for Attribute Type:
 - `PRODUCT_TYPE` requires `MANAGE_PRODUCTS` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions,
   - Previously it required only `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
 - `PAGE_TYPE` requires `MANAGE_PAGES` or `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES` permissions.
   - Previously it required only `MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES`.
   

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [x] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [x] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [x] The changes are covered by test cases
