### PR TITLE
[Test] Calculate simple taxes based on shipping country tax rate

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
+++ b/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
@@ -1,0 +1,262 @@
+import pytest
+
+from ..channel.utils import create_channel
+from ..product.utils.preparing_product import prepare_product
+from ..shipping_zone.utils import (
+    create_shipping_method,
+    create_shipping_method_channel_listing,
+    create_shipping_zone,
+)
+from ..taxes.utils import (
+    get_tax_configurations,
+    update_country_tax_rates,
+    update_tax_configuration,
+)
+from ..utils import assign_permissions
+from ..warehouse.utils import create_warehouse
+from .utils import (
+    checkout_billing_address_update,
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+    checkout_shipping_address_update,
+    get_checkout,
+)
+
+
+def prepare_shop_with_few_shipping_zone_counties(
+    e2e_staff_api_client,
+    shipping_price,
+):
+    warehouse_data = create_warehouse(e2e_staff_api_client)
+    warehouse_id = warehouse_data["id"]
+    channel_slug = "test"
+    warehouse_ids = [warehouse_id]
+    channel_data = create_channel(
+        e2e_staff_api_client,
+        slug=channel_slug,
+        warehouse_ids=warehouse_ids,
+    )
+    channel_id = channel_data["id"]
+    channel_ids = [channel_id]
+    shipping_zone_data = create_shipping_zone(
+        e2e_staff_api_client,
+        countries=["CZ", "DE", "US"],
+        warehouse_ids=warehouse_ids,
+        channel_ids=channel_ids,
+    )
+    shipping_zone_id = shipping_zone_data["id"]
+
+    shipping_method_data = create_shipping_method(
+        e2e_staff_api_client, shipping_zone_id
+    )
+    shipping_method_id = shipping_method_data["id"]
+    create_shipping_method_channel_listing(
+        e2e_staff_api_client,
+        shipping_method_id,
+        channel_id,
+        price=shipping_price,
+    )
+
+    return (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+        shipping_price,
+    )
+
+
+def prepare_tax_configuration(
+    e2e_staff_api_client,
+    channel_slug,
+    shipping_country_code,
+    shipping_country_tax_rate,
+    billing_country_code,
+    billing_country_tax_rate,
+):
+    tax_config_data = get_tax_configurations(e2e_staff_api_client)
+    channel_tax_config = tax_config_data[0]["node"]
+    assert channel_tax_config["channel"]["slug"] == channel_slug
+    tax_config_id = channel_tax_config["id"]
+
+    tax_config_data = update_tax_configuration(
+        e2e_staff_api_client,
+        tax_config_id,
+        charge_taxes=True,
+        tax_calculation_strategy="FLAT_RATES",
+        display_gross_prices=True,
+        prices_entered_with_tax=True,
+    )
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        shipping_country_code,
+        [{"rate": shipping_country_tax_rate}],
+    )
+    update_country_tax_rates(
+        e2e_staff_api_client, billing_country_code, [{"rate": billing_country_tax_rate}]
+    )
+    return shipping_country_tax_rate
+
+
+@pytest.mark.e2e
+def test_checkout_calculate_simple_tax_based_on_shipping_country_CORE_2001(
+    e2e_staff_api_client,
+    e2e_not_logged_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_taxes,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_taxes,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+        shipping_price,
+    ) = prepare_shop_with_few_shipping_zone_counties(e2e_staff_api_client, "6.66")
+
+    shipping_country_tax_rate = prepare_tax_configuration(
+        e2e_staff_api_client,
+        channel_slug,
+        shipping_country_code="CZ",
+        shipping_country_tax_rate=21,
+        billing_country_code="DE",
+        billing_country_tax_rate=19,
+    )
+
+    variant_price = "17.77"
+    (
+        _product_id,
+        product_variant_id,
+        _product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
+
+    # Step 1 - Create checkout.
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
+    ]
+
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+    )
+    checkout_id = checkout_data["id"]
+
+    assert checkout_data["isShippingRequired"] is True
+
+    # Step 2 - Set shipping address for checkout.
+
+    shipping_address = {
+        "firstName": "John",
+        "lastName": "Muller",
+        "companyName": "Saleor Commerce CZ",
+        "streetAddress1": "Sluneční 1396",
+        "streetAddress2": "",
+        "postalCode": "74784",
+        "country": "CZ",
+        "city": "Melc",
+        "phone": "+420722274643",
+        "countryArea": "",
+    }
+    checkout_data = checkout_shipping_address_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_address,
+    )
+    assert len(checkout_data["shippingMethods"]) == 1
+    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
+
+    # Step 3 - Set billing address for checkout.
+    billing_address = {
+        "firstName": "John",
+        "lastName": "Muller",
+        "companyName": "Saleor Commerce DE",
+        "streetAddress1": "Potsdamer Platz 47",
+        "streetAddress2": "",
+        "postalCode": "85131",
+        "country": "DE",
+        "city": "Pollenfeld",
+        "phone": "+498421499469",
+        "countryArea": "",
+    }
+    checkout_billing_address_update(e2e_staff_api_client, checkout_id, billing_address)
+
+    # Step 4 - Get checkout and verify taxes
+    checkout_data = get_checkout(e2e_not_logged_api_client, checkout_id)
+    assert checkout_data["totalPrice"]["gross"]["amount"] == float(variant_price)
+    calculated_tax = round(
+        (float(variant_price) * shipping_country_tax_rate)
+        / (100 + shipping_country_tax_rate),
+        2,
+    )
+    assert checkout_data["totalPrice"]["tax"]["amount"] == calculated_tax
+    assert (
+        checkout_data["totalPrice"]["net"]["amount"]
+        == float(variant_price) - calculated_tax
+    )
+
+    # Step 5 - Set DeliveryMethod for checkout.
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    assert checkout_data["shippingPrice"]["gross"]["amount"] == float(shipping_price)
+    shipping_tax = round(
+        (float(shipping_price) * shipping_country_tax_rate)
+        / (100 + shipping_country_tax_rate),
+        2,
+    )
+    assert checkout_data["shippingPrice"]["tax"]["amount"] == shipping_tax
+    assert (
+        checkout_data["shippingPrice"]["net"]["amount"]
+        == float(shipping_price) - shipping_tax
+    )
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    calculated_total = float(variant_price) + float(shipping_price)
+    total_gross_amount = calculated_total
+    total_tax = calculated_tax + shipping_tax
+    assert checkout_data["totalPrice"]["tax"]["amount"] == total_tax
+    # Step 6 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_not_logged_api_client,
+        checkout_id,
+        total_gross_amount,
+    )
+
+    # Step 7 - Complete checkout.
+    order_data = checkout_complete(
+        e2e_not_logged_api_client,
+        checkout_id,
+    )
+    assert order_data["isShippingRequired"] is True
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["total"]["tax"]["amount"] == total_tax
+    assert order_data["total"]["net"]["amount"] == round(
+        calculated_total - total_tax, 2
+    )

