### PR TITLE
Refactor sale catalogues mutations.

### DIFF
--- a/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
@@ -1,8 +1,8 @@
 from typing import List, Optional
 
 from .....core.tracing import traced_atomic_transaction
-from .....discount.models import PromotionRule
-from .....discount.sale_converter import create_catalogue_predicate
+from .....discount.error_codes import DiscountErrorCode
+from .....discount.models import Promotion, PromotionRule
 from .....permission.enums import DiscountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
 from ....channel import ChannelContext
@@ -10,8 +10,17 @@ from ....core import ResolveInfo
 from ....core.descriptions import DEPRECATED_IN_3X_MUTATION
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.types import DiscountError
-from ....core.utils import WebhookEventInfo
-from ...utils import merge_migrated_sale_predicates
+from ....core.utils import (
+    WebhookEventInfo,
+    from_global_id_or_error,
+    raise_validation_error,
+)
+from ...utils import (
+    CatalogueInfo,
+    convert_catalogue_info_into_predicate,
+    convert_migrated_sale_predicate_to_catalogue_info,
+    merge_catalogues_info,
+)
 from .sale_base_catalogue import SaleBaseCatalogueMutation
 
 
@@ -40,32 +49,49 @@ class SaleAddCatalogues(SaleBaseCatalogueMutation):
         promotion = cls.get_instance(info, id)
         rules = promotion.rules.all()
         previous_predicate = rules[0].catalogue_predicate
+        previous_catalogue_info = convert_migrated_sale_predicate_to_catalogue_info(
+            previous_predicate
+        )
 
         with traced_atomic_transaction():
-            new_predicate = cls.add_items_to_predicate(rules, previous_predicate, input)
-            if new_predicate:
-                cls.post_save_actions(
-                    info,
-                    promotion,
-                    previous_predicate,
-                    new_predicate,
-                )
+            new_catalogue_info = cls.add_items_to_catalogue(
+                rules, previous_catalogue_info, input
+            )
+            cls.post_save_actions(
+                info,
+                promotion,
+                previous_catalogue_info,
+                new_catalogue_info,
+            )
 
         return SaleAddCatalogues(sale=ChannelContext(node=promotion, channel_slug=None))
 
     @classmethod
