### PR TITLE
Drop `bulkOrderCreateInput.voucher` field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Highlights
 
 ### Breaking changes
+- Drop `OrderBulkCreateInput.voucher` field. Use `OrderBulkCreateInput.voucherCode` instead. - #14553 by @zedzior
 
 ### GraphQL API
 

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -525,13 +525,6 @@ class OrderBulkCreateInput(BaseInputObjectType):
         graphene.String,
         description="List of gift card codes associated with the order.",
     )
-    voucher = graphene.String(
-        description=(
-            "Code of a voucher associated with the order."
-            "\n\nDEPRECATED: this field will be removed in Saleor 3.19."
-            " Use `voucherCode` instead."
-        )
-    )
     voucher_code = graphene.String(
         description="Code of a voucher associated with the order." + ADDED_IN_318
     )
@@ -836,19 +829,6 @@ class OrderBulkCreate(BaseMutation, I18nMixin):
                     )
                 )
                 order_data.is_critical_error = True
-
-        if order_input.get("voucher") and order_input.get("voucher_code"):
-            order_data.errors.append(
-                OrderBulkError(
-                    message="Cannot use both voucher and voucher_code.",
-                    path="voucher_code",
-                    code=OrderBulkCreateErrorCode.INVALID,
-                )
-            )
-            order_data.is_critical_error = True
-
-        if order_input.get("voucher") is not None:
-            order_input["voucher_code"] = order_input.get("voucher")
 
     @classmethod
     def validate_order_status(cls, status: str, order_data: OrderBulkCreateData):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -26209,13 +26209,6 @@ input OrderBulkCreateInput @doc(category: "Orders") {
   """
   Code of a voucher associated with the order.
   
-  DEPRECATED: this field will be removed in Saleor 3.19. Use `voucherCode` instead.
-  """
-  voucher: String
-
-  """
-  Code of a voucher associated with the order.
-  
   Added in Saleor 3.18.
   """
   voucherCode: String


### PR DESCRIPTION
I want to merge this change because it drops `voucher` field from `bulkOrderCreateInput`. The field is replaced by `voucherCode`.

Issue: https://github.com/saleor/saleor/issues/14412

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [x] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
