### PR TITLE
Add missing undiscounted total price in order line

### DIFF
--- a/saleor/graphql/order/tests/queries/test_order_line.py
+++ b/saleor/graphql/order/tests/queries/test_order_line.py
@@ -46,6 +46,12 @@ def test_order_line_query(
                                     amount
                                 }
                             }
+                            undiscountedTotalPrice {
+                                currency
+                                gross {
+                                    amount
+                                }
+                            }
                             metadata {
                                 key
                                 value
@@ -104,6 +110,7 @@ def test_order_line_query(
         currency="USD",
     )
     assert first_order_data_line["totalPrice"]["currency"] == line.unit_price.currency
+    assert first_order_data_line["undiscountedTotalPrice"]["currency"] == line.currency
     assert expected_unit_price == line.unit_price.gross
 
     expected_total_price = Money(
@@ -111,6 +118,12 @@ def test_order_line_query(
         currency="USD",
     )
     assert expected_total_price == line.unit_price.gross * line.quantity
+
+    expected_undiscounted_total_price = Money(
+        amount=str(first_order_data_line["undiscountedTotalPrice"]["gross"]["amount"]),
+        currency="USD",
+    )
+    assert expected_undiscounted_total_price == line.undiscounted_total_price.gross
 
     allocation = line.allocations.first()
     allocation_id = graphene.Node.to_global_id("Allocation", allocation.pk)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -656,7 +656,7 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     )
     undiscounted_total_price = graphene.Field(
         TaxedMoney,
-        description=("Price of the order line without applied an order line discount."),
+        description="Price of the order line without discounts.",
         required=True,
     )
     variant = graphene.Field(

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -654,6 +654,13 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     total_price = graphene.Field(
         TaxedMoney, description="Price of the order line.", required=True
     )
+    undiscounted_total_price = graphene.Field(
+        TaxedMoney,
+        description=(
+            "Price of the order line without applied and order line discount."
+        ),
+        required=True,
+    )
     variant = graphene.Field(
         ProductVariant,
         required=False,

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -656,9 +656,7 @@ class OrderLine(ModelObjectType[models.OrderLine]):
     )
     undiscounted_total_price = graphene.Field(
         TaxedMoney,
-        description=(
-            "Price of the order line without applied and order line discount."
-        ),
+        description=("Price of the order line without applied an order line discount."),
         required=True,
     )
     variant = graphene.Field(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10811,6 +10811,9 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Price of the order line."""
   totalPrice: TaxedMoney!
 
+  """Price of the order line without applied and order line discount."""
+  undiscountedTotalPrice: TaxedMoney!
+
   """
   A purchased product variant. Note: this field may be null if the variant has been removed from stock at all. Requires one of the following permissions to include the unpublished items: MANAGE_ORDERS, MANAGE_DISCOUNTS, MANAGE_PRODUCTS.
   """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10811,7 +10811,7 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Price of the order line."""
   totalPrice: TaxedMoney!
 
-  """Price of the order line without applied an order line discount."""
+  """Price of the order line without discounts."""
   undiscountedTotalPrice: TaxedMoney!
 
   """

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10811,7 +10811,7 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   """Price of the order line."""
   totalPrice: TaxedMoney!
 
-  """Price of the order line without applied and order line discount."""
+  """Price of the order line without applied an order line discount."""
   undiscountedTotalPrice: TaxedMoney!
 
   """


### PR DESCRIPTION
Fixes: https://github.com/saleor/saleor/issues/14030

The resolver was already implemented, the field was just missing from our schema.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
