### PR TITLE
[TEST] Staff can void payment CORE_0116

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_void_payment.py
+++ b/saleor/tests/e2e/checkout/test_checkout_void_payment.py
@@ -1,0 +1,126 @@
+import pytest
+
+from ..orders.utils import order_void
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..utils import assign_permissions
+from .utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    raw_checkout_dummy_payment_create,
+)
+
+
+@pytest.mark.e2e
+def test_checkout_void_payment_CORE_0116(
+    e2e_staff_api_client,
+    e2e_app_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+    permission_manage_payments,
+    permission_handle_checkouts,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+    app_permissions = [
+        permission_manage_payments,
+        permission_handle_checkouts,
+        permission_manage_orders,
+        permission_manage_channels,
+    ]
+    assign_permissions(e2e_app_api_client, app_permissions)
+
+    price = 10
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    # Step 1 - Create checkout
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
+    ]
+    checkout_data = checkout_create(
+        e2e_staff_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+
+    assert checkout_id is not None
+    assert checkout_data["isShippingRequired"] is True
+    assert len(checkout_data["shippingMethods"]) == 1
+    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
+
+    # Step 2 - Assign shipping method
+    checkout_data = checkout_delivery_method_update(
+        e2e_staff_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    assert total_gross_amount is not None
+    assert checkout_data["deliveryMethod"]["id"] is not None
+
+    # Step 3 - Create payment for checkout.
+    data = raw_checkout_dummy_payment_create(
+        e2e_staff_api_client,
+        checkout_id,
+        total_gross_amount,
+        token="not-charged",
+    )
+    payment_id = data["payment"]["id"]
+    assert payment_id is not None
+
+    # Step 4 - Complete checkout
+    order_data = checkout_complete(
+        e2e_staff_api_client,
+        checkout_id,
+    )
+    order_id = order_data["id"]
+    assert order_id is not None
+    assert order_data["isShippingRequired"] is True
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == total_gross_amount
+    assert order_data["deliveryMethod"]["id"] == shipping_method_id
+
+    # Step 5 - Void the payment
+    order = order_void(
+        e2e_staff_api_client,
+        order_id,
+    )
+    events = order["order"]["events"]
+    assert events != []
+    assert any(event["type"] == "PAYMENT_VOIDED" for event in events)
+    assert order["order"]["status"] == "UNFULFILLED"

--- a/saleor/tests/e2e/checkout/test_should_pay_for_checkout_with_gift_card.py
+++ b/saleor/tests/e2e/checkout/test_should_pay_for_checkout_with_gift_card.py
@@ -104,6 +104,7 @@ def test_pay_for_checkout_with_gift_card_core_1101(
         e2e_logged_api_client,
         checkout_id,
         total_gross_amount,
+        token="fully_charged",
     )
     assert create_payment["errors"] == []
     assert create_payment["checkout"]["id"] == checkout_id

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_buy_product_without_shipping_option.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_buy_product_without_shipping_option.py
@@ -105,6 +105,7 @@ def test_unlogged_customer_unable_to_buy_product_without_shipping_option_CORE_01
         e2e_not_logged_api_client,
         checkout_id,
         total_gross_amount,
+        token="fully_charged",
     )
     errors = checkout_payment_data["errors"]
 

--- a/saleor/tests/e2e/checkout/utils/checkout_payment_create.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_payment_create.py
@@ -19,13 +19,15 @@ mutation createPayment($checkoutId: ID, $input: PaymentInput!) {
 """
 
 
-def raw_checkout_dummy_payment_create(api_client, checkout_id, total_gross_amount):
+def raw_checkout_dummy_payment_create(
+    api_client, checkout_id, total_gross_amount, token
+):
     variables = {
         "checkoutId": checkout_id,
         "input": {
             "amount": total_gross_amount,
             "gateway": "mirumee.payments.dummy",
-            "token": "fully_charged",
+            "token": token,
         },
     }
 
@@ -42,7 +44,10 @@ def raw_checkout_dummy_payment_create(api_client, checkout_id, total_gross_amoun
 
 def checkout_dummy_payment_create(api_client, checkout_id, total_gross_amount):
     checkout_payment_create_response = raw_checkout_dummy_payment_create(
-        api_client, checkout_id, total_gross_amount
+        api_client,
+        checkout_id,
+        total_gross_amount,
+        token="fully_charged",
     )
 
     assert checkout_payment_create_response["errors"] == []

--- a/saleor/tests/e2e/orders/utils/order_void.py
+++ b/saleor/tests/e2e/orders/utils/order_void.py
@@ -11,6 +11,13 @@ mutation VoidOrder ($id:ID!){
     order {
       id
       status
+      payments {
+        id
+      }
+      statusDisplay
+      events {
+        type
+      }
     }
   }
 }
@@ -46,4 +53,4 @@ def order_void(
 
     assert response["errors"] == []
 
-    return response["orderVoid"]
+    return response


### PR DESCRIPTION
I want to merge this change because it covers [TC: CORE_0116](https://saleor.testmo.net/repositories/5?group_id=125&case_id=2401) - Staff can void payment on checkout order

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
