### PR TITLE
add proper event_type when locking webhooks

### DIFF
--- a/saleor/graphql/account/bulk_mutations/staff_bulk_delete.py
+++ b/saleor/graphql/account/bulk_mutations/staff_bulk_delete.py
@@ -67,6 +67,6 @@ class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
         instances = list(queryset)
         queryset.delete()
         manager = get_plugin_manager_promise(info.context).get()
-        webhooks = get_webhooks_for_event(WebhookEventAsyncType.ATTRIBUTE_DELETED)
+        webhooks = get_webhooks_for_event(WebhookEventAsyncType.STAFF_DELETED)
         for instance in instances:
             cls.call_event(manager.staff_deleted, instance, webhooks=webhooks)

--- a/saleor/graphql/account/tests/bulk_mutations/test_staff_bulk_delete.py
+++ b/saleor/graphql/account/tests/bulk_mutations/test_staff_bulk_delete.py
@@ -48,7 +48,7 @@ def test_delete_staff_members(
     assert User.objects.filter(id__in=[user.id for user in users]).count() == len(users)
 
 
-@patch("saleor.plugins.webhook.plugin.get_webhooks_for_event")
+@patch("saleor.graphql.account.bulk_mutations.staff_bulk_delete.get_webhooks_for_event")
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_async")
 def test_delete_staff_members_trigger_webhook(
     mocked_webhook_trigger,

--- a/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
@@ -45,7 +45,7 @@ class PromotionBulkDelete(ModelBulkDeleteMutation):
         queryset.delete()
 
         manager = get_plugin_manager_promise(info.context).get()
-        webhooks = get_webhooks_for_event(WebhookEventAsyncType.ATTRIBUTE_DELETED)
+        webhooks = get_webhooks_for_event(WebhookEventAsyncType.PROMOTION_DELETED)
         for promotion in promotions:
             cls.call_event(manager.promotion_deleted, promotion, webhooks=webhooks)
 


### PR DESCRIPTION
I want to merge this change because it fixes getting webhooks for proper event types

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
