### PR TITLE
Add `FULFILLMENT_TRACKING_NUMBER_UPDATED` webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ in 3.17. Use `PaymentSettings.defaultTransactionFlowStrategy` instead.
 - Add `GIFT_CARD_EXPORT_COMPLETED` webhook - #13765, by @Air-t
   - Event sent when CSV export is completed.
 
+- Add `FULFILLMENT_TRACKING_NUMBER_UPDATED` webhook - #13708, by @Air-t
+  - Called after `fulfillmentUpdateTracking` or `orderFulfill` mutation if tracking number is updated.
+
 ### Other changes
 - Fix error in variant available stock calculation - 13593 by @awaisdar001
 

--- a/saleor/graphql/order/mutations/fulfillment_update_tracking.py
+++ b/saleor/graphql/order/mutations/fulfillment_update_tracking.py
@@ -6,11 +6,13 @@ from ....account.models import User
 from ....order.actions import fulfillment_tracking_updated
 from ....order.notifications import send_fulfillment_update
 from ....permission.enums import OrderPermissions
+from ....webhook.event_types import WebhookEventAsyncType
 from ...app.dataloaders import get_app_promise
 from ...core import ResolveInfo
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
+from ...core.utils import WebhookEventInfo
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Fulfillment, Order
 from .order_fulfill import FulfillmentUpdateTrackingInput
@@ -36,6 +38,12 @@ class FulfillmentUpdateTracking(BaseMutation):
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.FULFILLMENT_TRACKING_NUMBER_UPDATED,
+                description="Fulfillment tracking number is updated.",
+            )
+        ]
 
     @classmethod
     def perform_mutation(  # type: ignore[override]

--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -116,6 +116,10 @@ class OrderFulfill(BaseMutation):
                 description="Order is fulfilled.",
             ),
             WebhookEventInfo(
+                type=WebhookEventAsyncType.FULFILLMENT_TRACKING_NUMBER_UPDATED,
+                description="Sent when fulfillment tracking number is updated.",
+            ),
+            WebhookEventInfo(
                 type=WebhookEventAsyncType.FULFILLMENT_APPROVED,
                 description="A fulfillment is approved.",
             ),

--- a/saleor/graphql/order/tests/mutations/test_fulfillment_update_tracking.py
+++ b/saleor/graphql/order/tests/mutations/test_fulfillment_update_tracking.py
@@ -1,7 +1,9 @@
 from unittest.mock import ANY, patch
 
 import graphene
+import pytest
 
+from .....webhook.event_types import WebhookEventAsyncType
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 FULFILLMENT_UPDATE_TRACKING_QUERY = """
@@ -90,11 +92,13 @@ def test_fulfillment_update_tracking_by_app(
     send_fulfillment_update_mock.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.tracking_number_updated")
 @patch(
     "saleor.graphql.order.mutations.fulfillment_update_tracking.send_fulfillment_update"
 )
 def test_fulfillment_update_tracking_send_notification_true(
     send_fulfillment_update_mock,
+    mocked_tracking_number_updated_event,
     staff_api_client,
     fulfillment,
     permission_group_manage_orders,
@@ -113,11 +117,14 @@ def test_fulfillment_update_tracking_send_notification_true(
     send_fulfillment_update_mock.assert_called_once_with(
         fulfillment.order, fulfillment, ANY
     )
+    mocked_tracking_number_updated_event.assert_called_once_with(fulfillment)
 
 
+@patch("saleor.plugins.manager.PluginsManager.tracking_number_updated")
 @patch("saleor.order.notifications.send_fulfillment_update")
 def test_fulfillment_update_tracking_send_notification_false(
     send_fulfillment_update_mock,
+    mocked_tracking_number_updated_event,
     staff_api_client,
     fulfillment,
     permission_group_manage_orders,
@@ -134,3 +141,35 @@ def test_fulfillment_update_tracking_send_notification_false(
     data = content["data"]["orderFulfillmentUpdateTracking"]["fulfillment"]
     assert data["trackingNumber"] == tracking
     send_fulfillment_update_mock.assert_not_called()
+    mocked_tracking_number_updated_event.assert_called_once_with(fulfillment)
+
+
+@pytest.mark.parametrize("notify_customer", [True, False])
+@patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
+def test_fulfillment_tracking_number_updated_event_triggered(
+    mocked_webhooks,
+    notify_customer,
+    permission_group_manage_orders,
+    fulfillment,
+    settings,
+    subscription_fulfillment_tracking_number_updated,
+    staff_api_client,
+):
+    # given
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    fulfillment_id = graphene.Node.to_global_id("Fulfillment", fulfillment.id)
+    variables = {
+        "id": fulfillment_id,
+        "tracking": "tracking",
+        "notifyCustomer": notify_customer,
+    }
+
+    # when
+    staff_api_client.post_graphql(FULFILLMENT_UPDATE_TRACKING_QUERY, variables)
+
+    # then
+    mocked_webhooks.assert_called_once()
+    assert mocked_webhooks.call_args[0][1] == (
+        WebhookEventAsyncType.FULFILLMENT_TRACKING_NUMBER_UPDATED
+    )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1939,6 +1939,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   Added in Saleor 3.8.
   """
   FULFILLMENT_METADATA_UPDATED
