### PR TITLE
use `call_event` class method on all mutations which triggers webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable, unreleased changes to this project will be documented in this file.
 # 3.18.0 [Unreleased]
 
 ### Breaking changes
-- Optimize number of queries in bulk mutations when calling Webhooks. This change affects only users of open-source Saleor, who have their own custom plugin implementations. To adjust to this change, the `webhooks` parameter should be added to any of the affected method. Affected methods:
+- Optimize number of queries in bulk mutations when calling webhooks. This change affects only users of open-source Saleor, who have their own custom plugin implementations. To adjust to this change, the `webhooks` parameter should be added to any of the affected method. Affected methods:
   - `attribute_updated`
   - `attribute_deleted`
   - `attribute_value_deleted`

--- a/saleor/graphql/account/bulk_mutations/customer_bulk_delete.py
+++ b/saleor/graphql/account/bulk_mutations/customer_bulk_delete.py
@@ -53,4 +53,4 @@ class CustomerBulkDelete(CustomerDeleteMixin, UserBulkDelete):
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.CUSTOMER_DELETED)
         manager = get_plugin_manager_promise(info.context).get()
         for instance in instances:
-            manager.customer_deleted(instance, webhooks=webhooks)
+            cls.call_event(manager.customer_deleted, instance, webhooks=webhooks)

--- a/saleor/graphql/discount/mutations/bulk_mutations.py
+++ b/saleor/graphql/discount/mutations/bulk_mutations.py
@@ -97,7 +97,9 @@ class SaleBulkDelete(ModelBulkDeleteMutation):
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.SALE_DELETED)
         manager = get_plugin_manager_promise(info.context).get()
         for sale, catalogue_info in sales_and_catalogue_infos:
-            manager.sale_deleted(sale, catalogue_info, webhooks=webhooks)
+            cls.call_event(
+                manager.sale_deleted, sale, catalogue_info, webhooks=webhooks
+            )
 
         update_products_discounted_prices_for_promotion_task.delay(list(product_ids))
 
@@ -154,4 +156,4 @@ class VoucherBulkDelete(ModelBulkDeleteMutation):
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.VOUCHER_DELETED)
         manager = get_plugin_manager_promise(info.context).get()
         for voucher in vouchers:
-            manager.voucher_deleted(voucher, webhooks=webhooks)
+            cls.call_event(manager.voucher_deleted, voucher, webhooks=webhooks)

--- a/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
@@ -43,7 +43,6 @@ class PromotionBulkDelete(ModelBulkDeleteMutation):
         product_ids = cls.get_product_ids(queryset)
         promotions = [promotion for promotion in queryset]
         queryset.delete()
-
         manager = get_plugin_manager_promise(info.context).get()
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.PROMOTION_DELETED)
         for promotion in promotions:

--- a/saleor/graphql/discount/mutations/sale/sale_create.py
+++ b/saleor/graphql/discount/mutations/sale/sale_create.py
@@ -139,8 +139,8 @@ class SaleCreate(ModelMutation):
         cls.call_event(manager.sale_created, instance, catalogue_info)
         cls.send_sale_toggle_notification(manager, instance, catalogue_info)
 
-    @staticmethod
-    def send_sale_toggle_notification(manager, instance, catalogue):
+    @classmethod
+    def send_sale_toggle_notification(cls, manager, instance, catalogue):
         """Send a notification about starting or ending sale if it hasn't been sent yet.
 
         Send the notification when the start date is before the current date and the
@@ -152,6 +152,6 @@ class SaleCreate(ModelMutation):
         end_date = instance.end_date
 
         if (start_date and start_date <= now) and (not end_date or not end_date <= now):
-            manager.sale_toggle(instance, catalogue)
+            cls.call_event(manager.sale_toggle, instance, catalogue)
             instance.last_notification_scheduled_at = now
             instance.save(update_fields=["last_notification_scheduled_at"])

--- a/saleor/graphql/discount/mutations/sale/sale_update.py
+++ b/saleor/graphql/discount/mutations/sale/sale_update.py
@@ -217,9 +217,9 @@ class SaleUpdate(ModelMutation):
             manager, instance, input, current_catalogue, previous_end_date
         )
 
-    @staticmethod
+    @classmethod
     def send_sale_toggle_notification(
-        manager, instance, input, catalogue, previous_end_date
+        cls, manager, instance, input, catalogue, previous_end_date
     ):
         """Send the notification about starting or ending sale if it wasn't sent yet.
 
