### PR TITLE
Enable subscription webhook dry runs which were initially disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,12 @@ in 3.17. Use `PaymentSettings.defaultTransactionFlowStrategy` instead.
   - Event sent when CSV export for gift cards is completed.
 - Add `PRODUCT_EXPORT_COMPLETED` webhook - #13787, by @Air-t
   - Event sent when CSV export for products is completed.
-
 - Add `FULFILLMENT_TRACKING_NUMBER_UPDATED` webhook - #13708, by @Air-t
   - Called after `fulfillmentUpdateTracking` or `orderFulfill` mutation if tracking number is updated.
+- Enable webhook dry runs - #13816, by @Air-t
+  - Dry runs enabled: `AccountConfirmed`, `AccountConfirmationRequested`, `AccountChangeEmailRequested`
+  - `AccountEmailChanged`, `AccountSetPasswordRequested`, `AccountDeleteRequested`, `GiftCardSent`,
+  - `FulfillmentCreated`, `FulfillmentApproved`, `StaffSetPasswordRequested`
 
 ### Other changes
 - Fix error in variant available stock calculation - 13593 by @awaisdar001

--- a/saleor/graphql/core/types/event.py
+++ b/saleor/graphql/core/types/event.py
@@ -41,3 +41,7 @@ class SubscriptionObjectType(BaseObjectType):
             )
 
         super().__init_subclass_with_meta__(_meta=_meta, **options)
+
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return db_object

--- a/saleor/graphql/webhook/mutations/webhook_dry_run.py
+++ b/saleor/graphql/webhook/mutations/webhook_dry_run.py
@@ -111,8 +111,11 @@ class WebhookDryRun(BaseMutation):
         event_type, object, query = cls.validate_input(info, **data)
         payload = None
         if all([event_type, object, query]):
+            subscription_context = WEBHOOK_TYPES_MAP[
+                event_type
+            ].get_subscription_context(object)
             request = info.context
             payload = generate_payload_from_subscription(
-                event_type, object, query, request
+                event_type, subscription_context, query, request
             )
         return WebhookDryRun(payload=payload)

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -185,23 +185,36 @@ class AccountOperationBase(AbstractType):
 
 class AccountConfirmed(SubscriptionObjectType, AccountOperationBase):
     class Meta:
-        root_type = None
-        enable_dry_run = False
+        root_type = "User"
+        enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when account is confirmed." + ADDED_IN_315
         doc_category = DOC_CATEGORY_USERS
+
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return {"user": db_object}
 
 
 class AccountConfirmationRequested(SubscriptionObjectType, AccountOperationBase):
     class Meta:
         root_type = "User"
-        enable_dry_run = False
+        enable_dry_run = True
         interfaces = (Event,)
         description = (
             "Event sent when account confirmation requested. This event is always sent."
             " enableAccountConfirmationByEmail flag set to True is not required."
             + ADDED_IN_315
         )
+
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return {
+            "user": db_object,
+            "channel_slug": kwargs.get("channel_slug", "c-pln"),
+            "token": kwargs.get("token", "token"),
+            "redirect_url": kwargs.get("redirect_url", "http://localhost:3000"),
+        }
 
 
 class AccountChangeEmailRequested(SubscriptionObjectType, AccountOperationBase):
@@ -211,16 +224,25 @@ class AccountChangeEmailRequested(SubscriptionObjectType, AccountOperationBase):
 
     class Meta:
         root_type = "User"
-        enable_dry_run = False
+        enable_dry_run = True
         interfaces = (Event,)
         description = (
             "Event sent when account change email is requested." + ADDED_IN_315
         )
 
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return {
+            "user": db_object,
+            "channel_slug": kwargs.get("channel_slug", "c-pln"),
+            "token": kwargs.get("token", "token"),
+            "redirect_url": kwargs.get("redirect_url", "http://localhost:3000"),
+        }
+
     @staticmethod
     def resolve_new_email(root, _info: ResolveInfo):
         _, data = root
-        return data["new_email"]
+        return data.get("new_email")
 
 
 class AccountEmailChanged(SubscriptionObjectType, AccountOperationBase):
