### PR TITLE
[TEST] Fulfill order and add tracking number CORE_0219

### DIFF
--- a/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
@@ -20,7 +20,11 @@ def test_should_create_account_without_email_confirmation_core_1502(
     chanel_data = create_channel(e2e_staff_api_client)
     channel_slug = chanel_data["slug"]
 
-    update_shop_settings(e2e_staff_api_client, enableAccountConfirmationByEmail=False)
+    input = {
+        "enableAccountConfirmationByEmail": False,
+    }
+
+    update_shop_settings(e2e_staff_api_client, input)
 
     test_email = "new-user@saleor.io"
     test_password = "password!"

--- a/saleor/tests/e2e/orders/test_order_fulfill_and_add_tracking.py
+++ b/saleor/tests/e2e/orders/test_order_fulfill_and_add_tracking.py
@@ -1,0 +1,157 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils import prepare_shop, update_shop_settings
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    mark_order_paid,
+    order_add_tracking,
+    order_fulfill,
+    order_lines_create,
+    order_query,
+)
+
+
+def prepare_order(e2e_staff_api_client):
+    price = 10
+    (
+        warehouse_id,
+        channel_id,
+        _channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    data = {"fulfillmentAutoApprove": True, "fulfillmentAllowUnpaid": False}
+    update_shop_settings(e2e_staff_api_client, data)
+
+    _product_id, product_variant_id, _product_variant_price = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    draft_order_input = {
+        "channelId": channel_id,
+        "userEmail": "test_user@test.com",
+        "shippingAddress": DEFAULT_ADDRESS,
+        "billingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        draft_order_input,
+    )
+    order_id = data["order"]["id"]
+
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        }
+    ]
+    data = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_line_id = data["order"]["lines"][0]["id"]
+
+    input = {"shippingMethod": shipping_method_id}
+    draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+
+    return (
+        order_id,
+        product_variant_id,
+        warehouse_id,
+        order_line_id,
+    )
+
+
+@pytest.mark.e2e
+def test_order_fulfill_and_add_tracking_CORE_0219(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+    permission_manage_settings,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_settings,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        order_id,
+        product_variant_id,
+        warehouse_id,
+        order_line_id,
+    ) = prepare_order(e2e_staff_api_client)
+
+    # Step 1 - Complete the order
+    order = draft_order_complete(
+        e2e_staff_api_client,
+        order_id,
+    )
+    order_complete_id = order["order"]["id"]
+    assert order_complete_id == order_id
+    order_line = order["order"]["lines"][0]
+    assert order_line["productVariantId"] == product_variant_id
+    assert order["order"]["status"] == "UNFULFILLED"
+
+    # Step 2 - Mark order as paid
+    order_paid_data = mark_order_paid(
+        e2e_staff_api_client,
+        order_id,
+    )
+    assert order_paid_data["order"]["isPaid"] is True
+    assert order_paid_data["order"]["paymentStatus"] == "FULLY_CHARGED"
+    assert order_paid_data["order"]["status"] == "UNFULFILLED"
+
+    # Step 3 - Fulfill the order and check the status
+    input = {
+        "lines": [
+            {
+                "orderLineId": order_line_id,
+                "stocks": [
+                    {
+                        "quantity": 1,
+                        "warehouse": warehouse_id,
+                    }
+                ],
+            }
+        ],
+        "notifyCustomer": True,
+        "allowStockToBeExceeded": False,
+    }
+    order_data = order_fulfill(e2e_staff_api_client, order_id, input)
+    fulfillment_id = order_data["order"]["fulfillments"][0]["id"]
+    assert order_data["order"]["fulfillments"] != []
+    assert order_data["order"]["fulfillments"][0]["status"] == "FULFILLED"
+
+    order = order_query(e2e_staff_api_client, order_id)
+    assert order["status"] == "FULFILLED"
+
+    # Step 4 - Add tracking number to the order
+    tracking_number = "test"
+    data = order_add_tracking(
+        e2e_staff_api_client,
+        fulfillment_id,
+        tracking_number,
+    )
+    assert data["fulfillments"][0]["trackingNumber"] == tracking_number

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -5,6 +5,8 @@ from .draft_order_update import draft_order_update
 from .order_cancel import order_cancel
 from .order_create_from_checkout import order_create_from_checkout
 from .order_discount_add import order_discount_add
+from .order_fulfill import order_fulfill
+from .order_fulfill_add_tracking import order_add_tracking
 from .order_lines_create import order_lines_create
 from .order_mark_as_paid import mark_order_paid
 from .order_query import order_query
