### PR TITLE
Allow to pass voucher and code in fetch_checkout_lines function

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -1549,12 +1549,12 @@ def complete_checkout_with_payment(
         # We need to refetch the checkout info to ensure that we process checkout
         # for correct data.
         lines, _ = fetch_checkout_lines(checkout, skip_recalculation=True)
-        checkout_info = fetch_checkout_info(checkout, lines, manager)
 
         # reassign voucher data that was used during payment process to allow voucher
         # usage releasing in case of checkout complete failure
-        checkout_info.voucher = voucher
-        checkout_info.voucher_code = voucher_code
+        checkout_info = fetch_checkout_info(
+            checkout, lines, manager, voucher=voucher, voucher_code=voucher_code
+        )
 
         order, action_required, action_data = complete_checkout_post_payment_part(
             manager=manager,

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -415,6 +415,7 @@ def fetch_checkout_info(
     ] = None,
     fetch_delivery_methods=True,
     voucher: Optional["Voucher"] = None,
+    voucher_code: Optional["VoucherCode"] = None,
 ) -> CheckoutInfo:
     """Fetch checkout as CheckoutInfo object."""
     from .utils import get_voucher_for_checkout
@@ -425,7 +426,6 @@ def fetch_checkout_info(
     if shipping_channel_listings is None:
         shipping_channel_listings = channel.shipping_method_listings.all()
 
-    voucher_code = None
     if not voucher:
         voucher, voucher_code = get_voucher_for_checkout(
             checkout, channel_slug=channel.slug


### PR DESCRIPTION
I want to merge this change because it adds voucher parameters to `fetch_checkout_info` 

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
