### PR TITLE
Refactor sale channel listing update mutation.

### DIFF
--- a/saleor/discount/migrations/0045_promotion_promotionrule.py
+++ b/saleor/discount/migrations/0045_promotion_promotionrule.py
@@ -112,7 +112,12 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "reward_value",
-                    models.DecimalField(decimal_places=3, max_digits=12, null=True),
+                    models.DecimalField(
+                        decimal_places=3,
+                        max_digits=12,
+                        null=True,
+                        blank=True,
+                    ),
                 ),
                 ("channels", models.ManyToManyField(to="channel.Channel")),
                 (

--- a/saleor/discount/migrations/0050_old_sale_ids_sequence.py
+++ b/saleor/discount/migrations/0050_old_sale_ids_sequence.py
@@ -24,4 +24,21 @@ class Migration(migrations.Migration):
             ],
             reverse_sql=["DROP SEQUENCE discount_promotion_old_sale_id_seq"],
         ),
+        migrations.RunSQL(
+            sql=[
+                """
+            CREATE SEQUENCE discount_promotionrule_old_channel_listing_id_seq
+            OWNED BY discount_promotionrule.old_channel_listing_id;
+
+            SELECT setval(
+                'discount_promotionrule_old_channel_listing_id_seq',
+                 coalesce(max(old_channel_listing_id), 0) + 1, false
+            )
+            FROM discount_promotionrule;
+            """
+            ],
+            reverse_sql=[
+                "DROP SEQUENCE discount_promotionrule_old_channel_listing_id_seq"
+            ],
+        ),
     ]

--- a/saleor/discount/migrations/0050_old_sale_ids_sequence.py
+++ b/saleor/discount/migrations/0050_old_sale_ids_sequence.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
 
             SELECT setval(
                 'discount_promotionrule_old_channel_listing_id_seq',
-                 coalesce(max(old_channel_listing_id), 0) + 1, false
+                 coalesce(max(old_channel_listing_id), 0) + 1000, false
             )
             FROM discount_promotionrule;
             """

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -455,13 +455,16 @@ class PromotionRule(models.Model):
             )
         raise NotImplementedError("Unknown discount type")
 
-    def assign_old_channel_listing_id(self):
+    @staticmethod
+    def get_old_channel_listing_ids(qunatity):
         with connection.cursor() as cursor:
             cursor.execute(
-                "SELECT nextval('discount_promotionrule_old_channel_listing_id_seq')"
+                f"""
+                SELECT nextval('discount_promotionrule_old_channel_listing_id_seq')
+                FROM generate_series(1, {qunatity})
+                """
             )
-            result = cursor.fetchone()
-            self.old_channel_listing_id = result[0]
+            return cursor.fetchone()
 
 
 class PromotionRuleTranslation(Translation):

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -436,6 +436,7 @@ class PromotionRule(models.Model):
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
         null=True,
+        blank=True,
     )
     old_channel_listing_id = models.IntegerField(blank=True, null=True, unique=True)
 

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -464,7 +464,7 @@ class PromotionRule(models.Model):
                 FROM generate_series(1, {qunatity})
                 """
             )
-            return cursor.fetchone()
+            return cursor.fetchall()
 
 
 class PromotionRuleTranslation(Translation):

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -454,6 +454,14 @@ class PromotionRule(models.Model):
             )
         raise NotImplementedError("Unknown discount type")
 
+    def assign_old_channel_listing_id(self):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT nextval('discount_promotionrule_old_channel_listing_id_seq')"
+            )
+            result = cursor.fetchone()
+            self.old_channel_listing_id = result[0]
+
 
 class PromotionRuleTranslation(Translation):
     name = models.CharField(max_length=255, null=True, blank=True)

--- a/saleor/discount/sale_converter.py
+++ b/saleor/discount/sale_converter.py
@@ -128,14 +128,14 @@ def _create_promotion_rule(
 ):
     return PromotionRule(
         promotion=promotion,
-        catalogue_predicate=_create_catalogue_predicate_from_sale(sale),
+        catalogue_predicate=create_catalogue_predicate_from_sale(sale),
         reward_value_type=sale.type,
         reward_value=discount_value,
         old_channel_listing_id=old_channel_listing_id,
     )
 
 
