### PR TITLE
Fix getting webhook for events to use replica

### DIFF
--- a/saleor/webhook/utils.py
+++ b/saleor/webhook/utils.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Optional
 
+from django.conf import settings
 from django.db.models import Q
 from django.db.models.expressions import Exists, OuterRef
 
@@ -28,18 +29,26 @@ def get_webhooks_for_event(
         permissions["permissions__codename"] = codename
 
     if webhooks is None:
-        webhooks = Webhook.objects.all()
+        webhooks = Webhook.objects.using(
+            settings.DATABASE_CONNECTION_REPLICA_NAME
+        ).all()
+
     app_kwargs: dict = {"is_active": True, **permissions}
     if apps_ids:
         app_kwargs["id__in"] = apps_ids
     if apps_identifier:
         app_kwargs["identifier__in"] = apps_identifier
 
-    apps = App.objects.filter(**app_kwargs)
+    apps = App.objects.using(settings.DATABASE_CONNECTION_REPLICA_NAME).filter(
+        **app_kwargs
+    )
     event_types = [event_type]
     if event_type in WebhookEventAsyncType.ALL:
         event_types.append(WebhookEventAsyncType.ANY)
-    webhook_events = WebhookEvent.objects.filter(event_type__in=event_types)
+
+    webhook_events = WebhookEvent.objects.using(
+        settings.DATABASE_CONNECTION_REPLICA_NAME
+    ).filter(event_type__in=event_types)
     return (
         webhooks.filter(
             Q(is_active=True, app__in=apps)

--- a/saleor/webhook/utils.py
+++ b/saleor/webhook/utils.py
@@ -28,6 +28,9 @@ def get_webhooks_for_event(
         permissions["permissions__content_type__app_label"] = app_label
         permissions["permissions__codename"] = codename
 
+    # In this function we use the replica database for all queryset reads, as there is
+    # no risk that any mutation would change the result of these querysets.
+
     if webhooks is None:
         webhooks = Webhook.objects.using(
             settings.DATABASE_CONNECTION_REPLICA_NAME


### PR DESCRIPTION
Fixes `get_webhooks_for_event` function to always read data from the replica database.

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
