### PR TITLE
Adjust sale delete

### DIFF
--- a/saleor/graphql/discount/tests/mutations/test_sale_delete.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_delete.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import graphene
 import pytest
 
+from .....discount.models import Promotion
 from .....discount.utils import fetch_catalogue_info
 from ....tests.utils import get_graphql_content
 from ...mutations.utils import convert_catalogue_info_to_global_ids
@@ -64,3 +65,51 @@ def test_sale_delete_mutation(
     assert set(kwargs["collection_ids"]) == collection_ids
     assert set(kwargs["product_ids"]) == product_ids
     assert set(kwargs["variant_ids"]) == variant_ids
+
+
+@patch(
+    "saleor.product.tasks.update_products_discounted_prices_of_catalogues_task.delay"
+)
+@patch("saleor.plugins.manager.PluginsManager.sale_deleted")
+def test_sale_delete_mutation_deletes_promotion(
+    deleted_webhook_mock,
+    update_products_discounted_prices_of_catalogues_task_mock,
+    staff_api_client,
+    sale,
+    permission_manage_discounts,
+):
+    # given
+    query = SALE_DELETE_MUTATION
+
+    promotion = Promotion.objects.create(name="Test", old_sale_id=sale.pk)
+
+    variables = {"id": graphene.Node.to_global_id("Sale", sale.id)}
+    previous_catalogue = convert_catalogue_info_to_global_ids(
+        fetch_catalogue_info(sale)
+    )
+    category_ids = set(sale.categories.values_list("id", flat=True))
+    collection_ids = set(sale.collections.values_list("id", flat=True))
+    product_ids = set(sale.products.values_list("id", flat=True))
+    variant_ids = set(sale.variants.values_list("id", flat=True))
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_discounts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["saleDelete"]
+    assert data["sale"]["name"] == sale.name
+    deleted_webhook_mock.assert_called_once_with(sale, previous_catalogue)
+    with pytest.raises(sale._meta.model.DoesNotExist):
+        sale.refresh_from_db()
+    update_products_discounted_prices_of_catalogues_task_mock.assert_called_once()
+    args, kwargs = update_products_discounted_prices_of_catalogues_task_mock.call_args
+    assert set(kwargs["category_ids"]) == category_ids
+    assert set(kwargs["collection_ids"]) == collection_ids
+    assert set(kwargs["product_ids"]) == product_ids
+    assert set(kwargs["variant_ids"]) == variant_ids
+
+    with pytest.raises(promotion._meta.model.DoesNotExist):
+        promotion.refresh_from_db()


### PR DESCRIPTION
Adjust `saleDelete` and `SaleBulkDelete` to delete corresponding promotions

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
