### PR TITLE
Fix generating slug for product create mutation

### DIFF
--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -119,6 +119,11 @@ def generate_unique_slug(
     """
     slug = slugify(unidecode(slugable_value))
 
+    # in case when slugable_value contains only not allowed in slug characters, slugify
+    # function will return empty string, so we need to provide some default value
+    if slug == "":
+        slug = "-"
+
     ModelClass = instance.__class__
 
     search_field = f"{slug_field_name}__iregex"

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -150,7 +150,11 @@ def prepare_unique_slug(slug: str, slug_values: Iterable):
 
     while unique_slug in slug_values:
         extension += 1
-        unique_slug = f"{slug}-{extension}"
+
+        if slug == "-":
+            unique_slug = f"{slug}{extension}"
+        else:
+            unique_slug = f"{slug}-{extension}"
 
     return unique_slug
 

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -150,11 +150,7 @@ def prepare_unique_slug(slug: str, slug_values: Iterable):
 
     while unique_slug in slug_values:
         extension += 1
-
-        if slug == "-":
-            unique_slug = f"{slug}{extension}"
-        else:
-            unique_slug = f"{slug}-{extension}"
+        unique_slug = f"{slug}-{extension}"
 
     return unique_slug
 

--- a/saleor/graphql/product/tests/mutations/test_product_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_create.py
@@ -190,6 +190,32 @@ def test_create_product(
     update_product_discounted_price_task_mock.assert_called_once_with(product.id)
 
 
+def test_create_product_without_slug_and_not_allowed_characters_for_slug_in_name(
+    staff_api_client,
+    product_type,
+    permission_manage_products,
+):
+    # given
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    variables = {
+        "input": {
+            "productType": product_type_id,
+            "name": "->>",
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_PRODUCT_MUTATION, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["productCreate"]
+    assert data["errors"] == []
+    assert data["product"]["slug"] == "-"
+
+
 def test_create_product_use_tax_class_from_product_type(
     staff_api_client,
     product_type,

--- a/saleor/graphql/product/tests/mutations/test_product_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_create.py
@@ -240,7 +240,7 @@ def test_create_second_product_without_slug_and_not_allowed_characters_for_slug_
     content = get_graphql_content(response)
     data = content["data"]["productCreate"]
     assert data["errors"] == []
-    assert data["product"]["slug"] == "-2"
+    assert data["product"]["slug"] == "--2"
 
 
 def test_create_product_use_tax_class_from_product_type(

--- a/saleor/graphql/product/tests/mutations/test_product_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_create.py
@@ -216,6 +216,33 @@ def test_create_product_without_slug_and_not_allowed_characters_for_slug_in_name
     assert data["product"]["slug"] == "-"
 
 
+def test_create_second_product_without_slug_and_not_allowed_characters_for_slug_in_name(
+    staff_api_client, product_type, permission_manage_products, product
+):
+    # given
+    product.slug = "-"
+    product.save(update_fields=["slug"])
+
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    variables = {
+        "input": {
+            "productType": product_type_id,
+            "name": "->>",
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_PRODUCT_MUTATION, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["productCreate"]
+    assert data["errors"] == []
+    assert data["product"]["slug"] == "-2"
+
+
 def test_create_product_use_tax_class_from_product_type(
     staff_api_client,
     product_type,


### PR DESCRIPTION
I want to merge this change because it fixes generating `slug` for cases when `slug` is not provided and `name` contains characters that return an empty string after `slugify`. 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
