### PR TITLE
Add `PRODUCT_EXPORT_COMPLETED` webhook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ in 3.17. Use `PaymentSettings.defaultTransactionFlowStrategy` instead.
 - Add `NOTIFY_CUSTOMER` flag to `FulfillmentApproved` type - #13637, by @Air-t
   - Inform apps if customer should be notified when fulfillment is approved.
 - Add `GIFT_CARD_EXPORT_COMPLETED` webhook - #13765, by @Air-t
-  - Event sent when CSV export is completed.
+  - Event sent when CSV export for gift cards is completed.
+- Add `PRODUCT_EXPORT_COMPLETED` webhook - #13787, by @Air-t
+  - Event sent when CSV export for products is completed.
 
 ### Other changes
 - Fix error in variant available stock calculation - 13593 by @awaisdar001

--- a/saleor/csv/notifications.py
+++ b/saleor/csv/notifications.py
@@ -40,6 +40,8 @@ def send_export_download_link_notification(export_file: "ExportFile", data_type:
     manager.notify(NotifyEventType.CSV_EXPORT_SUCCESS, payload)
     if data_type == "gift cards":
         manager.gift_card_export_completed(export_file)
+    if data_type == "products":
+        manager.product_export_completed(export_file)
 
 
 def send_export_failed_info(export_file: "ExportFile", data_type: str):
@@ -54,3 +56,5 @@ def send_export_failed_info(export_file: "ExportFile", data_type: str):
     manager.notify(NotifyEventType.CSV_EXPORT_FAILED, payload)
     if data_type == "gift cards":
         manager.gift_card_export_completed(export_file)
+    if data_type == "products":
+        manager.product_export_completed(export_file)

--- a/saleor/csv/tests/export/test_export.py
+++ b/saleor/csv/tests/export/test_export.py
@@ -35,6 +35,7 @@ from ...utils.export import (
     "file_type",
     [FileTypes.CSV, FileTypes.XLSX],
 )
+@patch("saleor.plugins.manager.PluginsManager.product_export_completed")
 @patch("saleor.csv.utils.export.create_file_with_headers")
 @patch("saleor.csv.utils.export.export_products_in_batches")
 @patch("saleor.csv.utils.export.send_export_download_link_notification")
@@ -44,6 +45,7 @@ def test_export_products(
     send_email_mock,
     export_products_in_batches_mock,
     create_file_with_headers_mock,
+    mocked_product_export_completed,
     product_list,
     user_export_file,
     file_type,
@@ -87,6 +89,7 @@ def test_export_products(
     )
     send_email_mock.assert_called_once_with(user_export_file, "products")
     save_file_mock.assert_called_once_with(user_export_file, mock_file, ANY)
+    mocked_product_export_completed.assert_called_once_with(user_export_file)
 
 
 @patch("saleor.csv.utils.export.create_file_with_headers")

--- a/saleor/csv/tests/test_notifications.py
+++ b/saleor/csv/tests/test_notifications.py
@@ -12,9 +12,11 @@ from ..notifications import get_default_export_payload
 
 @freeze_time("2018-05-31 12:00:01")
 @mock.patch("saleor.plugins.manager.PluginsManager.gift_card_export_completed")
+@mock.patch("saleor.plugins.manager.PluginsManager.product_export_completed")
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
 def test_send_export_download_link_notification(
     mocked_notify,
+    mocked_product_export_completed,
     mocked_gift_card_export_completed,
     site_settings,
     user_export_file,
@@ -43,13 +45,16 @@ def test_send_export_download_link_notification(
         AdminNotifyEvent.CSV_EXPORT_SUCCESS, expected_payload
     )
     mocked_gift_card_export_completed.assert_not_called()
+    mocked_product_export_completed.assert_called_with(user_export_file)
 
 
 @freeze_time("2018-05-31 12:00:01")
 @mock.patch("saleor.plugins.manager.PluginsManager.gift_card_export_completed")
+@mock.patch("saleor.plugins.manager.PluginsManager.product_export_completed")
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
 def test_send_export_failed_info(
     mocked_notify,
+    mocked_product_export_completed,
     mocked_gift_card_export_completed,
     site_settings,
     user_export_file,
@@ -79,3 +84,4 @@ def test_send_export_failed_info(
         AdminNotifyEvent.CSV_EXPORT_FAILED, expected_payload
     )
     mocked_gift_card_export_completed.assert_called_once_with(user_export_file)
+    mocked_product_export_completed.assert_not_called()

--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -57,6 +57,9 @@ def export_products(
     temporary_file.close()
 
     send_export_download_link_notification(export_file, "products")
+    manager = get_plugins_manager()
+
+    manager.product_export_completed(export_file)
 
 
 def export_gift_cards(

--- a/saleor/graphql/csv/mutations/export_products.py
+++ b/saleor/graphql/csv/mutations/export_products.py
@@ -80,6 +80,10 @@ class ExportProducts(BaseExportMutation):
                 type=WebhookEventAsyncType.NOTIFY_USER,
                 description="A notification for the exported file.",
             ),
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.PRODUCT_EXPORT_COMPLETED,
+                description="A notification for the exported file.",
+            ),
         ]
 
     @classmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2019,6 +2019,13 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   PRODUCT_METADATA_UPDATED
 
   """
+  A product export is completed.
+  
+  Added in Saleor 3.16.
+  """
+  PRODUCT_EXPORT_COMPLETED
+
+  """
   A new product media is created.
   
   Added in Saleor 3.12.
@@ -2690,6 +2697,13 @@ enum WebhookEventTypeAsyncEnum @doc(category: "Webhooks") {
   Added in Saleor 3.8.
   """
   PRODUCT_METADATA_UPDATED
+
+  """
+  A product export is completed.
+  
+  Added in Saleor 3.16.
+  """
+  PRODUCT_EXPORT_COMPLETED
 
   """
   A new product media is created.
@@ -3499,6 +3513,7 @@ enum WebhookSampleEventTypeEnum @doc(category: "Webhooks") {
   PRODUCT_UPDATED
   PRODUCT_DELETED
   PRODUCT_METADATA_UPDATED
+  PRODUCT_EXPORT_COMPLETED
   PRODUCT_MEDIA_CREATED
   PRODUCT_MEDIA_UPDATED
   PRODUCT_MEDIA_DELETED
@@ -16993,11 +17008,12 @@ type Mutation {
   
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for the exported file.
+  - PRODUCT_EXPORT_COMPLETED (async): A notification for the exported file.
   """
   exportProducts(
     """Fields required to export product data."""
     input: ExportProductsInput!
-  ): ExportProducts @doc(category: "Products") @webhookEventsInfo(asyncEvents: [NOTIFY_USER], syncEvents: [])
+  ): ExportProducts @doc(category: "Products") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, PRODUCT_EXPORT_COMPLETED], syncEvents: [])
 
   """
   Export gift cards to csv file.
@@ -26206,8 +26222,9 @@ Requires one of the following permissions: MANAGE_PRODUCTS.
 
 Triggers the following webhook events:
 - NOTIFY_USER (async): A notification for the exported file.
+- PRODUCT_EXPORT_COMPLETED (async): A notification for the exported file.
 """
