### PR TITLE
Add 'promotionBulkDelete' mutation.

### DIFF
--- a/saleor/graphql/discount/mutations/__init__.py
+++ b/saleor/graphql/discount/mutations/__init__.py
@@ -1,3 +1,4 @@
+from .promotion.promotion_bulk_delete import PromotionBulkDelete
 from .promotion.promotion_create import PromotionCreate
 from .promotion.promotion_delete import PromotionDelete
 from .promotion.promotion_rule_create import PromotionRuleCreate
@@ -36,4 +37,5 @@ __all__ = [
     "PromotionRuleCreate",
     "PromotionRuleUpdate",
     "PromotionRuleDelete",
+    "PromotionBulkDelete",
 ]

--- a/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
@@ -1,0 +1,62 @@
+import graphene
+from django.db.models import Exists, OuterRef, QuerySet
+
+from .....discount import models
+from .....permission.enums import DiscountPermissions
+from .....product import models as product_models
+from .....product.tasks import update_products_discounted_prices_for_promotion_task
+from .....webhook.event_types import WebhookEventAsyncType
+from ....core import ResolveInfo
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
+from ....core.mutations import ModelBulkDeleteMutation
+from ....core.types import DiscountError, NonNullList
+from ....core.utils import WebhookEventInfo
+from ....plugins.dataloaders import get_plugin_manager_promise
+from ...types import Promotion
+from ...utils import get_variants_for_predicate
+
+
+class PromotionBulkDelete(ModelBulkDeleteMutation):
+    class Arguments:
+        ids = NonNullList(
+            graphene.ID, required=True, description="List of promotion IDs to delete."
+        )
+
+    class Meta:
+        description = "Deletes promotions."
+        model = models.Promotion
+        object_type = Promotion
+        permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)
+        error_type_class = DiscountError
+        doc_category = DOC_CATEGORY_DISCOUNTS
+        webhook_events_info = [
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.PROMOTION_DELETED,
+                description="A promotion was deleted.",
+            )
+        ]
+
+    @classmethod
+    def bulk_action(cls, info: ResolveInfo, queryset, /):
+        product_ids = cls.get_product_ids(queryset)
+        promotions = [promotion for promotion in queryset]
+        queryset.delete()
+
+        manager = get_plugin_manager_promise(info.context).get()
+        for promotion in promotions:
+            manager.promotion_deleted(promotion)
+
+        update_products_discounted_prices_for_promotion_task.delay(list(product_ids))
+
+    @classmethod
+    def get_product_ids(cls, qs: QuerySet[models.Promotion]):
+        rules = models.PromotionRule.objects.filter(
+            Exists(qs.filter(id=OuterRef("promotion_id")))
+        )
+        variants = product_models.ProductVariant.objects.none()
+        for rule in rules:
+            variants |= get_variants_for_predicate(rule.catalogue_predicate)
+        products = product_models.Product.objects.filter(
+            Exists(variants.filter(product_id=OuterRef("id")))
+        )
+        return set(products.values_list("id", flat=True))

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -21,6 +21,7 @@ from ..translations.mutations import (
 )
 from .filters import PromotionWhereInput, SaleFilter, VoucherFilter
 from .mutations import (
+    PromotionBulkDelete,
     PromotionCreate,
     PromotionDelete,
     PromotionRuleCreate,
@@ -208,6 +209,7 @@ class DiscountMutations(graphene.ObjectType):
     promotion_rule_delete = PromotionRuleDelete.Field()
     promotion_translate = PromotionTranslate.Field()
     promotion_rule_translate = PromotionRuleTranslate.Field()
+    promotion_bulk_delete = PromotionBulkDelete.Field()
 
     sale_create = SaleCreate.Field()
     sale_delete = SaleDelete.Field()

--- a/saleor/graphql/discount/tests/mutations/test_promotion_bulk_delete.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_bulk_delete.py
@@ -1,0 +1,107 @@
+from unittest import mock
+
+import graphene
+
+from .....discount.models import Promotion
+from ....tests.utils import get_graphql_content
+
+PROMOTION_BULK_DELETE_MUTATION = """
+    mutation promotionBulkDelete($ids: [ID!]!) {
+        promotionBulkDelete(ids: $ids) {
+            count
+            errors {
+                field
+                code
+            }
+        }
+    }
+    """
+
+
+def test_delete_promotions_by_staff(
+    staff_api_client,
+    promotion_list,
+    permission_manage_discounts,
+):
+    # given
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("Promotion", promotion.id)
+            for promotion in promotion_list
+        ]
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PROMOTION_BULK_DELETE_MUTATION,
+        variables,
+        permissions=[permission_manage_discounts],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["promotionBulkDelete"]["errors"]
+    assert content["data"]["promotionBulkDelete"]["count"] == 3
+    assert not Promotion.objects.filter(
+        pk__in=[promotion.id for promotion in promotion_list]
+    ).exists()
+
+
+def test_delete_promotions_by_app(
+    app_api_client,
+    promotion_list,
+    permission_manage_discounts,
+):
+    # given
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("Promotion", promotion.id)
+            for promotion in promotion_list
+        ]
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PROMOTION_BULK_DELETE_MUTATION,
+        variables,
+        permissions=[permission_manage_discounts],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert not content["data"]["promotionBulkDelete"]["errors"]
+    assert content["data"]["promotionBulkDelete"]["count"] == 3
+    assert not Promotion.objects.filter(
+        pk__in=[promotion.id for promotion in promotion_list]
+    ).exists()
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.promotion_deleted")
+@mock.patch(
+    "saleor.product.tasks.update_products_discounted_prices_for_promotion_task.delay"
+)
+def test_delete_promotions_trigger_webhooks(
+    update_products_discounted_prices_for_promotion_task,
+    deleted_webhook_mock,
+    staff_api_client,
+    promotion_list,
+    permission_manage_discounts,
+):
+    # given
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("Promotion", promotion.id)
+            for promotion in promotion_list
+        ]
+    }
+
+    # when
+    staff_api_client.post_graphql(
+        PROMOTION_BULK_DELETE_MUTATION,
+        variables,
+        permissions=[permission_manage_discounts],
+    )
+
+    # then
+    update_products_discounted_prices_for_promotion_task.called_once()
+    assert deleted_webhook_mock.call_count == len(promotion_list)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -17253,6 +17253,19 @@ type Mutation {
   ): PromotionRuleTranslate @doc(category: "Discounts")
 
   """
+  Deletes promotions. 
+  
+  Requires one of the following permissions: MANAGE_DISCOUNTS.
+  
+  Triggers the following webhook events:
+  - PROMOTION_DELETED (async): A promotion was deleted.
+  """
+  promotionBulkDelete(
+    """List of promotion IDs to delete."""
+    ids: [ID!]!
+  ): PromotionBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [PROMOTION_DELETED], syncEvents: [])
+
+  """
   Creates a new sale.
   
   DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionCreate` mutation instead. 
@@ -26676,19 +26689,17 @@ input PromotionRuleTranslationInput {
 }
 
 """
