### PR TITLE
Fix descriptions to not include storefront

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -724,8 +724,7 @@ class Checkout(ModelObjectType[models.Checkout]):
     )
     display_gross_prices = graphene.Boolean(
         description=(
-            "Determines whether checkout prices should include taxes when displayed "
-            "in a storefront." + ADDED_IN_39
+            "Determines whether displayed prices should include taxes." + ADDED_IN_39
         ),
         required=True,
     )

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -509,8 +509,7 @@ class OrderBulkCreateInput(BaseInputObjectType):
         LanguageCodeEnum, required=True, description="Order language code."
     )
     display_gross_prices = graphene.Boolean(
-        description="Determines whether checkout prices should include taxes, "
-        "when displayed in a storefront.",
+        description=("Determines whether displayed prices should include taxes."),
     )
     weight = WeightScalar(description="Weight of the order in kg.")
     redirect_url = graphene.String(

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1288,8 +1288,7 @@ class Order(ModelObjectType[models.Order]):
     )
     display_gross_prices = graphene.Boolean(
         description=(
-            "Determines whether checkout prices should include taxes when displayed "
-            "in a storefront." + ADDED_IN_39
+            "Determines whether displayed prices should include taxes." + ADDED_IN_39
         ),
         required=True,
     )

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -204,8 +204,7 @@ class VariantPricingInfo(BasePricingInfo):
 class ProductPricingInfo(BasePricingInfo):
     display_gross_prices = graphene.Boolean(
         description=(
-            "Determines whether this product's price displayed in a storefront "
-            "should include taxes." + ADDED_IN_39
+            "Determines whether displayed prices should include taxes." + ADDED_IN_39
         ),
         required=True,
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -7926,7 +7926,7 @@ type ProductPricingInfo @doc(category: "Products") {
   discountLocalCurrency: TaxedMoney @deprecated(reason: "This field will be removed in Saleor 4.0. Always returns `null`.")
 
   """
-  Determines whether this product's price displayed in a storefront should include taxes.
+  Determines whether displayed prices should include taxes.
   
   Added in Saleor 3.9.
   """
@@ -9701,9 +9701,7 @@ type TaxConfiguration implements Node & ObjectWithMetadata @doc(category: "Taxes
   """
   taxCalculationStrategy: TaxCalculationStrategy
 
-  """
-  Determines whether prices displayed in a storefront should include taxes.
-  """
+  """Determines whether displayed prices should include taxes."""
   displayGrossPrices: Boolean!
 
   """Determines whether prices are entered with the tax included."""
@@ -9736,7 +9734,7 @@ type TaxConfigurationPerCountry @doc(category: "Taxes") {
   taxCalculationStrategy: TaxCalculationStrategy
 
   """
-  Determines whether prices displayed in a storefront should include taxes for this country.
+  Determines whether displayed prices should include taxes for this country.
   """
   displayGrossPrices: Boolean!
 }
@@ -10654,7 +10652,7 @@ type Checkout implements Node & ObjectWithMetadata @doc(category: "Checkout") {
   transactions: [TransactionItem!]
 
   """
-  Determines whether checkout prices should include taxes when displayed in a storefront.
+  Determines whether displayed prices should include taxes.
   
   Added in Saleor 3.9.
   """
@@ -11527,7 +11525,7 @@ type Order implements Node & ObjectWithMetadata @doc(category: "Orders") {
   errors: [OrderError!]!
 
   """
-  Determines whether checkout prices should include taxes when displayed in a storefront.
+  Determines whether displayed prices should include taxes.
   
   Added in Saleor 3.9.
   """
@@ -20423,9 +20421,7 @@ input TaxConfigurationUpdateInput @doc(category: "Taxes") {
   """
   taxCalculationStrategy: TaxCalculationStrategy
 
-  """
-  Determines whether prices displayed in a storefront should include taxes.
-  """
+  """Determines whether displayed prices should include taxes."""
   displayGrossPrices: Boolean
 
   """Determines whether prices are entered with the tax included."""
@@ -20453,7 +20449,7 @@ input TaxConfigurationPerCountryInput @doc(category: "Taxes") {
   taxCalculationStrategy: TaxCalculationStrategy
 
   """
-  Determines whether prices displayed in a storefront should include taxes for this country.
+  Determines whether displayed prices should include taxes for this country.
   """
   displayGrossPrices: Boolean!
 }
@@ -25933,9 +25929,7 @@ input OrderBulkCreateInput @doc(category: "Orders") {
   """Order language code."""
   languageCode: LanguageCodeEnum!
 
-  """
-  Determines whether checkout prices should include taxes, when displayed in a storefront.
-  """
+  """Determines whether displayed prices should include taxes."""
   displayGrossPrices: Boolean
 
   """Weight of the order in kg."""

--- a/saleor/graphql/tax/mutations/tax_configuration_update.py
+++ b/saleor/graphql/tax/mutations/tax_configuration_update.py
@@ -38,8 +38,7 @@ class TaxConfigurationPerCountryInput(BaseInputObjectType):
     )
     display_gross_prices = graphene.Boolean(
         description=(
-            "Determines whether prices displayed in a storefront should include taxes "
-            "for this country."
+            "Determines whether displayed prices should include taxes for this country."
         ),
         required=True,
     )
@@ -63,9 +62,7 @@ class TaxConfigurationUpdateInput(BaseInputObjectType):
         ),
     )
     display_gross_prices = graphene.Boolean(
-        description=(
-            "Determines whether prices displayed in a storefront should include taxes."
-        )
+        description="Determines whether displayed prices should include taxes."
     )
     prices_entered_with_tax = graphene.Boolean(
         description="Determines whether prices are entered with the tax included."

--- a/saleor/graphql/tax/types.py
+++ b/saleor/graphql/tax/types.py
@@ -38,9 +38,7 @@ class TaxConfiguration(ModelObjectType[models.TaxConfiguration]):
         ),
     )
     display_gross_prices = graphene.Boolean(
-        description=(
-            "Determines whether prices displayed in a storefront should include taxes."
-        ),
+        description="Determines whether displayed prices should include taxes.",
         required=True,
     )
     prices_entered_with_tax = graphene.Boolean(
@@ -96,8 +94,7 @@ class TaxConfigurationPerCountry(ModelObjectType[models.TaxConfigurationPerCount
     )
     display_gross_prices = graphene.Boolean(
         description=(
-            "Determines whether prices displayed in a storefront should include taxes "
-            "for this country."
+            "Determines whether displayed prices should include taxes for this country."
         ),
         required=True,
     )


### PR DESCRIPTION
Fixes https://github.com/saleor/saleor/issues/12492.
The word "Storefront" word is removed from these descriptions, as they may have a wider context.