+  FULFILLMENT_TRACKING_NUMBER_UPDATED
 
   """A draft order is created."""
   DRAFT_ORDER_CREATED
@@ -2612,6 +2613,7 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   Added in Saleor 3.8.
   """
   FULFILLMENT_METADATA_UPDATED
+  FULFILLMENT_TRACKING_NUMBER_UPDATED
 
   """A draft order is created."""
   DRAFT_ORDER_CREATED
@@ -3477,6 +3479,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   FULFILLMENT_CANCELED
   FULFILLMENT_APPROVED
   FULFILLMENT_METADATA_UPDATED
+  FULFILLMENT_TRACKING_NUMBER_UPDATED
   DRAFT_ORDER_CREATED
   DRAFT_ORDER_UPDATED
   DRAFT_ORDER_DELETED
@@ -15928,6 +15931,7 @@ type Mutation {
   Triggers the following webhook events:
   - FULFILLMENT_CREATED (async): A new fulfillment is created.
   - ORDER_FULFILLED (async): Order is fulfilled.
+  - FULFILLMENT_TRACKING_NUMBER_UPDATED (async): Sent when fulfillment tracking number is updated.
   - FULFILLMENT_APPROVED (async): A fulfillment is approved.
   """
   orderFulfill(
@@ -15936,7 +15940,7 @@ type Mutation {
 
     """ID of the order to be fulfilled."""
     order: ID
-  ): OrderFulfill @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_CREATED, ORDER_FULFILLED, FULFILLMENT_APPROVED], syncEvents: [])
+  ): OrderFulfill @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_CREATED, ORDER_FULFILLED, FULFILLMENT_TRACKING_NUMBER_UPDATED, FULFILLMENT_APPROVED], syncEvents: [])
 
   """
   Cancels existing fulfillment and optionally restocks items. 
@@ -15976,6 +15980,9 @@ type Mutation {
   Updates a fulfillment for an order. 
   
   Requires one of the following permissions: MANAGE_ORDERS.
+  
+  Triggers the following webhook events:
+  - FULFILLMENT_TRACKING_NUMBER_UPDATED (async): Fulfillment tracking number is updated.
   """
   orderFulfillmentUpdateTracking(
     """ID of a fulfillment to update."""
@@ -15983,7 +15990,7 @@ type Mutation {
 
     """Fields required to update a fulfillment."""
     input: FulfillmentUpdateTrackingInput!
-  ): FulfillmentUpdateTracking @doc(category: "Orders")
+  ): FulfillmentUpdateTracking @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_TRACKING_NUMBER_UPDATED], syncEvents: [])
 
   """
   Refund products. 
@@ -23801,9 +23808,10 @@ Requires one of the following permissions: MANAGE_ORDERS.
 Triggers the following webhook events:
 - FULFILLMENT_CREATED (async): A new fulfillment is created.
 - ORDER_FULFILLED (async): Order is fulfilled.
+- FULFILLMENT_TRACKING_NUMBER_UPDATED (async): Sent when fulfillment tracking number is updated.
 - FULFILLMENT_APPROVED (async): A fulfillment is approved.
 """
