### PR TITLE
Deprecate external_url in Invoice in favour of url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - `SaleToggle` - Use `PromotionStarted` and `PromotionEnded` instead.
 
 ### Breaking changes
+- Deprecate `external_url` on `Invoice` GraphQL type in favour of `url`. No matter if the invoice is stored on Saleor or is a link to an external invoice it will get returned in the `url` field.
 
 ### GraphQL API
 

--- a/saleor/graphql/invoice/types.py
+++ b/saleor/graphql/invoice/types.py
@@ -1,7 +1,7 @@
 import graphene
 
 from ...invoice import models
-from ..core.descriptions import ADDED_IN_310
+from ..core.descriptions import ADDED_IN_310, DEPRECATED_IN_3X_FIELD
 from ..core.types import Job, ModelObjectType
 from ..meta.types import ObjectWithMetadata
 from ..order.dataloaders import OrderByIdLoader
@@ -9,7 +9,14 @@ from ..order.dataloaders import OrderByIdLoader
 
 class Invoice(ModelObjectType[models.Invoice]):
     number = graphene.String(description="Invoice number.")
-    external_url = graphene.String(description="URL to view an invoice.")
+    external_url = graphene.String(
+        description="URL to view an invoice.",
+        required=False,
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use `url` field."
+            "This field will be removed in 4.0"
+        ),
+    )
     created_at = graphene.DateTime(
         required=True, description="Date and time at which invoice was created."
     )
@@ -17,7 +24,13 @@ class Invoice(ModelObjectType[models.Invoice]):
         required=True, description="Date and time at which invoice was updated."
     )
     message = graphene.String(description="Message associated with an invoice.")
-    url = graphene.String(description="URL to download an invoice.")
+    url = graphene.String(
+        description=(
+            "URL to view/download an invoice. "
+            "This can be an internal URL if the Invoicing Plugin was used "
+            "or an external URL if it has been provided."
+        )
+    )
     order = graphene.Field(
         "saleor.graphql.order.types.Order",
         description="Order related to the invoice." + ADDED_IN_310,

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -716,6 +716,7 @@ def test_order_bulk_create(
     db_invoice = Invoice.objects.get()
     assert db_invoice.number == "01/12/2020/TEST"
     assert db_invoice.external_url == "http://www.example.com"
+    assert db_invoice.url == "http://www.example.com"
     assert db_invoice.private_metadata["pmd key"] == "pmd value"
     assert db_invoice.metadata["md key"] == "md value"
     assert db_invoice.order_id == db_order.id

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11973,9 +11973,11 @@ type Invoice implements ObjectWithMetadata & Job & Node @doc(category: "Orders")
   number: String
 
   """URL to view an invoice."""
-  externalUrl: String
+  externalUrl: String @deprecated(reason: "This field will be removed in Saleor 4.0. Use `url` field.This field will be removed in 4.0")
 
-  """URL to download an invoice."""
+  """
+  URL to view/download an invoice. This can be an internal URL if the Invoicing Plugin was used or an external URL if it has been provided.
+  """
   url: String
 
   """


### PR DESCRIPTION
I want to merge this change because it's closing #11506

`Invoice` now has only one `url` field instead of `external_url` and `url`. The underlying functionality already returned one or the other when using `url` field so the PR is only deprecating a GraphQL field.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [x] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [x] Link to documentation: Documentation will be automatically generated upon upgrade from canary to 3.17.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
