### PR TITLE
Order bulk create allow to import archive orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Breaking changes
 
+- **Feature preview breaking change**:
+  - `orderBulkCreate` now will attempt to create order with `IGNORE_FAILED` policy even if: - #14177 by @kadewu
+    - `User` cannot be resolved, and `email` wasn't provided.
+    - `Variant` wasn't provided.
+
 ### GraphQL API
 
 ### Saleor Apps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,13 +78,13 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Breaking changes
 
-- **Feature preview breaking change**:
+### GraphQL API
+
+- **Feature preview change**:
   - Order bulk create allow to import archive orders - #14177 by @kadewu
     - `orderBulkCreate` now will attempt to create order with `IGNORE_FAILED` policy even if:
       - `User` cannot be resolved and `email` wasn't provided.
-      - `Variant` wasn't provided.
-
-### GraphQL API
+      - `Variant` wasn't provided but `product_name` was provided.
 
 ### Saleor Apps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,9 +79,10 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Breaking changes
 
 - **Feature preview breaking change**:
-  - `orderBulkCreate` now will attempt to create order with `IGNORE_FAILED` policy even if: - #14177 by @kadewu
-    - `User` cannot be resolved, and `email` wasn't provided.
-    - `Variant` wasn't provided.
+  - Order bulk create allow to import archive orders - #14177 by @kadewu
+    - `orderBulkCreate` now will attempt to create order with `IGNORE_FAILED` policy even if:
+      - `User` cannot be resolved and `email` wasn't provided.
+      - `Variant` wasn't provided.
 
 ### GraphQL API
 

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -1709,12 +1709,17 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
                 )
                 return None
 
-            if (
+            line_variant_missmatch = (
                 variant
                 and order_line.line.variant
                 and order_line.line.variant.id != variant.id
-                or (variant and not order_line.line.variant)
-                or (not variant and order_line.line.variant)
+            )
+            missing_only_variant = not variant and order_line.line.variant
+            missing_only_line_variant = variant and not order_line.line.variant
+            if (
+                line_variant_missmatch
+                or missing_only_variant
+                or missing_only_line_variant
             ):
                 code = OrderBulkCreateErrorCode.ORDER_LINE_FULFILLMENT_LINE_MISMATCH
                 order_data.errors.append(

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -1021,7 +1021,7 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
         order_data.shipping_address = shipping_address
         order_data.voucher = voucher
 
-        if not (user or user_email) or not channel or not billing_address:
+        if not channel or not billing_address:
             order_data.is_critical_error = True
 
         return
@@ -1896,7 +1896,7 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
             order_data.user.email
             if order_data.user
             else order_input["user"].get("email")
-        )
+        ) or ""
         order_data.order.collection_point = delivery_method.warehouse
         order_data.order.collection_point_name = delivery_method.warehouse_name
         order_data.order.shipping_method = delivery_method.shipping_method

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -843,6 +843,120 @@ def test_order_bulk_create_multiple_lines(
     assert OrderLine.objects.count() == lines_count + 2
 
 
+def test_order_bulk_create_line_without_variant(
+    staff_api_client,
+    permission_manage_orders,
+    permission_manage_orders_import,
+    order_bulk_input,
+):
+    # given
+    lines_count = OrderLine.objects.count()
+
+    order = order_bulk_input
+    order["lines"][0]["variantId"] = None
+    order["lines"][0]["variantName"] = None
+    order["fulfillments"][0]["lines"][0]["variantId"] = None
+
+    staff_api_client.user.user_permissions.add(
+        permission_manage_orders_import,
+        permission_manage_orders,
+    )
+    variables = {
+        "orders": [order],
+        "stockUpdatePolicy": StockUpdatePolicyEnum.SKIP.name,
+        "errorPolicy": ErrorPolicyEnum.IGNORE_FAILED.name,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_BULK_CREATE, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["orderBulkCreate"]["count"] == 1
+    assert len(content["data"]["orderBulkCreate"]["results"][0]["errors"]) == 2
+
+    order = content["data"]["orderBulkCreate"]["results"][0]["order"]
+
+    line_1 = order["lines"][0]
+    assert line_1["unitPrice"]["gross"]["amount"] == Decimal(120 / 5)
+    assert line_1["unitPrice"]["net"]["amount"] == Decimal(100 / 5)
+
+    db_lines = OrderLine.objects.all()
+    db_line_1 = db_lines[0]
+    assert db_line_1.unit_price.gross.amount == Decimal(120 / 5)
+    assert db_line_1.unit_price.net.amount == Decimal(100 / 5)
+
+    assert order["total"]["gross"]["amount"] == 120
+    assert order["total"]["net"]["amount"] == 100
+    db_order = Order.objects.get()
+    assert db_order.total_gross_amount == 120
+    assert db_order.total_net_amount == 100
+
+    error0 = content["data"]["orderBulkCreate"]["results"][0]["errors"][0]
+    assert error0["message"] == (
+        "One of [variant_id, variant_external_reference, variant_sku] arguments"
+        " must be provided to resolve ProductVariant instance."
+    )
+    assert error0["code"] == OrderBulkCreateErrorCode.REQUIRED.name
+    assert error0["path"] == "lines.0"
+
+    error1 = content["data"]["orderBulkCreate"]["results"][0]["errors"][1]
+    assert error1["message"] == (
+        "One of [variant_id, variant_external_reference, variant_sku] arguments"
+        " must be provided to resolve ProductVariant instance."
+    )
+    assert error1["code"] == OrderBulkCreateErrorCode.REQUIRED.name
+    assert error1["path"] == "fulfillments.0.lines.0"
+
+    assert OrderLine.objects.count() == lines_count + 1
+
+
+def test_order_bulk_create_line_without_variant_and_product_name_fails(
+    staff_api_client,
+    permission_manage_orders,
+    permission_manage_orders_import,
+    order_bulk_input,
+):
+    # given
+
+    order = order_bulk_input
+    order["lines"][0]["variantId"] = None
+    order["lines"][0]["productName"] = None
+
+    staff_api_client.user.user_permissions.add(
+        permission_manage_orders_import,
+        permission_manage_orders,
+    )
+    variables = {
+        "orders": [order],
+        "stockUpdatePolicy": StockUpdatePolicyEnum.SKIP.name,
+        "errorPolicy": ErrorPolicyEnum.IGNORE_FAILED.name,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_BULK_CREATE, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["orderBulkCreate"]["count"] == 0
+    assert len(content["data"]["orderBulkCreate"]["results"][0]["errors"]) == 2
+
+    error0 = content["data"]["orderBulkCreate"]["results"][0]["errors"][0]
+    assert error0["message"] == (
+        "One of [variant_id, variant_external_reference, variant_sku] arguments"
+        " must be provided to resolve ProductVariant instance."
+    )
+    assert error0["code"] == OrderBulkCreateErrorCode.REQUIRED.name
+    assert error0["path"] == "lines.0"
+
+    error1 = content["data"]["orderBulkCreate"]["results"][0]["errors"][1]
+    assert error1["message"] == (
+        "Order line input must contain product name when no variant provided."
+    )
+    assert error1["code"] == OrderBulkCreateErrorCode.REQUIRED.name
+    assert error1["path"] == "lines.0"
+
+
 def test_order_bulk_create_multiple_notes(
     staff_api_client,
     permission_manage_orders,


### PR DESCRIPTION
Fix: https://github.com/saleor/saleor/issues/11720

To enable importing archive orders, we for now we introduce 2 changes to bulk create:
- allow to not provide user at all
- allow to skip variants

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation: https://github.com/saleor/saleor-docs/pull/968

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
