### PR TITLE
Fix order calculations

### DIFF
--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -13,6 +13,7 @@ from prices import Money, TaxedMoney
 from ...account.models import Address
 from ...core.taxes import zero_money
 from ...discount import DiscountType, DiscountValueType, RewardValueType, VoucherType
+from ...discount.interface import VariantPromotionRuleInfo
 from ...discount.models import (
     CheckoutLineDiscount,
     NotApplicable,
@@ -33,7 +34,6 @@ from ..fetch import (
     CheckoutInfo,
     CheckoutLineInfo,
     DeliveryMethodBase,
-    VariantPromotionRuleInfo,
     fetch_checkout_info,
     fetch_checkout_lines,
     get_delivery_method_info,

--- a/saleor/discount/interface.py
+++ b/saleor/discount/interface.py
@@ -1,7 +1,19 @@
 from dataclasses import dataclass
-from typing import List
+from typing import TYPE_CHECKING, List, NamedTuple, Optional
 
 from .models import Voucher
+
+if TYPE_CHECKING:
+    from ..product.models import (
+        ProductVariantChannelListing,
+        VariantChannelListingPromotionRule,
+    )
+    from .models import (
+        Promotion,
+        PromotionRule,
+        PromotionRuleTranslation,
+        PromotionTranslation,
+    )
 
 
 @dataclass
@@ -28,3 +40,51 @@ def fetch_voucher_info(voucher: Voucher) -> VoucherInfo:
         collection_pks=collection_pks,
         category_pks=category_pks,
     )
+
+
+class VariantPromotionRuleInfo(NamedTuple):
+    rule: "PromotionRule"
+    variant_listing_promotion_rule: "VariantChannelListingPromotionRule"
+    promotion: "Promotion"
+    promotion_translation: Optional["PromotionTranslation"]
+    rule_translation: Optional["PromotionRuleTranslation"]
+
+
+def fetch_variant_rules_info(
+    variant_channel_listing: "ProductVariantChannelListing",
+    translation_language_code: str,
+):
+    listings_rules = (
+        variant_channel_listing.variantlistingpromotionrule.all()
+        if variant_channel_listing
+        else []
+    )
+    rules_info = []
+    for listing_promotion_rule in listings_rules:
+        promotion = listing_promotion_rule.promotion_rule.promotion
+        promotion_translations = [
+            translation
+            for translation in promotion.translations.all()
+            if translation.language_code == translation_language_code
+        ]
+        promotion_translation = (
+            promotion_translations[0] if promotion_translations else None
+        )
+
+        rule_translations = [
+            translation
+            for translation in listing_promotion_rule.promotion_rule.translations.all()
+            if translation.language_code == translation_language_code
+        ]
+        rule_translation = rule_translations[0] if rule_translations else None
+
+        rules_info.append(
+            VariantPromotionRuleInfo(
+                rule=listing_promotion_rule.promotion_rule,
+                variant_listing_promotion_rule=listing_promotion_rule,
+                promotion=promotion,
+                promotion_translation=promotion_translation,
+                rule_translation=rule_translation,
+            )
+        )
+    return rules_info

--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -6,7 +6,7 @@ import pytest
 from django.utils import timezone
 from prices import Money, TaxedMoney
 
-from ...checkout.fetch import VariantPromotionRuleInfo
+from ...discount.interface import VariantPromotionRuleInfo
 from ...product.models import Product, ProductVariant, ProductVariantChannelListing
 from .. import DiscountInfo, DiscountValueType, RewardValueType, VoucherType
 from ..models import (

--- a/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
+++ b/saleor/discount/tests/test_utils/test_create_or_update_discount_objects_from_promotion_for_checkout.py
@@ -5,7 +5,7 @@ import pytest
 from django.utils import timezone
 from freezegun import freeze_time
 
-from ....checkout.fetch import VariantPromotionRuleInfo
+from ....discount.interface import VariantPromotionRuleInfo
 from ....product.models import VariantChannelListingPromotionRule
 from ... import DiscountType, RewardValueType
 from ...models import CheckoutLineDiscount, PromotionRule

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -41,11 +41,8 @@ from .models import (
 
 if TYPE_CHECKING:
     from ..account.models import User
-    from ..checkout.fetch import (
-        CheckoutInfo,
-        CheckoutLineInfo,
-        VariantPromotionRuleInfo,
-    )
+    from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
+    from ..discount.interface import VariantPromotionRuleInfo
     from ..order.models import Order
     from ..plugins.manager import PluginsManager
     from ..product.managers import ProductVariantQueryset

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -7,13 +7,13 @@ from promise import Promise
 from ...checkout.fetch import (
     CheckoutInfo,
     CheckoutLineInfo,
-    VariantPromotionRuleInfo,
     apply_voucher_to_checkout_line,
     get_delivery_method_info,
     update_delivery_method_lists_for_checkout_info,
 )
 from ...checkout.models import Checkout, CheckoutLine, CheckoutMetadata
 from ...discount import VoucherType
+from ...discount.interface import VariantPromotionRuleInfo
 from ...payment.models import TransactionItem
 from ..account.dataloaders import AddressByIdLoader, UserByUserIdLoader
 from ..channel.dataloaders import ChannelByIdLoader

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -4,9 +4,10 @@ from typing import Dict, List
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....checkout.fetch import get_variant_channel_listing, get_variant_rules_info
+from ....checkout.fetch import get_variant_channel_listing
 from ....core.taxes import TaxError
 from ....core.tracing import traced_atomic_transaction
+from ....discount.interface import fetch_variant_rules_info
 from ....order import events
 from ....order.error_codes import OrderErrorCode
 from ....order.fetch import fetch_order_lines
@@ -222,7 +223,9 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         )
         for variant in variants:
             variant_channel_listing = get_variant_channel_listing(variant, channel_id)
-            rules_info = get_variant_rules_info(variant_channel_listing, language_code)
+            rules_info = fetch_variant_rules_info(
+                variant_channel_listing, language_code
+            )
             variant_id_to_variant_and_rules_info_map[
                 graphene.Node.to_global_id("ProductVariant", variant.pk)
             ] = VariantData(variant=variant, rules_info=rules_info)

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -4,10 +4,8 @@ from typing import Dict, List
 import graphene
 from django.core.exceptions import ValidationError
 
-from ....checkout.fetch import get_variant_channel_listing
 from ....core.taxes import TaxError
 from ....core.tracing import traced_atomic_transaction
-from ....discount.interface import fetch_variant_rules_info
 from ....order import events
 from ....order.error_codes import OrderErrorCode
 from ....order.fetch import fetch_order_lines
@@ -18,7 +16,6 @@ from ....order.utils import (
     recalculate_order_weight,
 )
 from ....permission.enums import OrderPermissions
-from ....product import models as product_models
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
 from ...core.doc_category import DOC_CATEGORY_ORDERS
@@ -34,7 +31,11 @@ from ..utils import (
     validate_variant_channel_listings,
 )
 from .draft_order_create import OrderLineCreateInput
-from .utils import EditableOrderValidationMixin, get_webhook_handler_by_order_status
+from .utils import (
+    EditableOrderValidationMixin,
+    get_variant_rule_info_map,
+    get_webhook_handler_by_order_status,
+)
 
 VariantData = namedtuple("VariantData", ["variant", "rules_info"])
 
@@ -163,8 +164,11 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         cls.check_channel_permissions(info, [order.channel_id])
         cls.validate_order(order)
         existing_lines_info = fetch_order_lines(order)
-        variants_data = cls.get_variant_rule_info_map(
-            input, order.channel_id, order.language_code
+        variant_pks = cls.get_global_ids_or_error(
+            [line["variant_id"] for line in input], ProductVariant, "variant_id"
+        )
+        variants_data = get_variant_rule_info_map(
+            variant_pks, order.channel_id, order.language_code
         )
 
         lines_to_add = cls.validate_lines(
@@ -208,28 +212,6 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
             cls.call_event(func, order)
 
         return OrderLinesCreate(order=order, order_lines=added_lines)
-
-    @classmethod
-    def get_variant_rule_info_map(cls, data, channel_id, language_code):
-        variant_id_to_variant_and_rules_info_map = {}
-        variant_ids = [line["variant_id"] for line in data]
-        pks = cls.get_global_ids_or_error(variant_ids, ProductVariant, "variant_id")
-        variants = product_models.ProductVariant.objects.filter(
-            pk__in=pks
-        ).prefetch_related(
-            "channel_listings__variantlistingpromotionrule__promotion_rule__promotion",
-            "channel_listings__variantlistingpromotionrule__promotion_rule__promotion__translations",
-            "channel_listings__variantlistingpromotionrule__promotion_rule__translations",
-        )
-        for variant in variants:
-            variant_channel_listing = get_variant_channel_listing(variant, channel_id)
-            rules_info = fetch_variant_rules_info(
-                variant_channel_listing, language_code
-            )
-            variant_id_to_variant_and_rules_info_map[
-                graphene.Node.to_global_id("ProductVariant", variant.pk)
-            ] = VariantData(variant=variant, rules_info=rules_info)
-        return variant_id_to_variant_and_rules_info_map
 
     @classmethod
     def _find_line_id_for_variant_if_exist(cls, variant_id, lines_info):

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -1637,9 +1637,12 @@ def test_draft_order_create_product_on_promotion(
     )
     line_total = variant_channel_listing.discounted_price_amount * quantity
     assert line_data["totalPrice"]["gross"]["amount"] == line_total
-    # TODO: TO FIX
-    # assert line_data["unitDiscountReason"]
-    # assert line_data["unitDiscountType"]
+    assert line_data["unitDiscountReason"]
+    assert line_data["unitDiscountType"]
+
+    line = order.lines.first()
+    assert line.discounts.count() == 1
+    assert line.sale_id
 
     assert data["total"]["gross"]["amount"] == shipping_total + line_total
     assert (
@@ -1666,8 +1669,6 @@ def test_draft_order_create_product_on_promotion(
     assert event_parameters["lines"][0]["item"] == str(order_lines[0])
     assert event_parameters["lines"][0]["line_pk"] == str(order_lines[0].pk)
     assert event_parameters["lines"][0]["quantity"] == quantity
-
-    # TODO: check if OrderLineDiscount was created properly
 
 
 def test_draft_order_create_product_on_promotion_flat_taxes(
@@ -1767,9 +1768,12 @@ def test_draft_order_create_product_on_promotion_flat_taxes(
     )
     line_total = variant_channel_listing.discounted_price_amount * quantity
     assert line_data["totalPrice"]["gross"]["amount"] == line_total
-    # TODO: TO FIX
-    # assert line_data["unitDiscountReason"]
-    # assert line_data["unitDiscountType"]
+    assert line_data["unitDiscountReason"]
+    assert line_data["unitDiscountType"]
+
+    line = order.lines.first()
+    assert line.discounts.count() == 1
+    assert line.sale_id
 
     assert data["total"]["gross"]["amount"] == shipping_total + line_total
     assert (
@@ -1796,5 +1800,3 @@ def test_draft_order_create_product_on_promotion_flat_taxes(
     assert event_parameters["lines"][0]["item"] == str(order_lines[0])
     assert event_parameters["lines"][0]["line_pk"] == str(order_lines[0].pk)
     assert event_parameters["lines"][0]["quantity"] == quantity
-
-    # TODO: check if OrderLineDiscount was created properly

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
 import graphene
 from django.core.exceptions import ValidationError
 
-from ...checkout.fetch import VariantPromotionRuleInfo
 from ...core.exceptions import InsufficientStock
+from ...discount.interface import VariantPromotionRuleInfo
 from ...order.error_codes import OrderErrorCode
 from ...order.utils import get_valid_shipping_methods_for_order
 from ...plugins.manager import PluginsManager

--- a/saleor/order/tests/test_calculations.py
+++ b/saleor/order/tests/test_calculations.py
@@ -927,6 +927,45 @@ def test_fetch_order_prices_if_expired_flat_rates_and_no_tax_calc_strategy(
     assert order.shipping_tax_rate == Decimal("0.2300")
 
 
+def test_fetch_order_prices_on_promotion_if_expired_recalculate_all_prices(
+    plugins_manager,
+    fetch_kwargs,
+    order_with_lines,
+    order_line_on_promotion,
+    tax_data,
+):
+    # given
+    currency = order_with_lines.currency
+    order_line_on_promotion.order = order_with_lines
+    plugins_manager.get_taxes_for_order = Mock(return_value=tax_data)
+
+    # when
+    calculations.fetch_order_prices_if_expired(**fetch_kwargs)
+
+    # then
+    order_with_lines.refresh_from_db()
+    shipping_price = get_taxed_money(tax_data, "shipping_price", currency)
+    assert order_with_lines.shipping_price == shipping_price
+    assert order_with_lines.shipping_tax_rate == tax_data.shipping_tax_rate / 100
+    subtotal = zero_taxed_money(currency)
+    undiscounted_subtotal = zero_taxed_money(currency)
+    for order_line, tax_line in zip(order_with_lines.lines.all(), tax_data.lines):
+        line_total = get_taxed_money(tax_line, "total", currency)
+        subtotal += line_total
+        undiscounted_subtotal += order_line.undiscounted_total_price
+        assert order_line.total_price == line_total
+        assert order_line.unit_price == line_total / order_line.quantity
+        assert order_line.tax_rate == tax_line.tax_rate / 100
+
+    assert order_with_lines.total != order_with_lines.undiscounted_total
+
+    assert (
+        order_with_lines.undiscounted_total
+        == undiscounted_subtotal + shipping_price.net
+    )
+    assert order_with_lines.total == subtotal + shipping_price
+
+
 @patch("saleor.order.calculations.fetch_order_prices_if_expired")
 def test_order_line_unit(mocked_fetch_order_prices_if_expired):
     # given

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -5,10 +5,10 @@ import graphene
 import pytest
 from prices import Money, TaxedMoney
 
-from ...checkout.fetch import VariantPromotionRuleInfo
 from ...core.utils.translations import get_translation
 from ...core.weight import zero_weight
 from ...discount import DiscountType, RewardValueType
+from ...discount.interface import VariantPromotionRuleInfo
 from ...discount.models import (
     DiscountValueType,
     NotApplicable,

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -3,12 +3,9 @@ from decimal import Decimal
 import pytest
 from prices import Money, TaxedMoney
 
-from ...checkout.fetch import (
-    VariantPromotionRuleInfo,
-    fetch_checkout_info,
-    fetch_checkout_lines,
-)
+from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ...discount import DiscountType, DiscountValueType
+from ...discount.interface import VariantPromotionRuleInfo
 from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCardEvent
 from ...graphql.order.utils import OrderLineData

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -62,7 +62,8 @@ from .models import Order, OrderGrantedRefund, OrderLine
 if TYPE_CHECKING:
     from ..app.models import App
     from ..channel.models import Channel
-    from ..checkout.fetch import CheckoutInfo, VariantPromotionRuleInfo
+    from ..checkout.fetch import CheckoutInfo
+    from ..discount.interface import VariantPromotionRuleInfo
     from ..payment.models import Payment, TransactionItem
     from ..plugins.manager import PluginsManager
 

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -24,13 +24,14 @@ from ....account.notifications import (
     send_account_confirmation,
 )
 from ....app.models import App
-from ....checkout.fetch import VariantPromotionRuleInfo, fetch_checkout_lines
+from ....checkout.fetch import fetch_checkout_lines
 from ....core import EventDeliveryStatus
 from ....core.models import EventDelivery, EventDeliveryAttempt, EventPayload
 from ....core.notification.utils import get_site_context
 from ....core.notify_events import NotifyEventType
 from ....core.utils.url import prepare_url
 from ....discount import RewardValueType
+from ....discount.interface import VariantPromotionRuleInfo
 from ....discount.utils import (
     create_or_update_discount_objects_from_promotion_for_checkout,
     fetch_catalogue_info,

--- a/saleor/tax/calculations/order.py
+++ b/saleor/tax/calculations/order.py
@@ -148,7 +148,7 @@ def update_taxes_for_order_lines(
             tax_rate = default_tax_rate
 
         line_total_price = line.base_unit_price * line.quantity
-        undiscounted_subtotal += line_total_price
+        undiscounted_subtotal += line.undiscounted_base_unit_price * line.quantity
 
         price_with_discounts = line.base_unit_price
         if total_discount_amount:

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -38,11 +38,7 @@ from ..attribute.models import (
 )
 from ..attribute.utils import associate_attribute_values_to_instance
 from ..checkout import base_calculations
-from ..checkout.fetch import (
-    VariantPromotionRuleInfo,
-    fetch_checkout_info,
-    fetch_checkout_lines,
-)
+from ..checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ..checkout.models import Checkout, CheckoutLine, CheckoutMetadata
 from ..checkout.utils import add_variant_to_checkout, add_voucher_to_checkout
 from ..core import EventDeliveryStatus, JobStatus
@@ -61,6 +57,7 @@ from ..discount import (
     RewardValueType,
     VoucherType,
 )
+from ..discount.interface import VariantPromotionRuleInfo
 from ..discount.models import (
     CheckoutLineDiscount,
     NotApplicable,


### PR DESCRIPTION
Set proper `order.undiscountedTotal` and discount reason when draft order with product on promotion is created

Fixes https://github.com/saleor/saleor/issues/13692, https://github.com/saleor/saleor/issues/13691

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migrations are either absent or optimized for zero downtime
* [ ] The changes are covered by test cases
