### PR TITLE
Add missing ordering in dataloaders

### DIFF
--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -249,6 +249,7 @@ class CheckoutByUserAndChannelLoader(DataLoader[Tuple[int, str], List[Checkout]]
                 channel__is_active=True,
             )
             .annotate(channel_slug=F("channel__slug"))
+            .order_by("-last_change", "pk")
         )
         checkout_by_user_and_channel_map = defaultdict(list)
         for checkout in checkouts:

--- a/saleor/graphql/discount/dataloaders.py
+++ b/saleor/graphql/discount/dataloaders.py
@@ -30,6 +30,7 @@ class SaleChannelListingBySaleIdAndChanneSlugLoader(DataLoader):
             SaleChannelListing.objects.using(self.database_connection_name)
             .filter(sale_id__in=sale_ids, channel__slug__in=channel_slugs)
             .annotate(channel_slug=F("channel__slug"))
+            .order_by("pk")
         )
         sale_channel_listings_by_sale_and_channel_map = {}
         for sale_channel_listing in sale_channel_listings:
@@ -83,6 +84,7 @@ class VoucherChannelListingByVoucherIdAndChanneSlugLoader(DataLoader):
             VoucherChannelListing.objects.using(self.database_connection_name)
             .filter(voucher_id__in=voucher_ids, channel__slug__in=channel_slugs)
             .annotate(channel_slug=F("channel__slug"))
+            .order_by("pk")
         )
         voucher_channel_listings_by_voucher_and_channel_map = {}
         for voucher_channel_listing in voucher_channel_listings:

--- a/saleor/graphql/order/dataloaders.py
+++ b/saleor/graphql/order/dataloaders.py
@@ -29,6 +29,7 @@ class OrderLinesByVariantIdAndChannelIdLoader(
             OrderLine.objects.using(self.database_connection_name)
             .filter(order__channel_id__in=channel_ids, variant_id__in=variant_ids)
             .annotate(channel_id=F("order__channel_id"))
+            .order_by("created_at", "id")
         )
 
         order_line_by_variant_and_channel_map: DefaultDict[

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -215,6 +215,7 @@ class ProductVariantsByProductIdAndChannel(
             ProductVariant.objects.using(self.database_connection_name)
             .filter(**variants_filter)
             .annotate(channel_slug=F("channel_listings__channel__slug"))
+            .order_by("sort_order", "sku")
         )
         variant_map: DefaultDict[Tuple[int, str], List[ProductVariant]] = defaultdict(
             list
@@ -324,6 +325,7 @@ class VariantChannelListingByVariantIdAndChannelLoader(
             .using(self.database_connection_name)
             .filter(**filter)
             .annotate_preorder_quantity_allocated()
+            .order_by("pk")
         )
 
         variant_channel_listings_map: Dict[int, ProductVariantChannelListing] = {}
@@ -396,6 +398,7 @@ class VariantsChannelListingByProductIdAndChannelSlugLoader(
                 price_amount__isnull=False,
             )
             .annotate(product_id=F("variant__product_id"))
+            .order_by("pk")
         )
 
         variants_channel_listings_map: Dict[
@@ -615,6 +618,7 @@ class CollectionChannelListingByCollectionIdAndChannelSlugLoader(DataLoader):
             CollectionChannelListing.objects.using(self.database_connection_name)
             .filter(collection_id__in=collection_ids, channel__slug__in=channel_slugs)
             .annotate(channel_slug=F("channel__slug"))
+            .order_by("pk")
         )
         collections_channel_listings_by_collection_and_channel_map = {}
         for collections_channel_listing in collections_channel_listings.iterator():

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -268,6 +268,7 @@ class VariantChannelListingByVariantIdLoader(DataLoader):
             ProductVariantChannelListing.objects.using(self.database_connection_name)
             .filter(variant_id__in=keys)
             .annotate_preorder_quantity_allocated()
+            .order_by("pk")
         )
 
         variant_id_variant_channel_listings_map = defaultdict(list)

--- a/saleor/graphql/shipping/dataloaders.py
+++ b/saleor/graphql/shipping/dataloaders.py
@@ -105,6 +105,7 @@ class ShippingMethodsByShippingZoneIdAndChannelSlugLoader(DataLoader):
             ShippingMethod.objects.using(self.database_connection_name)
             .filter(shipping_zone_id__in=shipping_zone_ids)
             .annotate(channel_slug=F("channel_listings__channel__slug"))
+            .order_by("pk")
         )
 
         shipping_methods_by_shipping_zone_and_channel_map = defaultdict(list)
@@ -150,6 +151,7 @@ class ShippingMethodChannelListingByChannelSlugLoader(DataLoader):
             ShippingMethodChannelListing.objects.using(self.database_connection_name)
             .filter(channel__slug__in=keys)
             .annotate(channel_slug=F("channel__slug"))
+            .order_by("pk")
         )
         shipping_method_channel_listings_by_channel_slug = defaultdict(list)
         for shipping_method_channel_listing in shipping_method_channel_listings:

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -127,7 +127,7 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
             | Q(warehouse_id__in=cc_warehouses.values("id"))
         )
 
-        stocks = stocks.annotate_available_quantity()
+        stocks = stocks.annotate_available_quantity().order_by("pk")
 
         stocks_reservations = self.prepare_stocks_reservations_map(variant_ids)
 
@@ -247,6 +247,7 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
                 Stock.objects.using(self.database_connection_name)
                 .filter(product_variant_id__in=variant_ids)
                 .annotate_reserved_quantity()
+                .order_by("pk")
                 .values_list("id", "reserved_quantity")
             )
             for stock_id, quantity_reserved in reservations_qs:
@@ -448,7 +449,7 @@ class StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader(
                     ],
                 )
             )
-        stocks = stocks.annotate_available_quantity()
+        stocks = stocks.annotate_available_quantity().order_by("pk")
 
         stocks_by_variant_id_map: DefaultDict[int, List[Stock]] = defaultdict(list)
         for stock in stocks:
@@ -537,6 +538,7 @@ class PreorderQuantityReservedByVariantChannelListingIdLoader(DataLoader[int, in
                 ),
                 where=Q(preorder_reservations__reserved_until__gt=timezone.now()),
             )
+            .order_by("pk")
             .values("id", "quantity_reserved")
         )
 


### PR DESCRIPTION
Add missing ordering in `VariantChannelListingByVariantIdLoader` - it causes flaky tests

Port of https://github.com/saleor/saleor/pull/14200

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
