### PR TITLE
[Test] Order calculate simple taxes based on product tax class rate

### DIFF
--- a/saleor/tests/e2e/orders/test_order_calculate_simple_taxes_product_tax_class.py
+++ b/saleor/tests/e2e/orders/test_order_calculate_simple_taxes_product_tax_class.py
@@ -1,15 +1,8 @@
 import pytest
 
 from .. import DEFAULT_ADDRESS
-from ..product.utils import (
-    create_category,
-    create_product,
-    create_product_channel_listing,
-    create_product_type,
-    create_product_variant,
-    create_product_variant_channel_listing,
-    update_product_type,
-)
+from ..product.utils import update_product
+from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_shop
 from ..taxes.utils import (
     create_tax_class,
@@ -31,7 +24,7 @@ def prepare_tax_configuration(
     channel_slug,
     country_code,
     country_tax_rate,
-    product_type_tax_rate,
+    product_tax_rate,
     prices_entered_with_tax,
 ):
     tax_config_data = get_tax_configurations(e2e_staff_api_client)
@@ -45,7 +38,7 @@ def prepare_tax_configuration(
         charge_taxes=True,
         tax_calculation_strategy="FLAT_RATES",
         display_gross_prices=True,
-        prices_entered_with_tax=True,
+        prices_entered_with_tax=prices_entered_with_tax,
     )
     update_country_tax_rates(
         e2e_staff_api_client,
@@ -53,72 +46,19 @@ def prepare_tax_configuration(
         [{"rate": country_tax_rate}],
     )
 
-    country_rates = [{"countryCode": country_code, "rate": product_type_tax_rate}]
+    country_rates = [{"countryCode": country_code, "rate": product_tax_rate}]
     tax_class_data = create_tax_class(
         e2e_staff_api_client,
-        "Product type tax class",
+        "Product tax class",
         country_rates,
     )
     tax_class_id = tax_class_data["id"]
 
-    return country_tax_rate, product_type_tax_rate, tax_class_id
-
-
-def prepare_product(
-    e2e_staff_api_client,
-    warehouse_id,
-    channel_id,
-    variant_price,
-):
-    product_type_data = create_product_type(
-        e2e_staff_api_client,
-    )
-    product_type_id = product_type_data["id"]
-
-    category_data = create_category(e2e_staff_api_client)
-    category_id = category_data["id"]
-
-    product_data = create_product(
-        e2e_staff_api_client,
-        product_type_id,
-        category_id,
-    )
-    product_id = product_data["id"]
-
-    create_product_channel_listing(
-        e2e_staff_api_client,
-        product_id,
-        channel_id,
-    )
-
-    stocks = [
-        {
-            "warehouse": warehouse_id,
-            "quantity": 5,
-        }
-    ]
-    product_variant_data = create_product_variant(
-        e2e_staff_api_client,
-        product_id,
-        stocks=stocks,
-    )
-    product_variant_id = product_variant_data["id"]
-
-    product_variant_channel_listing_data = create_product_variant_channel_listing(
-        e2e_staff_api_client,
-        product_variant_id,
-        channel_id,
-        variant_price,
-    )
-    product_variant_price = product_variant_channel_listing_data["channelListings"][0][
-        "price"
-    ]["amount"]
-
-    return product_variant_id, product_variant_price, product_type_id
+    return country_tax_rate, product_tax_rate, tax_class_id
 
 
 @pytest.mark.e2e
-def test_order_calculate_simple_tax_based_on_product_type_tax_class_CORE_2004(
+def test_order_calculate_simple_tax_based_on_product_tax_class_CORE_2006(
     e2e_staff_api_client,
     permission_manage_products,
     permission_manage_channels,
@@ -145,24 +85,24 @@ def test_order_calculate_simple_tax_based_on_product_type_tax_class_CORE_2004(
         shipping_method_id,
     ) = prepare_shop(e2e_staff_api_client)
 
-    country_tax_rate, product_type_tax_rate, tax_class_id = prepare_tax_configuration(
+    country_tax_rate, product_tax_rate, tax_class_id = prepare_tax_configuration(
         e2e_staff_api_client,
         channel_slug,
         country_code="US",
-        country_tax_rate=21,
-        product_type_tax_rate=11,
-        prices_entered_with_tax=True,
+        country_tax_rate=20,
+        product_tax_rate=13,
+        prices_entered_with_tax=False,
     )
 
-    variant_price = "4.22"
-    (product_variant_id, product_variant_price, product_type_id) = prepare_product(
+    variant_price = "1234"
+    (product_id, product_variant_id, product_variant_price) = prepare_product(
         e2e_staff_api_client,
         warehouse_id,
         channel_id,
         variant_price,
     )
-    product_type_tax_class = {"taxClass": tax_class_id}
-    update_product_type(e2e_staff_api_client, product_type_id, product_type_tax_class)
+    product_tax_class = {"taxClass": tax_class_id}
+    update_product(e2e_staff_api_client, product_id, input=product_tax_class)
 
     # Step 1 - Create a draft order
     input = {
@@ -187,16 +127,17 @@ def test_order_calculate_simple_tax_based_on_product_type_tax_class_CORE_2004(
         lines,
     )
     order_data = order_data["order"]
-    assert order_data["total"]["gross"]["amount"] == product_variant_price
     calculated_tax = round(
-        (product_variant_price * product_type_tax_rate) / (100 + product_type_tax_rate),
+        (product_variant_price * (product_tax_rate / 100)),
         2,
     )
+    assert order_data["total"]["net"]["amount"] == product_variant_price
     assert order_data["total"]["tax"]["amount"] == calculated_tax
-    assert order_data["total"]["net"]["amount"] == round(
-        product_variant_price - calculated_tax, 2
+    assert order_data["total"]["gross"]["amount"] == round(
+        product_variant_price + calculated_tax, 2
     )
     shipping_method_id = order_data["shippingMethods"][0]["id"]
+    shipping_price = order_data["shippingMethods"][0]["price"]["amount"]
 
     # Step 3 - Add a shipping method to the order and check prices
     input = {"shippingMethod": shipping_method_id}
@@ -206,16 +147,15 @@ def test_order_calculate_simple_tax_based_on_product_type_tax_class_CORE_2004(
         input,
     )
     order_data = order_data["order"]
-    shipping_price = order_data["shippingPrice"]["gross"]["amount"]
-    shipping_tax = round(
-        (shipping_price * country_tax_rate / (100 + country_tax_rate)), 2
-    )
-    assert order_data["shippingPrice"]["tax"]["amount"] == shipping_tax
-    assert order_data["shippingPrice"]["net"]["amount"] == shipping_price - shipping_tax
+    shipping_tax = round((shipping_price * (country_tax_rate / 100)), 2)
     total_tax = calculated_tax + shipping_tax
-    assert order_data["total"]["tax"]["amount"] == total_tax
-    calculated_total = round(product_variant_price + shipping_price, 2)
-    assert order_data["total"]["gross"]["amount"] == calculated_total
+    calculated_net = round(product_variant_price + shipping_price, 2)
+
+    assert order_data["shippingPrice"]["net"]["amount"] == shipping_price
+    assert order_data["shippingPrice"]["tax"]["amount"] == shipping_tax
+    assert order_data["shippingPrice"]["gross"]["amount"] == round(
+        shipping_price + shipping_tax, 2
+    )
 
     # Step 4 - Complete the draft order
     order = draft_order_complete(
@@ -224,6 +164,8 @@ def test_order_calculate_simple_tax_based_on_product_type_tax_class_CORE_2004(
     )
     assert order["order"]["status"] == "UNFULFILLED"
     assert order["order"]["paymentStatus"] == "NOT_CHARGED"
-    assert order["order"]["total"]["gross"]["amount"] == calculated_total
-    assert order["order"]["total"]["tax"]["amount"] == total_tax
-    assert order["order"]["shippingPrice"]["tax"]["amount"] == shipping_tax
+    assert order_data["total"]["tax"]["amount"] == total_tax
+    assert order_data["total"]["net"]["amount"] == calculated_net
+    assert order_data["total"]["gross"]["amount"] == round(
+        calculated_net + total_tax, 2
+    )

--- a/saleor/tests/e2e/orders/utils/order_lines_create.py
+++ b/saleor/tests/e2e/orders/utils/order_lines_create.py
@@ -7,6 +7,9 @@ mutation orderLinesCreate($id: ID!, $input: [OrderLineCreateInput!]!) {
       id
       shippingMethods {
         id
+        price {
+          amount
+        }
       }
       total {
         gross {


### PR DESCRIPTION
I want to merge this change because it covers test case [CORE_2006](https://saleor.testmo.net/repositories/5?group_id=461&case_id=4728) Order calculate simple taxes based on product tax class rate


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
