### PR TITLE
Add `GIFT_CARD_EXPORT_COMPLETED` webhook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ in 3.17. Use `PaymentSettings.defaultTransactionFlowStrategy` instead.
   - Inform apps if customer should be notified when fulfillment is created.
 - Add `NOTIFY_CUSTOMER` flag to `FulfillmentApproved` type - #13637, by @Air-t
   - Inform apps if customer should be notified when fulfillment is approved.
+- Add `GIFT_CARD_EXPORT_COMPLETED` webhook - #13765, by @Air-t
+  - Event sent when CSV export is completed.
 
 ### Other changes
 - Fix error in variant available stock calculation - 13593 by @awaisdar001

--- a/saleor/csv/notifications.py
+++ b/saleor/csv/notifications.py
@@ -38,6 +38,8 @@ def send_export_download_link_notification(export_file: "ExportFile", data_type:
 
     manager = get_plugins_manager()
     manager.notify(NotifyEventType.CSV_EXPORT_SUCCESS, payload)
+    if data_type == "gift cards":
+        manager.gift_card_export_completed(export_file)
 
 
 def send_export_failed_info(export_file: "ExportFile", data_type: str):
@@ -50,3 +52,5 @@ def send_export_failed_info(export_file: "ExportFile", data_type: str):
     }
     manager = get_plugins_manager()
     manager.notify(NotifyEventType.CSV_EXPORT_FAILED, payload)
+    if data_type == "gift cards":
+        manager.gift_card_export_completed(export_file)

