### PR TITLE
Correct version labels for promotions.

### DIFF
--- a/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
@@ -7,7 +7,7 @@ from .....product import models as product_models
 from .....product.tasks import update_products_discounted_prices_for_promotion_task
 from .....webhook.event_types import WebhookEventAsyncType
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelBulkDeleteMutation
 from ....core.types import DiscountError, NonNullList
@@ -24,7 +24,7 @@ class PromotionBulkDelete(ModelBulkDeleteMutation):
         )
 
     class Meta:
-        description = "Deletes promotions." + ADDED_IN_315 + PREVIEW_FEATURE
+        description = "Deletes promotions." + ADDED_IN_317 + PREVIEW_FEATURE
         model = models.Promotion
         object_type = Promotion
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/promotion/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_create.py
@@ -17,7 +17,7 @@ from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....channel.types import Channel
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
 from ....core.scalars import JSON
@@ -74,7 +74,7 @@ class PromotionCreate(ModelMutation):
         )
 
     class Meta:
-        description = "Creates a new promotion." + ADDED_IN_315 + PREVIEW_FEATURE
+        description = "Creates a new promotion." + ADDED_IN_317 + PREVIEW_FEATURE
         model = models.Promotion
         object_type = Promotion
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/promotion/promotion_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_delete.py
@@ -7,7 +7,7 @@ from .....permission.enums import DiscountPermissions
 from .....product.tasks import update_products_discounted_prices_for_promotion_task
 from .....webhook.event_types import WebhookEventAsyncType
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.types import Error
 from ....core.utils import WebhookEventInfo
@@ -28,7 +28,7 @@ class PromotionDelete(ModelDeleteMutation):
         )
 
     class Meta:
-        description = "Deletes a promotion." + ADDED_IN_315 + PREVIEW_FEATURE
+        description = "Deletes a promotion." + ADDED_IN_317 + PREVIEW_FEATURE
         model = models.Promotion
         object_type = Promotion
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_create.py
@@ -10,7 +10,7 @@ from .....product.tasks import update_products_discounted_prices_for_promotion_t
 from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
 from ....core.types import Error
@@ -42,7 +42,7 @@ class PromotionRuleCreate(ModelMutation):
         )
 
     class Meta:
-        description = "Creates a new promotion rule." + ADDED_IN_315 + PREVIEW_FEATURE
+        description = "Creates a new promotion rule." + ADDED_IN_317 + PREVIEW_FEATURE
         model = models.PromotionRule
         object_type = PromotionRule
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_delete.py
@@ -7,7 +7,7 @@ from .....product.tasks import update_products_discounted_prices_for_promotion_t
 from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.types import Error
 from ....core.utils import WebhookEventInfo
@@ -29,7 +29,7 @@ class PromotionRuleDelete(ModelDeleteMutation):
         )
 
     class Meta:
-        description = "Deletes a promotion rule." + ADDED_IN_315 + PREVIEW_FEATURE
+        description = "Deletes a promotion rule." + ADDED_IN_317 + PREVIEW_FEATURE
         model = models.PromotionRule
         object_type = PromotionRule
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
@@ -8,7 +8,7 @@ from .....product.tasks import update_products_discounted_prices_for_promotion_t
 from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
 from ....core.types import Error, NonNullList
@@ -55,7 +55,7 @@ class PromotionRuleUpdate(ModelMutation):
 
     class Meta:
         description = (
-            "Updates an existing promotion rule." + ADDED_IN_315 + PREVIEW_FEATURE
+            "Updates an existing promotion rule." + ADDED_IN_317 + PREVIEW_FEATURE
         )
         model = models.PromotionRule
         object_type = PromotionRule

--- a/saleor/graphql/discount/mutations/promotion/promotion_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_update.py
@@ -13,7 +13,7 @@ from .....product.tasks import update_products_discounted_prices_of_promotion_ta
 from .....webhook.event_types import WebhookEventAsyncType
 from ....app.dataloaders import get_app_promise
 from ....core import ResolveInfo
-from ....core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ....core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.mutations import ModelMutation
 from ....core.types import Error
