### PR TITLE
Move update product search vector to celery task

### DIFF
--- a/saleor/graphql/attribute/bulk_mutations.py
+++ b/saleor/graphql/attribute/bulk_mutations.py
@@ -4,7 +4,6 @@ from django.db.models import Exists, OuterRef, Q
 from ...attribute import models
 from ...permission.enums import PageTypePermissions
 from ...product import models as product_models
-from ...product.search import update_products_search_vector
 from ...webhook.event_types import WebhookEventAsyncType
 from ..core import ResolveInfo
 from ..core.mutations import ModelBulkDeleteMutation
@@ -44,8 +43,8 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
         _, attribute_pks = resolve_global_ids_to_primary_keys(ids, "Attribute")
         product_ids = cls.get_product_ids_to_update(attribute_pks)
         response = super().perform_mutation(root, info, ids=ids)
-        update_products_search_vector(
-            product_models.Product.objects.filter(id__in=product_ids)
+        product_models.Product.objects.filter(id__in=product_ids).update(
+            search_index_dirty=True
         )
         return response
 
@@ -118,8 +117,8 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
         _, attribute_pks = resolve_global_ids_to_primary_keys(ids, "AttributeValue")
         product_ids = cls.get_product_ids_to_update(attribute_pks)
         response = super().perform_mutation(root, info, ids=ids)
-        update_products_search_vector(
-            product_models.Product.objects.filter(id__in=product_ids)
+        product_models.Product.objects.filter(id__in=product_ids).update(
+            search_index_dirty=True
         )
         return response
 

--- a/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_bulk_create.py
@@ -12,7 +12,6 @@ from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import ProductPermissions
 from ....product import models
 from ....product.error_codes import ProductVariantBulkErrorCode
-from ....product.search import update_product_search_vector
 from ....product.tasks import update_product_discounted_price_task
 from ....warehouse import models as warehouse_models
 from ...attribute.types import (
@@ -920,7 +919,8 @@ class ProductVariantBulkCreate(BaseMutation):
 
         # Recalculate the "discounted price" for the parent product
         update_product_discounted_price_task.delay(product.pk)
-        update_product_search_vector(product)
+        product.search_index_dirty = True
+        product.save(update_fields=["search_index_dirty"])
 
         for instance in instances:
             cls.call_event(manager.product_variant_created, instance.node)

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -11,7 +11,6 @@ from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import ProductPermissions, ProductTypePermissions
 from ....product import models
 from ....product.error_codes import ProductErrorCode
-from ....product.search import update_products_search_vector
 from ...attribute.mutations import (
     BaseReorderAttributesMutation,
     BaseReorderAttributeValuesMutation,
@@ -358,7 +357,7 @@ class ProductAttributeUnassign(BaseMutation):
         cls.save_field_values(product_type, "product_attributes", attribute_pks)
         cls.save_field_values(product_type, "variant_attributes", attribute_pks)
 
-        update_products_search_vector(product_type.products.all())
+        product_type.products.all().update(search_index_dirty=True)
 
         return cls(product_type=product_type)
 

--- a/saleor/graphql/product/mutations/product/product_update.py
+++ b/saleor/graphql/product/mutations/product/product_update.py
@@ -5,7 +5,6 @@ import graphene
 from .....attribute import models as attribute_models
 from .....permission.enums import ProductPermissions
 from .....product import models
-from .....product.search import update_product_search_vector
 from .....product.tasks import update_product_discounted_price_task
 from ....attribute.utils import AttributeAssignmentMixin, AttrValuesInput
 from ....core import ResolveInfo
@@ -53,7 +52,6 @@ class ProductUpdate(ProductCreate, ModelWithExtRefMutation):
     @classmethod
     def post_save_action(cls, info: ResolveInfo, instance, cleaned_input):
         product = models.Product.objects.prefetched_for_webhook().get(pk=instance.pk)
-        update_product_search_vector(instance)
         if "category" in cleaned_input or "collections" in cleaned_input:
             update_product_discounted_price_task.delay(instance.id)
         manager = get_plugin_manager_promise(info.context).get()

--- a/saleor/graphql/product/mutations/product_variant/product_variant_create.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_create.py
@@ -11,7 +11,6 @@ from .....core.tracing import traced_atomic_transaction
 from .....permission.enums import ProductPermissions
 from .....product import models
 from .....product.error_codes import ProductErrorCode
-from .....product.search import update_product_search_vector
 from .....product.tasks import update_product_discounted_price_task
 from .....product.utils.variants import generate_and_set_variant_name
 from ....attribute.types import AttributeValueInput
@@ -329,7 +328,8 @@ class ProductVariantCreate(ModelMutation):
                 generate_and_set_variant_name(instance, cleaned_input.get("sku"))
 
             manager = get_plugin_manager_promise(info.context).get()
-            update_product_search_vector(instance.product)
+            instance.product.search_index_dirty = True
+            instance.product.save(update_fields=["search_index_dirty"])
             event_to_call = (
                 manager.product_variant_created
                 if new_variant

--- a/saleor/graphql/product/tests/mutations/test_product_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_create.py
@@ -181,6 +181,7 @@ def test_create_product(
     assert color_value_slug in values
 
     product = Product.objects.first()
+    assert product.search_index_dirty is True
     assert product.metadata == {metadata_key: metadata_value}
     assert product.private_metadata == {metadata_key: metadata_value}
 

--- a/saleor/graphql/product/tests/mutations/test_product_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_update.py
@@ -155,6 +155,7 @@ def test_update_product(
     product.refresh_from_db()
 
     # then
+    assert product.search_index_dirty is True
     assert data["errors"] == []
     assert data["product"]["name"] == product_name
     assert data["product"]["slug"] == product_slug

--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -104,8 +104,10 @@ def test_product_variant_bulk_update(
     content = get_graphql_content(response)
     flush_post_commit_hooks()
     data = content["data"]["productVariantBulkUpdate"]
+    product_with_single_variant.refresh_from_db(fields=["search_index_dirty"])
 
     # then
+    assert product_with_single_variant.search_index_dirty is True
     assert not data["results"][0]["errors"]
     assert data["count"] == 1
     variant_data = data["results"][0]["productVariant"]

--- a/saleor/product/search.py
+++ b/saleor/product/search.py
@@ -53,13 +53,6 @@ def update_products_search_vector(products: "QuerySet", use_batches=True):
         _prep_product_search_vector_index(products)
 
 
-def update_product_search_vector(product: "Product"):
-    product.search_vector = FlatConcatSearchVector(
-        *prepare_product_search_vector_value(product)
-    )
-    product.save(update_fields=["search_vector", "updated_at"])
-
-
 def prepare_product_search_vector_value(
     product: "Product", *, already_prefetched=False
 ) -> List[NoValidationSearchVector]:

--- a/saleor/product/tests/test_product_search.py
+++ b/saleor/product/tests/test_product_search.py
@@ -1,25 +1,5 @@
 from ..models import Product
-from ..search import update_product_search_vector, update_products_search_vector
-
-
-def test_update_product_search_vector(product_type, category):
-    # given
-    name = "Test product"
-    description = "Test description"
-    product = Product.objects.create(
-        name=name,
-        slug="test-product-111",
-        product_type=product_type,
-        category=category,
-        description_plaintext=description,
-    )
-    assert not product.search_vector
-
-    # when
-    update_product_search_vector(product)
-
-    # then
-    assert product.search_vector
+from ..search import update_products_search_vector
 
 
 def test_update_products_search_vector(product_list):


### PR DESCRIPTION
I want to merge this change because it is a pot of https://github.com/saleor/saleor/pull/14270
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