-Creates a new sale.
-
-DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionCreate` mutation instead. 
+Deletes promotions. 
 
 Requires one of the following permissions: MANAGE_DISCOUNTS.
 
 Triggers the following webhook events:
-- SALE_CREATED (async): A sale was created.
+- PROMOTION_DELETED (async): A promotion was deleted.
 """
-type SaleCreate @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [SALE_CREATED], syncEvents: []) {
-  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
+type PromotionBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [PROMOTION_DELETED], syncEvents: []) {
+  """Returns how many objects were affected."""
+  count: Int!
   errors: [DiscountError!]!
-  sale: Sale
 }
 
 type DiscountError @doc(category: "Discounts") {
@@ -26720,6 +26731,22 @@ enum DiscountErrorCode @doc(category: "Discounts") {
   UNIQUE
   CANNOT_MANAGE_PRODUCT_WITHOUT_VARIANT
   DUPLICATED_INPUT_ITEM
+}
+
+"""
+Creates a new sale.
+
+DEPRECATED: this mutation will be removed in Saleor 4.0. Use `promotionCreate` mutation instead. 
+
+Requires one of the following permissions: MANAGE_DISCOUNTS.
+
+Triggers the following webhook events:
+- SALE_CREATED (async): A sale was created.
+"""
+type SaleCreate @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [SALE_CREATED], syncEvents: []) {
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
+  errors: [DiscountError!]!
+  sale: Sale
 }
 
 input SaleInput @doc(category: "Discounts") {


### PR DESCRIPTION
I want to merge this change because I want to delete multiple promotions at once.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
