### PR TITLE
[TEST] Order cancel fulfillment CORE_0220 & Order create invoice with metadata CORE_0212

### DIFF
--- a/saleor/tests/e2e/orders/test_order_cancel_fulfillment.py
+++ b/saleor/tests/e2e/orders/test_order_cancel_fulfillment.py
@@ -1,0 +1,158 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils import prepare_shop, update_shop_settings
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    mark_order_paid,
+    order_fulfill,
+    order_fulfillment_cancel,
+    order_lines_create,
+    order_query,
+)
+
+
+def prepare_order(e2e_staff_api_client):
+    price = 10
+    (
+        warehouse_id,
+        channel_id,
+        _channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    data = {"fulfillmentAutoApprove": True, "fulfillmentAllowUnpaid": False}
+    update_shop_settings(e2e_staff_api_client, data)
+
+    _product_id, product_variant_id, _product_variant_price = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    draft_order_input = {
+        "channelId": channel_id,
+        "userEmail": "test_user@test.com",
+        "shippingAddress": DEFAULT_ADDRESS,
+        "billingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        draft_order_input,
+    )
+    order_id = data["order"]["id"]
+
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        }
+    ]
+    data = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_line_id = data["order"]["lines"][0]["id"]
+
+    input = {"shippingMethod": shipping_method_id}
+    draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+
+    return (
+        order_id,
+        product_variant_id,
+        warehouse_id,
+        order_line_id,
+    )
+
+
+@pytest.mark.e2e
+def test_order_cancel_fulfillment_CORE_0220(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+    permission_manage_settings,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_settings,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        order_id,
+        product_variant_id,
+        warehouse_id,
+        order_line_id,
+    ) = prepare_order(e2e_staff_api_client)
+
+    # Step 1 - Complete the order
+    order = draft_order_complete(
+        e2e_staff_api_client,
+        order_id,
+    )
+    order_complete_id = order["order"]["id"]
+    assert order_complete_id == order_id
+    order_line = order["order"]["lines"][0]
+    assert order_line["productVariantId"] == product_variant_id
+    assert order["order"]["status"] == "UNFULFILLED"
+
+    # Step 2 - Mark order as paid
+    order_paid_data = mark_order_paid(
+        e2e_staff_api_client,
+        order_id,
+    )
+    assert order_paid_data["order"]["isPaid"] is True
+    assert order_paid_data["order"]["paymentStatus"] == "FULLY_CHARGED"
+    assert order_paid_data["order"]["status"] == "UNFULFILLED"
+
+    # Step 3 - Fulfill the order and check the status
+    input = {
+        "lines": [
+            {
+                "orderLineId": order_line_id,
+                "stocks": [
+                    {
+                        "quantity": 1,
+                        "warehouse": warehouse_id,
+                    }
+                ],
+            }
+        ],
+        "notifyCustomer": True,
+        "allowStockToBeExceeded": False,
+    }
+    order_data = order_fulfill(e2e_staff_api_client, order_id, input)
+    fulfillment_id = order_data["order"]["fulfillments"][0]["id"]
+    assert order_data["order"]["fulfillments"] != []
+    assert order_data["order"]["fulfillments"][0]["status"] == "FULFILLED"
+
+    order = order_query(e2e_staff_api_client, order_id)
+    assert order["status"] == "FULFILLED"
+
+    # Step 4 - Cancel the fulfillment
+    order_data = order_fulfillment_cancel(
+        e2e_staff_api_client,
+        fulfillment_id,
+        warehouse_id,
+    )
+    assert order_data["order"]["status"] == "UNFULFILLED"
+    assert order_data["order"]["fulfillments"] != []
+    assert order_data["order"]["fulfillments"][0]["status"] == "CANCELED"