@@ -47,7 +47,7 @@ class PromotionUpdate(ModelMutation):
         )
 
     class Meta:
-        description = "Updates an existing promotion." + ADDED_IN_315 + PREVIEW_FEATURE
+        description = "Updates an existing promotion." + ADDED_IN_317 + PREVIEW_FEATURE
         model = models.Promotion
         object_type = Promotion
         permissions = (DiscountPermissions.MANAGE_DISCOUNTS,)

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -4,7 +4,7 @@ from ...permission.enums import DiscountPermissions
 from ..core import ResolveInfo
 from ..core.connection import create_connection_slice, filter_connection_queryset
 from ..core.descriptions import (
-    ADDED_IN_315,
+    ADDED_IN_317,
     DEPRECATED_IN_3X_FIELD,
     DEPRECATED_IN_3X_INPUT,
     PREVIEW_FEATURE,
@@ -149,7 +149,7 @@ class DiscountQueries(graphene.ObjectType):
         id=graphene.Argument(
             graphene.ID, description="ID of the promotion.", required=True
         ),
-        description="Look up a promotion by ID." + ADDED_IN_315 + PREVIEW_FEATURE,
+        description="Look up a promotion by ID." + ADDED_IN_317 + PREVIEW_FEATURE,
         permissions=[
             DiscountPermissions.MANAGE_DISCOUNTS,
         ],
@@ -159,7 +159,7 @@ class DiscountQueries(graphene.ObjectType):
         PromotionCountableConnection,
         where=PromotionWhereInput(description="Where filtering options."),
         sort_by=PromotionSortingInput(description="Sort promotions."),
-        description="List of the promotions." + ADDED_IN_315 + PREVIEW_FEATURE,
+        description="List of the promotions." + ADDED_IN_317 + PREVIEW_FEATURE,
         permissions=[DiscountPermissions.MANAGE_DISCOUNTS],
         doc_category=DOC_CATEGORY_DISCOUNTS,
     )

--- a/saleor/graphql/discount/types/promotion_events.py
+++ b/saleor/graphql/discount/types/promotion_events.py
@@ -8,7 +8,7 @@ from ....permission.enums import AccountPermissions, AppPermission
 from ...account.dataloaders import UserByUserIdLoader
 from ...account.utils import is_owner_or_has_one_of_perms
 from ...app.dataloaders import AppByIdLoader
-from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import PermissionsField
 from ...core.types import ModelObjectType
