### PR TITLE
Fix generating slug for product create mutation

### DIFF
--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -111,6 +111,11 @@ def generate_unique_slug(
     """
     slug = slugify(unidecode(slugable_value))
 
+    # in case when slugable_value contains only not allowed in slug characters, slugify
+    # function will return empty string, so we need to provide some default value
+    if slug == "":
+        slug = "-"
+
     ModelClass = instance.__class__
 
     search_field = f"{slug_field_name}__iregex"


### PR DESCRIPTION
I want to merge this change because it fixes generating `slug` for cases when `slug` is not provided and `name` contains characters that return an empty string after `slugify`. 

Port of #14378

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