--- a/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
+++ b/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
@@ -25,7 +25,7 @@ from .utils import (
 )
 
 
-def prepare_shop_with_few_shipping_zone_counties(
+def prepare_shop_with_few_shipping_zone_countries(
     e2e_staff_api_client,
     shipping_price,
 ):
@@ -126,7 +126,7 @@ def test_checkout_calculate_simple_tax_based_on_shipping_country_CORE_2001(
         channel_slug,
         shipping_method_id,
         shipping_price,
-    ) = prepare_shop_with_few_shipping_zone_counties(e2e_staff_api_client, "6.66")
+    ) = prepare_shop_with_few_shipping_zone_countries(e2e_staff_api_client, "6.66")
 
     shipping_country_tax_rate = prepare_tax_configuration(
         e2e_staff_api_client,
@@ -168,7 +168,6 @@ def test_checkout_calculate_simple_tax_based_on_shipping_country_CORE_2001(
     assert checkout_data["isShippingRequired"] is True
 
     # Step 2 - Set shipping address for checkout.
-
     shipping_address = {
         "firstName": "John",
         "lastName": "Muller",
@@ -241,6 +240,7 @@ def test_checkout_calculate_simple_tax_based_on_shipping_country_CORE_2001(
     total_gross_amount = calculated_total
     total_tax = calculated_tax + shipping_tax
     assert checkout_data["totalPrice"]["tax"]["amount"] == total_tax
+
     # Step 6 - Create payment for checkout.
     checkout_dummy_payment_create(
         e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/utils/__init__.py
+++ b/saleor/tests/e2e/checkout/utils/__init__.py
@@ -17,6 +17,7 @@ from .checkout_payment_create import (
     raw_checkout_dummy_payment_create,
 )
 from .checkout_shipping_address_update import checkout_shipping_address_update
+from .query_checkout import get_checkout
 
 __all__ = [
     "checkout_billing_address_update",
@@ -36,4 +37,5 @@ __all__ = [
     "checkout_lines_add",
     "checkout_add_promo_code",
     "raw_checkout_add_promo_code",
+    "get_checkout",
 ]

--- a/saleor/tests/e2e/checkout/utils/checkout_complete.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_complete.py
@@ -21,6 +21,12 @@ mutation CheckoutComplete($checkoutId: ID!) {
         gross {
           amount
         }
+        net {
+          amount
+        }
+        tax {
+          amount
+        }
       }
       paymentStatus
       statusDisplay
@@ -45,6 +51,12 @@ mutation CheckoutComplete($checkoutId: ID!) {
       }
       shippingPrice {
         gross {
+          amount
+        }
+        net {
+          amount
+        }
+        tax {
           amount
         }
       }

--- a/saleor/tests/e2e/checkout/utils/checkout_delivery_method_update.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_delivery_method_update.py
@@ -17,6 +17,12 @@ mutation checkoutDeliveryMethodUpdate($checkoutId: ID!, $deliveryMethodId: ID!) 
         gross {
           amount
         }
+        net {
+          amount
+        }
+        tax {
+          amount
+        }
       }
       subtotalPrice {
         gross {
@@ -25,6 +31,17 @@ mutation checkoutDeliveryMethodUpdate($checkoutId: ID!, $deliveryMethodId: ID!) 
       }
       shippingMethods {
         id
+      }
+      shippingPrice {
+        gross {
+          amount
+        }
+        net {
+          amount
+        }
+        tax {
+          amount
+        }
       }
       deliveryMethod {
         ... on ShippingMethod {

--- a/saleor/tests/e2e/checkout/utils/query_checkout.py
+++ b/saleor/tests/e2e/checkout/utils/query_checkout.py
@@ -1,0 +1,43 @@
+from ...utils import get_graphql_content
+
+CHECKOUT_QUERY = """
+query Checkout($checkoutId: ID!){
+  checkout(id: $checkoutId){
+    id
+    totalPrice{
+      gross{
+        amount
+      }
+      net{
+        amount
+      }
+      tax{
+        amount
+      }
+    }
+    availablePaymentGateways{
+      id
+      name
+    }
+    shippingMethods{
+      id
+      name
+      price{
+        amount
+      }
+    }
+  }
+}
+"""
+
+
+def get_checkout(
+    api_client,
+    checkout_id,
+):
+    variables = {"checkoutId": checkout_id}
+
+    response = api_client.post_graphql(CHECKOUT_QUERY, variables)
+    content = get_graphql_content(response)
+
+    return content["data"]["checkout"]

--- a/saleor/tests/e2e/shipping_zone/utils/shipping_zone.py
+++ b/saleor/tests/e2e/shipping_zone/utils/shipping_zone.py
@@ -27,7 +27,7 @@ mutation createShipping($input: ShippingZoneCreateInput!) {
 def create_shipping_zone(
     staff_api_client,
     name="Test shipping zone",
-    countries="US",
+    countries=["US"],
     warehouse_ids=None,
     channel_ids=None,
 ):
@@ -39,7 +39,7 @@ def create_shipping_zone(
     variables = {
         "input": {
             "name": name,
-            "countries": [countries],
+            "countries": countries,
             "addWarehouses": warehouse_ids,
             "addChannels": channel_ids,
         }

--- a/saleor/tests/e2e/taxes/utils/__init__.py
+++ b/saleor/tests/e2e/taxes/utils/__init__.py
@@ -1,0 +1,9 @@
+from .query_tax_configurations import get_tax_configurations
+from .tax_configuration_update import update_tax_configuration
+from .tax_country_configuration_update import update_country_tax_rates
+
+__all__ = [
+    "get_tax_configurations",
+    "update_tax_configuration",
+    "update_country_tax_rates",
+]

--- a/saleor/tests/e2e/taxes/utils/query_tax_configurations.py
+++ b/saleor/tests/e2e/taxes/utils/query_tax_configurations.py
@@ -1,0 +1,34 @@
+from ...utils import get_graphql_content
+
+TAX_CONFIGURATIONS_QUERY = """
+query TaxConfigurationsList($first: Int) {
+  taxConfigurations(first: $first) {
+    edges {
+      node {
+        id
+        channel {
+          id
+          slug
+        }
+        displayGrossPrices
+        pricesEnteredWithTax
+        chargeTaxes
+        taxCalculationStrategy
+      }
+    }
+  }
+}
+
+"""
+
+
+def get_tax_configurations(
+    staff_api_client,
+    first=10,
+):
+    variables = {"first": 10}
+
+    response = staff_api_client.post_graphql(TAX_CONFIGURATIONS_QUERY, variables)
+    content = get_graphql_content(response)
+
+    return content["data"]["taxConfigurations"]["edges"]

--- a/saleor/tests/e2e/taxes/utils/tax_configuration_update.py
+++ b/saleor/tests/e2e/taxes/utils/tax_configuration_update.py
@@ -1,0 +1,68 @@
+from ...utils import get_graphql_content
+
+TAX_CONFIGURATION_UPDATE_MUTATION = """
+mutation TaxConfigurationUpdate($id: ID!, $input: TaxConfigurationUpdateInput!) {
+  taxConfigurationUpdate(id: $id, input: $input) {
+    errors {
+      field
+      code
+      message
+      countryCodes
+    }
+    taxConfiguration {
+      id
+      channel {
+        id
+        name
+      }
+      displayGrossPrices
+      pricesEnteredWithTax
+      chargeTaxes
+      taxCalculationStrategy
+      countries {
+        country {
+          code
+        }
+        chargeTaxes
+        taxCalculationStrategy
+        displayGrossPrices
+      }
+    }
+  }
+}
+"""
+
+
+def update_tax_configuration(
+    staff_api_client,
+    tax_config_id,
+    charge_taxes=True,
+    tax_calculation_strategy="FLAT_RATES",
+    display_gross_prices=True,
+    prices_entered_with_tax=True,
+    update_countries_configuration=[],
+    remove_countries_configuration=[],
+):
+    variables = {
+        "id": tax_config_id,
+        "input": {
+            "chargeTaxes": charge_taxes,
+            "taxCalculationStrategy": tax_calculation_strategy,
+            "displayGrossPrices": display_gross_prices,
+            "pricesEnteredWithTax": prices_entered_with_tax,
+            "updateCountriesConfiguration": update_countries_configuration,
+            "removeCountriesConfiguration": remove_countries_configuration,
+        },
+    }
+
+    response = staff_api_client.post_graphql(
+        TAX_CONFIGURATION_UPDATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["taxConfigurationUpdate"]["errors"] == []
+
+    data = content["data"]["taxConfigurationUpdate"]["taxConfiguration"]
+    assert data["id"] is not None
+
+    return data

--- a/saleor/tests/e2e/taxes/utils/tax_country_configuration_update.py
+++ b/saleor/tests/e2e/taxes/utils/tax_country_configuration_update.py
@@ -1,0 +1,55 @@
+from ...utils import get_graphql_content
+
+TAX_COUNTRY_CONFIGURATION_UPDATE_MUTATION = """
+mutation TaxCountryConfigurationUpdate($countryCode: CountryCode!,
+ $updateTaxClassRates: [TaxClassRateInput!]!) {
+  taxCountryConfigurationUpdate(
+    countryCode: $countryCode
+    updateTaxClassRates: $updateTaxClassRates
+  ) {
+    errors {
+      code
+      field
+      message
+      taxClassIds
+    }
+    taxCountryConfiguration {
+      country{
+        code
+      }
+      taxClassCountryRates{
+        country{
+          code
+        }
+        rate
+        taxClass{
+          id
+        }
+      }
+    }
+  }
+}
+
+"""
+
+
+def update_country_tax_rates(
+    staff_api_client,
+    country_code,
+    update_tax_class_rates=[],
+):
+    variables = {
+        "countryCode": country_code,
+        "updateTaxClassRates": update_tax_class_rates,
+    }
+
+    response = staff_api_client.post_graphql(
+        TAX_COUNTRY_CONFIGURATION_UPDATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["taxCountryConfigurationUpdate"]["errors"] == []
+
+    data = content["data"]["taxCountryConfigurationUpdate"]["taxCountryConfiguration"]
+
+    return data


### PR DESCRIPTION
I want to merge this change because covers Checkout calculates simple taxes based on shipping address country [CORE_2001](https://saleor.testmo.net/repositories/5?group_id=461&case_id=4465)


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
