### PR TITLE
Use main DB instead of replica DB for webhook subscriptions

### DIFF
--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -20,7 +20,7 @@ logger = get_task_logger(__name__)
 def initialize_request(
     requestor=None,
     sync_event=False,
-    allow_replica=True,
+    allow_replica=False,
     event_type: Optional[str] = None,
 ) -> SaleorContext:
     """Prepare a request object for webhook subscription.

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -308,7 +308,7 @@ def trigger_all_webhooks_sync(
     parse_response: Callable[[Any], Optional[R]],
     subscribable_object=None,
     requestor=None,
-    allow_replica=True,
+    allow_replica=False,
 ) -> Optional[R]:
     """Send all synchronous webhook request for given event type.
 

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
@@ -118,7 +118,7 @@ def test_trigger_webhook_sync_with_subscription_within_mutation_use_default_db(
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_async")
 @mock.patch("saleor.plugins.webhook.tasks.get_webhooks_for_event")
 @mock.patch("saleor.plugins.webhook.tasks.generate_payload_from_subscription")
-def test_trigger_webhook_async_with_subscription_use_replica_db(
+def test_trigger_webhook_async_with_subscription_use_main_db(
     mocked_generate_payload,
     mocked_get_webhooks_for_event,
     mocked_request,
@@ -155,4 +155,4 @@ def test_trigger_webhook_async_with_subscription_use_replica_db(
 
     # then
     mocked_generate_payload.assert_called_once()
-    assert mocked_generate_payload.call_args[1]["request"].allow_replica
+    assert not mocked_generate_payload.call_args[1]["request"].allow_replica


### PR DESCRIPTION
I want to merge this change because it covers the problem explained in https://github.com/saleor/saleor/issues/14473

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
