### PR TITLE
Extend rules validations

### DIFF
--- a/saleor/discount/error_codes.py
+++ b/saleor/discount/error_codes.py
@@ -36,6 +36,8 @@ class PromotionRuleCreateErrorCode(Enum):
     NOT_FOUND = "not_found"
     REQUIRED = "required"
     INVALID = "invalid"
+    MULTIPLE_CURRENCIES_NOT_ALLOWED = "multiple_currencies_not_allowed"
+    INVALID_PRECISION = "invalid_precision"
 
 
 class PromotionRuleUpdateErrorCode(Enum):
@@ -43,6 +45,9 @@ class PromotionRuleUpdateErrorCode(Enum):
     NOT_FOUND = "not_found"
     INVALID = "invalid"
     DUPLICATED_INPUT_ITEM = "duplicated_input_item"
+    MISSING_CHANNELS = "missing_channels"
+    MULTIPLE_CURRENCIES_NOT_ALLOWED = "multiple_currencies_not_allowed"
+    INVALID_PRECISION = "invalid_precision"
 
 
 class PromotionRuleDeleteErrorCode(Enum):

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_create.py
@@ -89,7 +89,7 @@ class PromotionRuleCreate(ModelMutation):
         if reward_value is None:
             errors["reward_value"].append(
                 ValidationError(
-                    "The rewardValue is required for when cataloguePredicate "
+                    "The rewardValue is required when cataloguePredicate "
                     "is provided.",
                     code=PromotionRuleCreateErrorCode.REQUIRED.value,
                 )
@@ -112,11 +112,14 @@ class PromotionRuleCreate(ModelMutation):
                 return
             currencies = {channel.currency_code for channel in channels}
             if len(currencies) > 1:
+                error_code = (
+                    PromotionRuleCreateErrorCode.MULTIPLE_CURRENCIES_NOT_ALLOWED.value
+                )
                 errors["reward_value_type"].append(
                     ValidationError(
                         "For FIXED rewardValueType, all channels must have "
                         "the same currency.",
-                        code=PromotionRuleCreateErrorCode.INVALID.value,
+                        code=error_code,
                     )
                 )
                 return
@@ -124,7 +127,9 @@ class PromotionRuleCreate(ModelMutation):
             currency = currencies.pop()
             try:
                 clean_fixed_discount_value(
-                    reward_value, PromotionRuleCreateErrorCode.INVALID.value, currency
+                    reward_value,
+                    PromotionRuleCreateErrorCode.INVALID_PRECISION.value,
+                    currency,
                 )
             except ValidationError as error:
                 errors["reward_value"].append(error)

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
@@ -140,7 +140,7 @@ class PromotionRuleUpdate(ModelMutation):
                         {
                             field: ValidationError(
                                 "Channels must be specified for FIXED rewardValueType.",
-                                code=PromotionRuleUpdateErrorCode.INVALID.value,
+                                code=PromotionRuleUpdateErrorCode.MISSING_CHANNELS.value,
                             )
                         }
                     )
@@ -150,12 +150,15 @@ class PromotionRuleUpdate(ModelMutation):
                         if "reward_value_type" in cleaned_input
                         else "add_channels"
                     )
+                    error_code = (
+                        PromotionRuleUpdateErrorCode.MULTIPLE_CURRENCIES_NOT_ALLOWED.value
+                    )
                     raise ValidationError(
                         {
                             field: ValidationError(
                                 "Channels must have the same currency code "
                                 "for FIXED rewardValueType.",
-                                code=PromotionRuleUpdateErrorCode.INVALID.value,
+                                code=error_code,
                             )
                         }
                     )
@@ -163,7 +166,7 @@ class PromotionRuleUpdate(ModelMutation):
                 try:
                     clean_fixed_discount_value(
                         reward_value,
-                        PromotionRuleUpdateErrorCode.INVALID.value,
+                        PromotionRuleUpdateErrorCode.INVALID_PRECISION.value,
                         currency,
                     )
                 except ValidationError as error:

