### PR TITLE
Fix inccorect statuses provided by order.paymentStatus when order is paid with transactions

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -184,14 +184,27 @@ def get_order_discount_event(discount_obj: dict):
     )
 
 
-def get_payment_status_for_order(order):
-    status = ChargeStatus.NOT_CHARGED
+def get_payment_status_for_order(
+    order, granted_refunds: list[models.OrderGrantedRefund]
+):
+    zero_price = zero_money(order.currency)
+    total_granted = sum(
+        [granted_refund.amount for granted_refund in granted_refunds],
+        zero_price,
+    )
     charged_money = order.total_charged
+    current_order_total = quantize_price(
+        order.total.gross - total_granted, order.currency
+    )
 
-    if charged_money >= order.total.gross:
+    if charged_money == zero_price and current_order_total <= zero_price:
         status = ChargeStatus.FULLY_CHARGED
-    elif charged_money and charged_money < order.total.gross:
+    elif charged_money >= current_order_total:
+        status = ChargeStatus.FULLY_CHARGED
+    elif charged_money < current_order_total and charged_money > zero_price:
         status = ChargeStatus.PARTIALLY_CHARGED
+    else:
+        status = ChargeStatus.NOT_CHARGED
     return status
 
 
@@ -1653,7 +1666,7 @@ class Order(ModelObjectType[models.Order]):
     @traced_resolver
     def resolve_payment_status(root: models.Order, info):
         def _resolve_payment_status(data):
-            transactions, payments, fulfillments = data
+            transactions, payments, fulfillments, granted_refunds = data
 
             total_fulfillment_refund = sum(
                 [
@@ -1669,7 +1682,7 @@ class Order(ModelObjectType[models.Order]):
                 return ChargeStatus.FULLY_REFUNDED
 
             if transactions:
-                return get_payment_status_for_order(root)
+                return get_payment_status_for_order(root, granted_refunds)
             last_payment = get_last_payment(payments)
             if not last_payment:
                 if root.total.gross.amount == 0:
@@ -1680,16 +1693,17 @@ class Order(ModelObjectType[models.Order]):
         transactions = TransactionItemsByOrderIDLoader(info.context).load(root.id)
         payments = PaymentsByOrderIdLoader(info.context).load(root.id)
         fulfillments = FulfillmentsByOrderIdLoader(info.context).load(root.id)
-        return Promise.all([transactions, payments, fulfillments]).then(
-            _resolve_payment_status
-        )
+        granted_refunds = OrderGrantedRefundsByOrderIdLoader(info.context).load(root.id)
+        return Promise.all(
+            [transactions, payments, fulfillments, granted_refunds]
+        ).then(_resolve_payment_status)
 
     @staticmethod
     def resolve_payment_status_display(root: models.Order, info):
         def _resolve_payment_status(data):
-            transactions, payments = data
+            transactions, payments, granted_refunds = data
             if transactions:
-                status = get_payment_status_for_order(root)
+                status = get_payment_status_for_order(root, granted_refunds)
                 return dict(ChargeStatus.CHOICES).get(status)
             last_payment = get_last_payment(payments)
             if not last_payment:
@@ -1700,7 +1714,10 @@ class Order(ModelObjectType[models.Order]):
 
         transactions = TransactionItemsByOrderIDLoader(info.context).load(root.id)
         payments = PaymentsByOrderIdLoader(info.context).load(root.id)
-        return Promise.all([transactions, payments]).then(_resolve_payment_status)
+        granted_refunds = OrderGrantedRefundsByOrderIdLoader(info.context).load(root.id)
+        return Promise.all([transactions, payments, granted_refunds]).then(
+            _resolve_payment_status
+        )
 
     @staticmethod
     def resolve_payments(root: models.Order, info):


### PR DESCRIPTION
I want to merge this change because it fixes the issue explained here: https://github.com/saleor/saleor/issues/14462

It is port of changes from https://github.com/saleor/saleor/pull/14461

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
