### PR TITLE
[TEST] Create order in channel with transaction flow as mark as paid strategy CORE_0209

### DIFF
--- a/saleor/tests/e2e/channel/utils.py
+++ b/saleor/tests/e2e/channel/utils.py
@@ -37,6 +37,7 @@ def create_channel(
     automatically_fulfill_non_shippable_giftcard=False,
     allow_unpaid_orders=False,
     automatically_confirm_all_new_orders=True,
+    mark_as_paid_strategy="PAYMENT_FLOW",
 ):
     if not warehouse_ids:
         warehouse_ids = []
@@ -50,6 +51,7 @@ def create_channel(
             "isActive": is_active,
             "addWarehouses": warehouse_ids,
             "orderSettings": {
+                "markAsPaidStrategy": mark_as_paid_strategy,
                 "automaticallyFulfillNonShippableGiftCard": (
                     automatically_fulfill_non_shippable_giftcard
                 ),

--- a/saleor/tests/e2e/orders/test_order_in_channel_with_transaction_flow_as_mark_as_paid_strategy.py
+++ b/saleor/tests/e2e/orders/test_order_in_channel_with_transaction_flow_as_mark_as_paid_strategy.py
@@ -1,0 +1,171 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..channel.utils import create_channel
+from ..product.utils.preparing_product import prepare_product
+from ..shipping_zone.utils import (
+    create_shipping_method,
+    create_shipping_method_channel_listing,
+    create_shipping_zone,
+)
+from ..utils import assign_permissions
+from ..warehouse.utils import create_warehouse
+from .utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    mark_order_paid,
+    order_lines_create,
+    order_query,
+)
+
+
+def prepare_shop_in_channel_with_transaction_flow_as_mark_as_paid_strategy(
+    e2e_staff_api_client,
+):
+    warehouse_data = create_warehouse(e2e_staff_api_client)
+    warehouse_id = warehouse_data["id"]
+    warehouse_ids = [warehouse_id]
+
+    channel_data = create_channel(
+        e2e_staff_api_client,
+        warehouse_ids=[warehouse_ids],
+        mark_as_paid_strategy="TRANSACTION_FLOW",
+    )
+    channel_id = channel_data["id"]
+
+    shipping_zone_data = create_shipping_zone(
+        e2e_staff_api_client,
+        warehouse_ids=[warehouse_id],
+        channel_ids=[channel_id],
+    )
+    shipping_zone_id = shipping_zone_data["id"]
+
+    shipping_method_data = create_shipping_method(
+        e2e_staff_api_client,
+        shipping_zone_id,
+        type="PRICE",
+    )
+    shipping_method_id = shipping_method_data["id"]
+
+    create_shipping_method_channel_listing(
+        e2e_staff_api_client,
+        shipping_method_id,
+        channel_id,
+    )
+
+    return (
+        warehouse_id,
+        channel_id,
+        shipping_method_id,
+    )
+
+
+@pytest.mark.e2e
+def test_order_in_channel_with_transaction_flow_as_mark_as_paid_strategy_CORE_0209(
+    e2e_staff_api_client,
+    e2e_app_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+    permission_manage_payments,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_payments,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+    app_permissions = [permission_manage_payments]
+    assign_permissions(e2e_app_api_client, app_permissions)
+
+    (
+        warehouse_id,
+        channel_id,
+        shipping_method_id,
+    ) = prepare_shop_in_channel_with_transaction_flow_as_mark_as_paid_strategy(
+        e2e_staff_api_client
+    )
+
+    price = 2
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    # Step 1 - Create draft order
+    draft_order_input = {
+        "channelId": channel_id,
+        "userEmail": "test_user@test.com",
+        "shippingAddress": DEFAULT_ADDRESS,
+        "billingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        draft_order_input,
+    )
+    order_id = data["order"]["id"]
+    assert order_id is not None
+
+    # Step 2 - Add lines to the order
+    lines = [{"variantId": product_variant_id, "quantity": 1}]
+    order_lines = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_product_variant_id = order_lines["order"]["lines"][0]["variant"]["id"]
+    assert order_product_variant_id == product_variant_id
+
+    # Step 3 - Update order's shipping method
+    input = {"shippingMethod": shipping_method_id}
+    draft_order = draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+    order_shipping_id = draft_order["order"]["deliveryMethod"]["id"]
+    assert order_shipping_id is not None
+
+    # Step 4 - Complete the order and check it's status
+    order = draft_order_complete(e2e_staff_api_client, order_id)
+    order_complete_id = order["order"]["id"]
+    assert order_complete_id == order_id
+    order_line = order["order"]["lines"][0]
+    assert order_line["productVariantId"] == product_variant_id
+    assert order["order"]["status"] == "UNFULFILLED"
+    assert (
+        order["order"]["channel"]["orderSettings"]["markAsPaidStrategy"]
+        == "TRANSACTION_FLOW"
+    )
+    order_total = order["order"]["total"]["gross"]["amount"]
+    assert order_total != 0
+
+    # Step 5 - Mark order as paid in transaction flow and check order's payment status
+    order_paid_data = mark_order_paid(
+        e2e_staff_api_client,
+        order_id,
+        transactionReference="test-pspreference",
+    )
+    assert order_paid_data["order"]["isPaid"] is True
+    assert order_paid_data["order"]["paymentStatus"] == "FULLY_CHARGED"
+    assert order_paid_data["order"]["status"] == "UNFULFILLED"
+    order_data = order_query(
+        e2e_staff_api_client,
+        order_id,
+    )
+    assert order_data["isPaid"] is True
+    assert order_data["paymentStatus"] == "FULLY_CHARGED"
+    assert order_data["transactions"] is not None

--- a/saleor/tests/e2e/orders/utils/draft_order_complete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_complete.py
@@ -35,6 +35,13 @@ mutation DraftOrderComplete($id: ID!) {
       }
       displayGrossPrices
       status
+      paymentStatus
+      isPaid
+      channel {
+        orderSettings{
+            markAsPaidStrategy
+        }
+     }
       lines {
         productVariantId
         quantity

--- a/saleor/tests/e2e/orders/utils/order_mark_as_paid.py
+++ b/saleor/tests/e2e/orders/utils/order_mark_as_paid.py
@@ -1,23 +1,41 @@
 from saleor.graphql.tests.utils import get_graphql_content
 
 ORDER_MARK_AS_PAID_MUTATION = """
-mutation OrderMarkAsPaid($id: ID!) {
-  orderMarkAsPaid(id: $id) {
+mutation OrderMarkAsPaid($id: ID!, $transactionReference: String) {
+  orderMarkAsPaid(id: $id, transactionReference: $transactionReference) {
     order {
-      isPaid
-      paymentStatus
-      paymentStatusDisplay
-      status
-      statusDisplay
+        id
+        isPaid
+        paymentStatus
+        paymentStatusDisplay
+        status
+        statusDisplay
+        transactions {
+            id
+            order {
+            id
+            }
+            name
+        }
     }
-    errors{message field}
+    errors {
+        message
+        field
+    }
   }
 }
 """
 
 
-def mark_order_paid(api_client, id):
-    variables = {"id": id}
+def mark_order_paid(
+    api_client,
+    id,
+    transactionReference=None,
+):
+    variables = {
+        "id": id,
+        "transactionReference": transactionReference,
+    }
 
     response = api_client.post_graphql(
         ORDER_MARK_AS_PAID_MUTATION,

--- a/saleor/tests/e2e/orders/utils/order_query.py
+++ b/saleor/tests/e2e/orders/utils/order_query.py
@@ -7,6 +7,8 @@ query OrderDetails($id:ID!) {
       id
       active
     }
+    paymentStatus
+    isPaid
     channel {
         id
         name
@@ -40,7 +42,9 @@ query OrderDetails($id:ID!) {
     }
     statusDisplay
     status
-    paymentStatus
+    transactions {
+        id
+    }
   }
 }
 """


### PR DESCRIPTION
I want to merge this change because it checks adding an order with transaction flow as mark as paid channel's strategy [CORE_0209](https://saleor.testmo.net/repositories/5?group_id=112&case_id=2379)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
