### PR TITLE
Optimize products bulk create

### DIFF
--- a/saleor/core/tests/test_core.py
+++ b/saleor/core/tests/test_core.py
@@ -24,6 +24,7 @@ from ..utils import (
     generate_unique_slug,
     get_client_ip,
     get_currency_for_country,
+    prepare_unique_attribute_value_slug,
     random_data,
 )
 
@@ -364,3 +365,28 @@ def test_cleardb_preserves_data(admin_user, app, site_settings, staff_user):
     app.refresh_from_db()
     site_settings.refresh_from_db()
     staff_user.refresh_from_db()
+
+
+def test_prepare_unique_attribute_value_slug(color_attribute):
+    # given
+    value_1 = color_attribute.values.first()
+
+    # when
+    value_2 = AttributeValue(
+        name=value_1.name, attribute=color_attribute, slug=value_1.slug
+    )
+
+    # then
+    result = prepare_unique_attribute_value_slug(value_2.attribute, value_2.slug)
+
+    assert result == f"{value_1.slug}-2"
+
+
+def test_prepare_unique_attribute_value_slug_non_existing_slug(color_attribute):
+    # when
+    non_existing_slug = "non-existing-slug"
+
+    # then
+    result = prepare_unique_attribute_value_slug(color_attribute, non_existing_slug)
+
+    assert result == non_existing_slug

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -14,6 +14,9 @@ from django_prices_openexchangerates import exchange_currency
 from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
 from text_unidecode import unidecode
 
+if TYPE_CHECKING:
+    from ...attribute.models import Attribute
+
 task_logger = get_task_logger(__name__)
 
 
@@ -145,3 +148,10 @@ def prepare_unique_slug(slug: str, slug_values: Iterable):
         unique_slug = f"{slug}-{extension}"
 
     return unique_slug
+
+
+def prepare_unique_attribute_value_slug(attribute: "Attribute", slug: str):
+    value_slugs = attribute.values.filter(slug__startswith=slug).values_list(
+        "slug", flat=True
+    )
+    return prepare_unique_slug(slug, value_slugs)

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -16,7 +16,11 @@ from text_unidecode import unidecode
 from ...attribute import AttributeEntityType, AttributeInputType, AttributeType
 from ...attribute import models as attribute_models
 from ...attribute.utils import associate_attribute_values_to_instance
-from ...core.utils import generate_unique_slug, prepare_unique_slug
+from ...core.utils import (
+    generate_unique_slug,
+    prepare_unique_attribute_value_slug,
+    prepare_unique_slug,
+)
 from ...core.utils.editorjs import clean_editor_js
 from ...core.utils.url import get_default_storage_root_url
 from ...page import models as page_models
@@ -180,22 +184,18 @@ class AttributeAssignmentMixin:
         )
 
     @classmethod
-    def _get_create_value_instance(
-        cls, attribute, attr_value, external_ref, attr_and_value_slugs_map
-    ):
-        slug = prepare_unique_slug(
-            slugify(unidecode(attr_value)), attr_and_value_slugs_map[attribute]
+    def _get_create_value_instance(cls, attribute, attr_value, external_ref):
+        value_slug = prepare_unique_attribute_value_slug(
+            attribute, slugify(unidecode(attr_value))
         )
-        value, created = attribute_models.AttributeValue.objects.get_or_create(
+        value, _ = attribute_models.AttributeValue.objects.get_or_create(
             external_reference=external_ref,
             defaults={
                 "attribute": attribute,
                 "name": attr_value,
-                "slug": slug,
+                "slug": value_slug,
             },
         )
-        if created:
-            attr_and_value_slugs_map[attribute].add(slug)
 
         return value
 
@@ -393,13 +393,6 @@ class AttributeAssignmentMixin:
             AttributeInputType.RICH_TEXT: cls._pre_save_rich_text_values,
         }
         clean_assignment = []
-        attr_and_value_slugs_map = {}
-
-        for attribute, _ in cleaned_input:
-            if attribute not in attr_and_value_slugs_map:
-                attr_and_value_slugs_map[attribute] = set(
-                    attribute.values.all().values_list("slug", flat=True)
-                )
 
         for attribute, attr_values in cleaned_input:
             is_handled_by_values_field = (
@@ -415,9 +408,7 @@ class AttributeAssignmentMixin:
                 attribute_values = cls._pre_save_values(attribute, attr_values)
             else:
                 pre_save_func = pre_save_methods_mapping[attribute.input_type]
-                attribute_values = pre_save_func(
-                    instance, attribute, attr_values, attr_and_value_slugs_map
-                )
+                attribute_values = pre_save_func(instance, attribute, attr_values)
 
             associate_attribute_values_to_instance(
                 instance, attribute, *attribute_values
@@ -437,7 +428,6 @@ class AttributeAssignmentMixin:
         _,
         attribute: attribute_models.Attribute,
         attr_values: AttrValuesInput,
-        attr_and_value_slugs_map,
     ):
         if not attr_values.dropdown:
             return tuple()
@@ -446,9 +436,7 @@ class AttributeAssignmentMixin:
         external_ref = attr_values.dropdown.external_reference
 
         if external_ref and attr_value:
-            value = cls._get_create_value_instance(
-                attribute, attr_value, external_ref, attr_and_value_slugs_map
-            )
+            value = cls._get_create_value_instance(attribute, attr_value, external_ref)
             return (value,)
 
         if external_ref:
@@ -482,7 +470,6 @@ class AttributeAssignmentMixin:
         _,
         attribute: attribute_models.Attribute,
         attr_values: AttrValuesInput,
-        attr_and_value_slugs_map,
     ):
         if not attr_values.swatch:
             return tuple()
@@ -491,9 +478,7 @@ class AttributeAssignmentMixin:
         external_ref = attr_values.swatch.external_reference
 
         if external_ref and attr_value:
-            value = cls._get_create_value_instance(
-                attribute, attr_value, external_ref, attr_and_value_slugs_map
-            )
+            value = cls._get_create_value_instance(attribute, attr_value, external_ref)
             return value
 
         if external_ref:
@@ -525,7 +510,6 @@ class AttributeAssignmentMixin:
         _,
         attribute: attribute_models.Attribute,
         attr_values_input: AttrValuesInput,
-        attr_and_value_slugs_map,
     ):
         if not attr_values_input.multiselect:
             return tuple()
