### PR TITLE
Fix `promotionDelete` mutation

### DIFF
--- a/saleor/graphql/discount/mutations/promotion/promotion_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_delete.py
@@ -42,9 +42,11 @@ class PromotionDelete(ModelDeleteMutation):
         product_ids = list(
             get_products_for_promotion(instance).values_list("id", flat=True)
         )
+        promotion_id = instance.id
 
         with transaction.atomic():
             response = super().perform_mutation(root, info, id=id)
-            cls.call_event(manager.promotion_deleted(instance))
+            instance.id = promotion_id
+            cls.call_event(manager.promotion_deleted, instance)
             update_products_discounted_prices_for_promotion_task.delay(product_ids)
         return response

--- a/saleor/graphql/discount/tests/benchmark/test_promotion_delete.py
+++ b/saleor/graphql/discount/tests/benchmark/test_promotion_delete.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import graphene
 import pytest
 
@@ -9,13 +7,7 @@ from ..mutations.test_promotion_delete import PROMOTION_DELETE_MUTATION
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-@patch(
-    "saleor.product.tasks.update_products_discounted_prices_for_promotion_task.delay"
-)
-@patch("saleor.plugins.manager.PluginsManager.promotion_deleted")
 def test_promotion_delete(
-    promotion_deleted_mock,
-    update_products_discounted_prices_for_promotion_task_mock,
     staff_api_client,
     permission_group_manage_discounts,
     promotion,


### PR DESCRIPTION
Fix event calling in `promotionDelete` mutation.

Fix https://github.com/saleor/saleor/issues/13671

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
