### PR TITLE
Clear promotion `old_sale_id` when new promotion mutations is used

### DIFF
--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_create.py
@@ -16,6 +16,7 @@ from ...enums import PromotionRuleCreateErrorCode
 from ...types import PromotionRule
 from ...utils import get_products_for_rule
 from ...validators import clean_predicate
+from ..utils import clear_promotion_old_sale_id
 from .promotion_create import PromotionRuleInput
 
 
@@ -93,3 +94,4 @@ class PromotionRuleCreate(ModelMutation):
             update_products_discounted_prices_for_promotion_task.delay(
                 list(products.values_list("id", flat=True))
             )
+        clear_promotion_old_sale_id(instance.promotion, save=True)

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_delete.py
@@ -11,6 +11,7 @@ from ....core.types import Error
 from ...enums import PromotionRuleDeleteErrorCode
 from ...types import PromotionRule
 from ...utils import get_products_for_rule
+from ..utils import clear_promotion_old_sale_id
 
 
 class PromotionRuleDeleteError(Error):
@@ -43,7 +44,10 @@ class PromotionRuleDelete(ModelDeleteMutation):
         product_ids = list(products.values_list("id", flat=True))
 
         db_id = instance.id
+        promotion = instance.promotion
         instance.delete()
+
+        clear_promotion_old_sale_id(promotion, save=True)
 
         # After the instance is deleted, set its ID to the original database's
         # ID so that the success response contains ID of the deleted object.

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
@@ -16,6 +16,7 @@ from ...inputs import PromotionRuleBaseInput
 from ...types import PromotionRule
 from ...utils import get_products_for_rule
 from ...validators import clean_predicate
+from ..utils import clear_promotion_old_sale_id
 
 
 class PromotionRuleUpdateError(Error):
@@ -69,6 +70,7 @@ class PromotionRuleUpdate(ModelMutation):
         cls.clean_instance(info, instance)
         cls.save(info, instance, cleaned_input)
         cls._save_m2m(info, instance, cleaned_input)
+        clear_promotion_old_sale_id(instance.promotion, save=True)
 
         products = get_products_for_rule(instance)
         product_ids = set(products.values_list("id", flat=True)) | previous_product_ids

--- a/saleor/graphql/discount/mutations/promotion/promotion_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_update.py
@@ -18,6 +18,7 @@ from ....core.validators import validate_end_is_after_start
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...enums import PromotionUpdateErrorCode
 from ...types import Promotion
+from ..utils import clear_promotion_old_sale_id
 from .promotion_create import PromotionInput
 
 
@@ -54,6 +55,7 @@ class PromotionUpdate(ModelMutation):
         with transaction.atomic():
             instance = cls.construct_instance(instance, cleaned_input)
             cls.clean_instance(info, instance)
+            clear_promotion_old_sale_id(instance)
             cls.save(info, instance, cleaned_input)
             cls._save_m2m(info, instance, cleaned_input)
             # update the product undiscounted prices for promotion only when

--- a/saleor/graphql/discount/mutations/utils.py
+++ b/saleor/graphql/discount/mutations/utils.py
@@ -31,5 +31,5 @@ def clear_promotion_old_sale_id(promotion: Promotion, *, save=False):
     """Clear the promotion `old_sale_id` if set."""
     if promotion.old_sale_id:
         promotion.old_sale_id = None
-    if save:
-        promotion.save(update_fields=["old_sale_id"])
+        if save:
+            promotion.save(update_fields=["old_sale_id"])

--- a/saleor/graphql/discount/mutations/utils.py
+++ b/saleor/graphql/discount/mutations/utils.py
@@ -3,6 +3,7 @@ from typing import DefaultDict, Set
 
 import graphene
 
+from ....discount.models import Promotion
 from ....discount.utils import CatalogueInfo
 
 CATALOGUE_FIELD_TO_TYPE_NAME = {
@@ -24,3 +25,11 @@ def convert_catalogue_info_to_global_ids(
             for id_ in catalogue_info[catalogue_field]
         )
     return converted_catalogue_info
+
+
+def clear_promotion_old_sale_id(promotion: Promotion, *, save=False):
+    """Clear the promotion `old_sale_id` if set."""
+    if promotion.old_sale_id:
+        promotion.old_sale_id = None
+    if save:
+        promotion.save(update_fields=["old_sale_id"])


### PR DESCRIPTION
Clear promotion `old_sale_id` when any new promotion mutations is used for old sale

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