-type ExportProducts @doc(category: "Products") @webhookEventsInfo(asyncEvents: [NOTIFY_USER], syncEvents: []) {
+type ExportProducts @doc(category: "Products") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, PRODUCT_EXPORT_COMPLETED], syncEvents: []) {
   """
   The newly created export file job which is responsible for export data.
   """
@@ -31046,6 +31063,28 @@ type ProductMetadataUpdated implements Event @doc(category: "Products") {
 
   """The category of the product."""
   category: Category
+}
+
+"""
+Event sent when product export is completed.
+
+Added in Saleor 3.16.
+"""
+type ProductExportCompleted implements Event @doc(category: "Products") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The export file for products."""
+  export: ExportFile
 }
 
 """

--- a/saleor/graphql/tests/queries/fragments.py
+++ b/saleor/graphql/tests/queries/fragments.py
@@ -268,6 +268,17 @@ fragment BasicProductFields on Product {
 }
 """
 
+PRODUCT_EXPORT_DETAILS = """
+fragment ProductExportDetails on ExportFile{
+  id
+  createdAt
+  updatedAt
+  status
+  url
+  message
+}
+"""
+
 
 COLLECTION = (
     BASIC_PRODUCT_FIELDS

--- a/saleor/graphql/webhook/enums.py
+++ b/saleor/graphql/webhook/enums.py
@@ -187,6 +187,9 @@ WEBHOOK_EVENT_DESCRIPTION = {
     WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED: (
         "A product variant stock is updated"
     ),
+    WebhookEventAsyncType.PRODUCT_EXPORT_COMPLETED: (
+        "A product export is completed." + ADDED_IN_316
+    ),
     WebhookEventAsyncType.SHIPPING_PRICE_CREATED: "A new shipping price is created.",
     WebhookEventAsyncType.SHIPPING_PRICE_UPDATED: "A shipping price is updated.",
     WebhookEventAsyncType.SHIPPING_PRICE_DELETED: "A shipping price is deleted.",

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1052,6 +1052,25 @@ class ProductVariantStockUpdated(SubscriptionObjectType, ProductVariantBase):
         return WarehouseByIdLoader(info.context).load(stock.warehouse_id)
 
 
+class ProductExportCompleted(SubscriptionObjectType):
+    export = graphene.Field(
+        "saleor.graphql.csv.types.ExportFile",
+        description="The export file for products.",
+    )
+
+    class Meta:
+        root_type = "ExportFile"
+        enable_dry_run = True
+        interfaces = (Event,)
+        description = "Event sent when product export is completed." + ADDED_IN_316
+        doc_category = DOC_CATEGORY_PRODUCTS
+
+    @staticmethod
+    def resolve_export(root, info: ResolveInfo):
+        _, export_file = root
+        return export_file
+
+
 class SaleBase(AbstractType):
     sale = graphene.Field(
         "saleor.graphql.discount.types.Sale",
@@ -2409,6 +2428,7 @@ WEBHOOK_TYPES_MAP = {
     WebhookEventAsyncType.PRODUCT_UPDATED: ProductUpdated,
     WebhookEventAsyncType.PRODUCT_DELETED: ProductDeleted,
     WebhookEventAsyncType.PRODUCT_METADATA_UPDATED: ProductMetadataUpdated,
+    WebhookEventAsyncType.PRODUCT_EXPORT_COMPLETED: ProductExportCompleted,
     WebhookEventAsyncType.PRODUCT_MEDIA_CREATED: ProductMediaCreated,
     WebhookEventAsyncType.PRODUCT_MEDIA_UPDATED: ProductMediaUpdated,
     WebhookEventAsyncType.PRODUCT_MEDIA_DELETED: ProductMediaDeleted,

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
@@ -241,6 +241,7 @@ def async_subscription_webhooks_with_root_objects(
     subscription_product_updated_webhook,
     subscription_product_created_webhook,
     subscription_product_deleted_webhook,
+    subscription_product_export_completed_webhook,
     subscription_product_media_updated_webhook,
     subscription_product_media_created_webhook,
     subscription_product_media_deleted_webhook,
@@ -425,6 +426,10 @@ def async_subscription_webhooks_with_root_objects(
         events.PRODUCT_CREATED: [subscription_product_created_webhook, product],
         events.PRODUCT_UPDATED: [subscription_product_updated_webhook, product],
         events.PRODUCT_DELETED: [subscription_product_deleted_webhook, product],
+        events.PRODUCT_EXPORT_COMPLETED: [
+            subscription_product_export_completed_webhook,
+            user_export_file,
+        ],
         events.PRODUCT_MEDIA_CREATED: [
             subscription_product_media_created_webhook,
             product_media_image,

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -983,6 +983,12 @@ class BasePlugin:
     # variant metadata is updated.
     product_variant_metadata_updated: Callable[["ProductVariant", Any], Any]
 
+    # Trigger when a product export is completed.
+    #
+    # Overwrite this method if you need to trigger specific logic after a product
+    # export is completed.
+    product_export_completed: Callable[["ExportFile", None], None]
+
     refund_payment: Callable[["PaymentData", Any], GatewayResponse]
 
     # Trigger when sale is created.

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -700,6 +700,12 @@ class PluginsManager(PaymentInterface):
             "product_variant_metadata_updated", default_value, product_variant
         )
 
+    def product_export_completed(self, export: "ExportFile"):
+        default_value = None
+        return self.__run_method_on_plugins(
+            "product_export_completed", default_value, export
+        )
+
     def order_created(self, order: "Order"):
         default_value = None
         return self.__run_method_on_plugins(

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -620,7 +620,7 @@ class WebhookPlugin(BasePlugin):
             WebhookEventAsyncType.GIFT_CARD_STATUS_CHANGED, gift_card
         )
 
-    def _trigger_export_gift_cards_event(self, event_type, export: "ExportFile"):
+    def _trigger_export_event(self, event_type: str, export: "ExportFile"):
         if webhooks := get_webhooks_for_event(event_type):
             payload = self._serialize_payload(
                 {
@@ -643,7 +643,7 @@ class WebhookPlugin(BasePlugin):
     ) -> None:
         if not self.active:
             return previous_value
-        self._trigger_export_gift_cards_event(
+        self._trigger_export_event(
             WebhookEventAsyncType.GIFT_CARD_EXPORT_COMPLETED,
             export,
         )
@@ -1128,8 +1128,19 @@ class WebhookPlugin(BasePlugin):
     def product_metadata_updated(self, product: "Product", previous_value: Any) -> Any:
         if not self.active:
             return previous_value
+
         self._trigger_metadata_updated_event(
             WebhookEventAsyncType.PRODUCT_METADATA_UPDATED, product
+        )
+
+    def product_export_completed(
+        self, export: "ExportFile", previous_value: None
+    ) -> None:
+        if not self.active:
+            return previous_value
+        self._trigger_export_event(
+            WebhookEventAsyncType.PRODUCT_EXPORT_COMPLETED,
+            export,
         )
 
     def product_deleted(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -396,6 +396,14 @@ def subscription_product_metadata_updated_webhook(subscription_webhook):
 
 
 @pytest.fixture
+def subscription_product_export_completed_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.PRODUCT_EXPORT_COMPLETED,
+        WebhookEventAsyncType.PRODUCT_EXPORT_COMPLETED,
+    )
+
+
+@pytest.fixture
 def subscription_product_media_created_webhook(subscription_webhook):
     return subscription_webhook(
         queries.PRODUCT_MEDIA_CREATED, WebhookEventAsyncType.PRODUCT_CREATED

--- a/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
@@ -428,7 +428,7 @@ def generate_gift_card_payload(gift_card, card_global_id):
     )
 
 
-def generate_gift_card_export_payload(export_file, export_global_id):
+def generate_export_payload(export_file, export_global_id):
     return json.dumps(
         {
             "export": {

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -920,6 +920,21 @@ PRODUCT_METADATA_UPDATED = """
     }
 """
 
+PRODUCT_EXPORT_COMPLETED = (
+    fragments.PRODUCT_EXPORT_DETAILS
+    + """
+    subscription{
+      event{
+        ...on ProductExportCompleted{
+          export{
+            ...ProductExportDetails
+          }
+        }
+      }
+    }
+"""
+)
+
 PRODUCT_MEDIA_CREATED = """
     subscription{
       event{

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -26,8 +26,8 @@ from .payloads import (
     generate_category_payload,
     generate_collection_payload,
     generate_customer_payload,
+    generate_export_payload,
     generate_fulfillment_payload,
-    generate_gift_card_export_payload,
     generate_gift_card_payload,
     generate_invoice_payload,
     generate_menu_item_payload,
@@ -795,7 +795,7 @@ def test_gift_card_export_completed(
     )
 
     # then
-    expected_payload = generate_gift_card_export_payload(user_export_file, gift_card_id)
+    expected_payload = generate_export_payload(user_export_file, gift_card_id)
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
@@ -1225,6 +1225,32 @@ def test_product_metadata_updated(
     deliveries = create_deliveries_for_subscriptions(event_type, product, webhooks)
     expected_payload = json.dumps({"product": {"id": product_id}})
 
+    assert deliveries[0].payload.payload == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_product_export_completed(
+    user_export_file, tmpdir, subscription_product_export_completed_webhook
+):
+    # given
+    file_mock = MagicMock(spec=File)
+    file_mock.name = "temp_file.csv"
+
+    user_export_file.content_file = file_mock
+    user_export_file.save()
+
+    webhooks = [subscription_product_export_completed_webhook]
+    event_type = WebhookEventAsyncType.PRODUCT_EXPORT_COMPLETED
+    export_id = graphene.Node.to_global_id("ExportFile", user_export_file.id)
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, user_export_file, webhooks
+    )
+
+    # then
+    expected_payload = generate_export_payload(user_export_file, export_id)
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -117,6 +117,7 @@ class WebhookEventAsyncType:
     PRODUCT_UPDATED = "product_updated"
     PRODUCT_DELETED = "product_deleted"
     PRODUCT_METADATA_UPDATED = "product_metadata_updated"
+    PRODUCT_EXPORT_COMPLETED = "product_export_completed"
 
     PRODUCT_MEDIA_CREATED = "product_media_created"
     PRODUCT_MEDIA_UPDATED = "product_media_updated"
@@ -500,6 +501,10 @@ class WebhookEventAsyncType:
         },
         PRODUCT_METADATA_UPDATED: {
             "name": "Product metadata updated",
+            "permission": ProductPermissions.MANAGE_PRODUCTS,
+        },
+        PRODUCT_EXPORT_COMPLETED: {
+            "name": "Product export completed",
             "permission": ProductPermissions.MANAGE_PRODUCTS,
         },
         PRODUCT_MEDIA_CREATED: {


### PR DESCRIPTION
I want to merge this change because it adds `PRODUCT_EXPORT_COMPLETED` webhook.

Resolves https://github.com/saleor/saleor/issues/13547

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
