### PR TITLE
[Test] Should be able to change channel in promotion

### DIFF
--- a/saleor/tests/e2e/product/utils/__init__.py
+++ b/saleor/tests/e2e/product/utils/__init__.py
@@ -11,7 +11,10 @@ from .product_channel_listing import (
 from .product_query import get_product
 from .product_type import create_product_type
 from .product_variant import create_product_variant, raw_create_product_variant
-from .product_variant_channel_listing import create_product_variant_channel_listing
+from .product_variant_channel_listing import (
+    create_product_variant_channel_listing,
+    raw_create_product_variant_channel_listing,
+)
 
 __all__ = [
     "create_category",
@@ -28,4 +31,5 @@ __all__ = [
     "create_collection_channel_listing",
     "get_product",
     "add_product_to_collection",
+    "raw_create_product_variant_channel_listing",
 ]

--- a/saleor/tests/e2e/product/utils/product_variant_channel_listing.py
+++ b/saleor/tests/e2e/product/utils/product_variant_channel_listing.py
@@ -27,7 +27,7 @@ mutation UpdateProductVariantChannelListing(
 """
 
 
-def create_product_variant_channel_listing(
+def raw_create_product_variant_channel_listing(
     staff_api_client,
     product_variant_id,
     channel_id,
@@ -50,9 +50,26 @@ def create_product_variant_channel_listing(
     )
     content = get_graphql_content(response)
 
-    assert content["data"]["productVariantChannelListingUpdate"]["errors"] == []
+    data = content["data"]["productVariantChannelListingUpdate"]
+    assert data["errors"] == []
 
-    data = content["data"]["productVariantChannelListingUpdate"]["variant"]
+    return data
+
+
+def create_product_variant_channel_listing(
+    staff_api_client,
+    product_variant_id,
+    channel_id,
+    price,
+):
+    response = raw_create_product_variant_channel_listing(
+        staff_api_client,
+        product_variant_id,
+        channel_id,
+        price,
+    )
+
+    data = response["variant"]
     assert data["id"] == product_variant_id
     channel_listing_data = data["channelListings"][0]
     assert channel_listing_data["channel"]["id"] == channel_id

--- a/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
@@ -47,7 +47,7 @@ def prepare_promotion(
 
 
 @pytest.mark.e2e
-def test_create_promotion_for_collection_core_2109(
+def test_staff_can_change_catalogue_predicate_core_2112(
     e2e_staff_api_client,
     permission_manage_products,
     permission_manage_channels,

--- a/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
@@ -100,11 +100,19 @@ def test_staff_can_change_catalogue_predicate_core_2112(
     )
 
     # Step 2 Update promotion rule of new variant
-    catalogue_predicate = {
-        "productPredicate": {},
-        "variantPredicate": {"ids": [second_product_variant_id]},
+    input = {
+        "cataloguePredicate": {
+            "collectionPredicate": {},
+        }
     }
-    update_promotion_rule(e2e_staff_api_client, promotion_rule_id, catalogue_predicate)
+    update_promotion_rule(e2e_staff_api_client, promotion_rule_id, input)
+
+    input = {
+        "cataloguePredicate": {
+            "variantPredicate": {"ids": [second_product_variant_id]},
+        }
+    }
+    update_promotion_rule(e2e_staff_api_client, promotion_rule_id, input)
 
     # Step 3 Check if promotion is applied to new variant
     product_data = get_product(e2e_staff_api_client, product_id, channel_slug)
@@ -112,7 +120,7 @@ def test_staff_can_change_catalogue_predicate_core_2112(
     assert first_variant["id"] == product_variant_id
     second_variant = product_data["variants"][1]
     assert second_variant["id"] == second_product_variant_id
-    assert product_data["pricing"]["onSale"] is False
+    assert product_data["pricing"]["onSale"] is True
     assert first_variant["pricing"]["onSale"] is False
     assert second_variant["pricing"]["onSale"] is True
     calculated_second_variant_discount = round(

--- a/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
@@ -103,12 +103,6 @@ def test_staff_can_change_catalogue_predicate_core_2112(
     input = {
         "cataloguePredicate": {
             "collectionPredicate": {},
-        }
-    }
-    update_promotion_rule(e2e_staff_api_client, promotion_rule_id, input)
-
-    input = {
-        "cataloguePredicate": {
             "variantPredicate": {"ids": [second_product_variant_id]},
         }
     }
@@ -120,7 +114,7 @@ def test_staff_can_change_catalogue_predicate_core_2112(
     assert first_variant["id"] == product_variant_id
     second_variant = product_data["variants"][1]
     assert second_variant["id"] == second_product_variant_id
-    assert product_data["pricing"]["onSale"] is True
+    assert product_data["pricing"]["onSale"] is False
     assert first_variant["pricing"]["onSale"] is False
     assert second_variant["pricing"]["onSale"] is True
     calculated_second_variant_discount = round(

--- a/saleor/tests/e2e/promotions/test_staff_can_change_channel_in_promotion_rule.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_channel_in_promotion_rule.py
@@ -129,10 +129,9 @@ def test_staff_can_change_promotion_rule_channel_core_2113(
         e2e_staff_api_client, product_id, second_channel_slug
     )
     assert product_data_channel_2["pricing"]["onSale"] is True
-    assert (
-        product_data_channel_2["variants"][0]["pricing"]["discount"]["gross"]["amount"]
-        == 49.5
-    )
+    variant = product_data_channel_2["variants"][0]
+    assert variant["pricing"]["discount"]["gross"]["amount"] == 49.5
+
     # Step 3 Check if promotion is not applied for product on first channel
     product_data_channel_1 = get_product(e2e_staff_api_client, product_id, channel_slug)
     assert product_data_channel_1["pricing"]["onSale"] is False

--- a/saleor/tests/e2e/promotions/test_staff_can_change_channel_in_promotion_rule.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_channel_in_promotion_rule.py
@@ -58,6 +58,9 @@ def prepare_second_channel_and_listing(
         e2e_staff_api_client,
         product_id,
         second_channel_id,
+        is_published=True,
+        visible_in_listings=True,
+        is_available_for_purchase=True,
     )
     assert (
         product_listing_data["product"]["channelListings"][1]["channel"]["id"]
@@ -71,7 +74,6 @@ def prepare_second_channel_and_listing(
         variant_listing_data["variant"]["channelListings"][1]["channel"]["id"]
         == second_channel_id
     )
-
     return second_channel_id, second_channel_slug
 
 
@@ -108,19 +110,17 @@ def test_staff_can_change_promotion_rule_channel_core_2113(
         predicate_input,
         channel_id=[channel_id],
     )
-
     second_channel_id, second_channel_slug = prepare_second_channel_and_listing(
         e2e_staff_api_client, warehouse_id, product_id, product_variant_id
     )
-
-    # Step 1 Update promotion rule switch channels
+    # Step 1 Update promotion rule: switch channels
     update_promotion_rule(
         e2e_staff_api_client,
         promotion_rule_id,
         input={
             "addChannels": [second_channel_id],
             "removeChannels": [channel_id],
-            "cataloguePredicate": {"productPredicate": {"ids": [product_id]}},
+            "cataloguePredicate": predicate_input,
         },
     )
 
@@ -129,7 +129,6 @@ def test_staff_can_change_promotion_rule_channel_core_2113(
         e2e_staff_api_client, product_id, second_channel_slug
     )
     assert product_data_channel_2["pricing"]["onSale"] is True
-    assert product_data_channel_2["variants"][0]["pricing"]["onSale"] is True
     assert (
         product_data_channel_2["variants"][0]["pricing"]["discount"]["gross"]["amount"]
         == 49.5

--- a/saleor/tests/e2e/promotions/test_staff_can_change_channel_in_promotion_rule.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_channel_in_promotion_rule.py
@@ -1,0 +1,133 @@
+import pytest
+
+from ..channel.utils import create_channel
+from ..product.utils import (
+    get_product,
+    raw_create_product_channel_listing,
+    raw_create_product_variant_channel_listing,
+)
+from ..product.utils.preparing_product import prepare_product
+from ..promotions.utils import (
+    create_promotion,
+    create_promotion_rule,
+    update_promotion_rule,
+)
+from ..shop.utils.preparing_shop import prepare_shop
+from ..utils import assign_permissions
+
+
+def prepare_promotion(
+    e2e_staff_api_client,
+    discount_value,
+    discount_type,
+    predicate_input,
+    promotion_rule_name="Test rule",
+    channel_id=None,
+):
+    promotion_name = "Promotion Test"
+    promotion_data = create_promotion(e2e_staff_api_client, promotion_name)
+    promotion_id = promotion_data["id"]
+
+    promotion_rule_data = create_promotion_rule(
+        e2e_staff_api_client,
+        promotion_id,
+        predicate_input,
+        discount_type,
+        discount_value,
+        promotion_rule_name,
+        channel_id,
+    )
+    promotion_rule_id = promotion_rule_data["id"]
+    discount_value = promotion_rule_data["rewardValue"]
+
+    return promotion_rule_id
+
+
+def prepare_second_channel_and_listing(
+    e2e_staff_api_client, warehouse_id, product_id, product_variant_id
+):
+    second_channel_slug = "channel_gbp"
+    channel_data = create_channel(
+        e2e_staff_api_client,
+        warehouse_ids=[warehouse_id],
+        slug=second_channel_slug,
+    )
+    second_channel_id = channel_data["id"]
+
+    product_listing_data = raw_create_product_channel_listing(
+        e2e_staff_api_client,
+        product_id,
+        second_channel_id,
+    )
+    assert (
+        product_listing_data["product"]["channelListings"][1]["channel"]["id"]
+        == second_channel_id
+    )
+
+    variant_listing_data = raw_create_product_variant_channel_listing(
+        e2e_staff_api_client, product_variant_id, second_channel_id, price="99"
+    )
+    assert (
+        variant_listing_data["variant"]["channelListings"][1]["channel"]["id"]
+        == second_channel_id
+    )
+
+    return second_channel_id, second_channel_slug
+
+
+@pytest.mark.e2e
+def test_staff_can_change_promotion_rule_channel_core_2113(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_shipping,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_shipping,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    warehouse_id, channel_id, channel_slug, _ = prepare_shop(e2e_staff_api_client)
+
+    product_id, product_variant_id, _ = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, "7.99"
+    )
+
+    predicate_input = {"productPredicate": {"ids": product_id}}
+    promotion_rule_id = prepare_promotion(
+        e2e_staff_api_client,
+        50,
+        "PERCENTAGE",
+        predicate_input,
+        channel_id=[channel_id],
+    )
+
+    second_channel_id, second_channel_slug = prepare_second_channel_and_listing(
+        e2e_staff_api_client, warehouse_id, product_id, product_variant_id
+    )
+
+    # Step 1 Update promotion rule add new channel remove first channel
+    update_promotion_rule(
+        e2e_staff_api_client,
+        promotion_rule_id,
+        predicate_input,
+        add_channels=[second_channel_id],
+        remove_channels=[channel_id],
+    )
+
+    # Step 2 Check if promotion is applied for product on second channel
+    product_data_channel_2 = get_product(
+        e2e_staff_api_client, product_id, second_channel_slug
+    )
+    assert product_data_channel_2["pricing"]["onSale"] is True
+
+    # Step 3 Check if promotion is not applied for product on first channel
+    product_data_channel_1 = get_product(e2e_staff_api_client, product_id, channel_slug)
+    assert product_data_channel_1["pricing"]["onSale"] is False

--- a/saleor/tests/e2e/promotions/utils/promotion_rule_update.py
+++ b/saleor/tests/e2e/promotions/utils/promotion_rule_update.py
@@ -28,11 +28,21 @@ def update_promotion_rule(
     staff_api_client,
     promotion_id,
     catalogue_predicate,
+    add_channels=None,
+    remove_channels=None,
 ):
+    if not add_channels:
+        add_channels = []
+
+    if not remove_channels:
+        remove_channels = []
+
     variables = {
         "id": promotion_id,
         "input": {
             "cataloguePredicate": catalogue_predicate,
+            "addChannels": add_channels,
+            "removeChannels": remove_channels,
         },
     }
 
@@ -45,4 +55,5 @@ def update_promotion_rule(
     assert content["data"]["promotionRuleUpdate"]["errors"] == []
 
     data = content["data"]["promotionRuleUpdate"]["promotionRule"]
+    print(data)
     return data

--- a/saleor/tests/e2e/promotions/utils/promotion_rule_update.py
+++ b/saleor/tests/e2e/promotions/utils/promotion_rule_update.py
@@ -27,24 +27,9 @@ mutation promotionRuleCreate($id: ID!, $input: PromotionRuleUpdateInput!) {
 def update_promotion_rule(
     staff_api_client,
     promotion_id,
-    catalogue_predicate,
-    add_channels=None,
-    remove_channels=None,
+    input,
 ):
-    if not add_channels:
-        add_channels = []
-
-    if not remove_channels:
-        remove_channels = []
-
-    variables = {
-        "id": promotion_id,
-        "input": {
-            "cataloguePredicate": catalogue_predicate,
-            "addChannels": add_channels,
-            "removeChannels": remove_channels,
-        },
-    }
+    variables = {"id": promotion_id, "input": input}
 
     response = staff_api_client.post_graphql(
         PROMOTION_RULE_UPDATE_MUTATION,
@@ -55,5 +40,4 @@ def update_promotion_rule(
     assert content["data"]["promotionRuleUpdate"]["errors"] == []
 
     data = content["data"]["promotionRuleUpdate"]["promotionRule"]
-    print(data)
     return data


### PR DESCRIPTION
I want to merge this change because it adds a test for updating the channel in the promotion rule [CORE_2113](https://saleor.testmo.net/repositories/5?group_id=133&case_id=2064)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
