### PR TITLE
Collection products replica and user caching ports

### DIFF
--- a/saleor/graphql/product/types/collections.py
+++ b/saleor/graphql/product/types/collections.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from typing import List, Optional
 
 import graphene
+from django.conf import settings
 from graphene import relay
 
 from ....permission.enums import ProductPermissions
@@ -143,6 +144,8 @@ class Collection(ChannelContextTypeWithMetadata[models.Collection]):
         requestor = get_user_or_app_from_context(info.context)
         qs = root.node.products.visible_to_user(  # type: ignore[attr-defined] # mypy does not properly resolve the related manager # noqa: E501
             requestor, root.channel_slug
+        ).using(
+            settings.DATABASE_CONNECTION_REPLICA_NAME
         )
 
         if search:

--- a/saleor/graphql/product/types/collections.py
+++ b/saleor/graphql/product/types/collections.py
@@ -144,9 +144,7 @@ class Collection(ChannelContextTypeWithMetadata[models.Collection]):
         requestor = get_user_or_app_from_context(info.context)
         qs = root.node.products.visible_to_user(  # type: ignore[attr-defined] # mypy does not properly resolve the related manager # noqa: E501
             requestor, root.channel_slug
-        ).using(
-            settings.DATABASE_CONNECTION_REPLICA_NAME
-        )
+        ).using(settings.DATABASE_CONNECTION_REPLICA_NAME)
 
         if search:
             qs = ChannelQsContext(

--- a/saleor/plugins/openid_connect/tests/test_plugin.py
+++ b/saleor/plugins/openid_connect/tests/test_plugin.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -363,12 +363,22 @@ def test_external_refresh_incorrect_csrf(
 
 
 @freeze_time("2019-03-18 12:00:00")
+@patch("saleor.plugins.openid_connect.utils.cache.set")
+@patch("saleor.plugins.openid_connect.utils.cache.get")
 def test_external_obtain_access_tokens(
-    openid_plugin, monkeypatch, rf, id_token, id_payload
+    mocked_cache_get,
+    mocked_cache_set,
+    openid_plugin,
+    monkeypatch,
+    rf,
+    id_token,
+    id_payload,
 ):
     mocked_jwt_validator = MagicMock()
     mocked_jwt_validator.__getitem__.side_effect = id_payload.__getitem__
     mocked_jwt_validator.get.side_effect = id_payload.get
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     monkeypatch.setattr(
         "saleor.plugins.openid_connect.utils.get_decoded_token",
@@ -424,12 +434,22 @@ def test_external_obtain_access_tokens(
 
 
 @freeze_time("2019-03-18 12:00:00")
+@patch("saleor.plugins.openid_connect.utils.cache.set")
+@patch("saleor.plugins.openid_connect.utils.cache.get")
 def test_external_obtain_access_tokens_with_permissions(
-    openid_plugin, monkeypatch, rf, id_token, id_payload
+    mocked_cache_get,
+    mocked_cache_set,
+    openid_plugin,
+    monkeypatch,
+    rf,
+    id_token,
+    id_payload,
 ):
     mocked_jwt_validator = MagicMock()
     mocked_jwt_validator.__getitem__.side_effect = id_payload.__getitem__
     mocked_jwt_validator.get.side_effect = id_payload.get
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     monkeypatch.setattr(
         "saleor.plugins.openid_connect.utils.get_decoded_token",
@@ -492,13 +512,23 @@ def test_external_obtain_access_tokens_with_permissions(
 
 
 @freeze_time("2019-03-18 12:00:00")
+@patch("saleor.plugins.openid_connect.utils.cache.set")
+@patch("saleor.plugins.openid_connect.utils.cache.get")
 @pytest.mark.vcr
 def test_external_obtain_access_tokens_with_saleor_staff(
-    openid_plugin, monkeypatch, rf, id_token, id_payload
+    mocked_cache_get,
+    mocked_cache_set,
+    openid_plugin,
+    monkeypatch,
+    rf,
+    id_token,
+    id_payload,
 ):
     mocked_jwt_validator = MagicMock()
     mocked_jwt_validator.__getitem__.side_effect = id_payload.__getitem__
     mocked_jwt_validator.get.side_effect = id_payload.get
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     monkeypatch.setattr(
         "saleor.plugins.openid_connect.utils.get_decoded_token",
@@ -559,9 +589,18 @@ def test_external_obtain_access_tokens_with_saleor_staff(
 
 
 @freeze_time("2019-03-18 12:00:00")
+@patch("saleor.plugins.openid_connect.utils.cache.set")
+@patch("saleor.plugins.openid_connect.utils.cache.get")
 @pytest.mark.vcr
 def test_external_obtain_access_tokens_user_which_is_no_more_staff(
-    openid_plugin, monkeypatch, rf, id_token, id_payload, staff_user
+    mocked_cache_get,
+    mocked_cache_set,
+    openid_plugin,
+    monkeypatch,
+    rf,
+    id_token,
+    id_payload,
+    staff_user,
 ):
     staff_user.is_staff = False
     staff_user.email = "admin@example.com"
@@ -570,6 +609,8 @@ def test_external_obtain_access_tokens_user_which_is_no_more_staff(
     mocked_jwt_validator = MagicMock()
     mocked_jwt_validator.__getitem__.side_effect = id_payload.__getitem__
     mocked_jwt_validator.get.side_effect = id_payload.get
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     monkeypatch.setattr(
         "saleor.plugins.openid_connect.utils.get_decoded_token",

--- a/saleor/plugins/openid_connect/tests/test_utils.py
+++ b/saleor/plugins/openid_connect/tests/test_utils.py
@@ -28,6 +28,7 @@ from ..exceptions import AuthenticationError
 from ..utils import (
     JWKS_CACHE_TIME,
     JWKS_KEY,
+    OIDC_DEFAULT_CACHE_TIME,
     _update_user_details,
     assign_staff_to_default_group_and_update_permissions,
     create_jwt_refresh_token,
@@ -43,6 +44,8 @@ from ..utils import (
     get_user_info,
     validate_refresh_token,
 )
+
+OIDC_CACHE_TIMEOUT = min(JWKS_CACHE_TIME, OIDC_DEFAULT_CACHE_TIME)
 
 
 @pytest.mark.parametrize(
@@ -213,76 +216,132 @@ def test_get_user_info_raises_http_error(monkeypatch):
     assert user_info is None
 
 
-def test_get_or_create_user_from_payload_retrieve_user_by_sub(customer_user):
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_get_or_create_user_from_payload_retrieve_user_by_sub(
+    mocked_cache_get, mocked_cache_set, customer_user
+):
+    # given
     oauth_url = "https://saleor.io/oauth"
     sub_id = "oauth|1234"
     customer_user.private_metadata = {f"oidc-{oauth_url}": sub_id}
     customer_user.save()
 
-    user_from_payload = get_or_create_user_from_payload(
-        payload={"sub": sub_id, "email": customer_user.email},
-        oauth_url=oauth_url,
-    )
-
-    assert user_from_payload.id == customer_user.id
-    assert user_from_payload.private_metadata[f"oidc-{oauth_url}"] == sub_id
-
-
-def test_get_or_create_user_from_payload_updates_sub(customer_user):
-    oauth_url = "https://saleor.io/oauth"
-    sub_id = "oauth|1234"
-    customer_user.private_metadata = {f"oidc-{oauth_url}": "old-sub"}
-    customer_user.save()
-
-    user_from_payload = get_or_create_user_from_payload(
-        payload={"sub": sub_id, "email": customer_user.email},
-        oauth_url=oauth_url,
-    )
-
-    assert user_from_payload.id == customer_user.id
-    assert user_from_payload.private_metadata[f"oidc-{oauth_url}"] == sub_id
-
-
-def test_get_or_create_user_from_payload_assigns_sub(customer_user):
-    # given
-    oauth_url = "https://saleor.io/oauth"
-    sub_id = "oauth|1234"
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     # when
     user_from_payload = get_or_create_user_from_payload(
         payload={"sub": sub_id, "email": customer_user.email},
         oauth_url=oauth_url,
     )
+    cache_key = f"oidc-{oauth_url}" + "-" + str(sub_id)
 
     # then
+    mocked_cache_get.assert_called_once_with(cache_key)
+    mocked_cache_set.assert_called_once_with(
+        cache_key, user_from_payload, OIDC_CACHE_TIMEOUT
+    )
+    assert user_from_payload.id == customer_user.id
+    assert user_from_payload.private_metadata[f"oidc-{oauth_url}"] == sub_id
+
+
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_get_or_create_user_from_payload_updates_sub(
+    mocked_cache_get, mocked_cache_set, customer_user
+):
+    # given
+    oauth_url = "https://saleor.io/oauth"
+    sub_id = "oauth|1234"
+    customer_user.private_metadata = {f"oidc-{oauth_url}": "old-sub"}
+    customer_user.save()
+
+    mocked_cache_get.side_effect = lambda cache_key: None
+
+    # when
+    user_from_payload = get_or_create_user_from_payload(
+        payload={"sub": sub_id, "email": customer_user.email},
+        oauth_url=oauth_url,
+    )
+    cache_key = f"oidc-{oauth_url}" + "-" + str(sub_id)
+
+    # then
+    mocked_cache_get.assert_called_once_with(cache_key)
+    mocked_cache_set.assert_called_once_with(
+        cache_key, user_from_payload, OIDC_CACHE_TIMEOUT
+    )
+    assert user_from_payload.id == customer_user.id
+    assert user_from_payload.private_metadata[f"oidc-{oauth_url}"] == sub_id
+
+
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_get_or_create_user_from_payload_assigns_sub(
+    mocked_cache_get, mocked_cache_set, customer_user
+):
+    # given
+    oauth_url = "https://saleor.io/oauth"
+    sub_id = "oauth|1234"
+
+    mocked_cache_get.side_effect = lambda cache_key: None
+
+    # when
+    user_from_payload = get_or_create_user_from_payload(
+        payload={"sub": sub_id, "email": customer_user.email},
+        oauth_url=oauth_url,
+    )
+    cache_key = f"oidc-{oauth_url}" + "-" + str(sub_id)
+
+    # then
+    mocked_cache_get.assert_called_once_with(cache_key)
+    mocked_cache_set.assert_called_once_with(
+        cache_key, user_from_payload, OIDC_CACHE_TIMEOUT
+    )
     assert user_from_payload.id == customer_user.id
     assert user_from_payload.private_metadata[f"oidc-{oauth_url}"] == sub_id
     assert customer_user.is_staff is False
 
 
-def test_get_or_create_user_from_payload_creates_user_with_sub():
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_get_or_create_user_from_payload_creates_user_with_sub(
+    mocked_cache_get, mocked_cache_set
+):
     # given
     oauth_url = "https://saleor.io/oauth"
     sub_id = "oauth|1234"
     customer_email = "email.customer@example.com"
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     # when
     user_from_payload = get_or_create_user_from_payload(
         payload={"sub": sub_id, "email": customer_email},
         oauth_url=oauth_url,
     )
+    cache_key = f"oidc-{oauth_url}" + "-" + str(sub_id)
 
     # then
+    mocked_cache_get.assert_called_once_with(cache_key)
+    mocked_cache_set.assert_called_once_with(
+        cache_key, user_from_payload, OIDC_CACHE_TIMEOUT
+    )
     assert user_from_payload.email == customer_email
     assert user_from_payload.private_metadata[f"oidc-{oauth_url}"] == sub_id
     assert not user_from_payload.has_usable_password()
 
 
-def test_get_or_create_user_from_payload_match_orders_for_new_user(order):
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_get_or_create_user_from_payload_match_orders_for_new_user(
+    mocked_cache_get, mocked_cache_set, order
+):
     # given
     oauth_url = "https://saleor.io/oauth"
     sub_id = "oauth|1234"
     customer_email = "email.customer@example.com"
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     order.user = None
     order.user_email = customer_email
@@ -293,19 +352,28 @@ def test_get_or_create_user_from_payload_match_orders_for_new_user(order):
         payload={"sub": sub_id, "email": customer_email},
         oauth_url=oauth_url,
     )
+    cache_key = f"oidc-{oauth_url}" + "-" + str(sub_id)
 
     # then
+    mocked_cache_get.assert_called_once_with(cache_key)
+    mocked_cache_set.assert_called_once_with(
+        cache_key, user_from_payload, OIDC_CACHE_TIMEOUT
+    )
     order.refresh_from_db()
     assert order.user == user_from_payload
 
 
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
 def test_get_or_create_user_from_payload_match_orders_when_changing_email(
-    customer_user, order
+    mocked_cache_get, mocked_cache_set, customer_user, order
 ):
     # given
     oauth_url = "https://saleor.io/oauth"
     sub_id = "oauth|1234"
     new_customer_email = "new.customer@example.com"
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     customer_user.private_metadata = {f"oidc-{oauth_url}": sub_id}
     customer_user.save()
@@ -319,8 +387,13 @@ def test_get_or_create_user_from_payload_match_orders_when_changing_email(
         payload={"sub": sub_id, "email": new_customer_email},
         oauth_url=oauth_url,
     )
+    cache_key = f"oidc-{oauth_url}" + "-" + str(sub_id)
 
     # then
+    mocked_cache_get.assert_called_once_with(cache_key)
+    mocked_cache_set.assert_called_once_with(
+        cache_key, user_from_payload, OIDC_CACHE_TIMEOUT
+    )
     customer_user.refresh_from_db()
     order.refresh_from_db()
     assert order.user == user_from_payload
@@ -349,11 +422,17 @@ def test_get_or_create_user_from_payload_multiple_subs(customer_user, admin_user
     assert user_from_payload.private_metadata[f"oidc-{oauth_url}"] == sub_id
 
 
-def test_get_or_create_user_from_payload_different_email(customer_user):
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_get_or_create_user_from_payload_different_email(
+    mocked_cache_get, mocked_cache_set, customer_user
+):
     # given
     oauth_url = "https://saleor.io/oauth"
     sub_id = "oauth|1234"
     new_customer_email = "new.customer@example.com"
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     customer_user.private_metadata = {f"oidc-{oauth_url}": sub_id}
     customer_user.save()
@@ -363,8 +442,13 @@ def test_get_or_create_user_from_payload_different_email(customer_user):
         payload={"sub": sub_id, "email": new_customer_email},
         oauth_url=oauth_url,
     )
+    cache_key = f"oidc-{oauth_url}" + "-" + str(sub_id)
 
     # then
+    mocked_cache_get.assert_called_once_with(cache_key)
+    mocked_cache_set.assert_called_once_with(
+        cache_key, user_from_payload, OIDC_CACHE_TIMEOUT
+    )
     customer_user.refresh_from_db()
     assert user_from_payload.id == customer_user.id
     assert customer_user.email == new_customer_email
@@ -372,24 +456,38 @@ def test_get_or_create_user_from_payload_different_email(customer_user):
 
 
 @freeze_time("2019-03-18 12:00:00")
-def test_get_or_create_user_from_payload_with_last_login(customer_user, settings):
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_get_or_create_user_from_payload_with_last_login(
+    mocked_cache_get, mocked_cache_set, customer_user, settings
+):
+    # given
     settings.TIME_ZONE = "UTC"
     current_ts = int(time.time())
 
     oauth_url = "https://saleor.io/oauth"
     sub_id = "oauth|1234"
 
+    mocked_cache_get.side_effect = lambda cache_key: None
+
     customer_user.last_login = timezone.make_aware(
         datetime.fromtimestamp(current_ts - 10), timezone=pytz.timezone("UTC")
     )
     customer_user.save()
 
+    # when
     user_from_payload = get_or_create_user_from_payload(
         payload={"sub": sub_id, "email": customer_user.email},
         oauth_url=oauth_url,
         last_login=current_ts,
     )
+    cache_key = f"oidc-{oauth_url}" + "-" + str(sub_id)
 
+    # then
+    mocked_cache_get.assert_called_once_with(cache_key)
+    mocked_cache_set.assert_called_once_with(
+        cache_key, user_from_payload, OIDC_CACHE_TIMEOUT
+    )
     customer_user.refresh_from_db()
     assert customer_user.last_login == timezone.make_aware(
         datetime.fromtimestamp(current_ts), timezone=pytz.timezone("UTC")
@@ -399,16 +497,31 @@ def test_get_or_create_user_from_payload_with_last_login(customer_user, settings
 
 
 @freeze_time("2019-03-18 12:00:00")
-def test_get_or_create_user_from_payload_update_last_login(customer_user):
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_get_or_create_user_from_payload_update_last_login(
+    mocked_cache_get, mocked_cache_set, customer_user
+):
+    # given
     assert customer_user.last_login is None
     oauth_url = "https://saleor.io/oauth"
     sub_id = "oauth|1234"
+
+    mocked_cache_get.side_effect = lambda cache_key: None
+
+    # when
     get_or_create_user_from_payload(
         payload={"sub": sub_id, "email": customer_user.email},
         oauth_url=oauth_url,
     )
+    cache_key = f"oidc-{oauth_url}" + "-" + str(sub_id)
 
+    # then
     customer_user.refresh_from_db()
+    mocked_cache_get.assert_called_once_with(cache_key)
+    mocked_cache_set.assert_called_once_with(
+        cache_key, customer_user, OIDC_CACHE_TIMEOUT
+    )
     assert customer_user.last_login
     last_login = customer_user.last_login.strftime("%Y-%m-%d %H:%M:%S")
     assert last_login == "2019-03-18 12:00:00"
@@ -429,18 +542,33 @@ def test_get_or_create_user_from_payload_last_login_stays_same(customer_user):
     assert customer_user.last_login == last_login
 
 
-def test_get_or_create_user_from_payload_last_login_modifies(customer_user):
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
+def test_get_or_create_user_from_payload_last_login_modifies(
+    mocked_cache_get, mocked_cache_set, customer_user
+):
+    # given
     last_login = timezone.now() - timedelta(minutes=16)
     customer_user.last_login = last_login
     customer_user.save()
     oauth_url = "https://saleor.io/oauth"
     sub_id = "oauth|1234"
+
+    mocked_cache_get.side_effect = lambda cache_key: None
+
+    # when
     get_or_create_user_from_payload(
         payload={"sub": sub_id, "email": customer_user.email},
         oauth_url=oauth_url,
     )
+    cache_key = f"oidc-{oauth_url}" + "-" + str(sub_id)
 
+    # then
     customer_user.refresh_from_db()
+    mocked_cache_get.assert_called_once_with(cache_key)
+    mocked_cache_set.assert_called_once_with(
+        cache_key, customer_user, OIDC_CACHE_TIMEOUT
+    )
     assert customer_user.last_login
     assert customer_user.last_login != last_login
 
@@ -471,8 +599,15 @@ def test_jwt_token_without_expiration_claim(monkeypatch, decoded_access_token):
     assert user.email == "test@example.org"
 
 
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
 def test_jwt_token_without_expiration_claim_mixed_permissions_from_group(
-    customer_user, monkeypatch, decoded_access_token, permission_group_manage_shipping
+    mocked_cache_get,
+    mocked_cache_set,
+    customer_user,
+    monkeypatch,
+    decoded_access_token,
+    permission_group_manage_shipping,
 ):
     # given
     customer_user.groups.add(permission_group_manage_shipping)
@@ -489,6 +624,8 @@ def test_jwt_token_without_expiration_claim_mixed_permissions_from_group(
         decoded_access_token,
         {},
     )
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     # when
     user = get_user_from_oauth_access_token_in_jwt_format(
@@ -510,8 +647,10 @@ def test_jwt_token_without_expiration_claim_mixed_permissions_from_group(
     assert "saleor:manage_shipping" not in token_payload["scope"]
 
 
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
 def test_jwt_token_without_expiration_claim_email_not_match_staff_user_domains(
-    customer_user, monkeypatch, decoded_access_token
+    mocked_cache_get, mocked_cache_set, customer_user, monkeypatch, decoded_access_token
 ):
     # given
     monkeypatch.setattr(
@@ -529,6 +668,8 @@ def test_jwt_token_without_expiration_claim_email_not_match_staff_user_domains(
     )
     default_group_name = "test group"
     assert Group.objects.count() == 0
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     # when
     user = get_user_from_oauth_access_token_in_jwt_format(
@@ -549,8 +690,10 @@ def test_jwt_token_without_expiration_claim_email_not_match_staff_user_domains(
     assert user.groups.count() == 0
 
 
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
 def test_jwt_token_without_expiration_claim_default_channel_group(
-    customer_user, monkeypatch, decoded_access_token
+    mocked_cache_get, mocked_cache_set, customer_user, monkeypatch, decoded_access_token
 ):
     # given
     decoded_access_token["scope"] = ""
@@ -569,6 +712,8 @@ def test_jwt_token_without_expiration_claim_default_channel_group(
     )
     default_group_name = "test group"
     assert Group.objects.count() == 0
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     # when
     user = get_user_from_oauth_access_token_in_jwt_format(
@@ -592,8 +737,15 @@ def test_jwt_token_without_expiration_claim_default_channel_group(
     assert user.groups.first() == group
 
 
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
 def test_jwt_token_without_expiration_claim_with_existing_default_channel_group(
-    customer_user, monkeypatch, decoded_access_token, permission_manage_users
+    mocked_cache_get,
+    mocked_cache_set,
+    customer_user,
+    monkeypatch,
+    decoded_access_token,
+    permission_manage_users,
 ):
     # given
     monkeypatch.setattr(
@@ -613,6 +765,8 @@ def test_jwt_token_without_expiration_claim_with_existing_default_channel_group(
     group = Group.objects.create(name=default_group_name)
     group.permissions.add(permission_manage_users)
     group_count = Group.objects.count()
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     # when
     user = get_user_from_oauth_access_token_in_jwt_format(
@@ -637,8 +791,15 @@ def test_jwt_token_without_expiration_claim_with_existing_default_channel_group(
 
 
 @pytest.mark.parametrize("staff_default_group_name", ["  ", ""])
+@mock.patch("saleor.plugins.openid_connect.utils.cache.set")
+@mock.patch("saleor.plugins.openid_connect.utils.cache.get")
 def test_jwt_token_without_expiration_claim_empty_default_channel_group(
-    staff_default_group_name, customer_user, monkeypatch, decoded_access_token
+    mocked_cache_get,
+    mocked_cache_set,
+    staff_default_group_name,
+    customer_user,
+    monkeypatch,
+    decoded_access_token,
 ):
     # given
     decoded_access_token["scope"] = ""
@@ -656,6 +817,8 @@ def test_jwt_token_without_expiration_claim_empty_default_channel_group(
         {},
     )
     assert Group.objects.count() == 0
+
+    mocked_cache_get.side_effect = lambda cache_key: None
 
     # when
     user = get_user_from_oauth_access_token_in_jwt_format(

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -50,6 +50,8 @@ JWKS_KEY = "oauth_jwks"
 JWKS_CACHE_TIME = 60 * 60  # 1 hour
 USER_INFO_DEFAULT_CACHE_TIME = 60 * 60  # 1 hour
 
+OIDC_DEFAULT_CACHE_TIME = 60 * 60  # 1 hour
+
 
 OAUTH_TOKEN_REFRESH_FIELD = "oauth_refresh_token"
 CSRF_FIELD = "csrf_token"
@@ -398,8 +400,11 @@ def get_or_create_user_from_payload(
         "private_metadata": {oidc_metadata_key: sub},
         "password": make_password(None),
     }
+    cache_key = oidc_metadata_key + "-" + str(sub)
     try:
-        user = User.objects.get(**get_kwargs)
+        user = cache.get(cache_key)
+        if not user:
+            user = User.objects.get(**get_kwargs)
     except User.DoesNotExist:
         user, _ = User.objects.get_or_create(
             email=user_email,
@@ -427,6 +432,7 @@ def get_or_create_user_from_payload(
         last_login=last_login,
     )
 
+    cache.set(cache_key, user, min(JWKS_CACHE_TIME, OIDC_DEFAULT_CACHE_TIME))
     return user
 
 

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -401,22 +401,22 @@ def get_or_create_user_from_payload(
         "password": make_password(None),
     }
     cache_key = oidc_metadata_key + "-" + str(sub)
-    try:
-        user = cache.get(cache_key)
-        if not user:
+    user = cache.get(cache_key)
+    if not user:
+        try:
             user = User.objects.get(**get_kwargs)
-    except User.DoesNotExist:
-        user, _ = User.objects.get_or_create(
-            email=user_email,
-            defaults=defaults_create,
-        )
-        match_orders_with_new_user(user)
-    except User.MultipleObjectsReturned:
-        logger.warning("Multiple users returned for single OIDC sub ID")
-        user, _ = User.objects.get_or_create(
-            email=user_email,
-            defaults=defaults_create,
-        )
+        except User.DoesNotExist:
+            user, _ = User.objects.get_or_create(
+                email=user_email,
+                defaults=defaults_create,
+            )
+            match_orders_with_new_user(user)
+        except User.MultipleObjectsReturned:
+            logger.warning("Multiple users returned for single OIDC sub ID")
+            user, _ = User.objects.get_or_create(
+                email=user_email,
+                defaults=defaults_create,
+            )
 
     site_settings = Site.objects.get_current().settings
     if not user.can_login(site_settings):  # it is true only if we fetch disabled user.


### PR DESCRIPTION
I want to merge this change because these are performance ports of https://github.com/saleor/saleor/pull/14345 and https://github.com/saleor/saleor/pull/14484.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
