### PR TITLE
[TEST] Unable to update voucher's single use settings after using one of the codes CORE_0926

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_unable_to_update_single_use_settings_after_usage.py
+++ b/saleor/tests/e2e/checkout/test_checkout_unable_to_update_single_use_settings_after_usage.py
@@ -1,0 +1,174 @@
+import pytest
+
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..utils import assign_permissions
+from ..vouchers.utils import (
+    create_voucher,
+    create_voucher_channel_listing,
+    raw_update_voucher,
+)
+from .utils import (
+    checkout_add_promo_code,
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_dummy_payment_create,
+)
+
+
+def prepare_voucher(
+    e2e_staff_api_client,
+    channel_id,
+    voucher_code_list,
+    voucher_discount_type,
+    voucher_discount_value,
+    voucher_type,
+):
+    input_data = {
+        "addCodes": voucher_code_list,
+        "discountValueType": voucher_discount_type,
+        "type": voucher_type,
+        "singleUse": True,
+    }
+    voucher_data = create_voucher(e2e_staff_api_client, input_data)
+
+    voucher_id = voucher_data["id"]
+    channel_listing = [
+        {
+            "channelId": channel_id,
+            "discountValue": voucher_discount_value,
+        },
+    ]
+    create_voucher_channel_listing(
+        e2e_staff_api_client,
+        voucher_id,
+        channel_listing,
+    )
+
+    return voucher_code_list, voucher_id
+
+
+@pytest.mark.e2e
+def test_checkout_unable_to_update_single_use_settings_after_usage_CORE_0926(
+    e2e_logged_api_client,
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_shipping,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_checkouts,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_checkouts,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    (
+        _product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=19.99,
+    )
+    voucher_code_list, voucher_id = prepare_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        voucher_code_list=["single_use_1", "single_use_2"],
+        voucher_discount_type="PERCENTAGE",
+        voucher_discount_value=15,
+        voucher_type="ENTIRE_ORDER",
+    )
+    # Step 1 - Create checkout
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 2,
+        },
+    ]
+    checkout = checkout_create(
+        e2e_logged_api_client,
+        lines,
+        channel_slug,
+        email="testEmail@example.com",
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout["id"]
+    checkout_lines = checkout["lines"][0]
+    shipping_method_id = checkout["shippingMethods"][0]["id"]
+    unit_price = float(product_variant_price)
+    assert checkout["isShippingRequired"] is True
+    assert checkout_lines["unitPrice"]["gross"]["amount"] == unit_price
+    assert checkout_lines["undiscountedUnitPrice"]["amount"] == float(
+        product_variant_price
+    )
+
+    # Step 2 - Set DeliveryMethod for checkout.
+    checkout_data = checkout_delivery_method_update(
+        e2e_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+
+    # Step 3 - Add voucher code to checkout
+    data = checkout_add_promo_code(
+        e2e_logged_api_client,
+        checkout_id,
+        voucher_code_list[0],
+    )
+    discounted_total_gross = data["totalPrice"]["gross"]["amount"]
+    discounted_unit_price = data["lines"][0]["unitPrice"]["gross"]["amount"]
+    voucher_discount = 2 * (round(float(product_variant_price) * 15 / 100, 2))
+    unit_price = float(product_variant_price)
+    assert data["discount"]["amount"] == voucher_discount
+    assert discounted_total_gross == total_gross_amount - voucher_discount
+    assert discounted_unit_price == unit_price - (
+        round(float(product_variant_price) * 15 / 100, 2)
+    )
+    # Step 4 - Create payment for checkout.
+    checkout_dummy_payment_create(
+        e2e_logged_api_client,
+        checkout_id,
+        discounted_total_gross,
+    )
+
+    # Step 5 - Complete checkout.
+    order_data = checkout_complete(e2e_logged_api_client, checkout_id)
+
+    order_line = order_data["lines"][0]
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == discounted_total_gross
+    assert order_line["undiscountedUnitPrice"]["gross"]["amount"] == float(
+        product_variant_price
+    )
+    assert order_line["unitPrice"]["gross"]["amount"] == discounted_unit_price
+
+    # Step 6 - Update the voucher's single use settings
+    data = raw_update_voucher(e2e_staff_api_client, voucher_id, {"singleUse": False})
+    errors = data["errors"][0]
+    assert errors["code"] == "VOUCHER_ALREADY_USED"
+    assert errors["field"] == "singleUse"
+    assert (
+        errors["message"]
+        == "Cannot change single use setting when any voucher code has already been used."
+    )

--- a/saleor/tests/e2e/vouchers/utils/__init__.py
+++ b/saleor/tests/e2e/vouchers/utils/__init__.py
@@ -6,6 +6,7 @@ from .voucher_channel_listing import create_voucher_channel_listing
 from .voucher_code_bulk_delete import voucher_code_bulk_delete
 from .voucher_create import create_voucher
 from .voucher_delete import voucher_delete
+from .voucher_update import raw_update_voucher, update_voucher
 
 __all__ = [
     "create_voucher",
@@ -16,4 +17,6 @@ __all__ = [
     "voucher_bulk_delete",
     "voucher_code_bulk_delete",
     "get_vouchers",
+    "raw_update_voucher",
+    "update_voucher",
 ]

--- a/saleor/tests/e2e/vouchers/utils/voucher_update.py
+++ b/saleor/tests/e2e/vouchers/utils/voucher_update.py
@@ -1,0 +1,59 @@
+from ...utils import get_graphql_content
+
+VOUCHER_UPDATE_MUTATION = """
+mutation VoucherUpdate($id:ID! $input: VoucherInput!) {
+  voucherUpdate(id: $id, input: $input) {
+    errors {
+      message
+      code
+      field
+    }
+    voucher {
+      id
+      applyOncePerCustomer
+      applyOncePerOrder
+      endDate
+      onlyForStaff
+      startDate
+      type
+      usageLimit
+      used
+      minCheckoutItemsQuantity
+      minSpent {
+        amount
+      }
+      code
+      discountValueType
+      discountValue
+    }
+  }
+}
+"""
+
+
+def raw_update_voucher(staff_api_client, voucher_id, input_data):
+    variables = {
+        "id": voucher_id,
+        "input": input_data,
+    }
+
+    response = staff_api_client.post_graphql(
+        VOUCHER_UPDATE_MUTATION,
+        variables,
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["voucherUpdate"]
+
+    return data
+
+
+def update_voucher(staff_api_client, voucher_id, input_data):
+    response = raw_update_voucher(staff_api_client, voucher_id, input_data)
+
+    assert response["errors"] == []
+    data = response["voucher"]
+    assert data["id"] is not None
+
+    return data


### PR DESCRIPTION
I want to merge this change because it covers [CORE_0926](https://saleor.testmo.net/repositories/5?group_id=131&sort_column=repository_cases:custom_tc_id&sort_direction=desc&case_id=4783)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
