### PR TITLE
[Test] Checkout calculate simple taxes base on product type tax class rate

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
+++ b/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
@@ -237,7 +237,7 @@ def test_checkout_calculate_simple_tax_based_on_shipping_country_CORE_2001(
     )
     total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
     calculated_total = float(variant_price) + float(shipping_price)
-    total_gross_amount = calculated_total
+    assert total_gross_amount == calculated_total
     total_tax = calculated_tax + shipping_tax
     assert checkout_data["totalPrice"]["tax"]["amount"] == total_tax
 

--- a/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_product_type_tax_class.py
+++ b/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_product_type_tax_class.py
@@ -1,0 +1,231 @@
+import pytest
+
+from ..product.utils import (
+    create_category,
+    create_product,
+    create_product_channel_listing,
+    create_product_type,
+    create_product_variant,
+    create_product_variant_channel_listing,
+    update_product_type,
+)
+from ..shop.utils.preparing_shop import prepare_shop
+from ..taxes.utils import (
+    create_tax_class,
+    get_tax_configurations,
+    update_country_tax_rates,
+    update_tax_configuration,
+)
+from ..utils import assign_permissions
+from .utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+)
+
+
+def prepare_tax_configuration(
+    e2e_staff_api_client,
+    channel_slug,
+    country_code,
+    country_tax_rate,
+    product_type_tax_rate,
+):
+    tax_config_data = get_tax_configurations(e2e_staff_api_client)
+    channel_tax_config = tax_config_data[0]["node"]
+    assert channel_tax_config["channel"]["slug"] == channel_slug
+    tax_config_id = channel_tax_config["id"]
+
+    tax_config_data = update_tax_configuration(
+        e2e_staff_api_client,
+        tax_config_id,
+        charge_taxes=True,
+        tax_calculation_strategy="FLAT_RATES",
+        display_gross_prices=True,
+        prices_entered_with_tax=False,
+    )
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country_code,
+        [{"rate": country_tax_rate}],
+    )
+
+    country_rates = [{"countryCode": country_code, "rate": product_type_tax_rate}]
+    tax_class_data = create_tax_class(
+        e2e_staff_api_client,
+        "Product type tax class",
+        country_rates,
+    )
+    tax_class_id = tax_class_data["id"]
+
+    return country_tax_rate, product_type_tax_rate, tax_class_id
+
+
+def prepare_product(
+    e2e_staff_api_client,
+    warehouse_id,
+    channel_id,
+    variant_price,
+):
+    product_type_data = create_product_type(
+        e2e_staff_api_client,
+    )
+    product_type_id = product_type_data["id"]
+
+    category_data = create_category(e2e_staff_api_client)
+    category_id = category_data["id"]
+
+    product_data = create_product(
+        e2e_staff_api_client,
+        product_type_id,
+        category_id,
+    )
+    product_id = product_data["id"]
+
+    create_product_channel_listing(
+        e2e_staff_api_client,
+        product_id,
+        channel_id,
+    )
+
+    stocks = [
+        {
+            "warehouse": warehouse_id,
+            "quantity": 5,
+        }
+    ]
+    product_variant_data = create_product_variant(
+        e2e_staff_api_client,
+        product_id,
+        stocks=stocks,
+    )
+    product_variant_id = product_variant_data["id"]
+
+    product_variant_channel_listing_data = create_product_variant_channel_listing(
+        e2e_staff_api_client,
+        product_variant_id,
+        channel_id,
+        variant_price,
+    )
+    product_variant_price = product_variant_channel_listing_data["channelListings"][0][
+        "price"
+    ]["amount"]
+
+    return product_variant_id, product_variant_price, product_type_id
+
+
+@pytest.mark.e2e
+def test_checkout_calculate_simple_tax_based_on_product_type_tax_class_CORE_2003(
+    e2e_staff_api_client,
+    e2e_not_logged_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_taxes,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_taxes,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    country_tax_rate, product_type_tax_rate, tax_class_id = prepare_tax_configuration(
+        e2e_staff_api_client,
+        channel_slug,
+        country_code="US",
+        country_tax_rate=10,
+        product_type_tax_rate=8,
+    )
+
+    variant_price = "155.88"
+    (product_variant_id, product_variant_price, product_type_id) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
+    product_type_tax_class = {"taxClass": tax_class_id}
+    update_product_type(e2e_staff_api_client, product_type_id, product_type_tax_class)
+
+    # Step 1 - Create checkout and check prices
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
+    ]
+
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+
+    assert checkout_data["isShippingRequired"] is True
+    variant_price = float(variant_price)
+    assert checkout_data["totalPrice"]["net"]["amount"] == variant_price
+    calculated_tax = round(variant_price * (product_type_tax_rate / 100), 2)
+    assert checkout_data["totalPrice"]["tax"]["amount"] == calculated_tax
+    assert checkout_data["totalPrice"]["gross"]["amount"] == round(
+        variant_price + calculated_tax, 2
+    )
+    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
+
+    # Step 2 - Set DeliveryMethod for checkout and check prices
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    assert checkout_data["shippingPrice"]["net"]["amount"] == float(shipping_price)
+    shipping_tax = round((float(shipping_price) * (country_tax_rate / 100)), 2)
+    assert checkout_data["shippingPrice"]["tax"]["amount"] == shipping_tax
+    assert (
+        checkout_data["shippingPrice"]["gross"]["amount"]
+        == float(shipping_price) + shipping_tax
+    )
+
+    total_tax = calculated_tax + shipping_tax
+    assert checkout_data["totalPrice"]["tax"]["amount"] == total_tax
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    calculated_total = round(variant_price + shipping_price + total_tax, 2)
+    assert total_gross_amount == calculated_total
+
+    # Step 3 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_not_logged_api_client,
+        checkout_id,
+        total_gross_amount,
+    )
+
+    # Step 4 - Complete checkout.
+    order_data = checkout_complete(
+        e2e_not_logged_api_client,
+        checkout_id,
+    )
+    assert order_data["isShippingRequired"] is True
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["total"]["tax"]["amount"] == total_tax
+    assert order_data["total"]["net"]["amount"] == round(
+        calculated_total - total_tax, 2
+    )