--- a/saleor/csv/tests/export/test_export.py
+++ b/saleor/csv/tests/export/test_export.py
@@ -293,6 +293,7 @@ def test_export_products_by_app(
     save_file_mock.assert_called_once_with(app_export_file, mock_file, ANY)
 
 
+@patch("saleor.plugins.manager.PluginsManager.gift_card_export_completed")
 @patch("saleor.csv.utils.export.create_file_with_headers")
 @patch("saleor.csv.utils.export.export_gift_cards_in_batches")
 @patch("saleor.csv.utils.export.send_export_download_link_notification")
@@ -302,6 +303,7 @@ def test_export_gift_cards(
     send_email_mock,
     export_in_batches_mock,
     create_file_with_headers_mock,
+    mocked_gift_card_export_completed,
     user_export_file,
     gift_card,
     gift_card_expiry_date,
@@ -333,6 +335,8 @@ def test_export_gift_cards(
     send_email_mock.assert_called_once_with(user_export_file, "gift cards")
 
     save_file_mock.assert_called_once_with(user_export_file, mock_file, ANY)
+
+    mocked_gift_card_export_completed.assert_called_once_with(user_export_file)
 
 
 @patch("saleor.csv.utils.export.create_file_with_headers")

--- a/saleor/csv/tests/test_notifications.py
+++ b/saleor/csv/tests/test_notifications.py
@@ -11,9 +11,15 @@ from ..notifications import get_default_export_payload
 
 
 @freeze_time("2018-05-31 12:00:01")
+@mock.patch("saleor.plugins.manager.PluginsManager.gift_card_export_completed")
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
 def test_send_export_download_link_notification(
-    mocked_notify, site_settings, user_export_file, tmpdir, media_root
+    mocked_notify,
+    mocked_gift_card_export_completed,
+    site_settings,
+    user_export_file,
+    tmpdir,
+    media_root,
 ):
     # given
     file_mock = mock.MagicMock(spec=File)
@@ -25,7 +31,6 @@ def test_send_export_download_link_notification(
 
     # when
     notifications.send_export_download_link_notification(user_export_file, data_type)
-
     # then
     expected_payload = {
         "export": get_default_export_payload(user_export_file),
@@ -34,16 +39,22 @@ def test_send_export_download_link_notification(
         "data_type": data_type,
         **get_site_context(),
     }
-
     mocked_notify.assert_called_once_with(
         AdminNotifyEvent.CSV_EXPORT_SUCCESS, expected_payload
     )
+    mocked_gift_card_export_completed.assert_not_called()
 
 
 @freeze_time("2018-05-31 12:00:01")
+@mock.patch("saleor.plugins.manager.PluginsManager.gift_card_export_completed")
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
 def test_send_export_failed_info(
-    mocked_notify, site_settings, user_export_file, tmpdir, media_root
+    mocked_notify,
+    mocked_gift_card_export_completed,
+    site_settings,
+    user_export_file,
+    tmpdir,
+    media_root,
 ):
     # given
     file_mock = mock.MagicMock(spec=File)
@@ -67,3 +78,4 @@ def test_send_export_failed_info(
     mocked_notify.assert_called_once_with(
         AdminNotifyEvent.CSV_EXPORT_FAILED, expected_payload
     )
+    mocked_gift_card_export_completed.assert_called_once_with(user_export_file)

--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -7,6 +7,7 @@ import petl as etl
 from django.utils import timezone
 
 from ...giftcard.models import GiftCard
+from ...plugins.manager import get_plugins_manager
 from ...product.models import Product
 from .. import FileTypes
 from ..notifications import send_export_download_link_notification
@@ -87,6 +88,8 @@ def export_gift_cards(
     temporary_file.close()
 
     send_export_download_link_notification(export_file, "gift cards")
+    manager = get_plugins_manager()
+    manager.gift_card_export_completed(export_file)
 
 
 def get_filename(model_name: str, file_type: str) -> str:

--- a/saleor/graphql/csv/mutations/export_gift_cards.py
+++ b/saleor/graphql/csv/mutations/export_gift_cards.py
@@ -51,6 +51,10 @@ class ExportGiftCards(BaseExportMutation):
                 type=WebhookEventAsyncType.NOTIFY_USER,
                 description="A notification for the exported file.",
             ),
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.GIFT_CARD_EXPORT_COMPLETED,
+                description="A notification for the exported file.",
+            ),
         ]
 
     @classmethod

--- a/saleor/graphql/csv/tests/mutations/test_export_gift_cards.py
+++ b/saleor/graphql/csv/tests/mutations/test_export_gift_cards.py
@@ -69,7 +69,6 @@ def test_export_gift_cards_mutation(
     query = EXPORT_GIFT_CARDS_MUTATION
     user = staff_api_client.user
     variables = {"input": input}
-
     response = staff_api_client.post_graphql(
         query,
         variables=variables,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1831,6 +1831,13 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   """
   GIFT_CARD_METADATA_UPDATED
 
+  """
+  A gift card export is completed.
+  
+  Added in Saleor 3.16.
+  """
+  GIFT_CARD_EXPORT_COMPLETED
+
   """A new menu created."""
   MENU_CREATED
 
@@ -2496,6 +2503,13 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   Added in Saleor 3.8.
   """
   GIFT_CARD_METADATA_UPDATED
+
+  """
+  A gift card export is completed.
+  
+  Added in Saleor 3.16.
+  """
+  GIFT_CARD_EXPORT_COMPLETED
 
   """A new menu created."""
   MENU_CREATED
@@ -3440,6 +3454,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   GIFT_CARD_SENT
   GIFT_CARD_STATUS_CHANGED
   GIFT_CARD_METADATA_UPDATED
+  GIFT_CARD_EXPORT_COMPLETED
   MENU_CREATED
   MENU_UPDATED
   MENU_DELETED
@@ -16993,11 +17008,12 @@ type Mutation {
   
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for the exported file.
+  - GIFT_CARD_EXPORT_COMPLETED (async): A notification for the exported file.
   """
   exportGiftCards(
     """Fields required to export gift cards data."""
     input: ExportGiftCardsInput!
-  ): ExportGiftCards @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [NOTIFY_USER], syncEvents: [])
+  ): ExportGiftCards @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, GIFT_CARD_EXPORT_COMPLETED], syncEvents: [])
 
   """
   Upload a file. This mutation must be sent as a `multipart` request. More detailed specs of the upload format can be found here: https://github.com/jaydenseric/graphql-multipart-request-spec 
@@ -26293,8 +26309,9 @@ Requires one of the following permissions: MANAGE_GIFT_CARD.
 
 Triggers the following webhook events:
 - NOTIFY_USER (async): A notification for the exported file.
+- GIFT_CARD_EXPORT_COMPLETED (async): A notification for the exported file.
 """
-type ExportGiftCards @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [NOTIFY_USER], syncEvents: []) {
+type ExportGiftCards @doc(category: "Gift cards") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, GIFT_CARD_EXPORT_COMPLETED], syncEvents: []) {
   """
   The newly created export file job which is responsible for export data.
   """
@@ -30405,6 +30422,28 @@ type GiftCardMetadataUpdated implements Event @doc(category: "Gift cards") {
 
   """The gift card the event relates to."""
   giftCard: GiftCard
+}
+
+"""
+Event sent when gift card export is completed.
+
+Added in Saleor 3.16.
+"""
+type GiftCardExportCompleted implements Event @doc(category: "Gift cards") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The export file for gift cards."""
+  export: ExportFile
 }
 
 """

--- a/saleor/graphql/tests/queries/fragments.py
+++ b/saleor/graphql/tests/queries/fragments.py
@@ -374,6 +374,17 @@ fragment GiftCardDetails on GiftCard{
 }
 """
 
+GIFT_CARD_EXPORT_DETAILS = """
+fragment GiftCardExportDetails on ExportFile{
+  id
+  createdAt
+  updatedAt
+  status
+  url
+  message
+}
+"""
+
 
 VOUCHER_DETAILS = """
 fragment VoucherDetails on Voucher{

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -8,6 +8,7 @@ from ..core.descriptions import (
     ADDED_IN_313,
     ADDED_IN_314,
     ADDED_IN_315,
+    ADDED_IN_316,
     DEPRECATED_IN_3X_ENUM_VALUE,
     PREVIEW_FEATURE,
 )
@@ -95,6 +96,9 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.GIFT_CARD_STATUS_CHANGED: "A gift card status is changed.",
     WebhookEventAsyncType.GIFT_CARD_METADATA_UPDATED: (
         "A gift card metadata is updated." + ADDED_IN_38
+    ),
+    WebhookEventAsyncType.GIFT_CARD_EXPORT_COMPLETED: (
+        "A gift card export is completed." + ADDED_IN_316
     ),
     WebhookEventAsyncType.INVOICE_REQUESTED: "An invoice for order requested.",
     WebhookEventAsyncType.INVOICE_DELETED: "An invoice is deleted.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -737,6 +737,25 @@ class GiftCardMetadataUpdated(SubscriptionObjectType, GiftCardBase):
         description = "Event sent when gift card metadata is updated." + ADDED_IN_38
 
 
+class GiftCardExportCompleted(SubscriptionObjectType):
+    export = graphene.Field(
+        "saleor.graphql.csv.types.ExportFile",
+        description="The export file for gift cards.",
+    )
+
+    class Meta:
+        root_type = "ExportFile"
+        enable_dry_run = True
+        interfaces = (Event,)
+        description = "Event sent when gift card export is completed." + ADDED_IN_316
+        doc_category = DOC_CATEGORY_GIFT_CARDS
+
+    @staticmethod
+    def resolve_export(root, info: ResolveInfo):
+        _, export_file = root
+        return export_file
+
+
 class MenuBase(AbstractType):
     menu = graphene.Field(
         "saleor.graphql.menu.types.Menu",
@@ -2364,6 +2383,7 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.GIFT_CARD_SENT: GiftCardSent,
     WebhookEventAsyncType.GIFT_CARD_STATUS_CHANGED: GiftCardStatusChanged,
     WebhookEventAsyncType.GIFT_CARD_METADATA_UPDATED: GiftCardMetadataUpdated,
+    WebhookEventAsyncType.GIFT_CARD_EXPORT_COMPLETED: GiftCardExportCompleted,
     WebhookEventAsyncType.MENU_CREATED: MenuCreated,
     WebhookEventAsyncType.MENU_UPDATED: MenuUpdated,
     WebhookEventAsyncType.MENU_DELETED: MenuDeleted,

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
@@ -224,6 +224,7 @@ def async_subscription_webhooks_with_root_objects(
     subscription_gift_card_sent_webhook,
     subscription_gift_card_status_changed_webhook,
     subscription_gift_card_metadata_updated_webhook,
+    subscription_gift_card_export_completed_webhook,
     subscription_menu_created_webhook,
     subscription_menu_updated_webhook,
     subscription_menu_deleted_webhook,
@@ -336,6 +337,7 @@ def async_subscription_webhooks_with_root_objects(
     translated_attribute,
     transaction_item_created_by_app,
     product_media_image,
+    user_export_file,
 ):
     events = WebhookEventAsyncType
     attr = numeric_attribute
@@ -391,6 +393,10 @@ def async_subscription_webhooks_with_root_objects(
         events.GIFT_CARD_METADATA_UPDATED: [
             subscription_gift_card_metadata_updated_webhook,
             gift_card,
+        ],
+        events.GIFT_CARD_EXPORT_COMPLETED: [
+            subscription_gift_card_export_completed_webhook,
+            user_export_file,
         ],
         events.MENU_CREATED: [subscription_menu_created_webhook, menu],
         events.MENU_UPDATED: [subscription_menu_updated_webhook, menu],

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from ..core.middleware import Requestor
     from ..core.notify_events import NotifyEventType
     from ..core.taxes import TaxData, TaxType
+    from ..csv.models import ExportFile
     from ..discount.models import Sale, Voucher
     from ..giftcard.models import GiftCard
     from ..invoice.models import Invoice
@@ -662,6 +663,12 @@ class BasePlugin:
     # Overwrite this method if you need to trigger specific logic after a gift card
     # status is changed.
     gift_card_status_changed: Callable[["GiftCard", None], None]
+
+    # Trigger when gift cards export is completed.
+    #
+    # Overwrite this method if you need to trigger specific logic after a gift cards
+    # export is completed.
+    gift_card_export_completed: Callable[["ExportFile", None], None]
 
     initialize_payment: Callable[
         [dict, Optional[InitializedPaymentResponse]], InitializedPaymentResponse

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
     from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
     from ..checkout.models import Checkout
     from ..core.middleware import Requestor
+    from ..csv.models import ExportFile
     from ..discount.models import Sale, Voucher
     from ..giftcard.models import GiftCard
     from ..invoice.models import Invoice
@@ -1281,6 +1282,12 @@ class PluginsManager(PaymentInterface):
         default_value = None
         return self.__run_method_on_plugins(
             "gift_card_metadata_updated", default_value, gift_card
+        )
+
+    def gift_card_export_completed(self, export: "ExportFile"):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "gift_card_export_completed", default_value, export
         )
 
     def menu_created(self, menu: "Menu"):

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -262,6 +262,14 @@ def subscription_gift_card_metadata_updated_webhook(subscription_webhook):
 
 
 @pytest.fixture
+def subscription_gift_card_export_completed_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.GIFT_CARD_EXPORT_COMPLETED,
+        WebhookEventAsyncType.GIFT_CARD_EXPORT_COMPLETED,
+    )
+
+
+@pytest.fixture
 def subscription_menu_created_webhook(subscription_webhook):
     return subscription_webhook(
         queries.MENU_CREATED, WebhookEventAsyncType.MENU_CREATED

--- a/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
@@ -4,6 +4,7 @@ import graphene
 from django.utils import timezone
 
 from ..... import __version__
+from .....core.utils import build_absolute_uri
 from .....graphql.attribute.enums import AttributeInputTypeEnum, AttributeTypeEnum
 from .....graphql.shop.types import SHOP_ID
 from .....product.models import Product
@@ -422,6 +423,21 @@ def generate_gift_card_payload(gift_card, card_global_id):
                 "isActive": gift_card.is_active,
                 "code": gift_card.code,
                 "createdBy": {"email": gift_card.created_by.email},
+            }
+        }
+    )
+
+
+def generate_gift_card_export_payload(export_file, export_global_id):
+    return json.dumps(
+        {
+            "export": {
+                "id": export_global_id,
+                "createdAt": export_file.created_at.isoformat(),
+                "updatedAt": export_file.updated_at.isoformat(),
+                "status": export_file.status.upper(),
+                "url": build_absolute_uri(export_file.content_file.url),
+                "message": export_file.message,
             }
         }
     )

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -459,6 +459,21 @@ GIFT_CARD_METADATA_UPDATED = (
 """
 )
 
+GIFT_CARD_EXPORT_COMPLETED = (
+    fragments.GIFT_CARD_EXPORT_DETAILS
+    + """
+    subscription{
+      event{
+        ...on GiftCardExportCompleted{
+          export{
+            ...GiftCardExportDetails
+          }
+        }
+      }
+    }
+"""
+)
+
 VOUCHER_CREATED = (
     fragments.VOUCHER_DETAILS
     + """

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -63,6 +63,7 @@ class WebhookEventAsyncType:
     GIFT_CARD_SENT = "gift_card_sent"
     GIFT_CARD_STATUS_CHANGED = "gift_card_status_changed"
     GIFT_CARD_METADATA_UPDATED = "gift_card_metadata_updated"
+    GIFT_CARD_EXPORT_COMPLETED = "gift_card_export_completed"
 
     MENU_CREATED = "menu_created"
     MENU_UPDATED = "menu_updated"
@@ -319,6 +320,10 @@ class WebhookEventAsyncType:
         },
         GIFT_CARD_METADATA_UPDATED: {
             "name": "Gift card metadata updated",
+            "permission": GiftcardPermissions.MANAGE_GIFT_CARD,
+        },
+        GIFT_CARD_EXPORT_COMPLETED: {
+            "name": "Gift card export completed",
             "permission": GiftcardPermissions.MANAGE_GIFT_CARD,
         },
         MENU_CREATED: {


### PR DESCRIPTION
* This webhook will replace `CSV_EXPORT_SUCCESS` and `CSV_EXPORT_FAILED` notifications.
* This event inform if data export was successful of failed.

I want to merge this change because it adds a `GIFT_CARD_EXPORT_COMPLETED` webhook

Resolves https://github.com/saleor/saleor/issues/13549

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