--- a/saleor/tests/e2e/orders/test_order_create_invoice_with_metadata.py
+++ b/saleor/tests/e2e/orders/test_order_create_invoice_with_metadata.py
@@ -1,0 +1,139 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils import prepare_shop, update_shop_settings
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    mark_order_paid,
+    order_fulfill,
+    order_invoice_create,
+    order_lines_create,
+    order_query,
+)
+
+
+def prepare_fulfilled_order(e2e_staff_api_client):
+    price = 10
+    (
+        warehouse_id,
+        channel_id,
+        _channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    data = {"fulfillmentAutoApprove": True, "fulfillmentAllowUnpaid": False}
+    update_shop_settings(e2e_staff_api_client, data)
+
+    _product_id, product_variant_id, _product_variant_price = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        price,
+    )
+
+    draft_order_input = {
+        "channelId": channel_id,
+        "userEmail": "test_user@test.com",
+        "shippingAddress": DEFAULT_ADDRESS,
+        "billingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        draft_order_input,
+    )
+    order_id = data["order"]["id"]
+
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        }
+    ]
+    data = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_line_id = data["order"]["lines"][0]["id"]
+
+    input = {"shippingMethod": shipping_method_id}
+    draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+    draft_order_complete(
+        e2e_staff_api_client,
+        order_id,
+    )
+
+    mark_order_paid(
+        e2e_staff_api_client,
+        order_id,
+    )
+
+    input = {
+        "lines": [
+            {
+                "orderLineId": order_line_id,
+                "stocks": [
+                    {
+                        "quantity": 1,
+                        "warehouse": warehouse_id,
+                    }
+                ],
+            }
+        ],
+        "notifyCustomer": True,
+        "allowStockToBeExceeded": False,
+    }
+    order_fulfill(e2e_staff_api_client, order_id, input)
+
+    return (order_id,)
+
+
+@pytest.mark.e2e
+def test_order_create_invoice_with_metadata_CORE_0212(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_orders,
+    permission_manage_settings,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_orders,
+        permission_manage_settings,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (order_id,) = prepare_fulfilled_order(e2e_staff_api_client)
+
+    # Step 1 - Create invoice for the order
+    order = order_query(e2e_staff_api_client, order_id)
+    assert order["status"] == "FULFILLED"
+    invoice_number = "FV_123"
+    invoice_url = "https://example.com"
+    invoice_metadata = [{"key": "invoice_code", "value": "abc"}]
+    invoice_private_metadata = [{"key": "invoice_code", "value": "priv-abc"}]
+    input = {
+        "number": invoice_number,
+        "url": invoice_url,
+        "metadata": invoice_metadata,
+        "privateMetadata": invoice_private_metadata,
+    }
+    data = order_invoice_create(e2e_staff_api_client, order_id, input)
+    assert data["invoice"]["number"] == invoice_number
+    assert data["invoice"]["url"] == invoice_url
+    assert data["invoice"]["metadata"] == invoice_metadata
+    assert data["invoice"]["privateMetadata"] == invoice_private_metadata

--- a/saleor/tests/e2e/orders/utils/__init__.py
+++ b/saleor/tests/e2e/orders/utils/__init__.py
@@ -7,6 +7,8 @@ from .order_create_from_checkout import order_create_from_checkout
 from .order_discount_add import order_discount_add
 from .order_fulfill import order_fulfill
 from .order_fulfill_add_tracking import order_add_tracking
+from .order_fulfillment_cancel import order_fulfillment_cancel
+from .order_invoice_create import order_invoice_create
 from .order_lines_create import order_lines_create
 from .order_mark_as_paid import mark_order_paid
 from .order_query import order_query
@@ -28,4 +30,6 @@ __all__ = [
     "order_void",
     "order_fulfill",
     "order_add_tracking",
+    "order_fulfillment_cancel",
+    "order_invoice_create",
 ]

--- a/saleor/tests/e2e/orders/utils/order_fulfillment_cancel.py
+++ b/saleor/tests/e2e/orders/utils/order_fulfillment_cancel.py
@@ -1,0 +1,44 @@
+from ...utils import get_graphql_content
+
+ORDER_FULFILLMENT_CANCEL_MUTATION = """
+mutation OrderFulfillmentCancel($id: ID!, $input: FulfillmentCancelInput!) {
+  orderFulfillmentCancel(id: $id, input: $input) {
+    errors {
+      message
+      field
+      code
+    }
+    order {
+      id
+      status
+      fulfillments {
+        id
+        status
+      }
+    }
+  }
+}
+"""
+
+
+def order_fulfillment_cancel(
+    staff_api_client,
+    fulfillment_id,
+    warehouse_id,
+):
+    variables = {
+        "id": fulfillment_id,
+        "input": {"warehouseId": warehouse_id},
+    }
+    response = staff_api_client.post_graphql(
+        ORDER_FULFILLMENT_CANCEL_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["orderFulfillmentCancel"]
+
+    errors = data["errors"]
+    assert errors == []
+
+    return data

--- a/saleor/tests/e2e/orders/utils/order_invoice_create.py
+++ b/saleor/tests/e2e/orders/utils/order_invoice_create.py
@@ -1,0 +1,48 @@
+from ...utils import get_graphql_content
+
+ORDER_INVOICE_CREATE_MUTATION = """
+mutation InvoiceCreate($id: ID!, $input: InvoiceCreateInput!){
+  invoiceCreate(orderId: $id,
+  input: $input,
+  ) {
+    errors {
+      code
+      field
+      message
+    }
+    invoice {
+      number
+      url
+      createdAt
+      metadata{
+        key
+        value
+      }
+      privateMetadata{
+        key
+        value
+      }
+    }
+  }
+}
+"""
+
+
+def order_invoice_create(
+    staff_api_client,
+    order_id,
+    input,
+):
+    variables = {
+        "id": order_id,
+        "input": input,
+    }
+    response = staff_api_client.post_graphql(
+        ORDER_INVOICE_CREATE_MUTATION,
+        variables=variables,
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["invoiceCreate"]
+    assert data["errors"] == []
+
+    return data


### PR DESCRIPTION
I want to merge this change because it covers:
- [CORE_0220](https://saleor.testmo.net/repositories/5?group_id=112&sort_column=repository_cases:custom_tc_id&sort_direction=asc&case_id=4459) - Staff should be able to cancel fulfillment in order
- [CORE_0212](https://saleor.testmo.net/repositories/5?group_id=112&sort_column=repository_cases:custom_tc_id&sort_direction=asc&case_id=811) - Staff should be able to add metadata when creating invoice

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
