### PR TITLE
[Test] Sale updated by promotionRuleUpdate cannot be handled by sale mutation

### DIFF
--- a/saleor/graphql/webhook/tests/mutations/test_webhook_trigger.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_trigger.py
@@ -2,6 +2,7 @@ import json
 from unittest import mock
 
 import graphene
+import pytest
 
 from .....core import EventDeliveryStatus
 from .....graphql.tests.utils import get_graphql_content

--- a/saleor/graphql/webhook/tests/mutations/test_webhook_trigger.py
+++ b/saleor/graphql/webhook/tests/mutations/test_webhook_trigger.py
@@ -2,7 +2,6 @@ import json
 from unittest import mock
 
 import graphene
-import pytest
 
 from .....core import EventDeliveryStatus
 from .....graphql.tests.utils import get_graphql_content

--- a/saleor/tests/e2e/promotions/test_sale_updated_by_promotion_can_not_be_handled_by_sales.py
+++ b/saleor/tests/e2e/promotions/test_sale_updated_by_promotion_can_not_be_handled_by_sales.py
@@ -48,7 +48,7 @@ def prepare_sale_for_product(
 
 
 @pytest.mark.e2e
-def test_staff_can_change_catalogue_predicate_core_2112(
+def test_sale_updated_by_promotion_can_not_be_handled_by_sales_core_2116(
     e2e_staff_api_client,
     permission_manage_products,
     permission_manage_channels,
@@ -105,6 +105,7 @@ def test_staff_can_change_catalogue_predicate_core_2112(
     sale_rule_id = sale_rule["id"]
     assert sale_rule["rewardValue"] == sale_discount_value
     assert sale_rule["rewardValueType"] == sale_discount_type
+
     # Step 2 - Update sale by promotion rule mutation
     input = {
         "rewardValue": 25.0,
@@ -124,5 +125,7 @@ def test_staff_can_change_catalogue_predicate_core_2112(
         sale_id,
         add_channels=sale_listing_input,
     )
-    assert sale_update["errors"][0]["message"] == "Internal Server Error"
-    assert sale_update["errors"][0]["extensions"]["exception"]["code"] == "DoesNotExist"
+    sale_update_error = sale_update["data"]["saleChannelListingUpdate"]["errors"]
+    assert sale_update_error[0]["message"] == "Sale with given ID can't be found."
+    assert sale_update_error[0]["field"] == "id"
+    assert sale_update_error[0]["code"] == "NOT_FOUND"

--- a/saleor/tests/e2e/promotions/test_sale_updated_by_promotion_can_not_be_handled_by_sales.py
+++ b/saleor/tests/e2e/promotions/test_sale_updated_by_promotion_can_not_be_handled_by_sales.py
@@ -1,0 +1,128 @@
+import pytest
+
+from ..product.utils.preparing_product import prepare_product
+from ..promotions.utils import promotions_query, update_promotion_rule
+from ..sales.utils import (
+    create_sale,
+    create_sale_channel_listing,
+    raw_create_sale_channel_listing,
+    sale_catalogues_add,
+)
+from ..shop.utils.preparing_shop import prepare_shop
+from ..utils import assign_permissions
+
+
+def prepare_sale_for_product(
+    e2e_staff_api_client,
+    channel_id,
+    product_id,
+    sale_discount_type,
+    sale_discount_value,
+):
+    sale_name = "Sale"
+    sale = create_sale(
+        e2e_staff_api_client,
+        sale_name,
+        sale_discount_type,
+    )
+    sale_id = sale["id"]
+    sale_listing_input = [
+        {
+            "channelId": channel_id,
+            "discountValue": sale_discount_value,
+        }
+    ]
+    create_sale_channel_listing(
+        e2e_staff_api_client,
+        sale_id,
+        add_channels=sale_listing_input,
+    )
+    catalogue_input = {"products": [product_id]}
+    sale_catalogues_add(
+        e2e_staff_api_client,
+        sale_id,
+        catalogue_input,
+    )
+
+    return sale_id, sale_name, sale_discount_type, sale_discount_value
+
+
+@pytest.mark.e2e
+def test_staff_can_change_catalogue_predicate_core_2112(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_shipping,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        warehouse_id,
+        channel_id,
+        _channel_slug,
+        _shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    (
+        product_id,
+        _product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price="41.99",
+    )
+
+    (
+        sale_id,
+        sale_name,
+        sale_discount_type,
+        sale_discount_value,
+    ) = prepare_sale_for_product(
+        e2e_staff_api_client,
+        channel_id,
+        product_id,
+        sale_discount_type="FIXED",
+        sale_discount_value=30,
+    )
+
+    # Step 1 - Get promotions and check for created sale
+    promotions = promotions_query(e2e_staff_api_client)
+    sale_as_promotion = promotions[0]["node"]
+    assert sale_as_promotion["name"] == sale_name
+    sale_rule = sale_as_promotion["rules"][1]
+    sale_rule_id = sale_rule["id"]
+    assert sale_rule["rewardValue"] == sale_discount_value
+    assert sale_rule["rewardValueType"] == sale_discount_type
+    # Step 2 - Update sale by promotion rule mutation
+    input = {
+        "rewardValue": 25.0,
+    }
+    sale_as_promotion = update_promotion_rule(e2e_staff_api_client, sale_rule_id, input)
+    assert sale_as_promotion["rewardValue"] == 25.0
+
+    # Step 3 - Try to update sale channel listing using sale mutation
+    sale_listing_input = [
+        {
+            "channelId": channel_id,
+            "discountValue": 20,
+        }
+    ]
+    sale_update = raw_create_sale_channel_listing(
+        e2e_staff_api_client,
+        sale_id,
+        add_channels=sale_listing_input,
+    )
+    assert sale_update["errors"][0]["message"] == "Internal Server Error"
+    assert sale_update["errors"][0]["extensions"]["exception"]["code"] == "DoesNotExist"

--- a/saleor/tests/e2e/promotions/utils/__init__.py
+++ b/saleor/tests/e2e/promotions/utils/__init__.py
@@ -3,6 +3,7 @@ from .promotion_delete import delete_promotion
 from .promotion_query import promotion_query
 from .promotion_rule_create import create_promotion_rule
 from .promotion_rule_update import update_promotion_rule
+from .promotions_query import promotions_query
 
 __all__ = [
     "create_promotion",
@@ -10,4 +11,5 @@ __all__ = [
     "update_promotion_rule",
     "delete_promotion",
     "promotion_query",
+    "promotions_query",
 ]

--- a/saleor/tests/e2e/promotions/utils/promotions_query.py
+++ b/saleor/tests/e2e/promotions/utils/promotions_query.py
@@ -1,0 +1,48 @@
+from ...utils import get_graphql_content
+
+PROMOTIONS_QUERY = """
+query Promotions($first: Int, $sortBy: PromotionSortingInput) {
+  promotions(first: $first, sortBy: $sortBy) {
+    totalCount
+    edges {
+      node {
+        id
+        events {
+          __typename
+        }
+        name
+        createdAt
+        rules {
+          id
+          name
+          description
+          rewardValueType
+          cataloguePredicate
+          rewardValue
+          channels {
+            name
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def promotions_query(
+    staff_api_client,
+    first=10,
+):
+    variables = {"first": first, "sortBy": {"field": "CREATED_AT", "direction": "DESC"}}
+
+    response = staff_api_client.post_graphql(
+        PROMOTIONS_QUERY,
+        variables,
+    )
+
+    content = get_graphql_content(response)
+
+    data = content["data"]["promotions"]["edges"]
+
+    return data

--- a/saleor/tests/e2e/sales/utils/__init__.py
+++ b/saleor/tests/e2e/sales/utils/__init__.py
@@ -1,9 +1,13 @@
 from .sale_catalogues_add import sale_catalogues_add
-from .sale_channel_listing import create_sale_channel_listing
+from .sale_channel_listing import (
+    create_sale_channel_listing,
+    raw_create_sale_channel_listing,
+)
 from .sale_create import create_sale
 
 __all__ = [
     "create_sale",
     "create_sale_channel_listing",
     "sale_catalogues_add",
+    "raw_create_sale_channel_listing",
 ]

--- a/saleor/tests/e2e/sales/utils/sale_channel_listing.py
+++ b/saleor/tests/e2e/sales/utils/sale_channel_listing.py
@@ -23,7 +23,7 @@ mutation SaleUpdate($id: ID!, $input: SaleChannelListingInput!) {
 """
 
 
-def create_sale_channel_listing(
+def raw_create_sale_channel_listing(
     staff_api_client,
     sale_id,
     add_channels=None,
@@ -48,9 +48,24 @@ def create_sale_channel_listing(
         variables,
         check_no_permissions=False,
     )
-    content = get_graphql_content(response)
+    content = get_graphql_content(response, ignore_errors=True)
 
-    assert content["data"]["saleChannelListingUpdate"]["errors"] == []
-    data = content["data"]["saleChannelListingUpdate"]["sale"]
+    return content
 
+
+def create_sale_channel_listing(
+    staff_api_client,
+    sale_id,
+    add_channels=None,
+    remove_channels=None,
+):
+    response = raw_create_sale_channel_listing(
+        staff_api_client,
+        sale_id,
+        add_channels=add_channels,
+        remove_channels=remove_channels,
+    )
+
+    assert response["data"]["saleChannelListingUpdate"]["errors"] == []
+    data = response["data"]["saleChannelListingUpdate"]["sale"]
     return data

--- a/saleor/tests/e2e/sales/utils/sale_channel_listing.py
+++ b/saleor/tests/e2e/sales/utils/sale_channel_listing.py
@@ -48,7 +48,7 @@ def raw_create_sale_channel_listing(
         variables,
         check_no_permissions=False,
     )
-    content = get_graphql_content(response, ignore_errors=True)
+    content = get_graphql_content(response)
 
     return content
 


### PR DESCRIPTION
I want to merge this change because it adds a test for an attempt to update the sale once updated by promotion [CORE_2116](https://saleor.testmo.net/repositories/5?group_id=133&case_id=1781)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
