### PR TITLE
[TEST] Should apply better promotion to the product

### DIFF
--- a/saleor/tests/e2e/orders/test_apply_better_promotion_to_product.py
+++ b/saleor/tests/e2e/orders/test_apply_better_promotion_to_product.py
@@ -70,14 +70,15 @@ def prepare_promotion_with_rules(
     promotion = create_promotion(e2e_staff_api_client, promotion_name)
     promotion_id = promotion["id"]
 
+    catalogue_predicate = {"productPredicate": {"ids": [product_id]}}
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
         promotion_id,
+        catalogue_predicate,
         discount_type,
         discount_value,
         rule_name,
         channel_id,
-        product_id,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id

--- a/saleor/tests/e2e/orders/test_apply_better_promotion_to_product.py
+++ b/saleor/tests/e2e/orders/test_apply_better_promotion_to_product.py
@@ -1,0 +1,192 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..channel.utils import create_channel
+from ..product.utils import (
+    create_category,
+    create_product,
+    create_product_channel_listing,
+    create_product_type,
+    create_product_variant,
+    create_product_variant_channel_listing,
+    get_product,
+)
+from ..promotions.utils import create_promotion, create_promotion_rule
+from ..utils import assign_permissions
+from .utils import draft_order_create, order_lines_create
+
+
+def prepare_product(
+    e2e_staff_api_client,
+    channel_slug,
+    variant_price,
+):
+    channel_data = create_channel(
+        e2e_staff_api_client,
+        slug=channel_slug,
+    )
+    channel_id = channel_data["id"]
+
+    product_type_data = create_product_type(
+        e2e_staff_api_client,
+    )
+    product_type_id = product_type_data["id"]
+
+    category_data = create_category(
+        e2e_staff_api_client,
+    )
+    category_id = category_data["id"]
+
+    product_data = create_product(
+        e2e_staff_api_client,
+        product_type_id,
+        category_id,
+    )
+    product_id = product_data["id"]
+    create_product_channel_listing(e2e_staff_api_client, product_id, channel_id)
+
+    variant_data = create_product_variant(e2e_staff_api_client, product_id)
+    product_variant_id = variant_data["id"]
+
+    create_product_variant_channel_listing(
+        e2e_staff_api_client,
+        product_variant_id,
+        channel_id,
+        variant_price,
+    )
+
+    return product_id, channel_id, product_variant_id
+
+
+def promotion_with_rules(
+    e2e_staff_api_client,
+    promotion_name,
+    discount_type,
+    discount_value,
+    rule_name,
+    channel_id,
+    product_id,
+):
+    promotion = create_promotion(e2e_staff_api_client, promotion_name)
+    promotion_id = promotion["id"]
+
+    promotion_rule = create_promotion_rule(
+        e2e_staff_api_client,
+        promotion_id,
+        discount_type,
+        discount_value,
+        rule_name,
+        channel_id,
+        product_id,
+    )
+    product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
+    assert promotion_rule["channels"][0]["id"] == channel_id
+    assert product_predicate[0] == product_id
+
+
+@pytest.mark.e2e
+def test_apply_best_promotion_to_product_core_2105(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    # Before
+    channel_slug = "test-channel"
+    variant_price = "30"
+
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    product_id, channel_id, product_variant_id = prepare_product(
+        e2e_staff_api_client,
+        channel_slug,
+        variant_price,
+    )
+
+    # Create first promotion
+    first_promotion_name = "Promotion Fixed"
+    first_discount_value = 5.5
+    first_discount_type = "FIXED"
+    first_rule_name = "rule for product"
+
+    promotion_with_rules(
+        e2e_staff_api_client,
+        first_promotion_name,
+        first_discount_type,
+        first_discount_value,
+        first_rule_name,
+        channel_id,
+        product_id,
+    )
+
+    # Create second promotion
+    second_promotion_name = "Promotion Percentage"
+    second_discount_value = 20
+    second_discount_type = "PERCENTAGE"
+    second_rule_name = "rule for product"
+
+    promotion_with_rules(
+        e2e_staff_api_client,
+        second_promotion_name,
+        second_discount_type,
+        second_discount_value,
+        second_rule_name,
+        channel_id,
+        product_id,
+    )
+
+    # Step 1 - Get product and check if it is on promotion
+    product_data = get_product(e2e_staff_api_client, product_id, channel_slug)
+
+    assert product_data["pricing"]["onSale"] is True
+    second_variant_discount = round(
+        float(variant_price) * second_discount_value / 100, 2
+    )
+
+    product_variant = product_data["variants"][0]
+    assert product_variant["pricing"]["onSale"] is True
+    assert (
+        product_variant["pricing"]["discount"]["gross"]["amount"]
+        == second_variant_discount
+    )
+    assert product_variant["pricing"]["priceUndiscounted"]["gross"]["amount"] == float(
+        variant_price
+    )
+
+    # Step 2 - Create draft order
+    input = {
+        "channelId": channel_id,
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+    }
+    order_data = draft_order_create(e2e_staff_api_client, input)
+
+    order_id = order_data["order"]["id"]
+    assert order_data["order"]["billingAddress"] is not None
+    assert order_data["order"]["shippingAddress"] is not None
+    assert order_id is not None
+
+    # Step 3 - Add product to order and verify prices
+    lines = [{"variantId": product_variant_id, "quantity": 1}]
+    order_lines = order_lines_create(e2e_staff_api_client, order_id, lines)
+
+    order_line = order_lines["order"]["lines"][0]
+    assert order_line["variant"]["id"] == product_variant_id
+    unit_price = float(variant_price) - second_variant_discount
+    undiscounted_price = order_line["undiscountedUnitPrice"]["gross"]["amount"]
+    assert undiscounted_price == float(variant_price)
+    assert order_line["unitPrice"]["gross"]["amount"] == unit_price
+    promotion_reason = order_line["unitDiscountReason"]
+    assert (
+        promotion_reason
+        == f"Promotion rules discounts: {second_promotion_name}: {second_rule_name}"
+    )

--- a/saleor/tests/e2e/orders/test_apply_better_promotion_to_product.py
+++ b/saleor/tests/e2e/orders/test_apply_better_promotion_to_product.py
@@ -85,6 +85,7 @@ def prepare_promotion_with_rules(
     assert product_predicate[0] == product_id
 
 
+@pytest.mark.e2e
 @pytest.mark.parametrize(
     "variant_price, first_discount_type, first_discount_value, second_discount_type, "
     "second_discount_value, expected_discount",

--- a/saleor/tests/e2e/product/utils/__init__.py
+++ b/saleor/tests/e2e/product/utils/__init__.py
@@ -5,6 +5,7 @@ from .product_channel_listing import (
     create_product_channel_listing,
     raw_create_product_channel_listing,
 )
+from .product_query import get_product
 from .product_type import create_product_type
 from .product_variant import create_product_variant, raw_create_product_variant
 from .product_variant_channel_listing import create_product_variant_channel_listing
@@ -20,4 +21,5 @@ __all__ = [
     "raw_create_product_variant",
     "create_product",
     "raw_create_product_channel_listing",
+    "get_product",
 ]

--- a/saleor/tests/e2e/product/utils/product_query.py
+++ b/saleor/tests/e2e/product/utils/product_query.py
@@ -1,0 +1,53 @@
+from ...utils import get_graphql_content
+
+PRODUCT_QUERY = """
+query Product($id: ID!, $channel: String) {
+  product(id: $id, channel: $channel) {
+    id
+    name
+    pricing {
+      onSale
+    }
+    variants {
+      id
+      name
+      pricing {
+        onSale
+        discount {
+          gross {
+            amount
+          }
+        }
+        priceUndiscounted {
+          gross {
+            amount
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def get_product(
+    staff_api_client,
+    product_id,
+    slug="default-channel",
+):
+    variables = {
+        "id": product_id,
+        "channel": slug,
+    }
+
+    response = staff_api_client.post_graphql(
+        PRODUCT_QUERY,
+        variables,
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["product"]
+    assert data["id"] is not None
+
+    return data

--- a/saleor/tests/e2e/promotions/utils/promotion_rule_create.py
+++ b/saleor/tests/e2e/promotions/utils/promotion_rule_create.py
@@ -29,7 +29,7 @@ def create_promotion_rule(
     promotion_id,
     catalogue_predicate,
     reward_value_type="PERCENTAGE",
-    reward_value=5,
+    reward_value=5.00,
     promotion_rule_name="Test rule",
     channel_id=None,
 ):


### PR DESCRIPTION
I want to merge this change because it adds a test for applying the best promotion to the product and verifies created order [CORE_2105](https://saleor.testmo.net/repositories/5?group_id=133&case_id=2059)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
