### PR TITLE
Fix passing shipping address to Adyen

### DIFF
--- a/saleor/payment/gateways/adyen/tests/utils/test_common.py
+++ b/saleor/payment/gateways/adyen/tests/utils/test_common.py
@@ -707,13 +707,19 @@ def test_to_adyen_price(value, currency, expected_result):
     assert result == expected_result
 
 
-def test_request_data_for_gateway_config(checkout_with_item, address):
+def test_request_data_for_gateway_config(
+    checkout_with_item, address, address_other_country
+):
     # given
-    checkout_with_item.billing_address = address
+    checkout_with_item.shipping_address = address
+    checkout_with_item.billing_address = address_other_country
+    assert address.country.code != address_other_country.country.code
+
     merchant_account = "test_account"
     manager = get_plugins_manager()
     lines_info, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines_info, manager)
+
     # when
     response_config = request_data_for_gateway_config(
         checkout_info, lines_info, merchant_account
@@ -722,7 +728,7 @@ def test_request_data_for_gateway_config(checkout_with_item, address):
     # then
     assert response_config == {
         "merchantAccount": merchant_account,
-        "countryCode": checkout_with_item.billing_address.country,
+        "countryCode": checkout_with_item.shipping_address.country,
         "channel": "web",
         "amount": {"currency": "USD", "value": "3000"},
     }

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -339,7 +339,7 @@ def request_data_for_gateway_config(
 ) -> Dict[str, Any]:
     manager = get_plugins_manager()
     checkout = checkout_info.checkout
-    address = checkout_info.billing_address or checkout_info.shipping_address
+    address = checkout_info.shipping_address or checkout_info.billing_address
     lines = lines or []
     total = checkout_total(
         manager=manager,


### PR DESCRIPTION
The `request_data_for_gateway_config` was using the wrong checkout address, it was using first the billing address, then the shipping. This caused flat rates to use the billing address country for the tax calculation in checkouts with addresses with different countries. The price recalculation is triggered by Adyen plugin, which needs to know the checkout total for the request to Adyen, and this recalculation affected all checkout prices if they were invalidated earlier. 

Steps to reproduce:
- Env 3.14 with Adyen plugin enabled.
- Enable flat rates in a channel and configure rates for two countries, e.g. NZ and IE (with different tax rates).
- In this channel, create a checkout with some lines, add the billing address and shipping address but, each address with different country of the two configured above. Include `availablePaymentGateways` field in the query to trigger Adyen logic.
- Checkout total is calculated using the billing address country which is incorrect, shipping address should be taken for tax calculation.

Example query to replicate this:
```
mutation checkoutCreate {
  checkoutCreate(
    input: {
      email: "test@example.com",
      channel: "channel-pln",
      lines: [
        { variantId: "UHJvZHVjdFZhcmlhbnQ6Mzg0=", quantity: 1 },
      ],
      shippingAddress: {
        firstName: "Test",
        lastName: "Test",
        streetAddress1: "Test",
        city: "Test",
        country: NZ,
        postalCode: "0630"
      },
      billingAddress: {
        firstName: "Test",
        lastName: "Test",
        streetAddress1: "Test",
        city: "Test",
        country: IE,
        countryArea: "Co. Wicklow"
        postalCode: "A67 N223"
      }
    }
  ) {
    checkout {
      id
      availablePaymentGateways {
        id
      }
      billingAddress {
        country {
          code
        }
      }
      totalPrice {
        gross {
          amount
        }
        net {
          amount
        }
      }
    }
  }
}
```

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