@@ -229,39 +251,65 @@ class AccountEmailChanged(SubscriptionObjectType, AccountOperationBase):
     )
 
     class Meta:
-        root_type = None
-        enable_dry_run = False
+        root_type = "User"
+        enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when account email is changed." + ADDED_IN_315
         doc_category = DOC_CATEGORY_USERS
 
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return {"user": db_object}
+
 
 class AccountSetPasswordRequested(SubscriptionObjectType, AccountOperationBase):
     class Meta:
-        root_type = None
-        enable_dry_run = False
+        root_type = "User"
+        enable_dry_run = True
         interfaces = (Event,)
         description = (
             "Event sent when setting a new password is requested." + ADDED_IN_315
         )
         doc_category = DOC_CATEGORY_USERS
 
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return {
+            "user": db_object,
+            "channel_slug": kwargs.get("channel_slug", "c-pln"),
+            "token": kwargs.get("token", "token"),
+            "redirect_url": kwargs.get("redirect_url", "http://localhost:3000"),
+        }
+
 
 class AccountDeleteRequested(SubscriptionObjectType, AccountOperationBase):
     class Meta:
         root_type = "User"
-        enable_dry_run = False
+        enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when account delete is requested." + ADDED_IN_315
+
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return {
+            "user": db_object,
+            "channel_slug": kwargs.get("channel_slug", "c-pln"),
+            "token": kwargs.get("token", "token"),
+            "redirect_url": kwargs.get("redirect_url", "http://localhost:3000"),
+        }
 
 
 class AccountDeleted(SubscriptionObjectType, AccountOperationBase):
     class Meta:
-        root_type = None
-        enable_dry_run = False
+        root_type = "User"
+        enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when account is deleted." + ADDED_IN_315
         doc_category = DOC_CATEGORY_USERS
+
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return {"user": db_object}
 
 
 class AddressBase(AbstractType):
@@ -704,13 +752,21 @@ class GiftCardSent(SubscriptionObjectType, GiftCardBase):
     )
 
     class Meta:
-        root_type = None
-        enable_dry_run = False
+        root_type = "GiftCard"
+        enable_dry_run = True
         interfaces = (Event,)
         description = (
             "Event sent when gift card is e-mailed." + ADDED_IN_313 + PREVIEW_FEATURE
         )
         doc_category = DOC_CATEGORY_GIFT_CARDS
+
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return {
+            "gift_card": db_object,
+            "channel_slug": kwargs.get("channel_slug", "c-pln"),
+            "sent_to_email": kwargs.get("sent_to_email", "example@example.com"),
+        }
 
     @staticmethod
     def resolve_gift_card(root, info: ResolveInfo):
@@ -1228,9 +1284,16 @@ class FulfillmentCreated(SubscriptionObjectType, FulfillmentBase):
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS
         root_type = "Fulfillment"
-        enable_dry_run = False
+        enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when new fulfillment is created." + ADDED_IN_34
+
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return {
+            "fulfillment": db_object,
+            "notify_customer": kwargs.get("notify_customer", True),
+        }
 
     @staticmethod
     def resolve_fulfillment(root, info: ResolveInfo):
@@ -1265,9 +1328,16 @@ class FulfillmentApproved(SubscriptionObjectType, FulfillmentBase):
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS
         root_type = "Fulfillment"
-        enable_dry_run = False
+        enable_dry_run = True
         interfaces = (Event,)
         description = "Event sent when fulfillment is approved." + ADDED_IN_37
+
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return {
+            "fulfillment": db_object,
+            "notify_customer": kwargs.get("notify_customer", True),
+        }
 
     @staticmethod
     def resolve_fulfillment(root, info: ResolveInfo):
@@ -1658,14 +1728,23 @@ class StaffDeleted(SubscriptionObjectType, UserBase):
 
 class StaffSetPasswordRequested(SubscriptionObjectType, AccountOperationBase):
     class Meta:
-        root_type = None
-        enable_dry_run = False
+        root_type = "User"
+        enable_dry_run = True
         interfaces = (Event,)
         description = (
             "Event sent when setting a new password for staff is requested."
             + ADDED_IN_315
         )
         doc_category = DOC_CATEGORY_USERS