--- a/saleor/graphql/discount/mutations/promotion/validators.py
+++ b/saleor/graphql/discount/mutations/promotion/validators.py
@@ -1,0 +1,28 @@
+from typing import TYPE_CHECKING
+
+from django.core.exceptions import ValidationError
+
+from ....core.validators import validate_price_precision
+
+if TYPE_CHECKING:
+    from decimal import Decimal
+
+
+def clean_fixed_discount_value(
+    reward_value: "Decimal", error_code: str, currency_code: str
+):
+    try:
+        validate_price_precision(reward_value, currency_code)
+    except ValidationError:
+        raise ValidationError(
+            "Invalid amount precision.",
+            code=error_code,
+        )
+
+
+def clean_percentage_discount_value(reward_value: "Decimal", error_code: str):
+    if reward_value > 100:
+        raise ValidationError(
+            "Invalid percentage value.",
+            code=error_code,
+        )

--- a/saleor/graphql/discount/tests/benchmark/test_promotion_rule_create.py
+++ b/saleor/graphql/discount/tests/benchmark/test_promotion_rule_create.py
@@ -64,7 +64,7 @@ def test_promotion_rule_create(
             "name": "Rule 1",
             "description": description_json,
             "channels": rule_channel_ids,
-            "rewardValueType": RewardValueTypeEnum.FIXED.name,
+            "rewardValueType": RewardValueTypeEnum.PERCENTAGE.name,
             "rewardValue": reward_value,
             "cataloguePredicate": catalogue_predicate,
         }

