### PR TITLE
[Programmatic payments] Change the response for paymentGatewayInitializeTokenization

### DIFF
--- a/saleor/graphql/payment/enums.py
+++ b/saleor/graphql/payment/enums.py
@@ -1,3 +1,5 @@
+import graphene
+
 from ...payment import (
     ChargeStatus,
     StorePaymentMethod,
@@ -6,6 +8,7 @@ from ...payment import (
     TransactionEventType,
     TransactionKind,
 )
+from ...payment.interface import PaymentGatewayInitializeTokenizationResult
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.enums import to_enum
 from ..core.types import BaseEnum
@@ -80,3 +83,9 @@ TokenizedPaymentFlowEnum = to_enum(
     type_name="TokenizedPaymentFlowEnum",
     description=TokenizedPaymentFlow.__doc__,
 )
+
+
+PaymentGatewayInitializeTokenizationResultEnum = graphene.Enum.from_enum(
+    PaymentGatewayInitializeTokenizationResult,
+)
+PaymentGatewayInitializeTokenizationResultEnum.doc_category = DOC_CATEGORY_PAYMENTS

--- a/saleor/graphql/payment/tests/mutations/test_payment_gateway_initialize_tokenization.py
+++ b/saleor/graphql/payment/tests/mutations/test_payment_gateway_initialize_tokenization.py
@@ -5,34 +5,45 @@ import pytest
 from .....payment.interface import (
     PaymentGatewayInitializeTokenizationRequestData,
     PaymentGatewayInitializeTokenizationResponseData,
+    PaymentGatewayInitializeTokenizationResult,
 )
 from .....plugins.manager import PluginsManager
 from ....core.enums import PaymentGatewayInitializeTokenizationErrorCode
 from ....tests.utils import assert_no_permission, get_graphql_content
+from ...enums import PaymentGatewayInitializeTokenizationResultEnum
 
 PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION = """
 mutation PaymentGatewayInitializeTokenization(
 $id: String!, $channel: String!, $data: JSON){
   paymentGatewayInitializeTokenization(id: $id, channel: $channel, data: $data){
-    success
-    message
+    result
     data
     errors{
       field
       code
+      message
     }
   }
 }
 """
 
 
-@pytest.mark.parametrize("expected_data", [None, {"foo": "bar"}])
+@pytest.mark.parametrize(
+    "expected_input_data, expected_output_data",
+    [
+        (None, None),
+        (None, {"foo": "bar1"}),
+        ({"foo": "bar2"}, None),
+        ({"foo": "bar3"}, {"foo": "bar4"}),
+    ],
+)
 @patch.object(PluginsManager, "payment_gateway_initialize_tokenization")
 @patch.object(PluginsManager, "is_event_active_for_any_plugin")
 def test_payment_gateway_initialize_tokenization(
     mocked_is_event_active_for_any_plugin,
     mocked_payment_gateway_initialize_tokenization,
-    expected_data,
+    expected_input_data,
+    expected_output_data,
     user_api_client,
     channel_USD,
 ):
@@ -40,9 +51,9 @@ def test_payment_gateway_initialize_tokenization(
     mocked_is_event_active_for_any_plugin.return_value = True
     mocked_payment_gateway_initialize_tokenization.return_value = (
         PaymentGatewayInitializeTokenizationResponseData(
-            success=True,
-            message=None,
-            data=None,
+            result=PaymentGatewayInitializeTokenizationResult.SUCCESSFULLY_INITIALIZED,
+            error=None,
+            data=expected_output_data,
         )
     )
     expected_id = "test_id"
@@ -53,13 +64,17 @@ def test_payment_gateway_initialize_tokenization(
         variables={
             "id": expected_id,
             "channel": channel_USD.slug,
-            "data": expected_data,
+            "data": expected_input_data,
         },
     )
 
     # then
     content = get_graphql_content(response)
-    assert content["data"]["paymentGatewayInitializeTokenization"]["success"] is True
+    response_data = content["data"]["paymentGatewayInitializeTokenization"]
+    assert response_data["result"] == (
+        PaymentGatewayInitializeTokenizationResultEnum.SUCCESSFULLY_INITIALIZED.name
+    )
+    assert response_data["data"] == expected_output_data
 
     mocked_is_event_active_for_any_plugin.assert_called_once_with(
         "payment_gateway_initialize_tokenization"
@@ -69,7 +84,7 @@ def test_payment_gateway_initialize_tokenization(
             user=user_api_client.user,
             channel=channel_USD,
             app_identifier=expected_id,
-            data=expected_data,
+            data=expected_input_data,
         )
     )
 
@@ -83,14 +98,6 @@ def test_payment_gateway_initialize_tokenization_called_by_anonymous_user(
     channel_USD,
 ):
     # given
-    mocked_is_event_active_for_any_plugin.return_value = True
-    mocked_payment_gateway_initialize_tokenization.return_value = (
-        PaymentGatewayInitializeTokenizationResponseData(
-            success=True,
-            message=None,
-            data=None,
-        )
-    )
     expected_id = "test_id"
 
     # when
@@ -115,14 +122,6 @@ def test_payment_gateway_initialize_tokenization_called_by_app(
     channel_USD,
 ):
     # given
-    mocked_is_event_active_for_any_plugin.return_value = True
-    mocked_payment_gateway_initialize_tokenization.return_value = (
-        PaymentGatewayInitializeTokenizationResponseData(
-            success=True,
-            message=None,
-            data=None,
-        )
-    )
     expected_id = "test_id"
 
     # when
@@ -148,13 +147,7 @@ def test_payment_gateway_initialize_tokenization_not_app_or_plugin_subscribed_to
 ):
     # given
     mocked_is_event_active_for_any_plugin.return_value = False
-    mocked_payment_gateway_initialize_tokenization.return_value = (
-        PaymentGatewayInitializeTokenizationResponseData(
-            success=True,
-            message=None,
-            data=None,
-        )
-    )
+
     expected_id = "test_id"
 
     # when
@@ -169,6 +162,9 @@ def test_payment_gateway_initialize_tokenization_not_app_or_plugin_subscribed_to
     assert (
         content["data"]["paymentGatewayInitializeTokenization"]["errors"][0]["code"]
         == PaymentGatewayInitializeTokenizationErrorCode.NOT_FOUND.name
+    )
+    assert content["data"]["paymentGatewayInitializeTokenization"]["result"] == (
+        PaymentGatewayInitializeTokenizationResultEnum.FAILED_TO_DELIVER.name
     )
 
     mocked_is_event_active_for_any_plugin.assert_called_once_with(
@@ -185,14 +181,6 @@ def test_payment_gateway_initialize_tokenization_incorrect_channel(
     user_api_client,
 ):
     # given
-    mocked_is_event_active_for_any_plugin.return_value = False
-    mocked_payment_gateway_initialize_tokenization.return_value = (
-        PaymentGatewayInitializeTokenizationResponseData(
-            success=True,
-            message=None,
-            data=None,
-        )
-    )
     expected_id = "test_id"
 
     # when
@@ -208,6 +196,65 @@ def test_payment_gateway_initialize_tokenization_incorrect_channel(
         content["data"]["paymentGatewayInitializeTokenization"]["errors"][0]["code"]
         == PaymentGatewayInitializeTokenizationErrorCode.NOT_FOUND.name
     )
+    assert content["data"]["paymentGatewayInitializeTokenization"]["result"] == (
+        PaymentGatewayInitializeTokenizationResultEnum.FAILED_TO_DELIVER.name
+    )
 
     assert not mocked_is_event_active_for_any_plugin.called
     assert not mocked_payment_gateway_initialize_tokenization.called
+
+
+@patch.object(PluginsManager, "payment_gateway_initialize_tokenization")
+@patch.object(PluginsManager, "is_event_active_for_any_plugin")
+def test_payment_gateway_initialize_tokenization_failure_from_app(
+    mocked_is_event_active_for_any_plugin,
+    mocked_payment_gateway_initialize_tokenization,
+    user_api_client,
+    channel_USD,
+):
+    # given
+    error_message = "Error message"
+    mocked_is_event_active_for_any_plugin.return_value = True
+    mocked_payment_gateway_initialize_tokenization.return_value = (
+        PaymentGatewayInitializeTokenizationResponseData(
+            result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_INITIALIZE,
+            error=error_message,
+            data=None,
+        )
+    )
+    expected_id = "test_id"
+
+    # when
+    response = user_api_client.post_graphql(
+        PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION,
+        variables={
+            "id": expected_id,
+            "channel": channel_USD.slug,
+            "data": None,
+        },
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["paymentGatewayInitializeTokenization"]["result"] == (
+        PaymentGatewayInitializeTokenizationResultEnum.FAILED_TO_INITIALIZE.name
+    )
+    assert len(content["data"]["paymentGatewayInitializeTokenization"]["errors"]) == 1
+    error = content["data"]["paymentGatewayInitializeTokenization"]["errors"][0]
+    assert (
+        error["code"]
+        == PaymentGatewayInitializeTokenizationErrorCode.GATEWAY_ERROR.name
+    )
+    assert error["message"] == error_message
+
+    mocked_is_event_active_for_any_plugin.assert_called_once_with(
+        "payment_gateway_initialize_tokenization"
+    )
+    mocked_payment_gateway_initialize_tokenization.assert_called_once_with(
+        request_data=PaymentGatewayInitializeTokenizationRequestData(
+            user=user_api_client.user,
+            channel=channel_USD,
+            app_identifier=expected_id,
+            data=None,
+        )
+    )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23264,15 +23264,26 @@ Triggers the following webhook events:
 - PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION (sync): The customer requested to initialize payment gateway for tokenization.
 """
 type PaymentGatewayInitializeTokenization @doc(category: "Payments") @webhookEventsInfo(asyncEvents: [], syncEvents: [PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION]) {
-  """True, if the request was processed successfully."""
-  success: Boolean
-
-  """A message returned by payment app."""
-  message: String
+  """A status of the payment gateway initialization."""
+  result: PaymentGatewayInitializeTokenizationResult!
 
   """A data returned by payment app."""
   data: JSON
   errors: [PaymentGatewayInitializeTokenizationError!]!
+}
+
+"""
+Result of initialize payment gateway for tokenization of payment method.
+
+    The result of initialize payment gateway for tokenization of payment method.
+    SUCCESSFULLY_INITIALIZED - The payment gateway was successfully initialized.
+    FAILED_TO_INITIALIZE - The payment gateway was not initialized.
+    FAILED_TO_DELIVER - The request to initialize payment gateway was not delivered.
+"""
+enum PaymentGatewayInitializeTokenizationResult @doc(category: "Payments") {
+  SUCCESSFULLY_INITIALIZED
+  FAILED_TO_INITIALIZE
+  FAILED_TO_DELIVER
 }
 
 type PaymentGatewayInitializeTokenizationError @doc(category: "Payments") {
@@ -23294,6 +23305,7 @@ enum PaymentGatewayInitializeTokenizationErrorCode @doc(category: "Payments") {
   INVALID
   NOT_FOUND
   CHANNEL_INACTIVE
+  GATEWAY_ERROR
 }
 
 """

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -104,3 +104,4 @@ class PaymentGatewayInitializeTokenizationErrorCode(Enum):
     INVALID = "invalid"
     NOT_FOUND = "not_found"
     CHANNEL_INACTIVE = "channel_inactive"
+    GATEWAY_ERROR = "gateway_error"

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -166,12 +166,26 @@ class PaymentGatewayInitializeTokenizationRequestData:
     data: Optional[dict] = None
 
 
+class PaymentGatewayInitializeTokenizationResult(str, Enum):
+    """Result of initialize payment gateway for tokenization of payment method.
+
+    The result of initialize payment gateway for tokenization of payment method.
+    SUCCESSFULLY_INITIALIZED - The payment gateway was successfully initialized.
+    FAILED_TO_INITIALIZE - The payment gateway was not initialized.
+    FAILED_TO_DELIVER - The request to initialize payment gateway was not delivered.
+    """
+
+    SUCCESSFULLY_INITIALIZED = "successfully_initialized"
+    FAILED_TO_INITIALIZE = "failed_to_initialize"
+    FAILED_TO_DELIVER = "failed_to_deliver"
+
+
 @dataclass
 class PaymentGatewayInitializeTokenizationResponseData:
     """Dataclass for storing the response information from payment app."""
 
-    success: bool
-    message: Optional[str] = None
+    result: PaymentGatewayInitializeTokenizationResult
+    error: Optional[str] = None
     data: Optional[dict] = None
 
 

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -42,6 +42,7 @@ from ..payment.interface import (
     PaymentGatewayData,
     PaymentGatewayInitializeTokenizationRequestData,
     PaymentGatewayInitializeTokenizationResponseData,
+    PaymentGatewayInitializeTokenizationResult,
     PaymentMethodData,
     StoredPaymentMethodRequestDeleteData,
     StoredPaymentMethodRequestDeleteResponseData,
@@ -1564,9 +1565,10 @@ class PluginsManager(PaymentInterface):
         request_data: "PaymentGatewayInitializeTokenizationRequestData",
     ) -> "PaymentGatewayInitializeTokenizationResponseData":
         default_response = PaymentGatewayInitializeTokenizationResponseData(
-            success=False,
-            message="Payment gateway initialize tokenization failed to deliver.",
+            result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER,
+            error="Payment gateway initialize tokenization failed to deliver.",
         )
+
         response = self.__run_method_on_plugins(
             "payment_gateway_initialize_tokenization",
             default_response,

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -23,6 +23,7 @@ from ...payment.interface import (
     PaymentGatewayData,
     PaymentGatewayInitializeTokenizationRequestData,
     PaymentGatewayInitializeTokenizationResponseData,
+    PaymentGatewayInitializeTokenizationResult,
     StoredPaymentMethodRequestDeleteData,
     StoredPaymentMethodRequestDeleteResponseData,
     TransactionProcessActionData,
@@ -1412,8 +1413,8 @@ def test_payment_gateway_initialize_tokenization(
         data={"data": "ABC"},
     )
     previous_response = PaymentGatewayInitializeTokenizationResponseData(
-        success=False,
-        message="Payment gateway initialize tokenization failed to deliver.",
+        result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER,
+        error="Payment gateway initialize tokenization failed to deliver.",
     )
 
     # when


### PR DESCRIPTION
I want to merge this change because it makes a clean up in the response that app should return. As well as in  mutation response

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
