### PR TITLE
Remove redundant webhook calls during export tasks.

### DIFF
--- a/saleor/csv/tests/export/test_export.py
+++ b/saleor/csv/tests/export/test_export.py
@@ -35,7 +35,6 @@ from ...utils.export import (
     "file_type",
     [FileTypes.CSV, FileTypes.XLSX],
 )
-@patch("saleor.plugins.manager.PluginsManager.product_export_completed")
 @patch("saleor.csv.utils.export.create_file_with_headers")
 @patch("saleor.csv.utils.export.export_products_in_batches")
 @patch("saleor.csv.utils.export.send_export_download_link_notification")
@@ -45,7 +44,6 @@ def test_export_products(
     send_email_mock,
     export_products_in_batches_mock,
     create_file_with_headers_mock,
-    mocked_product_export_completed,
     product_list,
     user_export_file,
     file_type,
@@ -89,7 +87,6 @@ def test_export_products(
     )
     send_email_mock.assert_called_once_with(user_export_file, "products")
     save_file_mock.assert_called_once_with(user_export_file, mock_file, ANY)
-    mocked_product_export_completed.assert_called_once_with(user_export_file)
 
 
 @patch("saleor.csv.utils.export.create_file_with_headers")
@@ -296,7 +293,23 @@ def test_export_products_by_app(
     save_file_mock.assert_called_once_with(app_export_file, mock_file, ANY)
 
 
-@patch("saleor.plugins.manager.PluginsManager.gift_card_export_completed")
+@patch("saleor.plugins.manager.PluginsManager.product_export_completed")
+def test_export_products_webhook(
+    mocked_product_export_completed,
+    product_list,
+    user_export_file,
+    media_root,
+):
+    # given
+    product_list[0].variants.update(sku=None)
+
+    # when
+    export_products(user_export_file, {"all": ""}, {}, FileTypes.CSV)
+
+    # then
+    mocked_product_export_completed.assert_called_once_with(user_export_file)
+
+
 @patch("saleor.csv.utils.export.create_file_with_headers")
 @patch("saleor.csv.utils.export.export_gift_cards_in_batches")
 @patch("saleor.csv.utils.export.send_export_download_link_notification")
@@ -306,12 +319,12 @@ def test_export_gift_cards(
     send_email_mock,
     export_in_batches_mock,
     create_file_with_headers_mock,
-    mocked_gift_card_export_completed,
     user_export_file,
     gift_card,
     gift_card_expiry_date,
     gift_card_used,
 ):
+    # given
     file_type = FileTypes.CSV
 
     mock_file = MagicMock(spec=File)
@@ -338,8 +351,6 @@ def test_export_gift_cards(
     send_email_mock.assert_called_once_with(user_export_file, "gift cards")
 
     save_file_mock.assert_called_once_with(user_export_file, mock_file, ANY)
-
-    mocked_gift_card_export_completed.assert_called_once_with(user_export_file)
 
 
 @patch("saleor.csv.utils.export.create_file_with_headers")
@@ -480,6 +491,25 @@ def test_export_gift_cards_with_filter(
     send_email_mock.assert_called_once_with(user_export_file, "gift cards")
 
     save_file_mock.assert_called_once_with(user_export_file, mock_file, ANY)
+
+
+@patch("saleor.plugins.manager.PluginsManager.gift_card_export_completed")
+def test_export_gift_cards_webhook(
+    mocked_gift_card_export_completed,
+    user_export_file,
+    gift_card,
+    gift_card_expiry_date,
+    gift_card_used,
+    media_root,
+):
+    # given
+    file_type = FileTypes.CSV
+
+    # when
+    export_gift_cards(user_export_file, {"all": ""}, file_type)
+
+    # then
+    mocked_gift_card_export_completed.assert_called_once_with(user_export_file)
 
 
 def test_get_filename_csv():

--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -7,7 +7,6 @@ import petl as etl
 from django.utils import timezone
 
 from ...giftcard.models import GiftCard
-from ...plugins.manager import get_plugins_manager
 from ...product.models import Product
 from .. import FileTypes
 from ..notifications import send_export_download_link_notification
@@ -57,9 +56,6 @@ def export_products(
     temporary_file.close()
 
     send_export_download_link_notification(export_file, "products")
-    manager = get_plugins_manager()
-
-    manager.product_export_completed(export_file)
 
 
 def export_gift_cards(
@@ -91,8 +87,6 @@ def export_gift_cards(
     temporary_file.close()
 
     send_export_download_link_notification(export_file, "gift cards")
-    manager = get_plugins_manager()
-    manager.gift_card_export_completed(export_file)
 
 
 def get_filename(model_name: str, file_type: str) -> str:

--- a/saleor/graphql/csv/tests/mutations/test_export_gift_cards.py
+++ b/saleor/graphql/csv/tests/mutations/test_export_gift_cards.py
@@ -66,15 +66,20 @@ def test_export_gift_cards_mutation(
     permission_manage_gift_card,
     permission_manage_apps,
 ):
+    # given
     query = EXPORT_GIFT_CARDS_MUTATION
     user = staff_api_client.user
     variables = {"input": input}
+
+    # when
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
         permissions=[permission_manage_gift_card, permission_manage_apps],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportGiftCards"]
     export_file_data = data["exportFile"]
 
@@ -103,6 +108,7 @@ def test_export_gift_cards_mutation_ids_scope(
     permission_manage_apps,
     permission_manage_staff,
 ):
+    # given
     query = EXPORT_GIFT_CARDS_MUTATION
     user = staff_api_client.user
 
@@ -118,6 +124,7 @@ def test_export_gift_cards_mutation_ids_scope(
         }
     }
 
+    # when
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
@@ -128,6 +135,8 @@ def test_export_gift_cards_mutation_ids_scope(
         ],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportGiftCards"]
     export_file_data = data["exportFile"]
 
@@ -161,6 +170,7 @@ def test_export_gift_cards_mutation_ids_scope_invalid_object_type(
     permission_manage_apps,
     permission_manage_staff,
 ):
+    # given
     query = EXPORT_GIFT_CARDS_MUTATION
     user = staff_api_client.user
 
@@ -176,6 +186,7 @@ def test_export_gift_cards_mutation_ids_scope_invalid_object_type(
         }
     }
 
+    # when
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
@@ -186,6 +197,8 @@ def test_export_gift_cards_mutation_ids_scope_invalid_object_type(
         ],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportGiftCards"]
 
     errors = data["errors"]
@@ -232,11 +245,13 @@ def test_export_gift_cards_mutation_failed(
     permission_manage_apps,
     permission_manage_staff,
 ):
+    # given
     query = EXPORT_GIFT_CARDS_MUTATION
     app = app_api_client.app
 
     variables = {"input": input}
 
+    # when
     response = app_api_client.post_graphql(
         query,
         variables=variables,
@@ -247,6 +262,8 @@ def test_export_gift_cards_mutation_failed(
         ],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportGiftCards"]
 
     errors = data["errors"]
@@ -295,6 +312,7 @@ def test_export_gift_cards_mutation_by_app(
     permission_manage_apps,
     permission_manage_staff,
 ):
+    # given
     query = EXPORT_GIFT_CARDS_MUTATION_BY_APP
     app = app_api_client.app
     variables = {
@@ -304,6 +322,7 @@ def test_export_gift_cards_mutation_by_app(
         }
     }
 
+    # when
     response = app_api_client.post_graphql(
         query,
         variables=variables,
@@ -313,6 +332,8 @@ def test_export_gift_cards_mutation_by_app(
         ],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportGiftCards"]
     export_file_data = data["exportFile"]
 
@@ -327,3 +348,33 @@ def test_export_gift_cards_mutation_by_app(
     assert ExportEvent.objects.filter(
         user=None, app=app, type=ExportEvents.EXPORT_PENDING
     ).exists()
+
+
+@patch("saleor.plugins.manager.PluginsManager.gift_card_export_completed")
+def test_export_gift_cards_webhooks(
+    gift_card_export_completed_mock,
+    staff_api_client,
+    gift_card,
+    gift_card_expiry_date,
+    permission_manage_gift_card,
+    permission_manage_apps,
+    media_root,
+):
+    # given
+    query = EXPORT_GIFT_CARDS_MUTATION
+    input = {"scope": ExportScope.ALL.name, "fileType": FileTypeEnum.CSV.name}
+    variables = {"input": input}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_gift_card, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["exportGiftCards"]
+    assert not data["errors"]
+
+    gift_card_export_completed_mock.assert_called_once()

--- a/saleor/graphql/csv/tests/mutations/test_export_products.py
+++ b/saleor/graphql/csv/tests/mutations/test_export_products.py
@@ -92,16 +92,20 @@ def test_export_products_mutation(
     input,
     called_data,
 ):
+    # given
     query = EXPORT_PRODUCTS_MUTATION
     user = staff_api_client.user
     variables = {"input": input}
 
+    # when
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
         permissions=[permission_manage_products, permission_manage_apps],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportProducts"]
     export_file_data = data["exportFile"]
 
@@ -127,6 +131,7 @@ def test_export_products_mutation_by_app(
     permission_manage_products,
     permission_manage_apps,
 ):
+    # given
     query = EXPORT_PRODUCTS_BY_APP_MUTATION
     app = app_api_client.app
     variables = {
@@ -137,6 +142,7 @@ def test_export_products_mutation_by_app(
         }
     }
 
+    # when
     response = app_api_client.post_graphql(
         query,
         variables=variables,
@@ -146,6 +152,8 @@ def test_export_products_mutation_by_app(
         ],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportProducts"]
     export_file_data = data["exportFile"]
 
@@ -170,6 +178,7 @@ def test_export_products_mutation_ids_scope(
     permission_manage_products,
     permission_manage_apps,
 ):
+    # given
     query = EXPORT_PRODUCTS_MUTATION
     user = staff_api_client.user
 
@@ -194,12 +203,15 @@ def test_export_products_mutation_ids_scope(
         }
     }
 
+    # when
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
         permissions=[permission_manage_products, permission_manage_apps],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportProducts"]
     export_file_data = data["exportFile"]
 
@@ -231,6 +243,7 @@ def test_export_products_mutation_ids_scope_invalid_object_type(
     permission_manage_products,
     permission_manage_apps,
 ):
+    # given
     query = EXPORT_PRODUCTS_MUTATION
 
     products = product_list[:2]
@@ -252,12 +265,15 @@ def test_export_products_mutation_ids_scope_invalid_object_type(
         }
     }
 
+    # when
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
         permissions=[permission_manage_products, permission_manage_apps],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportProducts"]
     errors = data["errors"]
     assert len(errors) == 1
@@ -278,6 +294,7 @@ def test_export_products_mutation_with_warehouse_and_attribute_ids(
     permission_manage_products,
     permission_manage_apps,
 ):
+    # given
     query = EXPORT_PRODUCTS_MUTATION
     user = staff_api_client.user
 
@@ -315,12 +332,15 @@ def test_export_products_mutation_with_warehouse_and_attribute_ids(
         }
     }
 
+    # when
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
         permissions=[permission_manage_products, permission_manage_apps],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportProducts"]
     export_file_data = data["exportFile"]
 
@@ -359,6 +379,7 @@ def test_export_products_mutation_with_warehouse_ids_invalid_object_type(
     permission_manage_products,
     permission_manage_apps,
 ):
+    # given
     query = EXPORT_PRODUCTS_MUTATION
 
     products = product_list[:2]
@@ -389,12 +410,15 @@ def test_export_products_mutation_with_warehouse_ids_invalid_object_type(
         }
     }
 
+    # when
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
         permissions=[permission_manage_products, permission_manage_apps],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportProducts"]
     errors = data["errors"]
     assert len(errors) == 1
@@ -415,6 +439,7 @@ def test_export_products_mutation_with_attribute_ids_invalid_object_type(
     permission_manage_products,
     permission_manage_apps,
 ):
+    # given
     query = EXPORT_PRODUCTS_MUTATION
 
     products = product_list[:2]
@@ -445,12 +470,15 @@ def test_export_products_mutation_with_attribute_ids_invalid_object_type(
         }
     }
 
+    # when
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
         permissions=[permission_manage_products, permission_manage_apps],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportProducts"]
     errors = data["errors"]
     assert len(errors) == 1
@@ -471,6 +499,7 @@ def test_export_products_mutation_with_channel_ids_invalid_object_type(
     permission_manage_products,
     permission_manage_apps,
 ):
+    # given
     query = EXPORT_PRODUCTS_MUTATION
 
     products = product_list[:2]
@@ -501,12 +530,15 @@ def test_export_products_mutation_with_channel_ids_invalid_object_type(
         }
     }
 
+    # when
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
         permissions=[permission_manage_products, permission_manage_apps],
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportProducts"]
     errors = data["errors"]
     assert len(errors) == 1
@@ -547,14 +579,18 @@ def test_export_products_mutation_failed(
     input,
     error_field,
 ):
+    # given
     query = EXPORT_PRODUCTS_MUTATION
     user = staff_api_client.user
     variables = {"input": input}
 
+    # when
     response = staff_api_client.post_graphql(
         query, variables=variables, permissions=[permission_manage_products]
     )
     content = get_graphql_content(response)
+
+    # then
     data = content["data"]["exportProducts"]
     errors = data["errors"]
 
@@ -565,3 +601,37 @@ def test_export_products_mutation_failed(
     assert not ExportEvent.objects.filter(
         user=user, type=ExportEvents.EXPORT_PENDING
     ).exists()
+
+
+@patch("saleor.plugins.manager.PluginsManager.product_export_completed")
+def test_export_products_webhooks(
+    product_export_completed_mock,
+    user_api_client,
+    product_list,
+    permission_manage_products,
+    permission_manage_apps,
+    media_root,
+):
+    # given
+    query = EXPORT_PRODUCTS_MUTATION
+    variables = {
+        "input": {
+            "scope": ExportScope.ALL.name,
+            "exportInfo": {},
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
+
+    # when
+    response = user_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["exportProducts"]
+    assert not data["errors"]
+
+    product_export_completed_mock.assert_called_once()


### PR DESCRIPTION
I want to merge this change, because currently during export tasks, `gift_card_export_completed` and `product_export_completed` webhooks are sent twice.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
