### PR TITLE
Update codeowners for openid_connect plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 .github/workflows/* @saleor/sre
-/saleor/plugins/openid_connect/ @saleor/cloud
+/saleor/plugins/openid_connect/ @saleor/cloud-backend


### PR DESCRIPTION
I want to merge this change because we don't want to ping fronted developers for plugins code review