### PR TITLE
[Test] Staff should be able change promotion rule catalog predicate

### DIFF
--- a/saleor/tests/e2e/product/utils/__init__.py
+++ b/saleor/tests/e2e/product/utils/__init__.py
@@ -1,5 +1,6 @@
 from .category import create_category
 from .collection import create_collection
+from .collection_add_products import add_product_to_collection
 from .collection_listing_update import create_collection_channel_listing
 from .digital_content import create_digital_content
 from .product import create_product
@@ -26,4 +27,5 @@ __all__ = [
     "create_collection",
     "create_collection_channel_listing",
     "get_product",
+    "add_product_to_collection",
 ]

--- a/saleor/tests/e2e/product/utils/collection_add_products.py
+++ b/saleor/tests/e2e/product/utils/collection_add_products.py
@@ -1,0 +1,43 @@
+from ...utils import get_graphql_content
+
+COLLECTION_ADD_PRODUCTS_MUTATION = """
+mutation CollectionAssignProduct($id: ID!, $productIds: [ID!]!) {
+  collectionAddProducts(collectionId: $id, products: $productIds) {
+    errors {
+      code
+      message
+      field
+    }
+    collection {
+      id
+      products(first: 5) {
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def add_product_to_collection(
+    staff_api_client,
+    collection_id,
+    products_ids,
+):
+    variables = {"id": collection_id, "productIds": products_ids}
+
+    response = staff_api_client.post_graphql(
+        COLLECTION_ADD_PRODUCTS_MUTATION,
+        variables,
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["collectionAddProducts"]["collection"]
+    assert content["data"]["collectionAddProducts"]["errors"] == []
+
+    return data

--- a/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
@@ -1,0 +1,173 @@
+import pytest
+
+from ..channel.utils import create_channel
+from ..product.utils import (
+    create_category,
+    create_collection,
+    create_collection_channel_listing,
+    create_product,
+    create_product_channel_listing,
+    create_product_type,
+    create_product_variant,
+    create_product_variant_channel_listing,
+    get_product,
+)
+from ..promotions.utils import (
+    create_promotion,
+    create_promotion_rule,
+    update_promotion_rule,
+)
+from ..utils import assign_permissions
+
+
+def prepare_product(
+    e2e_staff_api_client,
+    channel_slug,
+    variant_price,
+):
+    channel_data = create_channel(
+        e2e_staff_api_client,
+        slug=channel_slug,
+    )
+    channel_id = channel_data["id"]
+
+    product_type_data = create_product_type(
+        e2e_staff_api_client,
+    )
+    product_type_id = product_type_data["id"]
+
+    category_data = create_category(
+        e2e_staff_api_client,
+    )
+    category_id = category_data["id"]
+
+    collection_data = create_collection(e2e_staff_api_client)
+    collection_id = collection_data["id"]
+    collection_list = [collection_id]
+
+    create_collection_channel_listing(e2e_staff_api_client, collection_id, channel_id)
+    product_data = create_product(
+        e2e_staff_api_client,
+        product_type_id,
+        category_id,
+        collection_ids=collection_list,
+    )
+    product_id = product_data["id"]
+    create_product_channel_listing(e2e_staff_api_client, product_id, channel_id)
+
+    variant_data = create_product_variant(
+        e2e_staff_api_client,
+        product_id,
+    )
+    product_variant_id = variant_data["id"]
+
+    create_product_variant_channel_listing(
+        e2e_staff_api_client,
+        product_variant_id,
+        channel_id,
+        variant_price,
+    )
+
+    return product_id, channel_id, collection_id
+
+
+def prepare_promotion(
+    e2e_staff_api_client,
+    discount_value,
+    discount_type,
+    promotion_rule_name="Test rule",
+    collection_ids=None,
+    channel_id=None,
+):
+    promotion_name = "Promotion Test"
+    promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
+    promotion_id = promotion_data["id"]
+
+    predicate_input = {"collectionPredicate": {"ids": collection_ids}}
+    promotion_rule_data = create_promotion_rule(
+        e2e_staff_api_client,
+        promotion_id,
+        predicate_input,
+        discount_type,
+        discount_value,
+        promotion_rule_name,
+        channel_id,
+    )
+    promotion_rule_id = promotion_rule_data["id"]
+    discount_value = promotion_rule_data["rewardValue"]
+
+    return promotion_rule_id, discount_value
+
+
+@pytest.mark.e2e
+def test_create_promotion_for_collection_core_2109(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    channel_slug = "promotion_collections_channel"
+    variant_price = "7.99"
+    product_id, channel_id, collection_id = prepare_product(
+        e2e_staff_api_client,
+        channel_slug,
+        variant_price,
+    )
+
+    promotion_rule_id, discount_value = prepare_promotion(
+        e2e_staff_api_client,
+        30,
+        "PERCENTAGE",
+        collection_ids=[collection_id],
+        channel_id=channel_id,
+    )
+
+    # Step 1 Create new variant and listing channel for it
+    variant_data = create_product_variant(
+        e2e_staff_api_client,
+        product_id,
+    )
+    second_product_variant_id = variant_data["id"]
+
+    create_product_variant_channel_listing(
+        e2e_staff_api_client,
+        second_product_variant_id,
+        channel_id,
+        variant_price,
+    )
+
+    # Step 2 Update promotion rule of new variant
+    catalogue_predicate = {
+        "productPredicate": {},
+        "variantPredicate": {"ids": [second_product_variant_id]},
+    }
+    update_promotion_rule(e2e_staff_api_client, promotion_rule_id, catalogue_predicate)
+
+    # Step 3 Check if promotion is applied to new variant
+    product_data = get_product(e2e_staff_api_client, product_id, channel_slug)
+    first_variant = product_data["variants"][0]
+    second_variant = product_data["variants"][1]
+
+    assert product_data["pricing"]["onSale"] is True
+    assert first_variant["pricing"]["onSale"] is False
+    assert second_variant["pricing"]["onSale"] is True
+    calculated_variant_discount = round(
+        float(variant_price) * (discount_value / 100), 2
+    )
+    assert (
+        second_variant["pricing"]["discount"]["gross"]["amount"]
+        == calculated_variant_discount
+    )
+    assert second_variant["pricing"]["priceUndiscounted"]["gross"]["amount"] == float(
+        variant_price
+    )

--- a/saleor/tests/e2e/promotions/utils/__init__.py
+++ b/saleor/tests/e2e/promotions/utils/__init__.py
@@ -1,7 +1,9 @@
 from .promotion_create import create_promotion
 from .promotion_rule_create import create_promotion_rule
+from .promotion_rule_update import update_promotion_rule
 
 __all__ = [
     "create_promotion",
     "create_promotion_rule",
+    "update_promotion_rule",
 ]

--- a/saleor/tests/e2e/promotions/utils/promotion_rule_update.py
+++ b/saleor/tests/e2e/promotions/utils/promotion_rule_update.py
@@ -1,0 +1,48 @@
+from ...utils import get_graphql_content
+
+PROMOTION_RULE_UPDATE_MUTATION = """
+mutation promotionRuleCreate($id: ID!, $input: PromotionRuleUpdateInput!) {
+  promotionRuleUpdate(id: $id, input: $input) {
+    errors {
+      field
+      message
+      code
+    }
+    promotionRule {
+      id
+      name
+      description
+      rewardValueType
+      rewardValue
+      cataloguePredicate
+      channels {
+        id
+      }
+    }
+  }
+}
+"""
+
+
+def update_promotion_rule(
+    staff_api_client,
+    promotion_id,
+    catalogue_predicate,
+):
+    variables = {
+        "id": promotion_id,
+        "input": {
+            "cataloguePredicate": catalogue_predicate,
+        },
+    }
+
+    response = staff_api_client.post_graphql(
+        PROMOTION_RULE_UPDATE_MUTATION,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["promotionRuleUpdate"]["errors"] == []
+
+    data = content["data"]["promotionRuleUpdate"]["promotionRule"]
+    return data


### PR DESCRIPTION
I want to merge this change because it adds a test for [CORE_2112](https://saleor.testmo.net/repositories/5?group_id=133&case_id=2065)



<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
