### PR TITLE
Fix inccorect statuses provided by order.paymentStatus when order is paid with transactions

### DIFF
--- a/saleor/graphql/order/tests/queries/test_order.py
+++ b/saleor/graphql/order/tests/queries/test_order.py
@@ -9,7 +9,7 @@ from .....core.prices import quantize_price
 from .....core.taxes import zero_taxed_money
 from .....order import OrderStatus
 from .....order.events import transaction_event
-from .....order.models import Order
+from .....order.models import Order, OrderGrantedRefund
 from .....order.utils import (
     get_order_country,
     update_order_authorize_data,
@@ -1604,3 +1604,141 @@ def test_query_orders_by_customer(
 
     # then
     assert_no_permission(response)
+
+
+QUERY_ORDER_PAYMENT_STATUSES = """
+    query OrderQuery($id: ID!) {
+        order(id: $id) {
+            paymentStatus
+            paymentStatusDisplay
+        }
+    }
+"""
+
+
+@pytest.mark.parametrize(
+    "order_total, granted_refund_amount, total_charged, expected_payment_status",
+    [
+        (Decimal(100), Decimal(0), Decimal(0), PaymentChargeStatusEnum.NOT_CHARGED),
+        (Decimal(100), Decimal(50), Decimal(0), PaymentChargeStatusEnum.NOT_CHARGED),
+        # order total - total granted refund is bigger than total charged
+        (
+            Decimal(100),
+            Decimal(25),
+            Decimal(50),
+            PaymentChargeStatusEnum.PARTIALLY_CHARGED,
+        ),
+        # order total is bigger than total charged
+        (
+            Decimal(100),
+            Decimal(0),
+            Decimal(50),
+            PaymentChargeStatusEnum.PARTIALLY_CHARGED,
+        ),
+        # order total - total granted refund is 0, total charged is 100, order is
+        # marked as fully charged
+        (
+            Decimal(100),
+            Decimal(100),
+            Decimal(100),
+            PaymentChargeStatusEnum.FULLY_CHARGED,
+        ),
+        # order total is 0, total charged is 0, order is fully charged
+        (Decimal(0), Decimal(0), Decimal(0), PaymentChargeStatusEnum.FULLY_CHARGED),
+        # order total - total granted refund is equal to total charged = 0
+        (Decimal(100), Decimal(100), Decimal(0), PaymentChargeStatusEnum.FULLY_CHARGED),
+        # order total - total granted refund is equal to total charged = 50
+        (Decimal(100), Decimal(50), Decimal(50), PaymentChargeStatusEnum.FULLY_CHARGED),
+        # order total - total granted refund is equal to total charged = 100
+        (Decimal(100), Decimal(0), Decimal(100), PaymentChargeStatusEnum.FULLY_CHARGED),
+    ],
+)
+def test_order_payment_status_with_transaction_and_granted_refunds(
+    order_total,
+    granted_refund_amount,
+    total_charged,
+    expected_payment_status,
+    user_api_client,
+    order_with_lines,
+):
+    # given
+    variables = {"id": graphene.Node.to_global_id("Order", order_with_lines.id)}
+    order_with_lines.payment_transactions.create(
+        charged_value=total_charged, currency=order_with_lines.currency
+    )
+    order_with_lines.total_gross_amount = order_total
+    order_with_lines.total_net_amount = order_total
+    OrderGrantedRefund.objects.bulk_create(
+        [
+            OrderGrantedRefund(
+                order=order_with_lines,
+                amount_value=Decimal(0),
+                currency=order_with_lines.currency,
+            ),
+            OrderGrantedRefund(
+                order=order_with_lines,
+                amount_value=granted_refund_amount,
+                currency=order_with_lines.currency,
+            ),
+        ]
+    )
+    order_with_lines.total_charged_amount = total_charged
+    order_with_lines.save()
+    # when
+    response = user_api_client.post_graphql(QUERY_ORDER_PAYMENT_STATUSES, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["order"]
+
+    # then
+    assert data["paymentStatus"] == expected_payment_status.name
+    assert data["paymentStatusDisplay"] == dict(ChargeStatus.CHOICES).get(
+        expected_payment_status.value
+    )
+
+
+@pytest.mark.parametrize(
+    "order_total, total_charged, expected_payment_status",
+    [
+        (Decimal(100), Decimal(0), PaymentChargeStatusEnum.NOT_CHARGED),
+        # order total is bigger than total charged
+        (
+            Decimal(100),
+            Decimal(50),
+            PaymentChargeStatusEnum.PARTIALLY_CHARGED,
+        ),
+        # order total is 100, total charged is 100, order is fully charged
+        (
+            Decimal(100),
+            Decimal(100),
+            PaymentChargeStatusEnum.FULLY_CHARGED,
+        ),
+        # order total is 0, total charged is 0, order is fully charged
+        (Decimal(0), Decimal(0), PaymentChargeStatusEnum.FULLY_CHARGED),
+    ],
+)
+def test_order_payment_status_with_transaction_and_without_granted_refunds(
+    order_total,
+    total_charged,
+    expected_payment_status,
+    user_api_client,
+    order_with_lines,
+):
+    # given
+    order_with_lines.payment_transactions.create(
+        charged_value=total_charged, currency=order_with_lines.currency
+    )
+    variables = {"id": graphene.Node.to_global_id("Order", order_with_lines.id)}
+    order_with_lines.total_gross_amount = order_total
+    order_with_lines.total_net_amount = order_total
+    order_with_lines.total_charged_amount = total_charged
+    order_with_lines.save()
+    # when
+    response = user_api_client.post_graphql(QUERY_ORDER_PAYMENT_STATUSES, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["order"]
+
+    # then
+    assert data["paymentStatus"] == expected_payment_status.name
+    assert data["paymentStatusDisplay"] == dict(ChargeStatus.CHOICES).get(
+        expected_payment_status.value
+    )

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -185,14 +185,27 @@ def get_order_discount_event(discount_obj: dict):
     )
 
 
-def get_payment_status_for_order(order):
-    status = ChargeStatus.NOT_CHARGED
+def get_payment_status_for_order(
+    order, granted_refunds: list[models.OrderGrantedRefund]
+):
+    zero_price = zero_money(order.currency)
+    total_granted = sum(
+        [granted_refund.amount for granted_refund in granted_refunds],
+        zero_price,
+    )
     charged_money = order.total_charged
+    current_order_total = quantize_price(
+        order.total.gross - total_granted, order.currency
+    )
 
-    if charged_money >= order.total.gross:
+    if charged_money == zero_price and current_order_total <= zero_price:
         status = ChargeStatus.FULLY_CHARGED
-    elif charged_money and charged_money < order.total.gross:
+    elif charged_money >= current_order_total:
+        status = ChargeStatus.FULLY_CHARGED
+    elif charged_money < current_order_total and charged_money > zero_price:
         status = ChargeStatus.PARTIALLY_CHARGED
+    else:
+        status = ChargeStatus.NOT_CHARGED
     return status
 
 
@@ -1701,7 +1714,7 @@ class Order(ModelObjectType[models.Order]):
     @traced_resolver
     def resolve_payment_status(root: models.Order, info):
         def _resolve_payment_status(data):
-            transactions, payments, fulfillments = data
+            transactions, payments, fulfillments, granted_refunds = data
 
             total_fulfillment_refund = sum(
                 [
@@ -1717,7 +1730,7 @@ class Order(ModelObjectType[models.Order]):
                 return ChargeStatus.FULLY_REFUNDED
 
             if transactions:
-                return get_payment_status_for_order(root)
+                return get_payment_status_for_order(root, granted_refunds)
             last_payment = get_last_payment(payments)
             if not last_payment:
                 if root.total.gross.amount == 0:
@@ -1728,16 +1741,17 @@ class Order(ModelObjectType[models.Order]):
         transactions = TransactionItemsByOrderIDLoader(info.context).load(root.id)
         payments = PaymentsByOrderIdLoader(info.context).load(root.id)
         fulfillments = FulfillmentsByOrderIdLoader(info.context).load(root.id)
-        return Promise.all([transactions, payments, fulfillments]).then(
-            _resolve_payment_status
-        )
+        granted_refunds = OrderGrantedRefundsByOrderIdLoader(info.context).load(root.id)
+        return Promise.all(
+            [transactions, payments, fulfillments, granted_refunds]
+        ).then(_resolve_payment_status)
 
     @staticmethod
     def resolve_payment_status_display(root: models.Order, info):
         def _resolve_payment_status(data):
-            transactions, payments = data
+            transactions, payments, granted_refunds = data
             if transactions:
-                status = get_payment_status_for_order(root)
+                status = get_payment_status_for_order(root, granted_refunds)
                 return dict(ChargeStatus.CHOICES).get(status)
             last_payment = get_last_payment(payments)
             if not last_payment:
@@ -1748,7 +1762,10 @@ class Order(ModelObjectType[models.Order]):
 
         transactions = TransactionItemsByOrderIDLoader(info.context).load(root.id)
         payments = PaymentsByOrderIdLoader(info.context).load(root.id)
-        return Promise.all([transactions, payments]).then(_resolve_payment_status)
+        granted_refunds = OrderGrantedRefundsByOrderIdLoader(info.context).load(root.id)
+        return Promise.all([transactions, payments, granted_refunds]).then(
+            _resolve_payment_status
+        )
 
     @staticmethod
     def resolve_payments(root: models.Order, info):


### PR DESCRIPTION
I want to merge this change because it fixes the issue explained here: https://github.com/saleor/saleor/issues/14462

It is port of changes from https://github.com/saleor/saleor/pull/14461

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
