### PR TITLE
add `FULFILLMENT_CREATED` webhook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ in 3.17. Use `PaymentSettings.defaultTransactionFlowStrategy` instead.
   - Dry runs enabled: `AccountConfirmed`, `AccountConfirmationRequested`, `AccountChangeEmailRequested`
   - `AccountEmailChanged`, `AccountSetPasswordRequested`, `AccountDeleteRequested`, `GiftCardSent`,
   - `FulfillmentCreated`, `FulfillmentApproved`, `StaffSetPasswordRequested`
+- Add missing `FULFILLMENT_CREATED` event call to `automatically_fulfill_digital_lines_with_fulfillment_created` action. - #13823, by @Air-t
 
 ### Other changes
 - Fix error in variant available stock calculation - 13593 by @awaisdar001

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -730,7 +730,7 @@ def automatically_fulfill_digital_lines(
     with traced_atomic_transaction():
         if not digital_lines_data:
             return
-        fulfillment, _ = Fulfillment.objects.get_or_create(order=order)
+        fulfillment, created = Fulfillment.objects.get_or_create(order=order)
 
         fulfillments = []
         lines_info = []
@@ -766,6 +766,8 @@ def automatically_fulfill_digital_lines(
         send_fulfillment_confirmation_to_customer(
             order, fulfillment, user=order.user, app=None, manager=manager
         )
+        if created:
+            manager.fulfillment_created(fulfillment)
         update_order_status(order)
 
 


### PR DESCRIPTION
I want to merge this change because it triggers missing event

add missing `FULFILLMENT_CREATED` webhook call on `automatically_fulfill_digital_lines_with_fulfillment_created` action.

Resolves: https://github.com/saleor/saleor/issues/13579

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
