### PR TITLE
Remove unneeded calculation in applying tax data form plugins

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -414,19 +414,12 @@ def _apply_tax_data_from_plugins(
         )
         line.total_price = total_price
 
-        unit_price = manager.calculate_checkout_line_unit_price(
-            checkout_info,
-            lines,
-            line_info,
-            address,
-        )
-
         line.tax_rate = manager.get_checkout_line_tax_rate(
             checkout_info,
             lines,
             line_info,
             address,
-            unit_price,
+            total_price,
         )
 
     checkout.shipping_price = manager.calculate_checkout_shipping(

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -516,9 +516,9 @@ class PluginsManager(PaymentInterface):
         lines: Iterable["CheckoutLineInfo"],
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
-        unit_price: TaxedMoney,
+        price: TaxedMoney,
     ) -> Decimal:
-        default_value = calculate_tax_rate(unit_price)
+        default_value = calculate_tax_rate(price)
         return self.__run_method_on_plugins(
             "get_checkout_line_tax_rate",
             default_value,


### PR DESCRIPTION
I want to merge this change because it gets rid of unnecessary calculation of unit price just to calculate tax rate - tax rate can be fetched from total since it is already calculated beforehand.
Additionally changed the name of the parameter to `price` - since tax rate can be fetched not only from unit price but form any taxedPrice properly. 

It is an independent fix for one part of a bigger issue found in https://github.com/saleor/saleor/pull/13585#discussion_r1288170283 
it does not change Saleor logic, just gets rid of unnecessary code.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
