### PR TITLE
[TEST] refactor promotion e2e tests using new utils

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/checkout/test_checkout_products_on_fixed_promotion.py
@@ -1,22 +1,9 @@
 import pytest
 
-from ..channel.utils import create_channel
-from ..product.utils import (
-    create_category,
-    create_product,
-    create_product_channel_listing,
-    create_product_type,
-    create_product_variant,
-    create_product_variant_channel_listing,
-)
+from ..product.utils.preparing_product import prepare_product
 from ..promotions.utils import create_promotion, create_promotion_rule
-from ..shipping_zone.utils import (
-    create_shipping_method,
-    create_shipping_method_channel_listing,
-    create_shipping_zone,
-)
+from ..shop.utils.preparing_shop import prepare_shop
 from ..utils import assign_permissions
-from ..warehouse.utils import create_warehouse, update_warehouse
 from .utils import (
     checkout_complete,
     checkout_create,
@@ -25,20 +12,18 @@ from .utils import (
 )
 
 
-def prepare_product(
+@pytest.mark.e2e
+def test_checkout_products_on_fixed_promotion_core_2102(
+    e2e_not_logged_api_client,
     e2e_staff_api_client,
     permission_manage_products,
     permission_manage_channels,
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    channel_slug,
-    variant_price,
-    promotion_name,
-    discount_value,
-    discount_type,
-    promotion_rule_name,
 ):
+    # Before
+
     permissions = [
         permission_manage_products,
         permission_manage_channels,
@@ -48,74 +33,25 @@ def prepare_product(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-    update_warehouse(
-        e2e_staff_api_client,
-        warehouse_data["id"],
-        is_private=False,
-    )
-    warehouse_ids = [warehouse_id]
-
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        warehouse_ids,
-        slug=channel_slug,
-    )
-    channel_id = channel_data["id"]
-    channel_ids = [channel_id]
-
-    shipping_zone_data = create_shipping_zone(
-        e2e_staff_api_client,
-        warehouse_ids=warehouse_ids,
-        channel_ids=channel_ids,
-    )
-    shipping_zone_id = shipping_zone_data["id"]
-
-    shipping_method_data = create_shipping_method(
-        e2e_staff_api_client, shipping_zone_id
-    )
-    shipping_method_id = shipping_method_data["id"]
-
-    create_shipping_method_channel_listing(
-        e2e_staff_api_client, shipping_method_id, channel_id
-    )
-
-    product_type_data = create_product_type(
-        e2e_staff_api_client,
-    )
-    product_type_id = product_type_data["id"]
-
-    category_data = create_category(
-        e2e_staff_api_client,
-    )
-    category_id = category_data["id"]
-
-    product_data = create_product(
-        e2e_staff_api_client,
-        product_type_id,
-        category_id,
-    )
-    product_id = product_data["id"]
-    create_product_channel_listing(e2e_staff_api_client, product_id, channel_id)
-
-    stocks = [
-        {
-            "warehouse": warehouse_data["id"],
-            "quantity": 5,
-        }
-    ]
-    variant_data = create_product_variant(
-        e2e_staff_api_client, product_id, stocks=stocks
-    )
-    product_variant_id = variant_data["id"]
-
-    create_product_variant_channel_listing(
-        e2e_staff_api_client,
-        product_variant_id,
+    (
+        warehouse_id,
         channel_id,
-        variant_price,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    (
+        product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=20
     )
+
+    promotion_name = "Promotion Fixed"
+    discount_value = 5
+    discount_type = "FIXED"
+    promotion_rule_name = "rule for product"
 
     promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
     promotion_id = promotion_data["id"]
@@ -135,42 +71,6 @@ def prepare_product(
     assert promotion_rule["channels"][0]["id"] == channel_id
     assert product_predicate[0] == product_id
 
-    return product_variant_id
-
-
-@pytest.mark.e2e
-def test_checkout_products_on_fixed_promotion_core_2102(
-    e2e_not_logged_api_client,
-    e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_product_types_and_attributes,
-    permission_manage_discounts,
-):
-    # Before
-    channel_slug = "test-channel"
-    variant_price = "20"
-    promotion_name = "Promotion Fixed"
-    discount_value = 5
-    discount_type = "FIXED"
-    promotion_rule_name = "rule for product"
-
-    product_variant_id = prepare_product(
-        e2e_staff_api_client,
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_product_types_and_attributes,
-        permission_manage_discounts,
-        channel_slug,
-        variant_price,
-        promotion_name,
-        discount_value,
-        discount_type,
-        promotion_rule_name,
-    )
-
     # Step 1 - checkoutCreate for product on promotion
     lines = [
         {"variantId": product_variant_id, "quantity": 2},
@@ -186,11 +86,13 @@ def test_checkout_products_on_fixed_promotion_core_2102(
     checkout_id = checkout_data["id"]
     checkout_lines = checkout_data["lines"][0]
     shipping_method_id = checkout_data["shippingMethods"][0]["id"]
-    unit_price = float(variant_price) - discount_value
+    unit_price = float(product_variant_price) - discount_value
 
     assert checkout_data["isShippingRequired"] is True
     assert checkout_lines["unitPrice"]["gross"]["amount"] == unit_price
-    assert checkout_lines["undiscountedUnitPrice"]["amount"] == float(variant_price)
+    assert checkout_lines["undiscountedUnitPrice"]["amount"] == float(
+        product_variant_price
+    )
 
     # Step 2 - Set DeliveryMethod for checkout.
     checkout_data = checkout_delivery_method_update(
@@ -215,7 +117,7 @@ def test_checkout_products_on_fixed_promotion_core_2102(
     assert order_data["total"]["gross"]["amount"] == total_gross_amount
     assert order_data["subtotal"]["gross"]["amount"] == subtotal_gross_amount
     assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(
-        variant_price
+        product_variant_price
     )
     assert order_line["unitDiscountType"] == discount_type
     assert order_line["unitPrice"]["gross"]["amount"] == unit_price

--- a/saleor/tests/e2e/checkout/test_checkout_products_on_percentage_promotion.py
+++ b/saleor/tests/e2e/checkout/test_checkout_products_on_percentage_promotion.py
@@ -1,22 +1,9 @@
 import pytest
 
-from ..channel.utils import create_channel
-from ..product.utils import (
-    create_category,
-    create_product,
-    create_product_channel_listing,
-    create_product_type,
-    create_product_variant,
-    create_product_variant_channel_listing,
-)
+from ..product.utils.preparing_product import prepare_product
 from ..promotions.utils import create_promotion, create_promotion_rule
-from ..shipping_zone.utils import (
-    create_shipping_method,
-    create_shipping_method_channel_listing,
-    create_shipping_zone,
-)
+from ..shop.utils.preparing_shop import prepare_shop
 from ..utils import assign_permissions
-from ..warehouse.utils import create_warehouse, update_warehouse
 from .utils import (
     checkout_complete,
     checkout_create,
@@ -25,20 +12,18 @@ from .utils import (
 )
 
 
-def prepare_product(
+@pytest.mark.e2e
+def test_checkout_products_on_percentage_promotion_core_2104(
+    e2e_logged_api_client,
     e2e_staff_api_client,
     permission_manage_products,
     permission_manage_channels,
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    channel_slug,
-    variant_price,
-    promotion_name,
-    discount_value,
-    discount_type,
-    promotion_rule_name,
 ):
+    # Before
+
     permissions = [
         permission_manage_products,
         permission_manage_channels,
@@ -48,74 +33,25 @@ def prepare_product(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-    update_warehouse(
-        e2e_staff_api_client,
-        warehouse_data["id"],
-        is_private=False,
-    )
-    warehouse_ids = [warehouse_id]
-
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        warehouse_ids,
-        slug=channel_slug,
-    )
-    channel_id = channel_data["id"]
-    channel_ids = [channel_id]
-
-    shipping_zone_data = create_shipping_zone(
-        e2e_staff_api_client,
-        warehouse_ids=warehouse_ids,
-        channel_ids=channel_ids,
-    )
-    shipping_zone_id = shipping_zone_data["id"]
-
-    shipping_method_data = create_shipping_method(
-        e2e_staff_api_client, shipping_zone_id
-    )
-    shipping_method_id = shipping_method_data["id"]
-
-    create_shipping_method_channel_listing(
-        e2e_staff_api_client, shipping_method_id, channel_id
-    )
-
-    product_type_data = create_product_type(
-        e2e_staff_api_client,
-    )
-    product_type_id = product_type_data["id"]
-
-    category_data = create_category(
-        e2e_staff_api_client,
-    )
-    category_id = category_data["id"]
-
-    product_data = create_product(
-        e2e_staff_api_client,
-        product_type_id,
-        category_id,
-    )
-    product_id = product_data["id"]
-    create_product_channel_listing(e2e_staff_api_client, product_id, channel_id)
-
-    stocks = [
-        {
-            "warehouse": warehouse_data["id"],
-            "quantity": 5,
-        }
-    ]
-    variant_data = create_product_variant(
-        e2e_staff_api_client, product_id, stocks=stocks
-    )
-    product_variant_id = variant_data["id"]
-
-    create_product_variant_channel_listing(
-        e2e_staff_api_client,
-        product_variant_id,
+    (
+        warehouse_id,
         channel_id,
-        variant_price,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    (
+        product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=19.89
     )
+
+    promotion_name = "Promotion PERCENTAGE"
+    discount_value = 3
+    discount_type = "PERCENTAGE"
+    promotion_rule_name = "rule for product"
 
     promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
     promotion_id = promotion_data["id"]
@@ -135,42 +71,6 @@ def prepare_product(
     assert promotion_rule["channels"][0]["id"] == channel_id
     assert product_predicate[0] == product_id
 
-    return product_variant_id
-
-
-@pytest.mark.e2e
-def test_checkout_products_on_percentage_promotion_core_2104(
-    e2e_logged_api_client,
-    e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_product_types_and_attributes,
-    permission_manage_discounts,
-):
-    # Before
-    channel_slug = "test-channel"
-    variant_price = "19.89"
-    promotion_name = "Promotion PERCENTAGE"
-    discount_value = 3
-    discount_type = "PERCENTAGE"
-    promotion_rule_name = "rule for product"
-
-    product_variant_id = prepare_product(
-        e2e_staff_api_client,
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_product_types_and_attributes,
-        permission_manage_discounts,
-        channel_slug,
-        variant_price,
-        promotion_name,
-        discount_value,
-        discount_type,
-        promotion_rule_name,
-    )
-
     # Step 1 - checkoutCreate for product on promotion
     lines = [
         {"variantId": product_variant_id, "quantity": 2},
@@ -186,12 +86,14 @@ def test_checkout_products_on_percentage_promotion_core_2104(
     checkout_id = checkout_data["id"]
     checkout_lines = checkout_data["lines"][0]
     shipping_method_id = checkout_data["shippingMethods"][0]["id"]
-    line_discount = round(float(variant_price) * discount_value / 100, 2)
-    unit_price = float(variant_price) - line_discount
+    line_discount = round(float(product_variant_price) * discount_value / 100, 2)
+    unit_price = float(product_variant_price) - line_discount
 
     assert checkout_data["isShippingRequired"] is True
     assert checkout_lines["unitPrice"]["gross"]["amount"] == unit_price
-    assert checkout_lines["undiscountedUnitPrice"]["amount"] == float(variant_price)
+    assert checkout_lines["undiscountedUnitPrice"]["amount"] == float(
+        product_variant_price
+    )
 
     # Step 2 - Set DeliveryMethod for checkout.
     checkout_data = checkout_delivery_method_update(
@@ -214,7 +116,7 @@ def test_checkout_products_on_percentage_promotion_core_2104(
     assert order_data["status"] == "UNFULFILLED"
     assert order_data["total"]["gross"]["amount"] == total_gross_amount
     assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(
-        variant_price
+        product_variant_price
     )
     assert order_line["unitDiscountType"] == "FIXED"
     assert order_line["unitPrice"]["gross"]["amount"] == unit_price

--- a/saleor/tests/e2e/orders/test_order_product_with_percentage_promotion.py
+++ b/saleor/tests/e2e/orders/test_order_product_with_percentage_promotion.py
@@ -1,23 +1,10 @@
 import pytest
 
 from .. import DEFAULT_ADDRESS
-from ..channel.utils import create_channel
-from ..product.utils import (
-    create_category,
-    create_product,
-    create_product_channel_listing,
-    create_product_type,
-    create_product_variant,
-    create_product_variant_channel_listing,
-)
+from ..product.utils.preparing_product import prepare_product
 from ..promotions.utils import create_promotion, create_promotion_rule
-from ..shipping_zone.utils import (
-    create_shipping_method,
-    create_shipping_method_channel_listing,
-    create_shipping_zone,
-)
+from ..shop.utils.preparing_shop import prepare_shop
 from ..utils import assign_permissions
-from ..warehouse.utils import create_warehouse, update_warehouse
 from .utils import (
     draft_order_complete,
     draft_order_create,
@@ -26,7 +13,8 @@ from .utils import (
 )
 
 
-def prepare_product(
+@pytest.mark.e2e
+def test_order_products_on_percentage_promotion_CORE_2103(
     e2e_staff_api_client,
     permission_manage_products,
     permission_manage_channels,
@@ -34,12 +22,6 @@ def prepare_product(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    channel_slug,
-    variant_price,
-    promotion_name,
-    discount_value,
-    discount_type,
-    promotion_rule_name,
 ):
     permissions = [
         permission_manage_products,
@@ -51,74 +33,25 @@ def prepare_product(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-    update_warehouse(
-        e2e_staff_api_client,
-        warehouse_data["id"],
-        is_private=False,
-    )
-    warehouse_ids = [warehouse_id]
+    (
+        result_warehouse_id,
+        result_channel_id,
+        _,
+        result_shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
 
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        warehouse_ids,
-        slug=channel_slug,
-    )
-    channel_id = channel_data["id"]
-    channel_ids = [channel_id]
-
-    shipping_zone_data = create_shipping_zone(
-        e2e_staff_api_client,
-        warehouse_ids=warehouse_ids,
-        channel_ids=channel_ids,
-    )
-    shipping_zone_id = shipping_zone_data["id"]
-
-    shipping_method_data = create_shipping_method(
-        e2e_staff_api_client, shipping_zone_id
-    )
-    shipping_method_id = shipping_method_data["id"]
-
-    create_shipping_method_channel_listing(
-        e2e_staff_api_client, shipping_method_id, channel_id
-    )
-
-    product_type_data = create_product_type(
-        e2e_staff_api_client,
-    )
-    product_type_id = product_type_data["id"]
-
-    category_data = create_category(
-        e2e_staff_api_client,
-    )
-    category_id = category_data["id"]
-
-    product_data = create_product(
-        e2e_staff_api_client,
-        product_type_id,
-        category_id,
-    )
-    product_id = product_data["id"]
-    create_product_channel_listing(e2e_staff_api_client, product_id, channel_id)
-
-    stocks = [
-        {
-            "warehouse": warehouse_data["id"],
-            "quantity": 5,
-        }
-    ]
-    variant_data = create_product_variant(
-        e2e_staff_api_client, product_id, stocks=stocks
-    )
-    product_variant_id = variant_data["id"]
-
-    create_product_variant_channel_listing(
-        e2e_staff_api_client,
+    (
+        product_id,
         product_variant_id,
-        channel_id,
-        variant_price,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, result_warehouse_id, result_channel_id, variant_price=20
     )
+
+    promotion_name = "Promotion Fixed"
+    discount_value = 10
+    discount_type = "PERCENTAGE"
+    promotion_rule_name = "rule for product"
 
     promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
     promotion_id = promotion_data["id"]
@@ -132,59 +65,18 @@ def prepare_product(
         discount_type,
         discount_value,
         promotion_rule_name,
-        channel_id,
+        result_channel_id,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
-    assert promotion_rule["channels"][0]["id"] == channel_id
+    assert promotion_rule["channels"][0]["id"] == result_channel_id
     assert product_predicate[0] == product_id
-
-    return channel_id, product_variant_id, shipping_method_id
-
-
-@pytest.mark.e2e
-def test_order_products_on_percentage_promotion_CORE_2103(
-    e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_product_types_and_attributes,
-    permission_manage_discounts,
-    permission_manage_orders,
-):
-    # Before
-    channel_slug = "test-channel"
-    variant_price = "20"
-    promotion_name = "Promotion Fixed"
-    discount_value = 10
-    discount_type = "PERCENTAGE"
-    promotion_rule_name = "rule for product"
-
-    (
-        channel_id,
-        product_variant_id,
-        shipping_method_id,
-    ) = prepare_product(
-        e2e_staff_api_client,
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_product_types_and_attributes,
-        permission_manage_discounts,
-        permission_manage_orders,
-        channel_slug,
-        variant_price,
-        promotion_name,
-        discount_value,
-        discount_type,
-        promotion_rule_name,
-    )
 
     # Step 1 - Create a draft order for a product with fixed promotion
     input = {
-        "channelId": channel_id,
+        "channelId": result_channel_id,
         "billingAddress": DEFAULT_ADDRESS,
         "shippingAddress": DEFAULT_ADDRESS,
-        "shippingMethod": shipping_method_id,
+        "shippingMethod": result_shipping_method_id,
     }
     data = draft_order_create(e2e_staff_api_client, input)
     order_id = data["order"]["id"]
@@ -197,13 +89,13 @@ def test_order_products_on_percentage_promotion_CORE_2103(
     lines = [{"variantId": product_variant_id, "quantity": quantity}]
     order_lines = order_lines_create(e2e_staff_api_client, order_id, lines)
     order_product_variant_id = order_lines["order"]["lines"][0]["variant"]["id"]
-    discount = round(float(variant_price) * discount_value / 100, 2)
+    discount = round(float(product_variant_price) * discount_value / 100, 2)
     assert order_product_variant_id == product_variant_id
-    unit_price = float(variant_price) - discount
+    unit_price = float(product_variant_price) - discount
     undiscounted_price = order_lines["order"]["lines"][0]["undiscountedUnitPrice"][
         "gross"
     ]["amount"]
-    assert undiscounted_price == float(variant_price)
+    assert undiscounted_price == float(product_variant_price)
     assert (
         order_lines["order"]["lines"][0]["unitPrice"]["gross"]["amount"] == unit_price
     )
@@ -214,7 +106,7 @@ def test_order_products_on_percentage_promotion_CORE_2103(
     )
 
     # Step 3 - Add a shipping method to the order
-    input = {"shippingMethod": shipping_method_id}
+    input = {"shippingMethod": result_shipping_method_id}
     draft_update = draft_order_update(e2e_staff_api_client, order_id, input)
     order_shipping_id = draft_update["order"]["deliveryMethod"]["id"]
     shipping_price = draft_update["order"]["shippingPrice"]["gross"]["amount"]
@@ -229,7 +121,7 @@ def test_order_products_on_percentage_promotion_CORE_2103(
     order_line = order["order"]["lines"][0]
     assert order_line["productVariantId"] == product_variant_id
     product_price = order_line["undiscountedUnitPrice"]["gross"]["amount"]
-    assert product_price == float(variant_price)
+    assert product_price == float(product_variant_price)
     assert discount == order_line["unitDiscount"]["amount"]
     assert order_line["unitDiscountType"] == "FIXED"
     assert order_line["unitDiscountValue"] == discount

--- a/saleor/tests/e2e/orders/test_order_products_from_the_same_category_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/test_order_products_from_the_same_category_on_fixed_promotion.py
@@ -42,16 +42,6 @@ def prepare_product(
     discount_type,
     promotion_rule_name,
 ):
-    permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_product_types_and_attributes,
-        permission_manage_discounts,
-        permission_manage_orders,
-    ]
-    assign_permissions(e2e_staff_api_client, permissions)
-
     warehouse_data = create_warehouse(e2e_staff_api_client)
     warehouse_id = warehouse_data["id"]
     update_warehouse(
@@ -188,6 +178,16 @@ def test_order_products_from_category_on_fixed_promotion_CORE_2106(
     permission_manage_orders,
 ):
     # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
     channel_slug = "test-channel"
     variant_price_1 = "20"
     variant_price_2 = "10"

--- a/saleor/tests/e2e/orders/test_order_promotion_not_applied_when_not_within_time_range.py
+++ b/saleor/tests/e2e/orders/test_order_promotion_not_applied_when_not_within_time_range.py
@@ -4,118 +4,12 @@ import pytest
 from dateutil.tz import tzlocal
 
 from .. import DEFAULT_ADDRESS
-from ..channel.utils import create_channel
-from ..product.utils import (
-    create_category,
-    create_product,
-    create_product_channel_listing,
-    create_product_type,
-    create_product_variant,
-    create_product_variant_channel_listing,
-    get_product,
-)
+from ..product.utils import get_product
+from ..product.utils.preparing_product import prepare_product
 from ..promotions.utils import create_promotion, create_promotion_rule
-from ..shipping_zone.utils import (
-    create_shipping_method,
-    create_shipping_method_channel_listing,
-    create_shipping_zone,
-)
+from ..shop.utils.preparing_shop import prepare_shop
 from ..utils import assign_permissions
-from ..warehouse.utils import create_warehouse, update_warehouse
 from .utils import draft_order_create
-
-
-def prepare_product(
-    e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_product_types_and_attributes,
-    permission_manage_discounts,
-    permission_manage_orders,
-    channel_slug,
-    variant_price,
-):
-    permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_product_types_and_attributes,
-        permission_manage_discounts,
-        permission_manage_orders,
-    ]
-    assign_permissions(e2e_staff_api_client, permissions)
-
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-    update_warehouse(
-        e2e_staff_api_client,
-        warehouse_data["id"],
-        is_private=False,
-    )
-    warehouse_ids = [warehouse_id]
-
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        warehouse_ids,
-        slug=channel_slug,
-    )
-    channel_id = channel_data["id"]
-    channel_ids = [channel_id]
-
-    shipping_zone_data = create_shipping_zone(
-        e2e_staff_api_client,
-        warehouse_ids=warehouse_ids,
-        channel_ids=channel_ids,
-    )
-    shipping_zone_id = shipping_zone_data["id"]
-
-    shipping_method_data = create_shipping_method(
-        e2e_staff_api_client, shipping_zone_id
-    )
-    shipping_method_id = shipping_method_data["id"]
-
-    create_shipping_method_channel_listing(
-        e2e_staff_api_client, shipping_method_id, channel_id
-    )
-
-    product_type_data = create_product_type(
-        e2e_staff_api_client,
-    )
-    product_type_id = product_type_data["id"]
-
-    category_data = create_category(
-        e2e_staff_api_client,
-    )
-    category_id = category_data["id"]
-
-    product_data = create_product(
-        e2e_staff_api_client,
-        product_type_id,
-        category_id,
-    )
-    product_id = product_data["id"]
-    create_product_channel_listing(e2e_staff_api_client, product_id, channel_id)
-
-    stocks = [
-        {
-            "warehouse": warehouse_data["id"],
-            "quantity": 5,
-        }
-    ]
-    variant_data = create_product_variant(
-        e2e_staff_api_client, product_id, stocks=stocks
-    )
-    product_variant_id = variant_data["id"]
-
-    create_product_variant_channel_listing(
-        e2e_staff_api_client,
-        product_variant_id,
-        channel_id,
-        variant_price,
-    )
-
-    return channel_id, product_id, product_variant_id, shipping_method_id
 
 
 @pytest.mark.e2e
@@ -129,8 +23,16 @@ def test_order_promotion_not_applied_when_not_within_time_range_CORE_2110(
     permission_manage_orders,
 ):
     # Before
-    channel_slug = "test-channel"
-    variant_price = "20"
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
     promotion_name = "Promotion Fixed"
     discount_value = 5
     discount_type = "FIXED"
@@ -140,20 +42,18 @@ def test_order_promotion_not_applied_when_not_within_time_range_CORE_2110(
     month_after = (datetime.now(tzlocal()) + timedelta(days=30)).isoformat()
 
     (
+        warehouse_id,
         channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    (
         product_id,
         product_variant_id,
-        shipping_method_id,
+        product_variant_price,
     ) = prepare_product(
-        e2e_staff_api_client,
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_product_types_and_attributes,
-        permission_manage_discounts,
-        permission_manage_orders,
-        channel_slug,
-        variant_price,
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=20
     )
 
     # Step 1 - Create promotion lasting for a specific time range


### PR DESCRIPTION
I want to merge this change because it applies refactor changes from main, making use of new utils resulting in more readable tests.

**Please note:** I have not applied all the changes to `test_order_products_from_the_same_category_on_fixed_promotion.py` as it requires additional refactor of utils themself - I plan to do it in the next PR. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