@@ -536,7 +520,7 @@ class AttributeAssignmentMixin:
 
             if external_ref and attr_value.value:
                 value = cls._get_create_value_instance(
-                    attribute, attr_value.value, external_ref, attr_and_value_slugs_map
+                    attribute, attr_value.value, external_ref
                 )
                 if value.id not in [a.id for a in attribute_values]:
                     attribute_values.append(value)
@@ -582,7 +566,6 @@ class AttributeAssignmentMixin:
         instance: T_INSTANCE,
         attribute: attribute_models.Attribute,
         attr_values: AttrValuesInput,
-        attr_and_value_slugs_map,
     ):
         if attr_values.values:
             value = attr_values.values[0]
@@ -618,7 +601,6 @@ class AttributeAssignmentMixin:
         instance: T_INSTANCE,
         attribute: attribute_models.Attribute,
         attr_values: AttrValuesInput,
-        attr_and_value_slugs_map,
     ):
         if not attr_values.rich_text:
             return tuple()
@@ -636,7 +618,6 @@ class AttributeAssignmentMixin:
         instance: T_INSTANCE,
         attribute: attribute_models.Attribute,
         attr_values: AttrValuesInput,
-        attr_and_value_slugs_map,
     ):
         if not attr_values.plain_text:
             return tuple()
@@ -652,7 +633,6 @@ class AttributeAssignmentMixin:
         instance: T_INSTANCE,
         attribute: attribute_models.Attribute,
         attr_values: AttrValuesInput,
-        attr_and_value_slugs_map,
     ):
         if attr_values.boolean is None:
             return tuple()
@@ -674,7 +654,6 @@ class AttributeAssignmentMixin:
         instance: T_INSTANCE,
         attribute: attribute_models.Attribute,
         attr_values: AttrValuesInput,
-        attr_and_value_slugs_map,
     ):
         is_date_attr = attribute.input_type == AttributeInputType.DATE
         tz = timezone.utc
@@ -720,7 +699,6 @@ class AttributeAssignmentMixin:
         instance,
         attribute: attribute_models.Attribute,
         attr_values: AttrValuesInput,
-        attr_and_value_slugs_map,
     ):
         """Lazy-retrieve or create the database objects from the supplied raw values.
 
@@ -755,7 +733,6 @@ class AttributeAssignmentMixin:
         instance: T_INSTANCE,
         attribute: attribute_models.Attribute,
         attr_value: AttrValuesInput,
-        attr_and_value_slugs_map,
     ):
         """Create database file attribute value object from the supplied value.
 


### PR DESCRIPTION
I want to merge this change because it optimizes product bulk create mutation.
- `attribute.values.all()` is no longer called every single time for each attribute.
- Instead it calls a filter (only for attribute types that need it), uses `slug` field (does utilize an index).
- reduced core side memory consumption drastically.
- reduced DB returned row count drastically.
- improved mutation speed significantly.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
