### PR TITLE
Add doc category to voucherCodeBulkDelete mutation

### DIFF
--- a/saleor/graphql/discount/mutations/voucher/voucher_code_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/voucher/voucher_code_bulk_delete.py
@@ -5,6 +5,7 @@ from .....discount import models
 from .....permission.enums import DiscountPermissions
 from .....webhook.event_types import WebhookEventAsyncType
 from ....core.descriptions import ADDED_IN_318
+from ....core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ....core.enums import VoucherCodeBulkDeleteErrorCode
 from ....core.mutations import BaseMutation
 from ....core.types import NonNullList, VoucherCodeBulkDeleteError
@@ -37,6 +38,7 @@ class VoucherCodeBulkDelete(BaseMutation):
                 description="A voucher was updated.",
             )
         ]
+        doc_category = DOC_CATEGORY_DISCOUNTS
 
     @classmethod
     def clean_codes(cls, codes, errors_list):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -18179,7 +18179,7 @@ type Mutation {
   voucherCodeBulkDelete(
     """List of voucher codes IDs to delete."""
     ids: [ID!]!
-  ): VoucherCodeBulkDelete @webhookEventsInfo(asyncEvents: [VOUCHER_UPDATED], syncEvents: [])
+  ): VoucherCodeBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_UPDATED], syncEvents: [])
 
   """
   Export products to csv file. 
@@ -28121,7 +28121,7 @@ Requires one of the following permissions: MANAGE_DISCOUNTS.
 Triggers the following webhook events:
 - VOUCHER_UPDATED (async): A voucher was updated.
 """
-type VoucherCodeBulkDelete @webhookEventsInfo(asyncEvents: [VOUCHER_UPDATED], syncEvents: []) {
+type VoucherCodeBulkDelete @doc(category: "Discounts") @webhookEventsInfo(asyncEvents: [VOUCHER_UPDATED], syncEvents: []) {
   """Returns how many codes were deleted."""
   count: Int!
   errors: [VoucherCodeBulkDeleteError!]!


### PR DESCRIPTION
I want to merge this change because it adds `doc_category` to `voucherCodeBulkDelete`.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
