### PR TITLE
[Programmatic payments] Require id for additional-actions result

### DIFF
--- a/saleor/plugins/webhook/stored_payment_methods.py
+++ b/saleor/plugins/webhook/stored_payment_methods.py
@@ -235,7 +235,10 @@ def get_response_for_payment_method_tokenization(
             payment_method_id = response_data["id"]
             payment_method_id = to_payment_app_id(app, payment_method_id)
         except KeyError:
-            if result == PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED:
+            if result in [
+                PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED,
+                PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED,
+            ]:
                 result = PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE
                 error = "Missing payment method `id` in response."
 

--- a/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
@@ -326,9 +326,17 @@ def test_payment_method_initialize_tokenization_additional_action_required(
     )
 
 
+@pytest.mark.parametrize(
+    "result",
+    [
+        PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+        PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED.name,
+    ],
+)
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
 def test_payment_method_initialize_tokenization_missing_required_id(
     mock_request,
+    result,
     customer_user,
     webhook_plugin,
     payment_method_initialize_tokenization_app,
@@ -337,7 +345,7 @@ def test_payment_method_initialize_tokenization_missing_required_id(
     # given
     expected_error_msg = "Missing payment method `id` in response."
     mock_request.return_value = {
-        "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+        "result": result,
         "data": None,
     }
 

--- a/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
@@ -337,9 +337,17 @@ def test_payment_method_process_tokenization_additional_action_required(
     )
 
 
+@pytest.mark.parametrize(
+    "result",
+    [
+        PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+        PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED.name,
+    ],
+)
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
 def test_payment_method_process_tokenization_missing_required_id(
     mock_request,
+    result,
     customer_user,
     webhook_plugin,
     payment_method_process_tokenization_app,
@@ -349,7 +357,7 @@ def test_payment_method_process_tokenization_missing_required_id(
     # given
     expected_error_msg = "Missing payment method `id` in response."
     mock_request.return_value = {
-        "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+        "result": result,
         "data": None,
     }
 


### PR DESCRIPTION
I want to merge this change because it requires `id` for additiona-action result

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
