### PR TITLE
Don't reattempt webhook delivery after non-transient HTTP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - `attribute_value_deleted`
   - `promotion_deleted`
   - `staff_deleted`
+- Saleor will no longer reattempt delivery for webhooks that return non-transient HTTP errors (400, 404 etc.) or redirects - #14566 by @patrys
 
 ### GraphQL API
 - Fix draft order voucher assignment - #14336 by @IKarbowiak

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -203,7 +203,7 @@ def send_webhook_request_async(self, event_delivery_id):
 
         attempt_update(attempt, response)
         if response.status == EventDeliveryStatus.FAILED:
-            handle_webhook_retry(self, webhook, response.content, delivery, attempt)
+            handle_webhook_retry(self, webhook, response, delivery, attempt)
             delivery_status = EventDeliveryStatus.FAILED
         elif response.status == EventDeliveryStatus.SUCCESS:
             task_logger.info(

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -72,9 +72,7 @@ def handle_transaction_request_task(self, delivery_id, request_event_id):
     attempt = create_attempt(delivery, self.request.id)
     response, response_data = _send_webhook_request_sync(delivery, attempt=attempt)
     if response.response_status_code and response.response_status_code >= 500:
-        handle_webhook_retry(
-            self, delivery.webhook, response.content, delivery, attempt
-        )
+        handle_webhook_retry(self, delivery.webhook, response, delivery, attempt)
         response_data = None
     create_transaction_event_from_request_and_webhook_response(
         request_event,

--- a/saleor/webhook/transport/tests/test_utils.py
+++ b/saleor/webhook/transport/tests/test_utils.py
@@ -1,0 +1,76 @@
+import datetime
+
+import pytest
+from celery import Task
+from celery.exceptions import Retry
+from celery.utils.threads import LocalStack
+
+from ....core import EventDeliveryStatus
+from ....core.models import EventDeliveryAttempt
+from ..utils import WebhookResponse, handle_webhook_retry
+
+
+class DummyTask(Task):
+    retry_backoff = 10
+    retry_kwargs = {"max_retries": 2}
+    request_stack = LocalStack()
+
+
+def test_webhook_retry(webhook, event_delivery):
+    # given
+    attempt = EventDeliveryAttempt(
+        id=1,
+        created_at=datetime.datetime.utcnow(),
+        delivery=event_delivery,
+        request_headers="",
+        task_id="123",
+    )
+    task = DummyTask()
+    # when
+    task.push_request(retries=1)
+    response = WebhookResponse(
+        content="Error!", response_status_code=500, status=EventDeliveryStatus.FAILED
+    )
+    # then
+    with pytest.raises(Retry):
+        handle_webhook_retry(task, webhook, response, event_delivery, attempt)
+
+
+def test_webhook_retry_404(webhook, event_delivery):
+    # given
+    attempt = EventDeliveryAttempt(
+        id=1,
+        created_at=datetime.datetime.utcnow(),
+        delivery=event_delivery,
+        request_headers="",
+        task_id="123",
+    )
+    task = DummyTask()
+    # when
+    task.push_request(retries=1)
+    response = WebhookResponse(
+        content="Error!", response_status_code=404, status=EventDeliveryStatus.FAILED
+    )
+    # then
+    retry = handle_webhook_retry(task, webhook, response, event_delivery, attempt)
+    assert retry is False
+
+
+def test_webhook_retry_redirect(webhook, event_delivery):
+    # given
+    attempt = EventDeliveryAttempt(
+        id=1,
+        created_at=datetime.datetime.utcnow(),
+        delivery=event_delivery,
+        request_headers="",
+        task_id="123",
+    )
+    task = DummyTask()
+    # when
+    task.push_request(retries=1)
+    response = WebhookResponse(
+        content="Error!", response_status_code=302, status=EventDeliveryStatus.FAILED
+    )
+    # then
+    retry = handle_webhook_retry(task, webhook, response, event_delivery, attempt)
+    assert retry is False


### PR DESCRIPTION
Fixes #14559

This makes Saleor give up immediately when it encounters a non-transient HTTP error (HTTP 4xx) or a redirect attempt (HTTP 3xx).

Change in behavior: we previously considered any HTTP status between 200 and 399 a success. Now, only 200-299 are considered successful.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
