### PR TITLE
Fix links referencing mirumee/saleor GitHub project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
+All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/saleor/saleor/releases) page.
 
 # 3.16.0 [Unreleased]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,16 +6,12 @@ We welcome all contributions to Saleor, including issues, new features, docs, di
 
 ## Issues
 
-Use [Github Issues](https://github.com/mirumee/saleor/issues) to report a bug or a problem that you found in Saleor. Use the "Bug report" issue template to provide information that will help us confirm the bug, such as steps to reproduce, expected behavior, Saleor version, and any additional context. When our team confirms a bug, it will be added to the internal backlog and picked up as soon as possible. When willing to fix a bug, let us know in the issue comment, and we will try to assist you on the way.
+Use [Github Issues](https://github.com/saleor/saleor/issues) to report a bug or a problem that you found in Saleor. Use the "Bug report" issue template to provide information that will help us confirm the bug, such as steps to reproduce, expected behavior, Saleor version, and any additional context. When our team confirms a bug, it will be added to the internal backlog and picked up as soon as possible. When willing to fix a bug, let us know in the issue comment, and we will try to assist you on the way.
 
 ## New features
-When willing to propose or add a new feature, we encourage you first to open a [discussion](https://github.com/mirumee/saleor/discussions) or an [issue](https://github.com/mirumee/saleor/issues) (using "Feature request" template) to discuss it with the core team. This process helps us decide if a feature is suitable for Saleor or design it before any implementation starts.
+When willing to propose or add a new feature, we encourage you first to open a [discussion](https://github.com/saleor/saleor/discussions) or an [issue](https://github.com/saleor/saleor/issues) (using "Feature request" template) to discuss it with the core team. This process helps us decide if a feature is suitable for Saleor or design it before any implementation starts.
 
 Before merging, any new pull requests submitted to Saleor have to be reviewed and approved by the core team. We review pull requests daily, but if a pull request requires more time or feedback from the team, it will be marked as "queued for review".
-
-## Translations
-
-All translations are contributed by the community. To aid with translation, visit our [Transifex project](https://www.transifex.com/mirumee/saleor-1/).
 
 ## Managing dependencies
 
@@ -80,7 +76,7 @@ Use [pydocstyle](http://pydocstyle.pycqa.org/en/latest/) to check that your docs
 
 [EditorConfig](http://editorconfig.org/) is a standard configuration file that aims to ensure consistent style across multiple programming environments.
 
-Saleor’s repository contains [an `.editorconfig` file](https://github.com/mirumee/saleor/blob/master/.editorconfig) describing our formatting requirements.
+Saleor’s repository contains [an `.editorconfig` file](https://github.com/saleor/saleor/blob/master/.editorconfig) describing our formatting requirements.
 
 Most editors and IDEs support this file either directly or via plugins. See the [list of supported editors and IDEs](http://editorconfig.org/#download) for detailed instructions.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ ARG COMMIT_ID
 ARG PROJECT_VERSION
 ENV PROJECT_VERSION="${PROJECT_VERSION}"
 
-LABEL org.opencontainers.image.title="mirumee/saleor"                                  \
+LABEL org.opencontainers.image.title="saleor/saleor"                                  \
       org.opencontainers.image.description="\
 A modular, high performance, headless e-commerce platform built with Python, \
 GraphQL, Django, and ReactJS."                                                         \

--- a/deployment/elasticbeanstalk/Dockerrun.aws.json
+++ b/deployment/elasticbeanstalk/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 {
     "AWSEBDockerrunVersion": "1",
     "Image": {
-      "Name": "mirumee/saleor:latest",
+      "Name": "saleor/saleor:latest",
       "Update": "true"
     },
     "Ports": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"
 readme = "README.md"
 homepage = "https://saleor.io/"
-repository = "https://github.com/mirumee/saleor"
+repository = "https://github.com/saleor/saleor"
 documentation = "https://docs.saleor.io/"
 
   [tool.poetry.dependencies]

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -6306,7 +6306,7 @@ def description_json():
         ],
         "entityMap": {
             "0": {
-                "data": {"href": "https://github.com/mirumee/saleor"},
+                "data": {"href": "https://github.com/saleor/saleor"},
                 "type": "LINK",
                 "mutability": "MUTABLE",
             }

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -6306,7 +6306,7 @@ def description_json():
         ],
         "entityMap": {
             "0": {
-                "data": {"href": "https://github.com/saleor/saleor"},
+                "data": {"href": "https://github.com/mirumee/saleor"},
                 "type": "LINK",
                 "mutability": "MUTABLE",
             }

--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -201,7 +201,7 @@
               It looks like you're only running the Saleor core. If you're
               looking for an easy way to run all services locally, check out
               <a
-                href="https://github.com/mirumee/saleor-platform"
+                href="https://github.com/saleor/saleor-platform"
                 target="_blank"
                 >Saleor Platform.</a
               >


### PR DESCRIPTION
Links that are referencing the `mirumee/saleor` project and their packages are invalid.





# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