-    def add_items_to_predicate(
-        cls, rules: List[PromotionRule], previous_predicate: dict, input: dict
-    ) -> Optional[dict]:
-        catalogue_item_ids = cls.get_catalogue_item_ids(input)
-        if any(catalogue_item_ids):
-            predicate_to_merge = create_catalogue_predicate(*catalogue_item_ids)
-            new_predicate = merge_migrated_sale_predicates(
-                previous_predicate, predicate_to_merge
+    def get_instance(cls, _info: ResolveInfo, id):
+        type, _id = from_global_id_or_error(id, raise_error=False)
+        if type == "Promotion":
+            raise_validation_error(
+                field="id",
+                message="Provided ID refers to Promotion model. "
+                "Please use 'promotionRuleCreate' mutation instead.",
+                code=DiscountErrorCode.INVALID.value,
             )
+        object_id = cls.get_global_id_or_error(id, "Sale")
+        return Promotion.objects.get(old_sale_id=object_id)
+
+    @classmethod
+    def add_items_to_catalogue(
+        cls, rules: List[PromotionRule], previous_catalogue_info: CatalogueInfo, input
+    ) -> Optional[dict]:
+        catalogue_info_to_add = cls.get_catalogue_info_from_input(input)
+        if any(catalogue_info_to_add):
+            new_catalogue = merge_catalogues_info(
+                previous_catalogue_info, catalogue_info_to_add
+            )
+            new_predicate = convert_catalogue_info_into_predicate(new_catalogue)
             for rule in rules:
                 rule.catalogue_predicate = new_predicate
             PromotionRule.objects.bulk_update(rules, ["catalogue_predicate"])
-            return new_predicate
+            return new_catalogue
 
-        return None
+        return previous_catalogue_info

--- a/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
@@ -72,7 +72,6 @@ class SaleAddCatalogues(SaleBaseCatalogueMutation):
             for rule in rules:
                 rule.catalogue_predicate = new_predicate
             PromotionRule.objects.bulk_update(rules, ["catalogue_predicate"])
-
             return new_predicate
 
         return None
@@ -81,14 +80,12 @@ class SaleAddCatalogues(SaleBaseCatalogueMutation):
     def post_save_actions(
         cls, info: ResolveInfo, promotion, previous_predicate, new_predicate
     ):
-        manager = get_plugin_manager_promise(info.context).get()
-
         previous_catalogue = convert_migrated_sale_predicate_to_catalogue_info(
             previous_predicate
         )
         new_catalogue = convert_migrated_sale_predicate_to_catalogue_info(new_predicate)
-
         if previous_catalogue != new_catalogue:
+            manager = get_plugin_manager_promise(info.context).get()
             cls.call_event(
                 manager.sale_updated,
                 promotion,

--- a/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
+++ b/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
@@ -31,7 +31,7 @@ class SaleBaseCatalogueMutation(BaseDiscountCatalogueMutation):
             raise_validation_error(
                 field="id",
                 message="Provided ID refers to Promotion model. "
-                "Please use 'promotionUpdate' mutation instead.",
+                "Please use 'promotionRuleCreate' mutation instead.",
                 code=DiscountErrorCode.INVALID.value,
             )
         object_id = cls.get_global_id_or_error(id, "Sale")

--- a/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
+++ b/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
@@ -1,5 +1,9 @@
 import graphene
 
+from .....discount.error_codes import DiscountErrorCode
+from .....discount.models import Promotion
+from ....core import ResolveInfo
+from ....core.utils import from_global_id_or_error, raise_validation_error
 from ...types import Sale
 from ..voucher.voucher_add_catalogues import CatalogueInput
 from .sale_base_discount_catalogue import BaseDiscountCatalogueMutation
@@ -19,3 +23,16 @@ class SaleBaseCatalogueMutation(BaseDiscountCatalogueMutation):
 
     class Meta:
         abstract = True
+
+    @classmethod
+    def get_instance(cls, _info: ResolveInfo, id):
+        type, _id = from_global_id_or_error(id, raise_error=False)
+        if type == "Promotion":
+            raise_validation_error(
+                field="id",
+                message="Provided ID refers to Promotion model. "
+                "Please use 'promotionUpdate' mutation instead.",
+                code=DiscountErrorCode.INVALID.value,
+            )
+        object_id = cls.get_global_id_or_error(id, "Sale")
+        return Promotion.objects.get(old_sale_id=object_id)

--- a/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
+++ b/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
@@ -46,7 +46,8 @@ class SaleBaseCatalogueMutation(BaseDiscountCatalogueMutation):
         new_product_ids = get_product_ids_for_predicate(new_predicate)
 
         if previous_product_ids != new_product_ids:
-            if len(new_product_ids) > len(previous_product_ids):
+            is_add_mutation = len(new_product_ids) > len(previous_product_ids)
+            if is_add_mutation:
                 product_ids = new_product_ids - previous_product_ids
             else:
                 product_ids = previous_product_ids - new_product_ids

--- a/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
+++ b/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
@@ -1,3 +1,5 @@
+import copy
+
 import graphene
 
 from .....product.tasks import update_products_discounted_prices_for_promotion_task
@@ -42,8 +44,10 @@ class SaleBaseCatalogueMutation(BaseDiscountCatalogueMutation):
 
         previous_predicate = convert_catalogue_info_into_predicate(previous_catalogue)
         new_predicate = convert_catalogue_info_into_predicate(new_catalogue)
-        previous_product_ids = get_product_ids_for_predicate(previous_predicate)
-        new_product_ids = get_product_ids_for_predicate(new_predicate)
+        previous_product_ids = get_product_ids_for_predicate(
+            copy.deepcopy(previous_predicate)
+        )
+        new_product_ids = get_product_ids_for_predicate(copy.deepcopy(new_predicate))
 
         if previous_product_ids != new_product_ids:
             product_ids = previous_product_ids | new_product_ids

--- a/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
+++ b/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
@@ -1,5 +1,3 @@
-import copy
-
 import graphene
 
 from .....product.tasks import update_products_discounted_prices_for_promotion_task
@@ -44,13 +42,14 @@ class SaleBaseCatalogueMutation(BaseDiscountCatalogueMutation):
 
         previous_predicate = convert_catalogue_info_into_predicate(previous_catalogue)
         new_predicate = convert_catalogue_info_into_predicate(new_catalogue)
-        previous_product_ids = get_product_ids_for_predicate(
-            copy.deepcopy(previous_predicate)
-        )
-        new_product_ids = get_product_ids_for_predicate(copy.deepcopy(new_predicate))
+        previous_product_ids = get_product_ids_for_predicate(previous_predicate)
+        new_product_ids = get_product_ids_for_predicate(new_predicate)
 
         if previous_product_ids != new_product_ids:
-            product_ids = previous_product_ids | new_product_ids
+            if len(new_product_ids) > len(previous_product_ids):
+                product_ids = new_product_ids - previous_product_ids
+            else:
+                product_ids = previous_product_ids - new_product_ids
             update_products_discounted_prices_for_promotion_task.delay(
                 list(product_ids)
             )

--- a/saleor/graphql/discount/mutations/sale/sale_base_discount_catalogue.py
+++ b/saleor/graphql/discount/mutations/sale/sale_base_discount_catalogue.py
@@ -1,10 +1,23 @@
+import copy
+
 from django.core.exceptions import ValidationError
 
 from .....discount.error_codes import DiscountErrorCode
-from .....product.tasks import update_products_discounted_prices_of_catalogues_task
+from .....discount.models import Promotion
+from .....discount.sale_converter import create_catalogue_predicate
+from .....product.tasks import (
+    update_products_discounted_prices_for_promotion_task,
+    update_products_discounted_prices_of_catalogues_task,
+)
 from .....product.utils import get_products_ids_without_variants
 from ....core.mutations import BaseMutation
 from ....product.types import Category, Collection, Product, ProductVariant
+from ...utils import (
+    CatalogueInfo,
+    convert_migrated_sale_predicate_to_catalogue_info,
+    get_product_ids_for_predicate,
+    get_variants_for_predicate, merge_migrated_sale_predicates,
+)
 
 
 class BaseDiscountCatalogueMutation(BaseMutation):
@@ -79,3 +92,34 @@ class BaseDiscountCatalogueMutation(BaseMutation):
             node.variants.remove(*variants)
         # Updated the db entries, recalculating discounts of affected products
         cls.recalculate_discounted_prices(products, categories, collections, variants)
+
+    @classmethod
+    def get_catalogue_from_promotion(cls, promotion: Promotion) -> CatalogueInfo:
+        rules = promotion.rules.all()
+        previous_predicate = rules[0].catalogue_predicate
+        return convert_migrated_sale_predicate_to_catalogue_info(previous_predicate)
+
+    @classmethod
+    def add_items_to_predicate(
+        cls, promotion: Promotion, previous_catalogue: CatalogueInfo, input
+    ):
+        if product_ids := input.get("products", []):
+            products = cls.get_nodes_or_error(product_ids, "products", Product)
+            cls.clean_product(products)
+        if category_ids := input.get("categories", []):
+            cls.get_nodes_or_error(category_ids, "categories", Category)
+        if collection_ids := input.get("collections", []):
+            cls.get_nodes_or_error(collection_ids, "collections", Collection)
+        if variant_ids := input.get("variants", []):
+            cls.get_nodes_or_error(variant_ids, "variants", ProductVariant)
+
+        if product_ids or category_ids or collection_ids or variant_ids:
+            predicate_to_merge = create_catalogue_predicate(
+                collection_ids, category_ids, product_ids, variant_ids
+            )
+            product_ids = get_product_ids_for_predicate(predicate_to_merge)
+            update_products_discounted_prices_for_promotion_task.delay(
+                list(product_ids)
+            )
+
+            new_predicate = merge_migrated_sale_predicates()

--- a/saleor/graphql/discount/mutations/sale/sale_remove_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale/sale_remove_catalogues.py
@@ -1,8 +1,8 @@
 from typing import List, Optional
 
 from .....core.tracing import traced_atomic_transaction
-from .....discount.models import PromotionRule
-from .....discount.sale_converter import create_catalogue_predicate
+from .....discount.error_codes import DiscountErrorCode
+from .....discount.models import Promotion, PromotionRule
 from .....graphql.channel import ChannelContext
 from .....permission.enums import DiscountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
@@ -10,8 +10,17 @@ from ....core import ResolveInfo
 from ....core.descriptions import DEPRECATED_IN_3X_MUTATION
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.types import DiscountError
-from ....core.utils import WebhookEventInfo
-from ...utils import subtract_migrated_sale_predicates
+from ....core.utils import (
+    WebhookEventInfo,
+    from_global_id_or_error,
+    raise_validation_error,
+)
+from ...utils import (
+    CatalogueInfo,
+    convert_catalogue_info_into_predicate,
+    convert_migrated_sale_predicate_to_catalogue_info,
+    subtract_catalogues_info,
+)
 from .sale_base_catalogue import SaleBaseCatalogueMutation
 
 
@@ -40,36 +49,54 @@ class SaleRemoveCatalogues(SaleBaseCatalogueMutation):
         promotion = cls.get_instance(info, id)
         rules = promotion.rules.all()
         previous_predicate = rules[0].catalogue_predicate
+        previous_catalogue_info = convert_migrated_sale_predicate_to_catalogue_info(
+            previous_predicate
+        )
 
         with traced_atomic_transaction():
-            new_predicate = cls.remove_items_from_predicate(
-                rules, previous_predicate, input
+            new_catalogue_info = cls.remove_items_from_catalogue(
+                rules, previous_catalogue_info, input
             )
-            if new_predicate:
-                cls.post_save_actions(
-                    info,
-                    promotion,
-                    previous_predicate,
-                    new_predicate,
-                )
+            cls.post_save_actions(
+                info,
+                promotion,
+                previous_catalogue_info,
+                new_catalogue_info,
+            )
 
         return SaleRemoveCatalogues(
             sale=ChannelContext(node=promotion, channel_slug=None)
         )
 
     @classmethod
-    def remove_items_from_predicate(
-        cls, rules: List[PromotionRule], previous_predicate: dict, input: dict
-    ) -> Optional[dict]:
-        catalogue_item_ids = cls.get_catalogue_item_ids(input)
-        if any(catalogue_item_ids):
-            predicate_to_remove = create_catalogue_predicate(*catalogue_item_ids)
-            new_predicate = subtract_migrated_sale_predicates(
-                previous_predicate, predicate_to_remove
+    def get_instance(cls, _info: ResolveInfo, id):
+        type, _id = from_global_id_or_error(id, raise_error=False)
+        if type == "Promotion":
+            raise_validation_error(
+                field="id",
+                message="Provided ID refers to Promotion model. Please use "
+                "`promotionRuleUpdate` or `promotionRuleDelete` mutation instead.",
+                code=DiscountErrorCode.INVALID.value,
             )
+        object_id = cls.get_global_id_or_error(id, "Sale")
+        return Promotion.objects.get(old_sale_id=object_id)
+
+    @classmethod
+    def remove_items_from_catalogue(
+        cls, rules: List[PromotionRule], previous_catalogue_info: CatalogueInfo, input
+    ) -> Optional[dict]:
+        if not any(previous_catalogue_info):
+            return previous_catalogue_info
+
+        catalogue_info_to_remove = cls.get_catalogue_info_from_input(input)
+        if any(catalogue_info_to_remove):
+            new_catalogue = subtract_catalogues_info(
+                previous_catalogue_info, catalogue_info_to_remove
+            )
+            new_predicate = convert_catalogue_info_into_predicate(new_catalogue)
             for rule in rules:
                 rule.catalogue_predicate = new_predicate
             PromotionRule.objects.bulk_update(rules, ["catalogue_predicate"])
-            return new_predicate
+            return new_catalogue
 
-        return None
+        return previous_catalogue_info

--- a/saleor/graphql/discount/tests/mutations/test_sale_catalogues_add.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_catalogues_add.py
@@ -152,7 +152,7 @@ def test_sale_add_catalogues_no_changes_in_catalogue(
     "saleor.product.tasks.update_products_discounted_prices_for_promotion_task.delay"
 )
 @patch("saleor.plugins.manager.PluginsManager.sale_updated")
-def test_sale_add_empty_catalogues_to_sale(
+def test_sale_add_empty_catalogues(
     updated_webhook_mock,
     update_products_discounted_prices_for_promotion_task_mock,
     staff_api_client,
@@ -209,11 +209,11 @@ def test_sale_add_empty_catalogues_to_sale_with_empty_catalogues(
 ):
     # given
     query = SALE_CATALOGUES_ADD_MUTATION
+    convert_sales_to_promotions()
     variables = {
         "id": graphene.Node.to_global_id("Sale", new_sale.id),
         "input": {"products": [], "collections": [], "categories": [], "variants": []},
     }
-    convert_sales_to_promotions()
 
     # when
     response = staff_api_client.post_graphql(

--- a/saleor/graphql/discount/tests/mutations/test_sale_catalogues_add.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_catalogues_add.py
@@ -74,6 +74,7 @@ def test_sale_add_catalogues(
     # then
     content = get_graphql_content(response)
     assert not content["data"]["saleCataloguesAdd"]["errors"]
+    assert content["data"]["saleCataloguesAdd"]["sale"]["name"] == sale.name
     promotion = Promotion.objects.get(old_sale_id=sale.id)
     predicate = promotion.rules.first().catalogue_predicate
     current_catalogue = convert_migrated_sale_predicate_to_catalogue_info(predicate)

--- a/saleor/graphql/discount/tests/mutations/test_sale_catalogues_remove.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_catalogues_remove.py
@@ -1,11 +1,13 @@
 from unittest.mock import patch
 
 import graphene
-import pytest
 
+from .....discount.models import Promotion
+from .....discount.sale_converter import convert_sales_to_promotions
 from .....discount.utils import fetch_catalogue_info
 from ....tests.utils import get_graphql_content
 from ...mutations.utils import convert_catalogue_info_to_global_ids
+from ...utils import convert_migrated_sale_predicate_to_catalogue_info
 
 SALE_CATALOGUES_REMOVE_MUTATION = """
     mutation saleCataloguesRemove($id: ID!, $input: CatalogueInput!) {
@@ -23,28 +25,29 @@ SALE_CATALOGUES_REMOVE_MUTATION = """
 """
 
 
-# TODO will be fixed in PR refactoring the mutation
-@pytest.mark.skip
 @patch(
-    "saleor.product.tasks.update_products_discounted_prices_of_catalogues_task.delay"
+    "saleor.product.tasks.update_products_discounted_prices_for_promotion_task.delay"
 )
 @patch("saleor.plugins.manager.PluginsManager.sale_updated")
 def test_sale_remove_catalogues(
     updated_webhook_mock,
-    update_products_discounted_prices_of_catalogues_task_mock,
+    update_products_discounted_prices_for_promotion_task_mock,
     staff_api_client,
     sale,
     category,
     product,
     collection,
-    product_variant_list,
+    variant,
+    product_list,
     permission_manage_discounts,
 ):
     # given
-    sale.products.add(product)
-    sale.collections.add(collection)
-    sale.categories.add(category)
-    sale.variants.add(*product_variant_list)
+    sale.products.add(product_list[0])
+
+    assert collection in sale.collections.all()
+    assert category in sale.categories.all()
+    assert product in sale.products.all()
+    assert variant in sale.variants.all()
 
     query = SALE_CATALOGUES_REMOVE_MUTATION
     previous_catalogue = convert_catalogue_info_to_global_ids(
@@ -53,17 +56,16 @@ def test_sale_remove_catalogues(
     product_id = graphene.Node.to_global_id("Product", product.id)
     collection_id = graphene.Node.to_global_id("Collection", collection.id)
     category_id = graphene.Node.to_global_id("Category", category.id)
-    variant_ids = [
-        graphene.Node.to_global_id("ProductVariant", variant.id)
-        for variant in product_variant_list
-    ]
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    convert_sales_to_promotions()
+
     variables = {
         "id": graphene.Node.to_global_id("Sale", sale.id),
         "input": {
-            "products": [product_id],
             "collections": [collection_id],
             "categories": [category_id],
-            "variants": variant_ids,
+            "products": [product_id],
+            "variants": [variant_id],
         },
     }
 
@@ -73,25 +75,24 @@ def test_sale_remove_catalogues(
     )
 
     # then
-    current_catalogue = convert_catalogue_info_to_global_ids(fetch_catalogue_info(sale))
-
     content = get_graphql_content(response)
-    data = content["data"]["saleCataloguesRemove"]
-    product_variants = list(sale.variants.all())
+    assert not content["data"]["saleCataloguesRemove"]["errors"]
+    assert content["data"]["saleCataloguesRemove"]["sale"]["name"] == sale.name
+    promotion = Promotion.objects.get(old_sale_id=sale.id)
+    predicate = promotion.rules.first().catalogue_predicate
+    current_catalogue = convert_migrated_sale_predicate_to_catalogue_info(predicate)
 
-    assert not data["errors"]
-    assert product not in sale.products.all()
-    assert category not in sale.categories.all()
-    assert collection not in sale.collections.all()
-    assert not any(v in product_variants for v in product_variant_list)
+    assert collection_id not in current_catalogue["collections"]
+    assert category_id not in current_catalogue["categories"]
+    assert product_id not in current_catalogue["products"]
+    assert variant_id not in current_catalogue["variants"]
+
+    assert (
+        graphene.Node.to_global_id("Product", product_list[0].id)
+        in current_catalogue["products"]
+    )
 
     updated_webhook_mock.assert_called_once_with(
-        sale, previous_catalogue=previous_catalogue, current_catalogue=current_catalogue
+        promotion, previous_catalogue, current_catalogue
     )
-    args, kwargs = update_products_discounted_prices_of_catalogues_task_mock.call_args
-    assert kwargs["category_ids"] == [category.id]
-    assert kwargs["collection_ids"] == [collection.id]
-    assert kwargs["product_ids"] == [product.id]
-    assert set(kwargs["variant_ids"]) == {
-        variant.id for variant in product_variant_list
-    }
+    update_products_discounted_prices_for_promotion_task_mock.assert_called_once()

--- a/saleor/graphql/discount/tests/mutations/test_sale_catalogues_remove.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_catalogues_remove.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import graphene
 
+from .....discount.error_codes import DiscountErrorCode
 from .....discount.models import Promotion
 from .....discount.sale_converter import convert_sales_to_promotions
 from .....discount.utils import fetch_catalogue_info
@@ -96,3 +97,201 @@ def test_sale_remove_catalogues(
         promotion, previous_catalogue, current_catalogue
     )
     update_products_discounted_prices_for_promotion_task_mock.assert_called_once()
+
+
+@patch(
+    "saleor.product.tasks.update_products_discounted_prices_for_promotion_task.delay"
+)
+@patch("saleor.plugins.manager.PluginsManager.sale_updated")
+def test_sale_remove_empty_catalogues(
+    updated_webhook_mock,
+    update_products_discounted_prices_for_promotion_task_mock,
+    staff_api_client,
+    sale,
+    category,
+    product,
+    collection,
+    variant,
+    permission_manage_discounts,
+):
+    # given
+    assert collection in sale.collections.all()
+    assert category in sale.categories.all()
+    assert product in sale.products.all()
+    assert variant in sale.variants.all()
+
+    query = SALE_CATALOGUES_REMOVE_MUTATION
+    previous_catalogue = convert_catalogue_info_to_global_ids(
+        fetch_catalogue_info(sale)
+    )
+
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    collection_id = graphene.Node.to_global_id("Collection", collection.id)
+    category_id = graphene.Node.to_global_id("Category", category.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    convert_sales_to_promotions()
+
+    variables = {
+        "id": graphene.Node.to_global_id("Sale", sale.id),
+        "input": {
+            "collections": [],
+            "categories": [],
+            "products": [],
+            "variants": [],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_discounts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["saleCataloguesRemove"]["errors"]
+    assert content["data"]["saleCataloguesRemove"]["sale"]["name"] == sale.name
+    promotion = Promotion.objects.get(old_sale_id=sale.id)
+    predicate = promotion.rules.first().catalogue_predicate
+    current_catalogue = convert_migrated_sale_predicate_to_catalogue_info(predicate)
+    assert current_catalogue == previous_catalogue
+
+    assert collection_id in current_catalogue["collections"]
+    assert category_id in current_catalogue["categories"]
+    assert product_id in current_catalogue["products"]
+    assert variant_id in current_catalogue["variants"]
+
+    updated_webhook_mock.assert_not_called()
+    update_products_discounted_prices_for_promotion_task_mock.assert_not_called()
+
+
+@patch(
+    "saleor.product.tasks.update_products_discounted_prices_for_promotion_task.delay"
+)
+@patch("saleor.plugins.manager.PluginsManager.sale_updated")
+def test_sale_remove_empty_catalogues_from_sale_with_empty_catalogues(
+    updated_webhook_mock,
+    update_products_discounted_prices_for_promotion_task_mock,
+    staff_api_client,
+    new_sale,
+    permission_manage_discounts,
+):
+    # given
+    sale = new_sale
+    query = SALE_CATALOGUES_REMOVE_MUTATION
+    convert_sales_to_promotions()
+
+    variables = {
+        "id": graphene.Node.to_global_id("Sale", sale.id),
+        "input": {
+            "collections": [],
+            "categories": [],
+            "products": [],
+            "variants": [],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_discounts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["saleCataloguesRemove"]["errors"]
+    assert content["data"]["saleCataloguesRemove"]["sale"]["name"] == sale.name
+    promotion = Promotion.objects.get(old_sale_id=sale.id)
+    predicate = promotion.rules.first().catalogue_predicate
+    current_catalogue = convert_migrated_sale_predicate_to_catalogue_info(predicate)
+
+    assert not current_catalogue["collections"]
+    assert not current_catalogue["categories"]
+    assert not current_catalogue["products"]
+    assert not current_catalogue["variants"]
+
+    updated_webhook_mock.assert_not_called()
+    update_products_discounted_prices_for_promotion_task_mock.assert_not_called()
+
+
+@patch(
+    "saleor.product.tasks.update_products_discounted_prices_for_promotion_task.delay"
+)
+@patch("saleor.plugins.manager.PluginsManager.sale_updated")
+def test_sale_remove_catalogues_no_product_changes(
+    updated_webhook_mock,
+    update_products_discounted_prices_for_promotion_task_mock,
+    staff_api_client,
+    sale,
+    variant,
+    permission_manage_discounts,
+):
+    # given
+    query = SALE_CATALOGUES_REMOVE_MUTATION
+    previous_catalogue = convert_catalogue_info_to_global_ids(
+        fetch_catalogue_info(sale)
+    )
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    convert_sales_to_promotions()
+
+    variables = {
+        "id": graphene.Node.to_global_id("Sale", sale.id),
+        "input": {
+            "products": [],
+            "variants": [variant_id],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_discounts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["saleCataloguesRemove"]["errors"]
+    assert content["data"]["saleCataloguesRemove"]["sale"]["name"] == sale.name
+    promotion = Promotion.objects.get(old_sale_id=sale.id)
+    predicate = promotion.rules.first().catalogue_predicate
+    current_catalogue = convert_migrated_sale_predicate_to_catalogue_info(predicate)
+
+    assert variant_id not in current_catalogue["variants"]
+
+    updated_webhook_mock.assert_called_once_with(
+        promotion, previous_catalogue, current_catalogue
+    )
+    update_products_discounted_prices_for_promotion_task_mock.assert_not_called()
+
+
+def test_sale_remove_catalogues_with_promotion_id(
+    staff_api_client,
+    sale,
+    product,
+    permission_manage_discounts,
+):
+    # given
+    query = SALE_CATALOGUES_REMOVE_MUTATION
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    convert_sales_to_promotions()
+
+    promotion = Promotion.objects.get(old_sale_id=sale.id)
+
+    variables = {
+        "id": graphene.Node.to_global_id("Promotion", promotion.id),
+        "input": {
+            "products": [product_id],
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_discounts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    error = content["data"]["saleCataloguesRemove"]["errors"][0]
+
+    assert error["code"] == DiscountErrorCode.INVALID.name
+    assert error["message"] == (
+        "Provided ID refers to Promotion model. Please use "
+        "`promotionRuleUpdate` or `promotionRuleDelete` mutation instead."
+    )

--- a/saleor/graphql/discount/tests/test_utils.py
+++ b/saleor/graphql/discount/tests/test_utils.py
@@ -8,7 +8,6 @@ from ..utils import (
     convert_migrated_sale_predicate_to_catalogue_info,
     get_variants_for_predicate,
     get_variants_for_promotion,
-    merge_migrated_sale_predicates,
 )
 
 
@@ -286,61 +285,3 @@ def test_convert_migrated_sale_predicate_to_catalogue_info(
 
     # then
     assert catalogue_info == expected_result
-
-
-def test_merge_migrated_sale_predicate(
-    collection_list, category_list, product_list, product_variant_list
-):
-    # given
-    collection_ids = [
-        graphene.Node.to_global_id("Collection", item.id) for item in collection_list
-    ]
-    category_ids = [
-        graphene.Node.to_global_id("Category", item.id) for item in category_list
-    ]
-    product_ids = [
-        graphene.Node.to_global_id("Product", item.id) for item in product_list
-    ]
-    variant_ids = [
-        graphene.Node.to_global_id("ProductVariant", item.id)
-        for item in product_variant_list
-    ]
-
-    predicate_1 = {
-        "OR": [
-            {"collectionPredicate": {"ids": [collection_ids[0]]}},
-            {"categoryPredicate": {"ids": [category_ids[0]]}},
-            {"productPredicate": {"ids": [product_ids[0]]}},
-            {"variantPredicate": {"ids": [variant_ids[0]]}},
-        ]
-    }
-
-    predicate_2 = {
-        "OR": [
-            {"collectionPredicate": {"ids": [collection_ids[1]]}},
-            {"categoryPredicate": {"ids": category_ids[:2]}},
-            {"productPredicate": {"ids": [product_ids[0]]}},
-            {"variantPredicate": {"ids": [variant_ids[2]]}},
-        ]
-    }
-
-    expected_predicate = {
-        "OR": [
-            {"collectionPredicate": {"ids": collection_ids[:2]}},
-            {"categoryPredicate": {"ids": category_ids[:2]}},
-            {"productPredicate": {"ids": [product_ids[0]]}},
-            {"variantPredicate": {"ids": [variant_ids[0], variant_ids[2]]}},
-        ]
-    }
-
-    # when
-    merged_predicate = merge_migrated_sale_predicates(predicate_1, predicate_2)
-    merged_catalogue_info = convert_migrated_sale_predicate_to_catalogue_info(
-        merged_predicate
-    )
-    expected_catalogue_info = convert_migrated_sale_predicate_to_catalogue_info(
-        expected_predicate
-    )
-
-    # then
-    assert merged_catalogue_info == expected_catalogue_info

--- a/saleor/graphql/discount/tests/test_utils.py
+++ b/saleor/graphql/discount/tests/test_utils.py
@@ -335,6 +335,12 @@ def test_merge_migrated_sale_predicate(
 
     # when
     merged_predicate = merge_migrated_sale_predicates(predicate_1, predicate_2)
+    merged_catalogue_info = convert_migrated_sale_predicate_to_catalogue_info(
+        merged_predicate
+    )
+    expected_catalogue_info = convert_migrated_sale_predicate_to_catalogue_info(
+        expected_predicate
+    )
 
     # then
-    assert merged_predicate == expected_predicate
+    assert merged_catalogue_info == expected_catalogue_info

--- a/saleor/graphql/discount/utils.py
+++ b/saleor/graphql/discount/utils.py
@@ -248,10 +248,15 @@ def convert_migrated_sale_predicate_to_catalogue_info(
     into:
         {
             "collections": {"UHJvZHV3","UHJvZHV2","UHJvZHV1"},
+            "categories": {},
             "products": {"UHJvZHV9","UHJvZHV8","UHJvZHV7"},
+            "variants": {},
         }
     """
     catalogue_info: CatalogueInfo = defaultdict(set)
+    for field in PREDICATE_TO_CATALOGUE_INFO_MAP.values():
+        catalogue_info[field] = set()
+
     if catalogue_predicate.get("OR"):
         predicates = {
             list(item.keys())[0]: list(item.values())[0]["ids"]
@@ -282,10 +287,10 @@ def merge_migrated_sale_predicates(predicate_1: dict, predicate_2: dict) -> dict
     predicate_2_or = predicate_2.get("OR")
 
     if not predicate_1_or:
-        return predicate_2
+        return deepcopy(predicate_2)
 
     if not predicate_2_or:
-        return predicate_1
+        return deepcopy(predicate_1)
 
     catalogue_info_1 = convert_migrated_sale_predicate_to_catalogue_info(predicate_1)
     catalogue_info_2 = convert_migrated_sale_predicate_to_catalogue_info(predicate_2)

--- a/saleor/graphql/product/tests/test_product_discounted_price.py
+++ b/saleor/graphql/product/tests/test_product_discounted_price.py
@@ -372,8 +372,9 @@ def test_sale_add_catalogues_updates_products_discounted_prices(
         }
     """
     sale = new_sale
+    sale.products.add(product_list[0])
     sale_id = to_global_id("Sale", sale.pk)
-    product_ids = [to_global_id("Product", product.pk) for product in product_list]
+    product_ids = [to_global_id("Product", product.pk) for product in product_list[1:]]
     convert_sales_to_promotions()
 
     variables = {
@@ -395,7 +396,7 @@ def test_sale_add_catalogues_updates_products_discounted_prices(
     assert not content["data"]["saleCataloguesAdd"]["errors"]
 
     args, _ = mock_update_products_discounted_prices_for_promotion.delay.call_args
-    assert set(args[0]) == {product.id for product in product_list}
+    assert set(args[0]) == {product.id for product in product_list[1:]}
 
 
 @patch(
@@ -449,5 +450,6 @@ def test_sale_remove_catalogues_updates_products_discounted_prices(
     content = get_graphql_content(response)
     assert not content["data"]["saleCataloguesRemove"]["errors"]
 
-    args, _ = mock_update_products_discounted_prices_for_promotion.delay.call_args
-    assert set(args[0]) == {product.id for product in product_list}
+    mock_update_products_discounted_prices_for_promotion.delay.called_once_with(
+        product_id
+    )

--- a/saleor/graphql/product/tests/test_product_discounted_price.py
+++ b/saleor/graphql/product/tests/test_product_discounted_price.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-import pytest
 from freezegun import freeze_time
 from graphql_relay import to_global_id
 
@@ -264,7 +263,7 @@ def test_sale_create_updates_products_discounted_prices(
     ".update_products_discounted_prices_for_promotion_task"
 )
 def test_sale_update_updates_products_discounted_prices(
-    mock_update_products_discounted_prices_for_catalogues,
+    mock_update_products_discounted_prices_for_promotion,
     staff_api_client,
     sale,
     permission_manage_discounts,
@@ -283,7 +282,7 @@ def test_sale_update_updates_products_discounted_prices(
         }
     }
     """
-    product_ids = list(sale.products.values_list("id", flat=True).all())
+    product_ids = set(sale.products.values_list("id", flat=True).all())
     convert_sales_to_promotions()
     variables = {
         "id": to_global_id("Sale", sale.pk),
@@ -300,9 +299,8 @@ def test_sale_update_updates_products_discounted_prices(
     content = get_graphql_content(response)
     assert content["data"]["saleUpdate"]["errors"] == []
 
-    mock_update_products_discounted_prices_for_catalogues.delay.assert_called_once_with(
-        product_ids
-    )
+    args, _ = mock_update_products_discounted_prices_for_promotion.delay.call_args
+    assert set(args[0]) == product_ids
 
 
 @patch(
@@ -310,7 +308,7 @@ def test_sale_update_updates_products_discounted_prices(
     ".update_products_discounted_prices_for_promotion_task"
 )
 def test_sale_delete_updates_products_discounted_prices(
-    mock_update_products_discounted_prices_for_catalogues,
+    mock_update_products_discounted_prices_for_promotion,
     staff_api_client,
     sale,
     permission_manage_discounts,
@@ -344,25 +342,19 @@ def test_sale_delete_updates_products_discounted_prices(
     content = get_graphql_content(response)
     assert content["data"]["saleDelete"]["errors"] == []
 
-    mock_update_products_discounted_prices_for_catalogues.delay.assert_called_once_with(
-        list(product_ids)
-    )
+    args, _ = mock_update_products_discounted_prices_for_promotion.delay.call_args
+    assert set(args[0]) == product_ids
 
 
-# TODO will be fixed in PR refactoring the mutation
-@pytest.mark.skip
 @patch(
-    "saleor.graphql.discount.mutations.sale.sale_base_discount_catalogue"
-    ".update_products_discounted_prices_of_catalogues_task"
+    "saleor.graphql.discount.mutations.sale.sale_base_catalogue"
+    ".update_products_discounted_prices_for_promotion_task"
 )
 def test_sale_add_catalogues_updates_products_discounted_prices(
-    mock_update_products_discounted_prices_of_catalogues,
+    mock_update_products_discounted_prices_for_promotion,
     staff_api_client,
-    sale,
-    product,
-    category,
-    collection,
-    product_variant_list,
+    new_sale,
+    product_list,
     permission_manage_discounts,
 ):
     # given
@@ -379,20 +371,15 @@ def test_sale_add_catalogues_updates_products_discounted_prices(
             }
         }
     """
+    sale = new_sale
     sale_id = to_global_id("Sale", sale.pk)
-    product_id = to_global_id("Product", product.pk)
-    collection_id = to_global_id("Collection", collection.pk)
-    category_id = to_global_id("Category", category.pk)
-    variant_ids = [
-        to_global_id("ProductVariant", variant.pk) for variant in product_variant_list
-    ]
+    product_ids = [to_global_id("Product", product.pk) for product in product_list]
+    convert_sales_to_promotions()
+
     variables = {
         "id": sale_id,
         "input": {
-            "products": [product_id],
-            "collections": [collection_id],
-            "categories": [category_id],
-            "variants": variant_ids,
+            "products": product_ids,
         },
     }
 
@@ -407,38 +394,26 @@ def test_sale_add_catalogues_updates_products_discounted_prices(
     content = get_graphql_content(response)
     assert not content["data"]["saleCataloguesAdd"]["errors"]
 
-    mock_update_products_discounted_prices_of_catalogues.delay.assert_called_once_with(
-        product_ids=[product.pk],
-        category_ids=[category.pk],
-        collection_ids=[collection.pk],
-        variant_ids=[variant.pk for variant in product_variant_list],
-    )
+    args, _ = mock_update_products_discounted_prices_for_promotion.delay.call_args
+    assert set(args[0]) == {product.id for product in product_list}
 
 
-# TODO will be fixed in PR refactoring the mutation
-@pytest.mark.skip
 @patch(
-    "saleor.graphql.discount.mutations.sale.sale_base_discount_catalogue"
-    ".update_products_discounted_prices_of_catalogues_task"
+    "saleor.graphql.discount.mutations.sale.sale_base_catalogue"
+    ".update_products_discounted_prices_for_promotion_task"
 )
 def test_sale_remove_catalogues_updates_products_discounted_prices(
-    mock_update_products_discounted_prices_of_catalogues,
+    mock_update_products_discounted_prices_for_promotion,
     staff_api_client,
-    sale,
-    product,
-    category,
-    collection,
-    product_variant_list,
+    new_sale,
+    product_list,
     permission_manage_discounts,
 ):
     # given
-    assert product in sale.products.all()
-    assert category in sale.categories.all()
-    assert collection in sale.collections.all()
+    sale = new_sale
+    sale.products.add(*product_list)
+    convert_sales_to_promotions()
 
-    sale.variants.add(*product_variant_list)
-
-    assert all(variant in sale.variants.all() for variant in product_variant_list)
     query = """
         mutation SaleCataloguesRemove($id: ID!, $input: CatalogueInput!) {
             saleCataloguesRemove(id: $id, input: $input) {
@@ -452,20 +427,14 @@ def test_sale_remove_catalogues_updates_products_discounted_prices(
             }
         }
     """
+
     sale_id = to_global_id("Sale", sale.pk)
-    product_id = to_global_id("Product", product.pk)
-    collection_id = to_global_id("Collection", collection.pk)
-    category_id = to_global_id("Category", category.pk)
-    variant_ids = [
-        to_global_id("ProductVariant", variant.pk) for variant in product_variant_list
-    ]
+    product_id = to_global_id("Product", product_list[-1].pk)
+
     variables = {
         "id": sale_id,
         "input": {
             "products": [product_id],
-            "collections": [collection_id],
-            "categories": [category_id],
-            "variants": variant_ids,
         },
     }
 
@@ -480,9 +449,5 @@ def test_sale_remove_catalogues_updates_products_discounted_prices(
     content = get_graphql_content(response)
     assert not content["data"]["saleCataloguesRemove"]["errors"]
 
-    mock_update_products_discounted_prices_of_catalogues.delay.assert_called_once_with(
-        product_ids=[product.pk],
-        category_ids=[category.pk],
-        collection_ids=[collection.pk],
-        variant_ids=[variant.pk for variant in product_variant_list],
-    )
+    args, _ = mock_update_products_discounted_prices_for_promotion.delay.call_args
+    assert set(args[0]) == {product.id for product in product_list}


### PR DESCRIPTION
I want to merge this change because, because it makes `saleAddCatalogues` and `saleRemoveCatalogues` mutations compatible with new Promotion model.

Issue: https://github.com/saleor/saleor/issues/13319

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
