### PR TITLE
Add missing payload fields

### DIFF
--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -44,6 +44,7 @@ ORDER_LINES_CREATE_MUTATION = """
                 quantity
                 productSku
                 productVariantId
+                saleId
                 unitPrice {
                     gross {
                         amount
@@ -583,6 +584,7 @@ def test_order_lines_create_variant_on_sale(
         line_data["unitPrice"]["net"]["amount"]
         == variant_channel_listing.price_amount - sale_channel_listing.discount_value
     )
+    assert line_data["saleId"] == graphene.Node.to_global_id("Sale", sale.id)
 
     line = order.lines.get(product_sku=variant.sku)
     assert line.sale_id == graphene.Node.to_global_id("Sale", sale.id)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -728,6 +728,10 @@ class OrderLine(ModelObjectType[models.OrderLine]):
             "permissions to access." + ADDED_IN_39
         ),
     )
+    voucher_code = graphene.String(
+        required=False,
+        description="Voucher code that was used for this order line." + ADDED_IN_314,
+    )
 
     class Meta:
         description = "Represents order line of particular order."

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -74,6 +74,7 @@ from ..core.descriptions import (
     ADDED_IN_310,
     ADDED_IN_311,
     ADDED_IN_313,
+    ADDED_IN_314,
     DEPRECATED_IN_3X_FIELD,
     PREVIEW_FEATURE,
     PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD,
@@ -682,6 +683,13 @@ class OrderLine(ModelObjectType[models.OrderLine]):
             ProductPermissions.MANAGE_PRODUCTS,
             OrderPermissions.MANAGE_ORDERS,
         ],
+    )
+    sale_id = graphene.ID(
+        required=False,
+        description=(
+            "Denormalized sale ID, set when order line is created for a product "
+            "variant that is on sale." + ADDED_IN_314
+        ),
     )
     quantity_to_fulfill = graphene.Int(
         required=True,

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -18,6 +18,7 @@ from ..core.descriptions import (
     ADDED_IN_34,
     ADDED_IN_36,
     ADDED_IN_313,
+    ADDED_IN_314,
     PREVIEW_FEATURE,
     PREVIEW_FEATURE_DEPRECATED_IN_313_FIELD,
 )
@@ -165,6 +166,13 @@ class Payment(ModelObjectType[models.Payment]):
     )
     credit_card = graphene.Field(
         CreditCard, description="The details of the card used for this payment."
+    )
+    partial = graphene.Boolean(
+        required=True,
+        description="Informs whether this is a partial payment." + ADDED_IN_314,
+    )
+    psp_reference = graphene.String(
+        required=False, description="PSP reference of the payment." + ADDED_IN_314
     )
 
     class Meta:

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10878,6 +10878,13 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   Added in Saleor 3.9.
   """
   taxClassPrivateMetadata: [MetadataItem!]!
+
+  """
+  Voucher code that was used for this order line.
+  
+  Added in Saleor 3.14.
+  """
+  voucherCode: String
 }
 
 """
@@ -11185,6 +11192,20 @@ type Payment implements Node & ObjectWithMetadata @doc(category: "Payments") {
 
   """The details of the card used for this payment."""
   creditCard: CreditCard
+
+  """
+  Informs whether this is a partial payment.
+  
+  Added in Saleor 3.14.
+  """
+  partial: Boolean!
+
+  """
+  PSP reference of the payment.
+  
+  Added in Saleor 3.14.
+  """
+  pspReference: String
 }
 
 """An object representing a single payment."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -10833,6 +10833,13 @@ type OrderLine implements Node & ObjectWithMetadata @doc(category: "Orders") {
   allocations: [Allocation!]
 
   """
+  Denormalized sale ID, set when order line is created for a product variant that is on sale.
+  
+  Added in Saleor 3.14.
+  """
+  saleId: ID
+
+  """
   A quantity of items remaining to be fulfilled.
   
   Added in Saleor 3.1.


### PR DESCRIPTION
This PR adds some fields that are available in legacy order payloads, but cannot be fetched in the subscription GraphQL payloads.

- `OrderLine.saleId` stores denormalized info about a sale that was active for the variant when the order line was created. Note: I considered adding a `sale: Sale` field that would load the entire Sale object here, but `sale: ID` can also be resolved when the sale object is removed from DB. Also, in the future, it will be replaced by a list of all discounts as part of the promotions work, so this will eventually be deprecated at some point.

- `OrderLine.voucherCode`
- `Payment.pspReference`
- `Payment.partial`

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
