### PR TITLE
[Test] Should be able to create a page with each type of attribute

### DIFF
--- a/saleor/tests/e2e/attributes/utils/__init__.py
+++ b/saleor/tests/e2e/attributes/utils/__init__.py
@@ -1,5 +1,4 @@
 from .create_attribute import attribute_create
+from .prepare_attributes import prepare_all_attributes
 
-__all__ = [
-    "attribute_create",
-]
+__all__ = ["attribute_create", "prepare_all_attributes"]

--- a/saleor/tests/e2e/attributes/utils/create_attribute.py
+++ b/saleor/tests/e2e/attributes/utils/create_attribute.py
@@ -24,6 +24,7 @@ def attribute_create(
     type="PRODUCT_TYPE",
     value_required=True,
     is_variant_only=False,
+    values=None,
 ):
     variables = {
         "input": {
@@ -33,6 +34,7 @@ def attribute_create(
             "type": type,
             "valueRequired": value_required,
             "isVariantOnly": is_variant_only,
+            "values": values,
         }
     }
 

--- a/saleor/tests/e2e/attributes/utils/create_attribute.py
+++ b/saleor/tests/e2e/attributes/utils/create_attribute.py
@@ -25,6 +25,7 @@ def attribute_create(
     value_required=True,
     is_variant_only=False,
     values=None,
+    unit=None,
 ):
     variables = {
         "input": {
@@ -35,6 +36,7 @@ def attribute_create(
             "valueRequired": value_required,
             "isVariantOnly": is_variant_only,
             "values": values,
+            "unit": unit,
         }
     }
 

--- a/saleor/tests/e2e/attributes/utils/create_attribute.py
+++ b/saleor/tests/e2e/attributes/utils/create_attribute.py
@@ -26,6 +26,7 @@ def attribute_create(
     is_variant_only=False,
     values=None,
     unit=None,
+    entityType=None,
 ):
     variables = {
         "input": {
@@ -37,6 +38,7 @@ def attribute_create(
             "isVariantOnly": is_variant_only,
             "values": values,
             "unit": unit,
+            "entityType": entityType,
         }
     }
 

--- a/saleor/tests/e2e/attributes/utils/prepare_attributes.py
+++ b/saleor/tests/e2e/attributes/utils/prepare_attributes.py
@@ -1,0 +1,171 @@
+from .create_attribute import attribute_create
+
+
+def prepare_all_attributes(e2e_staff_api_client, attribute_type):
+    # Dropdown
+    values = [
+        {"name": "Freddy Torres"},
+        {"name": "Isabella Smith"},
+        {"name": "Hayden Blake"},
+    ]
+    attr_dropdown = attribute_create(
+        e2e_staff_api_client,
+        input_type="DROPDOWN",
+        name="Author",
+        slug="author",
+        type="PAGE_TYPE",
+        value_required=True,
+        values=values,
+    )
+
+    attr_dropdown_id = attr_dropdown["id"]
+
+    # Multiselect
+    values = [
+        {"name": "Security"},
+        {"name": "Support"},
+        {"name": "Medical"},
+        {"name": "General"},
+    ]
+
+    attr_multi = attribute_create(
+        e2e_staff_api_client,
+        input_type="MULTISELECT",
+        name="Department",
+        slug="department",
+        type="PAGE_TYPE",
+        value_required=True,
+        values=values,
+    )
+
+    attr_multiselect_id = attr_multi["id"]
+
+    # Date
+    attr_date = attribute_create(
+        e2e_staff_api_client,
+        input_type="DATE",
+        name="Date",
+        slug="date",
+        type="PAGE_TYPE",
+        value_required=True,
+    )
+
+    attr_date_id = attr_date["id"]
+
+    # Date time
+    attr_date_time = attribute_create(
+        e2e_staff_api_client,
+        input_type="DATE_TIME",
+        name="Date time",
+        slug="date-time",
+        type="PAGE_TYPE",
+        value_required=True,
+    )
+
+    attr_date_time_id = attr_date_time["id"]
+
+    # Plain text
+    attr_plain_text = attribute_create(
+        e2e_staff_api_client,
+        input_type="PLAIN_TEXT",
+        name="Plain text test",
+        slug="plain-text-test",
+        type="PAGE_TYPE",
+        value_required=True,
+    )
+
+    attr_plain_text_id = attr_plain_text["id"]
+
+    # Rich text
+    attr_rich_text = attribute_create(
+        e2e_staff_api_client,
+        input_type="RICH_TEXT",
+        name="Rich text test",
+        slug="rich-text-test",
+        type="PAGE_TYPE",
+        value_required=True,
+    )
+
+    attr_rich_text_id = attr_rich_text["id"]
+
+    # Numeric
+    attr_numeric = attribute_create(
+        e2e_staff_api_client,
+        input_type="NUMERIC",
+        name="Numeric test",
+        slug="numeric-test",
+        type="PAGE_TYPE",
+        value_required=True,
+        unit="G",
+    )
+
+    attr_numeric_id = attr_numeric["id"]
+
+    # Boolean
+    attr_bool = attribute_create(
+        e2e_staff_api_client,
+        input_type="BOOLEAN",
+        name="Bool test",
+        slug="bool-test",
+        type="PAGE_TYPE",
+        value_required=True,
+    )
+
+    attr_bool_id = attr_bool["id"]
+
+    # Swatch
+    values = [
+        {"name": "black", "value": "#000000"},
+        {"name": "blue", "value": "#4167E7"},
+    ]
+
+    attr_swatch = attribute_create(
+        e2e_staff_api_client,
+        input_type="SWATCH",
+        name="Swatch test",
+        slug="swatch-test",
+        type="PAGE_TYPE",
+        value_required=True,
+        values=values,
+    )
+
+    attr_swatch_id = attr_swatch["id"]
+
+    # Reference
+    attr_reference = attribute_create(
+        e2e_staff_api_client,
+        input_type="REFERENCE",
+        name="Reference test",
+        slug="reference-test",
+        type="PAGE_TYPE",
+        value_required=True,
+        entityType="PRODUCT",
+    )
+
+    attr_reference_id = attr_reference["id"]
+
+    # File
+    attr_file = attribute_create(
+        e2e_staff_api_client,
+        input_type="FILE",
+        name="File test",
+        slug="file-test",
+        type="PAGE_TYPE",
+        value_required=False,
+    )
+
+    attr_file_id = attr_file["id"]
+
+    return (
+        attr_dropdown_id,
+        attr_multiselect_id,
+        attr_date_id,
+        attr_date_time_id,
+        attr_plain_text_id,
+        attr_rich_text_id,
+        attr_numeric_id,
+        attr_bool_id,
+        attr_swatch_id,
+        attr_reference_id,
+        attr_file_id,
+    )

--- a/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
+++ b/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
@@ -3,6 +3,7 @@ import json
 
 import pytest
 import pytz
+from django.conf import settings
 
 from ....tests.utils import dummy_editorjs
 from ..attributes.utils import prepare_all_attributes
@@ -13,7 +14,7 @@ from ..utils import assign_permissions
 
 
 @pytest.mark.e2e
-def test_order_cancel_fulfillment_core_0220(
+def test_create_page_with_each_of_attribute_types_core_0701(
     e2e_staff_api_client,
     permission_manage_page_types_and_attributes,
     permission_manage_pages,
@@ -22,6 +23,7 @@ def test_order_cancel_fulfillment_core_0220(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    site_settings,
 ):
     # Before
     permissions = [
@@ -67,7 +69,7 @@ def test_order_cancel_fulfillment_core_0220(
         attr_file_id,
     ) = prepare_all_attributes(e2e_staff_api_client, attribute_type="PAGE_TYPE")
 
-    # Step 1 - Create page type with attributes
+    # Step 1 - Create page type with all attributes
     add_attributes = [
         attr_dropdown_id,
         attr_multiselect_id,
@@ -83,10 +85,17 @@ def test_order_cancel_fulfillment_core_0220(
     ]
     page_type_data = create_page_type(e2e_staff_api_client, "Page Type", add_attributes)
     page_type_id = page_type_data["id"]
+    assert page_type_data["name"] == "Page Type"
+    assert len(page_type_data["attributes"]) == 11
 
-    # Step 2 - Create page
+    # Step 2 - Create page with all attributes
     expected_base_text = "Test rich attribute text"
     expected_rich_text = json.dumps(dummy_editorjs(expected_base_text))
+
+    new_value = "new_test_value.txt"
+    file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{new_value}"
+    file_content_type = "text/plain"
+
     attributes = [
         {"id": attr_dropdown_id, "values": ["Freddy Torres"]},
         {"id": attr_multiselect_id, "values": ["security", "support"]},
@@ -101,7 +110,7 @@ def test_order_cancel_fulfillment_core_0220(
         {"id": attr_bool_id, "boolean": True},
         {"id": attr_swatch_id, "values": ["blue"]},
         {"id": attr_reference_id, "references": [product_id]},
-        # {"id": attr_file_id, "file": image, "contentFile": image_name},
+        {"id": attr_file_id, "file": file_url, "contentType": file_content_type},
     ]
 
     page = create_page(
@@ -112,3 +121,6 @@ def test_order_cancel_fulfillment_core_0220(
         attributes=attributes,
     )
     assert page["title"] == "test Page"
+    assert page["isPublished"] is True
+    attributes = page["attributes"]
+    assert len(attributes) == 11

--- a/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
+++ b/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
@@ -1,4 +1,7 @@
+import datetime
+
 import pytest
+import pytz
 
 from ..attributes.utils import attribute_create
 from ..pages.utils import create_page, create_page_type
@@ -6,6 +9,7 @@ from ..utils import assign_permissions
 
 
 def prepare_attributes(e2e_staff_api_client):
+    # Dropdown
     values = [
         {"name": "Freddy Torres"},
         {"name": "Isabella Smith"},
@@ -18,12 +22,133 @@ def prepare_attributes(e2e_staff_api_client):
         slug="author",
         type="PAGE_TYPE",
         value_required=True,
-        is_variant_only=False,
         values=values,
     )
 
     attr_dropdown_id = attr_dropdown["id"]
-    return attr_dropdown_id
+
+    # Multiselect
+    values = [
+        {"name": "Security"},
+        {"name": "Support"},
+        {"name": "Medical"},
+        {"name": "General"},
+    ]
+
+    attr_multi = attribute_create(
+        e2e_staff_api_client,
+        input_type="MULTISELECT",
+        name="Department",
+        slug="department",
+        type="PAGE_TYPE",
+        value_required=True,
+        values=values,
+    )
+
+    attr_multiselect_id = attr_multi["id"]
+
+    # Date
+    attr_date = attribute_create(
+        e2e_staff_api_client,
+        input_type="DATE",
+        name="Date",
+        slug="date",
+        type="PAGE_TYPE",
+        value_required=True,
+    )
+
+    attr_date_id = attr_date["id"]
+
+    # Date time
+    attr_date_time = attribute_create(
+        e2e_staff_api_client,
+        input_type="DATE_TIME",
+        name="Date time",
+        slug="date-time",
+        type="PAGE_TYPE",
+        value_required=True,
+    )
+
+    attr_date_time_id = attr_date_time["id"]
+
+    # Plain text
+    attr_plain_text = attribute_create(
+        e2e_staff_api_client,
+        input_type="PLAIN_TEXT",
+        name="Plain text test",
+        slug="plain-text-test",
+        type="PAGE_TYPE",
+        value_required=True,
+    )
+
+    attr_plain_text_id = attr_plain_text["id"]
+
+    # Rich text
+    attr_rich_text = attribute_create(
+        e2e_staff_api_client,
+        input_type="RICH_TEXT",
+        name="Rich text test",
+        slug="rich-text-test",
+        type="PAGE_TYPE",
+        value_required=True,
+    )
+
+    attr_rich_text_id = attr_rich_text["id"]
+
+    # Numeric
+    attr_numeric = attribute_create(
+        e2e_staff_api_client,
+        input_type="NUMERIC",
+        name="Numeric test",
+        slug="numeric-test",
+        type="PAGE_TYPE",
+        value_required=True,
+        unit="G",
+    )
+
+    attr_numeric_id = attr_numeric["id"]
+
+    # Boolean
+    attr_bool = attribute_create(
+        e2e_staff_api_client,
+        input_type="BOOLEAN",
+        name="Bool test",
+        slug="bool-test",
+        type="PAGE_TYPE",
+        value_required=True,
+    )
+
+    attr_bool_id = attr_bool["id"]
+
+    # Swatch
+    values = [
+        {"name": "black", "value": "#000000"},
+        {"name": "blue", "value": "#4167E7"},
+    ]
+
+    attr_swatch = attribute_create(
+        e2e_staff_api_client,
+        input_type="SWATCH",
+        name="Swatch test",
+        slug="swatch-test",
+        type="PAGE_TYPE",
+        value_required=True,
+        values=values,
+    )
+
+    attr_swatch_id = attr_swatch["id"]
+
+    return (
+        attr_dropdown_id,
+        attr_multiselect_id,
+        attr_date_id,
+        attr_date_time_id,
+        attr_plain_text_id,
+        attr_rich_text_id,
+        attr_numeric_id,
+        attr_bool_id,
+        attr_swatch_id,
+    )
 
 
 @pytest.mark.e2e
@@ -36,16 +161,53 @@ def test_order_cancel_fulfillment_core_0220(
     permissions = [permission_manage_page_types_and_attributes, permission_manage_pages]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    attr_dropdown_id = prepare_attributes(e2e_staff_api_client)
+    (
+        attr_dropdown_id,
+        attr_multiselect_id,
+        attr_date_id,
+        attr_date_time_id,
+        attr_plain_text_id,
+        attr_rich_text_id,
+        attr_numeric_id,
+        attr_bool_id,
+        attr_swatch_id,
+    ) = prepare_attributes(e2e_staff_api_client)
 
     # Step 1 - Create page type with attributes
     page_type_data = create_page_type(
-        e2e_staff_api_client, add_attributes=[attr_dropdown_id]
+        e2e_staff_api_client,
+        add_attributes=[
+            attr_dropdown_id,
+            attr_multiselect_id,
+            attr_date_id,
+            attr_date_time_id,
+            attr_plain_text_id,
+            attr_rich_text_id,
+            attr_numeric_id,
+            attr_bool_id,
+            attr_swatch_id,
+        ],
     )
     page_type_id = page_type_data["id"]
 
     # Step 2 - Create page
-    attributes = [{"id": attr_dropdown_id, "values": ["dennis-perkins"]}]
+    attributes = [
+        {"id": attr_dropdown_id, "values": ["Freddy Torres"]},
+        {"id": attr_multiselect_id, "values": ["security", "support"]},
+        {"id": attr_date_id, "date": "2021-01-01"},
+        {
+            "id": attr_date_time_id,
+            "dateTime": datetime.datetime(2023, 1, 1, tzinfo=pytz.utc),
+        },
+        {"id": attr_plain_text_id, "plainText": "test plain text"},
+        {
+            "id": attr_rich_text_id,
+            "richText": '{"time":1698938932209,"blocks":[{"id":"H3Dbv2kCI0","type":"header","data":{"text":"Hader","level":1}},{"id":"qLU4d0pmTT","type":"list","data":{"style":"ordered","items":["item1","item2","item2"]}}],"version":"2.24.3"}',
+        },
+        {"id": attr_numeric_id, "numeric": 10},
+        {"id": attr_bool_id, "boolean": True},
+        {"id": attr_swatch_id, "values": ["blue"]},
+    ]
     page = create_page(
         e2e_staff_api_client,
         page_type_id,

--- a/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
+++ b/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
@@ -1,0 +1,56 @@
+import pytest
+
+from ..attributes.utils import attribute_create
+from ..pages.utils import create_page, create_page_type
+from ..utils import assign_permissions
+
+
+def prepare_attributes(e2e_staff_api_client):
+    values = [
+        {"name": "Freddy Torres"},
+        {"name": "Isabella Smith"},
+        {"name": "Hayden Blake"},
+    ]
+    attr_dropdown = attribute_create(
+        e2e_staff_api_client,
+        input_type="DROPDOWN",
+        name="Author",
+        slug="author",
+        type="PAGE_TYPE",
+        value_required=True,
+        is_variant_only=False,
+        values=values,
+    )
+
+    attr_dropdown_id = attr_dropdown["id"]
+    return attr_dropdown_id
+
+
+@pytest.mark.e2e
+def test_order_cancel_fulfillment_core_0220(
+    e2e_staff_api_client,
+    permission_manage_page_types_and_attributes,
+    permission_manage_pages,
+):
+    # Before
+    permissions = [permission_manage_page_types_and_attributes, permission_manage_pages]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    attr_dropdown_id = prepare_attributes(e2e_staff_api_client)
+
+    # Step 1 - Create page type with attributes
+    page_type_data = create_page_type(
+        e2e_staff_api_client, add_attributes=[attr_dropdown_id]
+    )
+    page_type_id = page_type_data["id"]
+
+    # Step 2 - Create page
+    attributes = [{"id": attr_dropdown_id, "values": ["dennis-perkins"]}]
+    page = create_page(
+        e2e_staff_api_client,
+        page_type_id,
+        title="test Page",
+        is_published=True,
+        attributes=attributes,
+    )
+    assert page["title"] == "test Page"

--- a/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
+++ b/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
@@ -1,170 +1,15 @@
 import datetime
+import json
 
 import pytest
 import pytz
 
-from ..attributes.utils import attribute_create
+from ....tests.utils import dummy_editorjs
+from ..attributes.utils import prepare_all_attributes
 from ..pages.utils import create_page, create_page_type
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_shop
 from ..utils import assign_permissions
-
-
-def prepare_attributes(e2e_staff_api_client):
-    # Dropdown
-    values = [
-        {"name": "Freddy Torres"},
-        {"name": "Isabella Smith"},
-        {"name": "Hayden Blake"},
-    ]
-    attr_dropdown = attribute_create(
-        e2e_staff_api_client,
-        input_type="DROPDOWN",
-        name="Author",
-        slug="author",
-        type="PAGE_TYPE",
-        value_required=True,
-        values=values,
-    )
-
-    attr_dropdown_id = attr_dropdown["id"]
-
-    # Multiselect
-    values = [
-        {"name": "Security"},
-        {"name": "Support"},
-        {"name": "Medical"},
-        {"name": "General"},
-    ]
-
-    attr_multi = attribute_create(
-        e2e_staff_api_client,
-        input_type="MULTISELECT",
-        name="Department",
-        slug="department",
-        type="PAGE_TYPE",
-        value_required=True,
-        values=values,
-    )
-
-    attr_multiselect_id = attr_multi["id"]
-
-    # Date
-    attr_date = attribute_create(
-        e2e_staff_api_client,
-        input_type="DATE",
-        name="Date",
-        slug="date",
-        type="PAGE_TYPE",
-        value_required=True,
-    )
-
-    attr_date_id = attr_date["id"]
-
-    # Date time
-    attr_date_time = attribute_create(
-        e2e_staff_api_client,
-        input_type="DATE_TIME",
-        name="Date time",
-        slug="date-time",
-        type="PAGE_TYPE",
-        value_required=True,
-    )
-
-    attr_date_time_id = attr_date_time["id"]
-
-    # Plain text
-    attr_plain_text = attribute_create(
-        e2e_staff_api_client,
-        input_type="PLAIN_TEXT",
-        name="Plain text test",
-        slug="plain-text-test",
-        type="PAGE_TYPE",
-        value_required=True,
-    )
-
-    attr_plain_text_id = attr_plain_text["id"]
-
-    # Rich text
-    attr_rich_text = attribute_create(
-        e2e_staff_api_client,
-        input_type="RICH_TEXT",
-        name="Rich text test",
-        slug="rich-text-test",
-        type="PAGE_TYPE",
-        value_required=True,
-    )
-
-    attr_rich_text_id = attr_rich_text["id"]
-
-    # Numeric
-    attr_numeric = attribute_create(
-        e2e_staff_api_client,
-        input_type="NUMERIC",
-        name="Numeric test",
-        slug="numeric-test",
-        type="PAGE_TYPE",
-        value_required=True,
-        unit="G",
-    )
-
-    attr_numeric_id = attr_numeric["id"]
-
-    # Boolean
-    attr_bool = attribute_create(
-        e2e_staff_api_client,
-        input_type="BOOLEAN",
-        name="Bool test",
-        slug="bool-test",
-        type="PAGE_TYPE",
-        value_required=True,
-    )
-
-    attr_bool_id = attr_bool["id"]
-
-    # Swatch
-    values = [
-        {"name": "black", "value": "#000000"},
-        {"name": "blue", "value": "#4167E7"},
-    ]
-
-    attr_swatch = attribute_create(
-        e2e_staff_api_client,
-        input_type="SWATCH",
-        name="Swatch test",
-        slug="swatch-test",
-        type="PAGE_TYPE",
-        value_required=True,
-        values=values,
-    )
-
-    attr_swatch_id = attr_swatch["id"]
-
-    # Reference
-    attr_reference = attribute_create(
-        e2e_staff_api_client,
-        input_type="REFERENCE",
-        name="Reference test",
-        slug="reference-test",
-        type="PAGE_TYPE",
-        value_required=True,
-        entityType="PRODUCT",
-    )
-
-    attr_reference_id = attr_reference["id"]
-
-    return (
-        attr_dropdown_id,
-        attr_multiselect_id,
-        attr_date_id,
-        attr_date_time_id,
-        attr_plain_text_id,
-        attr_rich_text_id,
-        attr_numeric_id,
-        attr_bool_id,
-        attr_swatch_id,
-        attr_reference_id,
-    )
 
 
 @pytest.mark.e2e
@@ -219,27 +64,29 @@ def test_order_cancel_fulfillment_core_0220(
         attr_bool_id,
         attr_swatch_id,
         attr_reference_id,
-    ) = prepare_attributes(e2e_staff_api_client)
+        attr_file_id,
+    ) = prepare_all_attributes(e2e_staff_api_client, attribute_type="PAGE_TYPE")
 
     # Step 1 - Create page type with attributes
-    page_type_data = create_page_type(
-        e2e_staff_api_client,
-        add_attributes=[
-            attr_dropdown_id,
-            attr_multiselect_id,
-            attr_date_id,
-            attr_date_time_id,
-            attr_plain_text_id,
-            attr_rich_text_id,
-            attr_numeric_id,
-            attr_bool_id,
-            attr_swatch_id,
-            attr_reference_id,
-        ],
-    )
+    add_attributes = [
+        attr_dropdown_id,
+        attr_multiselect_id,
+        attr_date_id,
+        attr_date_time_id,
+        attr_plain_text_id,
+        attr_rich_text_id,
+        attr_numeric_id,
+        attr_bool_id,
+        attr_swatch_id,
+        attr_reference_id,
+        attr_file_id,
+    ]
+    page_type_data = create_page_type(e2e_staff_api_client, "Page Type", add_attributes)
     page_type_id = page_type_data["id"]
 
     # Step 2 - Create page
+    expected_base_text = "Test rich attribute text"
+    expected_rich_text = json.dumps(dummy_editorjs(expected_base_text))
     attributes = [
         {"id": attr_dropdown_id, "values": ["Freddy Torres"]},
         {"id": attr_multiselect_id, "values": ["security", "support"]},
@@ -249,15 +96,14 @@ def test_order_cancel_fulfillment_core_0220(
             "dateTime": datetime.datetime(2023, 1, 1, tzinfo=pytz.utc),
         },
         {"id": attr_plain_text_id, "plainText": "test plain text"},
-        {
-            "id": attr_rich_text_id,
-            "richText": '{"time":1698938932209,"blocks":[{"id":"H3Dbv2kCI0","type":"header","data":{"text":"Hader","level":1}},{"id":"qLU4d0pmTT","type":"list","data":{"style":"ordered","items":["item1","item2","item2"]}}],"version":"2.24.3"}',
-        },
+        {"id": attr_rich_text_id, "richText": expected_rich_text},
         {"id": attr_numeric_id, "numeric": 10},
         {"id": attr_bool_id, "boolean": True},
         {"id": attr_swatch_id, "values": ["blue"]},
         {"id": attr_reference_id, "references": [product_id]},
+        # {"id": attr_file_id, "file": image, "contentFile": image_name},
     ]
+
     page = create_page(
         e2e_staff_api_client,
         page_type_id,

--- a/saleor/tests/e2e/pages/utils/__init__.py
+++ b/saleor/tests/e2e/pages/utils/__init__.py
@@ -1,0 +1,7 @@
+from .page_create import create_page
+from .page_type_create import create_page_type
+
+__all__ = [
+    "create_page",
+    "create_page_type",
+]

--- a/saleor/tests/e2e/pages/utils/page_create.py
+++ b/saleor/tests/e2e/pages/utils/page_create.py
@@ -1,0 +1,79 @@
+from ...utils import get_graphql_content
+
+PAGE_CREATE_MUTATION = """
+mutation PageCreate($input: PageCreateInput!) {
+  pageCreate(input: $input) {
+    errors {
+      field
+      message
+      code
+    }
+    page {
+      id
+      title
+      slug
+      isPublished
+      publishedAt
+      attributes{
+        attribute{
+          id
+        }
+        values{
+          id
+          name
+          slug
+          value
+          inputType
+          reference
+          file{
+            url
+            contentType
+          }
+          richText
+          plainText
+          boolean
+          date
+          dateTime
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def create_page(
+    staff_api_client,
+    page_type_id,
+    title="test Page",
+    is_published=True,
+    publication_date=None,
+    content=None,
+    attributes=None,
+):
+    variables = {
+        "input": {
+            "pageType": page_type_id,
+            "title": title,
+            "content": content,
+            "isPublished": is_published,
+            "publicationDate": publication_date,
+            "attributes": attributes,
+        }
+    }
+
+    response = staff_api_client.post_graphql(
+        PAGE_CREATE_MUTATION,
+        variables,
+    )
+
+    content = get_graphql_content(response)
+
+    data = content["data"]["pageCreate"]
+    errors = data["errors"]
+    assert errors == []
+
+    page = data["page"]
+    assert page["id"] is not None
+
+    return page

--- a/saleor/tests/e2e/pages/utils/page_type_create.py
+++ b/saleor/tests/e2e/pages/utils/page_type_create.py
@@ -1,0 +1,42 @@
+from ...utils import get_graphql_content
+
+PAGE_TYPE_CREATE_MUTATION = """
+mutation PageTypeCreate($input: PageTypeCreateInput!) {
+  pageTypeCreate(input: $input) {
+    errors {
+      field
+      message
+      code
+    }
+    pageType {
+      id
+      name
+      slug
+    }
+  }
+}
+"""
+
+
+def create_page_type(
+    staff_api_client,
+    name="test Page Type",
+    add_attributes=None,
+):
+    variables = {"input": {"name": name, "addAttributes": add_attributes}}
+
+    response = staff_api_client.post_graphql(
+        PAGE_TYPE_CREATE_MUTATION,
+        variables,
+    )
+
+    content = get_graphql_content(response)
+
+    data = content["data"]["pageTypeCreate"]
+    errors = data["errors"]
+    assert errors == []
+
+    page = data["pageType"]
+    assert page["id"] is not None
+
+    return page

--- a/saleor/tests/e2e/pages/utils/page_type_create.py
+++ b/saleor/tests/e2e/pages/utils/page_type_create.py
@@ -12,6 +12,9 @@ mutation PageTypeCreate($input: PageTypeCreateInput!) {
       id
       name
       slug
+      attributes{
+        id
+      }
     }
   }
 }


### PR DESCRIPTION
I want to merge this change because it adds a test for [CORE_0701](https://saleor.testmo.net/repositories/5?group_id=116&case_id=4786) Should be able to create a page with each type of attribute


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
