### PR TITLE
Bump to 3.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,22 @@
 
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/saleor/saleor/releases) page.
 
-# 3.16.0 [Unreleased]
+# 3.17.0 [Unreleased]
+
+### Breaking changes
+
+### GraphQL API
+
+### Saleor Apps
+
+### Other changes
+
+# 3.16.0
 
 ### Breaking changes
 
 - **Feature preview breaking change**:
+
   - Deprecate `OrderSettingsInput.defaultTransactionFlowStrategy`. It will be removed
     in 3.17. Use `PaymentSettingsInput.defaultTransactionFlowStrategy` instead.
   - Deprecate `OrderSettings.defaultTransactionFlowStrategy`. It will be removed
@@ -30,7 +41,6 @@ All notable, unreleased changes to this project will be documented in this file.
   external reference. - #13342 by @Smit-Parmar
 - Add Filter warehouses by metadata - #13345 by @Smit-Parmar
 - Add API for tokenizing payment methods - #13879 by @korycins
-
 
 - Deprecate the `NOTIFY_USER` webhook and the `externalNotificationTrigger` mutation - #13881 by @maarcingebala
   - See the docs for more details about migrating from the `NOTIFY_USER` webhook to other events: https://docs.saleor.io/docs/next/upgrade-guides/notify-user-deprecation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saleor",
-  "version": "3.16.0-a.0",
+  "version": "3.17.0-a.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "saleor",
-      "version": "3.16.0-a.0",
+      "version": "3.17.0-a.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@release-it/bumper": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "3.16.0-a.0",
+  "version": "3.17.0-a.0",
   "engines": {
     "node": ">=16 <17",
     "npm": ">=7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "saleor"
-version = "3.16.0-a.0"
+version = "3.17.0-a.0"
 description = "A modular, high performance, headless e-commerce platform built with Python, GraphQL, Django, and React."
 authors = [ "Saleor Commerce <hello@saleor.io>" ]
 license = "BSD-3-Clause"

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -3,7 +3,7 @@ import pillow_avif  # noqa: F401 # imported for side effects
 from .celeryconf import app as celery_app
 
 __all__ = ["celery_app"]
-__version__ = "3.16.0-a.0"
+__version__ = "3.17.0-a.0"
 
 
 class PatchedSubscriberExecutionContext(object):

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -38,6 +38,7 @@ ADDED_IN_313 = "\n\nAdded in Saleor 3.13."
 ADDED_IN_314 = "\n\nAdded in Saleor 3.14."
 ADDED_IN_315 = "\n\nAdded in Saleor 3.15."
 ADDED_IN_316 = "\n\nAdded in Saleor 3.16."
+ADDED_IN_317 = "\n\nAdded in Saleor 3.17."
 
 
 PREVIEW_FEATURE = (


### PR DESCRIPTION
Bumping `main` to 3.17 since closed for 3.16 is now closed and the first alfa tag is ready.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
