### PR TITLE
Fix voucher update without codes

### DIFF
--- a/saleor/graphql/discount/mutations/voucher/voucher_update.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_update.py
@@ -39,7 +39,8 @@ class VoucherUpdate(VoucherCreate):
     def clean_codes(cls, data):
         if "code" in data:
             cls._clean_old_code(data)
-        else:
+
+        if "codes" in data:
             cls._clean_new_codes(data)
 
     @classmethod
@@ -69,6 +70,8 @@ class VoucherUpdate(VoucherCreate):
                         )
                     }
                 )
+
+        return []
 
     @classmethod
     def save(  # type: ignore[override]

--- a/saleor/graphql/discount/tests/mutations/test_voucher_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_voucher_create.py
@@ -228,7 +228,7 @@ def test_create_voucher_trigger_webhook(
             {
                 "id": graphene.Node.to_global_id("Voucher", voucher.id),
                 "name": voucher.name,
-                "code": code_1,
+                "code": code_2,
                 "meta": generate_meta(
                     requestor_data=generate_requestor(
                         SimpleLazyObject(lambda: staff_api_client.user)


### PR DESCRIPTION
I want to merge this change because it fixes `TypeError` when no `code` or `codes` are sent.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
