### PR TITLE
Update voucher code usage after settings change.

### DIFF
--- a/saleor/discount/tasks.py
+++ b/saleor/discount/tasks.py
@@ -9,10 +9,12 @@ from django.db.models import Exists, F, OuterRef, Q, QuerySet
 
 from ..celeryconf import app
 from ..graphql.discount.utils import get_variants_for_predicate
+from ..order import OrderStatus
+from ..order.models import Order
 from ..plugins.manager import get_plugins_manager
 from ..product.models import Product, ProductVariant
 from ..product.tasks import update_products_discounted_prices_for_promotion_task
-from .models import Promotion, PromotionRule
+from .models import Promotion, PromotionRule, VoucherCode, VoucherCustomer
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -150,3 +152,59 @@ def fetch_promotion_variants_and_product_ids(promotions: "QuerySet[Promotion]"):
         Exists(variants.filter(product_id=OuterRef("id")))
     )
     return promotion_id_to_variants, list(products.values_list("id", flat=True))
+
+
+def decrease_voucher_code_usage_of_draft_orders(channel_id: int):
+    codes = Order.objects.filter(
+        channel_id=channel_id, status=OrderStatus.DRAFT, voucher_code__isnull=False
+    ).values_list("voucher_code", flat=True)
+    voucher_code_ids = VoucherCode.objects.filter(code__in=codes).values_list(
+        "pk", flat=True
+    )
+    decrease_voucher_codes_usage_task.delay(list(voucher_code_ids))
+
+
+@app.task
+def decrease_voucher_codes_usage_task(voucher_code_ids):
+    # Batch of size 1000 takes ~1sec and consumes ~20mb at peak
+    BATCH_SIZE = 1000
+    ids = sorted(voucher_code_ids)[:BATCH_SIZE]
+    if (
+        voucher_codes := VoucherCode.objects.filter(pk__in=ids)
+        .select_related("voucher")
+        .only("voucher", "used", "is_active")
+    ):
+        for voucher_code in voucher_codes:
+            if voucher_code.voucher.usage_limit and voucher_code.used > 0:
+                voucher_code.used -= 1
+            if voucher_code.voucher.single_use:
+                voucher_code.is_active = True
+        VoucherCode.objects.bulk_update(voucher_codes, ["used", "is_active"])
+        VoucherCustomer.objects.filter(
+            Exists(VoucherCode.objects.filter(pk=OuterRef("voucher_code_id")))
+        ).delete()
+        if remaining_ids := list(set(voucher_code_ids) - set(ids)):
+            decrease_voucher_codes_usage_task.delay(remaining_ids)
+
+
+def disconnect_voucher_codes_from_draft_orders(channel_id: int):
+    order_ids = Order.objects.filter(
+        channel_id=channel_id, status=OrderStatus.DRAFT, voucher_code__isnull=False
+    ).values_list("pk", flat=True)
+    disconnect_voucher_codes_from_draft_orders_task.delay(list(order_ids))
+
+
+@app.task
+def disconnect_voucher_codes_from_draft_orders_task(order_ids):
+    # Batch of size 1000 takes ~1sec and consumes ~20mb at peak
+    BATCH_SIZE = 1000
+    ids = sorted(order_ids)[:BATCH_SIZE]
+    if orders := Order.objects.filter(pk__in=ids).only(
+        "voucher_code", "should_refresh_prices"
+    ):
+        for order in orders:
+            order.voucher_code = None
+            order.should_refresh_prices = True
+        Order.objects.bulk_update(orders, ["voucher_code", "should_refresh_prices"])
+        if remaining_ids := list(set(order_ids) - set(ids)):
+            disconnect_voucher_codes_from_draft_orders_task.delay(remaining_ids)

--- a/saleor/discount/tests/test_tasks.py
+++ b/saleor/discount/tests/test_tasks.py
@@ -3,12 +3,19 @@ from decimal import Decimal
 from unittest.mock import ANY, patch
 
 import graphene