@@ -251,6 +251,6 @@ class SaleUpdate(ModelMutation):
             send_notification = True
 
         if send_notification:
-            manager.sale_toggle(instance, catalogue)
+            cls.call_event(manager.sale_toggle, instance, catalogue)
             instance.last_notification_scheduled_at = now
             instance.save(update_fields=["last_notification_scheduled_at"])

--- a/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_activate.py
+++ b/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_activate.py
@@ -60,4 +60,4 @@ class GiftCardBulkActivate(BaseBulkMutation):
         )
         manager = get_plugin_manager_promise(info.context).get()
         for card in models.GiftCard.objects.filter(id__in=gift_card_ids):
-            manager.gift_card_status_changed(card, webhooks=webhooks)
+            cls.call_event(manager.gift_card_status_changed, card, webhooks=webhooks)

--- a/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_create.py
+++ b/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_create.py
@@ -172,9 +172,9 @@ class GiftCardBulkCreate(BaseMutation):
         for tag_instance in tags_instances.iterator():
             tag_instance.gift_cards.set(instances)
 
-    @staticmethod
-    def call_gift_card_created_on_plugins(instances, context):
+    @classmethod
+    def call_gift_card_created_on_plugins(cls, instances, context):
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.GIFT_CARD_CREATED)
         manager = get_plugin_manager_promise(context).get()
         for instance in instances:
-            manager.gift_card_created(instance, webhooks=webhooks)
+            cls.call_event(manager.gift_card_created, instance, webhooks=webhooks)

--- a/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_deactivate.py
+++ b/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_deactivate.py
@@ -51,4 +51,4 @@ class GiftCardBulkDeactivate(BaseBulkMutation):
         )
         manager = get_plugin_manager_promise(info.context).get()
         for card in models.GiftCard.objects.filter(id__in=gift_card_ids):
-            manager.gift_card_status_changed(card, webhooks=webhooks)
+            cls.call_event(manager.gift_card_status_changed, card, webhooks=webhooks)

--- a/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_delete.py
+++ b/saleor/graphql/giftcard/bulk_mutations/gift_card_bulk_delete.py
@@ -39,4 +39,4 @@ class GiftCardBulkDelete(ModelBulkDeleteMutation):
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.GIFT_CARD_DELETED)
         manager = get_plugin_manager_promise(info.context).get()
         for instance in instances:
-            manager.gift_card_deleted(instance, webhooks=webhooks)
+            cls.call_event(manager.gift_card_deleted, instance, webhooks=webhooks)

--- a/saleor/graphql/menu/bulk_mutations/menu_bulk_delete.py
+++ b/saleor/graphql/menu/bulk_mutations/menu_bulk_delete.py
@@ -39,4 +39,4 @@ class MenuBulkDelete(ModelBulkDeleteMutation):
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.MENU_DELETED)
         manager = get_plugin_manager_promise(info.context).get()
         for menu in menus:
-            manager.menu_deleted(menu, webhooks=webhooks)
+            cls.call_event(manager.menu_deleted, menu, webhooks=webhooks)

--- a/saleor/graphql/menu/bulk_mutations/menu_item_bulk_delete.py
+++ b/saleor/graphql/menu/bulk_mutations/menu_item_bulk_delete.py
@@ -39,4 +39,4 @@ class MenuItemBulkDelete(ModelBulkDeleteMutation):
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.MENU_ITEM_DELETED)
         manager = get_plugin_manager_promise(info.context).get()
         for menu_item in menu_items:
-            manager.menu_item_deleted(menu_item, webhooks=webhooks)
+            cls.call_event(manager.menu_item_deleted, menu_item, webhooks=webhooks)

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -1,6 +1,5 @@
 import graphene
 from django.core.exceptions import ValidationError
-from django.db import transaction
 
 from ...attribute import AttributeInputType
 from ...attribute import models as attribute_models
@@ -106,7 +105,7 @@ class PageTypeBulkDelete(ModelBulkDeleteMutation):
         queryset.delete()
         manager = get_plugin_manager_promise(info.context).get()
         for pt in page_types:
