### PR TITLE
Fix error when invalid variantId is sent in productVariantBulkUpdate

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_update.py
@@ -418,7 +418,7 @@ class ProductVariantBulkUpdate(BaseMutation):
         variants_global_id_to_instance_map,
         index_error_map,
     ):
-        cleaned_inputs_map = {}
+        cleaned_inputs_map: dict = {}
         product_type = product.product_type
 
         # fetch existing data required to validate inputs
@@ -473,11 +473,12 @@ class ProductVariantBulkUpdate(BaseMutation):
                 index_error_map[index].append(
                     ProductVariantBulkError(
                         field="id",
-                        pth="id",
+                        path="id",
                         message=message,
                         code=ProductErrorCode.INVALID,
                     )
                 )
+                cleaned_inputs_map[index] = None
                 continue
 
             cleaned_input = cls.clean_variant(


### PR DESCRIPTION
I want to merge this change because it fixes a bug with an invalid argument in `ProductVariantBulkError`.

port of #13699
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
