### PR TITLE
Fix collection products resolving on writer

### DIFF
--- a/saleor/graphql/product/types/collections.py
+++ b/saleor/graphql/product/types/collections.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from typing import List, Optional
 
 import graphene
+from django.conf import settings
 from graphene import relay
 
 from ....permission.enums import ProductPermissions
@@ -138,6 +139,8 @@ class Collection(ChannelContextTypeWithMetadata[models.Collection]):
         requestor = get_user_or_app_from_context(info.context)
         qs = root.node.products.visible_to_user(  # type: ignore[attr-defined] # mypy does not properly resolve the related manager # noqa: E501
             requestor, root.channel_slug
+        ).using(
+            settings.DATABASE_CONNECTION_REPLICA_NAME
         )
         qs = ChannelQsContext(qs=qs, channel_slug=root.channel_slug)
 


### PR DESCRIPTION
I want to merge this change because the collection products resolver used to get results from the writer. The query is quite heavy and read-only so we can do it on replica.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
