### PR TITLE
[TEST] order deletion after expiration

### DIFF
--- a/saleor/tests/e2e/channel/utils/channel_update.py
+++ b/saleor/tests/e2e/channel/utils/channel_update.py
@@ -11,6 +11,7 @@ mutation ChannelUpdate($id: ID!, $input: ChannelUpdateInput!) {
         automaticallyFulfillNonShippableGiftCard
         automaticallyConfirmAllNewOrders
         expireOrdersAfter
+        deleteExpiredOrdersAfter
       }
     }
     errors {

--- a/saleor/tests/e2e/orders/utils/order_create_from_checkout.py
+++ b/saleor/tests/e2e/orders/utils/order_create_from_checkout.py
@@ -19,6 +19,12 @@ mutation orderCreateFromCheckout($id: ID!) {
                 amount
             }
         }
+        channel {
+            orderSettings {
+                expireOrdersAfter
+                deleteExpiredOrdersAfter
+            }
+        }
         billingAddress {
         streetAddress1
         }

--- a/saleor/tests/e2e/orders/utils/order_query.py
+++ b/saleor/tests/e2e/orders/utils/order_query.py
@@ -13,6 +13,7 @@ query OrderDetails($id:ID!) {
         id
         name
     }
+    updatedAt
     fulfillments {
       created
       id


### PR DESCRIPTION
I want to merge this change because it covers [CORE_0216](https://saleor.testmo.net/repositories/5?group_id=112&case_id=2399) - expired order is deleted after specified time.
I've also modified test for expiring an order and creating an order from checkout.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
