### PR TITLE
Slim empty values in a CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ in 3.17. Use `PaymentSettings.defaultTransactionFlowStrategy` instead.
 
 ### Other changes
 - Fix error in variant available stock calculation - 13593 by @awaisdar001
+- The CSV export will now use empty string for empty attribute values instead of a single whitespace value - by @aniav
 
 # 3.15.0 [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable, unreleased changes to this project will be documented in this file.
 in 3.17. Use `PaymentSettingsInput.defaultTransactionFlowStrategy` instead.
   - Deprecate `OrderSettings.defaultTransactionFlowStrategy`. It will be removed
 in 3.17. Use `PaymentSettings.defaultTransactionFlowStrategy` instead.
+  - Change in the CSV export. It will now use empty string for empty attribute values instead of a single whitespace value.
 
 ### GraphQL API
 - Add `PaymentSettings` to `Channel` - #13677 by @korycins
@@ -21,7 +22,6 @@ in 3.17. Use `PaymentSettings.defaultTransactionFlowStrategy` instead.
 
 ### Other changes
 - Fix error in variant available stock calculation - 13593 by @awaisdar001
-- The CSV export will now use empty string for empty attribute values instead of a single whitespace value - by @aniav
 
 # 3.15.0 [Unreleased]
 

--- a/saleor/csv/tests/export/products_data/test_prepare_headers.py
+++ b/saleor/csv/tests/export/products_data/test_prepare_headers.py
@@ -150,7 +150,7 @@ def test_get_product_export_fields_and_headers_info(
 ):
     # given
     warehouse_ids = [w.pk for w in warehouses]
