### PR TITLE
Move update product search vector to celery task

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -12,7 +12,6 @@ from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import ProductPermissions
 from ....product import models
 from ....product.error_codes import ProductVariantBulkErrorCode
-from ....product.search import update_product_search_vector
 from ....product.tasks import update_product_discounted_price_task
 from ....warehouse import models as warehouse_models
 from ...attribute.types import (
@@ -913,7 +912,8 @@ class ProductVariantBulkCreate(BaseMutation):
 
         # Recalculate the "discounted price" for the parent product
         update_product_discounted_price_task.delay(product.pk)
-        update_product_search_vector(product)
+        product.search_index_dirty = True
+        product.save(update_fields=["search_index_dirty"])
 
         for instance in instances:
             cls.call_event(manager.product_variant_created, instance.node)

--- a/saleor/graphql/product/mutations/product/product_update.py
+++ b/saleor/graphql/product/mutations/product/product_update.py
@@ -5,7 +5,6 @@ import graphene
 from .....attribute import models as attribute_models
 from .....permission.enums import ProductPermissions
 from .....product import models
-from .....product.search import update_product_search_vector
 from .....product.tasks import update_product_discounted_price_task
 from ....attribute.utils import AttributeAssignmentMixin, AttrValuesInput
 from ....core import ResolveInfo
@@ -53,7 +52,8 @@ class ProductUpdate(ProductCreate, ModelWithExtRefMutation):
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
         product = models.Product.objects.prefetched_for_webhook().get(pk=instance.pk)
-        update_product_search_vector(instance)
+        product.search_index_dirty = True
+        product.save(update_fields=["search_index_dirty"])
         if "category" in cleaned_input or "collections" in cleaned_input:
             update_product_discounted_price_task.delay(instance.id)
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/graphql/product/mutations/product_variant/product_variant_create.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_create.py
@@ -11,7 +11,6 @@ from .....core.tracing import traced_atomic_transaction
 from .....permission.enums import ProductPermissions
 from .....product import models
 from .....product.error_codes import ProductErrorCode
-from .....product.search import update_product_search_vector
 from .....product.tasks import update_product_discounted_price_task
 from .....product.utils.variants import generate_and_set_variant_name
 from ....attribute.types import AttributeValueInput
@@ -316,7 +315,8 @@ class ProductVariantCreate(ModelMutation):
                 generate_and_set_variant_name(instance, cleaned_input.get("sku"))
 
             manager = get_plugin_manager_promise(info.context).get()
-            update_product_search_vector(instance.product)
+            instance.product.search_index_dirty = True
+            instance.product.save(update_fields=["search_index_dirty"])
             event_to_call = (
                 manager.product_variant_created
                 if new_variant

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -104,8 +104,10 @@ def test_product_variant_bulk_update(
     content = get_graphql_content(response)
     flush_post_commit_hooks()
     data = content["data"]["productVariantBulkUpdate"]
+    product_with_single_variant.refresh_from_db()
 
     # then
+    assert product_with_single_variant.search_index_dirty is True
     assert not data["results"][0]["errors"]
     assert data["count"] == 1
     variant_data = data["results"][0]["productVariant"]


### PR DESCRIPTION
I want to merge this change because it changes how the product search vector is updated in mutations. Instead of updating it synchronously in mutation the field `search_index_dirty` will be set to `True` and the search vector will be updated asynchronously with celery beat task `update_products_search_vector_task`. 

Synchronous updates caused multiple locks on db when updating many products in a short amount of time causing in long waiting time for locks to be freed.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
