### PR TITLE
Adjust sale catalogue mutations.

### DIFF
--- a/saleor/discount/sale_converter.py
+++ b/saleor/discount/sale_converter.py
@@ -1,9 +1,15 @@
-from collections import defaultdict
-from typing import DefaultDict, Dict, List, Set, Union
+from typing import Dict, List
 
 from ..graphql.discount.mutations.utils import convert_catalogue_info_to_global_ids
 from .models import Promotion, PromotionRule
 from .utils import fetch_catalogue_info
+
+
+def get_or_create_promotion(sale):
+    promotion = Promotion.objects.filter(old_sale_id=sale.id).first()
+    if promotion:
+        return promotion
+    return create_promotion_for_new_sale(sale)
 
 
 def create_promotion_for_new_sale(sale, catalogue_data=None):
@@ -66,30 +72,3 @@ def create_catalogue_predicate_from_catalogue_data(catalogue_data):
 def create_catalogue_predicate_from_sale(sale):
     catalogue_data = convert_catalogue_info_to_global_ids(fetch_catalogue_info(sale))
     return create_catalogue_predicate_from_catalogue_data(catalogue_data)
-
-
-CatalogueInfo = DefaultDict[str, Set[Union[int, str]]]
-PREDICATE_TO_CATALOGUE_INFO_MAP = {
-    "collectionPredicate": "collections",
-    "categoryPredicate": "categories",
-    "productPredicate": "products",
-    "variantPredicate": "variants",
-}
-
-
-def convert_migrated_sale_predicate_to_catalogue_info(
-    catalogue_predicate,
-) -> CatalogueInfo:
-    catalogue_info: CatalogueInfo = defaultdict(set)
-    for field in PREDICATE_TO_CATALOGUE_INFO_MAP.values():
-        catalogue_info[field] = set()
-
-    if catalogue_predicate.get("OR"):
-        predicates = {
-            list(item.keys())[0]: list(item.values())[0]["ids"]
-            for item in catalogue_predicate["OR"]
-        }
-        for predicate_name, field in PREDICATE_TO_CATALOGUE_INFO_MAP.items():
-            catalogue_info[field] = set(predicates.get(predicate_name, {}))
-
-    return catalogue_info

--- a/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
@@ -1,9 +1,8 @@
-from typing import List, cast
+from typing import cast
 
 from .....core.tracing import traced_atomic_transaction
 from .....discount import models
-from .....discount.models import Promotion, PromotionRule
-from .....discount.sale_converter import create_catalogue_predicate_from_catalogue_data
+from .....discount.models import Promotion
 from .....discount.utils import fetch_catalogue_info
 from .....permission.enums import DiscountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
@@ -65,10 +64,3 @@ class SaleAddCatalogues(SaleBaseCatalogueMutation):
             cls.call_event(sale_update_event)
 
         return SaleAddCatalogues(sale=ChannelContext(node=sale, channel_slug=None))
-
-    @classmethod
-    def update_promotion_rules_predicate(cls, rules, new_catalogue):
-        new_predicate = create_catalogue_predicate_from_catalogue_data(new_catalogue)
-        for rule in rules:
-            rule.catalogue_predicate = new_predicate
-        PromotionRule.objects.bulk_update(rules, ["catalogue_predicate"])

--- a/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale/sale_add_catalogues.py
@@ -2,7 +2,7 @@ from typing import cast
 
 from .....core.tracing import traced_atomic_transaction
 from .....discount import models
-from .....discount.models import Promotion
+from .....discount.sale_converter import get_or_create_promotion
 from .....discount.utils import fetch_catalogue_info
 from .....permission.enums import DiscountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
@@ -40,7 +40,7 @@ class SaleAddCatalogues(SaleBaseCatalogueMutation):
             cls.get_node_or_error(info, id, only_type=Sale, field="sale_id"),
         )
         previous_catalogue = fetch_catalogue_info(sale)
-        promotion = Promotion.objects.get(old_sale_id=sale.id)
+        promotion = get_or_create_promotion(sale)
         rules = promotion.rules.all()
         manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():

--- a/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
+++ b/saleor/graphql/discount/mutations/sale/sale_base_catalogue.py
@@ -1,5 +1,7 @@
 import graphene
 
+from .....discount.models import PromotionRule
+from .....discount.sale_converter import create_catalogue_predicate_from_catalogue_data
 from ...types import Sale
 from ..voucher.voucher_add_catalogues import CatalogueInput
 from .sale_base_discount_catalogue import BaseDiscountCatalogueMutation
