### PR TITLE
[TEST] Should be able to remove shipping method from checkout CORE_0115

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_should_be_able_to_remove_shipping_method.py
+++ b/saleor/tests/e2e/checkout/test_checkout_should_be_able_to_remove_shipping_method.py
@@ -1,0 +1,96 @@
+import pytest
+
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..utils import assign_permissions
+from .utils import checkout_create, checkout_delivery_method_update
+
+
+@pytest.mark.e2e
+def test_checkout_should_be_able_to_remove_shipping_method_CORE_0115(
+    e2e_staff_api_client,
+    e2e_not_logged_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+    permission_manage_checkouts,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_checkouts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    variant_price = 10
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
+
+    # Step 1 - Create checkout
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
+    ]
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    assert checkout_data["shippingMethods"] != []
+    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
+    assert checkout_data["isShippingRequired"] is True
+    assert checkout_data["deliveryMethod"] is None
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    assert total_gross_amount == variant_price
+
+    # Step 2 - Set DeliveryMethod for checkout
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    subtotal_price = checkout_data["subtotalPrice"]["gross"]["amount"]
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
+    assert subtotal_price == float(variant_price)
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    assert total_gross_amount == float(subtotal_price + shipping_price)
+
+    # Step 3 - Remove shipping method from the checkout
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+    )
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    shipping_price = checkout_data["shippingPrice"]["gross"]["amount"]
+    assert shipping_price == 0
+    assert total_gross_amount == float(variant_price)
+    assert checkout_data["deliveryMethod"] is None

--- a/saleor/tests/e2e/checkout/utils/checkout_delivery_method_update.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_delivery_method_update.py
@@ -1,7 +1,7 @@
 from ...utils import get_graphql_content
 
 CHECKOUT_DELIVERY_METHOD_UPDATE_MUTATION = """
-mutation checkoutDeliveryMethodUpdate($checkoutId: ID!, $deliveryMethodId: ID!) {
+mutation checkoutDeliveryMethodUpdate($checkoutId: ID!, $deliveryMethodId: ID) {
   checkoutDeliveryMethodUpdate(
     id: $checkoutId
     deliveryMethodId: $deliveryMethodId
@@ -21,6 +21,11 @@ mutation checkoutDeliveryMethodUpdate($checkoutId: ID!, $deliveryMethodId: ID!) 
       subtotalPrice {
         gross {
           amount
+        }
+      }
+      shippingPrice{
+        gross {
+        amount
         }
       }
       shippingMethods {
@@ -46,7 +51,7 @@ mutation checkoutDeliveryMethodUpdate($checkoutId: ID!, $deliveryMethodId: ID!) 
 def checkout_delivery_method_update(
     staff_api_client,
     checkout_id,
-    delivery_method_id,
+    delivery_method_id=None,
 ):
     variables = {
         "checkoutId": checkout_id,


### PR DESCRIPTION
I want to merge this change because it covers TC [CORE_0115](https://saleor.testmo.net/repositories/5?group_id=125&case_id=1732) - Should be able to remove shipping method from checkout


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
