### PR TITLE
Fix promotion/sale translation mutations.

### DIFF
--- a/saleor/graphql/translations/mutations/promotion_rule_translate.py
+++ b/saleor/graphql/translations/mutations/promotion_rule_translate.py
@@ -2,11 +2,14 @@ import graphene
 
 from ....discount import models as discount_models
 from ....permission.enums import SitePermissions
+from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_317, RICH_CONTENT
 from ...core.enums import LanguageCodeEnum
 from ...core.scalars import JSON
 from ...core.types import TranslationError
+from ...discount.mutations.utils import clear_promotion_old_sale_id
 from ...discount.types import PromotionRule
+from ...plugins.dataloaders import get_plugin_manager_promise
 from .utils import BaseTranslateMutation, NameTranslationInput
 
 
@@ -36,3 +39,25 @@ class PromotionRuleTranslate(BaseTranslateMutation):
         object_type = PromotionRule
         error_type_class = TranslationError
         permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
+
+    @classmethod
+    def perform_mutation(  # type: ignore[override]
+        cls, _root, info: ResolveInfo, /, *, id, input, language_code
+    ):
+        node_id, model_type = cls.clean_node_id(id)
+        instance = cls.get_node_or_error(info, node_id, only_type=model_type)
+        cls.validate_input(input)
+
+        input = cls.pre_update_or_create(instance, input)
+        translation, created = instance.translations.update_or_create(
+            language_code=language_code, defaults=input
+        )
+        clear_promotion_old_sale_id(instance.promotion, save=True)
+
+        manager = get_plugin_manager_promise(info.context).get()
+        if created:
+            cls.call_event(manager.translation_created, translation)
+        else:
+            cls.call_event(manager.translation_updated, translation)
+
+        return cls(**{cls._meta.return_field_name: instance})

--- a/saleor/graphql/translations/mutations/promotion_translate.py
+++ b/saleor/graphql/translations/mutations/promotion_translate.py
@@ -2,11 +2,14 @@ import graphene
 
 from ....discount import models as discount_models
 from ....permission.enums import SitePermissions
+from ...core import ResolveInfo
 from ...core.descriptions import ADDED_IN_317, RICH_CONTENT
 from ...core.enums import LanguageCodeEnum
 from ...core.scalars import JSON
 from ...core.types import TranslationError
+from ...discount.mutations.utils import clear_promotion_old_sale_id
 from ...discount.types import Promotion
+from ...plugins.dataloaders import get_plugin_manager_promise
 from .utils import BaseTranslateMutation, NameTranslationInput
 
 
@@ -34,3 +37,25 @@ class PromotionTranslate(BaseTranslateMutation):
         object_type = Promotion
         error_type_class = TranslationError
         permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
+
+    @classmethod
+    def perform_mutation(  # type: ignore[override]
+        cls, _root, info: ResolveInfo, /, *, id, input, language_code
+    ):
+        node_id, model_type = cls.clean_node_id(id)
+        instance = cls.get_node_or_error(info, node_id, only_type=model_type)
+        cls.validate_input(input)
+
+        input = cls.pre_update_or_create(instance, input)
+        translation, created = instance.translations.update_or_create(
+            language_code=language_code, defaults=input
+        )
+        clear_promotion_old_sale_id(instance, save=True)
+
+        manager = get_plugin_manager_promise(info.context).get()
+        if created:
+            cls.call_event(manager.translation_created, translation)
+        else:
+            cls.call_event(manager.translation_updated, translation)
+
+        return cls(**{cls._meta.return_field_name: instance})

--- a/saleor/graphql/translations/mutations/sale_translate.py
+++ b/saleor/graphql/translations/mutations/sale_translate.py
@@ -89,4 +89,11 @@ class SaleTranslate(BaseTranslateMutation):
             id = graphene.Node.to_global_id("Sale", node_pk)
 
         object_id = cls.get_global_id_or_error(id, "Sale")
-        return discount_models.Promotion.objects.get(old_sale_id=object_id)
+        try:
+            return discount_models.Promotion.objects.get(old_sale_id=object_id)
+        except discount_models.Promotion.DoesNotExist:
+            raise_validation_error(
+                field="id",
+                message="Sale with given ID can't be found.",
+                code=DiscountErrorCode.NOT_FOUND,
+            )