-    attribute_ids = [attr.pk for attr in Attribute.objects.all()]
+    attribute_ids = [str(attr.pk) for attr in Attribute.objects.all()]
     channel_ids = [channel_PLN.pk, channel_USD.pk]
     export_info = {
         "fields": [

--- a/saleor/csv/tests/export/test_export.py
+++ b/saleor/csv/tests/export/test_export.py
@@ -580,7 +580,7 @@ def test_append_to_file_for_csv(user_export_file, tmpdir, media_root):
     headers = ["id", "name", "collections"]
     delimiter = ","
 
-    table = etl.fromdicts([{"id": "1", "name": "A"}], header=headers, missing=" ")
+    table = etl.fromdicts([{"id": "1", "name": "A"}], header=headers, missing="")
 
     temp_file = NamedTemporaryFile()
     etl.tocsv(table, temp_file.name, delimiter=delimiter)
@@ -594,7 +594,7 @@ def test_append_to_file_for_csv(user_export_file, tmpdir, media_root):
     file_content = temp_file.read().decode().split("\r\n")
     assert ",".join(headers) in file_content
     assert ",".join(export_data[0].values()) in file_content
-    assert (",".join(export_data[1].values()) + ", ") in file_content
+    assert (",".join(export_data[1].values()) + ",") in file_content
 
     temp_file.close()
     shutil.rmtree(tmpdir)
@@ -607,41 +607,32 @@ def test_append_to_file_for_xlsx(user_export_file, tmpdir, media_root):
         {"id": "345", "name": "test2"},
     ]
     expected_headers = ["id", "name", "collections"]
-    delimiter = ","
 
     table = etl.fromdicts(
-        [{"id": "1", "name": "A"}], header=expected_headers, missing=" "
+        [{"id": "1", "name": "A"}], header=expected_headers, missing=""
     )
 
     temp_file = NamedTemporaryFile(suffix=".xlsx")
     etl.io.xlsx.toxlsx(table, temp_file.name)
 
     # when
-    append_to_file(export_data, expected_headers, temp_file, FileTypes.XLSX, delimiter)
+    append_to_file(export_data, expected_headers, temp_file, FileTypes.XLSX, ",")
 
     # then
     user_export_file.refresh_from_db()
 
-    wb_obj = openpyxl.load_workbook(temp_file)
+    workbook = openpyxl.load_workbook(temp_file)
 
-    sheet_obj = wb_obj.active
-    max_col = sheet_obj.max_column
-    max_row = sheet_obj.max_row
-    expected_headers = expected_headers
-    headers = [sheet_obj.cell(row=1, column=i).value for i in range(1, max_col + 1)]
-    data = []
-    for i in range(2, max_row + 1):
-        row = []
-        for j in range(1, max_col + 1):
-            row.append(sheet_obj.cell(row=i, column=j).value)
-        data.append(row)
-
-    assert headers == expected_headers
-    assert list(export_data[0].values()) in data
-    row2 = list(export_data[1].values())
-    # add string with space for collections column
-    row2.append(" ")
-    assert row2 in data
+    sheet = workbook.worksheets[0]
+    assert sheet.cell(1, 1).value == expected_headers[0]
+    assert sheet.cell(1, 2).value == expected_headers[1]
+    assert sheet.cell(1, 3).value == expected_headers[2]
+    assert sheet.cell(3, 1).value == export_data[0]["id"]
+    assert sheet.cell(3, 2).value == export_data[0]["name"]
+    assert sheet.cell(3, 3).value == export_data[0]["collections"]
+    assert sheet.cell(4, 1).value == export_data[1]["id"]
+    assert sheet.cell(4, 2).value == export_data[1]["name"]
+    assert sheet.cell(4, 3).value is None
 
     temp_file.close()
     shutil.rmtree(tmpdir)

--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -221,7 +221,7 @@ def append_to_file(
     file_type: str,
     delimiter: str,
 ):
-    table = etl.fromdicts(export_data, header=headers, missing=" ")
+    table = etl.fromdicts(export_data, header=headers, missing="")
 
     if file_type == FileTypes.CSV:
         etl.io.csv.appendcsv(table, temporary_file.name, delimiter=delimiter)

--- a/saleor/csv/utils/products_data.py
+++ b/saleor/csv/utils/products_data.py
@@ -22,9 +22,9 @@ if TYPE_CHECKING:
 def get_products_data(
     queryset: "QuerySet",
     export_fields: Set[str],
-    attribute_ids: Optional[List[int]],
-    warehouse_ids: Optional[List[int]],
-    channel_ids: Optional[List[int]],
+    attribute_ids: Optional[List[str]],
+    warehouse_ids: Optional[List[str]],
+    channel_ids: Optional[List[str]],
 ) -> List[Dict[str, Union[str, bool]]]:
     """Create data list of products and their variants with fields values.
 
@@ -100,8 +100,8 @@ def get_products_data(
 def get_products_relations_data(
     queryset: "QuerySet",
     export_fields: Set[str],
-    attribute_ids: Optional[List[int]],
-    channel_ids: Optional[List[int]],
+    attribute_ids: Optional[List[str]],
+    channel_ids: Optional[List[str]],
 ) -> Dict[int, Dict[str, str]]:
     """Get data about product relations fields.
 
@@ -124,8 +124,8 @@ def get_products_relations_data(
 def prepare_products_relations_data(
     queryset: "QuerySet",
     fields: Set[str],
-    attribute_ids: Optional[List[int]],
-    channel_ids: Optional[List[int]],
+    attribute_ids: Optional[List[str]],
+    channel_ids: Optional[List[str]],
 ) -> Dict[int, Dict[str, str]]:
     """Prepare data about products relation fields for given queryset.
 
@@ -179,9 +179,9 @@ def prepare_products_relations_data(
 def get_variants_relations_data(
     queryset: "QuerySet",
     export_fields: Set[str],
-    attribute_ids: Optional[List[int]],
-    warehouse_ids: Optional[List[int]],
-    channel_ids: Optional[List[int]],
+    attribute_ids: Optional[List[str]],
+    warehouse_ids: Optional[List[str]],
+    channel_ids: Optional[List[str]],
 ) -> Dict[int, Dict[str, str]]:
     """Get data about variants relations fields.
 
@@ -204,9 +204,9 @@ def get_variants_relations_data(
 def prepare_variants_relations_data(
     queryset: "QuerySet",
     fields: Set[str],
-    attribute_ids: Optional[List[int]],
-    warehouse_ids: Optional[List[int]],
-    channel_ids: Optional[List[int]],
+    attribute_ids: Optional[List[str]],
+    warehouse_ids: Optional[List[str]],
+    channel_ids: Optional[List[str]],
 ) -> Dict[int, Dict[str, str]]:
     """Prepare data about variants relation fields for given queryset.
 
@@ -323,7 +323,7 @@ class AttributeData:
 def handle_attribute_data(
     pk: int,
     data: dict,
-    attribute_ids: Optional[List[int]],
+    attribute_ids: Optional[List[str]],
     result_data: Dict[int, dict],
     attribute_fields: dict,
     attribute_owner: str,
@@ -348,7 +348,7 @@ def handle_attribute_data(
 def handle_channel_data(
     pk: int,
     data: dict,
-    channel_ids: Optional[List[int]],
+    channel_ids: Optional[List[str]],
     result_data: Dict[int, dict],
     pk_lookup: str,
     slug_lookup: str,
@@ -374,7 +374,7 @@ def handle_channel_data(
 def handle_warehouse_data(
     pk: int,
     data: dict,
-    warehouse_ids: Optional[List[int]],
+    warehouse_ids: Optional[List[str]],
     result_data: Dict[int, dict],
     warehouse_fields: dict,
 ):


### PR DESCRIPTION
I want to merge this change because it's changing how we treat empty values in CSV export. We're moving from a single whitespace to an empty string.

While working on the simplification of Product - Attribute relation I noticed empty assigned values are generating additional unwanted whitespaces for cells that are effectively empty. This is generating additional data where it's not needed and making the exported file bigger. 

Additionally in #13407 it would be generating a lot of additional db queries for no benefit and/or would require a major refactor in CSV export.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

No doc changes.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
