### PR TITLE
Fix invalid adyen mock

### DIFF
--- a/saleor/payment/gateways/adyen/tests/conftest.py
+++ b/saleor/payment/gateways/adyen/tests/conftest.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import Adyen
 import pytest
+from requests_hardened import HTTPSession
 
 from .....checkout import calculations
 from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
@@ -42,7 +43,7 @@ def adyen_plugin(settings, channel_USD):
         settings.PLUGINS = ["saleor.payment.gateways.adyen.plugin.AdyenGatewayPlugin"]
         manager = get_plugins_manager()
 
-        with mock.patch("saleor.payment.gateways.adyen.utils.apple_pay.requests.post"):
+        with mock.patch.object(HTTPSession, "request"):
             manager.save_plugin_configuration(
                 AdyenGatewayPlugin.PLUGIN_ID,
                 channel_USD.slug,


### PR DESCRIPTION
I want to merge this change because we now use `requests_hardened` and the old mock was invalid.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
