### PR TITLE
[Programatic Payments] Add missing part for tokenizing payment method API

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -14,6 +14,7 @@ from ...checkout.utils import get_valid_collection_points_for_checkout
 from ...core.taxes import zero_money, zero_taxed_money
 from ...core.utils.lazyobjects import unwrap_lazy
 from ...payment.interface import ListStoredPaymentMethodsRequestData
+from ...permission.auth_filters import AuthorizationFilters
 from ...permission.enums import (
     AccountPermissions,
     CheckoutPermissions,
@@ -477,7 +478,13 @@ class Checkout(ModelObjectType[models.Checkout]):
     )
     user = graphene.Field(
         "saleor.graphql.account.types.User",
-        description="The user assigned to the checkout.",
+        description=(
+            "The user assigned to the checkout. Requires one of the following "
+            "permissions: "
+            f"{AccountPermissions.MANAGE_USERS.name}, "
+            f"{PaymentPermissions.HANDLE_PAYMENTS.name}, "
+            f"{AuthorizationFilters.OWNER.name}."
+        ),
     )
     channel = graphene.Field(
         Channel,
@@ -803,7 +810,10 @@ class Checkout(ModelObjectType[models.Checkout]):
             return None
         requestor = get_user_or_app_from_context(info.context)
         check_is_owner_or_has_one_of_perms(
-            requestor, root.user, AccountPermissions.MANAGE_USERS
+            requestor,
+            root.user,
+            AccountPermissions.MANAGE_USERS,
+            PaymentPermissions.HANDLE_PAYMENTS,
         )
         return root.user
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -995,6 +995,7 @@ class Order(ModelObjectType[models.Order]):
             "and later, for other orders requires one of the following permissions: "
             f"{AccountPermissions.MANAGE_USERS.name}, "
             f"{OrderPermissions.MANAGE_ORDERS.name}, "
+            f"{PaymentPermissions.HANDLE_PAYMENTS.name}, "
             f"{AuthorizationFilters.OWNER.name}."
         ),
     )
@@ -1792,6 +1793,7 @@ class Order(ModelObjectType[models.Order]):
                 user,
                 AccountPermissions.MANAGE_USERS,
                 OrderPermissions.MANAGE_ORDERS,
+                PaymentPermissions.HANDLE_PAYMENTS,
             )
             return user
 

--- a/saleor/graphql/payment/enums.py
+++ b/saleor/graphql/payment/enums.py
@@ -87,7 +87,7 @@ TokenizedPaymentFlowEnum = to_enum(
     type_name="TokenizedPaymentFlowEnum",
     description=TokenizedPaymentFlow.__doc__,
 )
