### PR TITLE
Add transaction items deletion to cleardb command

### DIFF
--- a/saleor/core/management/commands/cleardb.py
+++ b/saleor/core/management/commands/cleardb.py
@@ -16,7 +16,7 @@ from ....discount.models import Promotion, Voucher
 from ....giftcard.models import GiftCard
 from ....order.models import Order
 from ....page.models import Page, PageType
-from ....payment.models import Payment, Transaction
+from ....payment.models import Payment, Transaction, TransactionItem
 from ....product.models import Category, Collection, Product, ProductType
 from ....shipping.models import ShippingMethod, ShippingZone
 from ....warehouse.models import Warehouse
@@ -45,6 +45,9 @@ class Command(BaseCommand):
 
         Checkout.objects.all().delete()
         self.stdout.write("Removed checkouts")
+
+        TransactionItem.objects.all().delete()
+        self.stdout.write("Removed transaction items")
 
         Transaction.objects.all().delete()
         self.stdout.write("Removed transactions")

--- a/saleor/core/tests/test_core.py
+++ b/saleor/core/tests/test_core.py
@@ -14,6 +14,7 @@ from ...channel.models import Channel
 from ...discount.models import Promotion, PromotionRule, Voucher, VoucherChannelListing
 from ...giftcard.models import GiftCard, GiftCardEvent
 from ...order.models import Order
+from ...payment.models import TransactionItem
 from ...product import ProductTypeKind
 from ...product.models import ProductType
 from ...shipping.models import ShippingZone
@@ -418,6 +419,17 @@ def test_cleardb_preserves_data(admin_user, app, site_settings, staff_user):
     app.refresh_from_db()
     site_settings.refresh_from_db()
     staff_user.refresh_from_db()
+
+
+@override_settings(DEBUG=True)
+def test_cleardb_remove_orders_and_transactions(transaction_item):
+    transaction_item.refresh_from_db()
+
+    call_command("cleardb")
+    with pytest.raises(TransactionItem.DoesNotExist):
+        transaction_item.refresh_from_db()
+    with pytest.raises(Order.DoesNotExist):
+        transaction_item.order.refresh_from_db()
 
 
 def test_prepare_unique_attribute_value_slug(color_attribute):


### PR DESCRIPTION
I want to merge this change because it is a backport of  #14198
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
