### PR TITLE
Deprecate `OrderSettingsUpdate` mutation

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -15185,7 +15185,7 @@ type Mutation {
   ): ShopAddressUpdate @doc(category: "Shop")
 
   """
-  Update shop order settings across all channels. Returns `orderSettings` for the first `channel` in alphabetical order.  
+  Update shop order settings across all channels. Returns `orderSettings` for the first `channel` in alphabetical order. This field will be removed in Saleor 4.0. Use `channelUpdate` instead to update order settings for a specific channel. 
   
   Requires one of the following permissions: MANAGE_ORDERS.
   """
@@ -20932,7 +20932,7 @@ type ShopAddressUpdate @doc(category: "Shop") {
 }
 
 """
-Update shop order settings across all channels. Returns `orderSettings` for the first `channel` in alphabetical order.  
+Update shop order settings across all channels. Returns `orderSettings` for the first `channel` in alphabetical order. This field will be removed in Saleor 4.0. Use `channelUpdate` instead to update order settings for a specific channel. 
 
 Requires one of the following permissions: MANAGE_ORDERS.
 """
@@ -20961,6 +20961,7 @@ enum OrderSettingsErrorCode @doc(category: "Orders") {
   INVALID
 }
 
+"""This field will be removed in Saleor 4.0."""
 input OrderSettingsUpdateInput @doc(category: "Orders") {
   """
   When disabled, all new orders from checkout will be marked as unconfirmed. When enabled orders from checkout will become unfulfilled immediately. By default set to True

--- a/saleor/graphql/shop/mutations/order_settings_update.py
+++ b/saleor/graphql/shop/mutations/order_settings_update.py
@@ -6,6 +6,7 @@ from ....permission.enums import OrderPermissions
 from ....site.error_codes import OrderSettingsErrorCode
 from ...channel.types import OrderSettings
 from ...core import ResolveInfo
+from ...core.descriptions import DEPRECATED_IN_3X_FIELD
 from ...core.doc_category import DOC_CATEGORY_ORDERS
 from ...core.mutations import BaseMutation
 from ...core.types import BaseInputObjectType, OrderSettingsError
@@ -26,6 +27,7 @@ class OrderSettingsUpdateInput(BaseInputObjectType):
 
     class Meta:
         doc_category = DOC_CATEGORY_ORDERS
+        description = DEPRECATED_IN_3X_FIELD
 
 
 class OrderSettingsUpdate(BaseMutation):
@@ -40,6 +42,8 @@ class OrderSettingsUpdate(BaseMutation):
         description = (
             "Update shop order settings across all channels. "
             "Returns `orderSettings` for the first `channel` in alphabetical order. "
+            f"{DEPRECATED_IN_3X_FIELD} Use `channelUpdate` instead to update "
+            "order settings for a specific channel."
         )
         doc_category = DOC_CATEGORY_ORDERS
         permissions = (OrderPermissions.MANAGE_ORDERS,)


### PR DESCRIPTION
Deprecate `OrderSettingsUpdate` mutation as `orderSettings` were moved to `channel`

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