@@ -19,3 +21,10 @@ class SaleBaseCatalogueMutation(BaseDiscountCatalogueMutation):
 
     class Meta:
         abstract = True
+
+    @classmethod
+    def update_promotion_rules_predicate(cls, rules, catalogue):
+        new_predicate = create_catalogue_predicate_from_catalogue_data(catalogue)
+        for rule in rules:
+            rule.catalogue_predicate = new_predicate
+        PromotionRule.objects.bulk_update(rules, ["catalogue_predicate"])

--- a/saleor/graphql/discount/mutations/sale/sale_remove_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale/sale_remove_catalogues.py
@@ -2,7 +2,7 @@ from typing import cast
 
 from .....core.tracing import traced_atomic_transaction
 from .....discount import models
-from .....discount.models import Promotion
+from .....discount.sale_converter import get_or_create_promotion
 from .....discount.utils import fetch_catalogue_info
 from .....graphql.channel import ChannelContext
 from .....permission.enums import DiscountPermissions
@@ -40,7 +40,7 @@ class SaleRemoveCatalogues(SaleBaseCatalogueMutation):
             cls.get_node_or_error(info, id, only_type=Sale, field="sale_id"),
         )
         previous_catalogue = fetch_catalogue_info(sale)
-        promotion = Promotion.objects.get(old_sale_id=sale.id)
+        promotion = get_or_create_promotion(sale)
         rules = promotion.rules.all()
         manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():

--- a/saleor/graphql/discount/mutations/sale/sale_remove_catalogues.py
+++ b/saleor/graphql/discount/mutations/sale/sale_remove_catalogues.py
@@ -2,6 +2,7 @@ from typing import cast
 
 from .....core.tracing import traced_atomic_transaction
 from .....discount import models
+from .....discount.models import Promotion
 from .....discount.utils import fetch_catalogue_info
 from .....graphql.channel import ChannelContext
 from .....permission.enums import DiscountPermissions
@@ -39,10 +40,14 @@ class SaleRemoveCatalogues(SaleBaseCatalogueMutation):
             cls.get_node_or_error(info, id, only_type=Sale, field="sale_id"),
         )
         previous_catalogue = fetch_catalogue_info(sale)
+        promotion = Promotion.objects.get(old_sale_id=sale.id)
+        rules = promotion.rules.all()
         manager = get_plugin_manager_promise(info.context).get()
         with traced_atomic_transaction():
             cls.remove_catalogues_from_node(sale, input)
             current_catalogue = fetch_catalogue_info(sale)
