### PR TITLE
Fix incorrect discount applied to checkout

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -20,6 +20,7 @@ from ..discount import VoucherType
 from ..discount.interface import VoucherInfo, fetch_voucher_info
 from ..discount.models import NotApplicable, Voucher
 from ..discount.utils import (
+    generate_sale_discount_objects_for_checkout,
     get_products_voucher_discount,
     validate_voucher_for_checkout,
 )
@@ -64,6 +65,7 @@ def invalidate_checkout_prices(
     checkout = checkout_info.checkout
 
     if recalculate_discount:
+        generate_sale_discount_objects_for_checkout(checkout_info, lines)
         recalculate_checkout_discount(manager, checkout_info, lines)
 
     checkout.price_expiration = timezone.now()

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -681,7 +681,7 @@ def test_update_checkout_lines_with_reservations(
         reservation_length=5,
     )
 
-    with django_assert_num_queries(74):
+    with django_assert_num_queries(75):
         variant_id = graphene.Node.to_global_id("ProductVariant", variants[0].pk)
         variables = {
             "id": to_global_id_or_none(checkout),
@@ -695,7 +695,7 @@ def test_update_checkout_lines_with_reservations(
         assert not data["errors"]
 
     # Updating multiple lines in checkout has same query count as updating one
-    with django_assert_num_queries(74):
+    with django_assert_num_queries(75):
         variables = {
             "id": to_global_id_or_none(checkout),
             "lines": [],
@@ -940,7 +940,7 @@ def test_add_checkout_lines_with_reservations(
         new_lines.append({"quantity": 2, "variantId": variant_id})
 
     # Adding multiple lines to checkout has same query count as adding one
-    with django_assert_num_queries(73):
+    with django_assert_num_queries(74):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": [new_lines[0]],
@@ -953,7 +953,7 @@ def test_add_checkout_lines_with_reservations(
 
     checkout.lines.exclude(id=line.id).delete()
 
-    with django_assert_num_queries(73):
+    with django_assert_num_queries(74):
         variables = {
             "id": Node.to_global_id("Checkout", checkout.pk),
             "lines": new_lines,

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -10,7 +10,14 @@ from django.utils import timezone
 from .....checkout.error_codes import CheckoutErrorCode
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout
-from .....checkout.utils import calculate_checkout_quantity, invalidate_checkout_prices
+from .....checkout.utils import (
+    calculate_checkout_quantity,
+    invalidate_checkout_prices,
+    recalculate_checkout_discount,
+)
+from .....discount import DiscountValueType
+from .....discount.models import Sale, SaleChannelListing
+from .....discount.utils import generate_sale_discount_objects_for_checkout
 from .....plugins.manager import get_plugins_manager
 from .....product.models import ProductChannelListing
 from .....warehouse import WarehouseClickAndCollectOption
@@ -21,27 +28,46 @@ from ....tests.utils import assert_no_permission, get_graphql_content
 from ...mutations.utils import update_checkout_shipping_method_if_invalid
 
 MUTATION_CHECKOUT_LINES_ADD = """
-    mutation checkoutLinesAdd(
-            $id: ID, $lines: [CheckoutLineInput!]!) {
-        checkoutLinesAdd(id: $id, lines: $lines) {
-            checkout {
-                token
-                quantity
-                lines {
-                    quantity
-                    variant {
-                        id
-                    }
-                }
-            }
-            errors {
-                field
-                code
-                message
-                variants
-            }
+mutation checkoutLinesAdd($id: ID, $lines: [CheckoutLineInput!]!) {
+  checkoutLinesAdd(id: $id, lines: $lines) {
+    checkout {
+      token
+      discount{
+        amount
+      }
+      quantity
+      lines {
+        unitPrice {
+          gross {
+            amount
+          }
         }
-    }"""
+        totalPrice {
+          gross {
+            amount
+          }
+        }
+        undiscountedTotalPrice {
+          amount
+        }
+        undiscountedUnitPrice {
+          amount
+        }
+        quantity
+        variant {
+          id
+        }
+      }
+    }
+    errors {
+      field
+      code
+      message
+      variants
+    }
+  }
+}
+"""
 
 
 @mock.patch(
@@ -98,6 +124,105 @@ def test_checkout_lines_add(
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change
     assert mocked_invalidate_checkout_prices.call_count == 1
+
+
+@mock.patch(
+    "saleor.graphql.checkout.mutations.checkout_lines_add."
+    "update_checkout_shipping_method_if_invalid",
+    wraps=update_checkout_shipping_method_if_invalid,
+)
+@mock.patch(
+    "saleor.graphql.checkout.mutations.checkout_lines_add."
+    "invalidate_checkout_prices",
+    wraps=invalidate_checkout_prices,
+)
+def test_add_to_existing_line_with_sale_when_checkout_has_voucher(
+    mocked_invalidate_checkout_prices,
+    mocked_update_shipping_method,
+    user_api_client,
+    checkout_with_item,
+    stock,
+    voucher_percentage,
+    channel_USD,
+):
+    # given
+
+    # prepare voucher with 50% discount
+    voucher_percentage_value = 50
+    voucher_percentage.channel_listings.update(discount_value=voucher_percentage_value)
+
+    checkout = checkout_with_item
+    checkout.voucher_code = voucher_percentage.code
+    checkout.save()
+
+    variant_unit_price = Decimal(100)
+    line = checkout.lines.first()
+    variant = line.variant
+    variant.channel_listings.update(price_amount=variant_unit_price)
+
+    manager = get_plugins_manager()
+
+    # prepare sale with 50% discount
+    sale_percentage_value = 50
+    sale = Sale.objects.create(name="Sale", type=DiscountValueType.PERCENTAGE)
+    SaleChannelListing.objects.create(
+        sale=sale,
+        channel=channel_USD,
+        discount_value=sale_percentage_value,
+        currency=channel_USD.currency_code,
+    )
+    sale.variants.add(variant)
+
+    # create checkout discount objects for checkout lines
+    lines_infos, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines_infos, manager)
+    generate_sale_discount_objects_for_checkout(checkout_info, lines_infos)
+    recalculate_checkout_discount(manager, checkout_info, lines_infos)
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", line.variant_id)
+
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "lines": [{"variantId": variant_id, "quantity": 1}],
+        "channelSlug": checkout.channel.slug,
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
+
+    # then
+    # unit_price: 100, sale 50% then voucher 50% = 25
+    expected_unit_price_after_all_discount = Decimal(25)
+
+    expected_discount_per_single_item = Decimal(25)
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutLinesAdd"]
+    print(data)
+    assert not data["errors"]
+    checkout.refresh_from_db()
+    lines, _ = fetch_checkout_lines(checkout)
+    line = checkout.lines.last()
+    assert (
+        line.total_price_gross_amount
+        == expected_unit_price_after_all_discount * line.quantity
+    )
+    assert (
+        line.total_price_net_amount
+        == expected_unit_price_after_all_discount * line.quantity
+    )
+    unit_price = data["checkout"]["lines"][0]["unitPrice"]["gross"]["amount"]
+    assert Decimal(unit_price) == expected_unit_price_after_all_discount
+    total_price = data["checkout"]["lines"][0]["totalPrice"]["gross"]["amount"]
+    assert (
+        Decimal(total_price) == expected_unit_price_after_all_discount * line.quantity
+    )
+    checkout_discount_amount = data["checkout"]["discount"]["amount"]
+    # unit price is 50 USD, (after applying sale), then 50% voucher gives us a
+    # unit_price equal to 25 USD. The discount amount is 25 USD * quantity
+    assert (
+        Decimal(checkout_discount_amount)
+        == expected_discount_per_single_item * line.quantity
+    )
 
 
 def test_checkout_lines_add_with_existing_variant_and_metadata(


### PR DESCRIPTION
I want to merge this change because it fixes incorrect calculation of prices in case of applying sale and discount. 

Solving https://github.com/saleor/saleor/issues/13831

Port of changes for  #13828


> **Warning**
> PR increases the number of DB queries. It is expected, and it is related to the current flow of handling the discounts. 
> Separate issue should clean up the discount logic: https://github.com/saleor/saleor/issues/13832


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
