### PR TITLE
[TEST] Staff should be able to create promotion for collection

### DIFF
--- a/saleor/tests/e2e/product/utils/__init__.py
+++ b/saleor/tests/e2e/product/utils/__init__.py
@@ -1,10 +1,13 @@
 from .category import create_category
+from .collection import create_collection
+from .collection_listing_update import create_collection_channel_listing
 from .digital_content import create_digital_content
 from .product import create_product
 from .product_channel_listing import (
     create_product_channel_listing,
     raw_create_product_channel_listing,
 )
+from .product_query import get_product
 from .product_type import create_product_type
 from .product_variant import create_product_variant, raw_create_product_variant
 from .product_variant_channel_listing import create_product_variant_channel_listing
@@ -20,4 +23,7 @@ __all__ = [
     "raw_create_product_variant",
     "create_product",
     "raw_create_product_channel_listing",
+    "create_collection",
+    "create_collection_channel_listing",
+    "get_product",
 ]

--- a/saleor/tests/e2e/product/utils/collection.py
+++ b/saleor/tests/e2e/product/utils/collection.py
@@ -1,0 +1,44 @@
+from ...utils import get_graphql_content
+
+CATEGORY_COLLECTION_MUTATION = """
+mutation CollectionCreate($input: CollectionCreateInput!) {
+  collectionCreate(input: $input) {
+    errors {
+      field
+      code
+      message
+    }
+    collection {
+      id
+      name
+      slug
+    }
+  }
+}
+"""
+
+
+def create_collection(
+    staff_api_client,
+    name="Test collection",
+):
+    variables = {
+        "input": {
+            "name": name,
+        }
+    }
+
+    response = staff_api_client.post_graphql(
+        CATEGORY_COLLECTION_MUTATION,
+        variables,
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["collectionCreate"]["errors"] == []
+
+    data = content["data"]["collectionCreate"]["collection"]
+    assert data["id"] is not None
+    assert data["name"] == name
+
+    return data

--- a/saleor/tests/e2e/product/utils/collection_listing_update.py
+++ b/saleor/tests/e2e/product/utils/collection_listing_update.py
@@ -1,0 +1,60 @@
+from ...utils import get_graphql_content
+
+COLLECTION_CHANNEL_LISTING_UPDATE_MUTATION = """
+mutation CollectionListing($id: ID!, $input: CollectionChannelListingUpdateInput!) {
+  collectionChannelListingUpdate(id: $id, input: $input) {
+    errors {
+      code
+      field
+      message
+      channels
+    }
+    collection {
+      id
+      channelListings {
+        id
+        isPublished
+        publishedAt
+        channel {
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def create_collection_channel_listing(
+    staff_api_client,
+    collection_id,
+    channel_id,
+    publication_date=None,
+    is_published=False,
+):
+    variables = {
+        "id": collection_id,
+        "input": {
+            "addChannels": [
+                {
+                    "channelId": channel_id,
+                    "isPublished": is_published,
+                    "publicationDate": publication_date,
+                }
+            ],
+            "removeChannels": [],
+        },
+    }
+
+    response = staff_api_client.post_graphql(
+        COLLECTION_CHANNEL_LISTING_UPDATE_MUTATION,
+        variables,
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["collectionChannelListingUpdate"]["collection"]
+    assert content["data"]["collectionChannelListingUpdate"]["errors"] == []
+    assert data["channelListings"][0]["channel"]["id"] == channel_id
+
+    return data

--- a/saleor/tests/e2e/product/utils/product.py
+++ b/saleor/tests/e2e/product/utils/product.py
@@ -17,6 +17,9 @@ mutation createProduct($input: ProductCreateInput!) {
       category {
         id
       }
+      collections {
+        id
+      }
     }
   }
 }
@@ -28,12 +31,17 @@ def create_product(
     product_type_id,
     category_id,
     product_name="Test product",
+    collection_ids=None,
 ):
+    if not collection_ids:
+        collection_ids = []
+
     variables = {
         "input": {
             "name": product_name,
             "productType": product_type_id,
             "category": category_id,
+            "collections": collection_ids,
         }
     }
 

--- a/saleor/tests/e2e/product/utils/product_query.py
+++ b/saleor/tests/e2e/product/utils/product_query.py
@@ -1,0 +1,53 @@
+from ...utils import get_graphql_content
+
+PRODUCT_QUERY = """
+query Product($id: ID!, $channel: String) {
+  product(id: $id, channel: $channel) {
+    id
+    name
+    pricing {
+      onSale
+    }
+    variants {
+      id
+      name
+      pricing {
+        onSale
+        discount {
+          gross {
+            amount
+          }
+        }
+        priceUndiscounted {
+          gross {
+            amount
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def get_product(
+    staff_api_client,
+    product_id,
+    slug="default-channel",
+):
+    variables = {
+        "id": product_id,
+        "channel": slug,
+    }
+
+    response = staff_api_client.post_graphql(
+        PRODUCT_QUERY,
+        variables,
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["product"]
+    assert data["id"] is not None
+
+    return data

--- a/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
@@ -112,6 +112,7 @@ def test_create_promotion_for_collections_core_2100(
     promotion_id = promotion_data["id"]
 
     collection_ids = [collection_id]
+    predicate_input = {"collectionPredicate": {"ids": collection_ids}}
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
         promotion_id,
@@ -119,10 +120,9 @@ def test_create_promotion_for_collections_core_2100(
         discount_value,
         promotion_rule_name,
         channel_id,
-        collection_ids,
+        predicate_input,
     )
 
-    print(promotion_rule)
     collection_predicate = promotion_rule["cataloguePredicate"]["collectionPredicate"]
     assert promotion_rule["channels"][0]["id"] == channel_id
     assert collection_predicate["ids"][0] == collection_id

--- a/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
@@ -80,7 +80,7 @@ def prepare_product(
 
 
 @pytest.mark.e2e
-def test_create_promotion_for_collections_core_2100(
+def test_create_promotion_for_collection_core_2109(
     e2e_staff_api_client,
     permission_manage_products,
     permission_manage_channels,
@@ -116,11 +116,11 @@ def test_create_promotion_for_collections_core_2100(
     promotion_rule = create_promotion_rule(
         e2e_staff_api_client,
         promotion_id,
+        predicate_input,
         discount_type,
         discount_value,
         promotion_rule_name,
         channel_id,
-        predicate_input,
     )
 
     collection_predicate = promotion_rule["cataloguePredicate"]["collectionPredicate"]

--- a/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
@@ -88,7 +88,6 @@ def test_create_promotion_for_collection_core_2109(
     permission_manage_discounts,
 ):
     # Before
-
     channel_slug = "promotion_collections_channel"
     variant_price = "9.99"
     product_id, channel_id, collection_id = prepare_product(
@@ -102,7 +101,6 @@ def test_create_promotion_for_collection_core_2109(
     )
 
     # Step 1 Crate percentage promotion for collection
-
     promotion_name = "Promotion PERCENTAGE"
     discount_value = 3
     discount_type = "PERCENTAGE"

--- a/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
@@ -1,0 +1,140 @@
+import pytest
+
+from ..channel.utils import create_channel
+from ..product.utils import (
+    create_category,
+    create_collection,
+    create_collection_channel_listing,
+    create_product,
+    create_product_channel_listing,
+    create_product_type,
+    create_product_variant,
+    create_product_variant_channel_listing,
+    get_product,
+)
+from ..promotions.utils import create_promotion, create_promotion_rule
+from ..utils import assign_permissions
+
+
+def prepare_product(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    channel_slug,
+    variant_price,
+):
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    channel_data = create_channel(
+        e2e_staff_api_client,
+        slug=channel_slug,
+    )
+    channel_id = channel_data["id"]
+
+    product_type_data = create_product_type(
+        e2e_staff_api_client,
+    )
+    product_type_id = product_type_data["id"]
+
+    category_data = create_category(
+        e2e_staff_api_client,
+    )
+    category_id = category_data["id"]
+
+    collection_data = create_collection(e2e_staff_api_client)
+    collection_id = collection_data["id"]
+    collection_list = [collection_id]
+
+    create_collection_channel_listing(e2e_staff_api_client, collection_id, channel_id)
+    product_data = create_product(
+        e2e_staff_api_client,
+        product_type_id,
+        category_id,
+        collection_ids=collection_list,
+    )
+    product_id = product_data["id"]
+    create_product_channel_listing(e2e_staff_api_client, product_id, channel_id)
+
+    variant_data = create_product_variant(
+        e2e_staff_api_client,
+        product_id,
+    )
+    product_variant_id = variant_data["id"]
+
+    create_product_variant_channel_listing(
+        e2e_staff_api_client,
+        product_variant_id,
+        channel_id,
+        variant_price,
+    )
+
+    return product_id, channel_id, collection_id
+
+
+@pytest.mark.e2e
+def test_create_promotion_for_collections_core_2100(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+):
+    # Before
+
+    channel_slug = "promotion_collections_channel"
+    variant_price = "9.99"
+    product_id, channel_id, collection_id = prepare_product(
+        e2e_staff_api_client,
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        channel_slug,
+        variant_price,
+    )
+
+    # Step 1 Crate percentage promotion for collection
+
+    promotion_name = "Promotion PERCENTAGE"
+    discount_value = 3
+    discount_type = "PERCENTAGE"
+    promotion_rule_name = "rule for collections"
+
+    promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
+    promotion_id = promotion_data["id"]
+
+    collection_ids = [collection_id]
+    promotion_rule = create_promotion_rule(
+        e2e_staff_api_client,
+        promotion_id,
+        discount_type,
+        discount_value,
+        promotion_rule_name,
+        channel_id,
+        collection_ids,
+    )
+
+    print(promotion_rule)
+    collection_predicate = promotion_rule["cataloguePredicate"]["collectionPredicate"]
+    assert promotion_rule["channels"][0]["id"] == channel_id
+    assert collection_predicate["ids"][0] == collection_id
+
+    # Step 2 Get product and verify that is on sale
+    product_data = get_product(e2e_staff_api_client, product_id, channel_slug)
+    variant_discount = round(float(variant_price) * discount_value / 100, 2)
+
+    product_variant = product_data["variants"][0]
+    assert product_data["pricing"]["onSale"] is True
+    assert product_variant["pricing"]["onSale"] is True
+    assert product_variant["pricing"]["discount"]["gross"]["amount"] == variant_discount
+    assert product_variant["pricing"]["priceUndiscounted"]["gross"]["amount"] == float(
+        variant_price
+    )


### PR DESCRIPTION
I want to merge this change because it adds a test for [CORE_2108](https://saleor.testmo.net/repositories/5?group_id=133&case_id=2050)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
