### PR TITLE
CI: add Poetry Venv to PATH

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,6 +20,7 @@ on:
       - Dockerfile
       - requirements_dev.txt
       - "saleor/**"
+      - ".github/workflows/pytest.yml"
       - pyproject.toml
       - poetry.lock
 
@@ -65,20 +66,25 @@ jobs:
 
       - name: Install dependencies
         run: |
+          poetry env use python3.9
           python -m poetry install --no-root
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+
+      - name: Add Python Virtual Environment to PATH
+        run: |
+          echo "$(python -m poetry env info -p)"/bin >> $GITHUB_PATH
 
       # Run linters and Django related checks
       # `git config` command is a workaround for https://github.com/actions/runner-images/issues/6775
       - name: Run Linters and Checks
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          python -m poetry run pre-commit run --all
+          pre-commit run --all
         if: ${{ always() }}
 
       - name: Run unit tests
         run: |
-          python -m poetry run pytest \
+          pytest \
             -m "not e2e" \
             --cov \
             --junitxml=junit/test-results.xml \
@@ -118,5 +124,4 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          python -m poetry run pytest \
-            -m "e2e"
+          pytest -m "e2e"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install and configure poetry
         run: |
-          python -m pip install poetry==1.5.0
+          pip install poetry==1.5.0
 
       - name: Cache the venv
         id: cached-poetry-dependencies
@@ -67,12 +67,15 @@ jobs:
       - name: Install dependencies
         run: |
           poetry env use python3.9
-          python -m poetry install --no-root
+          poetry install --no-root
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
 
       - name: Add Python Virtual Environment to PATH
         run: |
-          echo "$(python -m poetry env info -p)"/bin >> $GITHUB_PATH
+          # Note: requires `poetry env use` to be ran, otherwise poetry
+          # may not be able to find which virtual environment is in use.
+          # Ticket: https://github.com/python-poetry/poetry/issues/7190
+          echo "$(poetry env info -p)"/bin >> $GITHUB_PATH
 
       # Run linters and Django related checks
       # `git config` command is a workaround for https://github.com/actions/runner-images/issues/6775


### PR DESCRIPTION
This adds Poetry venv to PATH which allows `pytest-django-queries` integration to determine where to find `python`, as well as other future dependencies that could be looking for the location of `python`.

Prior to this change, `python3 -m pytest_django_queries.cli` would crash with:

```
/usr/local/bin/python3: Error while finding module specification for 'pytest_django_queries.cli' (ModuleNotFoundError: No module named 'pytest_django_queries')
```

(due to `python3` pointing to `/usr/local/bin/python3` instead of `~/.cache/pypoetry/virtualenvs/saleor-XXX-py3.9/bin/python3`)

The issue was introduced by https://github.com/saleor/saleor/pull/13736.