### PR TITLE
Improve GraphQL ID validation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### GraphQL API
 - Fix draft order voucher assignment - #14336 by @IKarbowiak
+- Improved GraphQL ID validation messages - #14447 by @patrys
 
 ### Saleor Apps
 

--- a/saleor/graphql/account/tests/queries/test_address.py
+++ b/saleor/graphql/account/tests/queries/test_address.py
@@ -77,7 +77,7 @@ def test_address_query_invalid_id(
     response = staff_api_client.post_graphql(ADDRESS_QUERY, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Address."
     assert content["data"]["address"] is None
 
 

--- a/saleor/graphql/account/tests/queries/test_user.py
+++ b/saleor/graphql/account/tests/queries/test_user.py
@@ -727,7 +727,7 @@ def test_user_query_invalid_id(
 
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: User."
     assert content["data"]["user"] is None
 
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_bulk_update.py
@@ -276,9 +276,8 @@ def test_attribute_bulk_update_with_invalid_type_id(
     staff_api_client, permission_manage_product_types_and_attributes
 ):
     # given
-    attributes = [
-        {"id": graphene.Node.to_global_id("Page", 1), "fields": {"name": "ExampleName"}}
-    ]
+    invalid_id = graphene.Node.to_global_id("Page", 1)
+    attributes = [{"id": invalid_id, "fields": {"name": "ExampleName"}}]
 
     # when
     staff_api_client.user.user_permissions.add(
@@ -296,7 +295,10 @@ def test_attribute_bulk_update_with_invalid_type_id(
     errors = data["results"][0]["errors"]
     assert errors
     assert errors[0]["code"] == AttributeBulkUpdateErrorCode.INVALID.name
-    assert errors[0]["message"] == "Must receive a Attribute id."
+    assert (
+        errors[0]["message"]
+        == f"Invalid ID: {invalid_id}. Expected: Attribute, received: Page."
+    )
 
 
 def test_attribute_bulk_update_without_id_and_external_ref(

--- a/saleor/graphql/attribute/tests/queries/test_attribute_query.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_query.py
@@ -187,7 +187,7 @@ def test_query_attribute_by_invalid_id(
     response = staff_api_client.post_graphql(QUERY_ATTRIBUTE, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Attribute."
     assert content["data"]["attribute"] is None
 
 

--- a/saleor/graphql/channel/tests/queries/test_channel.py
+++ b/saleor/graphql/channel/tests/queries/test_channel.py
@@ -99,7 +99,7 @@ def test_query_channel_by_invalid_id(staff_api_client, channel_USD):
     response = staff_api_client.post_graphql(QUERY_CHANNEL, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Channel."
     assert content["data"]["channel"] is None
 
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -2189,7 +2189,7 @@ def test_checkout_complete_invalid_id(user_api_client):
     response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
     content = get_graphql_content(response)
     data = content["data"]["checkoutComplete"]
-    assert data["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert data["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Checkout."
     assert data["errors"][0]["field"] == "id"
     assert orders_count == Order.objects.count()
 

--- a/saleor/graphql/core/tests/test_base_mutation.py
+++ b/saleor/graphql/core/tests/test_base_mutation.py
@@ -148,7 +148,7 @@ def test_user_error_nonexistent_id(schema_context, channel_USD):
     user_errors = result.data["test"]["errors"]
     assert user_errors
     assert user_errors[0]["field"] == "productId"
-    assert user_errors[0]["message"] == "Couldn't resolve id: not-really."
+    assert user_errors[0]["message"] == "Invalid ID: not-really. Expected: Product."
 
 
 TEST_ORDER_MUTATION = """
@@ -229,7 +229,10 @@ def test_user_error_id_of_different_type(product, schema_context, channel_USD):
     user_errors = result.data["test"]["errors"]
     assert user_errors
     assert user_errors[0]["field"] == "productId"
-    assert user_errors[0]["message"] == "Must receive a Product id."
+    assert (
+        user_errors[0]["message"]
+        == f"Invalid ID: {variant_id}. Expected: Product, received: ProductVariant."
+    )
 
 
 def test_get_node_or_error_returns_null_for_empty_id():

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -336,7 +336,7 @@ def test_get_nodes_for_order_with_uuid_and_int_id(order_list):
 
 def test_from_global_id_or_error(product):
     invalid_id = "invalid"
-    message = f"Couldn't resolve id: {invalid_id}."
+    message = f"Invalid ID: {invalid_id}."
 
     with pytest.raises(GraphQLError) as error:
         from_global_id_or_error(invalid_id)
@@ -346,7 +346,7 @@ def test_from_global_id_or_error(product):
 
 def test_from_global_id_or_error_wth_invalid_type(product):
     product_id = graphene.Node.to_global_id("Product", product.id)
-    message = "Must receive a ProductVariant id."
+    message = f"Invalid ID: {product_id}. Expected: ProductVariant, received: Product."
 
     with pytest.raises(GraphQLError) as error:
         from_global_id_or_error(product_id, "ProductVariant", raise_error=True)

--- a/saleor/graphql/core/utils/__init__.py
+++ b/saleor/graphql/core/utils/__init__.py
@@ -79,18 +79,21 @@ def from_global_id_or_error(
     """
     try:
         type_, id_ = graphene.Node.from_global_id(global_id)
-    except (binascii.Error, UnicodeDecodeError, ValueError):
-        raise GraphQLError(f"Couldn't resolve id: {global_id}.")
-    if type_ == APP_ID_PREFIX:
-        id_ = global_id
-    else:
-        if not validate_if_int_or_uuid(id_):
-            raise GraphQLError(f"Error occurred during ID - {global_id} validation.")
+        if type_ == APP_ID_PREFIX:
+            id_ = global_id
+        else:
+            validate_if_int_or_uuid(id_)
+    except (binascii.Error, UnicodeDecodeError, ValueError, ValidationError):
+        if only_type:
+            raise GraphQLError(f"Invalid ID: {global_id}. Expected: {only_type}.")
+        raise GraphQLError(f"Invalid ID: {global_id}.")
 
     if only_type and str(type_) != str(only_type):
         if not raise_error:
             return type_, None
-        raise GraphQLError(f"Must receive a {only_type} id.")
+        raise GraphQLError(
+            f"Invalid ID: {global_id}. Expected: {only_type}, received: {type_}."
+        )
     return type_, id_
 
 

--- a/saleor/graphql/core/validators/__init__.py
+++ b/saleor/graphql/core/validators/__init__.py
@@ -198,12 +198,10 @@ def validate_required_string_field(cleaned_input, field_name: str):
 
 
 def validate_if_int_or_uuid(id):
-    result = True
     try:
         int(id)
     except ValueError:
         try:
             UUID(id)
         except (AttributeError, ValueError):
-            result = False
-    return result
+            raise ValidationError("Must receive an int or UUID.")

--- a/saleor/graphql/csv/tests/queries/test_export_file.py
+++ b/saleor/graphql/csv/tests/queries/test_export_file.py
@@ -221,7 +221,7 @@ def test_query_export_file_by_invalid_id(
     )
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: ExportFile."
     assert content["data"]["exportFile"] is None
 
 

--- a/saleor/graphql/discount/tests/queries/test_sale.py
+++ b/saleor/graphql/discount/tests/queries/test_sale.py
@@ -146,7 +146,7 @@ def test_staff_query_sale_by_invalid_id(
     # then
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Sale."
     assert content["data"]["sale"] is None
 
 

--- a/saleor/graphql/discount/tests/queries/test_voucher.py
+++ b/saleor/graphql/discount/tests/queries/test_voucher.py
@@ -54,7 +54,7 @@ def test_staff_query_voucher_by_invalid_id(
     )
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Voucher."
     assert content["data"]["voucher"] is None
 
 

--- a/saleor/graphql/giftcard/tests/queries/test_gift_card.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_card.py
@@ -317,7 +317,7 @@ def test_staff_query_gift_card_by_invalid_id(
     # then
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: GiftCard."
     assert content["data"]["giftCard"] is None
 
 

--- a/saleor/graphql/menu/tests/mutations/test_menu_item_move.py
+++ b/saleor/graphql/menu/tests/mutations/test_menu_item_move.py
@@ -630,9 +630,15 @@ def test_menu_cannot_pass_an_invalid_menu_item_node_type(
     )
 
     # then
+    message = f"Invalid ID: {node_id}. Expected: MenuItem, received: User."
     assert json.loads(response.content)["data"] == {
         "menuItemMove": {
-            "errors": [{"field": "item", "message": "Must receive a MenuItem id."}],
+            "errors": [
+                {
+                    "field": "item",
+                    "message": message,
+                }
+            ],
             "menu": None,
         }
     }

--- a/saleor/graphql/menu/tests/queries/test_menu.py
+++ b/saleor/graphql/menu/tests/queries/test_menu.py
@@ -46,7 +46,7 @@ def test_staff_query_menu_by_invalid_id(staff_api_client, menu):
     # then
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Menu."
     assert content["data"]["menu"] is None
 
 

--- a/saleor/graphql/menu/tests/queries/test_menu_item.py
+++ b/saleor/graphql/menu/tests/queries/test_menu_item.py
@@ -81,7 +81,7 @@ def test_staff_query_menu_item_by_invalid_id(staff_api_client, menu_item):
     response = staff_api_client.post_graphql(QUERY_MENU_ITEM_BY_ID, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: MenuItem."
     assert content["data"]["menuItem"] is None
 
 

--- a/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
+++ b/saleor/graphql/order/tests/mutations/test_order_bulk_create.py
@@ -3268,7 +3268,7 @@ def test_order_bulk_create_error_path_fulfillments(
     # then
     assert content["data"]["orderBulkCreate"]["count"] == 0
     error = content["data"]["orderBulkCreate"]["results"][0]["errors"][0]
-    assert error["message"] == "Couldn't resolve id: dummy."
+    assert error["message"] == "Invalid ID: dummy. Expected: Warehouse."
     assert error["path"] == "fulfillments.1.lines.2.warehouse"
     assert error["code"] == OrderBulkCreateErrorCode.INVALID.name
 

--- a/saleor/graphql/order/tests/mutations/test_utils.py
+++ b/saleor/graphql/order/tests/mutations/test_utils.py
@@ -56,7 +56,7 @@ def test_get_instance_fail_invalid_global_id_syntax(customer_user):
     with pytest.raises(ValidationError) as error:
         get_instance(input, User, USER_KEY_MAP, {}, OrderBulkCreateErrorCode)
 
-    assert error.value.message == "Couldn't resolve id: wrong_global_ID."
+    assert error.value.message == "Invalid ID: wrong_global_ID. Expected: User."
 
 
 def test_get_instance_fail_invalid_global_id_model(customer_user, app):
@@ -65,7 +65,10 @@ def test_get_instance_fail_invalid_global_id_model(customer_user, app):
     with pytest.raises(ValidationError) as error:
         get_instance(input, User, USER_KEY_MAP, {}, OrderBulkCreateErrorCode)
 
-    assert error.value.message == "Must receive a User id."
+    assert (
+        error.value.message
+        == f"Invalid ID: {app_global_id}. Expected: User, received: App."
+    )
 
 
 def test_get_instance_fail_non_existing_global_id(customer_user):

--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -1079,7 +1079,7 @@ def test_staff_query_order_by_invalid_id(staff_api_client, order):
 
     # then
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Order."
     assert content["data"]["order"] is None
 
 

--- a/saleor/graphql/page/tests/queries/test_page.py
+++ b/saleor/graphql/page/tests/queries/test_page.py
@@ -251,7 +251,7 @@ def test_staff_query_page_by_invalid_id(staff_api_client, page):
     response = staff_api_client.post_graphql(PAGE_QUERY, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Page."
     assert content["data"]["page"] is None
 
 

--- a/saleor/graphql/page/tests/queries/test_page_type.py
+++ b/saleor/graphql/page/tests/queries/test_page_type.py
@@ -159,7 +159,7 @@ def test_staff_query_page_type_by_invalid_id(staff_api_client, page_type):
     response = staff_api_client.post_graphql(PAGE_TYPE_QUERY, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: PageType."
     assert content["data"]["pageType"] is None
 
 

--- a/saleor/graphql/payment/mutations/base.py
+++ b/saleor/graphql/payment/mutations/base.py
@@ -32,13 +32,14 @@ class TransactionSessionBase(BaseMutation):
             id, raise_error=False
         )
         if not source_object_type or not source_object_id:
-            raise GraphQLError(f"Couldn't resolve id: {id}.")
+            raise GraphQLError(f"Invalid ID: {id}. Expected one of: Checkout, Order.")
 
         if source_object_type not in ["Checkout", "Order"]:
             raise ValidationError(
                 {
                     "id": ValidationError(
-                        "Must receive a `Checkout` or `Order` id.",
+                        f"Invalid ID: {id}. Expected one of: Checkout, Order,"
+                        + f" received: {source_object_type}.",
                         code=incorrect_type_error_code,
                     )
                 }

--- a/saleor/graphql/payment/tests/queries/test_payments_query.py
+++ b/saleor/graphql/payment/tests/queries/test_payments_query.py
@@ -294,7 +294,7 @@ def test_staff_query_payment_by_invalid_id(
     # then
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Payment."
     assert content["data"]["payment"] is None
 
 

--- a/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
+++ b/saleor/graphql/product/tests/mutations/test_product_bulk_create.py
@@ -322,7 +322,7 @@ def test_product_bulk_create_with_invalid_attributes(
     assert data["results"][0]["errors"]
     error = data["results"][0]["errors"][0]
     assert error["path"] == "attributes"
-    assert error["message"] == "Couldn't resolve id: invalidID."
+    assert error["message"] == "Invalid ID: invalidID. Expected: Attribute."
 
 
 def test_product_bulk_create_with_media(

--- a/saleor/graphql/product/tests/queries/test_product_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_query.py
@@ -238,7 +238,7 @@ def test_product_query_by_invalid_id(
     )
     content = get_graphql_content_from_response(response)
     assert "errors" in content
-    assert content["errors"][0]["message"] == (f"Couldn't resolve id: {id}.")
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Product."
 
 
 QUERY_PRODUCT_BY_ID = """
@@ -290,7 +290,10 @@ def test_product_query_invalid_id(user_api_client, product, channel_USD):
     response = user_api_client.post_graphql(QUERY_PRODUCT_BY_ID, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {product_id}."
+    assert (
+        content["errors"][0]["message"]
+        == f"Invalid ID: {product_id}. Expected: Product."
+    )
     assert content["data"]["product"] is None
 
 
@@ -1660,7 +1663,9 @@ def test_query_product_image_by_invalid_id(
 
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert (
+        content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: ProductImage."
+    )
     assert content["data"]["product"]["imageById"] is None
 
 
@@ -1767,7 +1772,9 @@ def test_query_product_media_by_invalid_id(
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert (
+        content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: ProductMedia."
+    )
     assert content["data"]["product"]["mediaById"] is None
 
 

--- a/saleor/graphql/product/tests/queries/test_product_type_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_type_query.py
@@ -98,7 +98,10 @@ def test_product_type_query_invalid_id(
     response = staff_api_client.post_graphql(PRODUCT_TYPE_QUERY, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {product_type_id}."
+    assert (
+        content["errors"][0]["message"]
+        == f"Invalid ID: {product_type_id}. Expected: ProductType."
+    )
     assert content["data"]["productType"] is None
 
 

--- a/saleor/graphql/product/tests/queries/test_product_variants_query.py
+++ b/saleor/graphql/product/tests/queries/test_product_variants_query.py
@@ -169,7 +169,10 @@ def test_product_variants_by_invalid_ids(user_api_client, variant, channel_USD):
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {variant_id}."
+    assert (
+        content["errors"][0]["message"]
+        == f"Invalid ID: {variant_id}. Expected: ProductVariant."
+    )
     assert content["data"]["productVariants"] is None
 
 

--- a/saleor/graphql/product/tests/queries/test_variant_query.py
+++ b/saleor/graphql/product/tests/queries/test_variant_query.py
@@ -898,7 +898,10 @@ def test_variant_query_invalid_id(user_api_client, variant, channel_USD):
     response = user_api_client.post_graphql(QUERY_PRODUCT_VARIANT_BY_ID, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {variant_id}."
+    assert (
+        content["errors"][0]["message"]
+        == f"Invalid ID: {variant_id}. Expected: ProductVariant."
+    )
     assert content["data"]["productVariant"] is None
 
 

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -86,7 +86,10 @@ def test_category_query_invalid_id(user_api_client, product, channel_USD):
     response = user_api_client.post_graphql(QUERY_CATEGORY, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {category_id}."
+    assert (
+        content["errors"][0]["message"]
+        == f"Invalid ID: {category_id}. Expected: Category."
+    )
     assert content["data"]["category"] is None
 
 

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -1623,7 +1623,10 @@ def test_collection_query_invalid_id(
     response = user_api_client.post_graphql(FETCH_COLLECTION_QUERY, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {collection_id}."
+    assert (
+        content["errors"][0]["message"]
+        == f"Invalid ID: {collection_id}. Expected: Collection."
+    )
     assert content["data"]["collection"] is None
 
 

--- a/saleor/graphql/product/tests/test_digital_content.py
+++ b/saleor/graphql/product/tests/test_digital_content.py
@@ -80,7 +80,8 @@ def test_digital_content_query_invalid_id(
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
     assert (
-        content["errors"][0]["message"] == f"Couldn't resolve id: {digital_content_id}."
+        content["errors"][0]["message"]
+        == f"Invalid ID: {digital_content_id}. Expected: DigitalContent."
     )
     assert content["data"]["digitalContent"] is None
 

--- a/saleor/graphql/shipping/tests/queries/test_shipping_zone.py
+++ b/saleor/graphql/shipping/tests/queries/test_shipping_zone.py
@@ -145,7 +145,9 @@ def test_staff_query_shipping_zone_by_invalid_id(
     # then
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert (
+        content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: ShippingZone."
+    )
     assert content["data"]["shippingZone"] is None
 
 

--- a/saleor/graphql/warehouse/tests/queries/test_stock.py
+++ b/saleor/graphql/warehouse/tests/queries/test_stock.py
@@ -134,7 +134,7 @@ def test_staff_query_stock_by_invalid_id(
     # then
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Stock."
     assert content["data"]["stock"] is None
 
 

--- a/saleor/graphql/warehouse/tests/queries/test_warehouse.py
+++ b/saleor/graphql/warehouse/tests/queries/test_warehouse.py
@@ -178,7 +178,7 @@ def test_staff_query_warehouse_by_invalid_id(
     # then
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["errors"][0]["message"] == f"Invalid ID: {id}. Expected: Warehouse."
     assert content["data"]["warehouse"] is None
 
 

--- a/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
+++ b/saleor/graphql/webhook/tests/mutations/test_delivery_retry.py
@@ -65,7 +65,10 @@ def test_webhook_delivery_retry_wrong_type(
         "EventDeliveryAttempt", event_attempt.id
     )
     variables = {"id": delivery_wrong_id}
-    expected_message = "Must receive a EventDelivery id."
+    expected_message = (
+        f"Invalid ID: {delivery_wrong_id}. Expected: EventDelivery,"
+        + " received: EventDeliveryAttempt."
+    )
     response = staff_api_client.post_graphql(
         query,
         variables=variables,
@@ -85,7 +88,7 @@ def test_delivery_retry_mutation_wrong_id(
     # given
     query = WEBHOOK_DELIVERY_RETRY_MUTATION
     variables = {"id": "/w"}
-    expected_message = "Couldn't resolve id: /w."
+    expected_message = "Invalid ID: /w. Expected: EventDelivery."
     # when
     response = app_api_client.post_graphql(
         query,

--- a/saleor/graphql/webhook/tests/queries/test_webhook.py
+++ b/saleor/graphql/webhook/tests/queries/test_webhook.py
@@ -159,7 +159,10 @@ def test_webhook_query_invalid_id(staff_api_client, webhook, permission_manage_a
     response = staff_api_client.post_graphql(QUERY_WEBHOOK, variables)
     content = get_graphql_content_from_response(response)
     assert len(content["errors"]) == 1
-    assert content["errors"][0]["message"] == f"Couldn't resolve id: {webhook_id}."
+    assert (
+        content["errors"][0]["message"]
+        == f"Invalid ID: {webhook_id}. Expected: Webhook."
+    )
     assert content["data"]["webhook"] is None
 
 


### PR DESCRIPTION
This changes the messages returned by ID validation to explicitly state that the value passed is invalid and to provide hints about both the expected and passed type, if applicable.


# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
