### PR TITLE
Adjust `OrderBulkCreate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable, unreleased changes to this project will be documented in this file.
 # 3.18.0 [Unreleased]
 
 ### Breaking changes
+- Allow add multiple codes per voucher - #14123 by @SzymJ, @IKarbowiak, @michal-macioszczyk
+  - Rename `OrderBulkCreateInput.voucher` to `OrderBulkCreateInput.voucher_code`
 
 ### GraphQL API
 - Fix draft order voucher assignment - #14336 by @IKarbowiak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable, unreleased changes to this project will be documented in this file.
 # 3.18.0 [Unreleased]
 
 ### Breaking changes
-- Allow add multiple codes per voucher - #14123 by @SzymJ, @IKarbowiak, @michal-macioszczyk
-  - Rename `OrderBulkCreateInput.voucher` to `OrderBulkCreateInput.voucher_code`
 
 ### GraphQL API
 - Fix draft order voucher assignment - #14336 by @IKarbowiak
+- Allow add multiple codes per voucher - #14123 by @SzymJ, @IKarbowiak, @michal-macioszczyk
+  - Deprecate `OrderBulkCreateInput.voucher`
 
 ### Saleor Apps
 

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -759,6 +759,45 @@ def test_order_bulk_create(
     assert OrderDiscount.objects.count() == discount_count + 1
 
 
+def test_order_bulk_create_with_voucher(
+    staff_api_client,
+    permission_manage_orders,
+    permission_manage_orders_import,
+    order_bulk_input,
+):
+    # given
+    orders_count = Order.objects.count()
+    order_lines_count = OrderLine.objects.count()
+
+    code = order_bulk_input.pop("voucherCode")
+    order_bulk_input["voucher"] = code
+
+    staff_api_client.user.user_permissions.add(
+        permission_manage_orders_import,
+        permission_manage_orders,
+    )
+    variables = {
+        "orders": [order_bulk_input],
+        "stockUpdatePolicy": StockUpdatePolicyEnum.SKIP.name,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_BULK_CREATE, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["orderBulkCreate"]["count"] == 1
+    data = content["data"]["orderBulkCreate"]["results"]
+    assert not data[0]["errors"]
+    order = data[0]["order"]
+
+    assert order["lines"]
+    assert order["voucher"]["code"] == code
+    assert order["voucherCode"] == code
+    assert Order.objects.count() == orders_count + 1
+    assert OrderLine.objects.count() == order_lines_count + 1
+
+
 def test_order_bulk_create_multiple_orders(
     staff_api_client,
     permission_manage_orders,
@@ -1915,6 +1954,44 @@ def test_order_bulk_create_update_stocks_missing_stocks(
     )
     assert error["path"] == "lines.0"
     assert error["code"] == OrderBulkCreateErrorCode.NON_EXISTING_STOCK.name
+
+
+def test_order_bulk_create_both_voucher_and_voucher_code_given(
+    staff_api_client,
+    permission_manage_orders,
+    permission_manage_orders_import,
+    order_bulk_input,
+):
+    # given
+    orders_count = Order.objects.count()
+    order_lines_count = OrderLine.objects.count()
+
+    code = order_bulk_input.get("voucherCode")
+    order_bulk_input["voucher"] = code
+
+    staff_api_client.user.user_permissions.add(
+        permission_manage_orders_import,
+        permission_manage_orders,
+    )
+    variables = {
+        "orders": [order_bulk_input],
+        "stockUpdatePolicy": StockUpdatePolicyEnum.SKIP.name,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_BULK_CREATE, variables)
+    content = get_graphql_content(response)
+
+    # then
+    assert content["data"]["orderBulkCreate"]["count"] == 0
+    assert not content["data"]["orderBulkCreate"]["results"][0]["order"]
+    error = content["data"]["orderBulkCreate"]["results"][0]["errors"][0]
+    assert error["message"] == "Cannot use both voucher and voucher_code."
+    assert error["path"] == "voucher_code.0"
+    assert error["code"] == OrderBulkCreateErrorCode.INVALID.name
+
+    assert Order.objects.count() == orders_count
+    assert OrderLine.objects.count() == order_lines_count
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -1987,7 +1987,7 @@ def test_order_bulk_create_both_voucher_and_voucher_code_given(
     assert not content["data"]["orderBulkCreate"]["results"][0]["order"]
     error = content["data"]["orderBulkCreate"]["results"][0]["errors"][0]
     assert error["message"] == "Cannot use both voucher and voucher_code."
-    assert error["path"] == "voucher_code.0"
+    assert error["path"] == "voucher_code"
     assert error["code"] == OrderBulkCreateErrorCode.INVALID.name
 
     assert Order.objects.count() == orders_count

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -31,7 +31,7 @@ from .....payment import TransactionEventType
 from .....payment.models import TransactionEvent, TransactionItem
 from .....warehouse.models import Stock
 from ....core.enums import ErrorPolicyEnum
-from ....discount.enums import DiscountValueTypeEnum
+from ....discount.enums import DiscountValueTypeEnum, OrderDiscountTypeEnum
 from ....payment.enums import TransactionActionEnum
 from ....tests.utils import assert_no_permission, get_graphql_content
 from ...bulk_mutations.order_bulk_create import MAX_NOTE_LENGTH, MINUTES_DIFF
@@ -246,10 +246,16 @@ ORDER_BULK_CREATE = """
                         url
                     }
                     discounts {
+                        type
                         valueType
                         value
                         reason
                     }
+                    voucher {
+                        id
+                        code
+                    }
+                    voucherCode
                 }
                 errors {
                     path
@@ -396,7 +402,7 @@ def order_bulk_input(
         "invoices": [invoice],
         "discounts": [discount],
         "giftCards": ["never_expiry"],
-        "voucher": "mirumee",
+        "voucherCode": "mirumee",
         "metadata": [{"key": "md key", "value": "md value"}],
         "privateMetadata": [{"key": "pmd key", "value": "pmd value"}],
     }
@@ -484,6 +490,7 @@ def test_order_bulk_create(
     graphql_address_data,
     shipping_method_channel_PLN,
     variant,
+    voucher,
 ):
     # given
     orders_count = Order.objects.count()
@@ -496,6 +503,7 @@ def test_order_bulk_create(
     transaction_events_count = TransactionEvent.objects.count()
     invoice_count = Invoice.objects.count()
     discount_count = OrderDiscount.objects.count()
+    voucher_code = "mirumee"
 
     order = order_bulk_input
     order["externalReference"] = "ext-ref-1"
@@ -544,6 +552,9 @@ def test_order_bulk_create(
     assert order["metadata"][0]["value"] == "md value"
     assert order["privateMetadata"][0]["key"] == "pmd key"
     assert order["privateMetadata"][0]["value"] == "pmd value"
+    assert order["voucher"]["id"] == graphene.Node.to_global_id("Voucher", voucher.id)
+    assert order["voucher"]["code"] == voucher_code
+    assert order["voucherCode"] == voucher_code
     db_order = Order.objects.get()
     assert db_order.external_reference == "ext-ref-1"
     assert db_order.channel.slug == channel_PLN.slug
@@ -573,7 +584,8 @@ def test_order_bulk_create(
     assert db_order.display_gross_prices
     assert db_order.currency == "PLN"
     assert db_order.gift_cards.first().code == "never_expiry"
-    assert db_order.voucher.code == "mirumee"
+    assert db_order.voucher.code == voucher_code
+    assert db_order.voucher_code == voucher_code
     assert db_order.metadata["md key"] == "md value"
     assert db_order.private_metadata["pmd key"] == "pmd value"
     assert db_order.total_authorized_amount == Decimal("10")
@@ -722,11 +734,14 @@ def test_order_bulk_create(
     assert db_invoice.order_id == db_order.id
     assert db_invoice.status == JobStatus.SUCCESS
 
+    assert len(order["discounts"]) == 1
     discount = order["discounts"][0]
+    assert discount["type"] == OrderDiscountTypeEnum.MANUAL.name
     assert discount["valueType"] == DiscountValueTypeEnum.FIXED.name
     assert discount["value"] == 10
     assert discount["reason"] == "birthday"
     db_discount = OrderDiscount.objects.get()
+    assert db_discount.type == OrderDiscountTypeEnum.MANUAL.value
     assert db_discount.value_type == DiscountValueTypeEnum.FIXED.value
     assert db_discount.value == 10
     assert db_discount.reason == "birthday"

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -26067,7 +26067,18 @@ input OrderBulkCreateInput @doc(category: "Orders") {
   """List of gift card codes associated with the order."""
   giftCards: [String!]
 
-  """Code of a voucher associated with the order."""
+  """
+  Code of a voucher associated with the order.
+  
+  DEPRECATED: this field will be removed in Saleor 3.19. Use `voucherCode` instead.
+  """
+  voucher: String
+
+  """
+  Code of a voucher associated with the order.
+  
+  Added in Saleor 3.18.
+  """
   voucherCode: String
 
   """List of discounts."""

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -26068,7 +26068,7 @@ input OrderBulkCreateInput @doc(category: "Orders") {
   giftCards: [String!]
 
   """Code of a voucher associated with the order."""
-  voucher: String
+  voucherCode: String
 
   """List of discounts."""
   discounts: [OrderDiscountCommonInput!]


### PR DESCRIPTION
Adjust `OrderBulkCreate` to set both `voucher` and `voucher_code` on `Order`.

Resolves https://github.com/saleor/saleor/issues/14375

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
