### PR TITLE
Fix null amount when transaction amount is 0

### DIFF
--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -1417,7 +1417,7 @@ class TransactionRequestAction(BaseMutation):
             )
             request_cancelation_action(
                 **action_kwargs,
-                cancel_value=action_value,
+                cancel_value=None,
                 request_event=request_event,
                 action=action,
             )

--- a/saleor/graphql/webhook/subscription_types.py
+++ b/saleor/graphql/webhook/subscription_types.py
@@ -1437,7 +1437,7 @@ class TransactionAction(SubscriptionObjectType, AbstractType):
 
     @staticmethod
     def resolve_amount(root: TransactionActionData, _info: ResolveInfo):
-        if root.action_value:
+        if root.action_value is not None:
             return quantize_price(root.action_value, root.transaction.currency)
         return None
 


### PR DESCRIPTION
Fix: https://github.com/saleor/saleor/issues/14108

Needed to ensure also that for VOID and CANCEL actions we indeed return `null`

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
