### PR TITLE
Fix amount value comparison in transaction webhooks

### DIFF
--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -941,14 +941,20 @@ def test_create_transaction_event_from_request_and_webhook_response_twice_auth(
     assert failed_event.type == TransactionEventType.AUTHORIZATION_FAILURE
 
 
+@pytest.mark.parametrize(
+    "first_event_amount, second_event_amount",
+    [(12.02, 12.02), ("12.02", 12.02), (12.02, "12.02"), ("12.02", "12.02")],
+)
 @freeze_time("2018-05-31 12:00:01")
 def test_create_transaction_event_from_request_and_webhook_response_same_event(
     transaction_item_generator,
+    first_event_amount,
+    second_event_amount,
     app,
 ):
     # given
     expected_psp_reference = "psp:122:222"
-    event_amount = 12.00
+    event_amount = first_event_amount
     event_type = TransactionEventType.AUTHORIZATION_SUCCESS
     event_time = "2022-11-18T13:25:58.169685+00:00"
     event_url = "http://localhost:3000/event/ref123"
@@ -963,14 +969,14 @@ def test_create_transaction_event_from_request_and_webhook_response_same_event(
 
     request_event = TransactionEvent.objects.create(
         type=TransactionEventType.AUTHORIZATION_REQUEST,
-        amount_value=event_amount,
+        amount_value=second_event_amount,
         currency="USD",
         transaction_id=transaction.id,
     )
 
     response_data = {
         "pspReference": expected_psp_reference,
-        "amount": event_amount,
+        "amount": second_event_amount,
         "result": event_type.upper(),
         "time": event_time,
         "externalUrl": event_url,

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -995,6 +995,53 @@ def test_create_transaction_event_from_request_and_webhook_response_same_event(
     assert event.pk == existing_authorize_success.pk
 
 
+@pytest.mark.parametrize(
+    "event_amount",
+    [None, "NaN", "-Inf", "Inf", "One"],
+)
+@freeze_time("2018-05-31 12:00:01")
+def test_create_transaction_event_from_request_handle_incorrect_values(
+    transaction_item_generator,
+    event_amount,
+    app,
+):
+    # given
+    expected_psp_reference = "psp:122:222"
+    event_amount = event_amount
+    event_type = TransactionEventType.AUTHORIZATION_SUCCESS
+    event_time = "2022-11-18T13:25:58.169685+00:00"
+    event_url = "http://localhost:3000/event/ref123"
+
+    transaction = transaction_item_generator()
+
+    request_event = TransactionEvent.objects.create(
+        type=TransactionEventType.AUTHORIZATION_REQUEST,
+        amount_value=Decimal(10),
+        currency="USD",
+        transaction_id=transaction.id,
+        psp_reference=expected_psp_reference,
+    )
+
+    response_data = {
+        "pspReference": expected_psp_reference,
+        "amount": event_amount,
+        "result": event_type.upper(),
+        "time": event_time,
+        "externalUrl": event_url,
+    }
+
+    # when
+    event = create_transaction_event_from_request_and_webhook_response(
+        request_event, app, response_data
+    )
+
+    # then
+    assert event.type == TransactionEventType.AUTHORIZATION_FAILURE
+    assert TransactionEvent.objects.count() == 2
+    request_event.refresh_from_db()
+    assert request_event.psp_reference == expected_psp_reference
+
+
 @freeze_time("2018-05-31 12:00:01")
 def test_create_transaction_event_from_request_and_webhook_response_different_amount(
     transaction_item_generator,

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -781,12 +781,20 @@ def parse_transaction_event_data(
 
     amount_data = event_data.get("amount")
     if amount_data is not None:
+        amount_valid = True
+        amount = None
         try:
             amount = decimal.Decimal(amount_data).quantize(
                 decimal.Decimal(10) ** (-settings.DEFAULT_DECIMAL_PLACES)
             )
             parsed_event_data["amount"] = amount
         except decimal.DecimalException:
+            amount_valid = False
+
+        if amount and not amount.is_finite():
+            amount_valid = False
+
+        if not amount_valid:
             logger.warning(invalid_msg, "amount", amount_data)
             error_field_msg.append(invalid_msg % ("amount", amount_data))
     else:

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -734,6 +734,33 @@ def get_correct_event_types_based_on_request_type(request_type: str) -> list[str
     return type_map.get(request_type, [])
 
 
+def parse_transaction_event_amount(
+    amount_data: Union[str, int, float, None],
+    parsed_event_data: dict,
+    error_field_msg: list[str],
+    invalid_msg: str,
+    missing_msg: str,
+):
+    if amount_data is not None:
+        amount_valid = True
+        try:
+            amount = decimal.Decimal(amount_data).quantize(
+                decimal.Decimal(10) ** (-settings.DEFAULT_DECIMAL_PLACES)
+            )
+            parsed_event_data["amount"] = amount
+            if not amount.is_finite():
+                amount_valid = False
+        except decimal.DecimalException:
+            amount_valid = False
+
+        if not amount_valid:
+            logger.warning(invalid_msg, "amount", amount_data)
+            error_field_msg.append(invalid_msg % ("amount", amount_data))
+    else:
+        logger.warning(missing_msg, "amount")
+        error_field_msg.append(missing_msg % "amount")
+
+
 def parse_transaction_event_data(
     event_data: dict,
     parsed_event_data: dict,
@@ -780,26 +807,13 @@ def parse_transaction_event_data(
         error_field_msg.append(missing_msg % "result")
 
     amount_data = event_data.get("amount")
-    if amount_data is not None:
-        amount_valid = True
-        amount = None
-        try:
-            amount = decimal.Decimal(amount_data).quantize(
-                decimal.Decimal(10) ** (-settings.DEFAULT_DECIMAL_PLACES)
-            )
-            parsed_event_data["amount"] = amount
-        except decimal.DecimalException:
-            amount_valid = False
-
-        if amount and not amount.is_finite():
-            amount_valid = False
-
-        if not amount_valid:
-            logger.warning(invalid_msg, "amount", amount_data)
-            error_field_msg.append(invalid_msg % ("amount", amount_data))
-    else:
-        logger.warning(missing_msg, "amount")
-        error_field_msg.append(missing_msg % "amount")
+    parse_transaction_event_amount(
+        amount_data,
+        parsed_event_data=parsed_event_data,
+        error_field_msg=error_field_msg,
+        invalid_msg=invalid_msg,
+        missing_msg=missing_msg,
+    )
 
     if event_time_data := event_data.get("time"):
         try:
@@ -993,7 +1007,6 @@ def deduplicate_event(
     already_existing_event = get_already_existing_event(event)
     if already_existing_event:
         if already_existing_event.amount != event.amount:
-            # FIXME: add amounts and psp reference
             error_message = (
                 "The transaction with provided `pspReference` and "
                 "`type` already exists with different amount."


### PR DESCRIPTION
I want to merge this change because it fixes a case, when transactionEventReport was called first, and response from the transactionInitialize was returned as a second. In that case, there was a possibility that we will have a decimal value with different precision, which could cause a problem with de-duplication of the events.

Port of changes: #13953 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
