### PR TITLE
Fix updating product discounted price update recalculate price for too many products. 

### DIFF
--- a/saleor/product/tests/test_product_minimal_variant_price.py
+++ b/saleor/product/tests/test_product_minimal_variant_price.py
@@ -98,6 +98,77 @@ def test_update_products_discounted_prices_of_catalogues_for_product(
     assert variant_channel_listing.discounted_price == variant_channel_listing.price
 
 
+@patch("saleor.product.utils.variant_prices.update_products_discounted_prices")
+def test_update_products_discounted_prices_of_catalogues_via_products(
+    mock_update_products_discounted_prices, product, product_list
+):
+    # given
+
+    # when
+    update_products_discounted_prices_of_catalogues(
+        product_ids=[product.pk, product_list[0].pk]
+    )
+
+    # then
+    mock_update_products_discounted_prices.assert_called_once()
+    args, _kwargs = mock_update_products_discounted_prices.call_args
+    assert set(args[0].values_list("pk", flat=True)) == {product.pk, product_list[0].pk}
+
+
+@patch("saleor.product.utils.variant_prices.update_products_discounted_prices")
+def test_update_products_discounted_prices_of_catalogues_via_category(
+    mock_update_products_discounted_prices,
+    product,
+    product_list,
+    category_with_image,
+    category,
+):
+    # given
+    assert category.pk != category_with_image.pk
+    product.category = category_with_image
+    product.save()
+
+    # when
+    update_products_discounted_prices_of_catalogues(category_ids=[category.pk])
+
+    # then
+    mock_update_products_discounted_prices.assert_called_once()
+    args, _kwargs = mock_update_products_discounted_prices.call_args
+    assert set(args[0].values_list("pk", flat=True)) == {p.pk for p in product_list}
+
+
+@patch("saleor.product.utils.variant_prices.update_products_discounted_prices")
+def test_update_products_discounted_prices_of_catalogues_via_collection(
+    mock_update_products_discounted_prices, product, product_list, collection
+):
+    # given
+    collection.products.add(*product_list)
+
+    # when
+    update_products_discounted_prices_of_catalogues(collection_ids=[collection.pk])
+
+    # then
+    mock_update_products_discounted_prices.assert_called_once()
+    args, _kwargs = mock_update_products_discounted_prices.call_args
+    assert set(args[0].values_list("pk", flat=True)) == {p.pk for p in product_list}
+
+
+@patch("saleor.product.utils.variant_prices.update_products_discounted_prices")
+def test_update_products_discounted_prices_of_catalogues_via_variants(
+    mock_update_products_discounted_prices, product, product_list
+):
+    # given
+    variant_ids = [p.variants.first().pk for p in product_list]
+
+    # when
+    update_products_discounted_prices_of_catalogues(variant_ids=variant_ids)
+
+    # then
+    mock_update_products_discounted_prices.assert_called_once()
+    args, _kwargs = mock_update_products_discounted_prices.call_args
+    assert set(args[0].values_list("pk", flat=True)) == {p.pk for p in product_list}
+
+
 def test_update_products_discounted_prices_of_catalogues_for_category(
     category, product, channel_USD
 ):

--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -187,7 +187,8 @@ def update_products_discounted_prices_of_catalogues(
         )
         lookup |= Q(Exists(collection_products.filter(product_id=OuterRef("id"))))
     if variant_ids:
-        lookup |= Q(Exists(ProductVariant.objects.filter(product_id=OuterRef("id"))))
+        variants = ProductVariant.objects.filter(id__in=variant_ids)
+        lookup |= Q(Exists(variants.filter(product_id=OuterRef("id"))))
 
     if lookup:
         products = Product.objects.filter(lookup)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2012,7 +2012,7 @@ def category(db):  # pylint: disable=W0613
 @pytest.fixture
 def category_with_image(db, image, media_root):  # pylint: disable=W0613
     return Category.objects.create(
-        name="Default", slug="default", background_image=image
+        name="Default2", slug="default2", background_image=image
     )
 
 


### PR DESCRIPTION
I want to merge this change because fixing updating product discounted price update recalculate price for too many products.

In the current solution, recalculating the minimum product price triggers recalculation for all products with at least one variant, rather than just those variants assigned to a sale

Port https://github.com/saleor/saleor/pull/13853

<!-- Please mention all relevant issue numbers. -->

# Impact

- [x] New migrations
- [x] New/Updated API fields or mutations
- [x] Deprecated API fields or mutations
- [x] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [x] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
