### PR TITLE
[Test] Checkout calculate simple taxes base on product tax class rate

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_product_tax_class.py
+++ b/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_product_tax_class.py
@@ -1,0 +1,178 @@
+import pytest
+
+from ..product.utils import update_product
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..taxes.utils import (
+    create_tax_class,
+    get_tax_configurations,
+    update_country_tax_rates,
+    update_tax_configuration,
+)
+from ..utils import assign_permissions
+from .utils import (
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+)
+
+
+def prepare_tax_configuration(
+    e2e_staff_api_client,
+    channel_slug,
+    country_code,
+    country_tax_rate,
+    product_tax_rate,
+    prices_entered_with_tax,
+):
+    tax_config_data = get_tax_configurations(e2e_staff_api_client)
+    channel_tax_config = tax_config_data[0]["node"]
+    assert channel_tax_config["channel"]["slug"] == channel_slug
+    tax_config_id = channel_tax_config["id"]
+
+    tax_config_data = update_tax_configuration(
+        e2e_staff_api_client,
+        tax_config_id,
+        charge_taxes=True,
+        tax_calculation_strategy="FLAT_RATES",
+        display_gross_prices=True,
+        prices_entered_with_tax=prices_entered_with_tax,
+    )
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country_code,
+        [{"rate": country_tax_rate}],
+    )
+
+    country_rates = [{"countryCode": country_code, "rate": product_tax_rate}]
+    tax_class_data = create_tax_class(
+        e2e_staff_api_client,
+        "Product tax class",
+        country_rates,
+    )
+    tax_class_id = tax_class_data["id"]
+
+    return country_tax_rate, product_tax_rate, tax_class_id
+
+
+@pytest.mark.e2e
+def test_checkout_calculate_simple_tax_based_on_product_tax_class_CORE_2005(
+    e2e_staff_api_client,
+    e2e_not_logged_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_taxes,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_taxes,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    country_tax_rate, product_tax_rate, tax_class_id = prepare_tax_configuration(
+        e2e_staff_api_client,
+        channel_slug,
+        country_code="US",
+        country_tax_rate=23,
+        product_tax_rate=5,
+        prices_entered_with_tax=True,
+    )
+
+    variant_price = "25.55"
+    (product_id, product_variant_id, product_variant_price) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price,
+    )
+    product_tax_class = {"taxClass": tax_class_id}
+    update_product(e2e_staff_api_client, product_id, input=product_tax_class)
+
+    # Step 1 - Create checkout and check prices
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
+    ]
+
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+
+    assert checkout_data["isShippingRequired"] is True
+    product_variant_price = float(product_variant_price)
+    assert checkout_data["totalPrice"]["gross"]["amount"] == product_variant_price
+    calculated_tax = round(
+        (product_variant_price * product_tax_rate) / (100 + product_tax_rate),
+        2,
+    )
+    assert checkout_data["totalPrice"]["tax"]["amount"] == calculated_tax
+    assert checkout_data["totalPrice"]["net"]["amount"] == round(
+        product_variant_price - calculated_tax, 2
+    )
+    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
+
+    # Step 2 - Set DeliveryMethod for checkout and check prices
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
+    shipping_price = float(shipping_price)
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    assert checkout_data["shippingPrice"]["gross"]["amount"] == shipping_price
+    shipping_tax = round(
+        (shipping_price * country_tax_rate) / (100 + country_tax_rate), 2
+    )
+    assert checkout_data["shippingPrice"]["tax"]["amount"] == shipping_tax
+    assert checkout_data["shippingPrice"]["net"]["amount"] == round(
+        shipping_price - shipping_tax, 2
+    )
+
+    total_tax = calculated_tax + shipping_tax
+    assert checkout_data["totalPrice"]["tax"]["amount"] == total_tax
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    calculated_total = round(product_variant_price + shipping_price, 2)
+    assert total_gross_amount == calculated_total
+
+    # Step 3 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_not_logged_api_client,
+        checkout_id,
+        total_gross_amount,
+    )
+
+    # Step 4 - Complete checkout.
+    order_data = checkout_complete(
+        e2e_not_logged_api_client,
+        checkout_id,
+    )
+    assert order_data["isShippingRequired"] is True
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["total"]["tax"]["amount"] == total_tax
+    assert order_data["total"]["net"]["amount"] == round(
+        calculated_total - total_tax, 2
+    )

--- a/saleor/tests/e2e/product/utils/__init__.py
+++ b/saleor/tests/e2e/product/utils/__init__.py
@@ -14,6 +14,7 @@ from .product_channel_listing import (
 from .product_query import get_product
 from .product_type import create_product_type
 from .product_type_update import update_product_type
+from .product_update import update_product
 from .product_variant import create_product_variant, raw_create_product_variant
 from .product_variant_bulk_create import create_variants_in_bulk
 from .product_variant_channel_listing import (
@@ -40,4 +41,5 @@ __all__ = [
     "add_product_to_collection",
     "raw_create_product_variant_channel_listing",
     "update_product_type",
+    "update_product",
 ]

--- a/saleor/tests/e2e/product/utils/product_update.py
+++ b/saleor/tests/e2e/product/utils/product_update.py
@@ -1,0 +1,60 @@
+from ...utils import get_graphql_content
+
+PRODUCT_UPDATE_MUTATION = """
+mutation ProductUpdate($id: ID!, $input: ProductInput!) {
+  productUpdate(id: $id, input: $input) {
+    errors {
+      field
+      message
+      code
+    }
+    product {
+      id
+      name
+      productType {
+        id
+      }
+      category {
+        id
+      }
+      attributes {
+        attribute {
+          id
+        }
+        values {
+          name
+        }
+      }
+      collections {
+        id
+      }
+      taxClass {
+        id
+        name
+      }
+    }
+  }
+}
+"""
+
+
+def update_product(
+    staff_api_client,
+    product_id,
+    input,
+):
+    variables = {"id": product_id, "input": input}
+
+    response = staff_api_client.post_graphql(
+        PRODUCT_UPDATE_MUTATION,
+        variables,
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["productUpdate"]["errors"] == []
+
+    data = content["data"]["productUpdate"]["product"]
+    assert data["id"] is not None
+
+    return data


### PR DESCRIPTION
I want to merge this change because it adds a test for [CORE_2005](https://saleor.testmo.net/repositories/5?group_id=461&case_id=4727) Checkout calculate simple taxes base on product tax class rate

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
