### PR TITLE
Introduce `PUBLIC_URL` environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Other changes
 
 - Fix thumbnail redirects sometimes failing with an unsafe redirect warning - #14023 by @patrys
+- New environment variable `PUBLIC_URL` to define URL on which Saleor is hosted (e.g., https://api.example.com/). Takes precedence over `ENABLE_SSL` and `Shop.domain` for URL generation - #13841 by @przlada
 
 # 3.16.0
 

--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -7,7 +7,6 @@ import requests
 from celery.exceptions import MaxRetriesExceededError
 from celery.utils.log import get_task_logger
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.files import File
 from django.core.files.storage import default_storage
@@ -19,7 +18,7 @@ from .. import schema_version
 from ..app.headers import AppHeaders, DeprecatedAppHeaders
 from ..celeryconf import app
 from ..core.http_client import HTTPClient
-from ..core.utils import build_absolute_uri
+from ..core.utils import build_absolute_uri, get_domain
 from ..permission.enums import get_permission_names
 from ..plugins.manager import PluginsManager
 from ..thumbnail import ICON_MIME_TYPES
@@ -54,7 +53,7 @@ def validate_app_install_response(response: Response):
 
 
 def send_app_token(target_url: str, token: str):
-    domain = Site.objects.get_current().domain
+    domain = get_domain()
     headers = {
         "Content-Type": "application/json",
         # X- headers will be deprecated in Saleor 4.0, proper headers are without X-

--- a/saleor/app/management/commands/create_app.py
+++ b/saleor/app/management/commands/create_app.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, Optional
 
-from django.contrib.sites.models import Site
 from django.core.management import BaseCommand, CommandError
 from django.core.management.base import CommandParser
 from django.urls import reverse
@@ -10,7 +9,7 @@ from requests.exceptions import RequestException
 from .... import schema_version
 from ....app.headers import AppHeaders, DeprecatedAppHeaders
 from ....core.http_client import HTTPClient
-from ....core.utils import build_absolute_uri
+from ....core.utils import build_absolute_uri, get_domain
 from ...models import App
 from .utils import clean_permissions
 
@@ -43,7 +42,7 @@ class Command(BaseCommand):
         )
 
     def send_app_data(self, target_url, data: Dict[str, Any]):
-        domain = Site.objects.get_current().domain
+        domain = get_domain()
         headers = {
             # X- headers will be deprecated in Saleor 4.0, proper headers are without X-
             DeprecatedAppHeaders.DOMAIN: domain,

--- a/saleor/core/jwt_manager.py
+++ b/saleor/core/jwt_manager.py
@@ -8,7 +8,6 @@ from authlib.jose import JsonWebKey
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.color import color_style
 from django.urls import reverse
@@ -16,7 +15,7 @@ from django.utils.module_loading import import_string
 from jwt import api_jws
 from jwt.algorithms import RSAAlgorithm
 
-from .utils import build_absolute_uri
+from .utils import build_absolute_uri, get_domain
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +71,7 @@ class JWTManager(JWTManagerBase):
 
     @classmethod
     def get_domain(cls) -> str:
-        return Site.objects.get_current().domain
+        return get_domain()
 
     @classmethod
     def get_private_key(cls) -> rsa.RSAPrivateKey:

--- a/saleor/core/notification/utils.py
+++ b/saleor/core/notification/utils.py
@@ -1,7 +1,7 @@
 from django.contrib.sites.models import Site
 from django.contrib.staticfiles.storage import staticfiles_storage
 
-from ..utils import build_absolute_uri
+from ..utils import build_absolute_uri, get_domain
 
 LOGO_URL = "images/saleor-logo-sign.png"
 
@@ -9,7 +9,7 @@ LOGO_URL = "images/saleor-logo-sign.png"
 def get_site_context():
     site: Site = Site.objects.get_current()
     site_context = {
-        "domain": site.domain,
+        "domain": get_domain(),
         "site_name": site.name,
         "logo_url": build_absolute_uri(staticfiles_storage.url(LOGO_URL)),
     }

--- a/saleor/core/tests/test_core.py
+++ b/saleor/core/tests/test_core.py
@@ -22,6 +22,8 @@ from ..utils import (
     build_absolute_uri,
     generate_unique_slug,
     get_client_ip,
+    get_domain,
+    is_ssl_enabled,
     prepare_unique_attribute_value_slug,
     random_data,
 )
@@ -223,6 +225,68 @@ def test_build_absolute_uri_with_host(site_settings, settings):
 
     # then
     assert url == f"http://{host}/{location}"
+
+
+@pytest.mark.parametrize(
+    "public_url", ["https://api.example.com", "http://api.example.com"]
+)
+@pytest.mark.parametrize("enable_ssl", [True, False])
+@pytest.mark.parametrize("host", [None, "test.com"])
+def test_build_absolute_uri_with_public_url(
+    public_url, enable_ssl, host, site_settings, settings
+):
+    # given
+    location = "images/close.svg"
+    settings.PUBLIC_URL = public_url
+    settings.ENABLE_SSL = enable_ssl
+    # when
+    url = build_absolute_uri(location, host)
+    # then
+    assert url == f"{public_url}/{location}"
+
+
+def test_build_absolute_uri_with_public_url_and_absolute_location(
+    site_settings, settings
+):
+    # given
+    location = "https://example.com/static/images/image.jpg"
+    settings.PUBLIC_URL = "https://api.example.com"
+    # when
+    url = build_absolute_uri(location)
+    # then
+    assert url == location
+
+
+@pytest.mark.parametrize("enable_ssl", [True, False])
+def test_is_ssl_enabled(enable_ssl, settings):
+    # given
+    settings.ENABLE_SSL = enable_ssl
+    # then
+    assert is_ssl_enabled() == enable_ssl
+
+
+@pytest.mark.parametrize(
+    "public_url, expected",
+    [("https://api.example.com", True), ("http://api.example.com", False)],
+)
+@pytest.mark.parametrize("enable_ssl", [True, False])
+def test_is_ssl_enabled_with_public_url(public_url, expected, enable_ssl, settings):
+    # given
+    settings.PUBLIC_URL = public_url
+    settings.ENABLE_SSL = enable_ssl
+    # then
+    assert is_ssl_enabled() == expected
+
+
+def test_get_domain(site_settings, settings):
+    assert get_domain() == site_settings.site.domain
+
+
+def test_get_domain_with_public_url(site_settings, settings):
+    # given
+    domain = "api.example.com"
+    settings.PUBLIC_URL = f"https://{domain}"
+    assert get_domain() == domain
 
 
 def test_delete_sort_order_with_null_value(menu_item):

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -20,10 +20,10 @@ if TYPE_CHECKING:
     from django.utils.safestring import SafeText
 
 
-def get_domain() -> str:
+def get_domain(domain: Optional[str] = None) -> str:
     if settings.PUBLIC_URL:
         return urlparse(settings.PUBLIC_URL).netloc
-    return Site.objects.get_current().domain
+    return domain or Site.objects.get_current().domain
 
 
 def get_public_url(domain: Optional[str] = None) -> str:

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -20,10 +20,12 @@ if TYPE_CHECKING:
     from django.utils.safestring import SafeText
 
 
-def get_domain(domain: Optional[str] = None) -> str:
+def get_domain(site: Optional[Site] = None) -> str:
     if settings.PUBLIC_URL:
         return urlparse(settings.PUBLIC_URL).netloc
-    return domain or Site.objects.get_current().domain
+    if site is None:
+        site = Site.objects.get_current()
+    return site.domain
 
 
 def get_public_url(domain: Optional[str] = None) -> str:

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -1,6 +1,6 @@
 import socket
 from typing import TYPE_CHECKING, Iterable, Optional, Union
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -20,15 +20,33 @@ if TYPE_CHECKING:
     from django.utils.safestring import SafeText
 
 
+def get_domain() -> str:
+    if settings.PUBLIC_URL:
+        return urlparse(settings.PUBLIC_URL).netloc
+    return Site.objects.get_current().domain
+
+
+def get_public_url(domain: Optional[str] = None) -> str:
+    if settings.PUBLIC_URL:
+        return settings.PUBLIC_URL
+    host = domain or Site.objects.get_current().domain
+    protocol = "https" if settings.ENABLE_SSL else "http"
+    return f"{protocol}://{host}"
+
+
+def is_ssl_enabled() -> bool:
+    if settings.PUBLIC_URL:
+        return urlparse(settings.PUBLIC_URL).scheme.lower() == "https"
+    return settings.ENABLE_SSL
+
+
 def build_absolute_uri(location: str, domain: Optional[str] = None) -> str:
     """Create absolute uri from location.
 
     If provided location is absolute uri by itself, it returns unchanged value,
     otherwise if provided location is relative, absolute uri is built and returned.
     """
-    host = domain or Site.objects.get_current().domain
-    protocol = "https" if settings.ENABLE_SSL else "http"  # type: ignore[misc] # circular import # noqa: E501
-    current_uri = f"{protocol}://{host}"
+    current_uri = get_public_url(domain)
     location = urljoin(current_uri, location)
     return iri_to_uri(location)
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14399,14 +14399,16 @@ type Mutation {
   ): StaffNotificationRecipientDelete @doc(category: "Users")
 
   """
-  Updates site domain of the shop. 
+  Updates site domain of the shop.
+  
+  DEPRECATED: this mutation will be removed in Saleor 4.0. 
   
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   shopDomainUpdate(
     """Fields required to update site."""
     input: SiteDomainInput
-  ): ShopDomainUpdate @doc(category: "Shop")
+  ): ShopDomainUpdate @doc(category: "Shop") @deprecated(reason: "\\n\\nDEPRECATED: this mutation will be removed in Saleor 4.0.")
 
   """
   Updates shop settings. 
@@ -19782,7 +19784,9 @@ type StaffNotificationRecipientDelete @doc(category: "Users") {
 }
 
 """
-Updates site domain of the shop. 
+Updates site domain of the shop.
+
+DEPRECATED: this mutation will be removed in Saleor 4.0. 
 
 Requires one of the following permissions: MANAGE_SETTINGS.
 """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -14401,14 +14401,14 @@ type Mutation {
   """
   Updates site domain of the shop.
   
-  DEPRECATED: this mutation will be removed in Saleor 4.0. 
+  DEPRECATED: this mutation will be removed in Saleor 4.0. Use `PUBLIC_URL` environment variable instead. 
   
   Requires one of the following permissions: MANAGE_SETTINGS.
   """
   shopDomainUpdate(
     """Fields required to update site."""
     input: SiteDomainInput
-  ): ShopDomainUpdate @doc(category: "Shop") @deprecated(reason: "\\n\\nDEPRECATED: this mutation will be removed in Saleor 4.0.")
+  ): ShopDomainUpdate @doc(category: "Shop") @deprecated(reason: "\\n\\nDEPRECATED: this mutation will be removed in Saleor 4.0. Use `PUBLIC_URL` environment variable instead.")
 
   """
   Updates shop settings. 
@@ -19786,7 +19786,7 @@ type StaffNotificationRecipientDelete @doc(category: "Users") {
 """
 Updates site domain of the shop.
 
-DEPRECATED: this mutation will be removed in Saleor 4.0. 
+DEPRECATED: this mutation will be removed in Saleor 4.0. Use `PUBLIC_URL` environment variable instead. 
 
 Requires one of the following permissions: MANAGE_SETTINGS.
 """

--- a/saleor/graphql/shop/mutations/shop_domain_update.py
+++ b/saleor/graphql/shop/mutations/shop_domain_update.py
@@ -2,6 +2,7 @@ import graphene
 
 from ....permission.enums import SitePermissions
 from ...core import ResolveInfo
+from ...core.descriptions import DEPRECATED_IN_3X_MUTATION
 from ...core.doc_category import DOC_CATEGORY_SHOP
 from ...core.mutations import BaseMutation
 from ...core.types import ShopError
@@ -24,7 +25,7 @@ class ShopDomainUpdate(BaseMutation):
         input = SiteDomainInput(description="Fields required to update site.")
 
     class Meta:
-        description = "Updates site domain of the shop."
+        description = "Updates site domain of the shop." + DEPRECATED_IN_3X_MUTATION
         doc_category = DOC_CATEGORY_SHOP
         permissions = (SitePermissions.MANAGE_SETTINGS,)
         error_type_class = ShopError

--- a/saleor/graphql/shop/mutations/shop_domain_update.py
+++ b/saleor/graphql/shop/mutations/shop_domain_update.py
@@ -25,7 +25,11 @@ class ShopDomainUpdate(BaseMutation):
         input = SiteDomainInput(description="Fields required to update site.")
 
     class Meta:
-        description = "Updates site domain of the shop." + DEPRECATED_IN_3X_MUTATION
+        description = (
+            "Updates site domain of the shop."
+            + DEPRECATED_IN_3X_MUTATION
+            + " Use `PUBLIC_URL` environment variable instead."
+        )
         doc_category = DOC_CATEGORY_SHOP
         permissions = (SitePermissions.MANAGE_SETTINGS,)
         error_type_class = ShopError

--- a/saleor/graphql/shop/schema.py
+++ b/saleor/graphql/shop/schema.py
@@ -82,6 +82,7 @@ class ShopMutations(graphene.ObjectType):
 
     shop_domain_update = ShopDomainUpdate.Field(
         deprecation_reason=DEPRECATED_IN_3X_MUTATION
+        + " Use `PUBLIC_URL` environment variable instead."
     )
     shop_settings_update = ShopSettingsUpdate.Field()
     shop_fetch_tax_rates = ShopFetchTaxRates.Field(

--- a/saleor/graphql/shop/schema.py
+++ b/saleor/graphql/shop/schema.py
@@ -80,7 +80,9 @@ class ShopMutations(graphene.ObjectType):
     staff_notification_recipient_update = StaffNotificationRecipientUpdate.Field()
     staff_notification_recipient_delete = StaffNotificationRecipientDelete.Field()
 
-    shop_domain_update = ShopDomainUpdate.Field()
+    shop_domain_update = ShopDomainUpdate.Field(
+        deprecation_reason=DEPRECATED_IN_3X_MUTATION
+    )
     shop_settings_update = ShopSettingsUpdate.Field()
     shop_fetch_tax_rates = ShopFetchTaxRates.Field(
         deprecation_reason=DEPRECATED_IN_3X_MUTATION

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -428,7 +428,7 @@ class Shop(graphene.ObjectType):
     @load_site_callback
     def resolve_domain(_, _info, site):
         return Domain(
-            host=get_domain(site.domain),
+            host=get_domain(site),
             ssl_enabled=is_ssl_enabled(),
             url=build_absolute_uri("/"),
         )

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -9,7 +9,7 @@ from ... import __version__, schema_version
 from ...account import models as account_models
 from ...channel import models as channel_models
 from ...core.models import ModelWithMetadata
-from ...core.utils import build_absolute_uri
+from ...core.utils import build_absolute_uri, get_domain, is_ssl_enabled
 from ...permission.auth_filters import AuthorizationFilters
 from ...permission.enums import SitePermissions, get_permissions
 from ...site import models as site_models
@@ -428,8 +428,8 @@ class Shop(graphene.ObjectType):
     @load_site_callback
     def resolve_domain(_, _info, site):
         return Domain(
-            host=site.domain,
-            ssl_enabled=settings.ENABLE_SSL,
+            host=get_domain(site.domain),
+            ssl_enabled=is_ssl_enabled(),
             url=build_absolute_uri("/"),
         )
 

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -10,7 +10,7 @@ from promise import Promise
 
 from ...app.models import App
 from ...core.exceptions import PermissionDenied
-from ...settings import get_host
+from ...core.utils import get_domain
 from ..core import SaleorContext
 from ..utils import format_error
 
@@ -35,7 +35,7 @@ def initialize_request(
     request.path = "/graphql/"
     request.path_info = "/graphql/"
     request.method = "GET"
-    request.META = {"SERVER_NAME": SimpleLazyObject(get_host), "SERVER_PORT": "80"}
+    request.META = {"SERVER_NAME": SimpleLazyObject(get_domain), "SERVER_PORT": "80"}
     if settings.ENABLE_SSL:
         request.META["HTTP_X_FORWARDED_PROTO"] = "https"
         request.META["SERVER_PORT"] = "443"

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -1,12 +1,12 @@
 import logging
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
-from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse, HttpResponseNotFound
 from django.http.request import split_domain_port
 
+from ....core.utils import get_domain
 from ....graphql.core.enums import PluginErrorCode
 from ....plugins.base_plugin import BasePlugin, ConfigurationTypeField
 from ... import TransactionKind
@@ -21,6 +21,15 @@ from ...interface import (
 from ...models import Transaction
 from ...utils import price_from_minor_unit, price_to_minor_unit
 from ..utils import get_supported_currencies
+from .consts import (
+    ACTION_REQUIRED_STATUSES,
+    AUTHORIZED_STATUS,
+    PLUGIN_ID,
+    PLUGIN_NAME,
+    PROCESSING_STATUS,
+    SUCCESS_STATUS,
+    WEBHOOK_PATH,
+)
 from .stripe_api import (
     cancel_payment_intent,
     capture_payment_intent,
@@ -39,15 +48,6 @@ from .webhooks import handle_webhook
 if TYPE_CHECKING:
     from ....plugins.models import PluginConfiguration
 
-from .consts import (
-    ACTION_REQUIRED_STATUSES,
-    AUTHORIZED_STATUS,
-    PLUGIN_ID,
-    PLUGIN_NAME,
-    PROCESSING_STATUS,
-    SUCCESS_STATUS,
-    WEBHOOK_PATH,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -509,7 +509,7 @@ class StripeGatewayPlugin(BasePlugin):
 
         # check saved domain. Make sure that it is not localhost domain. We are not able
         # to subscribe to stripe webhooks with localhost.
-        domain = Site.objects.get_current().domain
+        domain = get_domain()
         localhost_domains = ["localhost", "127.0.0.1"]
         domain, _ = split_domain_port(domain)
         if not domain:

--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -5,13 +5,12 @@ from typing import Dict, List, Optional, Tuple
 from urllib.parse import urljoin
 
 import stripe
-from django.contrib.sites.models import Site
 from django.urls import reverse
 from stripe.error import AuthenticationError, InvalidRequestError, StripeError
 from stripe.stripe_object import StripeObject
 
 from ....core.tracing import opentracing_trace
-from ....core.utils import build_absolute_uri
+from ....core.utils import build_absolute_uri, get_domain
 from ...interface import PaymentMethodInfo
 from ...utils import price_to_minor_unit
 from .consts import (
@@ -60,7 +59,7 @@ def _extra_log_data(error: StripeError, payment_intent_id: Optional[str] = None)
 
 
 def subscribe_webhook(api_key: str, channel_slug: str) -> Optional[StripeObject]:
-    domain = Site.objects.get_current().domain
+    domain = get_domain()
     api_path = reverse(
         "plugins-per-channel",
         kwargs={"plugin_id": PLUGIN_ID, "channel_slug": channel_slug},

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -416,17 +416,6 @@ DEFAULT_MAX_EMAIL_DISPLAY_NAME_LENGTH = 78
 
 COUNTRIES_OVERRIDE = {"EU": "European Union"}
 
-
-def get_host():
-    from django.contrib.sites.models import Site
-
-    return Site.objects.get_current().domain
-
-
-PAYMENT_HOST = get_host
-
-PAYMENT_MODEL = "order.Payment"
-
 MAX_USER_ADDRESSES = int(os.environ.get("MAX_USER_ADDRESSES", 100))
 
 TEST_RUNNER = "saleor.tests.runner.PytestTestRunner"

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -5,6 +5,7 @@ import os.path
 import warnings
 from datetime import timedelta
 from typing import List
+from urllib.parse import urlparse
 
 import dj_database_url
 import dj_email_url
@@ -137,6 +138,14 @@ EMAIL_USE_TLS: bool = email_config.get("EMAIL_USE_TLS", False)
 EMAIL_USE_SSL: bool = email_config.get("EMAIL_USE_SSL", False)
 
 ENABLE_SSL = get_bool_from_env("ENABLE_SSL", False)
+
+# URL on which Saleor is hosted (e.g., https://api.example.com/). This has precedence
+# over ENABLE_SSL and Shop.domain when generating URLs pointing to itself.
+PUBLIC_URL = os.environ.get("PUBLIC_URL")
+if PUBLIC_URL:
+    if os.environ.get("ENABLE_SSL") is not None:
+        warnings.warn("ENABLE_SSL is ignored on URL generation if PUBLIC_URL is set.")
+    ENABLE_SSL = urlparse(PUBLIC_URL).scheme.lower() == "https"
 
 if ENABLE_SSL:
     SECURE_SSL_REDIRECT = not DEBUG

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -4,7 +4,7 @@ import os
 import os.path
 import warnings
 from datetime import timedelta
-from typing import List
+from typing import List, Optional
 from urllib.parse import urlparse
 
 import dj_database_url
@@ -137,11 +137,11 @@ EMAIL_BACKEND: str = email_config.get("EMAIL_BACKEND", "")
 EMAIL_USE_TLS: bool = email_config.get("EMAIL_USE_TLS", False)
 EMAIL_USE_SSL: bool = email_config.get("EMAIL_USE_SSL", False)
 
-ENABLE_SSL = get_bool_from_env("ENABLE_SSL", False)
+ENABLE_SSL: bool = get_bool_from_env("ENABLE_SSL", False)
 
 # URL on which Saleor is hosted (e.g., https://api.example.com/). This has precedence
 # over ENABLE_SSL and Shop.domain when generating URLs pointing to itself.
-PUBLIC_URL = os.environ.get("PUBLIC_URL")
+PUBLIC_URL: Optional[str] = os.environ.get("PUBLIC_URL")
 if PUBLIC_URL:
     if os.environ.get("ENABLE_SSL") is not None:
         warnings.warn("ENABLE_SSL is ignored on URL generation if PUBLIC_URL is set.")

--- a/saleor/webhook/observability/utils.py
+++ b/saleor/webhook/observability/utils.py
@@ -9,12 +9,12 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional
 
 from asgiref.local import Local
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.utils import timezone
 from graphql import GraphQLDocument
 from pytimeparse import parse
 
+from ...core.utils import get_domain
 from ..event_types import WebhookEventAsyncType
 from ..utils import get_webhooks_for_event
 from .buffers import get_buffer
@@ -66,7 +66,7 @@ def get_webhooks(timeout=CACHE_TIMEOUT) -> List[WebhookData]:
         if webhooks_data is None:
             webhooks_data = []
             if webhooks := get_webhooks_for_event(WebhookEventAsyncType.OBSERVABILITY):
-                domain = Site.objects.get_current().domain
+                domain = get_domain()
                 for webhook in webhooks:
                     webhooks_data.append(
                         WebhookData(

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -6,12 +6,12 @@ from urllib.parse import urlparse
 from celery import group
 from celery.utils.log import get_task_logger
 from django.conf import settings
-from django.contrib.sites.models import Site
 
 from ....celeryconf import app
 from ....core import EventDeliveryStatus
 from ....core.models import EventDelivery, EventPayload
 from ....core.tracing import webhooks_opentracing_trace
+from ....core.utils import get_domain
 from ....graphql.webhook.subscription_payload import (
     generate_payload_from_subscription,
     initialize_request,
@@ -181,7 +181,7 @@ def send_webhook_request_async(self, event_delivery_id):
         return None
 
     webhook = delivery.webhook
-    domain = Site.objects.get_current().domain
+    domain = get_domain()
     attempt = create_attempt(delivery, self.request.id)
     delivery_status = EventDeliveryStatus.SUCCESS
     try:

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -6,13 +6,13 @@ from urllib.parse import urlparse
 
 from celery.utils.log import get_task_logger
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.core.cache import cache
 
 from ....celeryconf import app
 from ....core import EventDeliveryStatus
 from ....core.models import EventDelivery, EventPayload
 from ....core.tracing import webhooks_opentracing_trace
+from ....core.utils import get_domain
 from ....graphql.webhook.subscription_payload import (
     generate_payload_from_subscription,
     initialize_request,
@@ -90,7 +90,7 @@ def _send_webhook_request_sync(
     data = event_payload.payload
     webhook = delivery.webhook
     parts = urlparse(webhook.target_url)
-    domain = Site.objects.get_current().domain
+    domain = get_domain()
     message = data.encode("utf-8")
     signature = signature_for_payload(message, webhook.secret_key)
 


### PR DESCRIPTION
I want to merge this change because it enables Saleor to generate accurate URLs referencing its own service. The `PUBLIC_URL` setting has been introduced for this purpose. When used, specify a value consisting of the 'base url', such as `https://api.example.com`. Notably, when set, this setting takes precedence over the `ENABLE_SSL` setting and the `shopDomainUpdate` mutation, and makes it easier to use and less error-prone.


Resolves: #12748
Docs: https://github.com/saleor/saleor-docs/pull/927

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