-def _create_catalogue_predicate_from_sale(sale):
+def create_catalogue_predicate_from_sale(sale):
     collection_ids = [
         graphene.Node.to_global_id("Collection", pk)
         for pk in sale.collections.values_list("pk", flat=True)

--- a/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
@@ -85,7 +85,7 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
     def add_channels(cls, promotion: Promotion, add_channels: List[Dict]):
         rules_data_to_add: List[RuleInfo] = []
         rules_to_update: List[PromotionRule] = []
-        # TODO many database hits - potential refactor
+
         rules = promotion.rules.all()
         PromotionRuleChannel = PromotionRule.channels.through
         rule_ids = [rule.id for rule in rules]
@@ -93,7 +93,7 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
             promotionrule_id__in=rule_ids
         )
         current_channel_ids = rule_channel.values_list("channel_id", flat=True)
-        rule = rules[0]
+        examplart_rule = rules[0]
         for add_channel in add_channels:
             channel = add_channel["channel"]
             discount_value = add_channel["discount_value"]
@@ -102,10 +102,10 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
                 rules_data_to_add.append(
                     RuleInfo(
                         rule=PromotionRule(
-                            name=rule.name,
+                            name=examplart_rule.name,
                             promotion=promotion,
-                            catalogue_predicate=rule.catalogue_predicate,
-                            reward_value_type=rule.reward_value_type,
+                            catalogue_predicate=examplart_rule.catalogue_predicate,
+                            reward_value_type=examplart_rule.reward_value_type,
                             reward_value=discount_value,
                         ),
                         channel=channel,

--- a/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
@@ -22,7 +22,10 @@ from ....core.scalars import PositiveDecimal
 from ....core.types import BaseInputObjectType, DiscountError, NonNullList
 from ....core.validators import validate_price_precision
 from ....discount.types import Sale
-from ...dataloaders import SaleChannelListingByPromotionIdLoader
+from ...dataloaders import (
+    PromotionRulesByPromotionIdLoader,
+    SaleChannelListingByPromotionIdLoader,
+)
 
 
 @dataclass
@@ -228,6 +231,7 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
 
         # Invalidate dataloader for channel listings
         SaleChannelListingByPromotionIdLoader(info.context).clear(promotion.pk)
+        PromotionRulesByPromotionIdLoader(info.context).clear(promotion.pk)
 
         return SaleChannelListingUpdate(
             sale=ChannelContext(node=promotion, channel_slug=None)

--- a/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
@@ -22,6 +22,7 @@ from ....core.scalars import PositiveDecimal
 from ....core.types import BaseInputObjectType, DiscountError, NonNullList
 from ....core.validators import validate_price_precision
 from ....discount.types import Sale
+from ...dataloaders import SaleChannelListingByPromotionIdLoader
 
 
 @dataclass
@@ -224,6 +225,9 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
             raise ValidationError(errors)
 
         cls.save(info, promotion, cleaned_input)
+
+        # Invalidate dataloader for channel listings
+        SaleChannelListingByPromotionIdLoader(info.context).clear(promotion.pk)
 
         return SaleChannelListingUpdate(
             sale=ChannelContext(node=promotion, channel_slug=None)

--- a/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
@@ -124,7 +124,7 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
             len(rules_data_to_add)
         )
         for i in range(len(rules_data_to_add)):
-            rules_data_to_add[i].rule.old_channel_listing_id = old_listing_ids[i]
+            rules_data_to_add[i].rule.old_channel_listing_id = old_listing_ids[i][0]
 
         new_rules = [rule_data.rule for rule_data in rules_data_to_add]
         PromotionRule.objects.bulk_create(new_rules)

--- a/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, List
-from uuid import UUID
 
 import graphene
 from django.core.exceptions import ValidationError
+from django.db.models import Exists, OuterRef
 
 from .....channel.models import Channel
 from .....core.tracing import traced_atomic_transaction
@@ -32,21 +32,6 @@ from ...dataloaders import (
 class RuleInfo:
     rule: PromotionRule
     channel: Channel
-
-
-@dataclass
-class Data:
-    promotion: Promotion
-    rules: Dict[UUID, PromotionRule]
-    channel_rule: Dict[int, PromotionRule]
-
-    @property
-    def all_rules(self):
-        return [rule for rule in self.rules.values()]
-
-    @property
-    def all_channel_ids(self):
-        return [channel_id for channel_id in self.channel_rule.keys()]
 
 
 class SaleChannelListingAddInput(BaseInputObjectType):
@@ -97,12 +82,18 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
         error_type_field = "discount_errors"
 
     @classmethod
-    def add_channels(cls, data: Data, add_channels: List[Dict]):
+    def add_channels(cls, promotion: Promotion, add_channels: List[Dict]):
         rules_data_to_add: List[RuleInfo] = []
         rules_to_update: List[PromotionRule] = []
-
-        current_channel_ids = data.all_channel_ids
-        examplary_rule = data.all_rules[0]
+        # TODO many database hits - potential refactor
+        rules = promotion.rules.all()
+        PromotionRuleChannel = PromotionRule.channels.through
+        rule_ids = [rule.id for rule in rules]
+        rule_channel = PromotionRuleChannel.objects.filter(
+            promotionrule_id__in=rule_ids
+        )
+        current_channel_ids = rule_channel.values_list("channel_id", flat=True)
+        rule = rules[0]
         for add_channel in add_channels:
             channel = add_channel["channel"]
             discount_value = add_channel["discount_value"]
@@ -111,10 +102,10 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
                 rules_data_to_add.append(
                     RuleInfo(
                         rule=PromotionRule(
-                            name=examplary_rule.name,
-                            promotion=data.promotion,
-                            catalogue_predicate=examplary_rule.catalogue_predicate,
-                            reward_value_type=examplary_rule.reward_value_type,
+                            name=rule.name,
+                            promotion=promotion,
+                            catalogue_predicate=rule.catalogue_predicate,
+                            reward_value_type=rule.reward_value_type,
                             reward_value=discount_value,
                         ),
                         channel=channel,
@@ -122,52 +113,44 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
                 )
             else:
                 # We ensure that every rule has one or none related channel
-                rule_to_update = data.channel_rule[channel.id]
+                rule_to_update = rules.get(
+                    id=rule_channel.get(channel_id=channel.id).promotionrule_id  # type: ignore[attr-defined] # noqa: E501
+                )
                 rule_to_update.reward_value = discount_value
                 rules_to_update.append(rule_to_update)
 
-        if rules_data_to_add:
-            for rule_data_to_add in rules_data_to_add:
-                rule_data_to_add.rule.assign_old_channel_listing_id()
+        for rule_data in rules_data_to_add:
+            rule_data.rule.assign_old_channel_listing_id()
 
-            new_rules = [rule_data.rule for rule_data in rules_data_to_add]
-
-            PromotionRule.objects.bulk_create(new_rules)
-            for new_rule in new_rules:
-                data.rules.update({new_rule.id: new_rule})
-
-            PromotionRuleChannel = PromotionRule.channels.through
-            rules_channels = [
-                PromotionRuleChannel(
-                    promotionrule=rule_data_to_add.rule,
-                    channel=rule_data_to_add.channel,
-                )
-                for rule_data_to_add in rules_data_to_add
-            ]
-            PromotionRuleChannel.objects.bulk_create(rules_channels)
-            for rule_channel in rules_channels:
-                data.channel_rule.update(
-                    {rule_channel.channel_id: rule_channel.promotionrule_id}  # type: ignore[attr-defined] # noqa: E501
-                )
-
-        if rules_to_update:
-            PromotionRule.objects.bulk_update(rules_to_update, ["reward_value"])
-            for rule_to_update in rules_to_update:
-                data.rules.update({rule_to_update.id: rule_to_update})
+        new_rules = [rule_data.rule for rule_data in rules_data_to_add]
+        PromotionRule.objects.bulk_create(new_rules)
+        rules_channels = [
+            PromotionRuleChannel(
+                promotionrule=rule_data.rule, channel=rule_data.channel
+            )
+            for rule_data in rules_data_to_add
+        ]
+        PromotionRuleChannel.objects.bulk_create(rules_channels)
+        PromotionRule.objects.bulk_update(rules_to_update, ["reward_value"])
 
     @classmethod
-    def remove_channels(cls, data: Data, remove_channels: List[str]):
-        rules_to_delete_ids = [
-            data.channel_rule[int(channel_id)].id for channel_id in remove_channels
-        ]
+    def remove_channels(cls, promotion: Promotion, remove_channels: List[int]):
+        rules = promotion.rules.all()
+        PromotionRuleChannel = PromotionRule.channels.through
+        rule_channel = PromotionRuleChannel.objects.filter(
+            channel_id__in=remove_channels
+        ).filter(Exists(rules.filter(id=OuterRef("promotionrule_id"))))
+        if not rule_channel:
+            return
+        rules_to_delete_ids = list(
+            rule_channel.values_list("promotionrule_id", flat=True)
+        )
         # We ensure at least one rule is assigned to promotion in order to
         # determine old sale's type and catalogue
-        if len(rules_to_delete_ids) >= len(data.rules):
+        if len(rule_channel) >= len(rules):
             rule_left_id = rules_to_delete_ids.pop()
-            PromotionRule.channels.through.objects.filter(
-                promotionrule_id=rule_left_id
-            ).delete()
-        PromotionRule.objects.filter(id__in=rules_to_delete_ids).delete()
+            rule_channel.filter(promotionrule_id=rule_left_id).delete()
+        rules.filter(id__in=rules_to_delete_ids).delete()
 
     @classmethod
     def clean_discount_values(
@@ -217,26 +200,11 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
         return cleaned_channels
 
     @classmethod
-    def save(cls, _info: ResolveInfo, data: Data, cleaned_input: Dict):
+    def save(cls, _info: ResolveInfo, promotion: Promotion, cleaned_input: Dict):
         with traced_atomic_transaction():
-            cls.add_channels(data, cleaned_input.get("add_channels", []))
-            cls.remove_channels(data, cleaned_input.get("remove_channels", []))
-            update_products_discounted_prices_of_promotion_task.delay(data.promotion.pk)
-
-    @classmethod
-    def get_initial_data(cls, rules) -> Data:
-        promotion = rules[0].promotion
-        PromotionRuleChannel = PromotionRule.channels.through
-        rule_ids = [rule.id for rule in rules]
-        rules_channels = PromotionRuleChannel.objects.filter(
-            promotionrule_id__in=rule_ids
-        )
-        ruleid_rule_map = {rule.pk: rule for rule in rules}
-        channelid_rule_map = {
-            item.channel_id: ruleid_rule_map[item.promotionrule_id]  # type: ignore[attr-defined] # noqa: E501
-            for item in rules_channels
-        }
-        return Data(promotion, ruleid_rule_map, channelid_rule_map)
+            cls.add_channels(promotion, cleaned_input.get("add_channels", []))
+            cls.remove_channels(promotion, cleaned_input.get("remove_channels", []))
+            update_products_discounted_prices_of_promotion_task.delay(promotion.pk)
 
     @classmethod
     def perform_mutation(  # type: ignore[override]
@@ -244,8 +212,9 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
     ):
         object_id = cls.get_global_id_or_error(id, "Sale")
         promotion = Promotion.objects.get(old_sale_id=object_id)
-        rules = promotion.rules.all()
-        sale_type = rules[0].reward_value_type
+        rule = promotion.rules.first()
+        assert rule
+        sale_type = rule.reward_value_type
 
         errors: defaultdict[str, List[ValidationError]] = defaultdict(list)
         cleaned_channels = cls.clean_channels(
@@ -258,8 +227,7 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
         if errors:
             raise ValidationError(errors)
 
-        data = cls.get_initial_data(rules)
-        cls.save(info, data, cleaned_input)
+        cls.save(info, promotion, cleaned_input)
 
         # Invalidate dataloader for channel listings
         SaleChannelListingByPromotionIdLoader(info.context).clear(promotion.pk)

--- a/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
@@ -336,6 +336,10 @@ def test_sale_channel_listing_add_update_remove_channels(
     for rule in rules:
         assert len(rule.channels.all()) == 1
 
+    mock_update_products_discounted_prices_task.delay.assert_called_once_with(
+        promotion.pk
+    )
+
 
 def test_sale_channel_listing_update_with_negative_discounted_value(
     staff_api_client,

--- a/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import graphene
-import pytest
 
 from .....discount import DiscountValueType
 from .....discount.error_codes import DiscountErrorCode
@@ -269,8 +268,6 @@ def test_sale_channel_listing_remove_all_channels(
     )
 
 
-@pytest.mark.django_db
-@pytest.mark.count_queries(autouse=False)
 @patch(
     "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
     ".update_products_discounted_prices_of_promotion_task"
@@ -283,7 +280,6 @@ def test_sale_channel_listing_add_update_remove_channels(
     channel_PLN,
     channel_USD,
     channel_JPY,
-    count_queries,
 ):
     # given
     sale = sale_with_many_channels
@@ -339,10 +335,6 @@ def test_sale_channel_listing_add_update_remove_channels(
     assert len(rules) == 2
     for rule in rules:
         assert len(rule.channels.all()) == 1
-
-    mock_update_products_discounted_prices_task.delay.assert_called_once_with(
-        promotion.pk
-    )
 
 
 def test_sale_channel_listing_update_with_negative_discounted_value(

--- a/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
@@ -268,7 +268,73 @@ def test_sale_channel_listing_remove_all_channels(
     )
 
 
-# TODO Another test for scenario: add -> remove all -> add -> remove all
+@patch(
+    "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
+    ".update_products_discounted_prices_of_promotion_task"
+)
+def test_sale_channel_listing_add_update_remove_channels(
+    mock_update_products_discounted_prices_task,
+    staff_api_client,
+    sale_with_many_channels,
+    permission_manage_discounts,
+    channel_PLN,
+    channel_USD,
+    channel_JPY,
+):
+    # given
+    sale = sale_with_many_channels
+    sale_id = graphene.Node.to_global_id("Sale", sale.pk)
+    channel_usd_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+    channel_pln_id = graphene.Node.to_global_id("Channel", channel_PLN.id)
+    channel_jpy_id = graphene.Node.to_global_id("Channel", channel_JPY.id)
+    discounted = 5
+
+    channel_listing = SaleChannelListing.objects.filter(sale_id=sale.pk).order_by(
+        "currency"
+    )
+    assert len(channel_listing) == 2
+    assert channel_listing[0].channel_id == channel_PLN.id
+    assert channel_listing[1].channel_id == channel_USD.id
+    convert_sales_to_promotions()
+
+    variables = {
+        "id": sale_id,
+        "input": {
+            "addChannels": [
+                {"channelId": channel_usd_id, "discountValue": discounted},
+                {"channelId": channel_jpy_id, "discountValue": discounted},
+            ],
+            "removeChannels": [channel_pln_id],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        SALE_CHANNEL_LISTING_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_discounts,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    assert not content["data"]["saleChannelListingUpdate"]["errors"]
+    data = content["data"]["saleChannelListingUpdate"]["sale"]
+    assert data["name"] == sale.name
+    channel_listings = data["channelListings"]
+    assert len(channel_listings) == 2
+    assert all(
+        [
+            listing["channel"]["slug"] in [channel_USD.slug, channel_JPY.slug]
+            for listing in channel_listings
+        ]
+    )
+    assert all([listing["discountValue"] == discounted for listing in channel_listings])
+
+    promotion = Promotion.objects.get(old_sale_id=sale.pk)
+    rules = promotion.rules.all()
+    assert len(rules) == 2
+    for rule in rules:
+        assert len(rule.channels.all()) == 1
 
 
 def test_sale_channel_listing_update_with_negative_discounted_value(
@@ -609,3 +675,57 @@ def test_invalidate_data_sale_channel_listings_update(
     mock_update_products_discounted_prices_task.delay.assert_called_once_with(
         promotion.pk,
     )
+
+
+@patch(
+    "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
+    ".update_products_discounted_prices_of_promotion_task"
+)
+def test_sale_channel_listing_remove_all_channels_multiple_times(
+    mock_update_products_discounted_prices_task,
+    staff_api_client,
+    sale,
+    permission_manage_discounts,
+    channel_PLN,
+    channel_USD,
+):
+    # Despite removing the promotion from all channels, we ensure at least one rule
+    # is assigned to promotion in order to determine old sale's type and catalogue.
+    # This test checks if only one rule remains when all channels are removed multiple
+    # times.
+
+    # given
+    sale_id = graphene.Node.to_global_id("Sale", sale.pk)
+    channel_usd_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+    channel_pln_id = graphene.Node.to_global_id("Channel", channel_PLN.id)
+    discounted = 2
+    convert_sales_to_promotions()
+    staff_api_client.user.user_permissions.add(permission_manage_discounts)
+    query = SALE_CHANNEL_LISTING_UPDATE_MUTATION
+    mock_update_products_discounted_prices_task.return_value = None
+
+    variables_add = {
+        "id": sale_id,
+        "input": {
+            "addChannels": [
+                {"channelId": channel_usd_id, "discountValue": discounted},
+                {"channelId": channel_pln_id, "discountValue": discounted},
+            ]
+        },
+    }
+    variables_remove = {
+        "id": sale_id,
+        "input": {"removeChannels": [channel_usd_id, channel_pln_id]},
+    }
+
+    # when
+    staff_api_client.post_graphql(query, variables=variables_add)
+    staff_api_client.post_graphql(query, variables=variables_remove)
+    staff_api_client.post_graphql(query, variables=variables_add)
+    staff_api_client.post_graphql(query, variables=variables_remove)
+
+    # then
+    promotion = Promotion.objects.get(old_sale_id=sale.pk)
+    rules = promotion.rules.all()
+    assert len(rules) == 1
+    assert not rules[0].channels.first()

--- a/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_channel_listing_update.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import graphene
+import pytest
 
 from .....discount import DiscountValueType
 from .....discount.error_codes import DiscountErrorCode
@@ -268,6 +269,8 @@ def test_sale_channel_listing_remove_all_channels(
     )
 
 
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
 @patch(
     "saleor.graphql.discount.mutations.sale.sale_channel_listing_update"
     ".update_products_discounted_prices_of_promotion_task"
@@ -280,6 +283,7 @@ def test_sale_channel_listing_add_update_remove_channels(
     channel_PLN,
     channel_USD,
     channel_JPY,
+    count_queries,
 ):
     # given
     sale = sale_with_many_channels
@@ -335,6 +339,10 @@ def test_sale_channel_listing_add_update_remove_channels(
     assert len(rules) == 2
     for rule in rules:
         assert len(rule.channels.all()) == 1
+
+    mock_update_products_discounted_prices_task.delay.assert_called_once_with(
+        promotion.pk
+    )
 
 
 def test_sale_channel_listing_update_with_negative_discounted_value(


### PR DESCRIPTION
I want to merge this change, because it makes `saleChannelListingUpdate` mutation compatible with new Promotion model.

The PR needs to ensure, that:

1. there is always at least one related rule for promotion (can have empty predicate)
2. if there is more rules, all have the same predicate and type
3. an "old" channel listing record is reflected in a single rule

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
