### PR TITLE
Adapt metadata mutations for old sales.

### DIFF
--- a/saleor/graphql/meta/mutations/base.py
+++ b/saleor/graphql/meta/mutations/base.py
@@ -10,6 +10,7 @@ from ....core import models
 from ....core.error_codes import MetadataErrorCode
 from ....core.exceptions import PermissionDenied
 from ....discount import models as discount_models
+from ....discount.models import Promotion
 from ....menu import models as menu_models
 from ....order import models as order_models
 from ....product import models as product_models
@@ -55,10 +56,13 @@ class BaseMetadataMutation(BaseMutation):
     @classmethod
     def get_instance(cls, info: ResolveInfo, /, *, id: str, qs=None, **kwargs):
         try:
-            type_name, _ = from_global_id_or_error(id)
+            type_name, db_id = from_global_id_or_error(id)
             # ShippingMethodType represents the ShippingMethod model
             if type_name == "ShippingMethodType":
                 qs = shipping_models.ShippingMethod.objects
+            # Sale is an old implementation of Promotion model
+            if type_name == "Sale":
+                return cls.get_old_sale_instance(id, db_id)
 
             return cls.get_node_or_error(info, id, qs=qs)
         except GraphQLError as e:
@@ -84,6 +88,21 @@ class BaseMetadataMutation(BaseMutation):
             return None
         if qs and "token" in [field.name for field in qs.model._meta.get_fields()]:
             return qs.filter(token=object_id).first()
+
+    @classmethod
+    def get_old_sale_instance(cls, global_id, old_sale_id):
+        if instance := discount_models.Promotion.objects.filter(
+            old_sale_id=old_sale_id
+        ).first():
+            return instance
+        else:
+            raise ValidationError(
+                {
+                    "id": ValidationError(
+                        f"Couldn't resolve to a node: {global_id}", code="not_found"
+                    )
+                }
+            )
 
     @classmethod
     def validate_model_is_model_with_metadata(cls, model, object_id):
@@ -258,4 +277,9 @@ class BaseMetadataMutation(BaseMutation):
         )
         if use_channel_context:
             instance = ChannelContext(node=instance, channel_slug=None)
+
+        # For old sales migrated into promotions
+        if isinstance(instance, Promotion) and instance.old_sale_id:
+            instance = ChannelContext(node=instance, channel_slug=None)
+
         return cls(**{"item": instance, "errors": []})

--- a/saleor/graphql/meta/types.py
+++ b/saleor/graphql/meta/types.py
@@ -5,6 +5,7 @@ from graphene.types.generic import GenericScalar
 
 from ...checkout.models import Checkout
 from ...core.models import ModelWithMetadata
+from ...discount.models import Promotion
 from ..channel import ChannelContext
 from ..core import ResolveInfo
 from ..core.types import NonNullList
@@ -157,5 +158,11 @@ class ObjectWithMetadata(graphene.Interface):
             from ..checkout.types import Checkout as CheckoutType
 
             return CheckoutType.resolve_type(instance, info)
+        if isinstance(instance, Promotion) and instance.old_sale_id:
+            # For old sales migrated into promotions
+            from ..discount.types.sales import Sale as SaleType
+
+            return SaleType
+
         item_type, _ = resolve_object_with_metadata_type(instance)
         return item_type


### PR DESCRIPTION
I want to merge this change, because I want to enable metadata mutations to use old sale id.

Issue: https://github.com/saleor/saleor/issues/13319 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