@@ -82,7 +82,7 @@ class PromotionCreatedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
         description = (
             "History log of the promotion created event."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
         interfaces = [relay.Node, PromotionEventInterface]
@@ -94,7 +94,7 @@ class PromotionUpdatedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
         description = (
             "History log of the promotion updated event."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
         interfaces = [relay.Node, PromotionEventInterface]
@@ -106,7 +106,7 @@ class PromotionStartedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
         description = (
             "History log of the promotion started event."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
         interfaces = [relay.Node, PromotionEventInterface]
@@ -117,7 +117,7 @@ class PromotionStartedEvent(ModelObjectType[models.PromotionEvent]):
 class PromotionEndedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
         description = (
-            "History log of the promotion ended event." + ADDED_IN_315 + PREVIEW_FEATURE
+            "History log of the promotion ended event." + ADDED_IN_317 + PREVIEW_FEATURE
         )
         interfaces = [relay.Node, PromotionEventInterface]
         model = models.PromotionEvent
@@ -128,7 +128,7 @@ class PromotionRuleEventInterface(graphene.Interface):
     class Meta:
         description = (
             "History log of the promotion event related to rule."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
         interfaces = [relay.Node]
@@ -148,7 +148,7 @@ class PromotionRuleCreatedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
         description = (
             "History log of the promotion rule created event."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
         interfaces = [relay.Node, PromotionEventInterface, PromotionRuleEventInterface]
@@ -160,7 +160,7 @@ class PromotionRuleUpdatedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
         description = (
             "History log of the promotion rule created event."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
         interfaces = [relay.Node, PromotionEventInterface, PromotionRuleEventInterface]
@@ -172,7 +172,7 @@ class PromotionRuleDeletedEvent(ModelObjectType[models.PromotionEvent]):
     class Meta:
         description = (
             "History log of the promotion rule created event."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
         interfaces = [relay.Node, PromotionEventInterface, PromotionRuleEventInterface]

--- a/saleor/graphql/discount/types/promotions.py
+++ b/saleor/graphql/discount/types/promotions.py
@@ -6,7 +6,7 @@ from ....permission.auth_filters import AuthorizationFilters
 from ...channel.types import Channel
 from ...core import ResolveInfo
 from ...core.connection import CountableConnection
-from ...core.descriptions import ADDED_IN_315, PREVIEW_FEATURE
+from ...core.descriptions import ADDED_IN_317, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import PermissionsField
 from ...core.scalars import JSON, PositiveDecimal
@@ -51,7 +51,7 @@ class Promotion(ModelObjectType[models.Promotion]):
         description = (
             "Represents the promotion that allow creating discounts based on given "
             "conditions, and is visible to all the customers."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
         interfaces = [relay.Node, ObjectWithMetadata]
@@ -101,7 +101,7 @@ class PromotionRule(ModelObjectType[models.PromotionRule]):
     class Meta:
         description = (
             "Represents the promotion rule that specifies the conditions that must "
-            "be met to apply the promotion discount." + ADDED_IN_315 + PREVIEW_FEATURE
+            "be met to apply the promotion discount." + ADDED_IN_317 + PREVIEW_FEATURE
         )
         interfaces = [relay.Node]
         model = models.PromotionRule

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1191,7 +1191,7 @@ type Query {
   """
   Look up a promotion by ID.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.17.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
@@ -1205,7 +1205,7 @@ type Query {
   """
   List of the promotions.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.17.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   
@@ -9525,7 +9525,7 @@ type Menu implements Node & ObjectWithMetadata @doc(category: "Menu") {
 """
 Represents promotion's original translatable fields and related translations.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 """
 type PromotionTranslatableContent implements Node @doc(category: "Discounts") {
   """ID of the promotion translatable content."""
@@ -9551,7 +9551,7 @@ type PromotionTranslatableContent implements Node @doc(category: "Discounts") {
 """
 Represents promotion translations.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 """
 type PromotionTranslation implements Node @doc(category: "Discounts") {
   """ID of the promotion translation."""
@@ -9574,7 +9574,7 @@ type PromotionTranslation implements Node @doc(category: "Discounts") {
 """
 Represents promotion rule's original translatable fields and related translations.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 """
 type PromotionRuleTranslatableContent implements Node @doc(category: "Discounts") {
   """ID of the promotion rule translatable content."""
@@ -9600,7 +9600,7 @@ type PromotionRuleTranslatableContent implements Node @doc(category: "Discounts"
 """
 Represents promotion rule translations.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 """
 type PromotionRuleTranslation implements Node @doc(category: "Discounts") {
   """ID of the promotion rule translation."""
@@ -13890,7 +13890,7 @@ enum VoucherSortField {
 """
 Represents the promotion that allow creating discounts based on given conditions, and is visible to all the customers.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -13969,7 +13969,7 @@ type Promotion implements Node & ObjectWithMetadata @doc(category: "Discounts") 
 """
 Represents the promotion rule that specifies the conditions that must be met to apply the promotion discount.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -14021,7 +14021,7 @@ union PromotionEvent = PromotionCreatedEvent | PromotionUpdatedEvent | Promotion
 """
 History log of the promotion created event.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -14073,7 +14073,7 @@ enum PromotionEventsEnum @doc(category: "Discounts") {
 """
 History log of the promotion updated event.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -14097,7 +14097,7 @@ type PromotionUpdatedEvent implements Node & PromotionEventInterface @doc(catego
 """
 History log of the promotion started event.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -14121,7 +14121,7 @@ type PromotionStartedEvent implements Node & PromotionEventInterface @doc(catego
 """
 History log of the promotion ended event.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -14145,7 +14145,7 @@ type PromotionEndedEvent implements Node & PromotionEventInterface @doc(category
 """
 History log of the promotion rule created event.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -14172,7 +14172,7 @@ type PromotionRuleCreatedEvent implements Node & PromotionEventInterface & Promo
 """
 History log of the promotion event related to rule.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -14184,7 +14184,7 @@ interface PromotionRuleEventInterface {
 """
 History log of the promotion rule created event.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -14211,7 +14211,7 @@ type PromotionRuleUpdatedEvent implements Node & PromotionEventInterface & Promo
 """
 History log of the promotion rule created event.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -17597,7 +17597,7 @@ type Mutation {
   """
   Creates a new promotion.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.17.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point. 
   
@@ -17615,7 +17615,7 @@ type Mutation {
   """
   Updates an existing promotion.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.17.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point. 
   
@@ -17637,7 +17637,7 @@ type Mutation {
   """
   Deletes a promotion.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.17.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point. 
   
@@ -17654,7 +17654,7 @@ type Mutation {
   """
   Creates a new promotion rule.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.17.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point. 
   
@@ -17671,7 +17671,7 @@ type Mutation {
   """
   Updates an existing promotion rule.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.17.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point. 
   
@@ -17691,7 +17691,7 @@ type Mutation {
   """
   Deletes a promotion rule.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.17.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point. 
   
@@ -17708,7 +17708,7 @@ type Mutation {
   """
   Creates/updates translations for a promotion.
   
-  Added in Saleor 3.15. 
+  Added in Saleor 3.17. 
   
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
@@ -17726,7 +17726,7 @@ type Mutation {
   """
   Creates/updates translations for a promotion rule.
   
-  Added in Saleor 3.15. 
+  Added in Saleor 3.17. 
   
   Requires one of the following permissions: MANAGE_TRANSLATIONS.
   """
@@ -17744,7 +17744,7 @@ type Mutation {
   """
   Deletes promotions.
   
-  Added in Saleor 3.15.
+  Added in Saleor 3.17.
   
   Note: this API is currently in Feature Preview and can be subject to changes at later point. 
   
@@ -27026,7 +27026,7 @@ input ExternalNotificationTriggerInput {
 """
 Creates a new promotion.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point. 
 
@@ -27131,7 +27131,7 @@ input CataloguePredicateInput @doc(category: "Discounts") {
 """
 Updates an existing promotion.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point. 
 
@@ -27185,7 +27185,7 @@ input PromotionUpdateInput {
 """
 Deletes a promotion.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point. 
 
@@ -27221,7 +27221,7 @@ enum PromotionDeleteErrorCode {
 """
 Creates a new promotion rule.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point. 
 
@@ -27290,7 +27290,7 @@ input PromotionRuleCreateInput {
 """
 Updates an existing promotion rule.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point. 
 
@@ -27363,7 +27363,7 @@ input PromotionRuleUpdateInput {
 """
 Deletes a promotion rule.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point. 
 
@@ -27399,7 +27399,7 @@ enum PromotionRuleDeleteErrorCode {
 """
 Creates/updates translations for a promotion.
 
-Added in Saleor 3.15. 
+Added in Saleor 3.17. 
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -27422,7 +27422,7 @@ input PromotionTranslationInput {
 """
 Creates/updates translations for a promotion rule.
 
-Added in Saleor 3.15. 
+Added in Saleor 3.17. 
 
 Requires one of the following permissions: MANAGE_TRANSLATIONS.
 """
@@ -27445,7 +27445,7 @@ input PromotionRuleTranslationInput {
 """
 Deletes promotions.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point. 
 
@@ -33104,7 +33104,7 @@ type SaleToggle implements Event @doc(category: "Discounts") {
 """
 Event sent when new promotion is created.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -33128,7 +33128,7 @@ type PromotionCreated implements Event @doc(category: "Discounts") {
 """
 Event sent when promotion is updated.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -33152,7 +33152,7 @@ type PromotionUpdated implements Event @doc(category: "Discounts") {
 """
 Event sent when promotion is deleted.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -33176,7 +33176,7 @@ type PromotionDeleted implements Event @doc(category: "Discounts") {
 """
 The event informs about the start of the promotion.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -33200,7 +33200,7 @@ type PromotionStarted implements Event @doc(category: "Discounts") {
 """
 The event informs about the end of the promotion.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -33224,7 +33224,7 @@ type PromotionEnded implements Event @doc(category: "Discounts") {
 """
 Event sent when new promotion rule is created.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -33248,7 +33248,7 @@ type PromotionRuleCreated implements Event @doc(category: "Discounts") {
 """
 Event sent when new promotion rule is updated.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """
@@ -33272,7 +33272,7 @@ type PromotionRuleUpdated implements Event @doc(category: "Discounts") {
 """
 Event sent when new promotion rule is deleted.
 
-Added in Saleor 3.15.
+Added in Saleor 3.17.
 
 Note: this API is currently in Feature Preview and can be subject to changes at later point.
 """

--- a/saleor/graphql/translations/mutations/promotion_rule_translate.py
+++ b/saleor/graphql/translations/mutations/promotion_rule_translate.py
@@ -2,7 +2,7 @@ import graphene
 
 from ....discount import models as discount_models
 from ....permission.enums import SitePermissions
-from ...core.descriptions import ADDED_IN_315, RICH_CONTENT
+from ...core.descriptions import ADDED_IN_317, RICH_CONTENT
 from ...core.enums import LanguageCodeEnum
 from ...core.scalars import JSON
 from ...core.types import TranslationError
@@ -30,7 +30,7 @@ class PromotionRuleTranslate(BaseTranslateMutation):
 
     class Meta:
         description = (
-            "Creates/updates translations for a promotion rule." + ADDED_IN_315
+            "Creates/updates translations for a promotion rule." + ADDED_IN_317
         )
         model = discount_models.PromotionRule
         object_type = PromotionRule

--- a/saleor/graphql/translations/mutations/promotion_translate.py
+++ b/saleor/graphql/translations/mutations/promotion_translate.py
@@ -2,7 +2,7 @@ import graphene
 
 from ....discount import models as discount_models
 from ....permission.enums import SitePermissions
-from ...core.descriptions import ADDED_IN_315, RICH_CONTENT
+from ...core.descriptions import ADDED_IN_317, RICH_CONTENT
 from ...core.enums import LanguageCodeEnum
 from ...core.scalars import JSON
 from ...core.types import TranslationError
@@ -29,7 +29,7 @@ class PromotionTranslate(BaseTranslateMutation):
         )
 
     class Meta:
-        description = "Creates/updates translations for a promotion." + ADDED_IN_315
+        description = "Creates/updates translations for a promotion." + ADDED_IN_317
         model = discount_models.Promotion
         object_type = Promotion
         error_type_class = TranslationError

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -18,7 +18,7 @@ from ..attribute.dataloaders import AttributesByAttributeId
 from ..channel import ChannelContext
 from ..core.descriptions import (
     ADDED_IN_39,
-    ADDED_IN_315,
+    ADDED_IN_317,
     DEPRECATED_IN_3X_FIELD,
     DEPRECATED_IN_3X_TYPE,
     RICH_CONTENT,
@@ -774,7 +774,7 @@ class PromotionTranslation(BaseTranslationType[discount_models.PromotionTranslat
     class Meta:
         model = discount_models.Promotion
         interfaces = [graphene.relay.Node]
-        description = "Represents promotion translations." + ADDED_IN_315
+        description = "Represents promotion translations." + ADDED_IN_317
 
 
 class PromotionTranslatableContent(ModelObjectType[discount_models.Promotion]):
@@ -790,7 +790,7 @@ class PromotionTranslatableContent(ModelObjectType[discount_models.Promotion]):
         interfaces = [graphene.relay.Node]
         description = (
             "Represents promotion's original translatable fields "
-            "and related translations." + ADDED_IN_315
+            "and related translations." + ADDED_IN_317
         )
 
 
@@ -808,7 +808,7 @@ class PromotionRuleTranslation(
     class Meta:
         model = discount_models.PromotionRule
         interfaces = [graphene.relay.Node]
-        description = "Represents promotion rule translations." + ADDED_IN_315
+        description = "Represents promotion rule translations." + ADDED_IN_317
 
 
 class PromotionRuleTranslatableContent(ModelObjectType[discount_models.Promotion]):
@@ -826,5 +826,5 @@ class PromotionRuleTranslatableContent(ModelObjectType[discount_models.Promotion
         interfaces = [graphene.relay.Node]
         description = (
             "Represents promotion rule's original translatable fields "
-            "and related translations." + ADDED_IN_315
+            "and related translations." + ADDED_IN_317
         )

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -51,6 +51,7 @@ from ..core.descriptions import (
     ADDED_IN_314,
     ADDED_IN_315,
     ADDED_IN_316,
+    ADDED_IN_317,
     DEPRECATED_IN_3X_EVENT,
     PREVIEW_FEATURE,
 )
@@ -1178,7 +1179,7 @@ class PromotionCreated(SubscriptionObjectType, PromotionBase):
         enable_dry_run = True
         interfaces = (Event,)
         description = (
-            "Event sent when new promotion is created." + ADDED_IN_315 + PREVIEW_FEATURE
+            "Event sent when new promotion is created." + ADDED_IN_317 + PREVIEW_FEATURE
         )
 
 
@@ -1188,7 +1189,7 @@ class PromotionUpdated(SubscriptionObjectType, PromotionBase):
         enable_dry_run = True
         interfaces = (Event,)
         description = (
-            "Event sent when promotion is updated." + ADDED_IN_315 + PREVIEW_FEATURE
+            "Event sent when promotion is updated." + ADDED_IN_317 + PREVIEW_FEATURE
         )
 
 
@@ -1198,7 +1199,7 @@ class PromotionDeleted(SubscriptionObjectType, PromotionBase):
         enable_dry_run = True
         interfaces = (Event,)
         description = (
-            "Event sent when promotion is deleted." + ADDED_IN_315 + PREVIEW_FEATURE
+            "Event sent when promotion is deleted." + ADDED_IN_317 + PREVIEW_FEATURE
         )
 
 
@@ -1208,7 +1209,7 @@ class PromotionStarted(SubscriptionObjectType, PromotionBase):
         enable_dry_run = True
         description = (
             "The event informs about the start of the promotion."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
         interfaces = (Event,)
@@ -1220,7 +1221,7 @@ class PromotionEnded(SubscriptionObjectType, PromotionBase):
         enable_dry_run = True
         description = (
             "The event informs about the end of the promotion."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
         interfaces = (Event,)
@@ -1245,7 +1246,7 @@ class PromotionRuleCreated(SubscriptionObjectType, PromotionRuleBase):
         interfaces = (Event,)
         description = (
             "Event sent when new promotion rule is created."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
 
@@ -1257,7 +1258,7 @@ class PromotionRuleUpdated(SubscriptionObjectType, PromotionRuleBase):
         interfaces = (Event,)
         description = (
             "Event sent when new promotion rule is updated."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
 
@@ -1269,7 +1270,7 @@ class PromotionRuleDeleted(SubscriptionObjectType, PromotionRuleBase):
         interfaces = (Event,)
         description = (
             "Event sent when new promotion rule is deleted."
-            + ADDED_IN_315
+            + ADDED_IN_317
             + PREVIEW_FEATURE
         )
 

--- a/saleor/tests/e2e/product/utils/__init__.py
+++ b/saleor/tests/e2e/product/utils/__init__.py
@@ -15,7 +15,6 @@ from .product_query import get_product
 from .product_type import create_product_type
 from .product_variant import create_product_variant, raw_create_product_variant
 from .product_variant_bulk_create import create_variants_in_bulk
-from .product_variant_channel_listing import create_product_variant_channel_listing
 from .product_variant_channel_listing import (
     create_product_variant_channel_listing,
     raw_create_product_variant_channel_listing,

--- a/saleor/tests/e2e/product/utils/product.py
+++ b/saleor/tests/e2e/product/utils/product.py
@@ -44,7 +44,7 @@ def create_product(
 ):
     if not attributes:
         attributes = []
-  
+
     if not collection_ids:
         collection_ids = []
 


### PR DESCRIPTION
I want to merge this change, because it replaces `ADDED_IN_315` label with `ADDED_IN_317`.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
