### PR TITLE
Add `customerIpAddress` to transactionAPI

### DIFF
--- a/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
@@ -11,7 +11,7 @@ from .....payment.utils import handle_transaction_initialize_session
 from .....permission.enums import PaymentPermissions
 from ....app.dataloaders import get_app_promise
 from ....channel.enums import TransactionFlowStrategyEnum
-from ....core.descriptions import ADDED_IN_313, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_313, ADDED_IN_316, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_PAYMENTS
 from ....core.enums import TransactionInitializeErrorCode
 from ....core.scalars import JSON, PositiveDecimal
@@ -20,6 +20,7 @@ from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import TransactionEvent, TransactionItem
 from ..base import TransactionSessionBase
 from ..payment.payment_gateway_initialize import PaymentGatewayToInitialize
+from .utils import clean_customer_ip_address
 
 
 class TransactionInitialize(TransactionSessionBase):
@@ -54,6 +55,16 @@ class TransactionInitialize(TransactionSessionBase):
                 "`channel.defaultTransactionFlowStrategy` will be used. The field "
                 "can be used only by app that has `HANDLE_PAYMENTS` permission."
             ),
+        )
+        customer_ip_address = graphene.String(
+            description=(
+                "The customer's IP address. If not provided Saleor will try to "
+                "determine the customer's IP address on its own."
+                " The customer's IP address will be passed to the payment app."
+                "The IP should be in ipv4 or ipv6 format. "
+                "The field can be used only by an app that has `HANDLE_PAYMENTS` "
+                "permission." + ADDED_IN_316
+            )
         )
         payment_gateway = graphene.Argument(
             PaymentGatewayToInitialize,
@@ -96,7 +107,15 @@ class TransactionInitialize(TransactionSessionBase):
 
     @classmethod
     def perform_mutation(
-        cls, root, info, *, id, payment_gateway, amount=None, action=None
+        cls,
+        root,
+        info,
+        *,
+        id,
+        payment_gateway,
+        amount=None,
+        action=None,
+        customer_ip_address=None
     ):
         manager = get_plugin_manager_promise(info.context).get()
         payment_gateway_data = PaymentGatewayData(
@@ -110,6 +129,11 @@ class TransactionInitialize(TransactionSessionBase):
             manager=manager,
         )
         action = cls.clean_action(info, action, source_object.channel)
+        customer_ip_address = clean_customer_ip_address(
+            info,
+            customer_ip_address,
+            error_code=TransactionInitializeErrorCode.INVALID.value,
+        )
 
         amount = cls.get_amount(
             source_object,
@@ -121,6 +145,7 @@ class TransactionInitialize(TransactionSessionBase):
             payment_gateway_data=payment_gateway_data,
             amount=amount,
             action=action,
+            customer_ip_address=customer_ip_address,
             app=app,
             manager=manager,
         )

--- a/saleor/graphql/payment/mutations/transaction/transaction_process.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_process.py
@@ -17,13 +17,14 @@ from .....payment.utils import (
     get_final_session_statuses,
     handle_transaction_process_session,
 )
-from ....core.descriptions import ADDED_IN_313, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_313, ADDED_IN_316, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_PAYMENTS
 from ....core.mutations import BaseMutation
 from ....core.scalars import JSON
 from ....core.types import common as common_types
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import TransactionEvent, TransactionItem
+from .utils import clean_customer_ip_address
 
 if TYPE_CHECKING:
     pass
@@ -48,6 +49,16 @@ class TransactionProcess(BaseMutation):
         )
         data = graphene.Argument(
             JSON, description="The data that will be passed to the payment gateway."
+        )
+        customer_ip_address = graphene.String(
+            description=(
+                "The customer's IP address. If not provided Saleor will try to "
+                "determine the customer's IP address on its own."
+                " The customer's IP address will be passed to the payment app."
+                "The IP should be in ipv4 or ipv6 format. "
+                "The field can be used only by an app that has `HANDLE_PAYMENTS` "
+                "permission." + ADDED_IN_316
+            )
         )
 
     class Meta:
@@ -150,7 +161,7 @@ class TransactionProcess(BaseMutation):
         return app
 
     @classmethod
-    def perform_mutation(cls, root, info, *, id, data=None):
+    def perform_mutation(cls, root, info, *, id, data=None, customer_ip_address=None):
         transaction_item = cls.get_node_or_error(
             info, id, only_type="TransactionItem", field="token"
         )
