### PR TITLE
Add missing stacktraces in error logs during app installations

### DIFF
--- a/saleor/app/tasks.py
+++ b/saleor/app/tasks.py
@@ -42,7 +42,7 @@ def install_app_task(job_id, activate=False):
             "Failed to connect to app. Try later or contact with app support."
         )
     except Exception as e:
-        logger.warning("Failed to install app. Error: %s", e)
+        logger.error("Failed to install app. Error: %s", e, exc_info=e)
         app_installation.message = "Unknown error. Contact with app support."
     app_installation.status = JobStatus.FAILED
     app_installation.save(update_fields=["message", "status"])


### PR DESCRIPTION
This adds stacktraces to unhandled exceptions during app installations, and uses the correct log-level "error" instead of "warning" as it's a fatal error.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
