### PR TITLE
Raise PaymentError instead of Exception

### DIFF
--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -32,6 +32,7 @@ from ..core.taxes import TaxData, TaxType, zero_money, zero_taxed_money
 from ..graphql.core import ResolveInfo, SaleorContext
 from ..order import base_calculations as base_order_calculations
 from ..order.interface import OrderTaxedPricesData
+from ..payment import PaymentError
 from ..payment.interface import (
     CustomerSource,
     GatewayResponse,
@@ -1752,7 +1753,7 @@ class PluginsManager(PaymentInterface):
             if resp is not None:
                 return resp
 
-        raise Exception(
+        raise PaymentError(
             f"Payment plugin {gateway} for {method_name}"
             " payment method is inaccessible!"
         )


### PR DESCRIPTION
I want to merge this change because is uses PaymentError instead of normal Exception. PaymentError is handled and should generate proper error in mutation response.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
