### PR TITLE
Do not allow changing single_use when any of voucher codes have already been used

### DIFF
--- a/saleor/discount/error_codes.py
+++ b/saleor/discount/error_codes.py
@@ -10,6 +10,7 @@ class DiscountErrorCode(Enum):
     UNIQUE = "unique"
     CANNOT_MANAGE_PRODUCT_WITHOUT_VARIANT = "cannot_manage_product_without_variant"
     DUPLICATED_INPUT_ITEM = "duplicated_input_item"
+    VOUCHER_ALREADY_USED = "voucher_already_used"
 
 
 class PromotionCreateErrorCode(Enum):

--- a/saleor/graphql/discount/mutations/voucher/voucher_create.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_create.py
@@ -87,7 +87,9 @@ class VoucherInput(BaseInputObjectType):
     single_use = graphene.Boolean(
         description=(
             "When set to 'True', each voucher is limited to a single use; "
-            "otherwise, usage remains unrestricted." + ADDED_IN_318
+            "otherwise, usage remains unrestricted."
+            "\n\nThe option can only be changed if none of the voucher codes "
+            "have been used." + ADDED_IN_318
         )
     )
     usage_limit = graphene.Int(

--- a/saleor/graphql/discount/mutations/voucher/voucher_update.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_update.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Exists, OuterRef
 
+from .....checkout import models as checkout_models
 from .....discount import models
 from .....discount.error_codes import DiscountErrorCode
 from .....order import models as order_models
@@ -62,6 +63,11 @@ class VoucherUpdate(VoucherCreate):
                 Exists(order_models.Order.objects.filter(voucher_code=OuterRef("code")))
                 | Exists(
                     order_models.OrderLine.objects.filter(voucher_code=OuterRef("code"))
+                )
+                | Exists(
+                    checkout_models.Checkout.objects.filter(
+                        voucher_code=OuterRef("code")
+                    )
                 )
             )
             if used_codes.exists():

--- a/saleor/graphql/discount/mutations/voucher/voucher_update.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_update.py
@@ -1,9 +1,11 @@
 import graphene
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.db.models import Exists, OuterRef
 
 from .....discount import models
 from .....discount.error_codes import DiscountErrorCode
+from .....order import models as order_models
 from .....permission.enums import DiscountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
 from ....core import ResolveInfo
@@ -36,12 +38,42 @@ class VoucherUpdate(VoucherCreate):
         ]
 
     @classmethod
+    def clean_input(cls, info: ResolveInfo, instance, data, **kwargs):
+        cls.clean_codes(data)
+        cls.clean_voucher_usage_setting(instance, data)
+        cleaned_input = super().clean_input(info, instance, data, **kwargs)
+
+        return cleaned_input
+
+    @classmethod
     def clean_codes(cls, data):
         if "code" in data:
             cls._clean_old_code(data)
 
         if "add_codes" in data:
             cls._clean_new_codes(data)
+
+    @classmethod
+    def clean_voucher_usage_setting(cls, instance, data):
+        """Ensure single use setting is not changed if voucher was already used."""
+        if "single_use" in data and instance.single_use != data["single_use"]:
+            voucher_codes = instance.codes.all()
+            used_codes = voucher_codes.filter(
+                Exists(order_models.Order.objects.filter(voucher_code=OuterRef("code")))
+                | Exists(
+                    order_models.OrderLine.objects.filter(voucher_code=OuterRef("code"))
+                )
+            )
+            if used_codes.exists():
+                raise ValidationError(
+                    {
+                        "single_use": ValidationError(
+                            "Cannot change single use setting when any voucher code has "
+                            "already been used.",
+                            code=DiscountErrorCode.VOUCHER_ALREADY_USED.value,
+                        )
+                    }
+                )
 
     @classmethod
     def construct_codes_instances(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -27706,6 +27706,7 @@ enum DiscountErrorCode @doc(category: "Discounts") {
   UNIQUE
   CANNOT_MANAGE_PRODUCT_WITHOUT_VARIANT
   DUPLICATED_INPUT_ITEM
+  VOUCHER_ALREADY_USED
 }
 
 """
@@ -27969,6 +27970,8 @@ input VoucherInput @doc(category: "Discounts") {
 
   """
   When set to 'True', each voucher is limited to a single use; otherwise, usage remains unrestricted.
+  
+  The option can only be changed if none of the voucher codes have been used.
   
   Added in Saleor 3.18.
   """


### PR DESCRIPTION
The `singleUse` setting can be changed only when none of the voucher codes have been used. 

Resolves https://github.com/saleor/saleor/issues/14463

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
