### PR TITLE
Fix webhook descriptions

### DIFF
--- a/saleor/graphql/account/mutations/account/account_request_deletion.py
+++ b/saleor/graphql/account/mutations/account/account_request_deletion.py
@@ -46,7 +46,11 @@ class AccountRequestDeletion(BaseMutation):
             WebhookEventInfo(
                 type=WebhookEventAsyncType.NOTIFY_USER,
                 description="A notification for account delete request.",
-            )
+            ),
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.ACCOUNT_DELETE_REQUESTED,
+                description="An account delete requested.",
+            ),
         ]
 
     @classmethod

--- a/saleor/graphql/account/mutations/account/request_email_change.py
+++ b/saleor/graphql/account/mutations/account/request_email_change.py
@@ -51,7 +51,11 @@ class RequestEmailChange(BaseMutation):
             WebhookEventInfo(
                 type=WebhookEventAsyncType.NOTIFY_USER,
                 description="A notification for account email change.",
-            )
+            ),
+            WebhookEventInfo(
+                type=WebhookEventAsyncType.ACCOUNT_CHANGE_EMAIL_REQUESTED,
+                description="An account email change was requested.",
+            ),
         ]
 
     @classmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -18232,6 +18232,7 @@ type Mutation {
   
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for account email change.
+  - ACCOUNT_CHANGE_EMAIL_REQUESTED (async): An account email change was requested.
   """
   requestEmailChange(
     """
@@ -18249,7 +18250,7 @@ type Mutation {
     URL of a view where users should be redirected to update the email address. URL in RFC 1808 format.
     """
     redirectUrl: String!
-  ): RequestEmailChange @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER], syncEvents: [])
+  ): RequestEmailChange @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, ACCOUNT_CHANGE_EMAIL_REQUESTED], syncEvents: [])
 
   """
   Confirm the email change of the logged-in user. 
@@ -18365,6 +18366,7 @@ type Mutation {
   
   Triggers the following webhook events:
   - NOTIFY_USER (async): A notification for account delete request.
+  - ACCOUNT_DELETE_REQUESTED (async): An account delete requested.
   """
   accountRequestDeletion(
     """
@@ -18376,7 +18378,7 @@ type Mutation {
     URL of a view where users should be redirected to delete their account. URL in RFC 1808 format.
     """
     redirectUrl: String!
-  ): AccountRequestDeletion @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER], syncEvents: [])
+  ): AccountRequestDeletion @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, ACCOUNT_DELETE_REQUESTED], syncEvents: [])
 
   """
   Remove user account. 
@@ -28504,8 +28506,9 @@ Requires one of the following permissions: AUTHENTICATED_USER.
 
 Triggers the following webhook events:
 - NOTIFY_USER (async): A notification for account email change.
+- ACCOUNT_CHANGE_EMAIL_REQUESTED (async): An account email change was requested.
 """
-type RequestEmailChange @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER], syncEvents: []) {
+type RequestEmailChange @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, ACCOUNT_CHANGE_EMAIL_REQUESTED], syncEvents: []) {
   """A user instance."""
   user: User
   accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
@@ -28681,8 +28684,9 @@ Requires one of the following permissions: AUTHENTICATED_USER.
 
 Triggers the following webhook events:
 - NOTIFY_USER (async): A notification for account delete request.
+- ACCOUNT_DELETE_REQUESTED (async): An account delete requested.
 """
-type AccountRequestDeletion @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER], syncEvents: []) {
+type AccountRequestDeletion @doc(category: "Users") @webhookEventsInfo(asyncEvents: [NOTIFY_USER, ACCOUNT_DELETE_REQUESTED], syncEvents: []) {
   accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }


### PR DESCRIPTION
While working on release notes for 3.15 I noticed some missing webhook mentions in mutation descriptions. I'll port these changes to main as well.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
