### PR TITLE
Remove CustomerVoucher creation from draftOrderCreate

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -59,8 +59,6 @@ def increase_voucher_usage(
 ) -> None:
     if voucher.usage_limit:
         increase_voucher_code_usage_value(code)
-    if voucher.apply_once_per_customer:
-        add_voucher_usage_by_customer(code, customer_email)
     if voucher.single_use:
         deactivate_voucher_code(code)
 

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -55,10 +55,15 @@ CATALOGUE_FIELDS = ["categories", "collections", "products", "variants"]
 
 
 def increase_voucher_usage(
-    voucher: "Voucher", code: "VoucherCode", customer_email: str
+    voucher: "Voucher",
+    code: "VoucherCode",
+    customer_email: str,
+    allow_customer_voucher_creation: bool = True,
 ) -> None:
     if voucher.usage_limit:
         increase_voucher_code_usage_value(code)
+    if voucher.apply_once_per_customer and allow_customer_voucher_creation:
+        add_voucher_usage_by_customer(code, customer_email)
     if voucher.single_use:
         deactivate_voucher_code(code)
 

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -58,11 +58,11 @@ def increase_voucher_usage(
     voucher: "Voucher",
     code: "VoucherCode",
     customer_email: str,
-    allow_customer_voucher_creation: bool = True,
+    increase_voucher_customer_usage: bool = True,
 ) -> None:
     if voucher.usage_limit:
         increase_voucher_code_usage_value(code)
-    if voucher.apply_once_per_customer and allow_customer_voucher_creation:
+    if voucher.apply_once_per_customer and increase_voucher_customer_usage:
         add_voucher_usage_by_customer(code, customer_email)
     if voucher.single_use:
         deactivate_voucher_code(code)

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -579,5 +579,8 @@ class DraftOrderCreate(
         channel = instance.channel
         if channel.include_draft_order_in_voucher_usage:
             increase_voucher_usage(
-                voucher, code_instance, instance.user_email or instance.user.email
+                voucher,
+                code_instance,
+                instance.user_email or instance.user.email,
+                allow_customer_voucher_creation=False,
             )

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -582,5 +582,5 @@ class DraftOrderCreate(
                 voucher,
                 code_instance,
                 instance.user_email or instance.user.email,
-                allow_customer_voucher_creation=False,
+                increase_voucher_customer_usage=False,
             )

--- a/saleor/graphql/order/tests/mutations/test_draft_order_create.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_create.py
@@ -779,7 +779,7 @@ def test_draft_order_create_with_voucher_including_drafts_in_voucher_usage(
     code = voucher.codes.first()
     assert code.used == 1
 
-    assert VoucherCustomer.objects.filter(voucher_code=code)
+    assert not VoucherCustomer.objects.filter(voucher_code=code).exists()
 
 
 def test_draft_order_create_with_voucher_including_drafts_in_voucher_usage_invalid_code(
@@ -929,7 +929,7 @@ def test_draft_order_create_with_voucher_code_including_drafts_in_voucher_usage(
     code = voucher.codes.first()
     assert code.used == 1
 
-    assert VoucherCustomer.objects.filter(voucher_code=code)
+    assert not VoucherCustomer.objects.filter(voucher_code=code).exists()
 
 
 def test_draft_order_create_voucher_code_including_drafts_in_voucher_usage_invalid_code(


### PR DESCRIPTION
I want to merge this change because I want to remove CustomerVoucher creation as the user might change (we should create VoucherCustomer during draftOrderComplete - will be done in https://github.com/saleor/saleor/issues/14382)

https://github.com/saleor/saleor/issues/14376

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