@@ -168,6 +179,12 @@ class TransactionProcess(BaseMutation):
         app_identifier = app.identifier
         app_identifier = cast(str, app_identifier)
         action = cls.get_action(request_event, source_object.channel)
+        customer_ip_address = clean_customer_ip_address(
+            info,
+            customer_ip_address,
+            error_code=TransactionProcessErrorCode.INVALID.value,
+        )
+
         manager = get_plugin_manager_promise(info.context).get()
         event, data = handle_transaction_process_session(
             transaction_item=transaction_item,
@@ -177,6 +194,7 @@ class TransactionProcess(BaseMutation):
             ),
             app=app,
             action=action,
+            customer_ip_address=customer_ip_address,
             manager=manager,
             request_event=request_event,
         )

--- a/saleor/graphql/payment/mutations/transaction/utils.py
+++ b/saleor/graphql/payment/mutations/transaction/utils.py
@@ -1,9 +1,14 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from django.core.exceptions import ValidationError
+from django.core.validators import validate_ipv46_address
 
+from .....core.exceptions import PermissionDenied
+from .....core.utils import get_client_ip
 from .....payment import models as payment_models
 from .....payment.error_codes import TransactionUpdateErrorCode
+from .....permission.enums import PaymentPermissions
+from ....app.dataloaders import get_app_promise
 from ....core.utils import from_global_id_or_error
 from ...types import TransactionItem
 
@@ -36,3 +41,25 @@ def get_transaction_item(id: str) -> payment_models.TransactionItem:
             }
         )
     return instance
+
+
+def clean_customer_ip_address(
+    info, customer_ip_address: Optional[str], error_code: str
+):
+    if not customer_ip_address:
+        return get_client_ip(info.context)
+    app = get_app_promise(info.context).get()
+    if not app or not app.has_perm(PaymentPermissions.HANDLE_PAYMENTS):
+        raise PermissionDenied(permissions=[PaymentPermissions.HANDLE_PAYMENTS])
+    try:
+        validate_ipv46_address(customer_ip_address)
+    except ValidationError as error:
+        raise ValidationError(
+            {
+                "customer_ip_address": ValidationError(
+                    message=error.message,
+                    code=error_code,
+                )
+            }
+        )
+    return customer_ip_address

