### PR TITLE
Test for deleting a draft order and a fix for issues caused by #13952

### DIFF
--- a/saleor/tests/e2e/orders/test_delete_draft_order.py
+++ b/saleor/tests/e2e/orders/test_delete_draft_order.py
@@ -4,11 +4,13 @@ from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_shop
 from ..utils import assign_permissions
-from .utils.draft_order_create import draft_order_create
-from .utils.draft_order_delete import draft_order_delete
-from .utils.draft_order_update import draft_order_update
-from .utils.order_lines_create import order_lines_create
-from .utils.order_query import order_query
+from .utils import (
+    draft_order_create,
+    draft_order_delete,
+    draft_order_update,
+    order_lines_create,
+    order_query,
+)
 
 
 @pytest.mark.e2e
@@ -46,6 +48,9 @@ def test_delete_draft_order_CORE_0205(
     # Step 1 - Create draft order
     draft_order_input = {
         "channelId": result_channel_id,
+        "userEmail": "test_user@test.com",
+        "shippingAddress": DEFAULT_ADDRESS,
+        "billingAddress": DEFAULT_ADDRESS,
     }
     data = draft_order_create(
         e2e_staff_api_client,
@@ -60,24 +65,13 @@ def test_delete_draft_order_CORE_0205(
     order_product_variant_id = order_lines["order"]["lines"][0]["variant"]["id"]
     assert order_product_variant_id == result_product_variant_id
 
-    # Step 3 - Update order's addresses and email
-    input = {
-        "userEmail": "test_user@test.com",
-        "shippingAddress": DEFAULT_ADDRESS,
-        "billingAddress": DEFAULT_ADDRESS,
-    }
-    draft_order = draft_order_update(e2e_staff_api_client, order_id, input)
-    assert draft_order["order"]["userEmail"] == "test_user@test.com"
-    assert draft_order["order"]["shippingAddress"] is not None
-    assert draft_order["order"]["billingAddress"] is not None
-
-    # Step 4 - Update order's shipping method
+    # Step 3 - Update order's shipping method
     input = {"shippingMethod": result_shipping_method_id}
     draft_order = draft_order_update(e2e_staff_api_client, order_id, input)
     order_shipping_id = draft_order["order"]["deliveryMethod"]["id"]
     assert order_shipping_id is not None
 
-    # Step 5 - Cancel the order
+    # Step 4 - Delete the order
     cancelled_order = draft_order_delete(e2e_staff_api_client, order_id)
     assert cancelled_order["order"]["status"] is not None
     order = order_query(e2e_staff_api_client, order_id)

--- a/saleor/tests/e2e/orders/test_delete_draft_order.py
+++ b/saleor/tests/e2e/orders/test_delete_draft_order.py
@@ -1,0 +1,84 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..utils import assign_permissions
+from .utils.draft_order_create import draft_order_create
+from .utils.draft_order_delete import draft_order_delete
+from .utils.draft_order_update import draft_order_update
+from .utils.order_lines_create import order_lines_create
+from .utils.order_query import order_query
+
+
+@pytest.mark.e2e
+def test_delete_draft_order_CORE_0205(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    price = 10
+
+    (
+        result_warehouse_id,
+        result_channel_id,
+        _,
+        result_shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    _, result_product_variant_id, _ = prepare_product(
+        e2e_staff_api_client, result_warehouse_id, result_channel_id, price
+    )
+
+    # Step 1 - Create draft order
+    draft_order_input = {
+        "channelId": result_channel_id,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        draft_order_input,
+    )
+    order_id = data["order"]["id"]
+    assert order_id is not None
+
+    # Step 2 - Add lines to the order
+    lines = [{"variantId": result_product_variant_id, "quantity": 1}]
+    order_lines = order_lines_create(e2e_staff_api_client, order_id, lines)
+    order_product_variant_id = order_lines["order"]["lines"][0]["variant"]["id"]
+    assert order_product_variant_id == result_product_variant_id
+
+    # Step 3 - Update order's addresses and email
+    input = {
+        "userEmail": "test_user@test.com",
+        "shippingAddress": DEFAULT_ADDRESS,
+        "billingAddress": DEFAULT_ADDRESS,
+    }
+    draft_order = draft_order_update(e2e_staff_api_client, order_id, input)
+    assert draft_order["order"]["userEmail"] == "test_user@test.com"
+    assert draft_order["order"]["shippingAddress"] is not None
+    assert draft_order["order"]["billingAddress"] is not None
+
+    # Step 4 - Update order's shipping method
+    input = {"shippingMethod": result_shipping_method_id}
+    draft_order = draft_order_update(e2e_staff_api_client, order_id, input)
+    order_shipping_id = draft_order["order"]["deliveryMethod"]["id"]
+    assert order_shipping_id is not None
+
+    # Step 5 - Cancel the order
+    cancelled_order = draft_order_delete(e2e_staff_api_client, order_id)
+    assert cancelled_order["order"]["status"] is not None
+    order = order_query(e2e_staff_api_client, order_id)
+    assert order is None

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -1,5 +1,6 @@
 from .draft_order_complete import draft_order_complete, raw_draft_order_complete
 from .draft_order_create import draft_order_create
+from .draft_order_delete import draft_order_delete
 from .draft_order_update import draft_order_update
 from .order_lines_create import order_lines_create
 from .order_mark_as_paid import mark_order_paid

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -14,4 +14,5 @@ __all__ = [
     "draft_order_update",
     "order_query",
     "mark_order_paid",
+    "draft_order_delete",
 ]

--- a/saleor/tests/e2e/orders/utils/draft_order_delete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_delete.py
@@ -1,0 +1,32 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+DRAFT_ORDER_DELETE_MUTATION = """
+mutation DraftOrderDelete($id: ID!) {
+  draftOrderDelete(id: $id) {
+    errors {
+		message
+        field
+    }
+    order {
+		status
+    }
+  }
+}
+"""
+
+
+def draft_order_delete(api_client, id):
+    variables = {"id": id}
+
+    response = api_client.post_graphql(
+        DRAFT_ORDER_DELETE_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["draftOrderDelete"]
+    errors = data["errors"]
+
+    assert errors == []
+
+    return data


### PR DESCRIPTION
I want to merge this change because it fixes issues caused by https://github.com/saleor/saleor/pull/13952/
and it adds a test for  [CORE_0205](https://saleor.testmo.net/repositories/5?group_id=112&case_id=2374) - deleting a draft order by a staff member

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