+
+    @classmethod
+    def get_subscription_context(cls, db_object, **kwargs):
+        return {
+            "user": db_object,
+            "channel_slug": kwargs.get("channel_slug", "c-pln"),
+            "token": kwargs.get("token", "token"),
+            "redirect_url": kwargs.get("redirect_url", "http://localhost:3000"),
+        }
 
 
 class TransactionAction(SubscriptionObjectType, AbstractType):

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_dry_run.py
@@ -198,6 +198,14 @@ def test_webhook_dry_run_event_type_not_supported(
 
 @pytest.fixture
 def async_subscription_webhooks_with_root_objects(
+    subscription_account_deleted_webhook,
+    subscription_account_confirmed_webhook,
+    subscription_account_email_changed_webhook,
+    subscription_account_set_password_requested_webhook,
+    subscription_account_confirmation_requested_webhook,
+    subscription_account_delete_requested_webhook,
+    subscription_account_change_email_requested_webhook,
+    subscription_staff_set_password_requested_webhook,
     subscription_address_created_webhook,
     subscription_address_updated_webhook,
     subscription_address_deleted_webhook,
@@ -275,6 +283,8 @@ def async_subscription_webhooks_with_root_objects(
     subscription_invoice_deleted_webhook,
     subscription_invoice_sent_webhook,
     subscription_fulfillment_canceled_webhook,
+    subscription_fulfillment_created_webhook,
+    subscription_fulfillment_approved_webhook,
     subscription_fulfillment_metadata_updated_webhook,
     subscription_fulfillment_tracking_number_updated,
     subscription_customer_created_webhook,
@@ -352,6 +362,38 @@ def async_subscription_webhooks_with_root_objects(
     transaction_item_created_by_app.save()
 
     return {
+        events.ACCOUNT_DELETED: [
+            subscription_account_deleted_webhook,
+            customer_user,
+        ],
+        events.ACCOUNT_EMAIL_CHANGED: [
+            subscription_account_email_changed_webhook,
+            customer_user,
+        ],
+        events.ACCOUNT_CONFIRMED: [
+            subscription_account_confirmed_webhook,
+            customer_user,
+        ],
+        events.ACCOUNT_DELETE_REQUESTED: [
+            subscription_account_delete_requested_webhook,
+            customer_user,
+        ],
+        events.ACCOUNT_SET_PASSWORD_REQUESTED: [
+            subscription_account_set_password_requested_webhook,
+            customer_user,
+        ],
+        events.ACCOUNT_CHANGE_EMAIL_REQUESTED: [
+            subscription_account_change_email_requested_webhook,
+            customer_user,
+        ],
+        events.ACCOUNT_CONFIRMATION_REQUESTED: [
+            subscription_account_confirmation_requested_webhook,
+            customer_user,
+        ],
+        events.STAFF_SET_PASSWORD_REQUESTED: [
+            subscription_staff_set_password_requested_webhook,
+            staff_user,
+        ],
         events.ADDRESS_UPDATED: [subscription_address_updated_webhook, address],
         events.ADDRESS_CREATED: [subscription_address_created_webhook, address],
         events.ADDRESS_DELETED: [subscription_address_deleted_webhook, address],
@@ -480,6 +522,14 @@ def async_subscription_webhooks_with_root_objects(
         events.INVOICE_SENT: [subscription_invoice_sent_webhook, invoice],
         events.FULFILLMENT_CANCELED: [
             subscription_fulfillment_canceled_webhook,
+            fulfillment,
+        ],
+        events.FULFILLMENT_CREATED: [
+            subscription_fulfillment_created_webhook,
+            fulfillment,
+        ],
+        events.FULFILLMENT_APPROVED: [
+            subscription_fulfillment_approved_webhook,
             fulfillment,
         ],
         events.FULFILLMENT_METADATA_UPDATED: [


### PR DESCRIPTION
I want to merge this change because it enables missing webhook dry runs

Resolves https://github.com/saleor/saleor/issues/13788

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