-            transaction.on_commit(lambda: manager.page_type_deleted(pt))
+            cls.call_event(manager.page_type_deleted, pt)
 
     @staticmethod
     def delete_assigned_attribute_values(instance_pks):

--- a/saleor/graphql/product/bulk_mutations/collection_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/collection_bulk_delete.py
@@ -40,12 +40,12 @@ class CollectionBulkDelete(ModelBulkDeleteMutation):
         manager = get_plugin_manager_promise(info.context).get()
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.COLLECTION_DELETED)
         for collection in queryset.iterator():
-            manager.collection_deleted(collection, webhooks=webhooks)
+            cls.call_event(manager.collection_deleted, collection, webhooks=webhooks)
         queryset.delete()
 
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.PRODUCT_UPDATED)
         for product in products:
-            manager.product_updated(product, webhooks=webhooks)
+            cls.call_event(manager.product_updated, product, webhooks=webhooks)
 
         update_products_discounted_prices_for_promotion_task.delay(
             [product.id for product in products]

--- a/saleor/graphql/product/bulk_mutations/product_bulk_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_delete.py
@@ -99,4 +99,6 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
         manager = get_plugin_manager_promise(info.context).get()
         for product in products:
             variants = product_variant_map.get(product.id, [])
-            manager.product_deleted(product, variants, webhooks=webhooks)
+            cls.call_event(
+                manager.product_deleted, product, variants, webhooks=webhooks
+            )

--- a/saleor/graphql/product/bulk_mutations/product_variant_stocks_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_stocks_create.py
@@ -3,7 +3,6 @@ from typing import List
 
 import graphene
 from django.core.exceptions import ValidationError
-from django.db import transaction
 
 from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import ProductPermissions
@@ -67,10 +66,8 @@ class ProductVariantStocksCreate(BaseMutation):
                 WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK
             )
             for stock in new_stocks:
-                transaction.on_commit(
-                    lambda: manager.product_variant_back_in_stock(
-                        stock, webhooks=webhooks
-                    )
+                cls.call_event(
+                    manager.product_variant_back_in_stock, stock, webhooks=webhooks
                 )
 
         StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader(

--- a/saleor/graphql/product/bulk_mutations/product_variant_stocks_delete.py
+++ b/saleor/graphql/product/bulk_mutations/product_variant_stocks_delete.py
@@ -1,6 +1,5 @@
 import graphene
 from django.core.exceptions import ValidationError
-from django.db import transaction
 
 from ....core.tracing import traced_atomic_transaction
 from ....permission.enums import ProductPermissions
@@ -80,8 +79,8 @@ class ProductVariantStocksDelete(BaseMutation):
             WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK
         )
         for stock in stocks_to_delete:
-            transaction.on_commit(
-                lambda: manager.product_variant_out_of_stock(stock, webhooks=webhooks)
+            cls.call_event(
+                manager.product_variant_out_of_stock, stock, webhooks=webhooks
             )
 
         stocks_to_delete.delete()

--- a/saleor/graphql/product/mutations/product_variant/product_variant_delete.py
+++ b/saleor/graphql/product/mutations/product_variant/product_variant_delete.py
@@ -137,7 +137,6 @@ class ProductVariantDelete(ModelDeleteMutation, ModelWithExtRefMutation):
             order_pks = draft_order_lines_data.order_pks
             if order_pks:
                 recalculate_orders_task.delay(list(order_pks))
-
             cls.call_event(manager.product_variant_deleted, variant)
 
         return response

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
@@ -538,20 +538,14 @@ def test_update_or_create_variant_stocks_with_out_of_stock_webhook_only(
     ]
 
     assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 10
-
     ProductVariantStocksUpdate.update_or_create_variant_stocks(
         variant, stocks_data, warehouses, plugins
     )
-
-    assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 2
-
     flush_post_commit_hooks()
 
+    assert variant.stocks.aggregate(Sum("quantity"))["quantity__sum"] == 2
     assert product_variant_stock_out_of_stock_webhook.call_count == 1
     assert product_variant_stock_update_webhook.call_count == 2
-    product_variant_stock_update_webhook.assert_called_with(
-        Stock.objects.last(), webhooks=[any_webhook]
-    )
     product_variant_back_in_stock_webhook.assert_not_called()
 
 

--- a/saleor/graphql/shipping/bulk_mutations/shipping_price_bulk_delete.py
+++ b/saleor/graphql/shipping/bulk_mutations/shipping_price_bulk_delete.py
@@ -51,4 +51,4 @@ class ShippingPriceBulkDelete(ModelBulkDeleteMutation):
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.SHIPPING_PRICE_DELETED)
         manager = get_plugin_manager_promise(info.context).get()
         for method in shipping_methods:
-            manager.shipping_price_deleted(method, webhooks=webhooks)
+            cls.call_event(manager.shipping_price_deleted, method, webhooks=webhooks)

--- a/saleor/graphql/shipping/bulk_mutations/shipping_zone_bulk_delete.py
+++ b/saleor/graphql/shipping/bulk_mutations/shipping_zone_bulk_delete.py
@@ -34,4 +34,4 @@ class ShippingZoneBulkDelete(ModelBulkDeleteMutation):
         webhooks = get_webhooks_for_event(WebhookEventAsyncType.SHIPPING_ZONE_DELETED)
         manager = get_plugin_manager_promise(info.context).get()
         for zone in zones:
-            manager.shipping_zone_deleted(zone, webhooks=webhooks)
+            cls.call_event(manager.shipping_zone_deleted, zone, webhooks=webhooks)

--- a/saleor/graphql/shop/mutations/shop_settings_update.py
+++ b/saleor/graphql/shop/mutations/shop_settings_update.py
@@ -213,6 +213,6 @@ class ShopSettingsUpdate(BaseMutation):
             or instance.private_metadata != old_private_metadata
         ):
             manager = get_plugin_manager_promise(info.context).get()
