### PR TITLE
Drop recursion from migrations

### DIFF
--- a/saleor/attribute/migrations/0036_assignedproductattributevalue_product_data_migration.py
+++ b/saleor/attribute/migrations/0036_assignedproductattributevalue_product_data_migration.py
@@ -10,20 +10,12 @@ def data_migration(apps, _schema_editor):
     AssignedProductAttributeValue = apps.get_model(
         "attribute", "AssignedProductAttributeValue"
     )
-    assign_products_to_attribute_values(AssignedProductAttributeValue)
-
-
-def assign_products_to_attribute_values(AssignedProductAttributeValue):
-    # Order events proceed from the newest to the oldest
-    assigned_values = (
+    while (
         AssignedProductAttributeValue.objects.filter(product__isnull=True)
         .values_list("pk", flat=True)
         .exists()
-    )
-    # If we found data, queue next execution of the task
-    if assigned_values:
+    ):
         update_product_assignment()
-        assign_products_to_attribute_values(AssignedProductAttributeValue)
 
 
 def update_product_assignment():

--- a/saleor/discount/migrations/0047_migrate_sales_to_promotions.py
+++ b/saleor/discount/migrations/0047_migrate_sales_to_promotions.py
@@ -71,11 +71,12 @@ def migrate_sales_with_listing(
     sales = Sale.objects.exclude(
         Exists(Promotion.objects.filter(old_sale_id=OuterRef("pk")))
     ).order_by("pk")
-    sales_listing = SaleChannelListing.objects.order_by("sale_id").filter(
-        Exists(sales.filter(id=OuterRef("sale_id")))
-    )[:BATCH_SIZE]
-    sale_ids = list(sales_listing.values_list("sale_id", flat=True))
-    if sale_ids:
+    sales_listing = (
+        SaleChannelListing.objects.order_by("sale_id")
+        .filter(Exists(sales.filter(id=OuterRef("sale_id"))))
+        .order_by("sale_id")
+    )
+    for sale_ids in sale_id_in_batches(sales_listing):
         with transaction.atomic():
             qs = (
                 Sale.objects.filter(
@@ -100,20 +101,19 @@ def migrate_sales_with_listing(
                 OrderLine,
                 CheckoutLineDiscount,
                 OrderLineDiscount,
-                sales,
+                qs,
             )
-        migrate_sales_with_listing(
-            Promotion,
-            PromotionRule,
-            PromotionTranslation,
-            Sale,
-            SaleChannelListing,
-            SaleTranslation,
-            RuleInfo,
-            OrderLine,
-            CheckoutLineDiscount,
-            OrderLineDiscount,
-        )
+
+
+def sale_id_in_batches(queryset):
+    sale_id = 0
+    while True:
+        qs = queryset.values("sale_id").filter(sale_id__gt=sale_id)[:BATCH_SIZE]
+        sale_pks = [v["sale_id"] for v in qs]
+        if not sale_pks:
+            break
+        yield sale_pks
+        sale_id = sale_pks[-1]
 
 
 def _migrate_sales_with_listing(
@@ -168,8 +168,7 @@ def migrate_sales_without_listing(
         ~Exists(sales_listing.filter(sale_id=OuterRef("pk"))),
         ~Exists(Promotion.objects.filter(old_sale_id=OuterRef("pk"))),
     ).order_by("pk")
-    ids = list(sales_not_listed.values_list("pk", flat=True)[:BATCH_SIZE])
-    if ids:
+    for ids in queryset_in_batches(sales_not_listed):
         with transaction.atomic():
             qs = Sale.objects.filter(
                 ~Exists(Promotion.objects.filter(old_sale_id=OuterRef("pk"))),
@@ -184,14 +183,17 @@ def migrate_sales_without_listing(
         _migrate_sales_without_listing(
             Promotion, PromotionRule, PromotionTranslation, Sale, SaleTranslation, qs
         )
-        migrate_sales_without_listing(
-            Promotion,
-            PromotionRule,
-            PromotionTranslation,
-            Sale,
-            SaleTranslation,
-            SaleChannelListing,
-        )
+
+
+def queryset_in_batches(queryset):
+    start_pk = 0
+    while True:
+        qs = queryset.values("pk").filter(pk__gt=start_pk)[:BATCH_SIZE]
+        pks = [v["pk"] for v in qs]
+        if not pks:
+            break
+        yield pks
+        start_pk = pks[-1]
 
 
 def _migrate_sales_without_listing(


### PR DESCRIPTION
Replace recursion with for loops as Python has limited recursion depth and it may crash.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
