### PR TITLE
[TEST] Unable to void once voided payment CORE_0218

### DIFF
--- a/saleor/tests/e2e/orders/test_order_void_once_voided_payment.py
+++ b/saleor/tests/e2e/orders/test_order_void_once_voided_payment.py
@@ -1,0 +1,136 @@
+import pytest
+
+from ..checkout.utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    raw_checkout_dummy_payment_create,
+)
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..utils import assign_permissions
+from .utils import order_query, order_void, raw_order_void
+
+
+def prepare_checkout_with_voided_payment(
+    e2e_staff_api_client,
+    e2e_app_api_client,
+):
+    price = 10
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
+    ]
+    checkout_data = checkout_create(
+        e2e_staff_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
+
+    checkout_data = checkout_delivery_method_update(
+        e2e_staff_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+
+    raw_checkout_dummy_payment_create(
+        e2e_staff_api_client,
+        checkout_id,
+        total_gross_amount,
+        token="not-charged",
+    )
+
+    order_data = checkout_complete(
+        e2e_staff_api_client,
+        checkout_id,
+    )
+    order_id = order_data["id"]
+
+    order_void(
+        e2e_staff_api_client,
+        order_id,
+    )
+
+    return order_id
+
+
+@pytest.mark.e2e
+def test_checkout_void_once_voided_payment_CORE_0218(
+    e2e_staff_api_client,
+    e2e_app_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+    permission_manage_payments,
+    permission_handle_checkouts,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+    app_permissions = [
+        permission_manage_payments,
+        permission_handle_checkouts,
+        permission_manage_orders,
+        permission_manage_channels,
+    ]
+    assign_permissions(e2e_app_api_client, app_permissions)
+
+    order_id = prepare_checkout_with_voided_payment(
+        e2e_staff_api_client,
+        e2e_app_api_client,
+    )
+
+    # Step 1 - Check the order's payment is voided
+    order_data = order_query(
+        e2e_staff_api_client,
+        order_id,
+    )
+    events = order_data["events"]
+    assert events != []
+    assert any(event["type"] == "PAYMENT_VOIDED" for event in events)
+    assert order_data["status"] == "UNFULFILLED"
+
+    # Step 2 - Void the payment
+    order = raw_order_void(
+        e2e_staff_api_client,
+        order_id,
+    )
+    error = order["errors"][0]
+    assert error["message"] == "Only pre-authorized payments can be voided"
+    assert error["code"] == "VOID_INACTIVE_PAYMENT"
+    assert error["field"] == "payment"

--- a/saleor/tests/e2e/orders/test_order_void_payment.py
+++ b/saleor/tests/e2e/orders/test_order_void_payment.py
@@ -1,19 +1,19 @@
 import pytest
 
-from ..orders.utils import order_void
-from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
-from ..utils import assign_permissions
-from .utils import (
+from ..checkout.utils import (
     checkout_complete,
     checkout_create,
     checkout_delivery_method_update,
     raw_checkout_dummy_payment_create,
 )
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..utils import assign_permissions
+from .utils import order_void
 
 
 @pytest.mark.e2e
-def test_checkout_void_payment_CORE_0116(
+def test_checkout_void_payment_CORE_0217(
     e2e_staff_api_client,
     e2e_app_api_client,
     permission_manage_products,

--- a/saleor/tests/e2e/orders/utils/order_query.py
+++ b/saleor/tests/e2e/orders/utils/order_query.py
@@ -9,6 +9,9 @@ query OrderDetails($id:ID!) {
     }
     paymentStatus
     isPaid
+    events {
+        type
+      }
     channel {
         id
         name


### PR DESCRIPTION
I want to merge this change because:
- it covers [CORE_0218](https://saleor.testmo.net/repositories/5?group_id=112&case_id=2382) - Unable to void once voided payment on the order
- Reorganizes tests within e2e folders (moving the ones regarding orderVoid to orders folder)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
