### PR TITLE
Fix duplicated authorization plugin calls

### DIFF
--- a/saleor/core/auth_backend.py
+++ b/saleor/core/auth_backend.py
@@ -7,6 +7,7 @@ from ..permission.enums import (
     get_permissions_from_codenames,
     get_permissions_from_names,
 )
+from ..plugins.manager import get_plugins_manager
 from .auth import get_token_from_request
 from .jwt import (
     JWT_ACCESS_TYPE,
@@ -108,7 +109,17 @@ class PluginBackend(JSONWebTokenBackend):
     def authenticate(self, request=None, **kwargs):
         if request is None:
             return None
-        manager = AnonymousPluginManagerLoader(request).load("Anonymous").get()
+        # We can't use `AnonymousPluginManagerLoader(request).load("Anonymous").get()`
+        # here because `get()` cause that many Promise are waiting in middle of caching
+        # authenticated user. Which cause as many authentication plugin calls
+        # as many Promise are waiting.
+
+        allow_replica = getattr(request, "allow_replica", True)
+        manager = get_plugins_manager(None, allow_replica)
+
+        # Store created manager in request to be used in other Dataloader.
+        plugin_loader = AnonymousPluginManagerLoader(request)
+        plugin_loader.prime("Anonymous", manager)
         return manager.authenticate_user(request)
 
 

--- a/saleor/graphql/plugins/dataloaders.py
+++ b/saleor/graphql/plugins/dataloaders.py
@@ -39,6 +39,9 @@ class AnonymousPluginManagerLoader(DataLoader):
     context_key = "anonymous_plugin_manager"
 
     def batch_load(self, keys):
+        # When modify this code, modify also code
+        # in `saleor.core.auth_backend.PluginBackend.authenticate`
+
         allow_replica = getattr(self.context, "allow_replica", True)
         return [get_plugins_manager(None, allow_replica) for key in keys]
 

--- a/saleor/graphql/tests/test_context.py
+++ b/saleor/graphql/tests/test_context.py
@@ -1,0 +1,46 @@
+from unittest import mock
+
+import graphene
+
+from .utils import get_graphql_content
+
+QUERY_ORDER_BY_ID = """
+query orderById($id: ID!) {
+  order(id: $id) {
+    lines {
+      totalPrice {
+        __typename
+      }
+    }
+  }
+}
+"""
+
+
+@mock.patch(
+    "saleor.plugins.tests.sample_plugins.SampleAuthorizationPlugin.authenticate_user"
+)
+def test_user_is_cached_on_request(
+    mocked_authenticate_user, api_client, order_with_lines, settings, staff_user
+):
+    """
+    This test case is added to cover edge case when user isn't cached on request
+    due to multiple Promises wait inside PluginBackend.authenticate method.
+    """
+    # given
+    settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.SampleAuthorizationPlugin"]
+    mocked_authenticate_user.return_value = staff_user
+    order = order_with_lines
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {
+        "id": order_id,
+    }
+
+    # when
+    response = api_client.post_graphql(QUERY_ORDER_BY_ID, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["order"]
+    assert len(data["lines"]) > 1
+    mocked_authenticate_user.assert_called_once()

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -462,6 +462,16 @@ class ActiveDummyPaymentGateway(BasePlugin):
         return {"test_response": "success"}
 
 
+class SampleAuthorizationPlugin(BasePlugin):
+    PLUGIN_ID = "saleor.sample.authorization"
+    PLUGIN_NAME = "SampleAuthorization"
+    DEFAULT_ACTIVE = True
+
+    def authenticate_user(self, request, previous_value) -> Optional[User]:
+        # This function will be mocked in test
+        raise NotImplementedError()
+
+
 class InactivePaymentGateway(BasePlugin):
     PLUGIN_ID = "gateway.inactive"
     PLUGIN_NAME = "stripe"


### PR DESCRIPTION
I want to merge this change because it is a port of https://github.com/saleor/saleor/pull/14299

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