--- a/saleor/tests/e2e/checkout/utils/checkout_create.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_create.py
@@ -24,6 +24,12 @@ mutation CreateCheckout($input: CheckoutCreateInput!) {
         gross {
           amount
         }
+        net {
+          amount
+        }
+        tax {
+          amount
+        }
       }
       isShippingRequired
       shippingMethods {

--- a/saleor/tests/e2e/product/utils/__init__.py
+++ b/saleor/tests/e2e/product/utils/__init__.py
@@ -13,6 +13,7 @@ from .product_channel_listing import (
 )
 from .product_query import get_product
 from .product_type import create_product_type
+from .product_type_update import update_product_type
 from .product_variant import create_product_variant, raw_create_product_variant
 from .product_variant_bulk_create import create_variants_in_bulk
 from .product_variant_channel_listing import (
@@ -38,4 +39,5 @@ __all__ = [
     "get_product",
     "add_product_to_collection",
     "raw_create_product_variant_channel_listing",
+    "update_product_type",
 ]

--- a/saleor/tests/e2e/product/utils/product_type_update.py
+++ b/saleor/tests/e2e/product/utils/product_type_update.py
@@ -1,0 +1,54 @@
+from ...utils import get_graphql_content
+
+PRODUCT_TYPE_UPDATE_MUTATION = """
+mutation ProductTypeUpdate($id: ID!, $input: ProductTypeInput!) {
+  productTypeUpdate(id: $id, input: $input) {
+    errors {
+      field
+      message
+      code
+    }
+    productType {
+      id
+      name
+      slug
+      kind
+      isShippingRequired
+      isDigital
+      hasVariants
+      productAttributes {
+        id
+      }
+      assignedVariantAttributes {
+        attribute {
+          id
+        }
+        variantSelection
+      }
+      taxClass {
+        id
+        name
+      }
+    }
+    __typename
+  }
+}
+"""
+
+
+def update_product_type(
+    staff_api_client,
+    product_type_id,
+    input,
+):
+    variables = {"id": product_type_id, "input": input}
+
+    response = staff_api_client.post_graphql(PRODUCT_TYPE_UPDATE_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    assert content["data"]["productTypeUpdate"]["errors"] == []
+
+    data = content["data"]["productTypeUpdate"]["productType"]
+    assert data["id"] is not None
+
+    return data

--- a/saleor/tests/e2e/taxes/utils/__init__.py
+++ b/saleor/tests/e2e/taxes/utils/__init__.py
@@ -1,4 +1,5 @@
 from .query_tax_configurations import get_tax_configurations
+from .tax_class_create import create_tax_class
 from .tax_configuration_update import update_tax_configuration
 from .tax_country_configuration_update import update_country_tax_rates
 
@@ -6,4 +7,5 @@ __all__ = [
     "get_tax_configurations",
     "update_tax_configuration",
     "update_country_tax_rates",
+    "create_tax_class",
 ]

--- a/saleor/tests/e2e/taxes/utils/tax_class_create.py
+++ b/saleor/tests/e2e/taxes/utils/tax_class_create.py
@@ -1,0 +1,44 @@
+from ...utils import get_graphql_content
+
+TAX_CLASS_CREATE_MUTATION = """
+mutation TaxClassCreate($input: TaxClassCreateInput!) {
+  taxClassCreate(input: $input) {
+    errors {
+      field
+      message
+      code
+    }
+    taxClass {
+      id
+      name
+      countries {
+        country {
+          code
+        }
+        rate
+        taxClass {
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def create_tax_class(
+    staff_api_client,
+    tax_class_name="Test Tax Class",
+    country_rates=None,
+):
+    variables = {"input": {"name": tax_class_name, "createCountryRates": country_rates}}
+
+    response = staff_api_client.post_graphql(TAX_CLASS_CREATE_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    assert content["data"]["taxClassCreate"]["errors"] == []
+
+    data = content["data"]["taxClassCreate"]["taxClass"]
+    assert data["id"] is not None
+
+    return data


### PR DESCRIPTION
I want to merge this change because it adds test for [CORE_2003](https://saleor.testmo.net/repositories/5?group_id=461&sort_column=repository_cases:tags&sort_direction=asc&case_id=4725) Checkout calculate simple taxes base on product type tax class rate

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
