### PR TITLE
Change the response for storedPaymentMethodRequestDelete

### DIFF
--- a/saleor/graphql/payment/enums.py
+++ b/saleor/graphql/payment/enums.py
@@ -83,7 +83,9 @@ TokenizedPaymentFlowEnum = to_enum(
     type_name="TokenizedPaymentFlowEnum",
     description=TokenizedPaymentFlow.__doc__,
 )
+TokenizedPaymentFlowEnum.doc_category = DOC_CATEGORY_PAYMENTS
 
 StoredPaymentMethodRequestDeleteResultEnum = graphene.Enum.from_enum(
     StoredPaymentMethodRequestDeleteResult,
 )
+StoredPaymentMethodRequestDeleteResultEnum.doc_category = DOC_CATEGORY_PAYMENTS

--- a/saleor/graphql/payment/enums.py
+++ b/saleor/graphql/payment/enums.py
@@ -1,3 +1,5 @@
+import graphene
+
 from ...payment import (
     ChargeStatus,
     StorePaymentMethod,
@@ -6,6 +8,7 @@ from ...payment import (
     TransactionEventType,
     TransactionKind,
 )
+from ...payment.interface import StoredPaymentMethodRequestDeleteResult
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.enums import to_enum
 from ..core.types import BaseEnum
@@ -79,4 +82,8 @@ TokenizedPaymentFlowEnum = to_enum(
     TokenizedPaymentFlow,
     type_name="TokenizedPaymentFlowEnum",
     description=TokenizedPaymentFlow.__doc__,
+)
+
+StoredPaymentMethodRequestDeleteResultEnum = graphene.Enum.from_enum(
+    StoredPaymentMethodRequestDeleteResult,
 )

--- a/saleor/graphql/payment/tests/mutations/test_stored_payment_method_request_delete.py
+++ b/saleor/graphql/payment/tests/mutations/test_stored_payment_method_request_delete.py
@@ -3,19 +3,21 @@ from unittest.mock import patch
 from .....payment.interface import (
     StoredPaymentMethodRequestDeleteData,
     StoredPaymentMethodRequestDeleteResponseData,
+    StoredPaymentMethodRequestDeleteResult,
 )
 from .....plugins.manager import PluginsManager
 from ....core.enums import StoredPaymentMethodRequestDeleteErrorCode
 from ....tests.utils import assert_no_permission, get_graphql_content
+from ...enums import StoredPaymentMethodRequestDeleteResultEnum
 
 STORED_PAYMENT_METHOD_REQUEST_DELETE_MUTATION = """
 mutation storedPaymentMethodRequestDelete($id: ID!, $channel: String!){
   storedPaymentMethodRequestDelete(id: $id, channel: $channel){
-    success
-    message
+    result
     errors{
       field
       code
+      message
     }
   }
 }
@@ -34,8 +36,8 @@ def test_stored_payment_method_request_delete(
     mocked_is_event_active_for_any_plugin.return_value = True
     mocked_stored_payment_method_request_delete.return_value = (
         StoredPaymentMethodRequestDeleteResponseData(
-            success=True,
-            message=None,
+            result=StoredPaymentMethodRequestDeleteResult.SUCCESSFULLY_DELETED.value,
+            error=None,
         )
     )
     expected_id = "test_id"
@@ -48,7 +50,58 @@ def test_stored_payment_method_request_delete(
 
     # then
     content = get_graphql_content(response)
-    assert content["data"]["storedPaymentMethodRequestDelete"]["success"] is True
+    assert (
+        content["data"]["storedPaymentMethodRequestDelete"]["result"]
+        == StoredPaymentMethodRequestDeleteResultEnum.SUCCESSFULLY_DELETED.name
+    )
+
+    mocked_is_event_active_for_any_plugin.assert_called_once_with(
+        "stored_payment_method_request_delete"
+    )
+    mocked_stored_payment_method_request_delete.assert_called_once_with(
+        request_delete_data=StoredPaymentMethodRequestDeleteData(
+            payment_method_id=expected_id,
+            user=user_api_client.user,
+            channel=channel_USD,
+        )
+    )
+
+
+@patch.object(PluginsManager, "stored_payment_method_request_delete")
+@patch.object(PluginsManager, "is_event_active_for_any_plugin")
+def test_stored_payment_method_request_delete_app_returned_failure_event(
+    mocked_is_event_active_for_any_plugin,
+    mocked_stored_payment_method_request_delete,
+    user_api_client,
+    channel_USD,
+):
+    # given
+    expected_error_message = "Failed to delete"
+    mocked_is_event_active_for_any_plugin.return_value = True
+    mocked_stored_payment_method_request_delete.return_value = (
+        StoredPaymentMethodRequestDeleteResponseData(
+            result=StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELETE.value,
+            error=expected_error_message,
+        )
+    )
+    expected_id = "test_id"
+
+    # when
+    response = user_api_client.post_graphql(
+        STORED_PAYMENT_METHOD_REQUEST_DELETE_MUTATION,
+        variables={"id": expected_id, "channel": channel_USD.slug},
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert (
+        content["data"]["storedPaymentMethodRequestDelete"]["result"]
+        == StoredPaymentMethodRequestDeleteResultEnum.FAILED_TO_DELETE.name
+    )
+    assert len(content["data"]["storedPaymentMethodRequestDelete"]["errors"]) == 1
+    error = content["data"]["storedPaymentMethodRequestDelete"]["errors"][0]
+    assert error["code"] == StoredPaymentMethodRequestDeleteErrorCode.GATEWAY_ERROR.name
+    assert error["message"] == expected_error_message
 
     mocked_is_event_active_for_any_plugin.assert_called_once_with(
         "stored_payment_method_request_delete"
@@ -74,8 +127,7 @@ def test_stored_payment_method_request_delete_called_by_app(
     mocked_is_event_active_for_any_plugin.return_value = True
     mocked_stored_payment_method_request_delete.return_value = (
         StoredPaymentMethodRequestDeleteResponseData(
-            success=True,
-            message="Payment method delete request was processed successfully.",
+            result=StoredPaymentMethodRequestDeleteResult.SUCCESSFULLY_DELETED.value,
         )
     )
     expected_id = "test_id"
@@ -105,8 +157,7 @@ def test_stored_payment_method_request_delete_called_by_anynoums_user(
     mocked_is_event_active_for_any_plugin.return_value = True
     mocked_stored_payment_method_request_delete.return_value = (
         StoredPaymentMethodRequestDeleteResponseData(
-            success=True,
-            message="Payment method delete request was processed successfully.",
+            result=StoredPaymentMethodRequestDeleteResult.SUCCESSFULLY_DELETED.value,
         )
     )
     expected_id = "test_id"
@@ -136,8 +187,8 @@ def test_stored_payment_method_request_delete_not_app_or_plugin_subscribed_to_ev
     mocked_is_event_active_for_any_plugin.return_value = False
     mocked_stored_payment_method_request_delete.return_value = (
         StoredPaymentMethodRequestDeleteResponseData(
-            success=True,
-            message=None,
+            result=StoredPaymentMethodRequestDeleteResult.SUCCESSFULLY_DELETED.value,
+            error=None,
         )
     )
     expected_id = "test_id"
@@ -150,6 +201,10 @@ def test_stored_payment_method_request_delete_not_app_or_plugin_subscribed_to_ev
 
     # then
     content = get_graphql_content(response)
+    assert (
+        content["data"]["storedPaymentMethodRequestDelete"]["result"]
+        == StoredPaymentMethodRequestDeleteResultEnum.FAILED_TO_DELIVER.name
+    )
     assert len(content["data"]["storedPaymentMethodRequestDelete"]["errors"]) == 1
     assert (
         content["data"]["storedPaymentMethodRequestDelete"]["errors"][0]["code"]
@@ -173,8 +228,8 @@ def test_stored_payment_method_request_delete_incorrect_channel(
     mocked_is_event_active_for_any_plugin.return_value = False
     mocked_stored_payment_method_request_delete.return_value = (
         StoredPaymentMethodRequestDeleteResponseData(
-            success=True,
-            message=None,
+            result=StoredPaymentMethodRequestDeleteResult.SUCCESSFULLY_DELETED,
+            error=None,
         )
     )
     expected_id = "test_id"
@@ -191,6 +246,10 @@ def test_stored_payment_method_request_delete_incorrect_channel(
     assert (
         content["data"]["storedPaymentMethodRequestDelete"]["errors"][0]["code"]
         == StoredPaymentMethodRequestDeleteErrorCode.NOT_FOUND.name
+    )
+    assert (
+        content["data"]["storedPaymentMethodRequestDelete"]["result"]
+        == StoredPaymentMethodRequestDeleteResultEnum.FAILED_TO_DELIVER.name
     )
 
     assert not mocked_is_event_active_for_any_plugin.called

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -12460,7 +12460,7 @@ Represents possible tokenized payment flows that can be used to process payment.
     INTERACTIVE - Payment method can be used for 1 click checkout - it's prefilled in
     checkout form (might require additional authentication from user)
 """
-enum TokenizedPaymentFlowEnum {
+enum TokenizedPaymentFlowEnum @doc(category: "Payments") {
   INTERACTIVE
 }
 
@@ -23215,7 +23215,7 @@ Result of deleting a stored payment method.
     FAILED_TO_DELIVER - The request to delete the stored payment method was not
     delivered.
 """
-enum StoredPaymentMethodRequestDeleteResult {
+enum StoredPaymentMethodRequestDeleteResult @doc(category: "Payments") {
   SUCCESSFULLY_DELETED
   FAILED_TO_DELETE
   FAILED_TO_DELIVER

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23201,12 +23201,24 @@ Triggers the following webhook events:
 - STORED_PAYMENT_METHOD_DELETE_REQUESTED (sync): The customer requested to delete a payment method.
 """
 type StoredPaymentMethodRequestDelete @doc(category: "Payments") @webhookEventsInfo(asyncEvents: [], syncEvents: [STORED_PAYMENT_METHOD_DELETE_REQUESTED]) {
-  """True, if the delete request was processed successfully."""
-  success: Boolean
-
-  """A message returned by payment app."""
-  message: String
+  """The result of deleting a stored payment method."""
+  result: StoredPaymentMethodRequestDeleteResult!
   errors: [PaymentMethodRequestDeleteError!]!
+}
+
+"""
+Result of deleting a stored payment method.
+
+    This enum is used to determine the result of deleting a stored payment method.
+    SUCCESSFULLY_DELETED - The stored payment method was successfully deleted.
+    FAILED_TO_DELETE - The stored payment method was not deleted.
+    FAILED_TO_DELIVER - The request to delete the stored payment method was not
+    delivered.
+"""
+enum StoredPaymentMethodRequestDeleteResult {
+  SUCCESSFULLY_DELETED
+  FAILED_TO_DELETE
+  FAILED_TO_DELIVER
 }
 
 type PaymentMethodRequestDeleteError @doc(category: "Payments") {
@@ -23228,6 +23240,7 @@ enum StoredPaymentMethodRequestDeleteErrorCode @doc(category: "Payments") {
   INVALID
   NOT_FOUND
   CHANNEL_INACTIVE
+  GATEWAY_ERROR
 }
 
 """

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -97,3 +97,4 @@ class StoredPaymentMethodRequestDeleteErrorCode(Enum):
     INVALID = "invalid"
     NOT_FOUND = "not_found"
     CHANNEL_INACTIVE = "channel_inactive"
+    GATEWAY_ERROR = "gateway_error"

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -21,11 +21,27 @@ JSONType = Union[Dict[str, JSONValue], List[JSONValue]]
 
 
 @dataclass
+class StoredPaymentMethodRequestDeleteResult(str, Enum):
+    """Result of deleting a stored payment method.
+
+    This enum is used to determine the result of deleting a stored payment method.
+    SUCCESSFULLY_DELETED - The stored payment method was successfully deleted.
+    FAILED_TO_DELETE - The stored payment method was not deleted.
+    FAILED_TO_DELIVER - The request to delete the stored payment method was not
+    delivered.
+    """
+
+    SUCCESSFULLY_DELETED = "successfully_deleted"
+    FAILED_TO_DELETE = "failed_to_delete"
+    FAILED_TO_DELIVER = "failed_to_deliver"
+
+
+@dataclass
 class StoredPaymentMethodRequestDeleteResponseData:
     """Dataclass for storing the response information from payment app."""
 
-    success: bool
-    message: Optional[str] = None
+    result: StoredPaymentMethodRequestDeleteResult
+    error: Optional[str] = None
 
 
 @dataclass

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -43,6 +43,7 @@ from ..payment.interface import (
     PaymentMethodData,
     StoredPaymentMethodRequestDeleteData,
     StoredPaymentMethodRequestDeleteResponseData,
+    StoredPaymentMethodRequestDeleteResult,
     TokenConfig,
     TransactionActionData,
     TransactionSessionData,
@@ -1551,7 +1552,8 @@ class PluginsManager(PaymentInterface):
         request_delete_data: "StoredPaymentMethodRequestDeleteData",
     ) -> "StoredPaymentMethodRequestDeleteResponseData":
         default_response = StoredPaymentMethodRequestDeleteResponseData(
-            success=False, message="Payment method request delete failed to deliver."
+            result=StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELIVER,
+            error="Payment method request delete failed to deliver.",
         )
         response = self.__run_method_on_plugins(
             "stored_payment_method_request_delete",

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -23,6 +23,7 @@ from ...payment.interface import (
     PaymentGatewayData,
     StoredPaymentMethodRequestDeleteData,
     StoredPaymentMethodRequestDeleteResponseData,
+    StoredPaymentMethodRequestDeleteResult,
     TransactionProcessActionData,
     TransactionSessionData,
     TransactionSessionResult,
@@ -1376,9 +1377,9 @@ def test_stored_payment_method_request_delete(
         user=customer_user, payment_method_id="123", channel=channel_USD
     )
     previous_response = StoredPaymentMethodRequestDeleteResponseData(
-        success=False, message="Payment method request delete failed to deliver."
+        result=StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELIVER,
+        error="Payment method request delete failed to deliver.",
     )
-
     # when
     manager.stored_payment_method_request_delete(
         request_delete_data=request_delete_data

--- a/saleor/plugins/webhook/stored_payment_methods.py
+++ b/saleor/plugins/webhook/stored_payment_methods.py
@@ -11,6 +11,7 @@ from ...payment.interface import (
     PaymentMethodCreditCardInfo,
     PaymentMethodData,
     StoredPaymentMethodRequestDeleteResponseData,
+    StoredPaymentMethodRequestDeleteResult,
 )
 from ...webhook.event_types import WebhookEventSyncType
 from ...webhook.utils import get_webhooks_for_event
@@ -148,10 +149,21 @@ def get_list_stored_payment_methods_from_response(
 def get_response_for_stored_payment_method_request_delete(
     response_data: Optional[dict],
 ) -> "StoredPaymentMethodRequestDeleteResponseData":
-    response_data = response_data or {"message": "Failed to delivery request."}
+    if response_data is None:
+        result = StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELIVER
+        error = "Failed to delivery request."
+    else:
+        try:
+            response_result = response_data.get("result") or ""
+            result = StoredPaymentMethodRequestDeleteResult[response_result]
+            error = None
+        except KeyError:
+            result = StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELETE
+            error = "Missing or incorrect `result` in response."
+
     return StoredPaymentMethodRequestDeleteResponseData(
-        success=response_data.get("success", False),
-        message=response_data.get("message", None),
+        result=result,
+        error=error,
     )
 
 

--- a/saleor/plugins/webhook/stored_payment_methods.py
+++ b/saleor/plugins/webhook/stored_payment_methods.py
@@ -156,7 +156,7 @@ def get_response_for_stored_payment_method_request_delete(
         try:
             response_result = response_data.get("result") or ""
             result = StoredPaymentMethodRequestDeleteResult[response_result]
-            error = None
+            error = response_data.get("error", None)
         except KeyError:
             result = StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELETE
             error = "Missing or incorrect `result` in response."


### PR DESCRIPTION
I want to merge this change because it improves the response from `storedPaymentMethodRequestDelete`. 
Previously the mutation was returning success and message field. Now it returns an enum value: `result`. 

RFC: https://github.com/saleor/saleor/issues/13395

> **Warning**
> It adds changes in the graphql scheme. It is ok, as this mutation hasn't been released yet (target is 3.16)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/878 (The pr contains whole description for the `storedPaymentMethodRequestDelete`, I will correct it to match with the changes that are introduced by this PR)

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
