### PR TITLE
[Test] Should be able to create variants in bulk

### DIFF
--- a/saleor/tests/e2e/attributes/utils/__init__.py
+++ b/saleor/tests/e2e/attributes/utils/__init__.py
@@ -1,0 +1,5 @@
+from .create_attribute import attribute_create
+
+__all__ = [
+    "attribute_create",
+]

--- a/saleor/tests/e2e/attributes/utils/create_attribute.py
+++ b/saleor/tests/e2e/attributes/utils/create_attribute.py
@@ -17,7 +17,7 @@ mutation AttributeCreate($input: AttributeCreateInput!) {
 
 
 def attribute_create(
-    e2e_not_logged_api_client,
+    staff_api_client,
     input_type="DROPDOWN",
     name="Color",
     slug="color",
@@ -36,7 +36,7 @@ def attribute_create(
         }
     }
 
-    response = e2e_not_logged_api_client.post_graphql(
+    response = staff_api_client.post_graphql(
         ATTRIBUTE_CREATE_MUTATION,
         variables,
     )

--- a/saleor/tests/e2e/attributes/utils/create_attribute.py
+++ b/saleor/tests/e2e/attributes/utils/create_attribute.py
@@ -1,0 +1,47 @@
+from ...utils import get_graphql_content
+
+ATTRIBUTE_CREATE_MUTATION = """
+mutation AttributeCreate($input: AttributeCreateInput!) {
+  attributeCreate(input: $input) {
+    attribute {
+      id
+    }
+    errors {
+      code
+      field
+      message
+    }
+  }
+}
+"""
+
+
+def attribute_create(
+    e2e_not_logged_api_client,
+    input_type="DROPDOWN",
+    name="Color",
+    slug="color",
+    type="PRODUCT_TYPE",
+    value_required=True,
+):
+    variables = {
+        "input": {
+            "inputType": input_type,
+            "name": name,
+            "slug": slug,
+            "type": type,
+            "valueRequired": value_required,
+        }
+    }
+
+    response = e2e_not_logged_api_client.post_graphql(
+        ATTRIBUTE_CREATE_MUTATION,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["attributeCreate"]["errors"] == []
+
+    data = content["data"]["attributeCreate"]["attribute"]
+    assert data["id"] is not None
+    return data

--- a/saleor/tests/e2e/attributes/utils/create_attribute.py
+++ b/saleor/tests/e2e/attributes/utils/create_attribute.py
@@ -23,6 +23,7 @@ def attribute_create(
     slug="color",
     type="PRODUCT_TYPE",
     value_required=True,
+    is_variant_only=False,
 ):
     variables = {
         "input": {
@@ -31,6 +32,7 @@ def attribute_create(
             "slug": slug,
             "type": type,
             "valueRequired": value_required,
+            "isVariantOnly": is_variant_only,
         }
     }
 

--- a/saleor/tests/e2e/product/test_should_create_variants_in_bulk.py
+++ b/saleor/tests/e2e/product/test_should_create_variants_in_bulk.py
@@ -1,0 +1,168 @@
+import pytest
+
+from ..attributes.utils import attribute_create
+from ..shop.utils import prepare_shop
+from ..utils import assign_permissions
+from .utils import (
+    create_category,
+    create_product,
+    create_product_channel_listing,
+    create_product_type,
+    create_variants_in_bulk,
+    get_product,
+    update_product_type_assignment_attribute,
+)
+
+
+def prepare_attributes_and_product_type(e2e_staff_api_client):
+    attribute_product = attribute_create(
+        e2e_staff_api_client,
+        input_type="DROPDOWN",
+        name="Flavor",
+        slug="flavor",
+        type="PRODUCT_TYPE",
+        value_required=True,
+    )
+    attribute_product_id = attribute_product["id"]
+
+    attribute_variant = attribute_create(
+        e2e_staff_api_client,
+        input_type="DROPDOWN",
+        name="Size",
+        slug="size",
+        type="PRODUCT_TYPE",
+        value_required=True,
+        is_variant_only=True,
+    )
+    attribute_variant_id = attribute_variant["id"]
+
+    product_type_data = create_product_type(
+        e2e_staff_api_client,
+        has_variants=True,
+        product_attributes=[attribute_product_id],
+        variant_attributes=[attribute_variant_id],
+    )
+    product_type_id = product_type_data["id"]
+
+    operations = [{"id": attribute_variant_id, "variantSelection": True}]
+    updated_variant_attribute = update_product_type_assignment_attribute(
+        e2e_staff_api_client, product_type_id, operations
+    )
+    assert (
+        updated_variant_attribute["assignedVariantAttributes"][0]["variantSelection"]
+        is True
+    )
+    assert (
+        updated_variant_attribute["assignedVariantAttributes"][0]["attribute"]["id"]
+        == attribute_variant_id
+    )
+    return attribute_product_id, attribute_variant_id, product_type_id
+
+
+@pytest.mark.e2e
+def test_should_create_product_with_few_variants_core_0301(
+    e2e_staff_api_client,
+    permission_manage_product_types_and_attributes,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_shipping,
+):
+    # Before
+    permissions = [
+        permission_manage_product_types_and_attributes,
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        _shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    (
+        attribute_product_id,
+        attribute_variant_id,
+        product_type_id,
+    ) = prepare_attributes_and_product_type(e2e_staff_api_client)
+
+    category_data = create_category(e2e_staff_api_client)
+    category_id = category_data["id"]
+
+    # Step 1 - Create product with attribute
+    attributes = [
+        {
+            "id": attribute_product_id,
+            "dropdown": {"value": "orange"},
+        }
+    ]
+    product_data = create_product(
+        e2e_staff_api_client,
+        product_type_id,
+        category_id,
+        attributes=attributes,
+    )
+    product_id = product_data["id"]
+    attribute = product_data["attributes"][0]
+    assert attribute["attribute"]["id"] == attribute_product_id
+    assert attribute["values"][0]["name"] == "orange"
+
+    # Step 2 - Update product channel listing
+
+    create_product_channel_listing(
+        e2e_staff_api_client,
+        product_id,
+        channel_id,
+    )
+
+    # Step 3 - Create variants with attributes, channel listing and stock in bulk
+    first_variant_name = "250ml"
+    first_variant_price = 1.99
+    second_variant_name = "250ml"
+    second_variant_price = 1.99
+
+    variants = [
+        {
+            "attributes": [
+                {"id": attribute_variant_id, "values": [first_variant_name]}
+            ],
+            "name": first_variant_name,
+            "channelListings": [
+                {"channelId": channel_id, "price": first_variant_price}
+            ],
+            "stocks": [{"warehouse": warehouse_id, "quantity": 99}],
+        },
+        {
+            "attributes": [
+                {"id": attribute_variant_id, "values": [second_variant_name]}
+            ],
+            "name": second_variant_name,
+            "channelListings": [
+                {"channelId": channel_id, "price": second_variant_price}
+            ],
+            "stocks": [{"warehouse": warehouse_id, "quantity": 20}],
+        },
+    ]
+    create_variants_in_bulk(e2e_staff_api_client, product_id, variants)
+
+    # Step 4 - Check product variants
+    product = get_product(e2e_staff_api_client, product_id, channel_slug)
+    first_variant = product["variants"][0]
+    second_variant = product["variants"][1]
+
+    assert first_variant["attributes"][0]["attribute"]["id"] == attribute_variant_id
+    assert first_variant["attributes"][0]["values"][0]["name"] == first_variant_name
+    assert first_variant["channelListings"][0]["channel"]["id"] == channel_id
+    assert first_variant["channelListings"][0]["price"]["amount"] == first_variant_price
+    assert first_variant["stocks"][0]["warehouse"]["id"] == warehouse_id
+
+    assert second_variant["attributes"][0]["attribute"]["id"] == attribute_variant_id
+    assert second_variant["attributes"][0]["values"][0]["name"] == second_variant_name
+    assert second_variant["channelListings"][0]["channel"]["id"] == channel_id
+    assert (
+        second_variant["channelListings"][0]["price"]["amount"] == second_variant_price
+    )
+    assert second_variant["stocks"][0]["warehouse"]["id"] == warehouse_id

--- a/saleor/tests/e2e/product/utils/__init__.py
+++ b/saleor/tests/e2e/product/utils/__init__.py
@@ -1,12 +1,17 @@
 from .category import create_category
 from .digital_content import create_digital_content
 from .product import create_product
+from .product_attribute_assignment_update import (
+    update_product_type_assignment_attribute,
+)
 from .product_channel_listing import (
     create_product_channel_listing,
     raw_create_product_channel_listing,
 )
+from .product_query import get_product
 from .product_type import create_product_type
 from .product_variant import create_product_variant, raw_create_product_variant
+from .product_variant_bulk_create import create_variants_in_bulk
 from .product_variant_channel_listing import create_product_variant_channel_listing
 
 __all__ = [
@@ -20,4 +25,7 @@ __all__ = [
     "raw_create_product_variant",
     "create_product",
     "raw_create_product_channel_listing",
+    "create_variants_in_bulk",
+    "update_product_type_assignment_attribute",
+    "get_product",
 ]

--- a/saleor/tests/e2e/product/utils/product.py
+++ b/saleor/tests/e2e/product/utils/product.py
@@ -17,6 +17,14 @@ mutation createProduct($input: ProductCreateInput!) {
       category {
         id
       }
+      attributes {
+        attribute {
+          id
+        }
+        values {
+          name
+        }
+      }
     }
   }
 }
@@ -28,12 +36,16 @@ def create_product(
     product_type_id,
     category_id,
     product_name="Test product",
+    attributes=None,
 ):
+    if not attributes:
+        attributes = []
     variables = {
         "input": {
             "name": product_name,
             "productType": product_type_id,
             "category": category_id,
+            "attributes": attributes,
         }
     }
 

--- a/saleor/tests/e2e/product/utils/product_attribute_assignment_update.py
+++ b/saleor/tests/e2e/product/utils/product_attribute_assignment_update.py
@@ -1,0 +1,50 @@
+from ...utils import get_graphql_content
+
+PRODUCT_ATTRIBUTE_ASSIGNMENT_UPDATE_MUTATION = """
+mutation ProductAttributeAssignmentUpdate(
+    $operations: [ProductAttributeAssignmentUpdateInput!]!, $id: ID!) {
+  productAttributeAssignmentUpdate(operations: $operations, productTypeId: $id) {
+    errors {
+      field
+      code
+      message
+    }
+    productType {
+      id
+      hasVariants
+      productAttributes {
+        id
+      }
+      assignedVariantAttributes {
+        attribute {
+          id
+        }
+        variantSelection
+      }
+    }
+  }
+}
+"""
+
+
+def update_product_type_assignment_attribute(
+    staff_api_client,
+    product_type_id,
+    operations,
+):
+    variables = {
+        "id": product_type_id,
+        "operations": operations,
+    }
+
+    response = staff_api_client.post_graphql(
+        PRODUCT_ATTRIBUTE_ASSIGNMENT_UPDATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["productAttributeAssignmentUpdate"]["errors"] == []
+
+    data = content["data"]["productAttributeAssignmentUpdate"]["productType"]
+    assert data["id"] is not None
+
+    return data

--- a/saleor/tests/e2e/product/utils/product_query.py
+++ b/saleor/tests/e2e/product/utils/product_query.py
@@ -1,0 +1,84 @@
+from ...utils import get_graphql_content
+
+PRODUCT_QUERY = """
+query Product($id: ID!, $channel: String) {
+  product(id: $id, channel: $channel) {
+    id
+    name
+    attributes {
+      attribute {
+        id
+      }
+      values {
+        name
+      }
+    }
+    pricing {
+      onSale
+    }
+    variants {
+      id
+      name
+      pricing {
+        onSale
+        discount {
+          gross {
+            amount
+          }
+        }
+        priceUndiscounted {
+          gross {
+            amount
+          }
+        }
+      }
+      attributes {
+        attribute {
+          id
+        }
+        values {
+          name
+        }
+      }
+      channelListings {
+        channel {
+          id
+        }
+        price {
+          amount
+          currency
+        }
+      }
+      stocks {
+        warehouse {
+          id
+        }
+        quantity
+      }
+    }
+  }
+}
+"""
+
+
+def get_product(
+    staff_api_client,
+    product_id,
+    slug="default-channel",
+):
+    variables = {
+        "id": product_id,
+        "channel": slug,
+    }
+
+    response = staff_api_client.post_graphql(
+        PRODUCT_QUERY,
+        variables,
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["product"]
+    assert data["id"] is not None
+
+    return data

--- a/saleor/tests/e2e/product/utils/product_query.py
+++ b/saleor/tests/e2e/product/utils/product_query.py
@@ -62,7 +62,7 @@ query Product($id: ID!, $channel: String) {
 
 
 def get_product(
-    staff_api_client,
+    api_client,
     product_id,
     slug="default-channel",
 ):
@@ -71,7 +71,7 @@ def get_product(
         "channel": slug,
     }
 
-    response = staff_api_client.post_graphql(
+    response = api_client.post_graphql(
         PRODUCT_QUERY,
         variables,
         check_no_permissions=False,

--- a/saleor/tests/e2e/product/utils/product_type.py
+++ b/saleor/tests/e2e/product/utils/product_type.py
@@ -27,13 +27,25 @@ def create_product_type(
     slug="test-type",
     is_shipping_required=True,
     is_digital=False,
+    has_variants=False,
+    product_attributes=None,
+    variant_attributes=None,
 ):
+    if not product_attributes:
+        product_attributes = []
+
+    if not variant_attributes:
+        variant_attributes = []
+
     variables = {
         "input": {
             "name": product_type_name,
             "slug": slug,
             "isShippingRequired": is_shipping_required,
             "isDigital": is_digital,
+            "hasVariants": has_variants,
+            "productAttributes": product_attributes,
+            "variantAttributes": variant_attributes,
         }
     }
 

--- a/saleor/tests/e2e/product/utils/product_type.py
+++ b/saleor/tests/e2e/product/utils/product_type.py
@@ -15,6 +15,16 @@ mutation createProductType($input: ProductTypeInput!) {
       kind
       isShippingRequired
       isDigital
+      hasVariants
+      productAttributes {
+        id
+      }
+      assignedVariantAttributes {
+        attribute {
+          id
+        }
+        variantSelection
+      }
     }
   }
 }

--- a/saleor/tests/e2e/product/utils/product_variant_bulk_create.py
+++ b/saleor/tests/e2e/product/utils/product_variant_bulk_create.py
@@ -1,0 +1,64 @@
+from ...utils import get_graphql_content
+
+PRODUCT_VARIANT_BULK_CREATE_MUTATION = """
+mutation ProductVariantBulkCreate($id: ID!, $input: [ProductVariantBulkCreateInput!]!) {
+  productVariantBulkCreate(product: $id, variants: $input) {
+    errors {
+      field
+      code
+      index
+      channels
+      message
+    }
+    productVariants {
+      id
+      name
+      attributes{
+        attribute{
+          id
+        }
+        values{
+          name
+        }
+      }
+      product{
+        id
+      }
+      channelListings{
+        channel{
+          id
+          slug
+        }
+        price{
+          amount
+          currency
+        }
+      }
+      stocks{
+        warehouse{
+          id
+        }
+        quantity
+      }
+    }
+  }
+}
+"""
+
+
+def create_variants_in_bulk(staff_api_client, product_id, variants_input):
+    variables = {
+        "id": product_id,
+        "input": variants_input,
+    }
+
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["productVariantBulkCreate"]["errors"] == []
+
+    data = content["data"]["productVariantBulkCreate"]["productVariants"]
+    assert data[0]["id"] is not None
+
+    return data


### PR DESCRIPTION
I want to merge this change because it adds a test for creating products in bulk [CORE_0301](https://saleor.testmo.net/repositories/5?group_id=111&case_id=750)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
