### PR TITLE
Adjust order line discount info

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -13,7 +13,6 @@ from typing import (
 )
 from uuid import UUID
 
-import graphene
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
@@ -38,7 +37,9 @@ from ..discount import DiscountType, DiscountValueType
 from ..discount.models import NotApplicable, OrderLineDiscount
 from ..discount.utils import (
     add_voucher_usage_by_customer,
+    get_sale_id,
     increase_voucher_usage,
+    prepare_promotion_discount_reason,
     release_voucher_usage,
 )
 from ..graphql.checkout.utils import (
@@ -51,7 +52,6 @@ from ..order.models import Order, OrderLine
 from ..order.notifications import send_order_confirmation
 from ..order.search import prepare_order_search_vector_value
 from ..order.utils import (
-    prepare_promotion_discount_reason,
     update_order_authorize_data,
     update_order_charge_data,
     update_order_display_gross_prices,
@@ -312,11 +312,7 @@ def _create_line_for_order(
         # Ultimately, this info should be taken from the orderLineDiscount instances.
 
         promotion = checkout_line_info.rules_info[0].promotion
-        sale_id = (
-            graphene.Node.to_global_id("Sale", promotion.old_sale_id)
-            if promotion.old_sale_id
-            else graphene.Node.to_global_id("Promotion", promotion.id)
-        )
+        sale_id = get_sale_id(promotion)
         line.sale_id = sale_id
         promotion_discount_reason = prepare_promotion_discount_reason(
             promotion, sale_id

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -311,11 +311,16 @@ def _create_line_for_order(
         # This is temporary solution until the discount API is implemented.
         # Ultimately, this info should be taken from the orderLineDiscount instances.
 
-        # TODO: this should be old_sale_id for old sales
-        line.sale_id = graphene.Node.to_global_id(
-            "Promotion", checkout_line_info.rules_info[0].promotion.pk
+        promotion = checkout_line_info.rules_info[0].promotion
+        sale_id = (
+            graphene.Node.to_global_id("Sale", promotion.old_sale_id)
+            if promotion.old_sale_id
+            else graphene.Node.to_global_id("Promotion", promotion.id)
         )
-        promotion_discount_reason = prepare_promotion_discount_reason(line_discounts)
+        line.sale_id = sale_id
+        promotion_discount_reason = prepare_promotion_discount_reason(
+            promotion, sale_id
+        )
         unit_discount_reason = (
             f"{unit_discount_reason} & {promotion_discount_reason}"
             if unit_discount_reason

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -18,6 +18,7 @@ from typing import (
 )
 from uuid import UUID
 
+import graphene
 from django.db.models import Exists, F, OuterRef, QuerySet
 from prices import Money, TaxedMoney, fixed_discount, percentage_discount
 
@@ -86,6 +87,18 @@ def release_voucher_usage(voucher: Optional["Voucher"], user_email: Optional[str
         decrease_voucher_usage(voucher)
     if user_email:
         remove_voucher_usage_by_customer(voucher, user_email)
+
+
+def prepare_promotion_discount_reason(promotion: "Promotion", sale_id: str):
+    return f"{'Sale' if promotion.old_sale_id else 'Promotion'}: {sale_id}"
+
+
+def get_sale_id(promotion: "Promotion"):
+    return (
+        graphene.Node.to_global_id("Sale", promotion.old_sale_id)
+        if promotion.old_sale_id
+        else graphene.Node.to_global_id("Promotion", promotion.id)
+    )
 
 
 def calculate_discounted_price_for_rules(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -1139,10 +1139,7 @@ def test_checkout_with_voucher_complete_product_on_promotion(
     assert order_line.sale_id == graphene.Node.to_global_id(
         "Promotion", promotion_without_rules.id
     )
-    unit_discount_reason = "Promotion rules discounts: " + graphene.Node.to_global_id(
-        "PromotionRule", rule.pk
-    )
-    assert order_line.unit_discount_reason == unit_discount_reason
+    assert order_line.unit_discount_reason == f"Promotion: {order_line.sale_id}"
 
     assert checkout_line_quantity == order_line.quantity
     assert checkout_line_variant == order_line.variant
@@ -1380,8 +1377,149 @@ def test_checkout_complete_product_on_promotion(
     assert order_line.sale_id == graphene.Node.to_global_id(
         "Promotion", promotion_without_rules.id
     )
-    unit_discount_reason = "Promotion rules discounts: " + promotion_without_rules.name
-    assert order_line.unit_discount_reason == unit_discount_reason
+    assert order_line.unit_discount_reason == f"Promotion: {order_line.sale_id}"
+
+    assert checkout_line_quantity == order_line.quantity
+    assert checkout_line_variant == order_line.variant
+    assert order.shipping_address == address
+    assert order.shipping_method == checkout.shipping_method
+    assert order.payments.exists()
+    order_payment = order.payments.first()
+    assert order_payment == payment
+    assert payment.transactions.count() == 1
+
+    assert not Checkout.objects.filter(
+        pk=checkout.pk
+    ).exists(), "Checkout should have been deleted"
+
+
+def test_checkout_complete_product_on_old_sale(
+    user_api_client,
+    checkout_with_item,
+    promotion_without_rules,
+    payment_dummy,
+    address,
+    shipping_method,
+):
+    # given
+    checkout = checkout_with_item
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.metadata_storage.store_value_in_metadata(items={"accepted": "true"})
+    checkout.metadata_storage.store_value_in_private_metadata(
+        items={"accepted": "false"}
+    )
+    checkout.save()
+    checkout.metadata_storage.save()
+
+    checkout_line = checkout.lines.first()
+    checkout_line_quantity = checkout_line.quantity
+    checkout_line_variant = checkout_line.variant
+
+    channel = checkout.channel
+
+    old_sale_id = 1
+    promotion_without_rules.old_sale_id = old_sale_id
+    promotion_without_rules.save(update_fields=["old_sale_id"])
+
+    reward_value = Decimal("5")
+    rule = promotion_without_rules.rules.create(
+        catalogue_predicate={
+            "productPredicate": {
+                "ids": [
+                    graphene.Node.to_global_id(
+                        "Product", checkout_line_variant.product.id
+                    )
+                ]
+            }
+        },
+        reward_value_type=RewardValueType.FIXED,
+        reward_value=reward_value,
+    )
+    rule.channels.add(channel)
+
+    variant_channel_listing = checkout_line_variant.channel_listings.get(
+        channel=channel
+    )
+
+    variant_channel_listing.discounted_price_amount = (
+        variant_channel_listing.price_amount - reward_value
+    )
+    variant_channel_listing.save(update_fields=["discounted_price_amount"])
+
+    variant_channel_listing.variantlistingpromotionrule.create(
+        promotion_rule=rule,
+        discount_amount=reward_value,
+        currency=channel.currency_code,
+    )
+    CheckoutLineDiscount.objects.create(
+        line=checkout_line,
+        type=DiscountType.PROMOTION,
+        value_type=DiscountValueType.FIXED,
+        amount_value=reward_value,
+        currency=channel.currency_code,
+        promotion_rule=rule,
+    )
+
+    manager = get_plugins_manager()
+    lines, _ = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, manager)
+
+    total = calculations.checkout_total(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=address,
+    )
+    payment = payment_dummy
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.checkout = checkout
+    payment.save()
+    assert not payment.transactions.exists()
+
+    orders_count = Order.objects.count()
+    variables = {
+        "id": to_global_id_or_none(checkout),
+        "redirectUrl": "https://www.example.com",
+    }
+
+    # when
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+
+    order_token = data["order"]["token"]
+    order_id = data["order"]["id"]
+    assert Order.objects.count() == orders_count + 1
+    order = Order.objects.first()
+    assert str(order.id) == order_token
+    assert order_id == graphene.Node.to_global_id("Order", order.id)
+    assert order.metadata == checkout.metadata_storage.metadata
+    assert order.private_metadata == checkout.metadata_storage.private_metadata
+
+    order_line = order.lines.first()
+    assert order.total == total
+    assert order.undiscounted_total == total + (
+        order_line.undiscounted_total_price - order_line.total_price
+    )
+
+    assert order_line.discounts.count() == 1
+    line_discount = order_line.discounts.first()
+    assert line_discount.promotion_rule == rule
+    assert line_discount.value_type == DiscountValueType.FIXED
+    assert line_discount.amount_value == reward_value * order_line.quantity
+
+    assert order_line.sale_id == graphene.Node.to_global_id(
+        "Sale", promotion_without_rules.old_sale_id
+    )
+    assert order_line.unit_discount_reason == f"Sale: {order_line.sale_id}"
 
     assert checkout_line_quantity == order_line.quantity
     assert checkout_line_variant == order_line.variant
@@ -1706,8 +1844,7 @@ def test_checkout_with_voucher_on_specific_product_complete_with_product_on_prom
     )
     unit_discount_reason = (
         f"Voucher code: {voucher_specific_product_type.code}"
-        + " & Promotion rules discounts: "
-        + promotion_without_rules.name
+        f" & Promotion: {order_line.sale_id}"
     )
     assert order_line.unit_discount_reason == unit_discount_reason
     assert order.shipping_address == address

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -1718,6 +1718,10 @@ def test_checkout_with_voucher_complete_product_on_sale(
     voucher_percentage.usage_limit = voucher_used_count + 1
     voucher_percentage.save(update_fields=["usage_limit"])
 
+    old_sale_id = 1
+    promotion_without_rules.old_sale_id = old_sale_id
+    promotion_without_rules.save(update_fields=["old_sale_id"])
+
     checkout_line = checkout.lines.first()
     checkout_line_variant = checkout_line.variant
 
@@ -1801,8 +1805,9 @@ def test_checkout_with_voucher_complete_product_on_sale(
         order_line.undiscounted_total_price - order_line.total_price
     )
     assert order_line.sale_id == graphene.Node.to_global_id(
-        "Promotion", promotion_without_rules.id
+        "Sale", promotion_without_rules.old_sale_id
     )
+    assert order_line.unit_discount_reason == f"Sale: {order_line.sale_id}"
 
     voucher_percentage.refresh_from_db()
     assert voucher_percentage.used == voucher_used_count + 1

--- a/saleor/graphql/order/tests/mutations/test_order_lines_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_lines_create.py
@@ -631,10 +631,7 @@ def test_order_lines_create_variant_on_promotion(
     )
     assert line.unit_discount_amount == reward_value
     assert line.unit_discount_value == reward_value
-    assert (
-        line.unit_discount_reason
-        == f"Promotion rules discounts: {promotion_without_rules.name}: {rule.name}"
-    )
+    assert line.unit_discount_reason == f"Promotion: {line.sale_id}"
     assert line.discounts.count() == 1
     discount = line.discounts.first()
     assert discount.promotion_rule == rule

--- a/saleor/tests/e2e/checkout/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
+++ b/saleor/tests/e2e/checkout/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
@@ -225,8 +225,7 @@ def test_checkout_calculate_discount_for_sale_and_voucher_1014(
     order_line = order_data["lines"][0]
     assert order_line["unitDiscountType"] == "FIXED"
     assert order_line["unitPrice"]["gross"]["amount"] == expected_unit_price
-    # TODO: to fix in separate PR
-    # assert order_line["unitDiscountReason"] == f"Sale: {sale_id}"
+    assert order_line["unitDiscountReason"] == f"Sale: {sale_id}"
     assert order_data["total"]["gross"]["amount"] == total_gross_amount
     assert order_data["subtotal"]["gross"]["amount"] == subtotal_amount
     assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(

--- a/saleor/tests/e2e/checkout/test_checkout_product_on_fixed_sale.py
+++ b/saleor/tests/e2e/checkout/test_checkout_product_on_fixed_sale.py
@@ -149,5 +149,4 @@ def test_checkout_products_on_fixed_sale_core_1002(
     assert order_line["unitDiscountType"] == "FIXED"
     assert order_line["unitPrice"]["gross"]["amount"] == unit_price
     assert order_line["unitDiscount"]["amount"] == float(sale_discount_value)
-    # TODO: to fix in separate PR
-    # assert order_line["unitDiscountReason"] == f"Sale: {sale_id}"
+    assert order_line["unitDiscountReason"] == f"Sale: {sale_id}"

--- a/saleor/tests/e2e/checkout/test_checkout_product_on_percentage_sale.py
+++ b/saleor/tests/e2e/checkout/test_checkout_product_on_percentage_sale.py
@@ -153,5 +153,4 @@ def test_checkout_products_on_percentage_sale_core_1004(
     assert order_line["unitDiscountType"] == "FIXED"
     assert order_line["unitPrice"]["gross"]["amount"] == unit_price
     assert order_line["unitDiscount"]["amount"] == line_discount
-    # TODO: to fix in separate PR
-    # assert order_line["unitDiscountReason"] == f"Sale: {sale_id}"
+    assert order_line["unitDiscountReason"] == f"Sale: {sale_id}"

--- a/saleor/tests/e2e/checkout/test_checkout_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/checkout/test_checkout_products_on_fixed_promotion.py
@@ -122,7 +122,4 @@ def test_checkout_products_on_fixed_promotion_core_2102(
     assert order_line["unitDiscountType"] == discount_type
     assert order_line["unitPrice"]["gross"]["amount"] == unit_price
     assert order_line["unitDiscount"]["amount"] == float(discount_value)
-    assert (
-        order_line["unitDiscountReason"]
-        == f"Promotion rules discounts: {promotion_name}: {promotion_rule_name}"
-    )
+    assert order_line["unitDiscountReason"] == f"Promotion: {promotion_id}"

--- a/saleor/tests/e2e/checkout/test_checkout_products_on_percentage_promotion.py
+++ b/saleor/tests/e2e/checkout/test_checkout_products_on_percentage_promotion.py
@@ -121,7 +121,4 @@ def test_checkout_products_on_percentage_promotion_core_2104(
     assert order_line["unitDiscountType"] == "FIXED"
     assert order_line["unitPrice"]["gross"]["amount"] == unit_price
     assert order_line["unitDiscount"]["amount"] == line_discount
-    assert (
-        order_line["unitDiscountReason"]
-        == f"Promotion rules discounts: {promotion_name}: {promotion_rule_name}"
-    )
+    assert order_line["unitDiscountReason"] == f"Promotion: {promotion_id}"

--- a/saleor/tests/e2e/checkout/test_checkout_with_promotion_and_voucher.py
+++ b/saleor/tests/e2e/checkout/test_checkout_with_promotion_and_voucher.py
@@ -56,8 +56,7 @@ def prepare_promotion(
     assert product_predicate[0] == product_id
 
     return (
-        promotion_name,
-        promotion_rule_name,
+        promotion_id,
         promotion_value,
     )
 
@@ -156,7 +155,7 @@ def test_checkout_with_promotion_and_voucher_CORE_2107(
         variant_price,
     )
 
-    promotion_name, promotion_rule_name, promotion_value = prepare_promotion(
+    promotion_id, promotion_value = prepare_promotion(
         e2e_staff_api_client,
         product_id,
         channel_id,
@@ -252,7 +251,4 @@ def test_checkout_with_promotion_and_voucher_CORE_2107(
     assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(
         product_variant_price
     )
-    assert (
-        order_line["unitDiscountReason"]
-        == f"Promotion rules discounts: {promotion_name}: {promotion_rule_name}"
-    )
+    assert order_line["unitDiscountReason"] == f"Promotion: {promotion_id}"

--- a/saleor/tests/e2e/orders/test_apply_better_promotion_to_product.py
+++ b/saleor/tests/e2e/orders/test_apply_better_promotion_to_product.py
@@ -34,6 +34,7 @@ def prepare_promotion_with_rules(
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
     assert promotion_rule["channels"][0]["id"] == channel_id
     assert product_predicate[0] == product_id
+    return promotion_id
 
 
 @pytest.mark.e2e
@@ -103,7 +104,7 @@ def test_apply_best_promotion_to_product_core_2105(
     second_promotion_name = "Promotion 2"
     second_rule_name = "rule for product"
 
-    prepare_promotion_with_rules(
+    second_promotion_id = prepare_promotion_with_rules(
         e2e_staff_api_client,
         second_promotion_name,
         second_discount_type,
@@ -151,7 +152,4 @@ def test_apply_best_promotion_to_product_core_2105(
     assert undiscounted_price == float(product_variant_price)
     assert order_line["unitPrice"]["gross"]["amount"] == unit_price
     promotion_reason = order_line["unitDiscountReason"]
-    assert (
-        promotion_reason
-        == f"Promotion rules discounts: {second_promotion_name}: {second_rule_name}"
-    )
+    assert promotion_reason == f"Promotion: {second_promotion_id}"

--- a/saleor/tests/e2e/orders/test_order_product_with_percentage_promotion.py
+++ b/saleor/tests/e2e/orders/test_order_product_with_percentage_promotion.py
@@ -100,10 +100,7 @@ def test_order_products_on_percentage_promotion_CORE_2103(
         order_lines["order"]["lines"][0]["unitPrice"]["gross"]["amount"] == unit_price
     )
     promotion_reason = order_lines["order"]["lines"][0]["unitDiscountReason"]
-    assert (
-        promotion_reason
-        == f"Promotion rules discounts: {promotion_name}: {promotion_rule_name}"
-    )
+    assert promotion_reason == f"Promotion: {promotion_id}"
 
     # Step 3 - Add a shipping method to the order
     input = {"shippingMethod": result_shipping_method_id}

--- a/saleor/tests/e2e/orders/test_order_products_from_the_same_category_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/test_order_products_from_the_same_category_on_fixed_promotion.py
@@ -164,6 +164,7 @@ def prepare_product(
         product_variant_id_1,
         product_variant_id_2,
         shipping_method_id,
+        promotion_id,
     )
 
 
@@ -200,6 +201,7 @@ def test_order_products_from_category_on_fixed_promotion_CORE_2106(
         product_variant_id_1,
         product_variant_id_2,
         shipping_method_id,
+        promotion_id,
     ) = prepare_product(
         e2e_staff_api_client,
         permission_manage_products,
@@ -260,10 +262,7 @@ def test_order_products_from_category_on_fixed_promotion_CORE_2106(
     )
 
     promotion_reason = order_lines["order"]["lines"][0]["unitDiscountReason"]
-    assert (
-        promotion_reason
-        == f"Promotion rules discounts: {promotion_name}: {promotion_rule_name}"
-    )
+    assert promotion_reason == f"Promotion: {promotion_id}"
 
     # Step 3 - Add a shipping method to the order
     input = {"shippingMethod": shipping_method_id}

--- a/saleor/tests/e2e/orders/test_order_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/test_order_products_on_fixed_promotion.py
@@ -99,10 +99,7 @@ def test_order_products_on_fixed_promotion_CORE_2101(
         order_lines["order"]["lines"][0]["unitPrice"]["gross"]["amount"] == unit_price
     )
     promotion_reason = order_lines["order"]["lines"][0]["unitDiscountReason"]
-    assert (
-        promotion_reason
-        == f"Promotion rules discounts: {promotion_name}: {promotion_rule_name}"
-    )
+    assert promotion_reason == f"Promotion: {promotion_id}"
 
     # Step 3 - Add a shipping method to the order
     input = {"shippingMethod": result_shipping_method_id}

--- a/saleor/tests/e2e/orders/test_order_products_on_fixed_sale.py
+++ b/saleor/tests/e2e/orders/test_order_products_on_fixed_sale.py
@@ -150,7 +150,6 @@ def test_order_products_on_fixed_sale_CORE_1001(
     assert order_line["unitDiscount"]["amount"] == sale_discount_value
     assert order_line["unitDiscountValue"] == sale_discount_value
     assert order_line["unitDiscountType"] == "FIXED"
-    # TODO: to fix in separate PR
-    # assert draft_line["unitDiscountReason"] == f"Sale: {sale_id}"
+    assert draft_line["unitDiscountReason"] == f"Sale: {sale_id}"
     product_price = order_line["undiscountedUnitPrice"]["gross"]["amount"]
     assert product_price == undiscounted_price

--- a/saleor/tests/e2e/orders/test_order_products_on_percentage_sale.py
+++ b/saleor/tests/e2e/orders/test_order_products_on_percentage_sale.py
@@ -151,7 +151,6 @@ def test_order_products_on_percentage_sale_CORE_1003(
     assert order_line["unitDiscount"]["amount"] == discount
     assert order_line["unitDiscountValue"] == discount
     assert order_line["unitDiscountType"] == "FIXED"
-    # TODO: to fix in separate PR
-    # assert draft_line["unitDiscountReason"] == f"Sale: {sale_id}"
+    assert draft_line["unitDiscountReason"] == f"Sale: {sale_id}"
     product_price = order_line["undiscountedUnitPrice"]["gross"]["amount"]
     assert product_price == undiscounted_price

--- a/saleor/tests/e2e/orders/test_order_products_on_promotion_and_manual_order_discount.py
+++ b/saleor/tests/e2e/orders/test_order_products_on_promotion_and_manual_order_discount.py
@@ -104,10 +104,7 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
         order_lines["order"]["lines"][0]["unitPrice"]["gross"]["amount"] == unit_price
     )
     promotion_reason = order_lines["order"]["lines"][0]["unitDiscountReason"]
-    assert (
-        promotion_reason
-        == f"Promotion rules discounts: {promotion_name}: {promotion_rule_name}"
-    )
+    assert promotion_reason == f"Promotion: {promotion_id}"
 
     # Step 3 - Add manual discount to the order
     manual_discount_input = {

--- a/saleor/tests/e2e/orders/test_order_promotion_still_applied_to_the_order_when_promotion_is_removed.py
+++ b/saleor/tests/e2e/orders/test_order_promotion_still_applied_to_the_order_when_promotion_is_removed.py
@@ -105,10 +105,7 @@ def test_order_promotion_still_applied_to_the_order_when_promotion_is_removed_CO
         order_lines["order"]["lines"][0]["unitPrice"]["gross"]["amount"] == unit_price
     )
     promotion_reason = order_lines["order"]["lines"][0]["unitDiscountReason"]
-    assert (
-        promotion_reason
-        == f"Promotion rules discounts: {promotion_name}: {promotion_rule_name}"
-    )
+    assert promotion_reason == f"Promotion: {promotion_id}"
 
     # Step 3 - Add a shipping method to the order
     input = {"shippingMethod": shipping_method_id}


### PR DESCRIPTION
Point `sale_id` and `unit_discount_reason` to point to `Sale` when `old_sale_id` is set.

Resolves https://github.com/saleor/saleor/issues/14003

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
