### PR TITLE
[TEST] order can: be created from checkout CORE_0215 and order is expired after specified time period CORE_0214

### DIFF
--- a/saleor/tests/e2e/channel/utils/__init__.py
+++ b/saleor/tests/e2e/channel/utils/__init__.py
@@ -1,0 +1,7 @@
+from .channel_create import create_channel
+from .channel_update import update_channel
+
+__all__ = [
+    "create_channel",
+    "update_channel",
+]

--- a/saleor/tests/e2e/channel/utils/channel_create.py
+++ b/saleor/tests/e2e/channel/utils/channel_create.py
@@ -1,4 +1,4 @@
-from ..utils import get_graphql_content
+from ...utils import get_graphql_content
 
 CHANNEL_CREATE_MUTATION = """
 mutation ChannelCreate($input: ChannelCreateInput!) {
@@ -38,6 +38,7 @@ def create_channel(
     allow_unpaid_orders=False,
     automatically_confirm_all_new_orders=True,
     mark_as_paid_strategy="PAYMENT_FLOW",
+    expire_orders_after=0,
 ):
     if not warehouse_ids:
         warehouse_ids = []
@@ -59,6 +60,7 @@ def create_channel(
                 "automaticallyConfirmAllNewOrders": (
                     automatically_confirm_all_new_orders
                 ),
+                "expireOrdersAfter": expire_orders_after,
             },
         }
     }

--- a/saleor/tests/e2e/channel/utils/channel_update.py
+++ b/saleor/tests/e2e/channel/utils/channel_update.py
@@ -1,0 +1,40 @@
+from ...utils import get_graphql_content
+
+CHANNEL_UPDATE_MUTATION = """
+mutation ChannelUpdate($id: ID!, $input: ChannelUpdateInput!) {
+  channelUpdate(id: $id, input: $input) {
+    channel {
+      id
+      orderSettings {
+        deleteExpiredOrdersAfter
+        allowUnpaidOrders
+        automaticallyFulfillNonShippableGiftCard
+        automaticallyConfirmAllNewOrders
+        expireOrdersAfter
+      }
+    }
+    errors {
+      message
+      field
+    }
+  }
+}
+
+"""
+
+
+def update_channel(staff_api_client, id, input):
+    variables = {
+        "id": id,
+        "input": input,
+    }
+
+    response = staff_api_client.post_graphql(CHANNEL_UPDATE_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    assert content["data"]["channelUpdate"]["errors"] == []
+
+    data = content["data"]["channelUpdate"]["channel"]
+    assert data["id"] is not None
+
+    return data

--- a/saleor/tests/e2e/orders/test_app_can_create_order_from_checkout.py
+++ b/saleor/tests/e2e/orders/test_app_can_create_order_from_checkout.py
@@ -1,0 +1,91 @@
+import pytest
+
+from ..checkout.utils import checkout_create, checkout_delivery_method_update
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..utils import assign_permissions
+from .utils import order_create_from_checkout
+
+
+@pytest.mark.e2e
+def test_app_can_create_order_from_checkout_CORE_0215(
+    e2e_staff_api_client,
+    e2e_app_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+    permission_manage_payments,
+    permission_handle_checkouts,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+    app_permissions = [
+        permission_manage_payments,
+        permission_handle_checkouts,
+    ]
+    assign_permissions(e2e_app_api_client, app_permissions)
+
+    price = 10
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    # Step 1 - Create checkout
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
+    ]
+    checkout_data = checkout_create(
+        e2e_staff_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    assert checkout_id is not None
+    assert checkout_data["isShippingRequired"] is True
+    assert len(checkout_data["shippingMethods"]) == 1
+    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
+
+    # Step 2 - Assign shipping method
+    checkout_data = checkout_delivery_method_update(
+        e2e_staff_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] is not None
+
+    # Step 3 - Create order from the checkout
+    order_data = order_create_from_checkout(e2e_app_api_client, checkout_id)
+    order_id = order_data["order"]["id"]
+    assert order_id is not None
+    assert order_data["order"]["status"] == "UNCONFIRMED"
+    assert order_data["order"]["paymentStatus"] == "NOT_CHARGED"

--- a/saleor/tests/e2e/orders/test_order_is_expired_after_specific_time.py
+++ b/saleor/tests/e2e/orders/test_order_is_expired_after_specific_time.py
@@ -1,0 +1,112 @@
+import time
+
+import pytest
+
+from ....order.tasks import expire_orders_task
+from ..channel.utils import update_channel
+from ..checkout.utils import checkout_create, checkout_delivery_method_update
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..utils import assign_permissions
+from .utils import order_create_from_checkout, order_query
+
+
+@pytest.mark.e2e
+def test_order_is_expired_after_specific_time_CORE_0214(
+    e2e_staff_api_client,
+    e2e_app_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+    permission_manage_payments,
+    permission_handle_checkouts,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+    app_permissions = [
+        permission_manage_payments,
+        permission_handle_checkouts,
+    ]
+    assign_permissions(e2e_app_api_client, app_permissions)
+
+    price = 10
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    channel_update_input = {
+        "orderSettings": {
+            "allowUnpaidOrders": True,
+            "automaticallyFulfillNonShippableGiftCard": True,
+            "automaticallyConfirmAllNewOrders": True,
+            "expireOrdersAfter": 1,
+        }
+    }
+    update_channel(e2e_staff_api_client, channel_id, channel_update_input)
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    # Step 1 - Create checkout
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
+    ]
+    checkout_data = checkout_create(
+        e2e_staff_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    assert checkout_id is not None
+    assert checkout_data["isShippingRequired"] is True
+    assert len(checkout_data["shippingMethods"]) == 1
+    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
+
+    # Step 2 - Assign shipping method
+    checkout_data = checkout_delivery_method_update(
+        e2e_staff_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] is not None
+
+    # Step 3 - Create order from the checkout
+    order_data = order_create_from_checkout(e2e_app_api_client, checkout_id)
+    order_id = order_data["order"]["id"]
+    assert order_id is not None
+    assert order_data["order"]["status"] == "UNCONFIRMED"
+    assert order_data["order"]["paymentStatus"] == "NOT_CHARGED"
+
+    # Step 4 - Wait and check the order's status
+    time.sleep(80)
+    expire_orders_task()
+    data = order_query(e2e_staff_api_client, order_id)
+    assert data["status"] == "EXPIRED"
+    assert data["paymentStatus"] == "NOT_CHARGED"

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -3,6 +3,7 @@ from .draft_order_create import draft_order_create
 from .draft_order_delete import draft_order_delete
 from .draft_order_update import draft_order_update
 from .order_cancel import order_cancel
+from .order_create_from_checkout import order_create_from_checkout
 from .order_lines_create import order_lines_create
 from .order_mark_as_paid import mark_order_paid
 from .order_query import order_query
@@ -17,4 +18,5 @@ __all__ = [
     "mark_order_paid",
     "order_cancel",
     "draft_order_delete",
+    "order_create_from_checkout",
 ]

--- a/saleor/tests/e2e/orders/utils/order_create_from_checkout.py
+++ b/saleor/tests/e2e/orders/utils/order_create_from_checkout.py
@@ -1,0 +1,73 @@
+from saleor.graphql.tests.utils import get_graphql_content
+
+ORDER_CREATE_FROM_CHECKOUT_MUTATION = """
+mutation orderCreateFromCheckout($id: ID!) {
+  orderCreateFromCheckout(id: $id) {
+    errors {
+      message
+      field
+      code
+    }
+    order {
+        id
+        created
+        status
+        paymentStatus
+        channel { id }
+        discounts {
+            amount {
+                amount
+            }
+        }
+        billingAddress {
+        streetAddress1
+        }
+        shippingAddress {
+            streetAddress1
+        }
+        shippingMethods {
+            id
+        }
+        lines {
+            productVariantId
+            quantity
+            undiscountedUnitPrice {
+                gross {
+                amount
+                }
+            }
+            unitPrice {
+                gross {
+                    amount
+                }
+            }
+            totalPrice {
+                gross {
+                    amount
+                }
+            }
+        }
+    }
+  }
+}
+"""
+
+
+def order_create_from_checkout(api_client, id):
+    variables = {"id": id}
+
+    response = api_client.post_graphql(
+        ORDER_CREATE_FROM_CHECKOUT_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["orderCreateFromCheckout"]
+
+    order_id = data["order"]["id"]
+    errors = data["errors"]
+
+    assert errors == []
+    assert order_id is not None
+
+    return data


### PR DESCRIPTION
I want to merge this change because it covers:
-  [TC 0214](https://saleor.testmo.net/repositories/5?group_id=112&case_id=752) - test for checking that orders expire after specified time period
- [TC 0215](https://saleor.testmo.net/repositories/5?group_id=112&case_id=2384) - staff can create order from checkout

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