-
+TokenizedPaymentFlowEnum.doc_category = DOC_CATEGORY_PAYMENTS
 
 PaymentGatewayInitializeTokenizationResultEnum = graphene.Enum.from_enum(
     PaymentGatewayInitializeTokenizationResult,
@@ -98,9 +98,6 @@ PaymentMethodTokenizationResultEnum = graphene.Enum.from_enum(
     PaymentMethodTokenizationResult
 )
 PaymentMethodTokenizationResultEnum.doc_category = DOC_CATEGORY_PAYMENTS
-
-
-TokenizedPaymentFlowEnum.doc_category = DOC_CATEGORY_PAYMENTS
 
 StoredPaymentMethodRequestDeleteResultEnum = graphene.Enum.from_enum(
     StoredPaymentMethodRequestDeleteResult,

--- a/saleor/graphql/payment/mutations/stored_payment_methods/utils.py
+++ b/saleor/graphql/payment/mutations/stored_payment_methods/utils.py
@@ -31,6 +31,7 @@ def handle_payment_method_action(
     result_without_error = [
         result_enum.SUCCESSFULLY_TOKENIZED,
         result_enum.ADDITIONAL_ACTION_REQUIRED,
+        result_enum.PENDING,
     ]
     if response.result not in result_without_error:
         error_code = error_type_class.GATEWAY_ERROR.value

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10192,7 +10192,9 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   updatedAt: DateTime!
   lastChange: DateTime! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `updatedAt` instead.")
 
-  """The user assigned to the checkout."""
+  """
+  The user assigned to the checkout. Requires one of the following permissions: MANAGE_USERS, HANDLE_PAYMENTS, OWNER.
+  """
   user: User
 
   """The channel for which checkout was created."""
@@ -11003,7 +11005,7 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   status: OrderStatus!
 
   """
-  User who placed the order. This field is set only for orders placed by authenticated users. Can be fetched for orders created in Saleor 3.2 and later, for other orders requires one of the following permissions: MANAGE_USERS, MANAGE_ORDERS, OWNER.
+  User who placed the order. This field is set only for orders placed by authenticated users. Can be fetched for orders created in Saleor 3.2 and later, for other orders requires one of the following permissions: MANAGE_USERS, MANAGE_ORDERS, HANDLE_PAYMENTS, OWNER.
   """
   user: User
 
@@ -15722,6 +15724,9 @@ type Mutation {
     The identifier of the payment gateway app to initialize payment method tokenization.
     """
     id: String!
+
+    """The payment flow that the tokenized payment method should support."""
+    paymentFlowToSupport: TokenizedPaymentFlowEnum!
   ): PaymentMethodInitializeTokenization @doc(category: "Payments") @webhookEventsInfo(asyncEvents: [], syncEvents: [PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION])
 
   """
@@ -23475,11 +23480,13 @@ Result of tokenization of payment method.
     SUCCESSFULLY_TOKENIZED - The payment method was successfully tokenized.
     ADDITIONAL_ACTION_REQUIRED - The additional action is required to tokenize payment
     method.
+    PENDING - The payment method is pending tokenization.
     FAILED_TO_TOKENIZE - The payment method was not tokenized.
     FAILED_TO_DELIVER - The request to tokenize payment method was not delivered.
 """
 enum PaymentMethodTokenizationResult @doc(category: "Payments") {
   SUCCESSFULLY_TOKENIZED
+  PENDING
   ADDITIONAL_ACTION_REQUIRED
   FAILED_TO_TOKENIZE
   FAILED_TO_DELIVER
@@ -33714,6 +33721,9 @@ type PaymentMethodInitializeTokenizationSession implements Event @doc(category: 
 
   """Payment gateway data in JSON format, received from storefront."""
   data: JSON
+
+  """The payment flow that the tokenized payment method should support."""
+  paymentFlowToSupport: TokenizedPaymentFlowEnum!
 }
 
 """

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -225,6 +225,7 @@ class PaymentMethodInitializeTokenizationRequestData(
     """Dataclass for storing the request information for payment app."""
 
     app_identifier: str
+    payment_flow_to_support: str
 
 
 @dataclass
@@ -242,11 +243,13 @@ class PaymentMethodTokenizationResult(str, Enum):
     SUCCESSFULLY_TOKENIZED - The payment method was successfully tokenized.
     ADDITIONAL_ACTION_REQUIRED - The additional action is required to tokenize payment
     method.
+    PENDING - The payment method is pending tokenization.
     FAILED_TO_TOKENIZE - The payment method was not tokenized.
     FAILED_TO_DELIVER - The request to tokenize payment method was not delivered.
     """
 
     SUCCESSFULLY_TOKENIZED = "successfully_tokenized"
+    PENDING = "pending"
     ADDITIONAL_ACTION_REQUIRED = "additional_action_required"
     FAILED_TO_TOKENIZE = "failed_to_tokenize"
     FAILED_TO_DELIVER = "failed_to_deliver"

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -17,6 +17,7 @@ from ...discount.utils import (
     fetch_catalogue_info,
 )
 from ...graphql.discount.mutations.utils import convert_catalogue_info_to_global_ids
+from ...payment import TokenizedPaymentFlow
 from ...payment.interface import (
     ListStoredPaymentMethodsRequestData,
     PaymentGateway,
@@ -1452,6 +1453,7 @@ def test_payment_method_initialize_tokenization(
         app_identifier=app.identifier,
         channel=channel_USD,
         data={"data": "ABC"},
+        payment_flow_to_support=TokenizedPaymentFlow.INTERACTIVE,
     )
     previous_response = PaymentMethodTokenizationResponseData(
         result=PaymentMethodTokenizationResult.FAILED_TO_DELIVER,

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -2133,14 +2133,17 @@ class WebhookPlugin(BasePlugin):
         webhook: "Webhook",
         event_type: str,
         request_data: PaymentMethodTokenizationBaseRequestData,
+        additional_legacy_payload_data: Optional[dict] = None,
     ) -> Optional[dict]:
-        payload = self._serialize_payload(
-            {
-                "user_id": graphene.Node.to_global_id("User", request_data.user.id),
-                "channel_slug": request_data.channel.slug,
-                "data": request_data.data,
-            }
-        )
+        payload_data = {
+            "user_id": graphene.Node.to_global_id("User", request_data.user.id),
+            "channel_slug": request_data.channel.slug,
+            "data": request_data.data,
+        }
+        if additional_legacy_payload_data:
+            payload_data.update(additional_legacy_payload_data)
+
+        payload = self._serialize_payload(payload_data)
         response_data = trigger_webhook_sync(
             event_type,
             payload,
@@ -2179,6 +2182,7 @@ class WebhookPlugin(BasePlugin):
         event_type: str,
         request_data: PaymentMethodTokenizationBaseRequestData,
         previous_value: "PaymentMethodTokenizationResponseData",
+        additional_legacy_payload_data: Optional[dict] = None,
     ):
         webhook = get_webhooks_for_event(
             event_type, apps_identifier=[app_identifier]
@@ -2188,13 +2192,19 @@ class WebhookPlugin(BasePlugin):
             return previous_value
 
         response_data = self._handle_payment_tokenization_request(
-            event_type=event_type, webhook=webhook, request_data=request_data
+            event_type=event_type,
+            webhook=webhook,
+            request_data=request_data,
+            additional_legacy_payload_data=additional_legacy_payload_data,
         )
 
         response = get_response_for_payment_method_tokenization(
             response_data, webhook.app
         )
-        if response.result == PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED:
+        if response.result in [
+            PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
+            PaymentMethodTokenizationResult.PENDING,
+        ]:
             invalidate_cache_for_stored_payment_methods(
                 request_data.user.id,
                 request_data.channel.slug,
@@ -2217,6 +2227,9 @@ class WebhookPlugin(BasePlugin):
             event_type=event_type,
             request_data=request_data,
             previous_value=previous_value,
+            additional_legacy_payload_data={
+                "payment_flow_to_support": request_data.payment_flow_to_support
+            },
         )
 
     def payment_method_process_tokenization(
@@ -2228,8 +2241,11 @@ class WebhookPlugin(BasePlugin):
             return previous_value
 
         app_data = from_payment_app_id(request_data.id)
+
         if not app_data or not app_data.app_identifier:
             return previous_value
+
+        request_data.id = app_data.name
 
         event_type = WebhookEventSyncType.PAYMENT_METHOD_PROCESS_TOKENIZATION_SESSION
         return self._handle_payment_method_tokenization(
@@ -2237,6 +2253,7 @@ class WebhookPlugin(BasePlugin):
             event_type=event_type,
             request_data=request_data,
             previous_value=previous_value,
+            additional_legacy_payload_data={"id": request_data.id},
         )
 
     def _request_transaction_action(

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_initialize_tokenization.py
@@ -2,6 +2,7 @@ import json
 
 import graphene
 
+from .....payment import TokenizedPaymentFlow
 from .....payment.interface import PaymentMethodInitializeTokenizationRequestData
 from .....webhook.event_types import WebhookEventSyncType
 from ...tasks import create_deliveries_for_subscriptions
@@ -10,6 +11,7 @@ PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION = """
 subscription{
   event{
     ...on PaymentMethodInitializeTokenizationSession{
+      paymentFlowToSupport
       user{
         id
       }
@@ -36,6 +38,7 @@ def test_payment_method_initialize_tokenization_without_data(
         app_identifier=payment_method_initialize_tokenization_app.identifier,
         channel=channel_USD,
         data=None,
+        payment_flow_to_support=TokenizedPaymentFlow.INTERACTIVE,
     )
 
     event_type = WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
@@ -52,6 +55,7 @@ def test_payment_method_initialize_tokenization_without_data(
         "data": None,
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
+        "paymentFlowToSupport": "INTERACTIVE",
     }
 
 
@@ -70,6 +74,7 @@ def test_payment_method_initialize_tokenization_with_data(
         app_identifier=payment_method_initialize_tokenization_app.identifier,
         channel=channel_USD,
         data=expected_data,
+        payment_flow_to_support=TokenizedPaymentFlow.INTERACTIVE,
     )
 
     event_type = WebhookEventSyncType.PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION
@@ -86,4 +91,5 @@ def test_payment_method_initialize_tokenization_with_data(
         "data": expected_data,
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
+        "paymentFlowToSupport": "INTERACTIVE",
     }

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_process_tokenization.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_payment_method_process_tokenization.py
@@ -10,6 +10,7 @@ PAYMENT_METHOD_PROCESS_TOKENIZATION_SESSION = """
 subscription{
   event{
     ...on PaymentMethodProcessTokenizationSession{
+      id
       user{
         id
       }
@@ -33,7 +34,7 @@ def test_payment_method_process_tokenization_without_data(
 
     expected_id = "test_id"
 
-    request_delete_data = PaymentMethodProcessTokenizationRequestData(
+    request_data = PaymentMethodProcessTokenizationRequestData(
         user=customer_user,
         id=expected_id,
         channel=channel_USD,
@@ -43,9 +44,9 @@ def test_payment_method_process_tokenization_without_data(
     event_type = WebhookEventSyncType.PAYMENT_METHOD_PROCESS_TOKENIZATION_SESSION
 
     # when
-    delivery = create_deliveries_for_subscriptions(
-        event_type, request_delete_data, [webhook]
-    )[0]
+    delivery = create_deliveries_for_subscriptions(event_type, request_data, [webhook])[
+        0
+    ]
 
     # then
     assert delivery.payload
@@ -54,6 +55,7 @@ def test_payment_method_process_tokenization_without_data(
         "data": None,
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
+        "id": expected_id,
     }
 
 
@@ -68,7 +70,7 @@ def test_payment_method_process_tokenization_with_data(
     expected_data = {"data": {"foo": "bar"}}
     expected_id = "test_id"
 
-    request_delete_data = PaymentMethodProcessTokenizationRequestData(
+    request_data = PaymentMethodProcessTokenizationRequestData(
         user=customer_user,
         id=expected_id,
         channel=channel_USD,
@@ -78,9 +80,9 @@ def test_payment_method_process_tokenization_with_data(
     event_type = WebhookEventSyncType.PAYMENT_METHOD_PROCESS_TOKENIZATION_SESSION
 
     # when
-    delivery = create_deliveries_for_subscriptions(
-        event_type, request_delete_data, [webhook]
-    )[0]
+    delivery = create_deliveries_for_subscriptions(event_type, request_data, [webhook])[
+        0
+    ]
 
     # then
     assert delivery.payload
@@ -89,4 +91,5 @@ def test_payment_method_process_tokenization_with_data(
         "data": expected_data,
         "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         "channel": {"id": graphene.Node.to_global_id("Channel", channel_USD.pk)},
+        "id": expected_id,
     }

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_initialize_session.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_initialize_session.py
@@ -29,6 +29,9 @@ subscription {
         __typename
         ... on Checkout{
           id
+          user{
+            id
+          }
           totalPrice{
             gross{
               amount
@@ -37,6 +40,9 @@ subscription {
         }
         ... on Order{
           id
+          user{
+            id
+          }
         }
       }
     }
@@ -46,9 +52,16 @@ subscription {
 
 
 def test_transaction_initialize_session_checkout_with_data(
-    checkout, webhook_app, permission_manage_payments, transaction_item_generator
+    checkout,
+    webhook_app,
+    permission_manage_payments,
+    transaction_item_generator,
+    customer_user,
 ):
     # given
+    checkout.user = customer_user
+    checkout.save()
+
     webhook_app.permissions.add(permission_manage_payments)
     webhook = Webhook.objects.create(
         name="Webhook",
@@ -107,6 +120,7 @@ def test_transaction_initialize_session_checkout_with_data(
             "__typename": "Checkout",
             "id": checkout_id,
             "totalPrice": {"gross": {"amount": 0.0}},
+            "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         },
     }
 
@@ -173,6 +187,7 @@ def test_transaction_initialize_session_checkout_without_data(
             "__typename": "Checkout",
             "id": checkout_id,
             "totalPrice": {"gross": {"amount": 0.0}},
+            "user": None,
         },
     }
 
@@ -239,6 +254,7 @@ def test_transaction_initialize_session_order_with_data(
         "sourceObject": {
             "__typename": "Order",
             "id": order_id,
+            "user": {"id": graphene.Node.to_global_id("User", order.user.pk)},
         },
     }
 
@@ -304,6 +320,7 @@ def test_transaction_initialize_session_order_without_data(
         "sourceObject": {
             "__typename": "Order",
             "id": order_id,
+            "user": {"id": graphene.Node.to_global_id("User", order.user.pk)},
         },
     }
 
@@ -369,5 +386,6 @@ def test_transaction_initialize_session_empty_customer_ip_addess(
         "sourceObject": {
             "__typename": "Order",
             "id": order_id,
+            "user": {"id": graphene.Node.to_global_id("User", order.user.pk)},
         },
     }

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_process_session.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_transaction_process_session.py
@@ -29,6 +29,9 @@ subscription {
         __typename
         ... on Checkout{
           id
+          user{
+            id
+          }
           totalPrice{
             gross{
               amount
@@ -37,6 +40,9 @@ subscription {
         }
         ... on Order{
           id
+          user{
+            id
+          }
         }
       }
     }
@@ -46,9 +52,15 @@ subscription {
 
 
 def test_transaction_process_session_checkout_with_data(
-    checkout, webhook_app, permission_manage_payments, transaction_item_generator
+    checkout,
+    webhook_app,
+    permission_manage_payments,
+    transaction_item_generator,
+    customer_user,
 ):
     # given
+    checkout.user = customer_user
+    checkout.save()
     webhook_app.permissions.add(permission_manage_payments)
     webhook = Webhook.objects.create(
         name="Webhook",
@@ -106,6 +118,7 @@ def test_transaction_process_session_checkout_with_data(
         "sourceObject": {
             "__typename": "Checkout",
             "id": checkout_id,
+            "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
             "totalPrice": {"gross": {"amount": 0.0}},
         },
     }
@@ -173,14 +186,22 @@ def test_transaction_process_session_checkout_without_data(
             "__typename": "Checkout",
             "id": checkout_id,
             "totalPrice": {"gross": {"amount": 0.0}},
+            "user": None,
         },
     }
 
 
 def test_transaction_process_session_order_with_data(
-    order, webhook_app, permission_manage_payments, transaction_item_generator
+    order,
+    webhook_app,
+    permission_manage_payments,
+    transaction_item_generator,
+    customer_user,
 ):
     # given
+    order.user = customer_user
+    order.save()
+
     webhook_app.permissions.add(permission_manage_payments)
     webhook = Webhook.objects.create(
         name="Webhook",
@@ -239,6 +260,7 @@ def test_transaction_process_session_order_with_data(
         "sourceObject": {
             "__typename": "Order",
             "id": order_id,
+            "user": {"id": graphene.Node.to_global_id("User", customer_user.pk)},
         },
     }
 
@@ -304,6 +326,7 @@ def test_transaction_process_session_order_without_data(
         "sourceObject": {
             "__typename": "Order",
             "id": order_id,
+            "user": {"id": graphene.Node.to_global_id("User", order.user.pk)},
         },
     }
 
@@ -369,5 +392,6 @@ def test_transaction_process_session_empty_customer_ip_address(
         "sourceObject": {
             "__typename": "Order",
             "id": order_id,
+            "user": {"id": graphene.Node.to_global_id("User", order.user.pk)},
         },
     }


### PR DESCRIPTION
I want to merge this change because it adds a missing part that we discovered during the review of the interface:
- add new result: PENDING as some payment providers could not know what is the status of the tokenized payment method
- add `paymentFlowToSupport` to mutation input and subscription. It allows to declare how tokenized payment method will be used
- add possibility to fetch `user` from `order`/`checkout` with `HANDLE_PAYMENTS` permission. It is mandatory to determine if there is a possibility to tokenized the payment method during the checkout  process.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
