### PR TITLE
Enforce decision about migrations performance test

### DIFF
--- a/.github/workflows/migrations-perf-test-check.yml
+++ b/.github/workflows/migrations-perf-test-check.yml
@@ -1,0 +1,24 @@
+name: "Migration performance test required"
+on:
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "**/migrations/**"
+    types: [labeled, unlabeled, opened, closed]
+
+jobs:
+  # Contributors of Saleor sometimes forget about executing migrations performance
+  # tests on PRs. This job is enforcing decision what to do. The decision is made by
+  # adding/removing the label to the PR. One of the label is required.
+  # Available labels:
+  # - skip migrations perf test - whenever migrations don't require performance
+  #   tests(e.g. when migrations are run in celery tasks)
+  # - migrations perf test - whenever migrations require performance tests
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check if the decision about migrations perf test was made
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip migrations perf test') && !contains(github.event.pull_request.labels.*.name, 'migrations perf test') }}
+        run: exit 1


### PR DESCRIPTION
I want to merge this change because it enforces the decision of whether a change should have a migration performance test if migrations have been changed.

After this change, anyone who modifies or creates migration files should explicitly add  one for labels:
- `skip migrations perf test` - whenever migrations don't require performance tests(e.g. when migrations are run in celery tasks)
- `migrations perf test` - whenever migrations require performance tests 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
