### PR TITLE
Adjust sale create

### DIFF
--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -437,17 +437,6 @@ class PromotionRule(models.Model):
             )
         raise NotImplementedError("Unknown discount type")
 
-    @staticmethod
-    def get_old_channel_listing_ids(qunatity):
-        with connection.cursor() as cursor:
-            cursor.execute(
-                f"""
-                SELECT nextval('discount_promotionrule_old_channel_listing_id_seq')
-                FROM generate_series(1, {qunatity})
-                """
-            )
-            return cursor.fetchall()
-
 
 class PromotionRuleTranslation(Translation):
     name = models.CharField(max_length=255, null=True, blank=True)

--- a/saleor/discount/sale_converter.py
+++ b/saleor/discount/sale_converter.py
@@ -8,6 +8,7 @@ from .utils import fetch_catalogue_info
 def create_promotion_for_new_sale(sale, catalogue_data=None):
     promotion = create_promotion(sale)
     create_promotion_rule(promotion, sale, catalogue_data)
+    return promotion
 
 
 def create_promotion(sale):

--- a/saleor/discount/sale_converter.py
+++ b/saleor/discount/sale_converter.py
@@ -1,0 +1,66 @@
+from typing import Dict, List
+
+from ..graphql.discount.mutations.utils import convert_catalogue_info_to_global_ids
+from .models import Promotion, PromotionRule
+from .utils import fetch_catalogue_info
+
+
+def create_promotion_for_new_sale(sale, catalogue_data):
+    promotion = create_promotion(sale)
+    create_promotion_rule(promotion, sale, catalogue_data)
+
+
+def create_promotion(sale):
+    return Promotion.objects.create(
+        name=sale.name,
+        old_sale_id=sale.id,
+        start_date=sale.start_date,
+        end_date=sale.end_date,
+        created_at=sale.created_at,
+        updated_at=sale.updated_at,
+        metadata=sale.metadata,
+        private_metadata=sale.private_metadata,
+        last_notification_scheduled_at=sale.notification_sent_datetime,
+    )
+
+
+def create_promotion_rule(
+    promotion,
+    sale,
+    catalogue_data=None,
+    discount_value=None,
+    old_channel_listing_id=None,
+):
+    if catalogue_data is None:
+        catalogue_data = convert_catalogue_info_to_global_ids(
+            fetch_catalogue_info(sale)
+        )
+    catalogue_predicate = create_catalogue_predicate_from_catalogue_data(catalogue_data)
+    return PromotionRule.objects.create(
+        promotion=promotion,
+        catalogue_predicate=catalogue_predicate,
+        reward_value_type=sale.type,
+        reward_value=discount_value,
+        old_channel_listing_id=old_channel_listing_id,
+    )
+
+
+def create_catalogue_predicate_from_catalogue_data(catalogue_data):
+    predicate: Dict[str, List] = {"OR": []}
+    if ids := catalogue_data.get("collections"):
+        predicate["OR"].append({"collectionPredicate": {"ids": list(ids)}})
+    if ids := catalogue_data.get("categories"):
+        predicate["OR"].append({"categoryPredicate": {"ids": list(ids)}})
+    if ids := catalogue_data.get("products"):
+        predicate["OR"].append({"productPredicate": {"ids": list(ids)}})
+    if ids := catalogue_data.get("variants"):
+        predicate["OR"].append({"variantPredicate": {"ids": list(ids)}})
+    if not predicate.get("OR"):
+        predicate = {}
+
+    return predicate
+
+
+def create_catalogue_predicate_from_sale(sale):
+    catalogue_data = convert_catalogue_info_to_global_ids(fetch_catalogue_info(sale))
+    return create_catalogue_predicate_from_catalogue_data(catalogue_data)

--- a/saleor/discount/sale_converter.py
+++ b/saleor/discount/sale_converter.py
@@ -5,7 +5,7 @@ from .models import Promotion, PromotionRule
 from .utils import fetch_catalogue_info
 
 