+import pytest
 from django.utils import timezone
 from freezegun import freeze_time
 
+from ...order.models import Order
 from .. import RewardValueType
 from ..models import Promotion, PromotionRule
-from ..tasks import fetch_promotion_variants_and_product_ids, handle_promotion_toggle
+from ..tasks import (
+    decrease_voucher_codes_usage_task,
+    disconnect_voucher_codes_from_draft_orders_task,
+    fetch_promotion_variants_and_product_ids,
+    handle_promotion_toggle,
+)
 
 
 def test_fetch_promotion_variants_and_product_ids(
@@ -177,3 +184,76 @@ def test_handle_promotion_toggle(
         product_list[0].id,
         product_list[2].id,
     }
+
+
+def test_decrease_voucher_code_usage_task_multiple_use(
+    draft_order_list_with_multiple_use_voucher, voucher_multiple_use
+):
+    # given
+    order_list = draft_order_list_with_multiple_use_voucher
+    voucher = voucher_multiple_use
+    voucher_codes = voucher.codes.all()[: len(order_list)]
+    assert all([voucher_code.used == 1 for voucher_code in voucher_codes])
+    voucher_code_ids = [voucher_code.pk for voucher_code in voucher_codes]
+
+    # when
+    decrease_voucher_codes_usage_task(voucher_code_ids)
+
+    # then
+    voucher_codes = voucher.codes.all()[: len(order_list)]
+    assert all([voucher_code.used == 0 for voucher_code in voucher_codes])
+
+
+def test_decrease_voucher_code_usage_task_single_use(
+    draft_order_list_with_single_use_voucher, voucher_single_use
+):
+    # given
+    order_list = draft_order_list_with_single_use_voucher
+    voucher = voucher_single_use
+    voucher_codes = voucher.codes.all()[: len(order_list)]
+    assert all([voucher_code.is_active is False for voucher_code in voucher_codes])
+    voucher_code_ids = [voucher_code.pk for voucher_code in voucher_codes]
+
+    # when
+    decrease_voucher_codes_usage_task(voucher_code_ids)
+
+    # then
+    voucher_codes = voucher.codes.all()[: len(order_list)]
+    assert all([voucher_code.is_active is True for voucher_code in voucher_codes])
+
+
+def test_decrease_voucher_code_usage_task_customer(
+    draft_order, voucher_customer, channel_USD
+):
+    # given
+    voucher_code = voucher_customer.voucher_code
+    draft_order.voucher_code = voucher_code.code
+    draft_order.save(update_fields=["voucher_code"])
+
+    # when
+    decrease_voucher_codes_usage_task([voucher_code.pk])
+
+    # then
+    with pytest.raises(voucher_customer._meta.model.DoesNotExist):
+        voucher_customer.refresh_from_db()
+
+
+def test_disconnect_voucher_codes_from_draft_orders(
+    draft_order_list_with_multiple_use_voucher,
+):
+    # given
+    order_list = draft_order_list_with_multiple_use_voucher
+    order_list_ids = [order.id for order in order_list]
+    assert all([order.voucher_code for order in order_list])
+    for order in order_list:
+        order.should_refresh_prices = False
+    Order.objects.bulk_update(order_list, ["should_refresh_prices"])
+    assert all([order.should_refresh_prices is False for order in order_list])
+
+    # when
+    disconnect_voucher_codes_from_draft_orders_task(order_list_ids)
+
+    # then
+    order_list = Order.objects.filter(id__in=order_list_ids).all()
+    assert all([order.voucher_code is None for order in order_list])
+    assert all([order.should_refresh_prices is True for order in order_list])

--- a/saleor/discount/tests/test_tasks.py
+++ b/saleor/discount/tests/test_tasks.py
@@ -9,7 +9,7 @@ from freezegun import freeze_time
 
 from ...order.models import Order
 from .. import RewardValueType
-from ..models import Promotion, PromotionRule
+from ..models import OrderDiscount, OrderLineDiscount, Promotion, PromotionRule
 from ..tasks import (
     decrease_voucher_codes_usage_task,
     disconnect_voucher_codes_from_draft_orders_task,
@@ -222,33 +222,26 @@ def test_decrease_voucher_code_usage_task_single_use(
     assert all([voucher_code.is_active is True for voucher_code in voucher_codes])
 
 
-def test_decrease_voucher_code_usage_task_customer(
-    draft_order, voucher_customer, channel_USD
-):
-    # given
-    voucher_code = voucher_customer.voucher_code
-    draft_order.voucher_code = voucher_code.code
-    draft_order.save(update_fields=["voucher_code"])
-
-    # when
-    decrease_voucher_codes_usage_task([voucher_code.pk])
-
-    # then
-    with pytest.raises(voucher_customer._meta.model.DoesNotExist):
-        voucher_customer.refresh_from_db()
-
-
 def test_disconnect_voucher_codes_from_draft_orders(
-    draft_order_list_with_multiple_use_voucher,
+    draft_order_list_with_multiple_use_voucher, order_line
 ):
     # given
     order_list = draft_order_list_with_multiple_use_voucher
+    order = order_list[0]
+    order.lines.add(order_line)
+
     order_list_ids = [order.id for order in order_list]
     assert all([order.voucher_code for order in order_list])
     for order in order_list:
         order.should_refresh_prices = False
     Order.objects.bulk_update(order_list, ["should_refresh_prices"])
     assert all([order.should_refresh_prices is False for order in order_list])
+
+    voucher_code = order.voucher_code
+    order_discount = OrderDiscount.objects.create(
+        order=order, voucher_code=voucher_code
+    )
+    line_discount = OrderLineDiscount.objects.create(line=order_line)
 
     # when
     disconnect_voucher_codes_from_draft_orders_task(order_list_ids)
@@ -257,3 +250,8 @@ def test_disconnect_voucher_codes_from_draft_orders(
     order_list = Order.objects.filter(id__in=order_list_ids).all()
     assert all([order.voucher_code is None for order in order_list])
     assert all([order.should_refresh_prices is True for order in order_list])
+
+    with pytest.raises(line_discount._meta.model.DoesNotExist):
+        line_discount.refresh_from_db()
+    with pytest.raises(order_discount._meta.model.DoesNotExist):
+        order_discount.refresh_from_db()

--- a/saleor/discount/tests/test_tasks.py
+++ b/saleor/discount/tests/test_tasks.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from ...order.models import Order
-from .. import RewardValueType
+from .. import DiscountType, RewardValueType
 from ..models import OrderDiscount, OrderLineDiscount, Promotion, PromotionRule
 from ..tasks import (
     decrease_voucher_codes_usage_task,
@@ -239,9 +239,11 @@ def test_disconnect_voucher_codes_from_draft_orders(
 
     voucher_code = order.voucher_code
     order_discount = OrderDiscount.objects.create(
-        order=order, voucher_code=voucher_code
+        order=order, voucher_code=voucher_code, type=DiscountType.VOUCHER
     )
-    line_discount = OrderLineDiscount.objects.create(line=order_line)
+    line_discount = OrderLineDiscount.objects.create(
+        line=order_line, type=DiscountType.VOUCHER
+    )
 
     # when
     disconnect_voucher_codes_from_draft_orders_task(order_list_ids)

--- a/saleor/graphql/channel/mutations/channel_create.py
+++ b/saleor/graphql/channel/mutations/channel_create.py
@@ -270,7 +270,7 @@ class ChannelCreate(ModelMutation):
         if stock_settings := cleaned_input.get("stock_settings"):
             cleaned_input["allocation_strategy"] = stock_settings["allocation_strategy"]
         if order_settings := cleaned_input.get("order_settings"):
-            clean_input_order_settings(order_settings, cleaned_input)
+            clean_input_order_settings(order_settings, cleaned_input, instance)
 
         if checkout_settings := cleaned_input.get("checkout_settings"):
             clean_input_checkout_settings(checkout_settings, cleaned_input)

--- a/saleor/graphql/channel/mutations/utils.py
+++ b/saleor/graphql/channel/mutations/utils.py
@@ -3,7 +3,8 @@ from typing import Optional
 
 from django.core.exceptions import ValidationError
 
-from saleor.graphql.core.enums import ChannelErrorCode
+from ....channel.models import Channel
+from ...core.enums import ChannelErrorCode
 
 DELETE_EXPIRED_ORDERS_MAX_DAYS = 120
 
@@ -40,7 +41,9 @@ def clean_delete_expired_orders_after(delete_expired_orders_after: int) -> timed
     return timedelta(days=delete_expired_orders_after)
 
 
-def clean_input_order_settings(order_settings: dict, cleaned_input: dict):
+def clean_input_order_settings(
+    order_settings: dict, cleaned_input: dict, instance: Channel
+):
     channel_settings = [
         "automatically_confirm_all_new_orders",
         "automatically_fulfill_non_shippable_gift_card",
@@ -70,6 +73,10 @@ def clean_input_order_settings(order_settings: dict, cleaned_input: dict):
         cleaned_input[
             "delete_expired_orders_after"
         ] = clean_delete_expired_orders_after(delete_expired_orders_after)
+
+    cleaned_input[
+        "prev_include_draft_order_in_voucher_usage"
+    ] = instance.include_draft_order_in_voucher_usage
 
 
 def clean_input_checkout_settings(checkout_settings: dict, cleaned_input: dict):

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4008,6 +4008,49 @@ def voucher_customer(voucher, customer_user):
 
 
 @pytest.fixture
+def voucher_multiple_use(voucher_with_many_codes):
+    voucher = voucher_with_many_codes
+    voucher.usage_limit = 3
+    voucher.save(update_fields=["usage_limit"])
+    codes = voucher.codes.all()
+    for code in codes:
+        code.used = 1
+    VoucherCode.objects.bulk_update(codes, ["used"])
+    voucher.refresh_from_db()
+    return voucher
+
+
+@pytest.fixture
+def voucher_single_use(voucher_with_many_codes):
+    voucher = voucher_with_many_codes
+    voucher.single_use = True
+    voucher.save(update_fields=["single_use"])
+    return voucher
+
+
+@pytest.fixture
+def draft_order_list_with_multiple_use_voucher(draft_order_list, voucher_multiple_use):
+    codes = voucher_multiple_use.codes.values_list("code", flat=True)
+    for idx, order in enumerate(draft_order_list):
+        order.voucher_code = codes[idx]
+    Order.objects.bulk_update(draft_order_list, ["voucher_code"])
+    return draft_order_list
+
+
+@pytest.fixture
+def draft_order_list_with_single_use_voucher(draft_order_list, voucher_single_use):
+    voucher_codes = voucher_single_use.codes.all()
+    codes = voucher_codes.values_list("code", flat=True)
+    for idx, order in enumerate(draft_order_list):
+        order.voucher_code = codes[idx]
+    for voucher_code in voucher_codes:
+        voucher_code.is_active = False
+    Order.objects.bulk_update(draft_order_list, ["voucher_code"])
+    VoucherCode.objects.bulk_update(voucher_codes, ["is_active"])
+    return draft_order_list
+
+
+@pytest.fixture
 def order_line(order, variant):
     product = variant.product
     channel = order.channel


### PR DESCRIPTION
Issue: https://github.com/saleor/saleor/issues/14333
RFC: https://github.com/saleor/saleor/issues/13713

When flag `include_draft_order_in_voucher_usage` is changed from `True` to `False`, then all voucher codes associated with draft orders should have usage decreased. 

When change from `False` to `True`, then vouchers from all draft orders should be disconnected.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
