### PR TITLE
Lazy legacy webhooks payload generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ in 3.17. Use `PaymentSettings.defaultTransactionFlowStrategy` instead.
 - Change error message when denying a permission - #13334 by @rafiwts
 - Add filter by slugs to attribute choices - #13761 by @rafiwts
 - Add a new `product` field on `AssignedProductAttributeValue`. First part of a simplification of Attribute - Product relation from #12881. by @aniav
+- Lazy legacy webhooks payload generation - #13758 by @maarcingebala
 
 # 3.15.0 [Unreleased]
 

--- a/saleor/graphql/account/tests/mutations/staff/test_customer_delete.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_customer_delete.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import graphene
 import pytest
@@ -7,7 +7,6 @@ from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
 from ......webhook.event_types import WebhookEventAsyncType
-from ......webhook.payloads import generate_customer_payload
 from .....tests.utils import get_graphql_content
 from ....mutations.staff import CustomerDelete
 
@@ -93,12 +92,14 @@ def test_customer_delete_trigger_webhook(
     assert data["errors"] == []
     assert data["user"]["id"] == customer_id
     mocked_webhook_trigger.assert_called_once_with(
-        generate_customer_payload(customer_user, staff_api_client.user),
+        None,
         WebhookEventAsyncType.CUSTOMER_DELETED,
         [any_webhook],
         customer_user,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @patch("saleor.account.signals.delete_from_storage_task.delay")

--- a/saleor/graphql/account/tests/mutations/staff/test_customer_delete.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_customer_delete.py
@@ -1,3 +1,4 @@
+from functools import partial
 from unittest.mock import ANY, Mock, patch
 
 import graphene
@@ -99,7 +100,9 @@ def test_customer_delete_trigger_webhook(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @patch("saleor.account.signals.delete_from_storage_task.delay")

--- a/saleor/graphql/discount/tests/mutations/test_sale_bulk_delete.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_bulk_delete.py
@@ -150,6 +150,7 @@ def test_delete_sales_with_variants_triggers_webhook(
     variables = {
         "ids": [graphene.Node.to_global_id("Sale", sale.id) for sale in sale_list]
     }
+
     # when
     response = staff_api_client.post_graphql(
         SALE_BULK_DELETE_MUTATION, variables, permissions=[permission_manage_discounts]
@@ -157,8 +158,10 @@ def test_delete_sales_with_variants_triggers_webhook(
     content = get_graphql_content(response)
     # create a list of payloads with which the webhook was called
     called_payloads_list = []
+
     for arg_list in mocked_webhook_trigger.call_args_list:
-        called_arg = json.loads(arg_list[0][0])
+        data_generator = arg_list[1]["legacy_data_generator"]
+        called_arg = json.loads(data_generator())
         # we don't want to compare meta fields, only rest of payloads
         called_arg[0].pop("meta")
         called_payloads_list.append(called_arg)

--- a/saleor/graphql/page/tests/mutations/test_page_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_create.py
@@ -7,12 +7,12 @@ from django.conf import settings
 from django.utils.functional import SimpleLazyObject
 from django.utils.text import slugify
 from freezegun import freeze_time
+from mock import ANY
 
 from .....page.error_codes import PageErrorCode
 from .....page.models import Page, PageType
 from .....tests.utils import dummy_editorjs
 from .....webhook.event_types import WebhookEventAsyncType
-from .....webhook.payloads import generate_page_payload
 from ....tests.utils import get_graphql_content
 
 CREATE_PAGE_MUTATION = """
@@ -214,15 +214,16 @@ def test_page_create_trigger_page_webhook(
     assert data["page"]["isPublished"] == page_is_published
     assert data["page"]["pageType"]["id"] == page_type_id
     page = Page.objects.first()
-    expected_data = generate_page_payload(page, staff_api_client.user)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PAGE_CREATED,
         [any_webhook],
         page,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 def test_page_create_required_fields(

--- a/saleor/graphql/page/tests/mutations/test_page_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_create.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from functools import partial
 from unittest import mock
 
 import graphene
@@ -223,7 +224,9 @@ def test_page_create_trigger_page_webhook(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 def test_page_create_required_fields(

--- a/saleor/graphql/page/tests/mutations/test_page_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_delete.py
@@ -1,3 +1,4 @@
+from functools import partial
 from unittest import mock
 
 import graphene
@@ -71,7 +72,9 @@ def test_page_delete_trigger_webhook(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 def test_page_delete_with_file_attribute(

--- a/saleor/graphql/page/tests/mutations/test_page_types_bulk_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_types_bulk_delete.py
@@ -91,7 +91,7 @@ def test_page_type_bulk_delete_trigger_webhooks(
 
     assert not data["errors"]
     assert data["count"] == page_type_count
-    mocked_webhook_trigger.call_count == page_type_count
+    assert mocked_webhook_trigger.call_count == page_type_count
 
 
 def test_page_type_bulk_delete_by_staff_no_perm(

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 from django.utils.text import slugify
 from freezegun import freeze_time
+from mock import ANY
 
 from .....attribute.models import AttributeValue
 from .....attribute.utils import associate_attribute_values_to_instance
@@ -16,7 +17,6 @@ from .....page.error_codes import PageErrorCode
 from .....page.models import Page
 from .....tests.utils import dummy_editorjs
 from .....webhook.event_types import WebhookEventAsyncType
-from .....webhook.payloads import generate_page_payload
 from ....tests.utils import get_graphql_content
 
 UPDATE_PAGE_MUTATION = """
@@ -177,14 +177,15 @@ def test_update_page_trigger_webhook(
     assert data["page"]["title"] == page_title
     assert data["page"]["slug"] == new_slug
     page.published_at = timezone.now()
-    expected_data = generate_page_payload(page, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PAGE_UPDATED,
         [any_webhook],
         page,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 def test_update_page_only_title(staff_api_client, permission_manage_pages, page):

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from functools import partial
 from unittest import mock
 
 import graphene
@@ -185,7 +186,9 @@ def test_update_page_trigger_webhook(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 def test_update_page_only_title(staff_api_client, permission_manage_pages, page):

--- a/saleor/graphql/product/tests/mutations/test_product_delete.py
+++ b/saleor/graphql/product/tests/mutations/test_product_delete.py
@@ -1,3 +1,4 @@
+from functools import partial
 from unittest.mock import patch
 
 import graphene
@@ -142,7 +143,9 @@ def test_delete_product_trigger_webhook(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
     mocked_recalculate_orders_task.assert_not_called()
 
 

--- a/saleor/graphql/product/tests/mutations/test_product_delete.py
+++ b/saleor/graphql/product/tests/mutations/test_product_delete.py
@@ -4,6 +4,7 @@ import graphene
 import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
+from mock import ANY
 from prices import Money, TaxedMoney
 
 from .....attribute.models import AttributeValue
@@ -12,7 +13,6 @@ from .....graphql.tests.utils import get_graphql_content
 from .....order import OrderEvents, OrderStatus
 from .....order.models import OrderEvent, OrderLine
 from .....webhook.event_types import WebhookEventAsyncType
-from .....webhook.payloads import generate_product_deleted_payload
 
 DELETE_PRODUCT_MUTATION = """
     mutation DeleteProduct($id: ID!) {
@@ -124,7 +124,6 @@ def test_delete_product_trigger_webhook(
 
     query = DELETE_PRODUCT_MUTATION
     node_id = graphene.Node.to_global_id("Product", product.id)
-    variants_id = list(product.variants.all().values_list("id", flat=True))
     variables = {"id": node_id}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products]
@@ -135,16 +134,15 @@ def test_delete_product_trigger_webhook(
     with pytest.raises(product._meta.model.DoesNotExist):
         product.refresh_from_db()
     assert node_id == data["product"]["id"]
-    expected_data = generate_product_deleted_payload(
-        product, variants_id, staff_api_client.user
-    )
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_DELETED,
         [any_webhook],
         product,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
     mocked_recalculate_orders_task.assert_not_called()
 
 

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -5,12 +5,12 @@ import graphene
 import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
+from mock import ANY
 
 from ....attribute.utils import associate_attribute_values_to_instance
 from ....permission.models import Permission
 from ....tests.utils import dummy_editorjs
 from ....webhook.event_types import WebhookEventAsyncType
-from ....webhook.payloads import generate_translation_payload
 from ...core.enums import LanguageCodeEnum
 from ...tests.utils import assert_no_permission, get_graphql_content
 from ..schema import TranslatableKinds
@@ -865,13 +865,13 @@ def test_product_create_translation(
     assert data["product"]["translation"]["language"]["code"] == "PL"
 
     translation = product.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1018,13 +1018,13 @@ def test_product_update_translation(
     assert data["product"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1080,13 +1080,13 @@ def test_product_variant_create_translation(
     assert data["productVariant"]["translation"]["language"]["code"] == "PL"
 
     translation = variant.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1138,13 +1138,13 @@ def test_product_variant_update_translation(
     assert data["productVariant"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1225,13 +1225,13 @@ def test_collection_create_translation(
     assert data["collection"]["translation"]["language"]["code"] == "PL"
 
     translation = published_collection.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1321,13 +1321,13 @@ def test_collection_update_translation(
     assert data["collection"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1396,13 +1396,13 @@ def test_category_create_translation(
     assert data["category"]["translation"]["language"]["code"] == "PL"
 
     translation = category.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1490,13 +1490,13 @@ def test_category_update_translation(
     assert data["category"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1545,13 +1545,13 @@ def test_voucher_create_translation(
     assert data["voucher"]["translation"]["language"]["code"] == "PL"
 
     translation = voucher.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1601,13 +1601,13 @@ def test_voucher_update_translation(
     assert data["voucher"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1656,13 +1656,13 @@ def test_sale_create_translation(
     assert data["sale"]["translation"]["language"]["code"] == "PL"
 
     translation = sale.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1713,13 +1713,13 @@ def test_sale_update_translation(
     assert data["sale"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1769,13 +1769,13 @@ def test_page_create_translation(
     assert data["page"]["translation"]["language"]["code"] == "PL"
 
     translation = page.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1859,13 +1859,13 @@ def test_page_update_translation(
     assert data["page"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1916,13 +1916,13 @@ def test_attribute_create_translation(
     assert data["attribute"]["translation"]["language"]["code"] == "PL"
 
     translation = color_attribute.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1973,13 +1973,13 @@ def test_attribute_update_translation(
     assert data["attribute"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -2037,13 +2037,13 @@ def test_attribute_value_create_translation(
     assert data["attributeValue"]["translation"]["language"]["code"] == "PL"
 
     translation = pink_attribute_value.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -2163,13 +2163,13 @@ def test_attribute_value_update_translation(
     assert data["attributeValue"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -2615,13 +2615,13 @@ def test_shipping_method_create_translation(
     assert data["shippingMethod"]["translation"]["language"]["code"] == "PL"
 
     translation = shipping_method.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -2698,13 +2698,13 @@ def test_shipping_method_update_translation(
     assert data["shippingMethod"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -2758,13 +2758,13 @@ def test_menu_item_update_translation(
     assert data["menuItem"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -2824,13 +2824,13 @@ def test_shop_create_translation(
     assert data["shop"]["translation"]["language"]["code"] == "PL"
 
     translation = site_settings.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -2885,13 +2885,13 @@ def test_shop_update_translation(
     assert data["shop"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -1,4 +1,5 @@
 import json
+from functools import partial
 from unittest.mock import patch
 
 import graphene
@@ -873,6 +874,9 @@ def test_product_create_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 def test_product_create_translation_for_description(
@@ -1026,6 +1030,9 @@ def test_product_update_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 PRODUCT_VARIANT_TRANSLATE_MUTATION = """
@@ -1087,6 +1094,9 @@ def test_product_variant_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1233,6 +1243,9 @@ def test_collection_create_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 def test_collection_create_translation_by_translatable_content_id(
@@ -1329,6 +1342,9 @@ def test_collection_update_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 def test_collection_translation_mutation_validates_inputs_length(
@@ -1403,6 +1419,9 @@ def test_category_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1498,6 +1517,9 @@ def test_category_update_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 VOUCHER_TRANSLATE_MUTATION = """
@@ -1552,6 +1574,9 @@ def test_voucher_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1609,6 +1634,9 @@ def test_voucher_update_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 SALE_TRANSLATION_MUTATION = """
@@ -1663,6 +1691,9 @@ def test_sale_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1721,6 +1752,9 @@ def test_sale_update_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 PAGE_TRANSLATE_MUTATION = """
@@ -1776,6 +1810,9 @@ def test_page_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1867,6 +1904,9 @@ def test_page_update_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 ATTRIBUTE_TRANSLATE_MUTATION = """
@@ -1924,6 +1964,9 @@ def test_attribute_create_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 def test_attribute_create_translation_by_translatable_content_id(
@@ -1980,6 +2023,9 @@ def test_attribute_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -2044,6 +2090,9 @@ def test_attribute_value_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -2170,6 +2219,9 @@ def test_attribute_value_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -2623,6 +2675,9 @@ def test_shipping_method_create_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 def test_shipping_method_create_translation_by_translatable_content_id(
@@ -2706,6 +2761,9 @@ def test_shipping_method_update_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 MENU_ITEM_TRANSLATE = """
@@ -2765,6 +2823,9 @@ def test_menu_item_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -2832,6 +2893,9 @@ def test_shop_create_translation(
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
     )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 SHOP_SETTINGS_TRANSLATE_MUTATION = """
@@ -2892,6 +2956,9 @@ def test_shop_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from decimal import Decimal
+from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -169,11 +170,16 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_metadata_updated_event(self, event_type, instance):
         if webhooks := get_webhooks_for_event(event_type):
-            metadata_updated_data = generate_metadata_updated_payload(
+            metadata_payload_generator = generate_metadata_updated_payload(
                 instance, self.requestor
             )
             trigger_webhooks_async(
-                metadata_updated_data, event_type, webhooks, instance, self.requestor
+                None,
+                event_type,
+                webhooks,
+                instance,
+                self.requestor,
+                legacy_data_generator=metadata_payload_generator,
             )
 
     def _trigger_account_request_event(
@@ -653,9 +659,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def _trigger_menu_event(self, event_type, menu):
@@ -726,9 +739,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_CONFIRMED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_fully_paid(self, order: "Order", previous_value: Any) -> Any:
@@ -736,9 +756,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_FULLY_PAID
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_paid(self, order: "Order", previous_value: Any) -> Any:
@@ -746,9 +773,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_PAID
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_refunded(self, order: "Order", previous_value: Any) -> Any:
@@ -756,9 +790,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_REFUNDED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_fully_refunded(self, order: "Order", previous_value: Any) -> Any:
@@ -766,9 +807,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_FULLY_REFUNDED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_updated(self, order: "Order", previous_value: Any) -> Any:
@@ -776,9 +824,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_expired(self, order: "Order", previous_value: Any) -> Any:
@@ -786,9 +841,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_EXPIRED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def sale_created(
@@ -801,14 +863,20 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.SALE_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            sale_data = generate_sale_payload(
+            sale_data_generator = partial(
+                generate_sale_payload,
                 sale,
                 previous_catalogue=None,
                 current_catalogue=current_catalogue,
                 requestor=self.requestor,
             )
             trigger_webhooks_async(
-                sale_data, event_type, webhooks, sale, self.requestor
+                None,
+                event_type,
+                webhooks,
+                sale,
+                self.requestor,
+                legacy_data_generator=sale_data_generator,
             )
 
     def sale_updated(
@@ -822,11 +890,20 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.SALE_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            sale_data = generate_sale_payload(
-                sale, previous_catalogue, current_catalogue, self.requestor
+            sale_data_generator = partial(
+                generate_sale_payload,
+                sale,
+                previous_catalogue,
+                current_catalogue,
+                self.requestor,
             )
             trigger_webhooks_async(
-                sale_data, event_type, webhooks, sale, self.requestor
+                None,
+                event_type,
+                webhooks,
+                sale,
+                self.requestor,
+                legacy_data_generator=sale_data_generator,
             )
 
     def sale_deleted(
@@ -839,11 +916,19 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.SALE_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            sale_data = generate_sale_payload(
-                sale, previous_catalogue=previous_catalogue, requestor=self.requestor
+            sale_data_generator = partial(
+                generate_sale_payload,
+                sale,
+                previous_catalogue=previous_catalogue,
+                requestor=self.requestor,
             )
             trigger_webhooks_async(
-                sale_data, event_type, webhooks, sale, self.requestor
+                None,
+                event_type,
+                webhooks,
+                sale,
+                self.requestor,
+                legacy_data_generator=sale_data_generator,
             )
 
     def sale_toggle(
@@ -856,11 +941,19 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.SALE_TOGGLE
         if webhooks := get_webhooks_for_event(event_type):
-            sale_data = generate_sale_toggle_payload(
-                sale, catalogue=catalogue, requestor=self.requestor
+            sale_data_generator = partial(
+                generate_sale_toggle_payload,
+                sale,
+                catalogue=catalogue,
+                requestor=self.requestor,
             )
             trigger_webhooks_async(
-                sale_data, event_type, webhooks, sale, self.requestor
+                None,
+                event_type,
+                webhooks,
+                sale,
+                self.requestor,
+                legacy_data_generator=sale_data_generator,
             )
 
     def invoice_request(
@@ -874,9 +967,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.INVOICE_REQUESTED
         if webhooks := get_webhooks_for_event(event_type):
-            invoice_data = generate_invoice_payload(invoice, self.requestor)
+            invoice_data_generator = partial(
+                generate_invoice_payload, invoice, self.requestor
+            )
             trigger_webhooks_async(
-                invoice_data, event_type, webhooks, invoice, self.requestor
+                None,
+                event_type,
+                webhooks,
+                invoice,
+                self.requestor,
+                legacy_data_generator=invoice_data_generator,
             )
 
     def invoice_delete(self, invoice: "Invoice", previous_value: Any):
@@ -884,9 +984,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.INVOICE_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            invoice_data = generate_invoice_payload(invoice, self.requestor)
+            invoice_data_generator = partial(
+                generate_invoice_payload, invoice, self.requestor
+            )
             trigger_webhooks_async(
-                invoice_data, event_type, webhooks, invoice, self.requestor
+                None,
+                event_type,
+                webhooks,
+                invoice,
+                self.requestor,
+                legacy_data_generator=invoice_data_generator,
             )
 
     def invoice_sent(self, invoice: "Invoice", email: str, previous_value: Any) -> Any:
@@ -894,9 +1001,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.INVOICE_SENT
         if webhooks := get_webhooks_for_event(event_type):
-            invoice_data = generate_invoice_payload(invoice, self.requestor)
+            invoice_data_generator = partial(
+                generate_invoice_payload, invoice, self.requestor
+            )
             trigger_webhooks_async(
-                invoice_data, event_type, webhooks, invoice, self.requestor
+                None,
+                event_type,
+                webhooks,
+                invoice,
+                self.requestor,
+                legacy_data_generator=invoice_data_generator,
             )
 
     def order_cancelled(self, order: "Order", previous_value: Any) -> Any:
@@ -904,9 +1018,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_CANCELLED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_fulfilled(self, order: "Order", previous_value: Any) -> Any:
@@ -914,9 +1035,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_FULFILLED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_metadata_updated(self, order: "Order", previous_value: Any) -> Any:
@@ -931,6 +1059,7 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_BULK_CREATED
         if webhooks := get_webhooks_for_event(event_type):
+            # TODO: FIXME
             order_data = [
                 generate_order_payload(order, self.requestor) for order in orders
             ]
@@ -943,9 +1072,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def draft_order_updated(self, order: "Order", previous_value: Any) -> Any:
@@ -953,9 +1089,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def draft_order_deleted(self, order: "Order", previous_value: Any) -> Any:
@@ -963,9 +1106,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def fulfillment_created(
@@ -978,9 +1128,11 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.FULFILLMENT_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
+            fulfillment_data_generator = partial(
+                generate_fulfillment_payload, fulfillment, self.requestor
+            )
             trigger_webhooks_async(
-                fulfillment_data,
+                None,
                 event_type,
                 webhooks,
                 {
@@ -988,6 +1140,7 @@ class WebhookPlugin(BasePlugin):
                     "fulfillment": fulfillment,
                 },
                 self.requestor,
+                legacy_data_generator=fulfillment_data_generator,
             )
 
     def fulfillment_canceled(self, fulfillment: "Fulfillment", previous_value):
@@ -995,9 +1148,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.FULFILLMENT_CANCELED
         if webhooks := get_webhooks_for_event(event_type):
-            fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
+            fulfillment_data_generator = partial(
+                generate_fulfillment_payload, fulfillment, self.requestor
+            )
             trigger_webhooks_async(
-                fulfillment_data, event_type, webhooks, fulfillment, self.requestor
+                None,
+                event_type,
+                webhooks,
+                fulfillment,
+                self.requestor,
+                legacy_data_generator=fulfillment_data_generator,
             )
 
     def fulfillment_approved(
@@ -1010,9 +1170,11 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.FULFILLMENT_APPROVED
         if webhooks := get_webhooks_for_event(event_type):
-            fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
+            fulfillment_data_generator = partial(
+                generate_fulfillment_payload, fulfillment, self.requestor
+            )
             trigger_webhooks_async(
-                fulfillment_data,
+                None,
                 event_type,
                 webhooks,
                 {
@@ -1020,6 +1182,7 @@ class WebhookPlugin(BasePlugin):
                     "notify_customer": notify_customer,
                 },
                 self.requestor,
+                legacy_data_generator=fulfillment_data_generator,
             )
 
     def fulfillment_metadata_updated(self, fulfillment: "Fulfillment", previous_value):
@@ -1044,9 +1207,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CUSTOMER_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            customer_data = generate_customer_payload(customer, self.requestor)
+            customer_data_generator = partial(
+                generate_customer_payload, customer, self.requestor
+            )
             trigger_webhooks_async(
-                customer_data, event_type, webhooks, customer, self.requestor
+                None,
+                event_type,
+                webhooks,
+                customer,
+                self.requestor,
+                legacy_data_generator=customer_data_generator,
             )
 
     def customer_updated(self, customer: "User", previous_value: Any) -> Any:
@@ -1054,9 +1224,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CUSTOMER_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            customer_data = generate_customer_payload(customer, self.requestor)
+            customer_data_generator = partial(
+                generate_customer_payload, customer, self.requestor
+            )
             trigger_webhooks_async(
-                customer_data, event_type, webhooks, customer, self.requestor
+                None,
+                event_type,
+                webhooks,
+                customer,
+                self.requestor,
+                legacy_data_generator=customer_data_generator,
             )
 
     def customer_deleted(self, customer: "User", previous_value: Any) -> Any:
@@ -1064,9 +1241,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CUSTOMER_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            customer_data = generate_customer_payload(customer, self.requestor)
+            customer_data_generator = partial(
+                generate_customer_payload, customer, self.requestor
+            )
             trigger_webhooks_async(
-                customer_data, event_type, webhooks, customer, self.requestor
+                None,
+                event_type,
+                webhooks,
+                customer,
+                self.requestor,
+                legacy_data_generator=customer_data_generator,
             )
 
     def customer_metadata_updated(self, customer: "User", previous_value: Any) -> Any:
@@ -1081,9 +1265,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.COLLECTION_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            collection_data = generate_collection_payload(collection, self.requestor)
+            collection_data_generator = partial(
+                generate_collection_payload, collection, self.requestor
+            )
             trigger_webhooks_async(
-                collection_data, event_type, webhooks, collection, self.requestor
+                None,
+                event_type,
+                webhooks,
+                collection,
+                self.requestor,
+                legacy_data_generator=collection_data_generator,
             )
 
     def collection_updated(self, collection: "Collection", previous_value: Any) -> Any:
@@ -1091,9 +1282,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.COLLECTION_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            collection_data = generate_collection_payload(collection, self.requestor)
+            collection_data_generator = partial(
+                generate_collection_payload, collection, self.requestor
+            )
             trigger_webhooks_async(
-                collection_data, event_type, webhooks, collection, self.requestor
+                None,
+                event_type,
+                webhooks,
+                collection,
+                self.requestor,
+                legacy_data_generator=collection_data_generator,
             )
 
     def collection_deleted(self, collection: "Collection", previous_value: Any) -> Any:
@@ -1101,9 +1299,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.COLLECTION_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            collection_data = generate_collection_payload(collection, self.requestor)
+            collection_data_generator = partial(
+                generate_collection_payload, collection, self.requestor
+            )
             trigger_webhooks_async(
-                collection_data, event_type, webhooks, collection, self.requestor
+                None,
+                event_type,
+                webhooks,
+                collection,
+                self.requestor,
+                legacy_data_generator=collection_data_generator,
             )
 
     def collection_metadata_updated(
@@ -1120,9 +1325,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            product_data = generate_product_payload(product, self.requestor)
+            product_data_generator = partial(
+                generate_product_payload, product, self.requestor
+            )
             trigger_webhooks_async(
-                product_data, event_type, webhooks, product, self.requestor
+                None,
+                event_type,
+                webhooks,
+                product,
+                self.requestor,
+                legacy_data_generator=product_data_generator,
             )
 
     def product_updated(self, product: "Product", previous_value: Any) -> Any:
@@ -1130,9 +1342,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            product_data = generate_product_payload(product, self.requestor)
+            product_data_generator = partial(
+                generate_product_payload, product, self.requestor
+            )
             trigger_webhooks_async(
-                product_data, event_type, webhooks, product, self.requestor
+                None,
+                event_type,
+                webhooks,
+                product,
+                self.requestor,
+                legacy_data_generator=product_data_generator,
             )
 
     def product_metadata_updated(self, product: "Product", previous_value: Any) -> Any:
@@ -1160,15 +1379,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            product_data = generate_product_deleted_payload(
-                product, variants, self.requestor
+            product_data_generator = partial(
+                generate_product_deleted_payload, product, variants, self.requestor
             )
             trigger_webhooks_async(
-                product_data,
+                None,
                 event_type,
                 webhooks,
                 product,
                 self.requestor,
+                legacy_data_generator=product_data_generator,
             )
 
     def product_media_created(self, media: "ProductMedia", previous_value: Any) -> Any:
@@ -1176,13 +1396,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_MEDIA_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            media_data = generate_product_media_payload(media)
+            media_data_generator = partial(generate_product_media_payload, media)
             trigger_webhooks_async(
-                media_data,
+                None,
                 event_type,
                 webhooks,
                 media,
                 self.requestor,
+                legacy_data_generator=media_data_generator,
             )
 
     def product_media_updated(self, media: "ProductMedia", previous_value: Any) -> Any:
@@ -1190,13 +1411,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_MEDIA_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            media_data = generate_product_media_payload(media)
+            media_data_generator = partial(generate_product_media_payload, media)
             trigger_webhooks_async(
-                media_data,
+                None,
                 event_type,
                 webhooks,
                 media,
                 self.requestor,
+                legacy_data_generator=media_data_generator,
             )
 
     def product_media_deleted(self, media: "ProductMedia", previous_value: Any) -> Any:
@@ -1204,13 +1426,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_MEDIA_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            media_data = generate_product_media_payload(media)
+            media_data_generator = partial(generate_product_media_payload, media)
             trigger_webhooks_async(
-                media_data,
+                None,
                 event_type,
                 webhooks,
                 media,
                 self.requestor,
+                legacy_data_generator=media_data_generator,
             )
 
     def product_variant_created(
@@ -1220,15 +1443,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            product_variant_data = generate_product_variant_payload(
-                [product_variant], self.requestor
+            product_variant_data_generator = partial(
+                generate_product_variant_payload, [product_variant], self.requestor
             )
             trigger_webhooks_async(
-                product_variant_data,
+                None,
                 event_type,
                 webhooks,
                 product_variant,
                 self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def product_variant_updated(
@@ -1238,15 +1462,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            product_variant_data = generate_product_variant_payload(
-                [product_variant], self.requestor
+            product_variant_data_generator = partial(
+                generate_product_variant_payload, [product_variant], self.requestor
             )
             trigger_webhooks_async(
-                product_variant_data,
+                None,
                 event_type,
                 webhooks,
                 product_variant,
                 self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def product_variant_deleted(
@@ -1256,15 +1481,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            product_variant_data = generate_product_variant_payload(
-                [product_variant], self.requestor
+            product_variant_data_generator = partial(
+                generate_product_variant_payload, [product_variant], self.requestor
             )
             trigger_webhooks_async(
-                product_variant_data,
+                None,
                 event_type,
                 webhooks,
                 product_variant,
                 self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def product_variant_metadata_updated(
@@ -1281,9 +1507,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK
         if webhooks := get_webhooks_for_event(event_type):
-            product_variant_data = generate_product_variant_with_stock_payload([stock])
+            product_variant_data_generator = (
+                generate_product_variant_with_stock_payload([stock])
+            )
             trigger_webhooks_async(
-                product_variant_data, event_type, webhooks, stock, self.requestor
+                None,
+                event_type,
+                webhooks,
+                stock,
+                self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def product_variant_back_in_stock(self, stock: "Stock", previous_value: Any) -> Any:
@@ -1291,11 +1524,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK
         if webhooks := get_webhooks_for_event(event_type):
-            product_variant_data = generate_product_variant_with_stock_payload(
-                [stock], self.requestor
+            product_variant_data_generator = (
+                generate_product_variant_with_stock_payload([stock], self.requestor)
             )
             trigger_webhooks_async(
-                product_variant_data, event_type, webhooks, stock, self.requestor
+                None,
+                event_type,
+                webhooks,
+                stock,
+                self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def product_variant_stock_updated(self, stock: "Stock", previous_value: Any) -> Any:
@@ -1303,11 +1541,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            product_variant_data = generate_product_variant_with_stock_payload(
-                [stock], self.requestor
+            product_variant_data_generator = (
+                generate_product_variant_with_stock_payload([stock], self.requestor)
             )
             trigger_webhooks_async(
-                product_variant_data, event_type, webhooks, stock, self.requestor
+                None,
+                event_type,
+                webhooks,
+                stock,
+                self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def checkout_created(self, checkout: "Checkout", previous_value: Any) -> Any:
@@ -1315,9 +1558,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CHECKOUT_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            checkout_data = generate_checkout_payload(checkout, self.requestor)
+            checkout_data_generator = generate_checkout_payload(
+                checkout, self.requestor
+            )
             trigger_webhooks_async(
-                checkout_data, event_type, webhooks, checkout, self.requestor
+                None,
+                event_type,
+                webhooks,
+                checkout,
+                self.requestor,
+                legacy_data_generator=checkout_data_generator,
             )
 
     def checkout_updated(self, checkout: "Checkout", previous_value: Any) -> Any:
@@ -1325,9 +1575,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CHECKOUT_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            checkout_data = generate_checkout_payload(checkout, self.requestor)
+            checkout_data_generator = generate_checkout_payload(
+                checkout, self.requestor
+            )
             trigger_webhooks_async(
-                checkout_data, event_type, webhooks, checkout, self.requestor
+                None,
+                event_type,
+                webhooks,
+                checkout,
+                self.requestor,
+                legacy_data_generator=checkout_data_generator,
             )
 
     def checkout_fully_paid(self, checkout: "Checkout", previous_value: Any) -> Any:
@@ -1335,9 +1592,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CHECKOUT_FULLY_PAID
         if webhooks := get_webhooks_for_event(event_type):
-            checkout_data = generate_checkout_payload(checkout, self.requestor)
+            checkout_data_generator = generate_checkout_payload(
+                checkout, self.requestor
+            )
             trigger_webhooks_async(
-                checkout_data, event_type, webhooks, checkout, self.requestor
+                None,
+                event_type,
+                webhooks,
+                checkout,
+                self.requestor,
+                legacy_data_generator=checkout_data_generator,
             )
 
     def checkout_metadata_updated(
@@ -1374,9 +1638,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PAGE_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            page_data = generate_page_payload(page, self.requestor)
+            page_data_generator = partial(generate_page_payload, page, self.requestor)
             trigger_webhooks_async(
-                page_data, event_type, webhooks, page, self.requestor
+                None,
+                event_type,
+                webhooks,
+                page,
+                self.requestor,
+                legacy_data_generator=page_data_generator,
             )
 
     def page_updated(self, page: "Page", previous_value: Any) -> Any:
@@ -1384,9 +1653,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PAGE_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            page_data = generate_page_payload(page, self.requestor)
+            page_data_generator = partial(generate_page_payload, page, self.requestor)
             trigger_webhooks_async(
-                page_data, event_type, webhooks, page, self.requestor
+                None,
+                event_type,
+                webhooks,
+                page,
+                self.requestor,
+                legacy_data_generator=page_data_generator,
             )
 
     def page_deleted(self, page: "Page", previous_value: Any) -> Any:
@@ -1394,9 +1668,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PAGE_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            page_data = generate_page_payload(page, self.requestor)
+            page_data_generator = partial(generate_page_payload, page, self.requestor)
             trigger_webhooks_async(
-                page_data, event_type, webhooks, page, self.requestor
+                None,
+                event_type,
+                webhooks,
+                page,
+                self.requestor,
+                legacy_data_generator=page_data_generator,
             )
 
     def _trigger_page_type_event(self, event_type, page_type):
@@ -1610,12 +1889,13 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.THUMBNAIL_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            thumbnail_data = generate_thumbnail_payload(thumbnail)
+            thumbnail_data_generator = partial(generate_thumbnail_payload, thumbnail)
             trigger_webhooks_async(
-                data=thumbnail_data,
+                data=None,
                 event_type=event_type,
                 webhooks=webhooks,
                 subscribable_object=thumbnail,
+                legacy_data_generator=thumbnail_data_generator,
             )
 
     def translation_created(self, translation: "Translation", previous_value: Any):
@@ -1623,9 +1903,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.TRANSLATION_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            translation_data = generate_translation_payload(translation, self.requestor)
+            translation_data_generator = partial(
+                generate_translation_payload, translation, self.requestor
+            )
             trigger_webhooks_async(
-                translation_data, event_type, webhooks, translation, self.requestor
+                None,
+                event_type,
+                webhooks,
+                translation,
+                self.requestor,
+                legacy_data_generator=translation_data_generator,
             )
 
     def translation_updated(self, translation: "Translation", previous_value: Any):
@@ -1633,9 +1920,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.TRANSLATION_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            translation_data = generate_translation_payload(translation, self.requestor)
+            translation_data_generator = partial(
+                generate_translation_payload, translation, self.requestor
+            )
             trigger_webhooks_async(
-                translation_data, event_type, webhooks, translation, self.requestor
+                None,
+                event_type,
+                webhooks,
+                translation,
+                self.requestor,
+                legacy_data_generator=translation_data_generator,
             )
 
     def _trigger_warehouse_event(self, event_type, warehouse):

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -170,8 +170,8 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_metadata_updated_event(self, event_type, instance):
         if webhooks := get_webhooks_for_event(event_type):
-            metadata_payload_generator = generate_metadata_updated_payload(
-                instance, self.requestor
+            metadata_payload_generator = partial(
+                generate_metadata_updated_payload, instance, self.requestor
             )
             trigger_webhooks_async(
                 None,
@@ -1059,12 +1059,19 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_BULK_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            # TODO: FIXME
-            order_data = [
-                generate_order_payload(order, self.requestor) for order in orders
-            ]
+
+            def generate_bulk_order_payload():
+                return [
+                    generate_order_payload(order, self.requestor) for order in orders
+                ]
+
             trigger_webhooks_async(
-                order_data, event_type, webhooks, orders, self.requestor
+                None,
+                event_type,
+                webhooks,
+                orders,
+                self.requestor,
+                legacy_data_generator=generate_bulk_order_payload,
             )
 
     def draft_order_created(self, order: "Order", previous_value: Any) -> Any:
@@ -1507,8 +1514,8 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK
         if webhooks := get_webhooks_for_event(event_type):
-            product_variant_data_generator = (
-                generate_product_variant_with_stock_payload([stock])
+            product_variant_data_generator = partial(
+                generate_product_variant_with_stock_payload, [stock]
             )
             trigger_webhooks_async(
                 None,
@@ -1524,8 +1531,8 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK
         if webhooks := get_webhooks_for_event(event_type):
-            product_variant_data_generator = (
-                generate_product_variant_with_stock_payload([stock], self.requestor)
+            product_variant_data_generator = partial(
+                generate_product_variant_with_stock_payload, [stock], self.requestor
             )
             trigger_webhooks_async(
                 None,
@@ -1558,8 +1565,8 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CHECKOUT_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            checkout_data_generator = generate_checkout_payload(
-                checkout, self.requestor
+            checkout_data_generator = partial(
+                generate_checkout_payload, checkout, self.requestor
             )
             trigger_webhooks_async(
                 None,
@@ -1575,8 +1582,8 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CHECKOUT_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            checkout_data_generator = generate_checkout_payload(
-                checkout, self.requestor
+            checkout_data_generator = partial(
+                generate_checkout_payload, checkout, self.requestor
             )
             trigger_webhooks_async(
                 None,
@@ -1592,8 +1599,8 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CHECKOUT_FULLY_PAID
         if webhooks := get_webhooks_for_event(event_type):
-            checkout_data_generator = generate_checkout_payload(
-                checkout, self.requestor
+            checkout_data_generator = partial(
+                generate_checkout_payload, checkout, self.requestor
             )
             trigger_webhooks_async(
                 None,

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -209,7 +209,7 @@ def trigger_webhooks_async(
         if legacy_data_generator:
             data = legacy_data_generator()
         elif data is None:
-            raise ValueError("No payload was provided for regular webhooks.")
+            raise NotImplementedError("No payload was provided for regular webhooks.")
 
         payload = EventPayload.objects.create(payload=data)
         deliveries.extend(

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -185,19 +185,32 @@ def create_delivery_for_subscription_sync_event(
 
 
 def trigger_webhooks_async(
-    data, event_type, webhooks, subscribable_object=None, requestor=None
+    data,  # deprecated, legacy_data_generator should be used instead
+    event_type,
+    webhooks,
+    subscribable_object=None,
+    requestor=None,
+    legacy_data_generator=None,
 ):
     """Trigger async webhooks - both regular and subscription.
 
     :param data: used as payload in regular webhooks.
+        Note: this is a legacy parameter, thus it is optional; if it's not provided,
+        `legacy_data_generator` function is used to generate the payload when needed.
     :param event_type: used in both webhook types as event type.
     :param webhooks: used in both webhook types, queryset of async webhooks.
     :param subscribable_object: subscribable object used in subscription webhooks.
     :param requestor: used in subscription webhooks to generate meta data for payload.
+    :param legacy_data_generator: used to generate payload for regular webhooks.
     """
     regular_webhooks, subscription_webhooks = group_webhooks_by_subscription(webhooks)
     deliveries = []
     if regular_webhooks:
+        if legacy_data_generator:
+            data = legacy_data_generator()
+        elif data is None:
+            raise ValueError("No payload was provided for regular webhooks.")
+
         payload = EventPayload.objects.create(payload=data)
         deliveries.extend(
             create_event_delivery_list_for_webhooks(

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from decimal import Decimal
+from functools import partial
 from unittest import mock
 from unittest.mock import ANY, MagicMock
 from urllib.parse import urlencode
@@ -139,7 +140,9 @@ def test_order_created(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -165,7 +168,9 @@ def test_order_confirmed(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -191,7 +196,9 @@ def test_draft_order_created(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -217,7 +224,9 @@ def test_draft_order_deleted(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -243,7 +252,9 @@ def test_draft_order_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -269,7 +280,9 @@ def test_customer_created(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -295,7 +308,9 @@ def test_customer_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -320,7 +335,9 @@ def test_customer_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -345,7 +362,9 @@ def test_order_fully_paid(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -375,7 +394,9 @@ def test_order_paid(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -405,7 +426,9 @@ def test_order_refunded(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -435,7 +458,9 @@ def test_order_fully_refunded(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -461,7 +486,9 @@ def test_collection_created(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -487,7 +514,9 @@ def test_collection_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -513,7 +542,9 @@ def test_collection_deleted(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -539,7 +570,9 @@ def test_collection_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -565,7 +598,9 @@ def test_product_created(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -591,7 +626,9 @@ def test_product_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -633,7 +670,9 @@ def test_product_deleted(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -659,7 +698,9 @@ def test_product_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -685,7 +726,9 @@ def test_product_variant_created(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -711,7 +754,9 @@ def test_product_variant_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -737,7 +782,9 @@ def test_product_variant_deleted(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -763,7 +810,9 @@ def test_product_variant_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -790,7 +839,9 @@ def test_product_variant_out_of_stock(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -817,7 +868,9 @@ def test_product_variant_back_in_stock(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -843,7 +896,9 @@ def test_order_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -869,7 +924,9 @@ def test_order_cancelled(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -895,7 +952,9 @@ def test_order_expired(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -921,7 +980,9 @@ def test_order_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -947,7 +1008,9 @@ def test_checkout_created(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 def test_checkout_payload_includes_sales(checkout_with_item, sale, discount_info):
@@ -1007,7 +1070,9 @@ def test_checkout_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("2014-06-28 10:50")
@@ -1037,7 +1102,9 @@ def test_checkout_fully_paid(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1063,7 +1130,9 @@ def test_checkout_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1085,7 +1154,9 @@ def test_page_created(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1107,7 +1178,9 @@ def test_page_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1132,7 +1205,9 @@ def test_page_deleted(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1159,7 +1234,9 @@ def test_invoice_request(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1186,7 +1263,9 @@ def test_invoice_delete(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1213,7 +1292,9 @@ def test_invoice_sent(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("2020-03-18 12:00:00")
@@ -1239,7 +1320,9 @@ def test_fulfillment_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1265,7 +1348,9 @@ def test_gift_card_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1291,7 +1376,9 @@ def test_voucher_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1318,7 +1405,9 @@ def test_shop_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1344,7 +1433,9 @@ def test_shipping_zone_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1370,7 +1461,9 @@ def test_warehouse_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1396,7 +1489,9 @@ def test_transaction_item_metadata_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("2020-03-18 12:00:00")
@@ -1509,7 +1604,9 @@ def test_sale_created(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1547,7 +1644,9 @@ def test_sale_updated(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1571,7 +1670,9 @@ def test_sale_deleted(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @freeze_time("2020-10-10 10:10")
@@ -1600,7 +1701,9 @@ def test_sale_toggle(
         None,
         legacy_data_generator=ANY,
     )
-    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
+    )
 
 
 @mock.patch("saleor.plugins.webhook.plugin.send_webhook_request_async.delay")

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -42,18 +42,7 @@ from ....site.models import SiteSettings
 from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....webhook.payloads import (
     generate_checkout_payload,
-    generate_collection_payload,
-    generate_customer_payload,
-    generate_invoice_payload,
-    generate_metadata_updated_payload,
-    generate_order_payload,
-    generate_page_payload,
     generate_product_deleted_payload,
-    generate_product_payload,
-    generate_product_variant_payload,
-    generate_product_variant_with_stock_payload,
-    generate_sale_payload,
-    generate_sale_toggle_payload,
 )
 from ....webhook.utils import get_webhooks_for_event
 from ...manager import get_plugins_manager
@@ -141,15 +130,16 @@ def test_order_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_created(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_CREATED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -166,15 +156,16 @@ def test_order_confirmed(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_confirmed(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_CONFIRMED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -191,15 +182,16 @@ def test_draft_order_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.draft_order_created(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.DRAFT_ORDER_CREATED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -216,15 +208,16 @@ def test_draft_order_deleted(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.draft_order_deleted(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.DRAFT_ORDER_DELETED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -241,15 +234,16 @@ def test_draft_order_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.draft_order_updated(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -266,15 +260,16 @@ def test_customer_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.customer_created(customer_user)
-    expected_data = generate_customer_payload(customer_user)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CUSTOMER_CREATED,
         [any_webhook],
         customer_user,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -291,15 +286,16 @@ def test_customer_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.customer_updated(customer_user)
-    expected_data = generate_customer_payload(customer_user)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CUSTOMER_UPDATED,
         [any_webhook],
         customer_user,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -316,15 +312,15 @@ def test_customer_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.customer_metadata_updated(customer_user)
-    expected_data = generate_metadata_updated_payload(customer_user)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CUSTOMER_METADATA_UPDATED,
         [any_webhook],
         customer_user,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -341,15 +337,15 @@ def test_order_fully_paid(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_fully_paid(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_FULLY_PAID,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -371,15 +367,15 @@ def test_order_paid(
     manager.order_paid(order_with_lines)
 
     # then
-    expected_data = generate_order_payload(order_with_lines)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_PAID,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -401,15 +397,15 @@ def test_order_refunded(
     manager.order_refunded(order_with_lines)
 
     # then
-    expected_data = generate_order_payload(order_with_lines)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_REFUNDED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -431,15 +427,15 @@ def test_order_fully_refunded(
     manager.order_fully_refunded(order_with_lines)
 
     # then
-    expected_data = generate_order_payload(order_with_lines)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -456,15 +452,16 @@ def test_collection_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.collection_created(collection)
-    expected_data = generate_collection_payload(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.COLLECTION_CREATED,
         [any_webhook],
         collection,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -481,15 +478,16 @@ def test_collection_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.collection_updated(collection)
-    expected_data = generate_collection_payload(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.COLLECTION_UPDATED,
         [any_webhook],
         collection,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -506,15 +504,16 @@ def test_collection_deleted(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.collection_deleted(collection)
-    expected_data = generate_collection_payload(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.COLLECTION_DELETED,
         [any_webhook],
         collection,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -531,15 +530,16 @@ def test_collection_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.collection_metadata_updated(collection)
-    expected_data = generate_metadata_updated_payload(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.COLLECTION_METADATA_UPDATED,
         [any_webhook],
         collection,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -556,15 +556,16 @@ def test_product_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_created(product)
-    expected_data = generate_product_payload(product)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_CREATED,
         [any_webhook],
         product,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -581,15 +582,16 @@ def test_product_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_updated(product)
-    expected_data = generate_product_payload(product)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_UPDATED,
         [any_webhook],
         product,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -624,12 +626,14 @@ def test_product_deleted(
     assert variant_global_ids == expected_data_dict["variants"]
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_DELETED,
         [any_webhook],
         product,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -646,15 +650,16 @@ def test_product_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_metadata_updated(product)
-    expected_data = generate_metadata_updated_payload(product)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_METADATA_UPDATED,
         [any_webhook],
         product,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -671,15 +676,16 @@ def test_product_variant_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_variant_created(variant)
-    expected_data = generate_product_variant_payload([variant])
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_CREATED,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -696,15 +702,16 @@ def test_product_variant_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_variant_updated(variant)
-    expected_data = generate_product_variant_payload([variant])
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -721,15 +728,16 @@ def test_product_variant_deleted(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_variant_deleted(variant)
-    expected_data = generate_product_variant_payload([variant])
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_DELETED,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -746,15 +754,16 @@ def test_product_variant_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_variant_metadata_updated(variant)
-    expected_data = generate_metadata_updated_payload(variant)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_METADATA_UPDATED,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -773,14 +782,15 @@ def test_product_variant_out_of_stock(
     manager = get_plugins_manager()
     manager.product_variant_out_of_stock(variant)
 
-    expected_data = generate_product_variant_with_stock_payload([variant])
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -799,14 +809,15 @@ def test_product_variant_back_in_stock(
     manager = get_plugins_manager()
     manager.product_variant_back_in_stock(variant)
 
-    expected_data = generate_product_variant_with_stock_payload([variant])
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -823,15 +834,16 @@ def test_order_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_updated(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_UPDATED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -848,15 +860,16 @@ def test_order_cancelled(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_cancelled(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_CANCELLED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -873,15 +886,16 @@ def test_order_expired(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_expired(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_EXPIRED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -898,15 +912,16 @@ def test_order_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_metadata_updated(order_with_lines)
-    expected_data = generate_metadata_updated_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_METADATA_UPDATED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -923,15 +938,16 @@ def test_checkout_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.checkout_created(checkout_with_items)
-    expected_data = generate_checkout_payload(checkout_with_items)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CHECKOUT_CREATED,
         [any_webhook],
         checkout_with_items,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 def test_checkout_payload_includes_sales(checkout_with_item, sale, discount_info):
@@ -982,15 +998,16 @@ def test_checkout_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.checkout_updated(checkout_with_items)
-    expected_data = generate_checkout_payload(checkout_with_items)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CHECKOUT_UPDATED,
         [any_webhook],
         checkout_with_items,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("2014-06-28 10:50")
@@ -1012,15 +1029,15 @@ def test_checkout_fully_paid(
     manager.checkout_fully_paid(checkout_with_items)
 
     # then
-    expected_data = generate_checkout_payload(checkout_with_items)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CHECKOUT_FULLY_PAID,
         [any_webhook],
         checkout_with_items,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1037,15 +1054,16 @@ def test_checkout_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.checkout_metadata_updated(checkout_with_items)
-    expected_data = generate_metadata_updated_payload(checkout_with_items)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CHECKOUT_METADATA_UPDATED,
         [any_webhook],
         checkout_with_items,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1058,11 +1076,16 @@ def test_page_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.page_created(page)
-    expected_data = generate_page_payload(page)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.PAGE_CREATED, [any_webhook], page, None
+        None,
+        WebhookEventAsyncType.PAGE_CREATED,
+        [any_webhook],
+        page,
+        None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1075,11 +1098,16 @@ def test_page_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.page_updated(page)
-    expected_data = generate_page_payload(page)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.PAGE_UPDATED, [any_webhook], page, None
+        None,
+        WebhookEventAsyncType.PAGE_UPDATED,
+        [any_webhook],
+        page,
+        None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1095,11 +1123,16 @@ def test_page_deleted(
     page.delete()
     page.id = page_id
     manager.page_deleted(page)
-    expected_data = generate_page_payload(page)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.PAGE_DELETED, [any_webhook], page, None
+        None,
+        WebhookEventAsyncType.PAGE_DELETED,
+        [any_webhook],
+        page,
+        None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1117,15 +1150,16 @@ def test_invoice_request(
     manager = get_plugins_manager()
     invoice = fulfilled_order.invoices.first()
     manager.invoice_request(fulfilled_order, invoice, invoice.number)
-    expected_data = generate_invoice_payload(invoice)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.INVOICE_REQUESTED,
         [any_webhook],
         invoice,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1143,15 +1177,16 @@ def test_invoice_delete(
     manager = get_plugins_manager()
     invoice = fulfilled_order.invoices.first()
     manager.invoice_delete(invoice)
-    expected_data = generate_invoice_payload(invoice)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.INVOICE_DELETED,
         [any_webhook],
         invoice,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1169,11 +1204,16 @@ def test_invoice_sent(
     manager = get_plugins_manager()
     invoice = fulfilled_order.invoices.first()
     manager.invoice_sent(invoice, fulfilled_order.user.email)
-    expected_data = generate_invoice_payload(invoice)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.INVOICE_SENT, [any_webhook], invoice, None
+        None,
+        WebhookEventAsyncType.INVOICE_SENT,
+        [any_webhook],
+        invoice,
+        None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("2020-03-18 12:00:00")
@@ -1190,15 +1230,16 @@ def test_fulfillment_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.fulfillment_metadata_updated(fulfillment)
-    expected_data = generate_metadata_updated_payload(fulfillment)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.FULFILLMENT_METADATA_UPDATED,
         [any_webhook],
         fulfillment,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1215,15 +1256,16 @@ def test_gift_card_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.gift_card_metadata_updated(gift_card)
-    expected_data = generate_metadata_updated_payload(gift_card)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.GIFT_CARD_METADATA_UPDATED,
         [any_webhook],
         gift_card,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1240,15 +1282,16 @@ def test_voucher_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.voucher_metadata_updated(voucher)
-    expected_data = generate_metadata_updated_payload(voucher)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.VOUCHER_METADATA_UPDATED,
         [any_webhook],
         voucher,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1266,15 +1309,16 @@ def test_shop_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.shop_metadata_updated(site_settings)
-    expected_data = generate_metadata_updated_payload(site_settings)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.SHOP_METADATA_UPDATED,
         [any_webhook],
         site_settings,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1291,15 +1335,16 @@ def test_shipping_zone_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.shipping_zone_metadata_updated(shipping_zone)
-    expected_data = generate_metadata_updated_payload(shipping_zone)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.SHIPPING_ZONE_METADATA_UPDATED,
         [any_webhook],
         shipping_zone,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1316,15 +1361,16 @@ def test_warehouse_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.warehouse_metadata_updated(warehouse)
-    expected_data = generate_metadata_updated_payload(warehouse)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.WAREHOUSE_METADATA_UPDATED,
         [any_webhook],
         warehouse,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1341,15 +1387,16 @@ def test_transaction_item_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.transaction_item_metadata_updated(transaction_item_created_by_app)
-    expected_data = generate_metadata_updated_payload(transaction_item_created_by_app)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.TRANSACTION_ITEM_METADATA_UPDATED,
         [any_webhook],
         transaction_item_created_by_app,
         None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("2020-03-18 12:00:00")
@@ -1454,10 +1501,15 @@ def test_sale_created(
         fetch_catalogue_info(sale)
     )
     manager.sale_created(sale, current_catalogue=sale_catalogue_info)
-    expected_data = generate_sale_payload(sale, current_catalogue=sale_catalogue_info)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.SALE_CREATED, [any_webhook], sale, None
+        None,
+        WebhookEventAsyncType.SALE_CREATED,
+        [any_webhook],
+        sale,
+        None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1487,14 +1539,15 @@ def test_sale_updated(
         previous_catalogue=previous_sale_catalogue_info,
         current_catalogue=current_sale_catalogue_info,
     )
-    expected_data = generate_sale_payload(
-        sale,
-        current_catalogue=current_sale_catalogue_info,
-        previous_catalogue=previous_sale_catalogue_info,
-    )
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.SALE_UPDATED, [any_webhook], sale, None
+        None,
+        WebhookEventAsyncType.SALE_UPDATED,
+        [any_webhook],
+        sale,
+        None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("1914-06-28 10:50")
@@ -1510,10 +1563,15 @@ def test_sale_deleted(
         fetch_catalogue_info(sale)
     )
     manager.sale_deleted(sale, previous_catalogue=sale_catalogue_info)
-    expected_data = generate_sale_payload(sale, previous_catalogue=sale_catalogue_info)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.SALE_DELETED, [any_webhook], sale, None
+        None,
+        WebhookEventAsyncType.SALE_DELETED,
+        [any_webhook],
+        sale,
+        None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @freeze_time("2020-10-10 10:10")
@@ -1534,10 +1592,15 @@ def test_sale_toggle(
     manager.sale_toggle(sale, catalogue=sale_catalogue_info)
 
     # then
-    expected_data = generate_sale_toggle_payload(sale, catalogue=sale_catalogue_info)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.SALE_TOGGLE, [any_webhook], sale, None
+        None,
+        WebhookEventAsyncType.SALE_TOGGLE,
+        [any_webhook],
+        sale,
+        None,
+        legacy_data_generator=ANY,
     )
+    assert mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"] is not None
 
 
 @mock.patch("saleor.plugins.webhook.plugin.send_webhook_request_async.delay")


### PR DESCRIPTION
The legacy webhook payloads are generated for each webhook call, even if a subscription query is defined. Some payloads (e.g. checkout or order) have large static payloads with lots of DB relations, which adds unnecessary dozens of DB queries to the webhook execution.

This PR refactors legacy payload generation to be called only when a subscription query is not defined, and the static payload should be generated.

Some examples of saved queries for event and payload generator function used:
- `checkout_created` event / `generate_checkout_payload` - 14 queries for checkout with 1 line
- `order_created` event / `generate_order_payload` - 3 queries for order with 1 line
- `fulfillment_approved` event / `generate_fulfillment_payload`  - 26 queries for order with 1 line and 1 fulfillment

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