--- a/saleor/graphql/translations/tests/mutations/test_promotion_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_promotion_translate.py
@@ -26,6 +26,7 @@ PROMOTION_TRANSLATE_MUTATION = """
                     language {
                         code
                     }
+                    __typename
                 }
             }
             errors {
@@ -81,6 +82,7 @@ def test_promotion_create_translation(
     assert translation_data["name"] == "Polish promotion name"
     assert translation_data["description"] == json.dumps(description_json)
     assert translation_data["language"]["code"] == "PL"
+    assert translation_data["__typename"] == "PromotionTranslation"
 
     translation = promotion.translations.first()
     mocked_webhook_trigger.assert_called_once_with(
@@ -186,3 +188,40 @@ def test_promotion_create_translation_by_translatable_content_id(
     translation_data = data["promotion"]["translation"]
     assert translation_data["name"] == "Polish promotion name"
     assert translation_data["language"]["code"] == "PL"
+
+
+def test_promotion_translate_clear_old_sale_id(
+    staff_api_client,
+    promotion_converted_from_sale,
+    permission_manage_translations,
+):
+    # given
+    promotion = promotion_converted_from_sale
+    promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
+
+    variables = {
+        "id": promotion_id,
+        "languageCode": "PL",
+        "input": {
+            "name": "Polish promotion name",
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PROMOTION_TRANSLATE_MUTATION,
+        variables,
+        permissions=[permission_manage_translations],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["promotionTranslate"]
+    assert not data["errors"]
+    translation_data = data["promotion"]["translation"]
+    assert translation_data["name"] == "Polish promotion name"
+    assert translation_data["language"]["code"] == "PL"
+    assert translation_data["__typename"] == "PromotionTranslation"
+
+    promotion.refresh_from_db()
+    assert not promotion.old_sale_id

--- a/saleor/graphql/translations/tests/mutations/test_promotion_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_promotion_translate.py
@@ -197,6 +197,7 @@ def test_promotion_translate_clear_old_sale_id(
 ):
     # given
     promotion = promotion_converted_from_sale
+    assert promotion.old_sale_id
     promotion_id = graphene.Node.to_global_id("Promotion", promotion.id)
 
     variables = {

--- a/saleor/graphql/translations/tests/mutations/test_sale_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_sale_translate.py
@@ -1,0 +1,130 @@
+from unittest.mock import ANY, patch
+
+import graphene
+from django.utils.functional import SimpleLazyObject
+from freezegun import freeze_time
+
+from .....webhook.event_types import WebhookEventAsyncType
+from ....tests.utils import get_graphql_content
+
+SALE_TRANSLATE_MUTATION = """
+    mutation (
+        $id: ID!,
+        $languageCode: LanguageCodeEnum!,
+        $input: NameTranslationInput!
+    ) {
+        saleTranslate(
+            id: $id,
+            languageCode: $languageCode,
+            input: $input
+        ) {
+            sale {
+                translation(languageCode: $languageCode) {
+                    name
+                    language {
+                        code
+                    }
+                    id
+                    __typename
+                }
+            }
+            errors {
+                message
+                code
+                field
+            }
+        }
+    }
+"""
+
+
+@freeze_time("2023-06-01 10:00")
+@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
+@patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
+def test_sale_create_translation(
+    mocked_webhook_trigger,
+    mocked_get_webhooks_for_event,
+    any_webhook,
+    staff_api_client,
+    promotion_converted_from_sale,
+    permission_manage_translations,
+    settings,
+    description_json,
+):
+    # given
+    promotion = promotion_converted_from_sale
+    mocked_get_webhooks_for_event.return_value = [any_webhook]
+    settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+    promotion_id = graphene.Node.to_global_id("Sale", promotion.old_sale_id)
+
+    variables = {
+        "id": promotion_id,
+        "languageCode": "PL",
+        "input": {
+            "name": "Polish sale name",
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        SALE_TRANSLATE_MUTATION,
+        variables,
+        permissions=[permission_manage_translations],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["saleTranslate"]
+    assert not data["errors"]
+    translation_data = data["sale"]["translation"]
+
+    assert translation_data["name"] == "Polish sale name"
+    assert translation_data["language"]["code"] == "PL"
+    assert translation_data["__typename"] == "SaleTranslation"
+
+    type, _ = graphene.Node.from_global_id(translation_data["id"])
+    assert type == "SaleTranslation"
+
+    translation = promotion.translations.first()
+    mocked_webhook_trigger.assert_called_once_with(
+        None,
+        WebhookEventAsyncType.TRANSLATION_CREATED,
+        [any_webhook],
+        translation,
+        SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+
+
+def test_sale_create_translation_by_translatable_content_id(
+    staff_api_client,
+    promotion_converted_from_sale,
+    permission_manage_translations,
+):
+    # given
+    promotion = promotion_converted_from_sale
+    translatable_content_id = graphene.Node.to_global_id(
+        "SaleTranslatableContent", promotion.old_sale_id
+    )
+    variables = {
+        "id": translatable_content_id,
+        "languageCode": "PL",
+        "input": {
+            "name": "Polish sale name",
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        SALE_TRANSLATE_MUTATION,
+        variables,
+        permissions=[permission_manage_translations],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["saleTranslate"]
+    assert not data["errors"]
+    translation_data = data["sale"]["translation"]
+    assert translation_data["name"] == "Polish sale name"
+    assert translation_data["language"]["code"] == "PL"

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -2318,6 +2318,8 @@ class TranslationTypes(Union):
     @classmethod
     def resolve_type(cls, instance, info: ResolveInfo):
         instance_type = type(instance)
+        if instance_type == PromotionTranslation and instance.promotion.old_sale_id:
+            return translation_types.SaleTranslation
         if instance_type in TRANSLATIONS_TYPES_MAP:
             return TRANSLATIONS_TYPES_MAP[instance_type]
 

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1962,6 +1962,7 @@ subscription {
         }
         ... on SaleTranslation {
           id
+          __typename
         }
         ... on VoucherTranslation {
           id
@@ -1974,6 +1975,7 @@ subscription {
         }
         ... on PromotionTranslation {
           id
+          __typename
         }
         ... on PromotionRuleTranslation {
           id
@@ -2012,6 +2014,7 @@ subscription {
         }
         ... on SaleTranslation {
           id
+          __typename
         }
         ... on VoucherTranslation {
           id
@@ -2024,6 +2027,7 @@ subscription {
         }
         ... on PromotionTranslation {
           id
+          __typename
         }
         ... on PromotionRuleTranslation {
           id

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_translation_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_translation_subscription.py
@@ -172,51 +172,6 @@ def test_translation_created_promotion(
         event_type, promotion_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps({"translation": {"id": translation_id}})
-
-    assert deliveries[0].payload.payload == expected_payload
-    assert len(deliveries) == len(webhooks)
-    assert deliveries[0].webhook == webhooks[0]
-
-
-def test_translation_created_promotion_rule(
-    promotion_rule_translation_fr, subscription_translation_created_webhook
-):
-    webhooks = [subscription_translation_created_webhook]
-    event_type = WebhookEventAsyncType.TRANSLATION_CREATED
-    translation_id = graphene.Node.to_global_id(
-        "PromotionRuleTranslation", promotion_rule_translation_fr.id
-    )
-    deliveries = create_deliveries_for_subscriptions(
-        event_type, promotion_rule_translation_fr, webhooks
-    )
-
-    expected_payload = json.dumps(
-        {
-            "translation": {
-                "id": translation_id,
-                "__typename": "SaleTranslation",
-            }
-        }
-    )
-
-    assert deliveries[0].payload.payload == expected_payload
-    assert len(deliveries) == len(webhooks)
-    assert deliveries[0].webhook == webhooks[0]
-
-
-def test_translation_created_promotion(
-    promotion_translation_fr, subscription_translation_created_webhook
-):
-    webhooks = [subscription_translation_created_webhook]
-    event_type = WebhookEventAsyncType.TRANSLATION_CREATED
-    translation_id = graphene.Node.to_global_id(
-        "PromotionTranslation", promotion_translation_fr.id
-    )
-    deliveries = create_deliveries_for_subscriptions(
-        event_type, promotion_translation_fr, webhooks
-    )
-
     expected_payload = json.dumps(
         {
             "translation": {
@@ -246,6 +201,31 @@ def test_translation_created_promotion_converted_from_sale(
             "translation": {
                 "id": translation_id,
                 "__typename": "SaleTranslation",
+            }
+        }
+    )
+
+    assert deliveries[0].payload.payload == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_translation_created_promotion_rule(
+    promotion_rule_translation_fr, subscription_translation_created_webhook
+):
+    webhooks = [subscription_translation_created_webhook]
+    event_type = WebhookEventAsyncType.TRANSLATION_CREATED
+    translation_id = graphene.Node.to_global_id(
+        "PromotionRuleTranslation", promotion_rule_translation_fr.id
+    )
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, promotion_rule_translation_fr, webhooks
+    )
+
+    expected_payload = json.dumps(
+        {
+            "translation": {
+                "id": translation_id,
             }
         }
     )
@@ -457,7 +437,9 @@ def test_translation_updated_promotion(
         event_type, promotion_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps({"translation": {"id": translation_id}})
+    expected_payload = json.dumps(
+        {"translation": {"id": translation_id, "__typename": "PromotionTranslation"}}
+    )
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_translation_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_translation_subscription.py
@@ -191,7 +191,64 @@ def test_translation_created_promotion_rule(
         event_type, promotion_rule_translation_fr, webhooks
     )
 
-    expected_payload = json.dumps({"translation": {"id": translation_id}})
+    expected_payload = json.dumps(
+        {
+            "translation": {
+                "id": translation_id,
+                "__typename": "SaleTranslation",
+            }
+        }
+    )
+
+    assert deliveries[0].payload.payload == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_translation_created_promotion(
+    promotion_translation_fr, subscription_translation_created_webhook
+):
+    webhooks = [subscription_translation_created_webhook]
+    event_type = WebhookEventAsyncType.TRANSLATION_CREATED
+    translation_id = graphene.Node.to_global_id(
+        "PromotionTranslation", promotion_translation_fr.id
+    )
+    deliveries = create_deliveries_for_subscriptions(
+        event_type, promotion_translation_fr, webhooks
+    )
+
+    expected_payload = json.dumps(
+        {
+            "translation": {
+                "id": translation_id,
+                "__typename": "PromotionTranslation",
+            }
+        }
+    )
+
+    assert deliveries[0].payload.payload == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_translation_created_promotion_converted_from_sale(
+    promotion_converted_from_sale_translation_fr,
+    subscription_translation_created_webhook,
+):
+    translation = promotion_converted_from_sale_translation_fr
+    webhooks = [subscription_translation_created_webhook]
+    event_type = WebhookEventAsyncType.TRANSLATION_CREATED
+    translation_id = graphene.Node.to_global_id("SaleTranslation", translation.id)
+    deliveries = create_deliveries_for_subscriptions(event_type, translation, webhooks)
+
+    expected_payload = json.dumps(
+        {
+            "translation": {
+                "id": translation_id,
+                "__typename": "SaleTranslation",
+            }
+        }
+    )
 
     assert deliveries[0].payload.payload == expected_payload
     assert len(deliveries) == len(webhooks)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -6386,6 +6386,16 @@ def promotion_translation_fr(promotion):
 
 
 @pytest.fixture
+def promotion_converted_from_sale_translation_fr(promotion_converted_from_sale):
+    return PromotionTranslation.objects.create(
+        language_code="fr",
+        promotion=promotion_converted_from_sale,
+        name="French sale name",
+        description=dummy_editorjs("French sale description."),
+    )
+
+
+@pytest.fixture
 def promotion_rule_translation_fr(promotion_rule):
     return PromotionRuleTranslation.objects.create(
         language_code="fr",


### PR DESCRIPTION
I want to merge this change, because it:

1. Returns proper translation type (`SaleTranslation` or `PromotionTranslation`) in webhooks
2. Remove `old_sale_id` from promotion object after `promotionTranslate` and `promotionRuleTranslate` mutation being called on the object
3. Handle object not found case for `saleTranslate` mutation.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
