### PR TITLE
Update sale to promotion migration

### DIFF
--- a/saleor/discount/migrations/tasks/saleor3_16.py
+++ b/saleor/discount/migrations/tasks/saleor3_16.py
@@ -20,12 +20,11 @@ from ...models import (
 )
 from babel.numbers import get_currency_precision
 
-
 # The batch of size 100 takes ~0.9 second and consumes ~30MB memory at peak
 BATCH_SIZE = 100
 
-# Results in memory usage of ~40MB for 500 products
-DISCOUNTED_PRICES_RECALCULATION_BATCH_SIZE = 500
+# Results in memory usage of ~40MB for 20K products
+DISCOUNTED_PRICES_RECALCULATION_BATCH_SIZE = 100
 
 
 @dataclass

--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -191,6 +191,7 @@ def variant_listing_promotion_rule_update(sale_id, variant_listing, discount_amo
     Return (None, None) if Promotion does not exist yet. The proper listing promotion
     rule instances will be created when migrating.
     """
+    # TODO: prepare mapping to optimize this
     promotion = Promotion.objects.filter(old_sale_id=sale_id)
     promotion_rules = PromotionRule.objects.filter(
         Exists(promotion.filter(id=OuterRef("promotion_id")))

--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from typing import Dict, Iterable, List, Set, Tuple
+from uuid import UUID
 
 from django.db.models import Exists, OuterRef, QuerySet
 from django.db.models.query_utils import Q
@@ -45,6 +46,11 @@ def update_products_discounted_price(products: Iterable[Product], discounts=None
         _get_product_to_variant_channel_listings_per_channel_map(product_qs)
     )
 
+    sale_id_to_rule_per_channel_map = _get_sale_id_to_promotion_rule_mapping()
+    variant_listing_to_listing_rule_per_rule_map = (
+        _get_variant_listings_to_listing_rule_per_rule_id_map(product_qs)
+    )
+
     changed_products_listings_to_update = []
     changed_variants_listings_to_update = []
     changed_rule_listings_to_update: List[VariantChannelListingPromotionRule] = []
@@ -73,6 +79,8 @@ def update_products_discounted_price(products: Iterable[Product], discounts=None
             collection_ids,
             discounts,
             product_channel_listing.channel,
+            sale_id_to_rule_per_channel_map,
+            variant_listing_to_listing_rule_per_rule_map,
         )
 
         product_discounted_price = min(discounted_variants_price)
@@ -130,12 +138,91 @@ def _get_product_to_variant_channel_listings_per_channel_map(
     return price_data
 
 
+def _get_sale_id_to_promotion_rule_mapping():
+    """Prepare old_sale_id to promotion rule per channel mapping.
+
+    Format:
+    {
+        old_sale_id: {
+            channel_id_1: promotion_rule_1,
+            channel_id_2: promotion_rule_2
+        }
+    }
+    """
+    sale_id_to_rule_per_channel_map: dict[int, dict[int, PromotionRule]] = defaultdict(
+        dict
+    )
+    promotions = Promotion.objects.filter(old_sale_id__isnull=False)
+    promotion_rules = PromotionRule.objects.filter(
+        Exists(promotions.filter(id=OuterRef("promotion_id")))
+    )
+    PromotionRuleChannel = PromotionRule.channels.through
+    rule_channels = PromotionRuleChannel.objects.filter(
+        Exists(promotion_rules.filter(id=OuterRef("promotionrule_id")))
+    )
+    # We ensure that we have the separate rule for each channel for old sale promotions
+    rule_id_to_channel_id_map = {
+        rule_id: channel_id
+        for rule_id, channel_id in rule_channels.values_list(
+            "promotionrule_id", "channel_id"
+        )
+    }
+    promotion_id_to_old_sale_id = {
+        promotion.id: promotion.old_sale_id for promotion in promotions
+    }
+    for rule in promotion_rules.iterator():
+        old_sale_id = promotion_id_to_old_sale_id[rule.promotion_id]
+        channel_id = rule_id_to_channel_id_map.get(rule.id)
+        if channel_id:
+            sale_id_to_rule_per_channel_map[old_sale_id][channel_id] = (  # type: ignore
+                rule
+            )
+
+    return sale_id_to_rule_per_channel_map
+
+
+def _get_variant_listings_to_listing_rule_per_rule_id_map(
+    products: QuerySet[Product],
+):
+    """Return map for fetching VariantChannelListingPromotionRule per listing per rule.
+
+    The map is in the format:
+    {
+        variant_channel_listing_id: {
+            rule_id: variant_channel_listing_promotion_rule
+        }
+    }
+    """
+    variants = ProductVariant.objects.filter(
+        Exists(products.filter(id=OuterRef("product_id")))
+    )
+    variant_listing_rule_data: Dict[
+        int, Dict[UUID, VariantChannelListingPromotionRule]
+    ] = defaultdict(dict)
+    variant_channel_listings = ProductVariantChannelListing.objects.filter(
+        Exists(variants.filter(id=OuterRef("variant_id"))), price_amount__isnull=False
+    )
+    variant_listing_promotion_rules = VariantChannelListingPromotionRule.objects.filter(
+        Exists(
+            variant_channel_listings.filter(id=OuterRef("variant_channel_listing_id"))
+        )
+    )
+    for variant_listing_promotion_rule in variant_listing_promotion_rules:
+        listing_id = variant_listing_promotion_rule.variant_channel_listing_id
+        rule_id = variant_listing_promotion_rule.promotion_rule_id
+        variant_listing_rule_data[listing_id][rule_id] = variant_listing_promotion_rule
+
+    return variant_listing_rule_data
+
+
 def _get_discounted_variants_prices(
     variant_listings: List[ProductVariantChannelListing],
     product: Product,
     collection_ids: Set[int],
     discounts: List[DiscountInfo],
     channel: Channel,
+    sale_id_to_rule_per_channel_map,
+    variant_listing_to_listing_rule_per_rule_map,
 ) -> Tuple[
     Money,
     List[ProductVariantChannelListing],
@@ -168,7 +255,11 @@ def _get_discounted_variants_prices(
                 rule_listing_to_update,
                 rule_listing_to_create,
             ) = variant_listing_promotion_rule_update(
-                sale_id, variant_listing, discount_amount
+                sale_id,
+                variant_listing,
+                discount_amount,
+                sale_id_to_rule_per_channel_map,
+                variant_listing_to_listing_rule_per_rule_map,
             )
             if rule_listing_to_update:
                 listings_promotion_rule_to_update.append(rule_listing_to_update)
@@ -182,7 +273,13 @@ def _get_discounted_variants_prices(
     )
 
 
-def variant_listing_promotion_rule_update(sale_id, variant_listing, discount_amount):
+def variant_listing_promotion_rule_update(
+    sale_id,
+    variant_listing,
+    discount_amount,
+    sale_id_to_rule_per_channel_map,
+    variant_listing_to_listing_rule_per_rule_map,
+):
     """Update or create VariantChannelListingPromotionRule for given sale.
 
     Return tuple, first element will be VariantChannelListingPromotionRule to update,
@@ -191,20 +288,16 @@ def variant_listing_promotion_rule_update(sale_id, variant_listing, discount_amo
     Return (None, None) if Promotion does not exist yet. The proper listing promotion
     rule instances will be created when migrating.
     """
-    # TODO: prepare mapping to optimize this
-    promotion = Promotion.objects.filter(old_sale_id=sale_id)
-    promotion_rules = PromotionRule.objects.filter(
-        Exists(promotion.filter(id=OuterRef("promotion_id")))
-    )
+    channel_id = variant_listing.channel_id
+    promotion_rule = sale_id_to_rule_per_channel_map[sale_id].get(channel_id)
     # If the promotion does not exists it mean that the sale wasn't migrated yet.
     # The proper VariantChannelListingPromotionRule will be created during migration.
-    if not promotion:
+    if not promotion_rule:
         return None, None
-    listing_promotion_rule_to_update = (
-        variant_listing.variantlistingpromotionrule.filter(
-            Exists(promotion_rules.filter(id=OuterRef("promotion_rule_id")))
-        ).first()
-    )
+
+    listing_promotion_rule_to_update = variant_listing_to_listing_rule_per_rule_map[
+        variant_listing.id
+    ].get(promotion_rule.id)
     if listing_promotion_rule_to_update:
         if listing_promotion_rule_to_update.discount_amount != discount_amount:
             listing_promotion_rule_to_update.discount_amount = discount_amount
@@ -212,13 +305,6 @@ def variant_listing_promotion_rule_update(sale_id, variant_listing, discount_amo
         return None, None
 
     # create VariantChannelListingPromotionRule
-    PromotionRuleChannel = PromotionRule.channels.through
-    rule_channels = PromotionRuleChannel.objects.filter(
-        channel_id=variant_listing.channel_id
-    )
-    promotion_rule = promotion_rules.filter(
-        Exists(rule_channels.filter(promotionrule_id=OuterRef("id")))
-    ).first()
     new_listing_promotion_rule = VariantChannelListingPromotionRule(
         variant_channel_listing=variant_listing,
         promotion_rule=promotion_rule,


### PR DESCRIPTION
Update sale migartion:
 - call `update_products_discounted_price` to create `VariantChannelListingPromotionRule` instances
 - update creation of `OrderLineDiscount`
 - add locks to prevent potential Promotion creation during sales to promotion migration
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
