### PR TITLE
Add update of user when logging in using openid connect

### DIFF
--- a/saleor/plugins/openid_connect/tests/test_utils.py
+++ b/saleor/plugins/openid_connect/tests/test_utils.py
@@ -740,7 +740,7 @@ def test_assign_staff_to_default_group_and_update_permissions_update_user_permis
 
 @patch("saleor.plugins.openid_connect.utils.match_orders_with_new_user")
 @patch("saleor.plugins.openid_connect.utils.logger")
-def test__update_user_details_no_user_with_new_email_in_db(
+def test_update_user_details_no_user_with_new_email_in_db(
     mock_logger,
     mock_match_orders_with_new_user,
     customer_user,
@@ -768,7 +768,7 @@ def test__update_user_details_no_user_with_new_email_in_db(
 
 @patch("saleor.plugins.openid_connect.utils.match_orders_with_new_user")
 @patch("saleor.plugins.openid_connect.utils.logger")
-def test__update_user_details_user_with_new_email_in_db(
+def test_update_user_details_user_with_new_email_in_db(
     mock_logger, mock_match_orders_with_new_user, customer_user, customer_user2
 ):
     # given
@@ -797,7 +797,7 @@ def test__update_user_details_user_with_new_email_in_db(
     mock_match_orders_with_new_user.assert_not_called()
 
 
-def test__update_user_details_update_user_first_name(
+def test_update_user_details_update_user_first_name(
     customer_user,
 ):
     # given
@@ -818,12 +818,11 @@ def test__update_user_details_update_user_first_name(
 
     # then
     customer_user.refresh_from_db()
-    print(repr(customer_user.search_document))
     assert customer_user.first_name == "test user_first_name"
     assert customer_user.search_document == expected_search_document
 
 
-def test__update_user_details_update_user_last_name(
+def test_update_user_details_update_user_last_name(
     customer_user,
 ):
     # given
@@ -844,6 +843,5 @@ def test__update_user_details_update_user_last_name(
 
     # then
     customer_user.refresh_from_db()
-    print(repr(customer_user.search_document))
     assert customer_user.last_name == "test user_last_name"
     assert customer_user.search_document == expected_search_document

--- a/saleor/plugins/openid_connect/tests/test_utils.py
+++ b/saleor/plugins/openid_connect/tests/test_utils.py
@@ -3,7 +3,7 @@ import time
 import warnings
 from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 import pytz
@@ -27,6 +27,7 @@ from ..exceptions import AuthenticationError
 from ..utils import (
     JWKS_CACHE_TIME,
     JWKS_KEY,
+    _update_user_details,
     assign_staff_to_default_group_and_update_permissions,
     create_jwt_refresh_token,
     create_jwt_token,
@@ -735,3 +736,114 @@ def test_assign_staff_to_default_group_and_update_permissions_update_user_permis
         permission_manage_users.name,
         permission_manage_orders.name,
     }
+
+
+@patch("saleor.plugins.openid_connect.utils.match_orders_with_new_user")
+@patch("saleor.plugins.openid_connect.utils.logger")
+def test__update_user_details_no_user_with_new_email_in_db(
+    mock_logger,
+    mock_match_orders_with_new_user,
+    customer_user,
+):
+    # given
+    assert customer_user.email != "test_user_email@example.com"
+
+    # when
+    _update_user_details(
+        customer_user,
+        "test oidc_key",
+        "test_user_email@example.com",
+        customer_user.first_name,
+        customer_user.last_name,
+        "test oidc_sub",
+        customer_user.last_login,
+    )
+
+    # then
+    customer_user.refresh_from_db()
+    assert customer_user.email == "test_user_email@example.com"
+    assert mock_logger.mock_calls == []
+    mock_match_orders_with_new_user.assert_called_once_with(customer_user)
+
+
+@patch("saleor.plugins.openid_connect.utils.match_orders_with_new_user")
+@patch("saleor.plugins.openid_connect.utils.logger")
+def test__update_user_details_user_with_new_email_in_db(
+    mock_logger, mock_match_orders_with_new_user, customer_user, customer_user2
+):
+    # given
+    assert customer_user.email != customer_user2.email
+
+    # when
+    _update_user_details(
+        customer_user,
+        "test oidc_key",
+        customer_user2.email,
+        customer_user.first_name,
+        customer_user.last_name,
+        "test oidc_sub",
+        customer_user.last_login,
+    )
+
+    # then
+    customer_user.refresh_from_db()
+    assert customer_user.email != customer_user2.email
+    assert mock_logger.mock_calls == [
+        call.warning(
+            "Unable to update user email as the new one already exists in DB",
+            extra={"oidc_key": "test oidc_key"},
+        )
+    ]
+    mock_match_orders_with_new_user.assert_not_called()
+
+
+def test__update_user_details_update_user_first_name(
+    customer_user,
+):
+    # given
+    expected_search_document = "test@example.com\ntest user_first_name\nwade\n"
+    assert customer_user.first_name != "test user_first_name"
+    assert customer_user.search_document != expected_search_document
+
+    # when
+    _update_user_details(
+        customer_user,
+        "test oidc_key",
+        customer_user.email,
+        "test user_first_name",
+        customer_user.last_name,
+        "test oidc_sub",
+        customer_user.last_login,
+    )
+
+    # then
+    customer_user.refresh_from_db()
+    print(repr(customer_user.search_document))
+    assert customer_user.first_name == "test user_first_name"
+    assert customer_user.search_document == expected_search_document
+
+
+def test__update_user_details_update_user_last_name(
+    customer_user,
+):
+    # given
+    expected_search_document = "test@example.com\nleslie\ntest user_last_name\n"
+    assert customer_user.last_name != "test user_last_name"
+    assert customer_user.search_document != expected_search_document
+
+    # when
+    _update_user_details(
+        customer_user,
+        "test oidc_key",
+        customer_user.email,
+        customer_user.first_name,
+        "test user_last_name",
+        "test oidc_sub",
+        customer_user.last_login,
+    )
+
+    # then
+    customer_user.refresh_from_db()
+    print(repr(customer_user.search_document))
+    assert customer_user.last_name == "test user_last_name"
+    assert customer_user.search_document == expected_search_document

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from jwt import PyJWTError
 
 from ...account.models import Group, User
+from ...account.search import prepare_user_search_document_value
 from ...account.utils import get_user_groups_permissions
 from ...core.jwt import (
     JWT_ACCESS_TYPE,
@@ -420,6 +421,8 @@ def get_or_create_user_from_payload(
         user=user,
         oidc_key=oidc_metadata_key,
         user_email=user_email,
+        user_first_name=defaults_create["first_name"],
+        user_last_name=defaults_create["last_name"],
         sub=sub,  # type: ignore
         last_login=last_login,
     )
@@ -437,14 +440,16 @@ def _update_user_details(
     user: User,
     oidc_key: str,
     user_email: str,
+    user_first_name: str,
+    user_last_name: str,
     sub: str,
     last_login: Optional[int],
 ):
     user_sub = user.get_value_from_private_metadata(oidc_key)
-    fields_to_save = []
+    fields_to_save = set()
     if user_sub != sub:
         user.store_value_in_private_metadata({oidc_key: sub})
-        fields_to_save.append("private_metadata")
+        fields_to_save.add("private_metadata")
 
     if user.email != user_email:
         if User.objects.filter(email=user_email).exists():
@@ -455,12 +460,13 @@ def _update_user_details(
             return
         user.email = user_email
         match_orders_with_new_user(user)
-        fields_to_save.append("email")
+        fields_to_save.update({"email", "search_document"})
+
     if last_login:
         if not user.last_login or user.last_login.timestamp() < last_login:
             login_time = timezone.make_aware(datetime.fromtimestamp(last_login))
             user.last_login = login_time
-            fields_to_save.append("last_login")
+            fields_to_save.add("last_login")
     else:
         if (
             not user.last_login
@@ -468,7 +474,20 @@ def _update_user_details(
             > settings.OAUTH_UPDATE_LAST_LOGIN_THRESHOLD
         ):
             user.last_login = timezone.now()
-            fields_to_save.append("last_login")
+            fields_to_save.add("last_login")
+
+    if user.first_name != user_first_name:
+        user.first_name = user_first_name
+        fields_to_save.update({"first_name", "search_document"})
+
+    if user.last_name != user_last_name:
+        user.last_name = user_last_name
+        fields_to_save.update({"last_name", "search_document"})
+
+    if "search_document" in fields_to_save:
+        user.search_document = prepare_user_search_document_value(
+            user, attach_addresses_data=False
+        )
 
     if fields_to_save:
         user.save(update_fields=fields_to_save)


### PR DESCRIPTION
I want to merge this change because those changes will update user information when logging in using openid connect

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