-type OrderFulfill @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_CREATED, ORDER_FULFILLED, FULFILLMENT_APPROVED], syncEvents: []) {
+type OrderFulfill @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_CREATED, ORDER_FULFILLED, FULFILLMENT_TRACKING_NUMBER_UPDATED, FULFILLMENT_APPROVED], syncEvents: []) {
   """List of created fulfillments."""
   fulfillments: [Fulfillment!]
 
@@ -23893,8 +23901,11 @@ type FulfillmentApprove @doc(category: "Orders") @webhookEventsInfo(asyncEvents:
 Updates a fulfillment for an order. 
 
 Requires one of the following permissions: MANAGE_ORDERS.
+
+Triggers the following webhook events:
+- FULFILLMENT_TRACKING_NUMBER_UPDATED (async): Fulfillment tracking number is updated.
 """
-type FulfillmentUpdateTracking @doc(category: "Orders") {
+type FulfillmentUpdateTracking @doc(category: "Orders") @webhookEventsInfo(asyncEvents: [FULFILLMENT_TRACKING_NUMBER_UPDATED], syncEvents: []) {
   """A fulfillment with updated tracking."""
   fulfillment: Fulfillment
 
@@ -31521,6 +31532,31 @@ type FulfillmentCreated implements Event @doc(category: "Orders") {
   Added in Saleor 3.16.
   """
   notifyCustomer: Boolean!
+}
+
+"""
+Event sent when the tracking number is updated.
+
+Added in Saleor 3.16.
+"""
+type FulfillmentTrackingNumberUpdated implements Event @doc(category: "Orders") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The fulfillment the event relates to."""
+  fulfillment: Fulfillment
+
+  """The order the fulfillment belongs to."""
+  order: Order
 }
 
 """

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1181,6 +1181,15 @@ class FulfillmentBase(AbstractType):
         return fulfillment.order
 
 
+class FulfillmentTrackingNumberUpdated(SubscriptionObjectType, FulfillmentBase):
+    class Meta:
+        doc_category = DOC_CATEGORY_ORDERS
+        root_type = "Fulfillment"
+        enable_dry_run = True
+        interfaces = (Event,)
+        description = "Event sent when the tracking number is updated." + ADDED_IN_316
+
+
 class FulfillmentCreated(SubscriptionObjectType, FulfillmentBase):
     notify_customer = graphene.Boolean(
         description=(
@@ -2429,6 +2438,7 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.INVOICE_DELETED: InvoiceDeleted,
     WebhookEventAsyncType.INVOICE_SENT: InvoiceSent,
     WebhookEventAsyncType.FULFILLMENT_CREATED: FulfillmentCreated,
+    WebhookEventAsyncType.FULFILLMENT_TRACKING_NUMBER_UPDATED: FulfillmentTrackingNumberUpdated,  # noqa: E501
     WebhookEventAsyncType.FULFILLMENT_CANCELED: FulfillmentCanceled,
     WebhookEventAsyncType.FULFILLMENT_APPROVED: FulfillmentApproved,
     WebhookEventAsyncType.FULFILLMENT_METADATA_UPDATED: FulfillmentMetadataUpdated,

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
@@ -275,6 +275,7 @@ def async_subscription_webhooks_with_root_objects(
     subscription_invoice_sent_webhook,
     subscription_fulfillment_canceled_webhook,
     subscription_fulfillment_metadata_updated_webhook,
+    subscription_fulfillment_tracking_number_updated,
     subscription_customer_created_webhook,
     subscription_customer_updated_webhook,
     subscription_customer_deleted_webhook,
@@ -478,6 +479,10 @@ def async_subscription_webhooks_with_root_objects(
         ],
         events.FULFILLMENT_METADATA_UPDATED: [
             subscription_fulfillment_metadata_updated_webhook,
+            fulfillment,
+        ],
+        events.FULFILLMENT_TRACKING_NUMBER_UPDATED: [
+            subscription_fulfillment_tracking_number_updated,
             fulfillment,
         ],
         events.CUSTOMER_CREATED: [subscription_customer_created_webhook, customer_user],

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1029,6 +1029,16 @@ class WebhookPlugin(BasePlugin):
             WebhookEventAsyncType.FULFILLMENT_METADATA_UPDATED, fulfillment
         )
 
+    def tracking_number_updated(self, fulfillment: "Fulfillment", previous_value):
+        if not self.active:
+            return previous_value
+        event_type = WebhookEventAsyncType.FULFILLMENT_TRACKING_NUMBER_UPDATED
+        if webhooks := get_webhooks_for_event(event_type):
+            fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
+            trigger_webhooks_async(
+                fulfillment_data, event_type, webhooks, fulfillment, self.requestor
+            )
+
     def customer_created(self, customer: "User", previous_value: Any) -> Any:
         if not self.active:
             return previous_value

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -658,6 +658,14 @@ def subscription_fulfillment_metadata_updated_webhook(subscription_webhook):
 
 
 @pytest.fixture
+def subscription_fulfillment_tracking_number_updated(subscription_webhook):
+    return subscription_webhook(
+        queries.FULFILLMENT_TRACKING_NUMBER_UPDATED,
+        WebhookEventAsyncType.FULFILLMENT_TRACKING_NUMBER_UPDATED,
+    )
+
+
+@pytest.fixture
 def subscription_customer_created_webhook(subscription_webhook):
     return subscription_webhook(
         queries.CUSTOMER_CREATED, WebhookEventAsyncType.CUSTOMER_CREATED

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1426,6 +1426,24 @@ FULFILLMENT_METADATA_UPDATED = (
 """
 )
 
+FULFILLMENT_TRACKING_NUMBER_UPDATED = (
+    fragments.FULFILLMENT_DETAILS
+    + """
+    subscription{
+      event{
+        ...on FulfillmentTrackingNumberUpdated{
+          fulfillment{
+            ...FulfillmentDetails
+          }
+          order{
+            id
+          }
+        }
+      }
+    }
+"""
+)
+
 
 CUSTOMER_CREATED = (
     fragments.CUSTOMER_DETAILS

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1756,6 +1756,23 @@ def test_fulfillment_metadata_updated(
     assert deliveries[0].webhook == webhooks[0]
 
 
+def test_fulfillment_tracking_number_updated(
+    fulfillment, subscription_fulfillment_tracking_number_updated
+):
+    # given
+    webhooks = [subscription_fulfillment_tracking_number_updated]
+    event_type = WebhookEventAsyncType.FULFILLMENT_TRACKING_NUMBER_UPDATED
+    expected_payload = generate_fulfillment_payload(fulfillment)
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, fulfillment, webhooks)
+
+    # then
+    assert deliveries[0].payload.payload == json.dumps(expected_payload)
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
 def test_customer_created(customer_user, subscription_customer_created_webhook):
     # given
     webhooks = [subscription_customer_created_webhook]

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -89,6 +89,7 @@ class WebhookEventAsyncType:
     FULFILLMENT_CANCELED = "fulfillment_canceled"
     FULFILLMENT_APPROVED = "fulfillment_approved"
     FULFILLMENT_METADATA_UPDATED = "fulfillment_metadata_updated"
+    FULFILLMENT_TRACKING_NUMBER_UPDATED = "fulfillment_tracking_number_updated"
 
     DRAFT_ORDER_CREATED = "draft_order_created"
     DRAFT_ORDER_UPDATED = "draft_order_updated"
@@ -412,6 +413,10 @@ class WebhookEventAsyncType:
         },
         FULFILLMENT_METADATA_UPDATED: {
             "name": "Fulfillment metadata updated",
+            "permission": OrderPermissions.MANAGE_ORDERS,
+        },
+        FULFILLMENT_TRACKING_NUMBER_UPDATED: {
+            "name": "Fulfillment tracking number updated.",
             "permission": OrderPermissions.MANAGE_ORDERS,
         },
         DRAFT_ORDER_CREATED: {


### PR DESCRIPTION
* Triggers event when tracking number is updated for `orderFulfill` and `FULFILLMENT_TRACKING_NUMBER_UPDATED` mutations.

I want to merge this change because it adds a dedicated event when a tracking number is updated

Resolves https://github.com/saleor/saleor/issues/13670

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