-            manager.shop_metadata_updated(instance)
+            cls.call_event(manager.shop_metadata_updated, instance)
 
         return ShopSettingsUpdate(shop=Shop())

--- a/saleor/graphql/webhook/mutations/event_delivery_retry.py
+++ b/saleor/graphql/webhook/mutations/event_delivery_retry.py
@@ -31,5 +31,5 @@ class EventDeliveryRetry(BaseMutation):
             only_type=EventDelivery,
         )
         manager = get_plugin_manager_promise(info.context).get()
-        manager.event_delivery_retry(delivery)
+        cls.call_event(manager.event_delivery_retry, delivery)
         return EventDeliveryRetry(delivery=delivery)

--- a/saleor/product/tests/test_category.py
+++ b/saleor/product/tests/test_category.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from ...plugins.manager import get_plugins_manager
+from ...tests.utils import flush_post_commit_hooks
 from ..models import Category
 from ..utils import collect_categories_tree_products, delete_categories
 
@@ -58,12 +59,16 @@ def test_delete_categories_trigger_product_updated_webhook(
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
+
     parent = categories_tree_with_published_products
     child = parent.children.first()
     product_list = [child.products.first(), parent.products.first()]
 
+    # when
     delete_categories([parent.pk], manager=get_plugins_manager())
+    flush_post_commit_hooks()
 
+    # then
     assert not Category.objects.filter(
         id__in=[category.id for category in [parent, child]]
     ).exists()

--- a/saleor/product/utils/__init__.py
+++ b/saleor/product/utils/__init__.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Union
 
 from ...core.taxes import TaxedMoney, zero_taxed_money
 from ...core.tracing import traced_atomic_transaction
+from ...core.utils.events import call_event
 from ...webhook.event_types import WebhookEventAsyncType
 from ...webhook.utils import get_webhooks_for_event
 from ..models import Product, ProductChannelListing
@@ -58,10 +59,10 @@ def delete_categories(categories_ids: List[Union[str, int]], manager):
     categories.delete()
     webhooks = get_webhooks_for_event(WebhookEventAsyncType.CATEGORY_DELETED)
     for category in category_instances:
-        manager.category_deleted(category, webhooks=webhooks)
+        call_event(manager.category_deleted, category, webhooks=webhooks)
     webhooks = get_webhooks_for_event(WebhookEventAsyncType.PRODUCT_UPDATED)
     for product in products:
-        manager.product_updated(product, webhooks=webhooks)
+        call_event(manager.product_updated, product, webhooks=webhooks)
 
     update_products_discounted_prices_for_promotion_task.delay(
         product_ids=[product.id for product in products]


### PR DESCRIPTION
I want to merge this change because it ensures that all webhooks called in mutations are run after a transaction commit

resolves: https://github.com/saleor/saleor/issues/10851

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
