### PR TITLE
[TEST] adding additional fields to prepare_product utils

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
@@ -29,6 +29,8 @@ def test_checkout_create_from_order_core_0104(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
+    price = 10
+
     (
         result_warehouse_id,
         result_channel_id,
@@ -36,8 +38,8 @@ def test_checkout_create_from_order_core_0104(
         _,
     ) = prepare_shop(e2e_staff_api_client)
 
-    product_variant_id = prepare_product(
-        e2e_staff_api_client, result_warehouse_id, result_channel_id
+    _, result_product_variant_id, _ = prepare_product(
+        e2e_staff_api_client, result_warehouse_id, result_channel_id, price
     )
 
     # Step 1 - Create checkout from order
@@ -48,7 +50,9 @@ def test_checkout_create_from_order_core_0104(
 
     order_id = data["order"]["id"]
     assert order_id is not None
-    order_lines = [{"variantId": product_variant_id, "quantity": 1, "price": 100}]
+    order_lines = [
+        {"variantId": result_product_variant_id, "quantity": 1, "price": 100}
+    ]
     order_data = order_lines_create(e2e_staff_api_client, order_id, order_lines)
     order_product_variant_id = order_data["order"]["lines"][0]["variant"]
     order_product_quantity = order_data["order"]["lines"][0]["quantity"]

--- a/saleor/tests/e2e/checkout/test_checkout_create_order_with_no_payment.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_order_with_no_payment.py
@@ -93,13 +93,20 @@ def test_should_be_able_to_create_order_with_no_payment_CORE_0111(
         permission_manage_checkouts,
     )
 
-    product_variant_id = prepare_product(e2e_staff_api_client, warehouse_id, channel_id)
+    variant_price = 10
+
+    _, result_product_variant_id, _ = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
 
     assert shipping_method_id is not None
 
     # Step 1 - Create checkout.
     lines = [
-        {"variantId": product_variant_id, "quantity": 1},
+        {"variantId": result_product_variant_id, "quantity": 1},
     ]
     checkout_data = checkout_create(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/checkout/test_checkout_create_partially_paid_order.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_partially_paid_order.py
@@ -101,12 +101,20 @@ def test_should_be_able_to_create_partially_paid_order_core_0112(
     )
     app_permissions = [permission_manage_payments]
     assign_permissions(e2e_app_api_client, app_permissions)
-    product_variant_id = prepare_product(e2e_staff_api_client, warehouse_id, channel_id)
+
+    variant_price = 10
+
+    _, result_product_variant_id, _ = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
 
     assert shipping_method_id is not None
     # Step 1 - Create checkout.
     lines = [
-        {"variantId": product_variant_id, "quantity": 1},
+        {"variantId": result_product_variant_id, "quantity": 1},
     ]
     checkout_data = checkout_create(
         e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/test_checkout_unable_to_make_purchase_with_no_payment.py
+++ b/saleor/tests/e2e/checkout/test_checkout_unable_to_make_purchase_with_no_payment.py
@@ -31,12 +31,18 @@ def test_should_not_be_able_to_make_purchase_with_no_payment_CORE_0113(
     warehouse_id, channel_id, channel_slug, shipping_method_id = prepare_shop(
         e2e_staff_api_client
     )
+    variant_price = 10
 
-    product_variant_id = prepare_product(e2e_staff_api_client, warehouse_id, channel_id)
+    _, result_product_variant_id, _ = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
 
     # Step 1 - Create checkout.
     lines = [
-        {"variantId": product_variant_id, "quantity": 1},
+        {"variantId": result_product_variant_id, "quantity": 1},
     ]
     checkout_data = checkout_create(
         e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/test_logged_customer_is_unable_to_buy_more_products_than_the_limit_per_customer.py
+++ b/saleor/tests/e2e/checkout/test_logged_customer_is_unable_to_buy_more_products_than_the_limit_per_customer.py
@@ -67,6 +67,7 @@ def prepare_product_with_limit(
         e2e_staff_api_client,
         product_variant_id,
         result_channel_id,
+        price=10,
     )
 
     return (

--- a/saleor/tests/e2e/checkout/test_logged_in_customer_should_be_able_to_order_physical_product.py
+++ b/saleor/tests/e2e/checkout/test_logged_in_customer_should_be_able_to_order_physical_product.py
@@ -40,15 +40,18 @@ def test_process_checkout_with_physical_product_CORE_0103(
         shipping_method_id,
     ) = prepare_shop(e2e_staff_api_client)
 
-    product_variant_id = prepare_product(
+    variant_price = 10
+
+    _, result_product_variant_id, _ = prepare_product(
         e2e_staff_api_client,
         warehouse_id,
         channel_id,
+        variant_price,
     )
 
     # Step 1 - Create checkout.
     lines = [
-        {"variantId": product_variant_id, "quantity": 1},
+        {"variantId": result_product_variant_id, "quantity": 1},
     ]
     checkout_data = checkout_create(
         e2e_logged_api_client,

--- a/saleor/tests/e2e/checkout/test_logged_in_customer_should_not_be_able_to_buy_unavailable_product.py
+++ b/saleor/tests/e2e/checkout/test_logged_in_customer_should_not_be_able_to_buy_unavailable_product.py
@@ -73,9 +73,7 @@ def prepare_unavailable_product(
     variant_id = variant_data["id"]
 
     create_product_variant_channel_listing(
-        e2e_staff_api_client,
-        variant_id,
-        result_channel_id,
+        e2e_staff_api_client, variant_id, result_channel_id, price=10
     )
 
     return variant_id, result_channel_slug

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_is_unable_to_buy_unpublished_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_is_unable_to_buy_unpublished_product.py
@@ -67,6 +67,7 @@ def prepare_unpublished_product(
         e2e_staff_api_client,
         product_variant_id,
         result_channel_id,
+        price=10,
     )
 
     return product_variant_id, result_channel_slug

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_buy_by_click_and_collect.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_buy_by_click_and_collect.py
@@ -55,11 +55,19 @@ def test_unlogged_customer_buy_by_click_and_collect_CORE_0105(
         permission_manage_channels,
         permission_manage_product_types_and_attributes,
     )
-    product_variant_id = prepare_product(e2e_staff_api_client, warehouse_id, channel_id)
+
+    variant_price = 10
+
+    _, result_product_variant_id, _ = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
 
     # Step 1 - Create checkout and check collection point
     lines = [
-        {"variantId": product_variant_id, "quantity": 1},
+        {"variantId": result_product_variant_id, "quantity": 1},
     ]
     checkout_data = checkout_create(
         e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
@@ -66,9 +66,7 @@ def prepare_product(
     product_variant_id = product_variant_data["id"]
 
     create_product_variant_channel_listing(
-        e2e_staff_api_client,
-        product_variant_id,
-        result_channel_id,
+        e2e_staff_api_client, product_variant_id, result_channel_id, price=10
     )
 
     create_digital_content(e2e_staff_api_client, product_variant_id)

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
@@ -41,15 +41,18 @@ def test_process_checkout_with_physical_product_CORE_0102(
         shipping_method_id,
     ) = prepare_shop(e2e_staff_api_client)
 
-    product_variant_id = prepare_product(
+    variant_price = 10
+
+    _, result_product_variant_id, _ = prepare_product(
         e2e_staff_api_client,
         warehouse_id,
         channel_id,
+        variant_price,
     )
 
     # Step 1 - Create checkout.
     lines = [
-        {"variantId": product_variant_id, "quantity": 1},
+        {"variantId": result_product_variant_id, "quantity": 1},
     ]
     checkout_data = checkout_create(
         e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_buy_product_without_shipping_option.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_buy_product_without_shipping_option.py
@@ -69,11 +69,18 @@ def test_unlogged_customer_unable_to_buy_product_without_shipping_option_CORE_01
         permission_manage_product_types_and_attributes,
         permission_manage_shipping,
     )
-    product_variant_id = prepare_product(e2e_staff_api_client, warehouse_id, channel_id)
+    variant_price = 10
+
+    _, result_product_variant_id, _ = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
 
     # Step 1 - Create checkout with no shipping method
     lines = [
-        {"variantId": product_variant_id, "quantity": 1},
+        {"variantId": result_product_variant_id, "quantity": 1},
     ]
     checkout_data = checkout_create(
         e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_order_product_quantity_greater_than_stock.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_order_product_quantity_greater_than_stock.py
@@ -73,6 +73,7 @@ def prepare_product(
         e2e_staff_api_client,
         product_variant_id,
         result_channel_id,
+        price=10,
     )
 
     return product_variant_id, product_variant_name, result_channel_slug, stock_quantity

--- a/saleor/tests/e2e/product/utils/preparing_product.py
+++ b/saleor/tests/e2e/product/utils/preparing_product.py
@@ -12,6 +12,7 @@ def prepare_product(
     e2e_staff_api_client,
     warehouse_id,
     channel_id,
+    variant_price,
 ):
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -47,9 +48,11 @@ def prepare_product(
     )
     product_variant_id = product_variant_data["id"]
 
-    create_product_variant_channel_listing(
-        e2e_staff_api_client,
-        product_variant_id,
-        channel_id,
+    product_variant_channel_listing_data = create_product_variant_channel_listing(
+        e2e_staff_api_client, product_variant_id, channel_id, variant_price
     )
-    return product_variant_id
+    product_variant_price = product_variant_channel_listing_data["channelListings"][0][
+        "price"
+    ]["amount"]
+
+    return product_id, product_variant_id, product_variant_price

--- a/saleor/tests/e2e/product/utils/product_variant_channel_listing.py
+++ b/saleor/tests/e2e/product/utils/product_variant_channel_listing.py
@@ -31,7 +31,7 @@ def create_product_variant_channel_listing(
     staff_api_client,
     product_variant_id,
     channel_id,
-    price="9.99",
+    price,
 ):
     variables = {
         "productVariantId": product_variant_id,


### PR DESCRIPTION
I want to merge this change because it updates `prepare_product` utils with fields which will be needed for promotions e2e tests.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