@@ -24,4 +26,6 @@ __all__ = [
     "order_discount_add",
     "raw_order_void",
     "order_void",
+    "order_fulfill",
+    "order_add_tracking",
 ]

--- a/saleor/tests/e2e/orders/utils/order_fulfill.py
+++ b/saleor/tests/e2e/orders/utils/order_fulfill.py
@@ -1,0 +1,49 @@
+from ...utils import get_graphql_content
+
+ORDER_FULFILL_MUTATION = """
+mutation orderFulfill ($order: ID!, $input: OrderFulfillInput!) {
+  orderFulfill(order: $order, input: $input) {
+    order {
+      status
+      fulfillments {
+        id
+        status
+        created
+      }
+      id
+    }
+    fulfillments {
+      id
+      status
+    }
+    errors {
+      message
+      code
+      field
+    }
+  }
+}
+"""
+
+
+def order_fulfill(
+    staff_api_client,
+    id,
+    input,
+):
+    variables = {
+        "order": id,
+        "input": input,
+    }
+    response = staff_api_client.post_graphql(
+        ORDER_FULFILL_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["orderFulfill"]
+
+    errors = data["errors"]
+    assert errors == []
+
+    return data

--- a/saleor/tests/e2e/orders/utils/order_fulfill_add_tracking.py
+++ b/saleor/tests/e2e/orders/utils/order_fulfill_add_tracking.py
@@ -1,0 +1,50 @@
+from ...utils import get_graphql_content
+
+ORDER_FULFILLMENT_UPDATE_TRACKING = """
+mutation OrderFulfillmentUpdateTracking(
+  $id: ID!
+  $input: FulfillmentUpdateTrackingInput!
+) {
+  orderFulfillmentUpdateTracking(id: $id, input: $input) {
+    errors {
+      message
+      code
+      field
+    }
+    order {
+      id
+      status
+      fulfillments {
+        id
+        status
+        trackingNumber
+      }
+    }
+  }
+}
+"""
+
+
+def order_add_tracking(
+    staff_api_client,
+    fulfillment_id,
+    tracking_number,
+):
+    variables = {
+        "id": fulfillment_id,
+        "input": {
+            "trackingNumber": tracking_number,
+            "notifyCustomer": True,
+        },
+    }
+
+    response = staff_api_client.post_graphql(
+        ORDER_FULFILLMENT_UPDATE_TRACKING, variables
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["orderFulfillmentUpdateTracking"]["errors"] == []
+
+    data = content["data"]["orderFulfillmentUpdateTracking"]["order"]
+
+    return data

--- a/saleor/tests/e2e/orders/utils/order_lines_create.py
+++ b/saleor/tests/e2e/orders/utils/order_lines_create.py
@@ -7,6 +7,7 @@ mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]!) {
       id
       shippingMethods { id }
       lines {
+        id
         quantity
         variant {
           id

--- a/saleor/tests/e2e/shop/utils/shop_update_settings.py
+++ b/saleor/tests/e2e/shop/utils/shop_update_settings.py
@@ -10,18 +10,15 @@ mutation ShopSettingsUpdate($input: ShopSettingsInput!) {
     }
     shop {
       enableAccountConfirmationByEmail
+      fulfillmentAutoApprove
     }
   }
 }
 """
 
 
-def update_shop_settings(staff_api_client, enableAccountConfirmationByEmail=False):
-    variables = {
-        "input": {
-            "enableAccountConfirmationByEmail": enableAccountConfirmationByEmail,
-        }
-    }
+def update_shop_settings(staff_api_client, input):
+    variables = {"input": input}
 
     response = staff_api_client.post_graphql(SHOP_SETTING_UPDATE_MUTATION, variables)
     content = get_graphql_content(response)
@@ -29,6 +26,5 @@ def update_shop_settings(staff_api_client, enableAccountConfirmationByEmail=Fals
     assert content["data"]["shopSettingsUpdate"]["errors"] == []
 
     data = content["data"]["shopSettingsUpdate"]["shop"]
-    assert data["enableAccountConfirmationByEmail"] == enableAccountConfirmationByEmail
 
     return data


### PR DESCRIPTION
I want to merge this change because it covers TC [CORE_0219](https://saleor.testmo.net/repositories/5?group_id=112&sort_column=repository_cases:custom_tc_id&sort_direction=asc&case_id=4458) - Staff should be able to fulfill order and add tracking number

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
