### PR TITLE
Fix updating product discounted price update recalculate price for too many products. 

### DIFF
--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -188,7 +188,8 @@ def update_products_discounted_prices_of_catalogues(
         )
         lookup |= Q(Exists(collection_products.filter(product_id=OuterRef("id"))))
     if variant_ids:
-        lookup |= Q(Exists(ProductVariant.objects.filter(product_id=OuterRef("id"))))
+        variants = ProductVariant.objects.filter(id__in=variant_ids)
+        lookup |= Q(Exists(variants.filter(product_id=OuterRef("id"))))
 
     if lookup:
         products = Product.objects.filter(lookup)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2281,7 +2281,7 @@ def category(category_generator):  # pylint: disable=W0613
 @pytest.fixture
 def category_with_image(db, image, media_root):  # pylint: disable=W0613
     return Category.objects.create(
-        name="Default", slug="default", background_image=image
+        name="Default2", slug="default2", background_image=image
     )
 
 


### PR DESCRIPTION
I want to merge this change because fixing updating product discounted price update recalculate price for too many products.

In the current solution, recalculating the minimum product price triggers recalculation for all products with at least one variant, rather than just those variants assigned to a sale

Port https://github.com/saleor/saleor/pull/13853

<!-- Please mention all relevant issue numbers. -->

# Impact

- [x] New migrations
- [x] New/Updated API fields or mutations
- [x] Deprecated API fields or mutations
- [x] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [x] Link to documentation: -

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
