### PR TITLE
[TEST] adding a test for fixed category promotion core_2106

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/checkout/test_checkout_products_on_fixed_promotion.py
@@ -120,14 +120,16 @@ def prepare_product(
     promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
     promotion_id = promotion_data["id"]
 
+    catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
+
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
         promotion_id,
+        catalogue_predicate,
         discount_type,
         discount_value,
         promotion_rule_name,
         channel_id,
-        product_id,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/checkout/test_checkout_products_on_percentage_promotion.py
+++ b/saleor/tests/e2e/checkout/test_checkout_products_on_percentage_promotion.py
@@ -120,14 +120,16 @@ def prepare_product(
     promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
     promotion_id = promotion_data["id"]
 
+    catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
+
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
         promotion_id,
+        catalogue_predicate,
         discount_type,
         discount_value,
         promotion_rule_name,
         channel_id,
-        product_id,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/orders/test_order_products_from_the_same_category_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/test_order_products_from_the_same_category_on_fixed_promotion.py
@@ -35,7 +35,8 @@ def prepare_product(
     permission_manage_discounts,
     permission_manage_orders,
     channel_slug,
-    variant_price,
+    variant_price_1,
+    variant_price_2,
     promotion_name,
     discount_value,
     discount_type,
@@ -93,14 +94,15 @@ def prepare_product(
         e2e_staff_api_client,
     )
     category_id = category_data["id"]
+    category_ids = [category_id]
 
-    product_data = create_product(
+    product_data_1 = create_product(
         e2e_staff_api_client,
         product_type_id,
         category_id,
     )
-    product_id = product_data["id"]
-    create_product_channel_listing(e2e_staff_api_client, product_id, channel_id)
+    product_id_1 = product_data_1["id"]
+    create_product_channel_listing(e2e_staff_api_client, product_id_1, channel_id)
 
     stocks = [
         {
@@ -108,22 +110,49 @@ def prepare_product(
             "quantity": 5,
         }
     ]
-    variant_data = create_product_variant(
-        e2e_staff_api_client, product_id, stocks=stocks
+    variant_data_1 = create_product_variant(
+        e2e_staff_api_client, product_id_1, stocks=stocks
     )
-    product_variant_id = variant_data["id"]
+    product_variant_id_1 = variant_data_1["id"]
 
     create_product_variant_channel_listing(
         e2e_staff_api_client,
-        product_variant_id,
+        product_variant_id_1,
         channel_id,
-        variant_price,
+        variant_price_1,
+    )
+    product_data_2 = create_product(
+        e2e_staff_api_client,
+        product_type_id,
+        category_id,
+    )
+    product_id_2 = product_data_2["id"]
+    create_product_channel_listing(e2e_staff_api_client, product_id_2, channel_id)
+
+    stocks = [
+        {
+            "warehouse": warehouse_data["id"],
+            "quantity": 5,
+        }
+    ]
+    variant_data_2 = create_product_variant(
+        e2e_staff_api_client, product_id_2, stocks=stocks
+    )
+    product_variant_id_2 = variant_data_2["id"]
+
+    create_product_variant_channel_listing(
+        e2e_staff_api_client,
+        product_variant_id_2,
+        channel_id,
+        variant_price_2,
     )
 
     promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
     promotion_id = promotion_data["id"]
 
-    catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
+    catalogue_predicate = {
+        "categoryPredicate": {"ids": category_ids},
+    }
 
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
@@ -134,15 +163,22 @@ def prepare_product(
         promotion_rule_name,
         channel_id,
     )
-    product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
+    category_predicate = promotion_rule["cataloguePredicate"]["categoryPredicate"][
+        "ids"
+    ]
     assert promotion_rule["channels"][0]["id"] == channel_id
-    assert product_predicate[0] == product_id
+    assert category_predicate[0] == category_id
 
-    return channel_id, product_variant_id, shipping_method_id
+    return (
+        channel_id,
+        product_variant_id_1,
+        product_variant_id_2,
+        shipping_method_id,
+    )
 
 
 @pytest.mark.e2e
-def test_order_products_on_percentage_promotion_CORE_2103(
+def test_order_products_from_category_on_fixed_promotion_CORE_2106(
     e2e_staff_api_client,
     permission_manage_products,
     permission_manage_channels,
@@ -153,15 +189,16 @@ def test_order_products_on_percentage_promotion_CORE_2103(
 ):
     # Before
     channel_slug = "test-channel"
-    variant_price = "20"
+    variant_price_1 = "20"
+    variant_price_2 = "10"
     promotion_name = "Promotion Fixed"
-    discount_value = 10
-    discount_type = "PERCENTAGE"
-    promotion_rule_name = "rule for product"
-
+    discount_value = 5
+    discount_type = "FIXED"
+    promotion_rule_name = "rule for category"
     (
         channel_id,
-        product_variant_id,
+        product_variant_id_1,
+        product_variant_id_2,
         shipping_method_id,
     ) = prepare_product(
         e2e_staff_api_client,
@@ -172,7 +209,8 @@ def test_order_products_on_percentage_promotion_CORE_2103(
         permission_manage_discounts,
         permission_manage_orders,
         channel_slug,
-        variant_price,
+        variant_price_1,
+        variant_price_2,
         promotion_name,
         discount_value,
         discount_type,
@@ -193,20 +231,34 @@ def test_order_products_on_percentage_promotion_CORE_2103(
     assert order_id is not None
 
     # Step 2 - Add order lines to the order
-    quantity = 2
-    lines = [{"variantId": product_variant_id, "quantity": quantity}]
+    lines = [
+        {"variantId": product_variant_id_1, "quantity": 2},
+        {"variantId": product_variant_id_2, "quantity": 2},
+    ]
     order_lines = order_lines_create(e2e_staff_api_client, order_id, lines)
-    order_product_variant_id = order_lines["order"]["lines"][0]["variant"]["id"]
-    discount = round(float(variant_price) * discount_value / 100, 2)
-    assert order_product_variant_id == product_variant_id
-    unit_price = float(variant_price) - discount
-    undiscounted_price = order_lines["order"]["lines"][0]["undiscountedUnitPrice"][
-        "gross"
-    ]["amount"]
-    assert undiscounted_price == float(variant_price)
+    order_product_variant_id_1 = order_lines["order"]["lines"][0]["variant"]["id"]
+    assert order_product_variant_id_1 == product_variant_id_1
+    unit_price_product_1 = float(variant_price_1) - float(discount_value)
+    undiscounted_price_product_1 = order_lines["order"]["lines"][0][
+        "undiscountedUnitPrice"
+    ]["gross"]["amount"]
+    assert float(undiscounted_price_product_1) == float(variant_price_1)
     assert (
-        order_lines["order"]["lines"][0]["unitPrice"]["gross"]["amount"] == unit_price
+        order_lines["order"]["lines"][0]["unitPrice"]["gross"]["amount"]
+        == unit_price_product_1
     )
+    order_product_variant_id_2 = order_lines["order"]["lines"][1]["variant"]["id"]
+    assert order_product_variant_id_2 == product_variant_id_2
+    unit_price_product_2 = float(variant_price_2) - float(discount_value)
+    undiscounted_price_product_2 = order_lines["order"]["lines"][1][
+        "undiscountedUnitPrice"
+    ]["gross"]["amount"]
+    assert float(undiscounted_price_product_2) == float(variant_price_2)
+    assert (
+        order_lines["order"]["lines"][1]["unitPrice"]["gross"]["amount"]
+        == unit_price_product_2
+    )
+
     promotion_reason = order_lines["order"]["lines"][0]["unitDiscountReason"]
     assert (
         promotion_reason
@@ -226,22 +278,33 @@ def test_order_products_on_percentage_promotion_CORE_2103(
     order = draft_order_complete(e2e_staff_api_client, order_id)
     order_complete_id = order["order"]["id"]
     assert order_complete_id == order_id
-    order_line = order["order"]["lines"][0]
-    assert order_line["productVariantId"] == product_variant_id
-    product_price = order_line["undiscountedUnitPrice"]["gross"]["amount"]
-    assert product_price == float(variant_price)
-    assert discount == order_line["unitDiscount"]["amount"]
-    assert order_line["unitDiscountType"] == "FIXED"
-    assert order_line["unitDiscountValue"] == discount
-    assert order_line["unitDiscountReason"] == promotion_reason
-    product_discounted_price = product_price - discount
-    assert product_discounted_price == order_line["unitPrice"]["gross"]["amount"]
+    order_line_1 = order["order"]["lines"][0]
+    assert order_line_1["productVariantId"] == product_variant_id_1
+    assert order_line_1["unitDiscount"]["amount"] == float(discount_value)
+    assert order_line_1["unitDiscountType"] == discount_type
+    assert order_line_1["unitDiscountValue"] == float(discount_value)
+    assert order_line_1["unitDiscountReason"] == promotion_reason
+    product_price_1 = order_line_1["undiscountedUnitPrice"]["gross"]["amount"]
+    price_for = product_price_1 - order_line_1["unitDiscountValue"]
+    order_line_2 = order["order"]["lines"][1]
+    assert order_line_2["productVariantId"] == product_variant_id_2
+    assert order_line_2["unitDiscount"]["amount"] == float(discount_value)
+    assert order_line_2["unitDiscountType"] == discount_type
+    assert order_line_2["unitDiscountValue"] == float(discount_value)
+    assert order_line_2["unitDiscountReason"] == promotion_reason
+    product_price_2 = order_line_2["undiscountedUnitPrice"]["gross"]["amount"]
+    price_e = product_price_2 - order_line_2["unitDiscountValue"]
+    assert product_price_1 == float(undiscounted_price_product_1)
+    assert product_price_1 == float(variant_price_1)
+    assert product_price_2 == float(undiscounted_price_product_2)
+    assert product_price_2 == float(variant_price_2)
     shipping_amount = order["order"]["shippingPrice"]["gross"]["amount"]
     assert shipping_amount == shipping_price
-    subtotal = quantity * product_discounted_price
+    subtotal = (price_for * 2) + (price_e * 2)
     assert subtotal == order["order"]["subtotal"]["gross"]["amount"]
     assert subtotal == subtotal_gross_amount
     total = shipping_amount + subtotal
     assert total == order["order"]["total"]["gross"]["amount"]
-    assert total == total_gross_amount
+    assert total == float(total_gross_amount)
+
     assert order["order"]["status"] == "UNFULFILLED"

--- a/saleor/tests/e2e/orders/test_order_products_from_the_same_category_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/test_order_products_from_the_same_category_on_fixed_promotion.py
@@ -284,23 +284,15 @@ def test_order_products_from_category_on_fixed_promotion_CORE_2106(
     assert order_line_1["unitDiscountType"] == discount_type
     assert order_line_1["unitDiscountValue"] == float(discount_value)
     assert order_line_1["unitDiscountReason"] == promotion_reason
-    product_price_1 = order_line_1["undiscountedUnitPrice"]["gross"]["amount"]
-    price_for = product_price_1 - order_line_1["unitDiscountValue"]
     order_line_2 = order["order"]["lines"][1]
     assert order_line_2["productVariantId"] == product_variant_id_2
     assert order_line_2["unitDiscount"]["amount"] == float(discount_value)
     assert order_line_2["unitDiscountType"] == discount_type
     assert order_line_2["unitDiscountValue"] == float(discount_value)
     assert order_line_2["unitDiscountReason"] == promotion_reason
-    product_price_2 = order_line_2["undiscountedUnitPrice"]["gross"]["amount"]
-    price_e = product_price_2 - order_line_2["unitDiscountValue"]
-    assert product_price_1 == float(undiscounted_price_product_1)
-    assert product_price_1 == float(variant_price_1)
-    assert product_price_2 == float(undiscounted_price_product_2)
-    assert product_price_2 == float(variant_price_2)
     shipping_amount = order["order"]["shippingPrice"]["gross"]["amount"]
     assert shipping_amount == shipping_price
-    subtotal = (price_for * 2) + (price_e * 2)
+    subtotal = unit_price_product_1 * 2 + unit_price_product_2 * 2
     assert subtotal == order["order"]["subtotal"]["gross"]["amount"]
     assert subtotal == subtotal_gross_amount
     total = shipping_amount + subtotal

--- a/saleor/tests/e2e/orders/test_order_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/test_order_products_on_fixed_promotion.py
@@ -123,14 +123,16 @@ def prepare_product(
     promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
     promotion_id = promotion_data["id"]
 
+    catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
+
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
         promotion_id,
+        catalogue_predicate,
         discount_type,
         discount_value,
         promotion_rule_name,
         channel_id,
-        product_id,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/promotions/utils/promotion_rule_create.py
+++ b/saleor/tests/e2e/promotions/utils/promotion_rule_create.py
@@ -27,17 +27,14 @@ mutation promotionRuleCreate($input: PromotionRuleCreateInput!) {
 def create_promotion_rule(
     staff_api_client,
     promotion_id,
+    catalogue_predicate,
     reward_value_type="PERCENTAGE",
     reward_value=5,
     promotion_rule_name="Test rule",
     channel_id=None,
-    product_ids=None,
 ):
     if not channel_id:
         channel_id = []
-
-    if not product_ids:
-        product_ids = []
 
     variables = {
         "input": {
@@ -46,9 +43,7 @@ def create_promotion_rule(
             "rewardValueType": reward_value_type,
             "rewardValue": reward_value,
             "channels": channel_id,
-            "cataloguePredicate": {
-                "productPredicate": {"ids": product_ids},
-            },
+            "cataloguePredicate": catalogue_predicate,
         }
     }
 


### PR DESCRIPTION
I want to merge this change because it adds a test for fixed category promotion core_2106

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
