### PR TITLE
Release voucher after draft order delete.

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_delete.py
+++ b/saleor/graphql/order/mutations/draft_order_delete.py
@@ -66,7 +66,4 @@ class DraftOrderDelete(
         if code := instance.voucher_code:
             if voucher_code := VoucherCode.objects.filter(code=code).first():
                 voucher = voucher_code.voucher
-                user_email = (
-                    instance.user.email if instance.user else instance.user_email
-                )
-                release_voucher_code_usage(voucher_code, voucher, user_email)
+                release_voucher_code_usage(voucher_code, voucher, None)

--- a/saleor/graphql/order/mutations/draft_order_delete.py
+++ b/saleor/graphql/order/mutations/draft_order_delete.py
@@ -2,6 +2,8 @@ import graphene
 from django.core.exceptions import ValidationError
 
 from ....core.tracing import traced_atomic_transaction
+from ....discount.models import VoucherCode
+from ....discount.utils import release_voucher_code_usage
 from ....order import OrderStatus, models
 from ....order.error_codes import OrderErrorCode
 from ....permission.enums import OrderPermissions
@@ -58,3 +60,13 @@ class DraftOrderDelete(
     @classmethod
     def get_instance_channel_id(cls, instance):
         return instance.channel_id
+
+    @classmethod
+    def post_save_action(cls, info, instance, _):
+        if code := instance.voucher_code:
+            if voucher_code := VoucherCode.objects.filter(code=code).first():
+                voucher = voucher_code.voucher
+                user_email = (
+                    instance.user.email if instance.user else instance.user_email
+                )
+                release_voucher_code_usage(voucher_code, voucher, user_email)

--- a/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
@@ -1,6 +1,7 @@
 import graphene
 import pytest
 
+from .....discount.models import VoucherCode
 from .....order import OrderStatus
 from .....order.error_codes import OrderErrorCode
 from ....tests.utils import assert_no_permission, get_graphql_content
@@ -209,3 +210,74 @@ def test_draft_order_delete_by_external_reference_not_existing(
     # then
     errors = content["data"]["draftOrderDelete"]["errors"]
     assert errors[0]["message"] == f"Couldn't resolve to a node: {ext_ref}"
+
+
+def test_draft_order_delete_release_voucher_codes_multiple_use(
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order_list_with_multiple_use_voucher,
+):
+    # given
+    query = DRAFT_ORDER_DELETE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order = draft_order_list_with_multiple_use_voucher[0]
+    voucher_code = VoucherCode.objects.get(code=order.voucher_code)
+    assert voucher_code.used == 1
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id}
+
+    # when
+    staff_api_client.post_graphql(query, variables)
+
+    # then
+    voucher_code.refresh_from_db()
+    assert voucher_code.used == 0
+
+
+def test_draft_order_delete_release_voucher_codes_single_use(
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order_list_with_single_use_voucher,
+):
+    # given
+    query = DRAFT_ORDER_DELETE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    order = draft_order_list_with_single_use_voucher[0]
+    voucher_code = VoucherCode.objects.get(code=order.voucher_code)
+    assert voucher_code.is_active is False
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id}
+
+    # when
+    staff_api_client.post_graphql(query, variables)
+
+    # then
+    voucher_code.refresh_from_db()
+    assert voucher_code.is_active is True
+
+
+def test_draft_order_delete_release_voucher_code_customer(
+    staff_api_client,
+    permission_group_manage_orders,
+    draft_order,
+    voucher_customer,
+):
+    # given
+    query = DRAFT_ORDER_DELETE_MUTATION
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    voucher_code = voucher_customer.voucher_code
+    draft_order.voucher_code = voucher_code.code
+    draft_order.save(update_fields=["voucher_code"])
+    assert voucher_customer.customer_email == draft_order.user_email
+
+    order_id = graphene.Node.to_global_id("Order", draft_order.id)
+    variables = {"id": order_id}
+
+    # when
+    staff_api_client.post_graphql(query, variables)
+
+    # then
+    with pytest.raises(voucher_customer._meta.model.DoesNotExist):
+        voucher_customer.refresh_from_db()

--- a/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_delete.py
@@ -256,28 +256,3 @@ def test_draft_order_delete_release_voucher_codes_single_use(
     # then
     voucher_code.refresh_from_db()
     assert voucher_code.is_active is True
-
-
-def test_draft_order_delete_release_voucher_code_customer(
-    staff_api_client,
-    permission_group_manage_orders,
-    draft_order,
-    voucher_customer,
-):
-    # given
-    query = DRAFT_ORDER_DELETE_MUTATION
-    permission_group_manage_orders.user_set.add(staff_api_client.user)
-    voucher_code = voucher_customer.voucher_code
-    draft_order.voucher_code = voucher_code.code
-    draft_order.save(update_fields=["voucher_code"])
-    assert voucher_customer.customer_email == draft_order.user_email
-
-    order_id = graphene.Node.to_global_id("Order", draft_order.id)
-    variables = {"id": order_id}
-
-    # when
-    staff_api_client.post_graphql(query, variables)
-
-    # then
-    with pytest.raises(voucher_customer._meta.model.DoesNotExist):
-        voucher_customer.refresh_from_db()

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4008,6 +4008,49 @@ def voucher_customer(voucher, customer_user):
 
 
 @pytest.fixture
+def voucher_multiple_use(voucher_with_many_codes):
+    voucher = voucher_with_many_codes
+    voucher.usage_limit = 3
+    voucher.save(update_fields=["usage_limit"])
+    codes = voucher.codes.all()
+    for code in codes:
+        code.used = 1
+    VoucherCode.objects.bulk_update(codes, ["used"])
+    voucher.refresh_from_db()
+    return voucher
+
+
+@pytest.fixture
+def voucher_single_use(voucher_with_many_codes):
+    voucher = voucher_with_many_codes
+    voucher.single_use = True
+    voucher.save(update_fields=["single_use"])
+    return voucher
+
+
+@pytest.fixture
+def draft_order_list_with_multiple_use_voucher(draft_order_list, voucher_multiple_use):
+    codes = voucher_multiple_use.codes.values_list("code", flat=True)
+    for idx, order in enumerate(draft_order_list):
+        order.voucher_code = codes[idx]
+    Order.objects.bulk_update(draft_order_list, ["voucher_code"])
+    return draft_order_list
+
+
+@pytest.fixture
+def draft_order_list_with_single_use_voucher(draft_order_list, voucher_single_use):
+    voucher_codes = voucher_single_use.codes.all()
+    codes = voucher_codes.values_list("code", flat=True)
+    for idx, order in enumerate(draft_order_list):
+        order.voucher_code = codes[idx]
+    for voucher_code in voucher_codes:
+        voucher_code.is_active = False
+    Order.objects.bulk_update(draft_order_list, ["voucher_code"])
+    VoucherCode.objects.bulk_update(voucher_codes, ["is_active"])
+    return draft_order_list
+
+
+@pytest.fixture
 def order_line(order, variant):
     product = variant.product
     channel = order.channel


### PR DESCRIPTION
Issue: https://github.com/saleor/saleor/issues/14180
RFC: https://github.com/saleor/saleor/issues/13713

I want to merge this change because, because I want to release voucher code usage when deleting draft order.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
