### PR TITLE
Add missing refund fields to fulfillment

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -618,6 +618,17 @@ class Fulfillment(ModelObjectType[models.Fulfillment]):
         required=False,
         description="Warehouse from fulfillment was fulfilled.",
     )
+    shipping_refunded_amount = graphene.Field(
+        Money,
+        description="Amount of refunded shipping price." + ADDED_IN_314,
+        required=False,
+    )
+    total_refunded_amount = graphene.Field(
+        Money,
+        description="Total refunded amount assigned to this fulfillment."
+        + ADDED_IN_314,
+        required=False,
+    )
 
     class Meta:
         description = "Represents order fulfillment."
@@ -658,6 +669,34 @@ class Fulfillment(ModelObjectType[models.Fulfillment]):
             FulfillmentLinesByFulfillmentIdLoader(info.context)
             .load(root.id)
             .then(_resolve_stock)
+        )
+
+    @staticmethod
+    def resolve_shipping_refunded_amount(root: models.Fulfillment, info):
+        if root.shipping_refund_amount is None:
+            return None
+
+        def _resolve_shipping_refund(order):
+            return prices.Money(root.shipping_refund_amount, currency=order.currency)
+
+        return (
+            OrderByIdLoader(info.context)
+            .load(root.order_id)
+            .then(_resolve_shipping_refund)
+        )
+
+    @staticmethod
+    def resolve_total_refunded_amount(root: models.Fulfillment, info):
+        if root.total_refund_amount is None:
+            return None
+
+        def _resolve_total_refund_amount(order):
+            return prices.Money(root.total_refund_amount, currency=order.currency)
+
+        return (
+            OrderByIdLoader(info.context)
+            .load(root.order_id)
+            .then(_resolve_total_refund_amount)
         )
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -11416,6 +11416,20 @@ type Fulfillment implements Node & ObjectWithMetadata @doc(category: "Orders") {
 
   """Warehouse from fulfillment was fulfilled."""
   warehouse: Warehouse
+
+  """
+  Amount of refunded shipping price.
+  
+  Added in Saleor 3.14.
+  """
+  shippingRefundedAmount: Money
+
+  """
+  Total refunded amount assigned to this fulfillment.
+  
+  Added in Saleor 3.14.
+  """
+  totalRefundedAmount: Money
 }
 
 """An enumeration."""

--- a/saleor/graphql/tests/queries/fragments.py
+++ b/saleor/graphql/tests/queries/fragments.py
@@ -190,6 +190,12 @@ fragment FulfillmentDetails on Fulfillment {
   fulfillmentOrder
   trackingNumber
   status
+  shippingRefundedAmount{
+    amount
+  }
+  totalRefundedAmount{
+    amount
+  }
   lines {
     id
     quantity

--- a/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
@@ -117,6 +117,8 @@ def generate_fulfillment_payload(fulfillment, add_notify_customer_field=False):
     payload = {
         "fulfillment": {
             "id": fulfillment_id,
+            "shippingRefundedAmount": None,
+            "totalRefundedAmount": None,
             "fulfillmentOrder": fulfillment.fulfillment_order,
             "trackingNumber": fulfillment.tracking_number,
             "status": fulfillment.status.upper(),

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -1,4 +1,5 @@
 import json
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import graphene
@@ -1726,6 +1727,42 @@ def test_fulfillment_created(fulfillment, subscription_fulfillment_created_webho
     assert deliveries[0].webhook == webhooks[0]
 
 
+def test_fulfillment_with_refund_amounts(
+    fulfillment, subscription_fulfillment_created_webhook
+):
+    # given
+    shipping_refund = Decimal("10")
+    total_refund = Decimal("15")
+    fulfillment.shipping_refund_amount = shipping_refund
+    fulfillment.total_refund_amount = total_refund
+    fulfillment.save()
+
+    webhooks = [subscription_fulfillment_created_webhook]
+    event_type = WebhookEventAsyncType.FULFILLMENT_CREATED
+    expected_payload = generate_fulfillment_payload(
+        fulfillment, add_notify_customer_field=True
+    )
+    expected_payload["fulfillment"]["shippingRefundedAmount"] = {
+        "amount": shipping_refund
+    }
+    expected_payload["fulfillment"]["totalRefundedAmount"] = {"amount": total_refund}
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(
+        event_type,
+        {
+            "fulfillment": fulfillment,
+            "notify_customer": True,
+        },
+        webhooks,
+    )
+
+    # then
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
 def test_fulfillment_canceled(fulfillment, subscription_fulfillment_canceled_webhook):
     # given
     webhooks = [subscription_fulfillment_canceled_webhook]
@@ -1736,7 +1773,7 @@ def test_fulfillment_canceled(fulfillment, subscription_fulfillment_canceled_web
     deliveries = create_deliveries_for_subscriptions(event_type, fulfillment, webhooks)
 
     # then
-    assert deliveries[0].payload.payload == json.dumps(expected_payload)
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
 
@@ -1777,7 +1814,7 @@ def test_fulfillment_metadata_updated(
     deliveries = create_deliveries_for_subscriptions(event_type, fulfillment, webhooks)
 
     # then
-    assert deliveries[0].payload.payload == json.dumps(expected_payload)
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
 
@@ -1794,7 +1831,7 @@ def test_fulfillment_tracking_number_updated(
     deliveries = create_deliveries_for_subscriptions(event_type, fulfillment, webhooks)
 
     # then
-    assert deliveries[0].payload.payload == json.dumps(expected_payload)
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
     assert len(deliveries) == len(webhooks)
     assert deliveries[0].webhook == webhooks[0]
 


### PR DESCRIPTION
I want to merge this change because it fixes the problem described here: https://github.com/saleor/saleor/issues/14498

It is port of changes from https://github.com/saleor/saleor/pull/14499

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