--- a/saleor/graphql/discount/tests/mutations/test_promotion_rule_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_rule_create.py
@@ -574,7 +574,7 @@ def test_promotion_rule_create_invalid_price_precision(
 
     assert not data["promotionRule"]
     assert len(errors) == 1
-    assert errors[0]["code"] == PromotionRuleCreateErrorCode.INVALID.name
+    assert errors[0]["code"] == PromotionRuleCreateErrorCode.INVALID_PRECISION.name
     assert errors[0]["field"] == "rewardValue"
     assert promotion.rules.count() == rules_count
 
@@ -638,7 +638,10 @@ def test_promotion_rule_create_fixed_reward_value_multiple_currencies(
 
     assert not data["promotionRule"]
     assert len(errors) == 1
-    assert errors[0]["code"] == PromotionRuleCreateErrorCode.INVALID.name
+    assert (
+        errors[0]["code"]
+        == PromotionRuleCreateErrorCode.MULTIPLE_CURRENCIES_NOT_ALLOWED.name
+    )
     assert errors[0]["field"] == "rewardValueType"
     assert promotion.rules.count() == rules_count
 

--- a/saleor/graphql/discount/tests/mutations/test_promotion_rule_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_rule_update.py
@@ -386,7 +386,10 @@ def test_promotion_rule_update_add_channel_with_different_currency_to_fixed_disc
 
     assert not data["promotionRule"]
     assert len(errors) == 1
-    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID.name
+    assert (
+        errors[0]["code"]
+        == PromotionRuleUpdateErrorCode.MULTIPLE_CURRENCIES_NOT_ALLOWED.name
+    )
     assert errors[0]["field"] == "addChannels"
 
 
@@ -425,7 +428,7 @@ def test_promotion_rule_update_remove_last_channel_from_fixed_discount(
 
     assert not data["promotionRule"]
     assert len(errors) == 1
-    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID.name
+    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.MISSING_CHANNELS.name
     assert errors[0]["field"] == "removeChannels"
 
 
@@ -464,7 +467,10 @@ def test_promotion_rule_update_change_reward_value_type_to_fixed_multiple_channe
 
     assert not data["promotionRule"]
     assert len(errors) == 1
-    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID.name
+    assert (
+        errors[0]["code"]
+        == PromotionRuleUpdateErrorCode.MULTIPLE_CURRENCIES_NOT_ALLOWED.name
+    )
     assert errors[0]["field"] == "rewardValueType"
 
 
@@ -502,7 +508,7 @@ def test_promotion_rule_update_change_reward_value_type_to_fixed_no_channels(
 
     assert not data["promotionRule"]
     assert len(errors) == 1
-    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID.name
+    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.MISSING_CHANNELS.name
     assert errors[0]["field"] == "rewardValueType"
 
 
@@ -544,7 +550,7 @@ def test_promotion_rule_update_reward_value_invalid_precision(
 
     assert not data["promotionRule"]
     assert len(errors) == 1
-    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID.name
+    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID_PRECISION.name
     assert errors[0]["field"] == "rewardValue"
 
 

--- a/saleor/graphql/discount/tests/mutations/test_promotion_rule_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_rule_update.py
@@ -351,6 +351,245 @@ def test_promotion_rule_update_invalid_catalogue_predicate(
     assert errors[0]["field"] == "cataloguePredicate"
 
 
+def test_promotion_rule_update_add_channel_with_different_currency_to_fixed_discount(
+    app_api_client,
+    permission_manage_discounts,
+    channel_PLN,
+    promotion,
+):
+    # given
+    rule = promotion.rules.get(name="Fixed promotion rule")
+    rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
+
+    add_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+    reward_value = Decimal("10")
+
+    variables = {
+        "id": rule_id,
+        "input": {
+            "addChannels": add_channel_ids,
+            "rewardValue": reward_value,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_RULE_UPDATE_MUTATION,
+        variables,
+        permissions=(permission_manage_discounts,),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleUpdate"]
+    errors = data["errors"]
+
+    assert not data["promotionRule"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID.name
+    assert errors[0]["field"] == "addChannels"
+
+
+def test_promotion_rule_update_remove_last_channel_from_fixed_discount(
+    app_api_client,
+    permission_manage_discounts,
+    channel_USD,
+    promotion,
+):
+    # given
+    rule = promotion.rules.get(name="Fixed promotion rule")
+    rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
+
+    remove_channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    reward_value = Decimal("10")
+
+    variables = {
+        "id": rule_id,
+        "input": {
+            "removeChannels": remove_channel_ids,
+            "rewardValue": reward_value,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_RULE_UPDATE_MUTATION,
+        variables,
+        permissions=(permission_manage_discounts,),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleUpdate"]
+    errors = data["errors"]
+
+    assert not data["promotionRule"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID.name
+    assert errors[0]["field"] == "removeChannels"
+
+
+def test_promotion_rule_update_change_reward_value_type_to_fixed_multiple_channels(
+    app_api_client,
+    permission_manage_discounts,
+    channel_PLN,
+    promotion,
+):
+    # given
+    rule = promotion.rules.get(name="Percentage promotion rule")
+    rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
+
+    rule.channels.add(channel_PLN)
+
+    reward_value_type = RewardValueTypeEnum.FIXED.name
+
+    variables = {
+        "id": rule_id,
+        "input": {
+            "rewardValueType": reward_value_type,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_RULE_UPDATE_MUTATION,
+        variables,
+        permissions=(permission_manage_discounts,),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleUpdate"]
+    errors = data["errors"]
+
+    assert not data["promotionRule"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID.name
+    assert errors[0]["field"] == "rewardValueType"
+
+
+def test_promotion_rule_update_change_reward_value_type_to_fixed_no_channels(
+    app_api_client,
+    permission_manage_discounts,
+    promotion,
+):
+    # given
+    rule = promotion.rules.get(name="Percentage promotion rule")
+    rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
+
+    rule.channels.clear()
+
+    reward_value_type = RewardValueTypeEnum.FIXED.name
+
+    variables = {
+        "id": rule_id,
+        "input": {
+            "rewardValueType": reward_value_type,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_RULE_UPDATE_MUTATION,
+        variables,
+        permissions=(permission_manage_discounts,),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleUpdate"]
+    errors = data["errors"]
+
+    assert not data["promotionRule"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID.name
+    assert errors[0]["field"] == "rewardValueType"
+
+
+def test_promotion_rule_update_reward_value_invalid_precision(
+    app_api_client,
+    permission_manage_discounts,
+    channel_USD,
+    channel_PLN,
+    promotion,
+):
+    # given
+    rule = promotion.rules.get(name="Fixed promotion rule")
+    rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
+
+    add_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+    remove_channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    reward_value = Decimal("10.12212")
+
+    variables = {
+        "id": rule_id,
+        "input": {
+            "addChannels": add_channel_ids,
+            "removeChannels": remove_channel_ids,
+            "rewardValue": reward_value,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_RULE_UPDATE_MUTATION,
+        variables,
+        permissions=(permission_manage_discounts,),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleUpdate"]
+    errors = data["errors"]
+
+    assert not data["promotionRule"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID.name
+    assert errors[0]["field"] == "rewardValue"
+
+
+def test_promotion_rule_update_reward_value_invalid_percentage_value(
+    app_api_client,
+    permission_manage_discounts,
+    channel_USD,
+    channel_PLN,
+    promotion,
+):
+    # given
+    rule = promotion.rules.get(name="Percentage promotion rule")
+    rule_id = graphene.Node.to_global_id("PromotionRule", rule.id)
+
+    add_channel_ids = [graphene.Node.to_global_id("Channel", channel_PLN.pk)]
+    remove_channel_ids = [graphene.Node.to_global_id("Channel", channel_USD.pk)]
+    reward_value = Decimal("101")
+
+    variables = {
+        "id": rule_id,
+        "input": {
+            "addChannels": add_channel_ids,
+            "removeChannels": remove_channel_ids,
+            "rewardValue": reward_value,
+        },
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_RULE_UPDATE_MUTATION,
+        variables,
+        permissions=(permission_manage_discounts,),
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionRuleUpdate"]
+    errors = data["errors"]
+
+    assert not data["promotionRule"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == PromotionRuleUpdateErrorCode.INVALID.name
+    assert errors[0]["field"] == "rewardValue"
+
+
 @patch(
     "saleor.product.tasks.update_products_discounted_prices_for_promotion_task.delay"
 )
@@ -406,7 +645,7 @@ def test_promotion_rule_update_clears_old_sale_id(
     }
     collection.products.add(product_list[2])
     reward_value = Decimal("10")
-    reward_value_type = RewardValueTypeEnum.FIXED.name
+    reward_value_type = RewardValueTypeEnum.PERCENTAGE.name
     promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
     rules_count = promotion.rules.count()
 

--- a/saleor/graphql/discount/utils.py
+++ b/saleor/graphql/discount/utils.py
@@ -30,6 +30,7 @@ class Operators(Enum):
     OR = "or"
 
 
+# TODO: move to validators in promotion dir
 def clean_predicate(predicate: Union[Dict[str, Union[dict, list]], list]):
     """Convert camel cases keys into snake case."""
     if isinstance(predicate, list):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -26239,6 +26239,8 @@ enum PromotionRuleCreateErrorCode {
   NOT_FOUND
   REQUIRED
   INVALID
+  MULTIPLE_CURRENCIES_NOT_ALLOWED
+  INVALID_PRECISION
 }
 
 input PromotionRuleCreateInput {
@@ -26306,6 +26308,9 @@ enum PromotionRuleUpdateErrorCode {
   NOT_FOUND
   INVALID
   DUPLICATED_INPUT_ITEM
+  MISSING_CHANNELS
+  MULTIPLE_CURRENCIES_NOT_ALLOWED
+  INVALID_PRECISION
 }
 
 input PromotionRuleUpdateInput {


### PR DESCRIPTION
Update `promotionRuleCreate` and `promotionRuleUpdate` mutations.

Validations:
- check the fixed reward value precision
- check the percentage reward value - raise an error if the value is above 100
- require channels from one currencies for fixed discount

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