+            cls.update_promotion_rules_predicate(rules, current_catalogue)
+
             cls.call_event(
                 lambda: manager.sale_updated(
                     sale,

--- a/saleor/graphql/discount/tests/mutations/test_sale_catalogues_add.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_catalogues_add.py
@@ -4,13 +4,10 @@ import graphene
 
 from .....discount.error_codes import DiscountErrorCode
 from .....discount.models import Promotion
-from .....discount.sale_converter import (
-    convert_migrated_sale_predicate_to_catalogue_info,
-    create_promotion_for_new_sale,
-)
 from .....discount.utils import fetch_catalogue_info
 from ....tests.utils import get_graphql_content
 from ...mutations.utils import convert_catalogue_info_to_global_ids
+from .utils import convert_migrated_sale_predicate_to_catalogue_info
 
 SALE_CATALOGUES_ADD_MUTATION = """
     mutation saleCataloguesAdd($id: ID!, $input: CatalogueInput!) {
@@ -56,7 +53,7 @@ def test_sale_add_catalogues(
         graphene.Node.to_global_id("ProductVariant", variant.id)
         for variant in product_variant_list
     ]
-    create_promotion_for_new_sale(sale, previous_catalogue)
+
     variables = {
         "id": graphene.Node.to_global_id("Sale", sale.id),
         "input": {
@@ -115,7 +112,6 @@ def test_sale_add_no_catalogues(
 ):
     # given
     query = SALE_CATALOGUES_ADD_MUTATION
-    create_promotion_for_new_sale(new_sale)
     variables = {
         "id": graphene.Node.to_global_id("Sale", new_sale.id),
         "input": {"products": [], "collections": [], "categories": [], "variants": []},
@@ -165,7 +161,6 @@ def test_sale_remove_no_catalogues(
     sale.collections.add(collection)
     sale.categories.add(category)
     sale.variants.add(*product_variant_list)
-    create_promotion_for_new_sale(sale)
 
     query = SALE_CATALOGUES_ADD_MUTATION
     variables = {
@@ -216,7 +211,6 @@ def test_sale_add_catalogues_with_product_without_variants(
     product_id = graphene.Node.to_global_id("Product", product.id)
     collection_id = graphene.Node.to_global_id("Collection", collection.id)
     category_id = graphene.Node.to_global_id("Category", category.id)
-    create_promotion_for_new_sale(sale)
 
     variables = {
         "id": graphene.Node.to_global_id("Sale", sale.id),

--- a/saleor/graphql/discount/tests/mutations/test_sale_catalogues_remove.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_catalogues_remove.py
@@ -3,13 +3,10 @@ from unittest.mock import patch
 import graphene
 
 from .....discount.models import Promotion
-from .....discount.sale_converter import (
-    convert_migrated_sale_predicate_to_catalogue_info,
-    create_promotion_for_new_sale,
-)
 from .....discount.utils import fetch_catalogue_info
 from ....tests.utils import get_graphql_content
 from ...mutations.utils import convert_catalogue_info_to_global_ids
+from .utils import convert_migrated_sale_predicate_to_catalogue_info
 
 SALE_CATALOGUES_REMOVE_MUTATION = """
     mutation saleCataloguesRemove($id: ID!, $input: CatalogueInput!) {
@@ -60,7 +57,6 @@ def test_sale_remove_catalogues(
         graphene.Node.to_global_id("ProductVariant", variant.id)
         for variant in product_variant_list
     ]
-    create_promotion_for_new_sale(sale, previous_catalogue)
     variables = {
         "id": graphene.Node.to_global_id("Sale", sale.id),
         "input": {

--- a/saleor/graphql/discount/tests/mutations/utils.py
+++ b/saleor/graphql/discount/tests/mutations/utils.py
@@ -19,7 +19,7 @@ def convert_migrated_sale_predicate_to_catalogue_info(
 
     if catalogue_predicate.get("OR"):
         predicates = {
-            next(item.keys()): next(item.values())["ids"]
+            list(item.keys())[0]: list(item.values())[0]["ids"]
             for item in catalogue_predicate["OR"]
         }
         for predicate_name, field in PREDICATE_TO_CATALOGUE_INFO_MAP.items():

--- a/saleor/graphql/discount/tests/mutations/utils.py
+++ b/saleor/graphql/discount/tests/mutations/utils.py
@@ -19,7 +19,7 @@ def convert_migrated_sale_predicate_to_catalogue_info(
 
     if catalogue_predicate.get("OR"):
         predicates = {
-            list(item.keys())[0]: list(item.values())[0]["ids"]
+            next(item.keys()): next(item.values())["ids"]
             for item in catalogue_predicate["OR"]
         }
         for predicate_name, field in PREDICATE_TO_CATALOGUE_INFO_MAP.items():

--- a/saleor/graphql/discount/tests/mutations/utils.py
+++ b/saleor/graphql/discount/tests/mutations/utils.py
@@ -1,0 +1,28 @@
+from collections import defaultdict
+from typing import DefaultDict, Set, Union
+
+CatalogueInfo = DefaultDict[str, Set[Union[int, str]]]
+PREDICATE_TO_CATALOGUE_INFO_MAP = {
+    "collectionPredicate": "collections",
+    "categoryPredicate": "categories",
+    "productPredicate": "products",
+    "variantPredicate": "variants",
+}
+
+
+def convert_migrated_sale_predicate_to_catalogue_info(
+    catalogue_predicate,
+) -> CatalogueInfo:
+    catalogue_info: CatalogueInfo = defaultdict(set)
+    for field in PREDICATE_TO_CATALOGUE_INFO_MAP.values():
+        catalogue_info[field] = set()
+
+    if catalogue_predicate.get("OR"):
+        predicates = {
+            list(item.keys())[0]: list(item.values())[0]["ids"]
+            for item in catalogue_predicate["OR"]
+        }
+        for predicate_name, field in PREDICATE_TO_CATALOGUE_INFO_MAP.items():
+            catalogue_info[field] = set(predicates.get(predicate_name, {}))
+
+    return catalogue_info


### PR DESCRIPTION
I want to merge this change, because it updates promotion rules predicate during `saleCatalogueAdd` and `saleCatalogueRemove` mutations.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
