### PR TITLE
Bump main to 3.16.0-a.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,22 @@
 
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
+# 3.16.0 [Unreleased]
+
+### Breaking changes
+
+### GraphQL API
+
+### Saleor Apps
+
+### Other changes
 
 # 3.15.0 [Unreleased]
 
 ### Breaking changes
+
 - Remove input and fields related to transaction API and deprecated in 3.13 - #13020 by @korycins
+
   - `WebhookEventTypeEnum.TRANSACTION_ACTION_REQUEST` - Use `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead.
   - `WebhookEventTypeAsyncEnum.TRANSACTION_ACTION_REQUEST` - Use `TRANSACTION_CHARGE_REQUESTED`, `TRANSACTION_REFUND_REQUESTED`, `TRANSACTION_CANCELATION_REQUESTED` instead.
   - `WebhookSampleEventTypeEnum.TRANSACTION_ACTION_REQUEST`
@@ -19,10 +30,10 @@ All notable, unreleased changes to this project will be documented in this file.
   - `OrderEvent.status` - Use `TransactionEvent` to track the status of `TransactionItem`.
   - `OrderEventsEnum`:
     - `TRANSACTION_CAPTURE_REQUESTED` - Use `TRANSACTION_CHARGE_REQUESTED` instead.
-    - `TRANSACTION_VOID_REQUESTED` -  Use `TRANSACTION_CANCEL_REQUESTED` instead.
+    - `TRANSACTION_VOID_REQUESTED` - Use `TRANSACTION_CANCEL_REQUESTED` instead.
   - `TransactionStatus`
   - `TransactionEvent`:
-    - `status` -  Use `type` instead.
+    - `status` - Use `type` instead.
     - `reference` - Use `pspReference` instead.
     - `name` - Use `message` instead.
   - `TransactionCreateInput`:
@@ -52,13 +63,14 @@ All notable, unreleased changes to this project will be documented in this file.
 - Change order of resolving country code in checkout - #13159 by @jakubkuc
   - Until now, checkout mutations were ignoring provided shipping address when shipping was not required. After this change, the shipping address is always set when supplied in the input. It might be breaking, as the shipping address affects the country code used for tax calculation.
   - The order of resolving the checkout country code is always as follows:
-      1. Shipping address
-      2. Billing address
-      3. Channel's default country
-
+    1. Shipping address
+    2. Billing address
+    3. Channel's default country
 
 ### GraphQL API
-Shipping methods can be removed by the user after it has been assigned to a checkout; `shippingMethodId` is now a nullable input in the `checkoutShippingMethodUpdate` mutation.  - #13068 by @FremahA
+
+Shipping methods can be removed by the user after it has been assigned to a checkout; `shippingMethodId` is now a nullable input in the `checkoutShippingMethodUpdate` mutation. - #13068 by @FremahA
+
 - Add `lines` to `OrderGrantedRefund` - #13014 by @korycins
 - Add `orderNoteAdd` and `orderNoteUpdate` mutations and deprecate `orderAddNote` mutation - #12434 by @pawelzar
 - Deprecate `Order.trackingClientId` field - #13146 by @SzymJ
@@ -70,14 +82,14 @@ Shipping methods can be removed by the user after it has been assigned to a chec
 - Added `GiftCardFilterInput.createdByEmail` filter - #13132 by @Smit-Parmar
 - Add metadata support for channels. #13230 by @Smit-Parmar
 - Remove `Preview feature` label from `metafield`, `metafields`, `metadata`,
-`privateMetafield`, `privateMetafields` and `privateMetadata` fields - #13245 by @korycins
+  `privateMetafield`, `privateMetafields` and `privateMetadata` fields - #13245 by @korycins
 - [Preview] Add possibility to completeCheckout without payment in transaction flow - #13339 by @kadewu:
   - New field `allowUnpaidOrders` in `OrderSettings` for `Channel`
 - Add `search` to `giftCards` query - #13173 by @zedzior
 - Add `ProductBulkTranslate` mutation - #13329 by @SzymJ
 - Add `ProductVariantBulkTranslate` mutation - #13329 by @SzymJ
 - Add `AttributeBulkCreate` mutation - #13398 by @SzymJ
-- Deprecate `WebhookEventTypeAsyncEnum.ANY_EVENTS` and `WebhookEventTypeEnum.ANY_EVENTS`; instead listeners should subscribe to specific webhook events -  #13452 by @maarcingebala
+- Deprecate `WebhookEventTypeAsyncEnum.ANY_EVENTS` and `WebhookEventTypeEnum.ANY_EVENTS`; instead listeners should subscribe to specific webhook events - #13452 by @maarcingebala
 - Add ability to update `warehouse` address with `MANAGE_PRODUCTS` permissions: - #13248 by @Air-t
 - Add ability to update `site` address with `MANAGE_SETTINGS` permissions: - #13248 by @Air-t
 - Add the ability to set address public metadata in the following mutations: - #13248 by @Air-t
@@ -113,6 +125,7 @@ Shipping methods can be removed by the user after it has been assigned to a chec
   - Called after `requestPasswordReset` or `customerCreate` mutation for staff users.
 
 ### Other changes
+
 - Add possibility to log without confirming email - #13059 by @kadewu
   - New mutation `sendConfirmationEmail` to send an email with confirmation link
   - New environment variable `CONFIRMATION_EMAIL_LOCK_TIME` to control lock time between new email confirmations
@@ -150,7 +163,6 @@ Shipping methods can be removed by the user after it has been assigned to a chec
 - Fix seo field to accept null value - #13512 by @ssuraliya
 - Add missing descriptions to payment module - #13546 by @devilsautumn
 - Fix `NOTIFY_USER` allow to create webhook with only one event - #13584 by @Air-t
-
 
 # 3.14.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.15.0-a.0",
+  "version": "3.16.0-a.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.15.0-a.0",
+      "version": "3.16.0-a.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.15.0-a.0",
+  "version": "3.16.0-a.0",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "saleor"
-version = "3.15.0-a.0"
+version = "3.16.0-a.0"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.15.0-a.0"
+__version__ = "3.16.0-a.0"
 
 
 class PatchedSubscriberExecutionContext(object):

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -30,6 +30,7 @@ ADDED_IN_312 = "\n\nAdded in Saleor 3.12."
 ADDED_IN_313 = "\n\nAdded in Saleor 3.13."
 ADDED_IN_314 = "\n\nAdded in Saleor 3.14."
 ADDED_IN_315 = "\n\nAdded in Saleor 3.15."
+ADDED_IN_316 = "\n\nAdded in Saleor 3.16."
 
 
 PREVIEW_FEATURE = (


### PR DESCRIPTION
The alfa tag for incoming 3.15 is now released which effectively freezes the scope for this new version. The `main` branch can now be updated to 3.16 alfa.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
