### PR TITLE
Enhance DraftOrderComplete with voucher validation

### DIFF
--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -78,6 +78,7 @@ class DraftOrderComplete(BaseMutation):
             order.voucher
             and order.voucher_code
             and order.voucher.apply_once_per_customer
+            and order.channel.include_draft_order_in_voucher_usage
         ):
             code = VoucherCode.objects.filter(code=order.voucher_code).first()
             if code:

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -254,7 +254,7 @@ def test_draft_order_complete_with_invalid_voucher(
     assert data["errors"][0]["field"] == "voucher"
 
 
-def test_draft_order_complete_with_voucher_customer(
+def test_draft_order_complete_with_voucher_once_per_customer(
     staff_api_client,
     permission_group_manage_orders,
     staff_user,

--- a/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
+++ b/saleor/graphql/order/tests/mutations/test_draft_order_complete.py
@@ -6,6 +6,7 @@ import pytz
 from django.db.models import Sum
 
 from .....core.taxes import zero_taxed_money
+from .....discount.models import VoucherCustomer
 from .....order import OrderOrigin, OrderStatus
 from .....order import events as order_events
 from .....order.error_codes import OrderErrorCode
@@ -224,6 +225,9 @@ def test_draft_order_complete_with_voucher(
     product_variant_out_of_stock_webhook_mock.assert_called_once_with(
         Stock.objects.last()
     )
+    assert not VoucherCustomer.objects.filter(
+        voucher_code=code_instance, customer_email=order.get_customer_email()
+    ).exists()
 
 
 def test_draft_order_complete_with_invalid_voucher(
@@ -248,6 +252,38 @@ def test_draft_order_complete_with_invalid_voucher(
     assert not data["order"]
     assert data["errors"][0]["code"] == OrderErrorCode.INVALID_VOUCHER.name
     assert data["errors"][0]["field"] == "voucher"
+
+
+def test_draft_order_complete_with_voucher_customer(
+    staff_api_client,
+    permission_group_manage_orders,
+    staff_user,
+    draft_order_with_voucher,
+):
+    # given
+    order = draft_order_with_voucher
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+
+    order.voucher.apply_once_per_customer = True
+    order.voucher.save(update_fields=["apply_once_per_customer"])
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id}
+    code_instance = order.voucher.codes.first()
+    assert not VoucherCustomer.objects.filter(
+        voucher_code=code_instance, customer_email=order.get_customer_email()
+    ).exists()
+    # when
+    response = staff_api_client.post_graphql(DRAFT_ORDER_COMPLETE_MUTATION, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderComplete"]["order"]
+    assert data["voucherCode"] == code_instance.code
+    assert data["voucher"]["code"] == order.voucher.code
+    assert VoucherCustomer.objects.filter(
+        voucher_code=code_instance, customer_email=order.get_customer_email()
+    ).exists()
 
 
 @patch("saleor.plugins.manager.PluginsManager.product_variant_out_of_stock")


### PR DESCRIPTION
I want to merge this change because we need to create `VoucherCustomer` object while using `Voucher` 
 with active flag `apply_once_per_customer` in DraftOrderComplete

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
