### PR TITLE
Prepare `manage_discounts` permission resolver for two database entries.

### DIFF
--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2404,7 +2404,13 @@ def non_default_category(db):  # pylint: disable=W0613
 
 @pytest.fixture
 def permission_manage_discounts():
-    return Permission.objects.get(codename="manage_discounts")
+    return (
+        Permission.objects.filter(
+            codename__in=["manage_discounts", "manage_discounts_old"]
+        )
+        .order_by("pk")
+        .last()
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
I want to merge this change because we are going to delete `Sale` model which is associated with `manage_discounts` permission in favour of `Promotion` model. This PR ensures zero downtime policy and allows to resolve the permission when two entries are present in db. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
