### PR TITLE
fix: streetAddress1, streetAddress2 field validation #12389

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ All notable, unreleased changes to this project will be documented in this file.
 - Unify how undiscounted prices are handled in orders and checkouts - #14780 by @jakubkuc
 - Drop demo - #14835 by @fowczarek
 - Add JSON serialization immediately after creating observability events to eliminate extra cPickle serialization and deserialization steps - #14992 by @przlada
-
 - Added caching of GraphQL documents for common queries to improve performance - #14843 by @patrys
 - Added `VOUCHER_CODES_CREATED` and `VOUCHER_CODES_DELETED` webhooks events. - #14652 by @SzymJ
+- Fixed validation for streetAddress1 or streetAddress2 are too long - #13973 by sonbui00
 
 
 # 3.18.0

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -173,9 +173,7 @@ class CountryAwareAddressForm(AddressForm):
     def validate_address(self, data):
         try:
             data["country_code"] = data.get("country", "")
-            data["street_address"] = "\n".join(
-                [data.get("street_address_1", ""), data.get("street_address_2", "")]
-            )
+            data["street_address"] = f'{data.get("street_address_1", "")}\n{data.get("street_address_2", "")}'
             normalized_data = i18naddress.normalize_address(data)
             if getattr(self, "enable_normalization", True):
                 data = normalized_data

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -173,7 +173,12 @@ class CountryAwareAddressForm(AddressForm):
     def validate_address(self, data):
         try:
             data["country_code"] = data.get("country", "")
-            data["street_address"] = f'{data.get("street_address_1", "")}\n{data.get("street_address_2", "")}'
+
+            street_address_1 = data.get("street_address_1", "")
+            street_address_2 = data.get("street_address_2", "")
+            if street_address_1 or street_address_2:
+                data["street_address"] = f"{street_address_1}\n{street_address_2}"
+
             normalized_data = i18naddress.normalize_address(data)
             if getattr(self, "enable_normalization", True):
                 data = normalized_data

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -173,10 +173,9 @@ class CountryAwareAddressForm(AddressForm):
     def validate_address(self, data):
         try:
             data["country_code"] = data.get("country", "")
-            if data["street_address_1"] or data["street_address_2"]:
-                data[
-                    "street_address"
-                ] = f'{data["street_address_1"]}\n{data["street_address_2"]}'
+            data["street_address"] = "\n".join(
+                [data.get("street_address_1", ""), data.get("street_address_2", "")]
+            )
             normalized_data = i18naddress.normalize_address(data)
             if getattr(self, "enable_normalization", True):
                 data = normalized_data

--- a/saleor/account/tests/test_account.py
+++ b/saleor/account/tests/test_account.py
@@ -25,6 +25,7 @@ def test_address_form_for_country(country):
     errors = form.errors
     rules = i18naddress.get_validation_rules({"country_code": country})
     required = rules.required_fields
+
     if "street_address" in required:
         assert "street_address_1" in errors
     else:
@@ -57,6 +58,30 @@ def test_address_form_postal_code_validation():
     form = forms.get_address_form(data, country_code="PL")
     errors = form.errors
     assert "postal_code" in errors
+
+
+def test_address_form_long_street_address_validation():
+    data = {
+        "city": "test",
+        "city_area": "test",
+        "company_name": "test",
+        "first_name": "Amelia",
+        "last_name": "Doe",
+        "country": "US",
+        "country_area": "IN",
+        "phone": "",
+        "postal_code": "46802",
+        "street_address_1": (
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut "
+            "labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris "
+            "nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit "
+            "esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt "
+            "in culpa qui officia deserunt mollit anim id est laborum"
+        ),
+    }
+    form = forms.get_address_form(data, country_code="US")
+    errors = form.errors
+    assert "street_address_1" in errors
 
 
 @pytest.mark.parametrize(
@@ -181,11 +206,6 @@ def test_copy_address(address):
     copied_address = address.get_copy()
     assert copied_address.pk != address.pk
     assert copied_address == address
-
-
-def test_compare_addresses(address):
-    copied_address = address.get_copy()
-    assert address == copied_address
 
 
 def test_compare_addresses_with_country_object(address):

--- a/saleor/account/tests/test_account.py
+++ b/saleor/account/tests/test_account.py
@@ -14,6 +14,7 @@ from ..validators import validate_possible_number
 
 @pytest.mark.parametrize("country", ["CN", "PL", "US", "IE"])
 def test_address_form_for_country(country):
+    # given
     data = {
         "first_name": "John",
         "last_name": "Doe",
@@ -21,11 +22,13 @@ def test_address_form_for_country(country):
         "phone": "123456789",
     }
 
+    # when
     form = forms.get_address_form(data, country_code=country)
     errors = form.errors
     rules = i18naddress.get_validation_rules({"country_code": country})
     required = rules.required_fields
 
+    # then
     if "street_address" in required:
         assert "street_address_1" in errors
     else:
@@ -49,18 +52,23 @@ def test_address_form_for_country(country):
 
 
 def test_address_form_postal_code_validation():
+    # given
     data = {
         "first_name": "John",
         "last_name": "Doe",
         "country": "PL",
         "postal_code": "XXX",
     }
+
+    # when
     form = forms.get_address_form(data, country_code="PL")
     errors = form.errors
+    # then
     assert "postal_code" in errors
 
 
 def test_address_form_long_street_address_validation():
+    # given
     data = {
         "city": "test",
         "city_area": "test",
@@ -79,8 +87,12 @@ def test_address_form_long_street_address_validation():
             "in culpa qui officia deserunt mollit anim id est laborum"
         ),
     }
+
+    # when
     form = forms.get_address_form(data, country_code="US")
     errors = form.errors
+
+    # then
     assert "street_address_1" in errors
 
 


### PR DESCRIPTION

I want to merge this change because it fix #12389
streetAddress1, streetAddress2 validation does not work when update address

<!-- Please mention all relevant issue numbers. -->
Fix #12389
