### PR TITLE
Set voucher name for old vouchers

### DIFF
--- a/saleor/discount/migrations/0057_move_codes_to_new_model.py
+++ b/saleor/discount/migrations/0057_move_codes_to_new_model.py
@@ -31,6 +31,7 @@ def move_codes_to_new_model(apps, schema_editor):
         voucher_codes = []
         vouchers = Voucher.objects.filter(pk__in=batch_pks)
 
+        vouchers_to_update = []
         for voucher in vouchers.values("id", "code", "used"):
             voucher_codes.append(
                 VoucherCode(
@@ -39,7 +40,12 @@ def move_codes_to_new_model(apps, schema_editor):
                     used=voucher["used"],
                 )
             )
+            if not voucher.name:
+                voucher.name = voucher["code"]
+                vouchers_to_update.append(voucher)
+
         VoucherCode.objects.bulk_create(voucher_codes)
+        Voucher.objects.bulk_update(vouchers, ["name"])
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
I want to merge this change because it fixes names for old voucher during migration.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
