### PR TITLE
Fix translation type resolver.

### DIFF
--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -53,9 +53,11 @@ class TranslatableItem(graphene.Union):
     def resolve_type(cls, instance, info: ResolveInfo):
         instance_type = type(instance)
         kind = info.variable_values.get("kind")
-        if kind == TranslatableKinds.SALE:
+        if kind == TranslatableKinds.SALE or (
+            instance_type == Promotion and instance.old_sale_id
+        ):
             return translation_types.SaleTranslatableContent
-        if instance_type in TYPES_TRANSLATIONS_MAP:
+        elif instance_type in TYPES_TRANSLATIONS_MAP:
             return TYPES_TRANSLATIONS_MAP[instance_type]
 
         return super(TranslatableItem, cls).resolve_type(instance, info)

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -3069,7 +3069,7 @@ def test_translations_query(
     product,
     published_collection,
     voucher,
-    promotion_converted_from_sale,
+    promotion,
     shipping_method,
     page,
     menu_item,
@@ -3095,6 +3095,33 @@ def test_translations_query(
     data = get_graphql_content(response)["data"]["translations"]
 
     assert data["edges"][0]["node"]["__typename"] == expected_typename
+    assert data["totalCount"] > 0
+
+
+def test_translations_query_promotion_converted_from_sale(
+    staff_api_client, permission_manage_translations, promotion_converted_from_sale
+):
+    query = """
+    query TranslationsQuery($kind: TranslatableKinds!) {
+        translations(kind: $kind, first: 1) {
+            edges {
+                node {
+                    __typename
+                }
+            }
+            totalCount
+        }
+    }
+    """
+
+    response = staff_api_client.post_graphql(
+        query,
+        {"kind": TranslatableKinds.PROMOTION.name},
+        permissions=[permission_manage_translations],
+    )
+    data = get_graphql_content(response)["data"]["translations"]
+
+    assert data["edges"][0]["node"]["__typename"] == "SaleTranslatableContent"
     assert data["totalCount"] > 0
 
 


### PR DESCRIPTION
I want to merge this change, because it fixes type resolver of `TranslatableItem` in case of sales converted to promotions.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
