### PR TITLE
Fix failing promotion mutations with only end_date provided

### DIFF
--- a/saleor/graphql/core/tests/test_validators.py
+++ b/saleor/graphql/core/tests/test_validators.py
@@ -60,21 +60,15 @@ def test_validate_end_is_after_start_raise_error():
     assert error.value.message == "End date cannot be before the start date."
 
 
-def test_validate_end_is_after_start():
-    # given
-    start_date = timezone.now() - timedelta(days=365)
-    end_date = timezone.now() + timedelta(days=365)
-
-    # when & then
+@pytest.mark.parametrize(
+    "start_date, end_date",
+    [
+        (timezone.now() - timedelta(days=365), timezone.now() + timedelta(days=365)),
+        (timezone.now() + timedelta(days=365), None),
+    ],
+)
+def test_validate_end_is_after_start(start_date, end_date):
     validate_end_is_after_start(start_date, end_date)
-
-
-def test_validate_end_is_after_start_empty_end_date():
-    # given
-    start_date = timezone.now() + timedelta(days=365)
-
-    # when & then
-    validate_end_is_after_start(start_date, None)
 
 
 def test_validate_one_of_args_is_in_query():

--- a/saleor/graphql/core/tests/test_validators.py
+++ b/saleor/graphql/core/tests/test_validators.py
@@ -69,14 +69,6 @@ def test_validate_end_is_after_start():
     validate_end_is_after_start(start_date, end_date)
 
 
-def test_validate_end_is_after_start_empty_start_date():
-    # given
-    end_date = timezone.now() + timedelta(days=365)
-
-    # when & then
-    validate_end_is_after_start(None, end_date)
-
-
 def test_validate_end_is_after_start_empty_end_date():
     # given
     start_date = timezone.now() + timedelta(days=365)

--- a/saleor/graphql/core/tests/test_validators.py
+++ b/saleor/graphql/core/tests/test_validators.py
@@ -60,6 +60,31 @@ def test_validate_end_is_after_start_raise_error():
     assert error.value.message == "End date cannot be before the start date."
 
 
+def test_validate_end_is_after_start():
+    # given
+    start_date = timezone.now() - timedelta(days=365)
+    end_date = timezone.now() + timedelta(days=365)
+
+    # when & then
+    validate_end_is_after_start(start_date, end_date)
+
+
+def test_validate_end_is_after_start_empty_start_date():
+    # given
+    end_date = timezone.now() + timedelta(days=365)
+
+    # when & then
+    validate_end_is_after_start(None, end_date)
+
+
+def test_validate_end_is_after_start_empty_end_date():
+    # given
+    start_date = timezone.now() + timedelta(days=365)
+
+    # when & then
+    validate_end_is_after_start(start_date, None)
+
+
 def test_validate_one_of_args_is_in_query():
     assert validate_one_of_args_is_in_query("arg1", "present", "arg2", None) is None
 

--- a/saleor/graphql/core/validators/__init__.py
+++ b/saleor/graphql/core/validators/__init__.py
@@ -135,8 +135,8 @@ def validate_variants_available_in_channel(
 def validate_end_is_after_start(start_date, end_date):
     """Validate if the end date provided is after start date."""
 
-    # check is not needed if no end or start date
-    if end_date is None or start_date is None:
+    # check is not needed if no end date
+    if end_date is None:
         return
 
     if start_date > end_date:

--- a/saleor/graphql/core/validators/__init__.py
+++ b/saleor/graphql/core/validators/__init__.py
@@ -135,8 +135,8 @@ def validate_variants_available_in_channel(
 def validate_end_is_after_start(start_date, end_date):
     """Validate if the end date provided is after start date."""
 
-    # check is not needed if no end date
-    if end_date is None:
+    # check is not needed if no end or start date
+    if end_date is None or start_date is None:
         return
 
     if start_date > end_date:

--- a/saleor/graphql/discount/mutations/promotion/promotion_create.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_create.py
@@ -98,7 +98,7 @@ class PromotionCreate(ModelMutation):
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
 
         errors: DefaultDict[str, List[ValidationError]] = defaultdict(list)
-        start_date = cleaned_input.get("start_date")
+        start_date = cleaned_input.get("start_date") or instance.start_date
         end_date = cleaned_input.get("end_date")
         try:
             validate_end_is_after_start(start_date, end_date)

--- a/saleor/graphql/discount/mutations/promotion/promotion_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_update.py
@@ -88,8 +88,8 @@ class PromotionUpdate(ModelMutation):
         cls, info: ResolveInfo, instance: models.Promotion, data: dict, **kwargs
     ):
         cleaned_input = super().clean_input(info, instance, data, **kwargs)
-        start_date = cleaned_input.get("start_date")
-        end_date = cleaned_input.get("end_date")
+        start_date = cleaned_input.get("start_date") or instance.start_date
+        end_date = cleaned_input.get("end_date") or instance.end_date
         try:
             validate_end_is_after_start(start_date, end_date)
         except ValidationError as error:

--- a/saleor/graphql/discount/tests/mutations/test_promotion_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_update.py
@@ -109,7 +109,6 @@ def test_promotion_update_by_app(
     promotion.end_date = None
     promotion.save(update_fields=["end_date"])
 
-    start_date = timezone.now() - timedelta(days=10)
     end_date = timezone.now() - timedelta(days=2)
 
     new_promotion_name = "new test promotion"
@@ -117,7 +116,6 @@ def test_promotion_update_by_app(
         "id": graphene.Node.to_global_id("Promotion", promotion.id),
         "input": {
             "name": new_promotion_name,
-            "startDate": start_date.isoformat(),
             "endDate": end_date.isoformat(),
         },
     }
@@ -135,7 +133,6 @@ def test_promotion_update_by_app(
     assert not data["errors"]
     assert promotion_data["name"] == new_promotion_name
     assert promotion_data["description"] == promotion.description
-    assert promotion_data["startDate"] == start_date.isoformat()
     assert promotion_data["endDate"] == end_date.isoformat()
     assert promotion_data["createdAt"] == promotion.created_at.isoformat()
     assert promotion_data["updatedAt"] == timezone.now().isoformat()

--- a/saleor/graphql/discount/tests/mutations/test_promotion_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_promotion_update.py
@@ -106,10 +106,11 @@ def test_promotion_update_by_app(
     promotion,
 ):
     # given
+    promotion.start_date = timezone.now()
     promotion.end_date = None
-    promotion.save(update_fields=["end_date"])
+    promotion.save(update_fields=["start_date", "end_date"])
 
-    end_date = timezone.now() - timedelta(days=2)
+    end_date = timezone.now() + timedelta(days=2)
 
     new_promotion_name = "new test promotion"
     variables = {
@@ -138,10 +139,10 @@ def test_promotion_update_by_app(
     assert promotion_data["updatedAt"] == timezone.now().isoformat()
     event_types = [event["type"] for event in promotion_data["events"]]
     assert PromotionEvents.PROMOTION_UPDATED.upper() in event_types
-    assert PromotionEvents.PROMOTION_ENDED.upper() in event_types
+    assert PromotionEvents.PROMOTION_ENDED.upper() not in event_types
 
     promotion_updated_mock.assert_called_once_with(promotion)
-    promotion_ended_mock.assert_called_once_with(promotion)
+    promotion_ended_mock.assert_not_called()
     update_products_discounted_prices_of_promotion_task_mock.assert_called_once_with(
         promotion.id
     )


### PR DESCRIPTION
Fix failing promotion mutations when providing `end_date` without `start_date`.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
