### PR TITLE
Return sale ID instead of promotion ID in sale webhook payloads.

### DIFF
--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -421,7 +421,7 @@ def _calculate_removed(
 
 @traced_payload_generator
 def generate_sale_payload(
-    sale: "Promotion",
+    promotion: "Promotion",
     previous_catalogue: Optional[DefaultDict[str, Set[str]]] = None,
     current_catalogue: Optional[DefaultDict[str, Set[str]]] = None,
     requestor: Optional["RequestorOrLazyObject"] = None,
@@ -432,12 +432,12 @@ def generate_sale_payload(
         current_catalogue = defaultdict(set)
 
     serializer = PayloadSerializer()
-    sale_fields = ("id",)
 
     return serializer.serialize(
-        [sale],
-        fields=sale_fields,
+        [promotion],
+        fields=[],
         extra_dict_data={
+            "id": graphene.Node.to_global_id("Sale", promotion.old_sale_id),
             "meta": generate_meta(requestor_data=generate_requestor(requestor)),
             "categories_added": _calculate_added(
                 previous_catalogue, current_catalogue, "categories"
@@ -469,22 +469,22 @@ def generate_sale_payload(
 
 @traced_payload_generator
 def generate_sale_toggle_payload(
-    sale: "Promotion",
+    promotion: "Promotion",
     catalogue: DefaultDict[str, Set[str]],
     requestor: Optional["RequestorOrLazyObject"] = None,
 ):
     serializer = PayloadSerializer()
-    sale_fields = ("id",)
 
     extra_dict_data = {key: list(ids) for key, ids in catalogue.items()}
     extra_dict_data["meta"] = generate_meta(
         requestor_data=generate_requestor(requestor)
     )
-    extra_dict_data["is_active"] = sale.is_active()
+    extra_dict_data["is_active"] = promotion.is_active()
+    extra_dict_data["id"] = graphene.Node.to_global_id("Sale", promotion.old_sale_id)
 
     return serializer.serialize(
-        [sale],
-        fields=sale_fields,
+        [promotion],
+        fields=[],
         extra_dict_data=extra_dict_data,
     )
 


### PR DESCRIPTION
I want to merge this change, because it returns sale ID instead of promotion ID in sale webhook payloads.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
