### PR TITLE
[Test] Digital order taxes based on billing country tax rate

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
+++ b/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
@@ -75,6 +75,7 @@ def prepare_tax_configuration(
     shipping_country_tax_rate,
     billing_country_code,
     billing_country_tax_rate,
+    prices_entered_with_tax,
 ):
     tax_config_data = get_tax_configurations(e2e_staff_api_client)
     channel_tax_config = tax_config_data[0]["node"]
@@ -87,7 +88,7 @@ def prepare_tax_configuration(
         charge_taxes=True,
         tax_calculation_strategy="FLAT_RATES",
         display_gross_prices=True,
-        prices_entered_with_tax=True,
+        prices_entered_with_tax=prices_entered_with_tax,
     )
     update_country_tax_rates(
         e2e_staff_api_client,
@@ -135,6 +136,7 @@ def test_checkout_calculate_simple_tax_based_on_shipping_country_CORE_2001(
         shipping_country_tax_rate=21,
         billing_country_code="DE",
         billing_country_tax_rate=19,
+        prices_entered_with_tax=True,
     )
 
     variant_price = "17.77"

--- a/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_product_type_tax_class.py
+++ b/saleor/tests/e2e/checkout/test_checkout_calculate_simple_taxes_product_type_tax_class.py
@@ -31,6 +31,7 @@ def prepare_tax_configuration(
     country_code,
     country_tax_rate,
     product_type_tax_rate,
+    prices_entered_with_tax,
 ):
     tax_config_data = get_tax_configurations(e2e_staff_api_client)
     channel_tax_config = tax_config_data[0]["node"]
@@ -43,7 +44,7 @@ def prepare_tax_configuration(
         charge_taxes=True,
         tax_calculation_strategy="FLAT_RATES",
         display_gross_prices=True,
-        prices_entered_with_tax=False,
+        prices_entered_with_tax=prices_entered_with_tax,
     )
     update_country_tax_rates(
         e2e_staff_api_client,
@@ -148,6 +149,7 @@ def test_checkout_calculate_simple_tax_based_on_product_type_tax_class_CORE_2003
         country_code="US",
         country_tax_rate=10,
         product_type_tax_rate=8,
+        prices_entered_with_tax=False,
     )
 
     variant_price = "155.88"

--- a/saleor/tests/e2e/orders/test_order_calculate_simple_taxes_for_digital_product.py
+++ b/saleor/tests/e2e/orders/test_order_calculate_simple_taxes_for_digital_product.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..channel.utils import create_channel
-from ..product.utils import prepare_digital_product
+from ..product.utils.preparing_product import prepare_digital_product
 from ..shipping_zone.utils import (
     create_shipping_method,
     create_shipping_method_channel_listing,

--- a/saleor/tests/e2e/orders/test_order_calculate_simple_taxes_for_digital_product.py
+++ b/saleor/tests/e2e/orders/test_order_calculate_simple_taxes_for_digital_product.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..channel.utils import create_channel
-from ..product.utils.preparing_product import prepare_digital_product
+from ..product.utils import prepare_digital_product
 from ..shipping_zone.utils import (
     create_shipping_method,
     create_shipping_method_channel_listing,
@@ -165,7 +165,7 @@ def test_digital_order_calculate_simple_tax_based_on_billing_country_CORE_2008(
     assert data["order"]["billingAddress"] is not None
     assert data["order"]["isShippingRequired"] is False
 
-    # Step 2 - Add product on sale to draft order and check prices
+    # Step 2 - Add product to draft order and check prices
     lines = [{"variantId": product_variant_id, "quantity": 1}]
     order_data = order_lines_create(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/orders/test_order_calculate_simple_taxes_for_digital_product.py
+++ b/saleor/tests/e2e/orders/test_order_calculate_simple_taxes_for_digital_product.py
@@ -1,0 +1,195 @@
+import pytest
+
+from ..channel.utils import create_channel
+from ..product.utils.preparing_product import prepare_digital_product
+from ..shipping_zone.utils import (
+    create_shipping_method,
+    create_shipping_method_channel_listing,
+    create_shipping_zone,
+)
+from ..taxes.utils import (
+    get_tax_configurations,
+    update_country_tax_rates,
+    update_tax_configuration,
+)
+from ..utils import assign_permissions
+from ..warehouse.utils import create_warehouse
+from .utils import draft_order_complete, draft_order_create, order_lines_create
+
+
+def prepare_shop(
+    e2e_staff_api_client,
+    shipping_price,
+):
+    warehouse_data = create_warehouse(e2e_staff_api_client)
+    warehouse_id = warehouse_data["id"]
+    channel_slug = "channel-de"
+    warehouse_ids = [warehouse_id]
+    channel_data = create_channel(
+        e2e_staff_api_client,
+        slug=channel_slug,
+        warehouse_ids=warehouse_ids,
+        currency="EUR",
+        country="DE",
+    )
+    channel_id = channel_data["id"]
+    channel_ids = [channel_id]
+    shipping_zone_data = create_shipping_zone(
+        e2e_staff_api_client,
+        countries=["DE", "US"],
+        warehouse_ids=warehouse_ids,
+        channel_ids=channel_ids,
+    )
+    shipping_zone_id = shipping_zone_data["id"]
+
+    shipping_method_data = create_shipping_method(
+        e2e_staff_api_client, shipping_zone_id
+    )
+    shipping_method_id = shipping_method_data["id"]
+    create_shipping_method_channel_listing(
+        e2e_staff_api_client,
+        shipping_method_id,
+        channel_id,
+        price=shipping_price,
+    )
+
+    return (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+        shipping_price,
+    )
+
+
+def prepare_tax_configuration(
+    e2e_staff_api_client,
+    channel_slug,
+    shipping_country_code,
+    shipping_country_tax_rate,
+    billing_country_code,
+    billing_country_tax_rate,
+    prices_entered_with_tax,
+):
+    tax_config_data = get_tax_configurations(e2e_staff_api_client)
+    channel_tax_config = tax_config_data[0]["node"]
+    assert channel_tax_config["channel"]["slug"] == channel_slug
+    tax_config_id = channel_tax_config["id"]
+
+    tax_config_data = update_tax_configuration(
+        e2e_staff_api_client,
+        tax_config_id,
+        charge_taxes=True,
+        tax_calculation_strategy="FLAT_RATES",
+        display_gross_prices=True,
+        prices_entered_with_tax=prices_entered_with_tax,
+    )
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        shipping_country_code,
+        [{"rate": shipping_country_tax_rate}],
+    )
+    update_country_tax_rates(
+        e2e_staff_api_client, billing_country_code, [{"rate": billing_country_tax_rate}]
+    )
+
+    return billing_country_tax_rate
+
+
+@pytest.mark.e2e
+def test_digital_order_calculate_simple_tax_based_on_billing_country_CORE_2008(
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_orders,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_taxes,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    shipping_price = 10
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+        shipping_price,
+    ) = prepare_shop(e2e_staff_api_client, shipping_price)
+
+    billing_country_tax_rate = prepare_tax_configuration(
+        e2e_staff_api_client,
+        channel_slug,
+        shipping_country_code="US",
+        shipping_country_tax_rate=5,
+        billing_country_code="DE",
+        billing_country_tax_rate=19,
+        prices_entered_with_tax=True,
+    )
+    variant_price = 100
+    product_id, product_variant_id, product_variant_price = prepare_digital_product(
+        e2e_staff_api_client, channel_id, warehouse_id, variant_price
+    )
+
+    # Step 1 - Create a draft order
+    billing_address = {
+        "firstName": "John",
+        "lastName": "Muller",
+        "companyName": "Saleor Commerce DE",
+        "streetAddress1": "Potsdamer Platz 47",
+        "streetAddress2": "",
+        "postalCode": "85131",
+        "country": "DE",
+        "city": "Pollenfeld",
+        "phone": "+498421499469",
+        "countryArea": "",
+    }
+    input = {
+        "channelId": channel_id,
+        "billingAddress": billing_address,
+    }
+    data = draft_order_create(
+        e2e_staff_api_client,
+        input,
+    )
+    order_id = data["order"]["id"]
+    assert data["order"]["billingAddress"] is not None
+    assert data["order"]["isShippingRequired"] is False
+
+    # Step 2 - Add product on sale to draft order and check prices
+    lines = [{"variantId": product_variant_id, "quantity": 1}]
+    order_data = order_lines_create(
+        e2e_staff_api_client,
+        order_id,
+        lines,
+    )
+    order_data = order_data["order"]
+    product_variant_price = float(product_variant_price)
+    assert order_data["total"]["gross"]["amount"] == product_variant_price
+    calculated_tax = round(
+        (product_variant_price * billing_country_tax_rate)
+        / (100 + billing_country_tax_rate),
+        2,
+    )
+    assert order_data["total"]["tax"]["amount"] == calculated_tax
+    assert order_data["total"]["net"]["amount"] == round(
+        product_variant_price - calculated_tax, 2
+    )
+
+    # Step 3 - Complete the draft order
+    order = draft_order_complete(
+        e2e_staff_api_client,
+        order_id,
+    )
+    assert order["order"]["status"] == "UNFULFILLED"
+    assert order["order"]["paymentStatus"] == "NOT_CHARGED"
+    assert order["order"]["total"]["tax"]["amount"] == calculated_tax

--- a/saleor/tests/e2e/orders/utils/draft_order_create.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_create.py
@@ -9,41 +9,42 @@ mutation OrderDraftCreate($input: DraftOrderCreateInput!) {
       code
     }
     order {
-        id
-        created
-        discounts {
-            amount {
-                amount
-            }
+      id
+      created
+      discounts {
+        amount {
+          amount
         }
-        billingAddress {
+      }
+      billingAddress {
         streetAddress1
+      }
+      shippingAddress {
+        streetAddress1
+      }
+      isShippingRequired
+      shippingMethods {
+        id
+      }
+      lines {
+        productVariantId
+        quantity
+        undiscountedUnitPrice {
+          gross {
+            amount
+          }
         }
-        shippingAddress {
-            streetAddress1
+        unitPrice {
+          gross {
+            amount
+          }
         }
-        shippingMethods {
-            id
+        totalPrice {
+          gross {
+            amount
+          }
         }
-        lines {
-            productVariantId
-            quantity
-            undiscountedUnitPrice {
-                gross {
-                amount
-                }
-            }
-            unitPrice {
-                gross {
-                    amount
-                }
-            }
-            totalPrice {
-                gross {
-                    amount
-                }
-            }
-        }
+      }
     }
   }
 }

--- a/saleor/tests/e2e/product/utils/__init__.py
+++ b/saleor/tests/e2e/product/utils/__init__.py
@@ -3,6 +3,7 @@ from .collection import create_collection
 from .collection_add_products import add_product_to_collection
 from .collection_listing_update import create_collection_channel_listing
 from .digital_content import create_digital_content
+from .preparing_product import prepare_digital_product, prepare_product
 from .product import create_product
 from .product_attribute_assignment_update import (
     update_product_type_assignment_attribute,
@@ -42,4 +43,6 @@ __all__ = [
     "raw_create_product_variant_channel_listing",
     "update_product_type",
     "update_product",
+    "prepare_digital_product",
+    "prepare_product",
 ]

--- a/saleor/tests/e2e/product/utils/__init__.py
+++ b/saleor/tests/e2e/product/utils/__init__.py
@@ -3,7 +3,6 @@ from .collection import create_collection
 from .collection_add_products import add_product_to_collection
 from .collection_listing_update import create_collection_channel_listing
 from .digital_content import create_digital_content
-from .preparing_product import prepare_digital_product, prepare_product
 from .product import create_product
 from .product_attribute_assignment_update import (
     update_product_type_assignment_attribute,
@@ -43,6 +42,4 @@ __all__ = [
     "raw_create_product_variant_channel_listing",
     "update_product_type",
     "update_product",
-    "prepare_digital_product",
-    "prepare_product",
 ]

--- a/saleor/tests/e2e/product/utils/preparing_product.py
+++ b/saleor/tests/e2e/product/utils/preparing_product.py
@@ -1,5 +1,6 @@
 from . import (
     create_category,
+    create_digital_content,
     create_product,
     create_product_channel_listing,
     create_product_type,
@@ -58,4 +59,56 @@ def prepare_product(
         "price"
     ]["amount"]
 
+    return product_id, product_variant_id, product_variant_price
+
+
+def prepare_digital_product(
+    e2e_staff_api_client,
+    channel_id,
+    warehouse_id,
+    variant_price,
+):
+    product_type_data = create_product_type(
+        e2e_staff_api_client,
+        is_shipping_required=False,
+        is_digital=True,
+    )
+    product_type_id = product_type_data["id"]
+
+    category_data = create_category(e2e_staff_api_client)
+    category_id = category_data["id"]
+
+    product_data = create_product(
+        e2e_staff_api_client,
+        product_type_id,
+        category_id,
+    )
+    product_id = product_data["id"]
+
+    create_product_channel_listing(
+        e2e_staff_api_client,
+        product_id,
+        channel_id,
+    )
+
+    stocks = [
+        {
+            "warehouse": warehouse_id,
+            "quantity": 5,
+        }
+    ]
+    product_variant_data = create_product_variant(
+        e2e_staff_api_client,
+        product_id,
+        stocks=stocks,
+    )
+    product_variant_id = product_variant_data["id"]
+
+    variant_listing = create_product_variant_channel_listing(
+        e2e_staff_api_client, product_variant_id, channel_id, price=10
+    )
+
+    create_digital_content(e2e_staff_api_client, product_variant_id)
+
+    product_variant_price = variant_listing["channelListings"][0]["price"]["amount"]
     return product_id, product_variant_id, product_variant_price


### PR DESCRIPTION
I want to merge this change because it covers test [CORE_2008](https://saleor.testmo.net/repositories/5?group_id=461&case_id=4730) Digital Order calculate simple taxes based on Billing address


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
