### PR TITLE
Fix managers calculate checkout line unit price default value

### DIFF
--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -448,7 +448,7 @@ class PluginsManager(PaymentInterface):
             default_value * quantity,
         )
         default_taxed_value = TaxedMoney(
-            net=total_value / quantity, gross=default_value
+            net=total_value / quantity, gross=total_value / quantity
         )
         unit_price = self.__run_method_on_plugins(
             "calculate_checkout_line_unit_price",

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -481,7 +481,6 @@ def test_manager_calculates_checkout_line_unit_price(
 def test_manager_calculate_unit_price_correct_default_taxed_value(
     checkout_with_voucher_percentage, address
 ):
-
     # given
     # no tax plugins are configured
     plugins = []
@@ -506,8 +505,8 @@ def test_manager_calculate_unit_price_correct_default_taxed_value(
 
     # expected unit default taxed value without plugins
     expected_default_taxed_value = TaxedMoney(
-            net=total_value / quantity, gross=total_value / quantity
-        )
+        net=total_value / quantity, gross=total_value / quantity
+    )
 
     # when
     result = PluginsManager(plugins=plugins).calculate_checkout_line_unit_price(


### PR DESCRIPTION
I want to merge this change because it fixes #13920 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
