### PR TITLE
[Test] Order calculate simple taxes based on product type tax class rate

### DIFF
--- a/saleor/tests/e2e/orders/test_order_calculate_simple_taxes_product_type_tax_class.py
+++ b/saleor/tests/e2e/orders/test_order_calculate_simple_taxes_product_type_tax_class.py
@@ -1,0 +1,229 @@
+import pytest
+
+from .. import DEFAULT_ADDRESS
+from ..product.utils import (
+    create_category,
+    create_product,
+    create_product_channel_listing,
+    create_product_type,
+    create_product_variant,
+    create_product_variant_channel_listing,
+    update_product_type,
+)
+from ..shop.utils.preparing_shop import prepare_shop
+from ..taxes.utils import (
+    create_tax_class,
+    get_tax_configurations,
+    update_country_tax_rates,
+    update_tax_configuration,
+)
+from ..utils import assign_permissions
+from .utils import (
+    draft_order_complete,
+    draft_order_create,
+    draft_order_update,
+    order_lines_create,
+)
+
+
+def prepare_tax_configuration(
+    e2e_staff_api_client,
+    channel_slug,
+    country_code,
+    country_tax_rate,
+    product_type_tax_rate,
+    prices_entered_with_tax,
+):
+    tax_config_data = get_tax_configurations(e2e_staff_api_client)
+    channel_tax_config = tax_config_data[0]["node"]
+    assert channel_tax_config["channel"]["slug"] == channel_slug
+    tax_config_id = channel_tax_config["id"]
+
+    tax_config_data = update_tax_configuration(
+        e2e_staff_api_client,
+        tax_config_id,
+        charge_taxes=True,
+        tax_calculation_strategy="FLAT_RATES",
+        display_gross_prices=True,
+        prices_entered_with_tax=True,
+    )
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country_code,
+        [{"rate": country_tax_rate}],
+    )
+
+    country_rates = [{"countryCode": country_code, "rate": product_type_tax_rate}]
+    tax_class_data = create_tax_class(
+        e2e_staff_api_client,
+        "Product type tax class",
+        country_rates,
+    )
+    tax_class_id = tax_class_data["id"]
+
+    return country_tax_rate, product_type_tax_rate, tax_class_id
+
+
+def prepare_product(
+    e2e_staff_api_client,
+    warehouse_id,
+    channel_id,
+    variant_price,
+):
+    product_type_data = create_product_type(
+        e2e_staff_api_client,
+    )
+    product_type_id = product_type_data["id"]
+
+    category_data = create_category(e2e_staff_api_client)
+    category_id = category_data["id"]
+
+    product_data = create_product(
+        e2e_staff_api_client,
+        product_type_id,
+        category_id,
+    )
+    product_id = product_data["id"]
+
+    create_product_channel_listing(
+        e2e_staff_api_client,
+        product_id,
+        channel_id,
+    )
+
+    stocks = [
+        {
+            "warehouse": warehouse_id,
+            "quantity": 5,
+        }
+    ]
+    product_variant_data = create_product_variant(
+        e2e_staff_api_client,
+        product_id,
+        stocks=stocks,
+    )
+    product_variant_id = product_variant_data["id"]
+
+    product_variant_channel_listing_data = create_product_variant_channel_listing(
+        e2e_staff_api_client,
+        product_variant_id,
+        channel_id,
+        variant_price,
+    )
+    product_variant_price = product_variant_channel_listing_data["channelListings"][0][
+        "price"
+    ]["amount"]
+
+    return product_variant_id, product_variant_price, product_type_id
+
+
+@pytest.mark.e2e
+def test_order_calculate_simple_tax_based_on_product_type_tax_class_CORE_2004(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_orders,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_taxes,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    country_tax_rate, product_type_tax_rate, tax_class_id = prepare_tax_configuration(
+        e2e_staff_api_client,
+        channel_slug,
+        country_code="US",
+        country_tax_rate=21,
+        product_type_tax_rate=11,
+        prices_entered_with_tax=True,
+    )
+
+    variant_price = "4.22"
+    (product_variant_id, product_variant_price, product_type_id) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
+    product_type_tax_class = {"taxClass": tax_class_id}
+    update_product_type(e2e_staff_api_client, product_type_id, product_type_tax_class)
+
+    # Step 1 - Create a draft order
+    input = {
+        "channelId": channel_id,
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        input,
+    )
+    order_id = data["order"]["id"]
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["shippingAddress"] is not None
+    product_variant_price = float(product_variant_price)
+
+    # Step 2 - Add product on sale to draft order and check prices
+    lines = [{"variantId": product_variant_id, "quantity": 1}]
+    order_data = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_data = order_data["order"]
+    assert order_data["total"]["gross"]["amount"] == product_variant_price
+    calculated_tax = round(
+        (product_variant_price * product_type_tax_rate) / (100 + product_type_tax_rate),
+        2,
+    )
+    assert order_data["total"]["tax"]["amount"] == calculated_tax
+    assert order_data["total"]["net"]["amount"] == round(
+        product_variant_price - calculated_tax, 2
+    )
+    shipping_method_id = order_data["shippingMethods"][0]["id"]
+
+    # Step 3 - Add a shipping method to the order and check prices
+    input = {"shippingMethod": shipping_method_id}
+    order_data = draft_order_update(
+        e2e_staff_api_client,
+        order_id,
+        input,
+    )
+    order_data = order_data["order"]
+    shipping_price = order_data["shippingPrice"]["gross"]["amount"]
+    shipping_tax = round(
+        (shipping_price * country_tax_rate / (100 + country_tax_rate)), 2
+    )
+    assert order_data["shippingPrice"]["tax"]["amount"] == shipping_tax
+    assert order_data["shippingPrice"]["net"]["amount"] == shipping_price - shipping_tax
+    total_tax = calculated_tax + shipping_tax
+    assert order_data["total"]["tax"]["amount"] == total_tax
+    calculated_total = round(product_variant_price + shipping_price, 2)
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+
+    # Step 4 - Complete the draft order
+    order = draft_order_complete(
+        e2e_staff_api_client,
+        order_id,
+    )
+    assert order["order"]["status"] == "UNFULFILLED"
+    assert order["order"]["paymentStatus"] == "NOT_CHARGED"
+    assert order["order"]["total"]["gross"]["amount"] == calculated_total
+    assert order["order"]["total"]["tax"]["amount"] == total_tax
+    assert order["order"]["shippingPrice"]["tax"]["amount"] == shipping_tax

--- a/saleor/tests/e2e/orders/utils/draft_order_complete.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_complete.py
@@ -22,6 +22,12 @@ mutation DraftOrderComplete($id: ID!) {
         gross {
           amount
         }
+        net {
+          amount
+        }
+        tax {
+          amount
+        }
       }
       subtotal {
         gross {
@@ -32,16 +38,22 @@ mutation DraftOrderComplete($id: ID!) {
         gross {
           amount
         }
+        net {
+          amount
+        }
+        tax {
+          amount
+        }
       }
       displayGrossPrices
       status
       paymentStatus
       isPaid
       channel {
-        orderSettings{
-            markAsPaidStrategy
+        orderSettings {
+          markAsPaidStrategy
         }
-     }
+      }
       lines {
         productVariantId
         quantity

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -27,6 +27,12 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
         gross {
           amount
         }
+        net {
+          amount
+        }
+        tax {
+          amount
+        }
       }
       totalBalance {
         amount
@@ -35,15 +41,23 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
         gross {
           amount
         }
+        net {
+          amount
+        }
+        tax {
+          amount
+        }
       }
-    billingAddress {
+      billingAddress {
         firstName
         lastName
         companyName
         streetAddress1
         streetAddress2
         postalCode
-        country{ code }
+        country {
+          code
+        }
         city
         countryArea
         phone
@@ -55,7 +69,9 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
         streetAddress1
         streetAddress2
         postalCode
-        country{ code }
+        country {
+          code
+        }
         city
         countryArea
         phone
@@ -63,6 +79,12 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
       isShippingRequired
       shippingPrice {
         gross {
+          amount
+        }
+        net {
+          amount
+        }
+        tax {
           amount
         }
       }

--- a/saleor/tests/e2e/orders/utils/order_lines_create.py
+++ b/saleor/tests/e2e/orders/utils/order_lines_create.py
@@ -5,7 +5,20 @@ mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]!) {
   orderLinesCreate(id: $id, input: $input) {
     order {
       id
-      shippingMethods { id }
+      shippingMethods {
+        id
+      }
+      total {
+        gross {
+          amount
+        }
+        net {
+          amount
+        }
+        tax {
+          amount
+        }
+      }
       lines {
         id
         quantity


### PR DESCRIPTION
I want to merge this change because it adds a test for [CORE_2004](https://saleor.testmo.net/repositories/5?group_id=461&case_id=4726) Order calculate simple taxes based on product type tax class rate

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