--- a/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
+++ b/saleor/graphql/payment/tests/mutations/test_transaction_initialize.py
@@ -26,12 +26,14 @@ mutation TransactionInitialize(
   $amount: PositiveDecimal,
   $id: ID!,
   $paymentGateway: PaymentGatewayToInitialize!
+  $customerIpAddress: String
 ) {
   transactionInitialize(
     action: $action
     amount: $amount
     id: $id
     paymentGateway: $paymentGateway
+    customerIpAddress: $customerIpAddress
   ) {
     data
     transaction {
@@ -167,6 +169,7 @@ def _assert_fields(
                 amount=expected_amount,
                 currency=source_object.currency,
             ),
+            customer_ip_address="127.0.0.1",
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=app_identifier, data=None, error=None
             ),
@@ -824,7 +827,6 @@ def test_app_with_action_field_and_handle_payments(
     checkout_with_prices,
     webhook_app,
     transaction_session_response,
-    transaction_item_generator,
     permission_manage_payments,
     plugins_manager,
 ):
@@ -1062,7 +1064,6 @@ def test_checkout_doesnt_exist(
     checkout_with_prices,
     webhook_app,
     transaction_session_response,
-    transaction_item_generator,
     permission_manage_payments,
 ):
     # given
@@ -1097,7 +1098,6 @@ def test_order_doesnt_exists(
     order_with_lines,
     webhook_app,
     transaction_session_response,
-    transaction_item_generator,
     permission_manage_payments,
 ):
     # given
@@ -1177,3 +1177,268 @@ def test_checkout_fully_paid(
     mocked_fully_paid.assert_called_once_with(checkout)
     assert checkout.charge_status == CheckoutChargeStatus.FULL
     assert checkout.authorize_status == CheckoutAuthorizeStatus.FULL
+
+
+def test_user_missing_permission_for_customer_ip_address(
+    user_api_client,
+    order_with_lines,
+    webhook_app,
+    transaction_session_response,
+):
+    # given
+    order = order_with_lines
+
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    variables = {
+        "action": None,
+        "amount": None,
+        "id": to_global_id_or_none(order),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+        "customerIpAddress": "127.0.0.1",
+    }
+
+    # when
+    response = user_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+def test_app_missing_permission_for_customer_ip_address(
+    app_api_client,
+    order_with_lines,
+    webhook_app,
+    transaction_session_response,
+):
+    # given
+    order = order_with_lines
+
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    variables = {
+        "action": None,
+        "amount": None,
+        "id": to_global_id_or_none(order),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+        "customerIpAddress": "127.0.0.1",
+    }
+
+    # when
+    response = app_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    assert_no_permission(response)
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_with_customer_ip_address(
+    mocked_initialize,
+    app_api_client,
+    order_with_lines,
+    webhook_app,
+    transaction_session_response,
+    permission_manage_payments,
+):
+    # given
+    order = order_with_lines
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    expected_amount = Decimal("10.00")
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+    app_api_client.app.permissions.set([permission_manage_payments])
+
+    variables = {
+        "action": None,
+        "amount": expected_amount,
+        "id": to_global_id_or_none(order),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+        "customerIpAddress": "127.0.0.2",
+    }
+
+    # when
+    response = app_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    get_graphql_content(response)
+
+    transaction = order.payment_transactions.last()
+    mocked_initialize.assert_called_with(
+        TransactionSessionData(
+            transaction=transaction,
+            source_object=order,
+            action=TransactionProcessActionData(
+                action_type=TransactionFlowStrategy.CHARGE,
+                amount=expected_amount,
+                currency=order.currency,
+            ),
+            customer_ip_address="127.0.0.2",
+            payment_gateway_data=PaymentGatewayData(
+                app_identifier=webhook_app.identifier, data=None, error=None
+            ),
+        )
+    )
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_sets_customer_ip_address_when_not_provided(
+    mocked_initialize,
+    app_api_client,
+    order_with_lines,
+    webhook_app,
+    transaction_session_response,
+    permission_manage_payments,
+):
+    # given
+    order = order_with_lines
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    expected_amount = Decimal("10.00")
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+    app_api_client.app.permissions.set([permission_manage_payments])
+
+    variables = {
+        "action": None,
+        "amount": expected_amount,
+        "id": to_global_id_or_none(order),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        TRANSACTION_INITIALIZE, variables, REMOTE_ADDR="127.0.0.2"
+    )
+
+    # then
+    get_graphql_content(response)
+
+    transaction = order.payment_transactions.last()
+    mocked_initialize.assert_called_with(
+        TransactionSessionData(
+            transaction=transaction,
+            source_object=order,
+            action=TransactionProcessActionData(
+                action_type=TransactionFlowStrategy.CHARGE,
+                amount=expected_amount,
+                currency=order.currency,
+            ),
+            customer_ip_address="127.0.0.2",
+            payment_gateway_data=PaymentGatewayData(
+                app_identifier=webhook_app.identifier, data=None, error=None
+            ),
+        )
+    )
+
+
+def test_customer_ip_address_wrong_format(
+    app_api_client,
+    order_with_lines,
+    webhook_app,
+    transaction_session_response,
+    permission_manage_payments,
+):
+    # given
+    order = order_with_lines
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    expected_amount = Decimal("10.00")
+
+    app_api_client.app.permissions.set([permission_manage_payments])
+
+    variables = {
+        "action": None,
+        "amount": expected_amount,
+        "id": to_global_id_or_none(order),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+        "customerIpAddress": "127.0.02",
+    }
+
+    # when
+    response = app_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    content = get_graphql_content(response)
+
+    errors = content["data"]["transactionInitialize"]["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "customerIpAddress"
+    assert errors[0]["code"] == TransactionInitializeErrorCode.INVALID.name
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.transaction_initialize_session")
+def test_customer_ip_address_ipv6(
+    mocked_initialize,
+    app_api_client,
+    order_with_lines,
+    webhook_app,
+    transaction_session_response,
+    permission_manage_payments,
+):
+    # given
+    order = order_with_lines
+    expected_app_identifier = "webhook.app.identifier"
+    webhook_app.identifier = expected_app_identifier
+    webhook_app.save()
+
+    expected_amount = Decimal("10.00")
+    expected_psp_reference = "ppp-123"
+    expected_response = transaction_session_response.copy()
+    expected_response["result"] = TransactionEventType.CHARGE_REQUEST.upper()
+    expected_response["pspReference"] = expected_psp_reference
+    mocked_initialize.return_value = TransactionSessionResult(
+        app_identifier=expected_app_identifier, response=expected_response
+    )
+    app_api_client.app.permissions.set([permission_manage_payments])
+
+    variables = {
+        "action": None,
+        "amount": expected_amount,
+        "id": to_global_id_or_none(order),
+        "paymentGateway": {"id": expected_app_identifier, "data": None},
+        "customerIpAddress": "::1",
+    }
+
+    # when
+    response = app_api_client.post_graphql(TRANSACTION_INITIALIZE, variables)
+
+    # then
+    get_graphql_content(response)
+
+    transaction = order.payment_transactions.last()
+    mocked_initialize.assert_called_with(
+        TransactionSessionData(
+            transaction=transaction,
+            source_object=order,
+            action=TransactionProcessActionData(
+                action_type=TransactionFlowStrategy.CHARGE,
+                amount=expected_amount,
+                currency=order.currency,
+            ),
+            customer_ip_address="::1",
+            payment_gateway_data=PaymentGatewayData(
+                app_identifier=webhook_app.identifier, data=None, error=None
+            ),
+        )
+    )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15545,6 +15545,13 @@ type Mutation {
     """
     amount: PositiveDecimal
 
+    """
+    The customer's IP address. If not provided Saleor will try to determine the customer's IP address on its own. The customer's IP address will be passed to the payment app.The IP should be in ipv4 or ipv6 format. The field can be used only by an app that has `HANDLE_PAYMENTS` permission.
+    
+    Added in Saleor 3.16.
+    """
+    customerIpAddress: String
+
     """The ID of the checkout or order."""
     id: ID!
 
@@ -15560,6 +15567,13 @@ type Mutation {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   transactionProcess(
+    """
+    The customer's IP address. If not provided Saleor will try to determine the customer's IP address on its own. The customer's IP address will be passed to the payment app.The IP should be in ipv4 or ipv6 format. The field can be used only by an app that has `HANDLE_PAYMENTS` permission.
+    
+    Added in Saleor 3.16.
+    """
+    customerIpAddress: String
+
     """The data that will be passed to the payment gateway."""
     data: JSON
 
@@ -32943,11 +32957,18 @@ type TransactionInitializeSession implements Event @doc(category: "Payments") {
   """Checkout or order"""
   sourceObject: OrderOrCheckout!
 
-  """Payment gateway data in JSON format, recieved from storefront."""
+  """Payment gateway data in JSON format, received from storefront."""
   data: JSON
 
   """Merchant reference assigned to this payment."""
   merchantReference: String!
+
+  """
+  The customer's IP address. If not provided as a parameter in the mutation, Saleor will try to determine the customer's IP address on its own.
+  
+  Added in Saleor 3.16.
+  """
+  customerIpAddress: String
 
   """Action to proceed for the transaction"""
   action: TransactionProcessAction!
@@ -32988,11 +33009,18 @@ type TransactionProcessSession implements Event @doc(category: "Payments") {
   """Checkout or order"""
   sourceObject: OrderOrCheckout!
 
-  """Payment gateway data in JSON format, recieved from storefront."""
+  """Payment gateway data in JSON format, received from storefront."""
   data: JSON
 
   """Merchant reference assigned to this payment."""
   merchantReference: String!
+
+  """
+  The customer's IP address. If not provided as a parameter in the mutation, Saleor will try to determine the customer's IP address on its own.
+  
+  Added in Saleor 3.16.
+  """
+  customerIpAddress: String
 
   """Action to proceed for the transaction"""
   action: TransactionProcessAction!

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -46,6 +46,7 @@ from ..core.descriptions import (
     ADDED_IN_313,
     ADDED_IN_314,
     ADDED_IN_315,
+    ADDED_IN_316,
     PREVIEW_FEATURE,
 )
 from ..core.doc_category import (
@@ -1725,10 +1726,17 @@ class TransactionSessionBase(SubscriptionObjectType, AbstractType):
     )
     data = graphene.Field(
         JSON,
-        description="Payment gateway data in JSON format, recieved from storefront.",
+        description="Payment gateway data in JSON format, received from storefront.",
     )
     merchant_reference = graphene.String(
         description="Merchant reference assigned to this payment.", required=True
+    )
+    customer_ip_address = graphene.String(
+        description=(
+            "The customer's IP address. If not provided as a parameter in the "
+            "mutation, Saleor will try to determine the customer's IP address on its "
+            "own." + ADDED_IN_316
+        ),
     )
     action = graphene.Field(
         TransactionProcessAction,
@@ -1771,6 +1779,13 @@ class TransactionSessionBase(SubscriptionObjectType, AbstractType):
     ):
         _, transaction_session_data = root
         return transaction_session_data.action
+
+    @classmethod
+    def resolve_customer_ip_address(
+        cls, root: tuple[str, TransactionSessionData], _info: ResolveInfo
+    ):
+        _, transaction_session_data = root
+        return transaction_session_data.customer_ip_address
 
 
 class TransactionInitializeSession(TransactionSessionBase):

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -130,6 +130,7 @@ class TransactionSessionData:
     source_object: Union["Checkout", "Order"]
     action: TransactionProcessActionData
     payment_gateway_data: PaymentGatewayData
+    customer_ip_address: Optional[str]
 
 
 @dataclass

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -1435,6 +1435,7 @@ def handle_transaction_initialize_session(
     payment_gateway_data: PaymentGatewayData,
     amount: Decimal,
     action: str,
+    customer_ip_address: Optional[str],
     app: App,
     manager: PluginsManager,
 ):
@@ -1448,6 +1449,7 @@ def handle_transaction_initialize_session(
         action=TransactionProcessActionData(
             action_type=action, currency=source_object.currency, amount=amount
         ),
+        customer_ip_address=customer_ip_address,
     )
 
     request_event = transaction_item.events.create(
@@ -1478,6 +1480,7 @@ def handle_transaction_process_session(
     payment_gateway_data: PaymentGatewayData,
     action: str,
     app: App,
+    customer_ip_address: Optional[str],
     manager: PluginsManager,
     request_event: TransactionEvent,
 ):
@@ -1490,6 +1493,7 @@ def handle_transaction_process_session(
             currency=source_object.currency,
             amount=request_event.amount_value,
         ),
+        customer_ip_address=customer_ip_address,
     )
 
     result = manager.transaction_process_session(session_data)

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1213,6 +1213,7 @@ def test_manager_transaction_initialize_session(
             currency=transaction.currency,
             action_type=action_type,
         ),
+        customer_ip_address="127.0.0.1",
         payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=None, error=None
         ),
@@ -1254,6 +1255,7 @@ def test_manager_transaction_process_session(
             currency=transaction.currency,
             action_type=action_type,
         ),
+        customer_ip_address="127.0.0.1",
         payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=None, error=None
         ),

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_initialize_session.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_initialize_session.py
@@ -24,6 +24,7 @@ subscription {
         actionType
       }
       data
+      customerIpAddress
       sourceObject{
         __typename
         ... on Checkout{
@@ -75,6 +76,7 @@ def test_transaction_initialize_session_checkout_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
+        customer_ip_address="127.0.0.1",
         payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
@@ -100,6 +102,7 @@ def test_transaction_initialize_session_checkout_with_data(
             "actionType": action_type.upper(),
         },
         "data": payload_data,
+        "customerIpAddress": "127.0.0.1",
         "sourceObject": {
             "__typename": "Checkout",
             "id": checkout_id,
@@ -140,6 +143,7 @@ def test_transaction_initialize_session_checkout_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
+        customer_ip_address="127.0.0.1",
         payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
@@ -164,6 +168,7 @@ def test_transaction_initialize_session_checkout_without_data(
             "actionType": action_type.upper(),
         },
         "data": payload_data,
+        "customerIpAddress": "127.0.0.1",
         "sourceObject": {
             "__typename": "Checkout",
             "id": checkout_id,
@@ -204,6 +209,7 @@ def test_transaction_initialize_session_order_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
+        customer_ip_address="127.0.0.1",
         payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
@@ -229,6 +235,7 @@ def test_transaction_initialize_session_order_with_data(
             "actionType": action_type.upper(),
         },
         "data": payload_data,
+        "customerIpAddress": "127.0.0.1",
         "sourceObject": {
             "__typename": "Order",
             "id": order_id,
@@ -268,6 +275,7 @@ def test_transaction_initialize_session_order_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
+        customer_ip_address="127.0.0.1",
         payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
@@ -292,6 +300,72 @@ def test_transaction_initialize_session_order_without_data(
             "actionType": action_type.upper(),
         },
         "data": payload_data,
+        "customerIpAddress": "127.0.0.1",
+        "sourceObject": {
+            "__typename": "Order",
+            "id": order_id,
+        },
+    }
+
+
+def test_transaction_initialize_session_empty_customer_ip_addess(
+    order, webhook_app, permission_manage_payments, transaction_item_generator
+):
+    # given
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        subscription_query=TRANSACTION_INITIALIZE_SESSION,
+    )
+    event_type = WebhookEventSyncType.TRANSACTION_INITIALIZE_SESSION
+    webhook.events.create(event_type=event_type)
+    payload_data = None
+    amount = Decimal("10")
+
+    transaction = transaction_item_generator(
+        order_id=order.pk,
+        app=webhook_app,
+        psp_reference=None,
+        name=None,
+        message=None,
+    )
+    action_type = TransactionFlowStrategy.CHARGE
+
+    subscribable_object = TransactionSessionData(
+        transaction=transaction,
+        source_object=order,
+        action=TransactionProcessActionData(
+            amount=amount,
+            currency=transaction.currency,
+            action_type=action_type,
+        ),
+        customer_ip_address=None,
+        payment_gateway_data=PaymentGatewayData(
+            app_identifier=webhook_app.identifier, data=payload_data, error=None
+        ),
+    )
+
+    # when
+    delivery = create_deliveries_for_subscriptions(
+        event_type, subscribable_object, [webhook]
+    )[0]
+
+    # then
+    order_id = graphene.Node.to_global_id("Order", order.pk)
+    assert delivery.payload
+    assert delivery.payload.payload
+    assert json.loads(delivery.payload.payload) == {
+        "merchantReference": graphene.Node.to_global_id(
+            "TransactionItem", transaction.token
+        ),
+        "action": {
+            "amount": amount,
+            "currency": "USD",
+            "actionType": action_type.upper(),
+        },
+        "data": payload_data,
+        "customerIpAddress": None,
         "sourceObject": {
             "__typename": "Order",
             "id": order_id,

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_process_session.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_process_session.py
@@ -24,6 +24,7 @@ subscription {
         actionType
       }
       data
+      customerIpAddress
       sourceObject{
         __typename
         ... on Checkout{
@@ -75,6 +76,7 @@ def test_transaction_process_session_checkout_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
+        customer_ip_address="127.0.0.1",
         payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
@@ -100,6 +102,7 @@ def test_transaction_process_session_checkout_with_data(
             "actionType": action_type.upper(),
         },
         "data": payload_data,
+        "customerIpAddress": "127.0.0.1",
         "sourceObject": {
             "__typename": "Checkout",
             "id": checkout_id,
@@ -140,6 +143,7 @@ def test_transaction_process_session_checkout_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
+        customer_ip_address="127.0.0.1",
         payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
@@ -164,6 +168,7 @@ def test_transaction_process_session_checkout_without_data(
             "actionType": action_type.upper(),
         },
         "data": payload_data,
+        "customerIpAddress": "127.0.0.1",
         "sourceObject": {
             "__typename": "Checkout",
             "id": checkout_id,
@@ -204,6 +209,7 @@ def test_transaction_process_session_order_with_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
+        customer_ip_address="127.0.0.1",
         payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
@@ -229,6 +235,7 @@ def test_transaction_process_session_order_with_data(
             "actionType": action_type.upper(),
         },
         "data": payload_data,
+        "customerIpAddress": "127.0.0.1",
         "sourceObject": {
             "__typename": "Order",
             "id": order_id,
@@ -268,6 +275,7 @@ def test_transaction_process_session_order_without_data(
             currency=transaction.currency,
             action_type=action_type,
         ),
+        customer_ip_address="127.0.0.1",
         payment_gateway_data=PaymentGatewayData(
             app_identifier=webhook_app.identifier, data=payload_data, error=None
         ),
@@ -292,6 +300,72 @@ def test_transaction_process_session_order_without_data(
             "actionType": action_type.upper(),
         },
         "data": payload_data,
+        "customerIpAddress": "127.0.0.1",
+        "sourceObject": {
+            "__typename": "Order",
+            "id": order_id,
+        },
+    }
+
+
+def test_transaction_process_session_empty_customer_ip_address(
+    order, webhook_app, permission_manage_payments, transaction_item_generator
+):
+    # given
+    webhook_app.permissions.add(permission_manage_payments)
+    webhook = Webhook.objects.create(
+        name="Webhook",
+        app=webhook_app,
+        subscription_query=TRANSACTION_PROCESS_SESSION,
+    )
+    event_type = WebhookEventSyncType.TRANSACTION_PROCESS_SESSION
+    webhook.events.create(event_type=event_type)
+    payload_data = None
+    amount = Decimal("10")
+
+    transaction = transaction_item_generator(
+        order_id=order.pk,
+        app=webhook_app,
+        psp_reference=None,
+        name=None,
+        message=None,
+    )
+    action_type = TransactionFlowStrategy.CHARGE
+
+    subscribable_object = TransactionSessionData(
+        transaction=transaction,
+        source_object=order,
+        action=TransactionProcessActionData(
+            amount=amount,
+            currency=transaction.currency,
+            action_type=action_type,
+        ),
+        customer_ip_address=None,
+        payment_gateway_data=PaymentGatewayData(
+            app_identifier=webhook_app.identifier, data=payload_data, error=None
+        ),
+    )
+
+    # when
+    delivery = create_deliveries_for_subscriptions(
+        event_type, subscribable_object, [webhook]
+    )[0]
+
+    # then
+    order_id = graphene.Node.to_global_id("Order", order.pk)
+    assert delivery.payload
+    assert delivery.payload.payload
+    assert json.loads(delivery.payload.payload) == {
+        "merchantReference": graphene.Node.to_global_id(
+            "TransactionItem", transaction.token
+        ),
+        "action": {
+            "amount": amount,
+            "currency": "USD",
+            "actionType": action_type.upper(),
+        },
+        "data": payload_data,
+        "customerIpAddress": None,
         "sourceObject": {
             "__typename": "Order",
             "id": order_id,

--- a/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_initialize_session_webhook.py
@@ -163,6 +163,7 @@ def test_transaction_initialize_checkout_without_request_data_and_static_payload
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address="127.0.0.1",
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
@@ -231,6 +232,7 @@ def test_transaction_initialize_checkout_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address="127.0.0.1",
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
@@ -299,6 +301,7 @@ def test_transaction_initialize_checkout_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address="127.0.0.1",
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
@@ -368,6 +371,7 @@ def test_transaction_initialize_checkout_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address="127.0.0.1",
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
@@ -437,6 +441,7 @@ def test_transaction_initialize_session_skips_app_without_identifier(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address="127.0.0.1",
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
@@ -499,6 +504,7 @@ def test_transaction_initialize_order_without_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address="127.0.0.1",
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
@@ -567,6 +573,7 @@ def test_transaction_initialize_order_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address="127.0.0.1",
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
@@ -635,6 +642,7 @@ def test_transaction_initialize_order_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address="127.0.0.1",
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
@@ -704,6 +712,7 @@ def test_transaction_initialize_order_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address="127.0.0.1",
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),

--- a/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
+++ b/saleor/plugins/webhook/tests/test_transaction_process_session_webhook.py
@@ -163,6 +163,7 @@ def test_transaction_process_checkout_without_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address=None,
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
@@ -231,6 +232,7 @@ def test_transaction_process_checkout_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address=None,
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
@@ -299,6 +301,7 @@ def test_transaction_process_checkout_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address=None,
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
@@ -368,6 +371,7 @@ def test_transaction_process_checkout_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address=None,
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
@@ -437,6 +441,7 @@ def test_transaction_process_session_skips_app_without_identifier(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address=None,
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
@@ -499,6 +504,7 @@ def test_transaction_process_order_without_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address=None,
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
@@ -567,6 +573,7 @@ def test_transaction_process_order_with_request_data_and_static_payload(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address=None,
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),
@@ -635,6 +642,7 @@ def test_transaction_process_order_without_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address=None,
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=None, error=None
             ),
@@ -704,6 +712,7 @@ def test_transaction_process_order_with_request_data(
                 currency=transaction.currency,
                 action_type=action_type,
             ),
+            customer_ip_address=None,
             payment_gateway_data=PaymentGatewayData(
                 app_identifier=webhook_app.identifier, data=data, error=None
             ),


### PR DESCRIPTION
I want to merge this change because it covers: https://github.com/saleor/saleor/issues/13605

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
