### PR TITLE
Fix migrations dependencies and revert options

### DIFF
--- a/saleor/discount/migrations/0065_remove_voucher_code_index.py
+++ b/saleor/discount/migrations/0065_remove_voucher_code_index.py
@@ -12,6 +12,7 @@ class Migration(migrations.Migration):
         migrations.RunSQL(
             """
             DROP INDEX CONCURRENTLY IF EXISTS discount_voucher_code_ff8dc52c_like;
-            """
+            """,
+            reverse_sql=migrations.RunSQL.noop,
         )
     ]

--- a/saleor/discount/migrations/0067_voucher_single_use.py
+++ b/saleor/discount/migrations/0067_voucher_single_use.py
@@ -19,6 +19,7 @@ class Migration(migrations.Migration):
                 ALTER TABLE discount_voucher
                 ALTER COLUMN single_use
                 SET DEFAULT false;
-            """
+            """,
+            reverse_sql=migrations.RunSQL.noop,
         ),
     ]

--- a/saleor/product/migrations/0187_auto_20230614_0838.py
+++ b/saleor/product/migrations/0187_auto_20230614_0838.py
@@ -9,6 +9,11 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
     dependencies = [
         ("product", "0186_remove_product_charge_taxes"),
+        ("discount", "0045_promotions"),
+    ]
+
+    run_before = [
+        ("discount", "0047_migrate_sales_to_promotions"),
     ]
 
     operations = [


### PR DESCRIPTION
- Ensure `0187_auto_20230614_0838` migrations is called after `PromotionRule` creation.
- Allow reverting discount migrations

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
