### PR TITLE
Don't run Saleor or Celery by default inside a devcontainer

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -32,23 +32,10 @@ services:
       - POSTGRES_PASSWORD=saleor
 
   redis:
-    image: library/redis:5.0-alpine
+    image: library/redis:7.0-alpine
     restart: unless-stopped
     volumes:
       - saleor-redis:/data
-
-  worker:
-    image: saleor
-    command: celery -A saleor --app=saleor.celeryconf:app worker --loglevel=info -B
-    restart: unless-stopped
-    env_file:
-      - common.env
-      - backend.env
-    depends_on:
-      - db
-      - redis
-    volumes:
-      - ..:/app
 
   mailpit:
     image: axllent/mailpit

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-    command: uvicorn --reload saleor.asgi:application --host 0.0.0.0 --port 8000
+    command: /bin/sh -c "while sleep 1000; do :; done"
     env_file:
       - common.env
       - backend.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Użyj funkcji IntelliSense, aby uzyskać informacje o możliwych atrybutach.
+    // Najedź kursorem, aby wyświetlić opisy istniejących atrybutów.
+    // Aby uzyskać więcej informacji, odwiedź stronę: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Saleor",
+            "type": "python",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "saleor.asgi:application",
+                "--lifespan=off"
+            ]
+        },
+        {
+            "name": "Celery (worker)",
+            "type": "python",
+            "request": "launch",
+            "module": "celery",
+            "args": [
+                "--app=saleor.celeryconf:app",
+                "worker",
+                "--beat"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This requires people to run `uvicorn saleor.asgi:application` manually in a terminal but it makes it easier to debug and/or restart. It's also closer to the flow of working without devcontainers.

Update: Celery is now also not started manually. In exchange VSCode is preconfigured to launch either with a single click (and debugger support).

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
