### PR TITLE
[Programmatic Payments] Add payment method initialize tokenization

### DIFF
--- a/saleor/graphql/core/enums.py
+++ b/saleor/graphql/core/enums.py
@@ -305,6 +305,11 @@ PaymentGatewayInitializeTokenizationErrorCode = graphene.Enum.from_enum(
 )
 PaymentGatewayInitializeTokenizationErrorCode.doc_category = DOC_CATEGORY_PAYMENTS
 
+PaymentMethodInitializeTokenizationErrorCode = graphene.Enum.from_enum(
+    payment_error_codes.PaymentMethodInitializeTokenizationErrorCode
+)
+PaymentMethodInitializeTokenizationErrorCode.doc_category = DOC_CATEGORY_PAYMENTS
+
 PermissionGroupErrorCode = graphene.Enum.from_enum(
     account_error_codes.PermissionGroupErrorCode
 )

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -64,6 +64,7 @@ from ..enums import (
     PaymentGatewayConfigErrorCode,
     PaymentGatewayInitializeErrorCode,
     PaymentGatewayInitializeTokenizationErrorCode,
+    PaymentMethodInitializeTokenizationErrorCode,
     PermissionEnum,
     PermissionGroupErrorCode,
     PluginErrorCode,
@@ -693,6 +694,15 @@ class PaymentMethodRequestDeleteError(Error):
 
 class PaymentGatewayInitializeTokenizationError(Error):
     code = PaymentGatewayInitializeTokenizationErrorCode(
+        description="The error code.", required=True
+    )
+
+    class Meta:
+        doc_category = DOC_CATEGORY_PAYMENTS
+
+
+class PaymentMethodInitializeTokenizationError(Error):
+    code = PaymentMethodInitializeTokenizationErrorCode(
         description="The error code.", required=True
     )
 

--- a/saleor/graphql/payment/enums.py
+++ b/saleor/graphql/payment/enums.py
@@ -8,7 +8,10 @@ from ...payment import (
     TransactionEventType,
     TransactionKind,
 )
-from ...payment.interface import PaymentGatewayInitializeTokenizationResult
+from ...payment.interface import (
+    PaymentGatewayInitializeTokenizationResult,
+    PaymentMethodTokenizationResult,
+)
 from ..core.doc_category import DOC_CATEGORY_PAYMENTS
 from ..core.enums import to_enum
 from ..core.types import BaseEnum
@@ -89,3 +92,8 @@ PaymentGatewayInitializeTokenizationResultEnum = graphene.Enum.from_enum(
     PaymentGatewayInitializeTokenizationResult,
 )
 PaymentGatewayInitializeTokenizationResultEnum.doc_category = DOC_CATEGORY_PAYMENTS
+
+PaymentMethodTokenizationResultEnum = graphene.Enum.from_enum(
+    PaymentMethodTokenizationResult
+)
+PaymentMethodTokenizationResultEnum.doc_category = DOC_CATEGORY_PAYMENTS

--- a/saleor/graphql/payment/mutations/__init__.py
+++ b/saleor/graphql/payment/mutations/__init__.py
@@ -8,6 +8,7 @@ from .payment import (
 )
 from .stored_payment_methods import (
     PaymentGatewayInitializeTokenization,
+    PaymentMethodInitializeTokenization,
     StoredPaymentMethodRequestDelete,
 )
 from .transaction import (
@@ -31,6 +32,7 @@ __all__ = [
     "PaymentVoid",
     "PaymentGatewayInitializeTokenization",
     "StoredPaymentMethodRequestDelete",
+    "PaymentMethodInitializeTokenization",
     "TransactionCreate",
     "TransactionEventReport",
     "TransactionInitialize",

--- a/saleor/graphql/payment/mutations/stored_payment_methods/__init__.py
+++ b/saleor/graphql/payment/mutations/stored_payment_methods/__init__.py
@@ -1,9 +1,11 @@
 from .payment_gateway_initialize_tokenization import (
     PaymentGatewayInitializeTokenization,
 )
+from .payment_method_intialize_tokenization import PaymentMethodInitializeTokenization
 from .payment_method_request_delete import StoredPaymentMethodRequestDelete
 
 __all__ = [
     "StoredPaymentMethodRequestDelete",
     "PaymentGatewayInitializeTokenization",
+    "PaymentMethodInitializeTokenization",
 ]

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -14,6 +14,7 @@ from .mutations import (
     PaymentGatewayInitialize,
     PaymentGatewayInitializeTokenization,
     PaymentInitialize,
+    PaymentMethodInitializeTokenization,
     PaymentRefund,
     PaymentVoid,
     StoredPaymentMethodRequestDelete,
@@ -104,3 +105,4 @@ class PaymentMutations(graphene.ObjectType):
     payment_gateway_initialize_tokenization = (
         PaymentGatewayInitializeTokenization.Field()
     )
+    payment_method_initialize_tokenization = PaymentMethodInitializeTokenization.Field()

--- a/saleor/graphql/payment/tests/mutations/test_payment_method_initialize_tokenization.py
+++ b/saleor/graphql/payment/tests/mutations/test_payment_method_initialize_tokenization.py
@@ -1,0 +1,264 @@
+from unittest.mock import patch
+
+import pytest
+
+from .....payment.interface import (
+    PaymentMethodInitializeTokenizationRequestData,
+    PaymentMethodInitializeTokenizationResponseData,
+    PaymentMethodTokenizationResult,
+)
+from .....plugins.manager import PluginsManager
+from .....plugins.webhook.utils import to_payment_app_id
+from ....core.enums import PaymentMethodInitializeTokenizationErrorCode
+from ....tests.utils import assert_no_permission, get_graphql_content
+from ...enums import PaymentMethodTokenizationResultEnum
+
+PAYMENT_METHOD_INITIALIZE_TOKENIZATION = """
+mutation PaymentMethodInitializeTokenization(
+$id: String!, $channel: String!, $data: JSON){
+  paymentMethodInitializeTokenization(id: $id, channel: $channel, data: $data){
+    result
+    data
+    id
+    errors{
+      field
+      code
+      message
+    }
+  }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "expected_input_data, expected_output_data",
+    [
+        (None, None),
+        (None, {"foo": "bar1"}),
+        ({"foo": "bar2"}, None),
+        ({"foo": "bar3"}, {"foo": "bar4"}),
+    ],
+)
+@patch.object(PluginsManager, "payment_method_initialize_tokenization")
+@patch.object(PluginsManager, "is_event_active_for_any_plugin")
+def test_payment_method_initialize_tokenization(
+    mocked_is_event_active_for_any_plugin,
+    mocked_payment_method_initialize_tokenization,
+    expected_input_data,
+    expected_output_data,
+    user_api_client,
+    channel_USD,
+    app,
+):
+    # given
+    expected_payment_method_id = to_payment_app_id(app, "test_id")
+    mocked_is_event_active_for_any_plugin.return_value = True
+    mocked_payment_method_initialize_tokenization.return_value = (
+        PaymentMethodInitializeTokenizationResponseData(
+            result=PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
+            id=expected_payment_method_id,
+            error=None,
+            data=expected_output_data,
+        )
+    )
+    expected_id = "test_id"
+
+    # when
+    response = user_api_client.post_graphql(
+        PAYMENT_METHOD_INITIALIZE_TOKENIZATION,
+        variables={
+            "id": expected_id,
+            "channel": channel_USD.slug,
+            "data": expected_input_data,
+        },
+    )
+
+    # then
+    content = get_graphql_content(response)
+    response_data = content["data"]["paymentMethodInitializeTokenization"]
+    assert response_data["result"] == (
+        PaymentMethodTokenizationResultEnum.SUCCESSFULLY_TOKENIZED.name
+    )
+    assert response_data["data"] == expected_output_data
+    assert response_data["id"] == expected_payment_method_id
+    mocked_is_event_active_for_any_plugin.assert_called_once_with(
+        "payment_method_initialize_tokenization"
+    )
+    mocked_payment_method_initialize_tokenization.assert_called_once_with(
+        request_data=PaymentMethodInitializeTokenizationRequestData(
+            user=user_api_client.user,
+            channel=channel_USD,
+            app_identifier=expected_id,
+            data=expected_input_data,
+        )
+    )
+
+
+@patch.object(PluginsManager, "payment_method_initialize_tokenization")
+@patch.object(PluginsManager, "is_event_active_for_any_plugin")
+def test_payment_method_initialize_tokenization_called_by_anonymous_user(
+    mocked_is_event_active_for_any_plugin,
+    mocked_payment_method_initialize_tokenization,
+    api_client,
+    channel_USD,
+):
+    # given
+    expected_id = "test_id"
+
+    # when
+    response = api_client.post_graphql(
+        PAYMENT_METHOD_INITIALIZE_TOKENIZATION,
+        variables={"id": expected_id, "channel": channel_USD.slug},
+    )
+
+    # then
+    assert_no_permission(response)
+
+    assert not mocked_is_event_active_for_any_plugin.called
+    assert not mocked_payment_method_initialize_tokenization.called
+
+
+@patch.object(PluginsManager, "payment_method_initialize_tokenization")
+@patch.object(PluginsManager, "is_event_active_for_any_plugin")
+def test_payment_method_initialize_tokenization_called_by_app(
+    mocked_is_event_active_for_any_plugin,
+    mocked_payment_method_initialize_tokenization,
+    app_api_client,
+    channel_USD,
+):
+    # given
+    expected_id = "test_id"
+
+    # when
+    response = app_api_client.post_graphql(
+        PAYMENT_METHOD_INITIALIZE_TOKENIZATION,
+        variables={"id": expected_id, "channel": channel_USD.slug},
+    )
+
+    # then
+    assert_no_permission(response)
+
+    assert not mocked_is_event_active_for_any_plugin.called
+    assert not mocked_payment_method_initialize_tokenization.called
+
+
+@patch.object(PluginsManager, "payment_method_initialize_tokenization")
+@patch.object(PluginsManager, "is_event_active_for_any_plugin")
+def test_payment_method_initialize_tokenization_not_app_or_plugin_subscribed_to_event(
+    mocked_is_event_active_for_any_plugin,
+    mocked_payment_method_initialize_tokenization,
+    user_api_client,
+    channel_USD,
+):
+    # given
+    mocked_is_event_active_for_any_plugin.return_value = False
+
+    expected_id = "test_id"
+
+    # when
+    response = user_api_client.post_graphql(
+        PAYMENT_METHOD_INITIALIZE_TOKENIZATION,
+        variables={"id": expected_id, "channel": channel_USD.slug},
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["paymentMethodInitializeTokenization"]["errors"]) == 1
+    assert (
+        content["data"]["paymentMethodInitializeTokenization"]["errors"][0]["code"]
+        == PaymentMethodInitializeTokenizationErrorCode.NOT_FOUND.name
+    )
+    assert content["data"]["paymentMethodInitializeTokenization"]["result"] == (
+        PaymentMethodTokenizationResultEnum.FAILED_TO_DELIVER.name
+    )
+
+    mocked_is_event_active_for_any_plugin.assert_called_once_with(
+        "payment_method_initialize_tokenization"
+    )
+    assert not mocked_payment_method_initialize_tokenization.called
+
+
+@patch.object(PluginsManager, "payment_method_initialize_tokenization")
+@patch.object(PluginsManager, "is_event_active_for_any_plugin")
+def test_payment_method_initialize_tokenization_incorrect_channel(
+    mocked_is_event_active_for_any_plugin,
+    mocked_payment_method_initialize_tokenization,
+    user_api_client,
+):
+    # given
+    expected_id = "test_id"
+
+    # when
+    response = user_api_client.post_graphql(
+        PAYMENT_METHOD_INITIALIZE_TOKENIZATION,
+        variables={"id": expected_id, "channel": "non-exiting-channel"},
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["paymentMethodInitializeTokenization"]["errors"]) == 1
+    assert (
+        content["data"]["paymentMethodInitializeTokenization"]["errors"][0]["code"]
+        == PaymentMethodInitializeTokenizationErrorCode.NOT_FOUND.name
+    )
+    assert content["data"]["paymentMethodInitializeTokenization"]["result"] == (
+        PaymentMethodTokenizationResultEnum.FAILED_TO_DELIVER.name
+    )
+
+    assert not mocked_is_event_active_for_any_plugin.called
+    assert not mocked_payment_method_initialize_tokenization.called
+
+
+@patch.object(PluginsManager, "payment_method_initialize_tokenization")
+@patch.object(PluginsManager, "is_event_active_for_any_plugin")
+def test_payment_method_initialize_tokenization_failure_from_app(
+    mocked_is_event_active_for_any_plugin,
+    mocked_payment_method_initialize_tokenization,
+    user_api_client,
+    channel_USD,
+):
+    # given
+    error_message = "Error message"
+    mocked_is_event_active_for_any_plugin.return_value = True
+    mocked_payment_method_initialize_tokenization.return_value = (
+        PaymentMethodInitializeTokenizationResponseData(
+            result=PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE,
+            error=error_message,
+            data=None,
+        )
+    )
+    expected_id = "test_id"
+
+    # when
+    response = user_api_client.post_graphql(
+        PAYMENT_METHOD_INITIALIZE_TOKENIZATION,
+        variables={
+            "id": expected_id,
+            "channel": channel_USD.slug,
+            "data": None,
+        },
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["paymentMethodInitializeTokenization"]["result"] == (
+        PaymentMethodTokenizationResultEnum.FAILED_TO_TOKENIZE.name
+    )
+    assert len(content["data"]["paymentMethodInitializeTokenization"]["errors"]) == 1
+    error = content["data"]["paymentMethodInitializeTokenization"]["errors"][0]
+    assert (
+        error["code"] == PaymentMethodInitializeTokenizationErrorCode.GATEWAY_ERROR.name
+    )
+    assert error["message"] == error_message
+
+    mocked_is_event_active_for_any_plugin.assert_called_once_with(
+        "payment_method_initialize_tokenization"
+    )
+    mocked_payment_method_initialize_tokenization.assert_called_once_with(
+        request_data=PaymentMethodInitializeTokenizationRequestData(
+            user=user_api_client.user,
+            channel=channel_USD,
+            app_identifier=expected_id,
+            data=None,
+        )
+    )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2278,6 +2278,7 @@ enum WebhookEventTypeEnum @doc(category: "Webhooks") {
   LIST_STORED_PAYMENT_METHODS
   STORED_PAYMENT_METHOD_DELETE_REQUESTED
   PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION
+  PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
 }
 
 """Synchronous webhook event."""
@@ -2367,6 +2368,7 @@ enum WebhookEventTypeSyncEnum @doc(category: "Webhooks") {
   LIST_STORED_PAYMENT_METHODS
   STORED_PAYMENT_METHOD_DELETE_REQUESTED
   PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION
+  PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
 }
 
 """Asynchronous webhook event."""
@@ -15627,7 +15629,7 @@ type Mutation {
   - PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION (sync): The customer requested to initialize payment gateway for tokenization.
   """
   paymentGatewayInitializeTokenization(
-    """Slug of a channel related to delete request."""
+    """Slug of a channel related to tokenization request."""
     channel: String!
 
     """The data that will be passed to the payment gateway."""
@@ -15636,6 +15638,31 @@ type Mutation {
     """The identifier of the payment gateway app to initialize tokenization."""
     id: String!
   ): PaymentGatewayInitializeTokenization @doc(category: "Payments") @webhookEventsInfo(asyncEvents: [], syncEvents: [PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION])
+
+  """
+  Tokenize payment method.
+  
+  Added in Saleor 3.16.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+  
+  Requires one of the following permissions: AUTHENTICATED_USER.
+  
+  Triggers the following webhook events:
+  - PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION (sync): The customer requested to tokenize payment method.
+  """
+  paymentMethodInitializeTokenization(
+    """Slug of a channel related to tokenization request."""
+    channel: String!
+
+    """The data that will be passed to the payment gateway."""
+    data: JSON
+
+    """
+    The identifier of the payment gateway app to initialize payment method tokenization.
+    """
+    id: String!
+  ): PaymentMethodInitializeTokenization @doc(category: "Payments") @webhookEventsInfo(asyncEvents: [], syncEvents: [PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION])
 
   """
   Creates a new page. 
@@ -23301,6 +23328,68 @@ type PaymentGatewayInitializeTokenizationError @doc(category: "Payments") {
 
 """An enumeration."""
 enum PaymentGatewayInitializeTokenizationErrorCode @doc(category: "Payments") {
+  GRAPHQL_ERROR
+  INVALID
+  NOT_FOUND
+  CHANNEL_INACTIVE
+  GATEWAY_ERROR
+}
+
+"""
+Tokenize payment method.
+
+Added in Saleor 3.16.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point. 
+
+Requires one of the following permissions: AUTHENTICATED_USER.
+
+Triggers the following webhook events:
+- PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION (sync): The customer requested to tokenize payment method.
+"""
+type PaymentMethodInitializeTokenization @doc(category: "Payments") @webhookEventsInfo(asyncEvents: [], syncEvents: [PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION]) {
+  """A status of the payment method tokenization."""
+  result: PaymentMethodTokenizationResult!
+
+  """The identifier of the payment method."""
+  id: String
+
+  """A data returned by the payment app."""
+  data: JSON
+  errors: [PaymentMethodInitializeTokenizationError!]!
+}
+
+"""
+Result of tokenization of payment method.
+
+    SUCCESSFULLY_TOKENIZED - The payment method was successfully tokenized.
+    ADDITIONAL_ACTION_REQUIRED - The additional action is required to tokenize payment
+    method.
+    FAILED_TO_TOKENIZE - The payment method was not tokenized.
+    FAILED_TO_DELIVER - The request to tokenize payment method was not delivered.
+"""
+enum PaymentMethodTokenizationResult @doc(category: "Payments") {
+  SUCCESSFULLY_TOKENIZED
+  ADDITIONAL_ACTION_REQUIRED
+  FAILED_TO_TOKENIZE
+  FAILED_TO_DELIVER
+}
+
+type PaymentMethodInitializeTokenizationError @doc(category: "Payments") {
+  """
+  Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field.
+  """
+  field: String
+
+  """The error message."""
+  message: String
+
+  """The error code."""
+  code: PaymentMethodInitializeTokenizationErrorCode!
+}
+
+"""An enumeration."""
+enum PaymentMethodInitializeTokenizationErrorCode @doc(category: "Payments") {
   GRAPHQL_ERROR
   INVALID
   NOT_FOUND
@@ -33322,10 +33411,40 @@ type PaymentGatewayInitializeTokenizationSession implements Event @doc(category:
   """The application receiving the webhook."""
   recipient: App
 
-  """The user related to the requested payment gateway tokenization."""
+  """The user related to the requested action."""
   user: User!
 
-  """Channel related to the requested delete action."""
+  """Channel related to the requested action."""
+  channel: Channel!
+
+  """Payment gateway data in JSON format, received from storefront."""
+  data: JSON
+}
+
+"""
+Event sent when user requests a tokenization of payment method.
+
+Added in Saleor 3.16.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type PaymentMethodInitializeTokenizationSession implements Event @doc(category: "Payments") {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The user related to the requested action."""
+  user: User!
+
+  """Channel related to the requested action."""
   channel: Channel!
 
   """Payment gateway data in JSON format, received from storefront."""

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -105,3 +105,11 @@ class PaymentGatewayInitializeTokenizationErrorCode(Enum):
     NOT_FOUND = "not_found"
     CHANNEL_INACTIVE = "channel_inactive"
     GATEWAY_ERROR = "gateway_error"
+
+
+class PaymentMethodInitializeTokenizationErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
+    INVALID = "invalid"
+    NOT_FOUND = "not_found"
+    CHANNEL_INACTIVE = "channel_inactive"
+    GATEWAY_ERROR = "gateway_error"

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -157,13 +157,25 @@ class TransactionSessionResult:
 
 
 @dataclass
-class PaymentGatewayInitializeTokenizationRequestData:
+class PaymentMethodTokenizationBaseRequestData:
+    channel: "Channel"
+    user: "User"
+    data: Optional[dict]
+
+
+@dataclass
+class PaymentMethodTokenizationBaseResponseData:
+    error: Optional[str]
+    data: Optional[dict]
+
+
+@dataclass
+class PaymentGatewayInitializeTokenizationRequestData(
+    PaymentMethodTokenizationBaseRequestData
+):
     """Dataclass for storing the request information for payment app."""
 
     app_identifier: str
-    channel: "Channel"
-    user: "User"
-    data: Optional[dict] = None
 
 
 class PaymentGatewayInitializeTokenizationResult(str, Enum):
@@ -181,12 +193,47 @@ class PaymentGatewayInitializeTokenizationResult(str, Enum):
 
 
 @dataclass
-class PaymentGatewayInitializeTokenizationResponseData:
+class PaymentGatewayInitializeTokenizationResponseData(
+    PaymentMethodTokenizationBaseResponseData
+):
     """Dataclass for storing the response information from payment app."""
 
     result: PaymentGatewayInitializeTokenizationResult
-    error: Optional[str] = None
-    data: Optional[dict] = None
+
+
+@dataclass
+class PaymentMethodInitializeTokenizationRequestData(
+    PaymentMethodTokenizationBaseRequestData
+):
+    """Dataclass for storing the request information for payment app."""
+
+    app_identifier: str
+
+
+class PaymentMethodTokenizationResult(str, Enum):
+    """Result of tokenization of payment method.
+
+    SUCCESSFULLY_TOKENIZED - The payment method was successfully tokenized.
+    ADDITIONAL_ACTION_REQUIRED - The additional action is required to tokenize payment
+    method.
+    FAILED_TO_TOKENIZE - The payment method was not tokenized.
+    FAILED_TO_DELIVER - The request to tokenize payment method was not delivered.
+    """
+
+    SUCCESSFULLY_TOKENIZED = "successfully_tokenized"
+    ADDITIONAL_ACTION_REQUIRED = "additional_action_required"
+    FAILED_TO_TOKENIZE = "failed_to_tokenize"
+    FAILED_TO_DELIVER = "failed_to_deliver"
+
+
+@dataclass
+class PaymentMethodInitializeTokenizationResponseData(
+    PaymentMethodTokenizationBaseResponseData
+):
+    """Dataclass for storing the response information from payment app."""
+
+    result: PaymentMethodTokenizationResult
+    id: Optional[str] = None
 
 
 @dataclass

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -35,6 +35,8 @@ from ..payment.interface import (
     PaymentGatewayInitializeTokenizationRequestData,
     PaymentGatewayInitializeTokenizationResponseData,
     PaymentMethodData,
+    PaymentMethodInitializeTokenizationRequestData,
+    PaymentMethodInitializeTokenizationResponseData,
     StoredPaymentMethodRequestDeleteData,
     StoredPaymentMethodRequestDeleteResponseData,
     TransactionActionData,
@@ -706,6 +708,14 @@ class BasePlugin:
             "PaymentGatewayInitializeTokenizationResponseData",
         ],
         "PaymentGatewayInitializeTokenizationResponseData",
+    ]
+
+    payment_method_initialize_tokenization: Callable[
+        [
+            "PaymentMethodInitializeTokenizationRequestData",
+            "PaymentMethodInitializeTokenizationResponseData",
+        ],
+        "PaymentMethodInitializeTokenizationResponseData",
     ]
 
     # Trigger when menu is created.

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -44,6 +44,9 @@ from ..payment.interface import (
     PaymentGatewayInitializeTokenizationResponseData,
     PaymentGatewayInitializeTokenizationResult,
     PaymentMethodData,
+    PaymentMethodInitializeTokenizationRequestData,
+    PaymentMethodInitializeTokenizationResponseData,
+    PaymentMethodTokenizationResult,
     StoredPaymentMethodRequestDeleteData,
     StoredPaymentMethodRequestDeleteResponseData,
     TokenConfig,
@@ -1567,10 +1570,28 @@ class PluginsManager(PaymentInterface):
         default_response = PaymentGatewayInitializeTokenizationResponseData(
             result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER,
             error="Payment gateway initialize tokenization failed to deliver.",
+            data=None,
         )
 
         response = self.__run_method_on_plugins(
             "payment_gateway_initialize_tokenization",
+            default_response,
+            request_data,
+        )
+        return response
+
+    def payment_method_initialize_tokenization(
+        self,
+        request_data: "PaymentMethodInitializeTokenizationRequestData",
+    ) -> "PaymentMethodInitializeTokenizationResponseData":
+        default_response = PaymentMethodInitializeTokenizationResponseData(
+            result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
+            error="Payment method initialize tokenization failed to deliver.",
+            data=None,
+        )
+
+        response = self.__run_method_on_plugins(
+            "payment_method_initialize_tokenization",
             default_response,
             request_data,
         )

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -359,6 +359,9 @@ class PluginSample(BasePlugin):
     def payment_gateway_initialize_tokenization(self, request_data, previous_value):
         return previous_value
 
+    def payment_method_initialize_tokenization(self, request_data, previous_value):
+        return previous_value
+
 
 class ChannelPluginSample(PluginSample):
     PLUGIN_ID = "channel.plugin.sample"

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -24,6 +24,9 @@ from ...payment.interface import (
     PaymentGatewayInitializeTokenizationRequestData,
     PaymentGatewayInitializeTokenizationResponseData,
     PaymentGatewayInitializeTokenizationResult,
+    PaymentMethodInitializeTokenizationRequestData,
+    PaymentMethodInitializeTokenizationResponseData,
+    PaymentMethodTokenizationResult,
     StoredPaymentMethodRequestDeleteData,
     StoredPaymentMethodRequestDeleteResponseData,
     TransactionProcessActionData,
@@ -1415,6 +1418,7 @@ def test_payment_gateway_initialize_tokenization(
     previous_response = PaymentGatewayInitializeTokenizationResponseData(
         result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER,
         error="Payment gateway initialize tokenization failed to deliver.",
+        data=None,
     )
 
     # when
@@ -1422,5 +1426,39 @@ def test_payment_gateway_initialize_tokenization(
 
     # then
     mocked_payment_gateway_initialize_tokenization.assert_called_once_with(
+        request_data, previous_value=previous_response
+    )
+
+
+@patch(
+    "saleor.plugins.tests.sample_plugins.PluginSample."
+    "payment_method_initialize_tokenization"
+)
+def test_payment_method_initialize_tokenization(
+    mocked_payment_method_initialize_tokenization, customer_user, channel_USD, app
+):
+    # given
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+        "saleor.plugins.tests.sample_plugins.PluginInactive",
+    ]
+    manager = PluginsManager(plugins=plugins)
+    request_data = PaymentMethodInitializeTokenizationRequestData(
+        user=customer_user,
+        app_identifier=app.identifier,
+        channel=channel_USD,
+        data={"data": "ABC"},
+    )
+    previous_response = PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
+        error="Payment method initialize tokenization failed to deliver.",
+        data=None,
+    )
+
+    # when
+    manager.payment_method_initialize_tokenization(request_data=request_data)
+
+    # then
+    mocked_payment_method_initialize_tokenization.assert_called_once_with(
         request_data, previous_value=previous_response
     )

--- a/saleor/plugins/webhook/stored_payment_methods.py
+++ b/saleor/plugins/webhook/stored_payment_methods.py
@@ -12,6 +12,8 @@ from ...payment.interface import (
     PaymentGatewayInitializeTokenizationResult,
     PaymentMethodCreditCardInfo,
     PaymentMethodData,
+    PaymentMethodInitializeTokenizationResponseData,
+    PaymentMethodTokenizationResult,
     StoredPaymentMethodRequestDeleteResponseData,
 )
 from ...webhook.event_types import WebhookEventSyncType
@@ -196,4 +198,35 @@ def get_response_for_payment_gateway_initialize_tokenization(
 
     return PaymentGatewayInitializeTokenizationResponseData(
         result=result, error=error, data=data
+    )
+
+
+def get_response_for_payment_method_tokenization(
+    response_data: Optional[dict], app: "App"
+) -> "PaymentMethodInitializeTokenizationResponseData":
+    data = None
+    payment_method_id = None
+    if response_data is None:
+        result = PaymentMethodTokenizationResult.FAILED_TO_DELIVER
+        error = "Failed to delivery request."
+    else:
+        try:
+            response_result = response_data.get("result") or ""
+            result = PaymentMethodTokenizationResult[response_result]
+            error = response_data.get("error", None)
+            data = response_data.get("data", None)
+        except KeyError:
+            result = PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE
+            error = "Missing or incorrect `result` in response."
+
+        try:
+            payment_method_id = response_data["id"]
+            payment_method_id = to_payment_app_id(app, payment_method_id)
+        except KeyError:
+            if result == PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED:
+                result = PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE
+                error = "Missing payment method `id` in response."
+
+    return PaymentMethodInitializeTokenizationResponseData(
+        result=result, error=error, data=data, id=payment_method_id
     )

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_initialize_tokenization.py
@@ -1,0 +1,89 @@
+import json
+
+import graphene
+
+from .....payment.interface import PaymentMethodInitializeTokenizationRequestData
+from .....webhook.event_types import WebhookEventSyncType
+from ...tasks import create_deliveries_for_subscriptions
+
+PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION = """
+subscription{
+  event{
+    ...on PaymentMethodInitializeTokenizationSession{
+      user{
+        id
+      }
+      channel{
+        id
+      }
+      data
+    }
+  }
+}
+"""
+
+
+def test_payment_method_initialize_tokenization_without_data(
+    payment_method_initialize_tokenization_app, customer_user, channel_USD
+):
+    # given
+    webhook = payment_method_initialize_tokenization_app.webhooks.first()
+    webhook.subscription_query = PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
+    webhook.save()
+
+    request_delete_data = PaymentMethodInitializeTokenizationRequestData(
+        user=customer_user,
+        app_identifier=payment_method_initialize_tokenization_app.identifier,
+        channel=channel_USD,
+        data=None,
+    )
+
+    event_type = WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
+
+    # when
+    delivery = create_deliveries_for_subscriptions(
+        event_type, request_delete_data, [webhook]
+    )[0]
+
+    # then
+    assert delivery.payload
+    assert delivery.payload.payload
+    assert json.loads(delivery.payload.payload) == {
+        "data": None,
+        "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
+        "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
+    }
+
+
+def test_payment_method_initialize_tokenization_with_data(
+    payment_method_initialize_tokenization_app, customer_user, channel_USD
+):
+    # given
+    webhook = payment_method_initialize_tokenization_app.webhooks.first()
+    webhook.subscription_query = PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
+    webhook.save()
+
+    expected_data = {"data": {"foo": "bar"}}
+
+    request_delete_data = PaymentMethodInitializeTokenizationRequestData(
+        user=customer_user,
+        app_identifier=payment_method_initialize_tokenization_app.identifier,
+        channel=channel_USD,
+        data=expected_data,
+    )
+
+    event_type = WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
+
+    # when
+    delivery = create_deliveries_for_subscriptions(
+        event_type, request_delete_data, [webhook]
+    )[0]
+
+    # then
+    assert delivery.payload
+    assert delivery.payload.payload
+    assert json.loads(delivery.payload.payload) == {
+        "data": expected_data,
+        "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
+        "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
+    }

--- a/saleor/plugins/webhook/tests/test_payment_gateway_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_gateway_initialize_tokenization.py
@@ -64,6 +64,7 @@ def test_payment_gateway_initialize_tokenization_with_static_payload(
     previous_value = PaymentGatewayInitializeTokenizationResponseData(
         result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER,
         error="Payment gateway initialize tokenization failed to deliver.",
+        data=None,
     )
 
     # when
@@ -117,6 +118,7 @@ def test_payment_gateway_initialize_tokenization_with_subscription_payload(
     previous_value = PaymentGatewayInitializeTokenizationResponseData(
         result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER,
         error="Payment gateway initialize tokenization failed to deliver.",
+        data=None,
     )
 
     # when
@@ -169,6 +171,7 @@ def test_payment_gateway_initialize_tokenization_missing_correct_response_from_w
     previous_value = PaymentGatewayInitializeTokenizationResponseData(
         result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER,
         error="Payment gateway initialize tokenization failed to deliver.",
+        data=None,
     )
 
     # when
@@ -217,6 +220,7 @@ def test_payment_gateway_initialize_tokenization_failure_from_app(
     previous_value = PaymentGatewayInitializeTokenizationResponseData(
         result=PaymentGatewayInitializeTokenizationResult.FAILED_TO_DELIVER,
         error="Payment gateway initialize tokenization failed to deliver.",
+        data=None,
     )
 
     # when

--- a/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
@@ -1,0 +1,479 @@
+import json
+
+import graphene
+import mock
+import pytest
+
+from ....core.models import EventDelivery
+from ....payment.interface import (
+    ListStoredPaymentMethodsRequestData,
+    PaymentMethodInitializeTokenizationRequestData,
+    PaymentMethodInitializeTokenizationResponseData,
+    PaymentMethodTokenizationResult,
+)
+from ....settings import WEBHOOK_SYNC_TIMEOUT
+from ....webhook.event_types import WebhookEventSyncType
+from ....webhook.models import Webhook
+from ..const import WEBHOOK_CACHE_DEFAULT_TIMEOUT
+from ..utils import generate_cache_key_for_webhook, to_payment_app_id
+
+PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION = """
+subscription{
+  event{
+    ...on PaymentMethodInitializeTokenizationSession{
+      user{
+        id
+      }
+      channel{
+        id
+      }
+      data
+    }
+  }
+}
+"""
+
+
+@pytest.fixture
+def webhook_payment_method_initialize_tokenization_response():
+    return {
+        "result": (PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name),
+        "id": "payment-method-id",
+        "data": {"foo": "bar"},
+    }
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_payment_method_initialize_tokenization_with_static_payload(
+    mock_request,
+    customer_user,
+    webhook_plugin,
+    payment_method_initialize_tokenization_app,
+    webhook_payment_method_initialize_tokenization_response,
+    channel_USD,
+):
+    # given
+    mock_request.return_value = webhook_payment_method_initialize_tokenization_response
+
+    plugin = webhook_plugin()
+
+    expected_data = {"foo": "bar"}
+    request_data = PaymentMethodInitializeTokenizationRequestData(
+        user=customer_user,
+        app_identifier=payment_method_initialize_tokenization_app.identifier,
+        channel=channel_USD,
+        data=expected_data,
+    )
+
+    previous_value = PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
+        error="Payment method initialize tokenization failed to deliver.",
+        data=None,
+    )
+
+    # when
+    response = plugin.payment_method_initialize_tokenization(
+        request_data, previous_value
+    )
+
+    # then
+    delivery = EventDelivery.objects.get()
+    assert json.loads(delivery.payload.payload) == {
+        "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+        "channel_slug": channel_USD.slug,
+        "data": expected_data,
+    }
+    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+
+    assert response == PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
+        id=to_payment_app_id(
+            payment_method_initialize_tokenization_app,
+            webhook_payment_method_initialize_tokenization_response["id"],
+        ),
+        error=None,
+        data=webhook_payment_method_initialize_tokenization_response["data"],
+    )
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_payment_method_initialize_tokenization_with_subscription_payload(
+    mock_request,
+    customer_user,
+    webhook_plugin,
+    payment_method_initialize_tokenization_app,
+    webhook_payment_method_initialize_tokenization_response,
+    channel_USD,
+):
+    # given
+    mock_request.return_value = webhook_payment_method_initialize_tokenization_response
+
+    webhook = payment_method_initialize_tokenization_app.webhooks.first()
+    webhook.subscription_query = PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
+    webhook.save()
+
+    plugin = webhook_plugin()
+
+    expected_data = {"foo": "bar"}
+
+    request_data = PaymentMethodInitializeTokenizationRequestData(
+        user=customer_user,
+        app_identifier=payment_method_initialize_tokenization_app.identifier,
+        channel=channel_USD,
+        data=expected_data,
+    )
+
+    previous_value = PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
+        error="Payment method initialize tokenization failed to deliver.",
+        data=None,
+    )
+
+    # when
+    response = plugin.payment_method_initialize_tokenization(
+        request_data, previous_value
+    )
+
+    # then
+    delivery = EventDelivery.objects.get()
+    assert json.loads(delivery.payload.payload) == {
+        "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
+        "data": expected_data,
+        "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
+    }
+    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+
+    assert response == PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
+        id=to_payment_app_id(
+            payment_method_initialize_tokenization_app,
+            webhook_payment_method_initialize_tokenization_response["id"],
+        ),
+        error=None,
+        data=webhook_payment_method_initialize_tokenization_response["data"],
+    )
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_payment_method_initialize_tokenization_missing_correct_response_from_webhook(
+    mock_request,
+    customer_user,
+    webhook_plugin,
+    payment_method_initialize_tokenization_app,
+    channel_USD,
+):
+    # given
+    mock_request.return_value = None
+
+    webhook = payment_method_initialize_tokenization_app.webhooks.first()
+    webhook.subscription_query = PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
+    webhook.save()
+
+    plugin = webhook_plugin()
+
+    expected_data = {"foo": "bar"}
+
+    request_data = PaymentMethodInitializeTokenizationRequestData(
+        user=customer_user,
+        app_identifier=payment_method_initialize_tokenization_app.identifier,
+        channel=channel_USD,
+        data=expected_data,
+    )
+
+    previous_value = PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
+        error="Payment method initialize tokenization failed to deliver.",
+        data=None,
+    )
+
+    # when
+    response = plugin.payment_method_initialize_tokenization(
+        request_data, previous_value
+    )
+
+    # then
+    delivery = EventDelivery.objects.get()
+
+    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+
+    assert response == PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
+        error="Failed to delivery request.",
+        id=None,
+        data=None,
+    )
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_payment_method_initialize_tokenization_failure_from_app(
+    mock_request,
+    customer_user,
+    webhook_plugin,
+    payment_method_initialize_tokenization_app,
+    channel_USD,
+):
+    # given
+    expected_error_msg = "Expected error msg."
+    mock_request.return_value = {
+        "result": PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name,
+        "error": expected_error_msg,
+        "data": None,
+    }
+
+    plugin = webhook_plugin()
+
+    expected_data = {"foo": "bar"}
+    request_data = PaymentMethodInitializeTokenizationRequestData(
+        user=customer_user,
+        app_identifier=payment_method_initialize_tokenization_app.identifier,
+        channel=channel_USD,
+        data=expected_data,
+    )
+
+    previous_value = PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
+        error="Payment method initialize tokenization failed to deliver.",
+        data=None,
+    )
+
+    # when
+    response = plugin.payment_method_initialize_tokenization(
+        request_data, previous_value
+    )
+
+    # then
+    delivery = EventDelivery.objects.get()
+    assert json.loads(delivery.payload.payload) == {
+        "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+        "channel_slug": channel_USD.slug,
+        "data": expected_data,
+    }
+    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+
+    assert response == PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE,
+        error=expected_error_msg,
+        id=None,
+        data=None,
+    )
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_payment_method_initialize_tokenization_additional_action_required(
+    mock_request,
+    customer_user,
+    webhook_plugin,
+    payment_method_initialize_tokenization_app,
+    channel_USD,
+):
+    # given
+    expected_payment_method_id = "payment_method_id"
+    expected_additiona_data = {"foo": "bar1"}
+    mock_request.return_value = {
+        "result": PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED.name,
+        "id": expected_payment_method_id,
+        "data": expected_additiona_data,
+    }
+
+    plugin = webhook_plugin()
+
+    expected_data = {"foo": "bar"}
+    request_data = PaymentMethodInitializeTokenizationRequestData(
+        user=customer_user,
+        app_identifier=payment_method_initialize_tokenization_app.identifier,
+        channel=channel_USD,
+        data=expected_data,
+    )
+
+    previous_value = PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
+        error="Payment method initialize tokenization failed to deliver.",
+        data=None,
+    )
+
+    # when
+    response = plugin.payment_method_initialize_tokenization(
+        request_data, previous_value
+    )
+
+    # then
+    delivery = EventDelivery.objects.get()
+    assert json.loads(delivery.payload.payload) == {
+        "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+        "channel_slug": channel_USD.slug,
+        "data": expected_data,
+    }
+    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+
+    assert response == PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED,
+        id=to_payment_app_id(
+            payment_method_initialize_tokenization_app, expected_payment_method_id
+        ),
+        data=expected_additiona_data,
+        error=None,
+    )
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_payment_method_initialize_tokenization_missing_required_id(
+    mock_request,
+    customer_user,
+    webhook_plugin,
+    payment_method_initialize_tokenization_app,
+    channel_USD,
+):
+    # given
+    expected_error_msg = "Missing payment method `id` in response."
+    mock_request.return_value = {
+        "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+        "data": None,
+    }
+
+    plugin = webhook_plugin()
+
+    expected_data = {"foo": "bar"}
+    request_data = PaymentMethodInitializeTokenizationRequestData(
+        user=customer_user,
+        app_identifier=payment_method_initialize_tokenization_app.identifier,
+        channel=channel_USD,
+        data=expected_data,
+    )
+
+    previous_value = PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
+        error="Payment method initialize tokenization failed to deliver.",
+        data=None,
+    )
+
+    # when
+    response = plugin.payment_method_initialize_tokenization(
+        request_data, previous_value
+    )
+
+    # then
+    delivery = EventDelivery.objects.get()
+    assert json.loads(delivery.payload.payload) == {
+        "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+        "channel_slug": channel_USD.slug,
+        "data": expected_data,
+    }
+    mock_request.assert_called_once_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+
+    assert response == PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE,
+        error=expected_error_msg,
+        id=None,
+        data=None,
+    )
+
+
+@mock.patch("saleor.plugins.webhook.tasks.cache.delete")
+@mock.patch("saleor.plugins.webhook.tasks.cache.set")
+@mock.patch("saleor.plugins.webhook.tasks.cache.get")
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_stored_payment_method_request_delete_invalidates_cache_for_app(
+    mocked_request,
+    mocked_cache_get,
+    mocked_cache_set,
+    mocked_cache_delete,
+    customer_user,
+    webhook_plugin,
+    payment_method_initialize_tokenization_app,
+    webhook_payment_method_initialize_tokenization_response,
+    channel_USD,
+):
+    # given
+    mocked_cache_get.return_value = None
+
+    webhook = Webhook.objects.create(
+        name="list_stored_payment_methods",
+        app=payment_method_initialize_tokenization_app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+    )
+    list_stored_payment_methods_response = {"paymentMethods": []}
+    mocked_request.side_effect = [
+        list_stored_payment_methods_response,
+        webhook_payment_method_initialize_tokenization_response,
+    ]
+
+    webhook = payment_method_initialize_tokenization_app.webhooks.first()
+    webhook.subscription_query = PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
+    webhook.save()
+
+    plugin = webhook_plugin()
+
+    expected_data = {"foo": "bar"}
+
+    request_data = PaymentMethodInitializeTokenizationRequestData(
+        user=customer_user,
+        app_identifier=payment_method_initialize_tokenization_app.identifier,
+        channel=channel_USD,
+        data=expected_data,
+    )
+
+    previous_value = PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,
+        error="Payment method initialize tokenization failed to deliver.",
+        data=None,
+    )
+
+    data = ListStoredPaymentMethodsRequestData(
+        channel=channel_USD,
+        user=customer_user,
+    )
+    expected_payload = {
+        "user_id": graphene.Node.to_global_id("User", customer_user.pk),
+        "channel_slug": channel_USD.slug,
+    }
+    expected_cache_key = generate_cache_key_for_webhook(
+        expected_payload,
+        webhook.target_url,
+        WebhookEventSyncType.LIST_STORED_PAYMENT_METHODS,
+        payment_method_initialize_tokenization_app.id,
+    )
+
+    # call mocked list_stored_payment_methods to call mocked cache logic
+    # this will make sure that we're deleting the same cache key as the one created
+    # in list_stored_payment_methods
+    plugin.list_stored_payment_methods(data, [])
+
+    mocked_cache_get.assert_called_once_with(expected_cache_key)
+    mocked_cache_set.assert_called_once_with(
+        expected_cache_key,
+        list_stored_payment_methods_response,
+        timeout=WEBHOOK_CACHE_DEFAULT_TIMEOUT,
+    )
+
+    # when
+    response = plugin.payment_method_initialize_tokenization(
+        request_data, previous_value
+    )
+
+    # then
+    delivery = EventDelivery.objects.filter(
+        event_type=WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
+    ).first()
+    assert json.loads(delivery.payload.payload) == {
+        "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
+        "data": expected_data,
+        "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
+    }
+
+    # delete the same cache key as created when fetching stored payment methods
+    mocked_cache_delete.assert_called_once_with(expected_cache_key)
+
+    mocked_request.assert_called_with(delivery, timeout=WEBHOOK_SYNC_TIMEOUT)
+
+    assert response == PaymentMethodInitializeTokenizationResponseData(
+        result=PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
+        id=to_payment_app_id(
+            payment_method_initialize_tokenization_app,
+            webhook_payment_method_initialize_tokenization_response["id"],
+        ),
+        error=None,
+        data=webhook_payment_method_initialize_tokenization_response["data"],
+    )

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -6545,6 +6545,27 @@ def payment_gateway_initialize_tokenization_app(db, permission_manage_payments):
 
 
 @pytest.fixture
+def payment_method_initialize_tokenization_app(db, permission_manage_payments):
+    app = App.objects.create(
+        name="Payment method initialize tokenization",
+        is_active=True,
+        identifier="saleor.payment.app.payment.method.initialize.tokenization",
+    )
+    app.tokens.create(name="Default")
+    app.permissions.add(permission_manage_payments)
+
+    webhook = Webhook.objects.create(
+        name="payment_method_initialize_tokenization",
+        app=app,
+        target_url="http://localhost:8000/endpoint/",
+    )
+    webhook.events.create(
+        event_type=WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION,
+    )
+    return app
+
+
+@pytest.fixture
 def tax_app(db, permission_handle_taxes):
     app = App.objects.create(name="Tax App", is_active=True)
     app.permissions.add(permission_handle_taxes)

--- a/saleor/webhook/event_types.py
+++ b/saleor/webhook/event_types.py
@@ -738,6 +738,9 @@ class WebhookEventSyncType:
     PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION = (
         "payment_gateway_initialize_tokenization_session"
     )
+    PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION = (
+        "payment_method_initialize_tokenization_session"
+    )
 
     EVENT_MAP: dict[str, dict[str, Any]] = {
         PAYMENT_LIST_GATEWAYS: {
@@ -822,6 +825,10 @@ class WebhookEventSyncType:
         },
         PAYMENT_GATEWAY_INITIALIZE_TOKENIZATION_SESSION: {
             "name": "Initialize payment gateway tokenization session.",
+            "permission": PaymentPermissions.HANDLE_PAYMENTS,
+        },
+        PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION: {
+            "name": "Initialize payment method tokenization session.",
             "permission": PaymentPermissions.HANDLE_PAYMENTS,
         },
     }


### PR DESCRIPTION
I want to merge this change because it adds a logic for payment-method-initialize-tokenization as described here:
https://github.com/saleor/saleor/issues/13386

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