-def create_promotion_for_new_sale(sale, catalogue_data):
+def create_promotion_for_new_sale(sale, catalogue_data=None):
     promotion = create_promotion(sale)
     create_promotion_rule(promotion, sale, catalogue_data)
 

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -164,8 +164,9 @@ def calculate_discounted_price(
     variant_id: Optional[int] = None,
 ) -> Money:
     """Return minimum product's price of all prices with discounts applied."""
+    sale_id = None
     if discounts:
-        _, price = get_sale_id_with_min_price(
+        sale_id, price = get_sale_id_with_min_price(
             product=product,
             price=price,
             collection_ids=collection_ids,
@@ -173,7 +174,7 @@ def calculate_discounted_price(
             channel=channel,
             variant_id=variant_id,
         )
-    return price
+    return sale_id, price
 
 
 def get_sale_id_applied_as_a_discount(

--- a/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_channel_listing_update.py
@@ -3,12 +3,15 @@ from typing import TYPE_CHECKING, Dict, List
 
 import graphene
 from django.core.exceptions import ValidationError
+from django.db.models import Exists, OuterRef
 
 from .....core.tracing import traced_atomic_transaction
 from .....discount import DiscountValueType
 from .....discount.error_codes import DiscountErrorCode
-from .....discount.models import SaleChannelListing
+from .....discount.models import Promotion, PromotionRule, SaleChannelListing
+from .....discount.sale_converter import create_promotion_for_new_sale
 from .....permission.enums import DiscountPermissions
+from .....product.models import VariantChannelListingPromotionRule
 from .....product.tasks import update_products_discounted_prices_of_sale_task
 from ....channel import ChannelContext
 from ....channel.mutations import BaseChannelListingMutation
@@ -68,18 +71,73 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
         error_type_field = "discount_errors"
 
     @classmethod
-    def add_channels(cls, sale: "SaleModel", add_channels: List[Dict]):
+    def add_channels(cls, sale: "SaleModel", promotion, add_channels: List[Dict]):
+        channelid_rule_map = cls.get_channel_to_rule_id_map(promotion)
+        rules_to_create = []
+        rules_to_update = []
+        examplary_rule: PromotionRule = promotion.rules.first()
+
         for add_channel in add_channels:
             channel = add_channel["channel"]
             defaults = {"currency": channel.currency_code}
             channel = add_channel["channel"]
-            if "discount_value" in add_channel.keys():
-                defaults["discount_value"] = add_channel.get("discount_value")
-            SaleChannelListing.objects.update_or_create(
+            discount_value = add_channel["discount_value"]
+            defaults["discount_value"] = discount_value
+            channel_listing, _ = SaleChannelListing.objects.update_or_create(
                 sale=sale,
                 channel=channel,
                 defaults=defaults,
             )
+            if channel.id not in channelid_rule_map:
+                rules_to_create.append(
+                    (
+                        channel,
+                        PromotionRule(
+                            promotion=promotion,
+                            catalogue_predicate=examplary_rule.catalogue_predicate,
+                            reward_value_type=examplary_rule.reward_value_type,
+                            reward_value=discount_value,
+                            old_channel_listing_id=channel_listing.id,
+                        ),
+                    )
+                )
+            else:
+                rule = channelid_rule_map[channel.id]
+                rule.reward_value = discount_value
+                rules_to_update.append(rule)
+
+        cls.save_promotion_rules(rules_to_create, rules_to_update)
+
+    @classmethod
+    def get_channel_to_rule_id_map(cls, promotion):
+        if not promotion:
+            return {}
+        rules = promotion.rules.all()
+        PromotionRuleChannel = PromotionRule.channels.through
+        rule_channel = PromotionRuleChannel.objects.filter(
+            Exists(rules.filter(id=OuterRef("promotionrule_id")))
+        )
+        rules_in_bulk = rules.in_bulk()
+        return {
+            channel_id: rules_in_bulk[rule_id]
+            for channel_id, rule_id in rule_channel.values_list(
+                "channel_id", "promotionrule_id"
+            )
+        }
+
+    @classmethod
+    def save_promotion_rules(cls, rules_to_create, rules_to_update):
+        new_rules = [rule_data[1] for rule_data in rules_to_create]
+        PromotionRule.objects.bulk_create(new_rules)
+
+        PromotionRuleChannel = PromotionRule.channels.through
+        rules_channels = [
+            PromotionRuleChannel(promotionrule=rule, channel=channel)
+            for channel, rule in rules_to_create
+        ]
+
+        PromotionRuleChannel.objects.bulk_create(rules_channels)
+        PromotionRule.objects.bulk_update(rules_to_update, ["reward_value"])
 
     @classmethod
     def clean_discount_values(
@@ -129,14 +187,47 @@ class SaleChannelListingUpdate(BaseChannelListingMutation):
         return cleaned_channels
 
     @classmethod
-    def remove_channels(cls, sale: "SaleModel", remove_channels: List[int]):
+    def remove_channels(
+        cls,
+        sale: "SaleModel",
+        promotion,
+        remove_channels: List[int],
+    ):
         sale.channel_listings.filter(channel_id__in=remove_channels).delete()
+        cls.remove_promotion_rules(promotion, remove_channels)
+
+    @classmethod
+    def remove_promotion_rules(cls, promotion, remove_channels: List[int]):
+        rules = promotion.rules.all()
+        PromotionRuleChannel = PromotionRule.channels.through
+        rule_channel = PromotionRuleChannel.objects.filter(
+            channel_id__in=remove_channels
+        ).filter(Exists(rules.filter(id=OuterRef("promotionrule_id"))))
+        if not rule_channel:
+            return
+        rules_to_delete_ids = list(
+            rule_channel.values_list("promotionrule_id", flat=True)
+        )
+        # We ensure at least one rule is assigned to promotion in order to
+        # determine old sale's type and catalogue
+        if len(rule_channel) >= len(rules):
+            rule_left_id = rules_to_delete_ids.pop()
+            rule_channel.filter(promotionrule_id=rule_left_id).delete()
+            VariantChannelListingPromotionRule.objects.filter(
+                promotion_rule_id=rule_left_id
+            ).delete()
+        rules.filter(id__in=rules_to_delete_ids).delete()
 
     @classmethod
     def save(cls, info: ResolveInfo, sale: "SaleModel", cleaned_input: Dict):
         with traced_atomic_transaction():
-            cls.add_channels(sale, cleaned_input.get("add_channels", []))
-            cls.remove_channels(sale, cleaned_input.get("remove_channels", []))
+            promotion = Promotion.objects.filter(old_sale_id=sale.pk).first()
+            if not promotion:
+                promotion = create_promotion_for_new_sale(sale)
+            cls.add_channels(sale, promotion, cleaned_input.get("add_channels", []))
+            cls.remove_channels(
+                sale, promotion, cleaned_input.get("remove_channels", [])
+            )
             update_products_discounted_prices_of_sale_task.delay(sale.pk)
 
     @classmethod

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -414,7 +414,7 @@ class ProductVariant(SortableModel, ModelWithMetadata, ModelWithExternalReferenc
             collection_ids=collection_ids,
             channel=channel,
             variant_id=self.id,
-        )
+        )[1]
 
     def get_weight(self):
         return self.weight or self.product.weight or self.product.product_type.weight

--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -163,8 +163,6 @@ def _get_discounted_variants_prices(
             variant_listing.price_amount  # type: ignore
             - variant_listing.discounted_price_amount
         )
-        # TODO: we should also remove the VariantChannelListingPromotionRule
-        # when the discount is not valid anymore
         if discount_amount:
             (
                 rule_listing_to_update,

--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -163,6 +163,8 @@ def _get_discounted_variants_prices(
             variant_listing.price_amount  # type: ignore
             - variant_listing.discounted_price_amount
         )
+        # TODO: we should also remove the VariantChannelListingPromotionRule
+        # when the discount is not valid anymore
         if discount_amount:
             (
                 rule_listing_to_update,

--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -7,7 +7,7 @@ from prices import Money
 
 from ...channel.models import Channel
 from ...discount import DiscountInfo
-from ...discount.models import Sale
+from ...discount.models import Promotion, PromotionRule, Sale
 from ...discount.utils import calculate_discounted_price, fetch_active_discounts
 from ..models import (
     Category,
@@ -16,6 +16,7 @@ from ..models import (
     ProductChannelListing,
     ProductVariant,
     ProductVariantChannelListing,
+    VariantChannelListingPromotionRule,
 )
 
 
@@ -46,6 +47,9 @@ def update_products_discounted_price(products: Iterable[Product], discounts=None
 
     changed_products_listings_to_update = []
     changed_variants_listings_to_update = []
+    changed_rule_listings_to_update: List[VariantChannelListingPromotionRule] = []
+    rule_listings_to_create: List[VariantChannelListingPromotionRule] = []
+
     product_channel_listings = ProductChannelListing.objects.filter(
         Exists(product_qs.filter(id=OuterRef("product_id")))
     ).prefetch_related("product", "channel")
@@ -61,6 +65,8 @@ def update_products_discounted_price(products: Iterable[Product], discounts=None
         (
             discounted_variants_price,
             variant_listings_to_update,
+            listings_promotion_rule_to_update,
+            listings_promotion_rule_to_create,
         ) = _get_discounted_variants_prices(
             variant_listings,
             product_channel_listing.product,
@@ -71,6 +77,8 @@ def update_products_discounted_price(products: Iterable[Product], discounts=None
 
         product_discounted_price = min(discounted_variants_price)
         changed_variants_listings_to_update.extend(variant_listings_to_update)
+        changed_rule_listings_to_update.extend(listings_promotion_rule_to_update)
+        rule_listings_to_create.extend(listings_promotion_rule_to_create)
 
         # check if the product discounted_price has changed
         if product_channel_listing.discounted_price != product_discounted_price:
@@ -87,6 +95,12 @@ def update_products_discounted_price(products: Iterable[Product], discounts=None
         ProductVariantChannelListing.objects.bulk_update(
             changed_variants_listings_to_update, ["discounted_price_amount"]
         )
+    if changed_rule_listings_to_update:
+        VariantChannelListingPromotionRule.objects.bulk_update(
+            changed_rule_listings_to_update, ["discount_amount"]
+        )
+    if rule_listings_to_create:
+        VariantChannelListingPromotionRule.objects.bulk_create(rule_listings_to_create)
 
 
 def _get_product_to_variant_channel_listings_per_channel_map(
@@ -122,11 +136,18 @@ def _get_discounted_variants_prices(
     collection_ids: Set[int],
     discounts: List[DiscountInfo],
     channel: Channel,
-) -> Tuple[Money, List[ProductVariantChannelListing]]:
+) -> Tuple[
+    Money,
+    List[ProductVariantChannelListing],
+    List[VariantChannelListingPromotionRule],
+    List[VariantChannelListingPromotionRule],
+]:
+    listings_promotion_rule_to_update: List[VariantChannelListingPromotionRule] = []
+    listings_promotion_rule_to_create: List[VariantChannelListingPromotionRule] = []
     variants_listings_to_update: List[ProductVariantChannelListing] = []
     discounted_variants_price: List[Money] = []
     for variant_listing in variant_listings:
-        discounted_variant_price = calculate_discounted_price(
+        sale_id, discounted_variant_price = calculate_discounted_price(
             product=product,
             price=variant_listing.price,
             collection_ids=collection_ids,
@@ -135,11 +156,75 @@ def _get_discounted_variants_prices(
             variant_id=variant_listing.variant_id,
         )
         if variant_listing.discounted_price != discounted_variant_price:
-            # TODO: we should create here `VariantChannelListingPromotionRule`
             variant_listing.discounted_price_amount = discounted_variant_price.amount
             variants_listings_to_update.append(variant_listing)
         discounted_variants_price.append(discounted_variant_price)
-    return discounted_variants_price, variants_listings_to_update
+        discount_amount = (
+            variant_listing.price_amount  # type: ignore
+            - variant_listing.discounted_price_amount
+        )
+        if discount_amount:
+            (
+                rule_listing_to_update,
+                rule_listing_to_create,
+            ) = variant_listing_promotion_rule_update(
+                sale_id, variant_listing, discount_amount
+            )
+            if rule_listing_to_update:
+                listings_promotion_rule_to_update.append(rule_listing_to_update)
+            if rule_listing_to_create:
+                listings_promotion_rule_to_create.append(rule_listing_to_create)
+    return (
+        discounted_variants_price,
+        variants_listings_to_update,
+        listings_promotion_rule_to_update,
+        listings_promotion_rule_to_create,
+    )
+
+
+def variant_listing_promotion_rule_update(sale_id, variant_listing, discount_amount):
+    """Update or create VariantChannelListingPromotionRule for given sale.
+
+    Return tuple, first element will be VariantChannelListingPromotionRule to update,
+    second will be VariantChannelListingPromotionRule to create.
+
+    Return (None, None) if Promotion does not exist yet. The proper listing promotion
+    rule instances will be created when migrating.
+    """
+    promotion = Promotion.objects.filter(old_sale_id=sale_id)
+    promotion_rules = PromotionRule.objects.filter(
+        Exists(promotion.filter(id=OuterRef("promotion_id")))
+    )
+    # If the promotion does not exists it mean that the sale wasn't migrated yet.
+    # The proper VariantChannelListingPromotionRule will be created during migration.
+    if not promotion:
+        return None, None
+    listing_promotion_rule_to_update = (
+        variant_listing.variantlistingpromotionrule.filter(
+            Exists(promotion_rules.filter(id=OuterRef("promotion_rule_id")))
+        ).first()
+    )
+    if listing_promotion_rule_to_update:
+        if listing_promotion_rule_to_update.discount_amount != discount_amount:
+            listing_promotion_rule_to_update.discount_amount = discount_amount
+            return listing_promotion_rule_to_update, None
+        return None, None
+
+    # create VariantChannelListingPromotionRule
+    PromotionRuleChannel = PromotionRule.channels.through
+    rule_channels = PromotionRuleChannel.objects.filter(
+        channel_id=variant_listing.channel_id
+    )
+    promotion_rule = promotion_rules.filter(
+        Exists(rule_channels.filter(promotionrule_id=OuterRef("id")))
+    ).first()
+    new_listing_promotion_rule = VariantChannelListingPromotionRule(
+        variant_channel_listing=variant_listing,
+        promotion_rule=promotion_rule,
+        discount_amount=discount_amount,
+        currency=variant_listing.currency,
+    )
+    return None, new_listing_promotion_rule
 
 
 def _products_in_batches(products_qs):

--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -135,6 +135,7 @@ def _get_discounted_variants_prices(
             variant_id=variant_listing.variant_id,
         )
         if variant_listing.discounted_price != discounted_variant_price:
+            # TODO: we should create here `VariantChannelListingPromotionRule`
             variant_listing.discounted_price_amount = discounted_variant_price.amount
             variants_listings_to_update.append(variant_listing)
         discounted_variants_price.append(discounted_variant_price)


### PR DESCRIPTION
- Create also `Promotion` in `SaleCreate` mutation.
- Update `saleChannelListingUpdate`, create or remove corresponding `PromotionRule`s

Update `update_products_discounted_price` to create `VariantChannelListingPromotionRule` instances.


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
