### PR TITLE
[Test] Should create a product with all attribute types created in bulk

### DIFF
--- a/saleor/tests/e2e/attributes/utils/__init__.py
+++ b/saleor/tests/e2e/attributes/utils/__init__.py
@@ -1,4 +1,10 @@
+from .attribute_bulk_create import bulk_create_attributes
 from .create_attribute import attribute_create
-from .prepare_attributes import prepare_all_attributes
+from .prepare_attributes import prepare_all_attributes, prepare_all_attributes_in_bulk
 
-__all__ = ["attribute_create", "prepare_all_attributes"]
+__all__ = [
+    "attribute_create",
+    "prepare_all_attributes",
+    "bulk_create_attributes",
+    "prepare_all_attributes_in_bulk",
+]

--- a/saleor/tests/e2e/attributes/utils/attribute_bulk_create.py
+++ b/saleor/tests/e2e/attributes/utils/attribute_bulk_create.py
@@ -1,0 +1,61 @@
+from ...utils import get_graphql_content
+
+ATTRIBUTE_BULK_CREATE_MUTATION = """
+mutation AttributeBulkCreate($attributes: [AttributeCreateInput!]!) {
+  attributeBulkCreate(attributes: $attributes) {
+    results {
+      errors {
+        path
+        message
+        code
+      }
+      attribute {
+        id
+        name
+        slug
+        choices(first: 10) {
+          edges {
+            node {
+              id
+              name
+              slug
+              value
+              inputType
+              reference
+              file {
+                url
+                contentType
+              }
+              richText
+              plainText
+              boolean
+              date
+              dateTime
+            }
+          }
+        }
+      }
+    }
+    count
+  }
+}
+"""
+
+
+def bulk_create_attributes(
+    staff_api_client,
+    attributes=None,
+):
+    variables = {"attributes": attributes}
+
+    response = staff_api_client.post_graphql(
+        ATTRIBUTE_BULK_CREATE_MUTATION,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["attributeBulkCreate"]["results"][0]["errors"] == []
+
+    data = content["data"]["attributeBulkCreate"]
+
+    return data

--- a/saleor/tests/e2e/attributes/utils/prepare_attributes.py
+++ b/saleor/tests/e2e/attributes/utils/prepare_attributes.py
@@ -1,7 +1,8 @@
+from .attribute_bulk_create import bulk_create_attributes
 from .create_attribute import attribute_create
 
 
-def prepare_all_attributes(e2e_staff_api_client, attribute_type):
+def prepare_all_attributes(e2e_staff_api_client, attribute_type, entity_type):
     # Dropdown
     values = [
         {"name": "Freddy Torres"},
@@ -13,7 +14,7 @@ def prepare_all_attributes(e2e_staff_api_client, attribute_type):
         input_type="DROPDOWN",
         name="Author",
         slug="author",
-        type="PAGE_TYPE",
+        type=attribute_type,
         value_required=True,
         values=values,
     )
@@ -33,7 +34,7 @@ def prepare_all_attributes(e2e_staff_api_client, attribute_type):
         input_type="MULTISELECT",
         name="Department",
         slug="department",
-        type="PAGE_TYPE",
+        type=attribute_type,
         value_required=True,
         values=values,
     )
@@ -46,7 +47,7 @@ def prepare_all_attributes(e2e_staff_api_client, attribute_type):
         input_type="DATE",
         name="Date",
         slug="date",
-        type="PAGE_TYPE",
+        type=attribute_type,
         value_required=True,
     )
 
@@ -58,7 +59,7 @@ def prepare_all_attributes(e2e_staff_api_client, attribute_type):
         input_type="DATE_TIME",
         name="Date time",
         slug="date-time",
-        type="PAGE_TYPE",
+        type=attribute_type,
         value_required=True,
     )
 
@@ -70,7 +71,7 @@ def prepare_all_attributes(e2e_staff_api_client, attribute_type):
         input_type="PLAIN_TEXT",
         name="Plain text test",
         slug="plain-text-test",
-        type="PAGE_TYPE",
+        type=attribute_type,
         value_required=True,
     )
 
@@ -82,7 +83,7 @@ def prepare_all_attributes(e2e_staff_api_client, attribute_type):
         input_type="RICH_TEXT",
         name="Rich text test",
         slug="rich-text-test",
-        type="PAGE_TYPE",
+        type=attribute_type,
         value_required=True,
     )
 
@@ -94,7 +95,7 @@ def prepare_all_attributes(e2e_staff_api_client, attribute_type):
         input_type="NUMERIC",
         name="Numeric test",
         slug="numeric-test",
-        type="PAGE_TYPE",
+        type=attribute_type,
         value_required=True,
         unit="G",
     )
@@ -107,7 +108,7 @@ def prepare_all_attributes(e2e_staff_api_client, attribute_type):
         input_type="BOOLEAN",
         name="Bool test",
         slug="bool-test",
-        type="PAGE_TYPE",
+        type=attribute_type,
         value_required=True,
     )
 
@@ -124,7 +125,7 @@ def prepare_all_attributes(e2e_staff_api_client, attribute_type):
         input_type="SWATCH",
         name="Swatch test",
         slug="swatch-test",
-        type="PAGE_TYPE",
+        type=attribute_type,
         value_required=True,
         values=values,
     )
@@ -137,9 +138,9 @@ def prepare_all_attributes(e2e_staff_api_client, attribute_type):
         input_type="REFERENCE",
         name="Reference test",
         slug="reference-test",
-        type="PAGE_TYPE",
+        type=attribute_type,
         value_required=True,
-        entityType="PRODUCT",
+        entityType=entity_type,
     )
 
     attr_reference_id = attr_reference["id"]
@@ -150,11 +151,136 @@ def prepare_all_attributes(e2e_staff_api_client, attribute_type):
         input_type="FILE",
         name="File test",
         slug="file-test",
-        type="PAGE_TYPE",
+        type=attribute_type,
         value_required=False,
     )
 
     attr_file_id = attr_file["id"]
+
+    return (
+        attr_dropdown_id,
+        attr_multiselect_id,
+        attr_date_id,
+        attr_date_time_id,
+        attr_plain_text_id,
+        attr_rich_text_id,
+        attr_numeric_id,
+        attr_bool_id,
+        attr_swatch_id,
+        attr_reference_id,
+        attr_file_id,
+    )
+
+
+def prepare_all_attributes_in_bulk(e2e_staff_api_client, attribute_type, entity_type):
+    attributes = [
+        {
+            "name": "Dropdown",
+            "slug": "dropdown",
+            "inputType": "DROPDOWN",
+            "type": attribute_type,
+            "valueRequired": True,
+            "values": [
+                {"name": "Freddy Torres"},
+                {"name": "Isabella Smith"},
+                {"name": "Hayden Blake"},
+            ],
+        },
+        {
+            "name": "Multiselect",
+            "slug": "multiselect",
+            "inputType": "MULTISELECT",
+            "type": attribute_type,
+            "valueRequired": True,
+            "values": [
+                {"name": "Security"},
+                {"name": "Support"},
+                {"name": "Medical"},
+                {"name": "General"},
+            ],
+        },
+        {
+            "name": "Date",
+            "slug": "date",
+            "inputType": "DATE",
+            "type": attribute_type,
+            "valueRequired": True,
+        },
+        {
+            "name": "Date time",
+            "slug": "date-time",
+            "inputType": "DATE_TIME",
+            "type": attribute_type,
+            "valueRequired": True,
+        },
+        {
+            "name": "Plain text",
+            "slug": "plain-text",
+            "inputType": "PLAIN_TEXT",
+            "type": attribute_type,
+            "valueRequired": True,
+        },
+        {
+            "name": "Rich text",
+            "slug": "rich-text",
+            "inputType": "RICH_TEXT",
+            "type": attribute_type,
+            "valueRequired": True,
+        },
+        {
+            "name": "Numeric",
+            "slug": "numeric",
+            "inputType": "NUMERIC",
+            "type": attribute_type,
+            "valueRequired": True,
+        },
+        {
+            "name": "Boolean",
+            "slug": "boolean",
+            "inputType": "BOOLEAN",
+            "type": attribute_type,
+            "valueRequired": True,
+        },
+        {
+            "name": "Swatch",
+            "slug": "swatch",
+            "inputType": "SWATCH",
+            "type": attribute_type,
+            "valueRequired": True,
+            "values": [
+                {"name": "black", "value": "#000000"},
+                {"name": "blue", "value": "#4167E7"},
+            ],
+        },
+        {
+            "name": "Reference",
+            "slug": "reference",
+            "inputType": "REFERENCE",
+            "type": attribute_type,
+            "valueRequired": False,
+            "entityType": entity_type,
+        },
+        {
+            "name": "File",
+            "slug": "file",
+            "inputType": "FILE",
+            "type": attribute_type,
+            "valueRequired": False,
+        },
+    ]
+    attributes_data = bulk_create_attributes(e2e_staff_api_client, attributes)
+
+    attr_dropdown_id = attributes_data["results"][0]["attribute"]["id"]
+    attr_multiselect_id = attributes_data["results"][1]["attribute"]["id"]
+    attr_date_id = attributes_data["results"][2]["attribute"]["id"]
+    attr_date_time_id = attributes_data["results"][3]["attribute"]["id"]
+    attr_plain_text_id = attributes_data["results"][4]["attribute"]["id"]
+    attr_rich_text_id = attributes_data["results"][5]["attribute"]["id"]
+    attr_numeric_id = attributes_data["results"][6]["attribute"]["id"]
+    attr_bool_id = attributes_data["results"][7]["attribute"]["id"]
+    attr_swatch_id = attributes_data["results"][8]["attribute"]["id"]
+    attr_reference_id = attributes_data["results"][9]["attribute"]["id"]
+    attr_file_id = attributes_data["results"][10]["attribute"]["id"]
 
     return (
         attr_dropdown_id,

--- a/saleor/tests/e2e/product/test_create_product_with_all_attributes_types.py
+++ b/saleor/tests/e2e/product/test_create_product_with_all_attributes_types.py
@@ -6,21 +6,22 @@ import pytz
 from django.conf import settings
 
 from ....tests.utils import dummy_editorjs
-from ..attributes.utils import prepare_all_attributes
+from ..attributes.utils import prepare_all_attributes_in_bulk
 from ..pages.utils import create_page, create_page_type
-from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
 from ..utils import assign_permissions
+from .utils import (
+    create_category,
+    create_product,
+    create_product_type,
+)
 
 
 @pytest.mark.e2e
-def test_create_page_with_each_of_attribute_types_core_0701(
+def test_create_product_with_attributes_created_in_bulk_core_0704(
     e2e_staff_api_client,
     permission_manage_page_types_and_attributes,
     permission_manage_pages,
     permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     site_settings,
 ):
@@ -29,30 +30,18 @@ def test_create_page_with_each_of_attribute_types_core_0701(
         permission_manage_page_types_and_attributes,
         permission_manage_pages,
         permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
         permission_manage_product_types_and_attributes,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    category_data = create_category(e2e_staff_api_client)
+    category_id = category_data["id"]
+    page_type_data = create_page_type(e2e_staff_api_client)
+    page_type_id = page_type_data["id"]
+    page_data = create_page(e2e_staff_api_client, page_type_id)
+    page_id = page_data["id"]
 
-    (
-        product_id,
-        _product_variant_id,
-        _product_variant_price,
-    ) = prepare_product(
-        e2e_staff_api_client,
-        warehouse_id,
-        channel_id,
-        23,
-    )
-
+    # Step 1 - Bulk create attributes for each input type
     (
         attr_dropdown_id,
         attr_multiselect_id,
@@ -65,13 +54,11 @@ def test_create_page_with_each_of_attribute_types_core_0701(
         attr_swatch_id,
         attr_reference_id,
         attr_file_id,
-    ) = prepare_all_attributes(
-        e2e_staff_api_client,
-        attribute_type="PAGE_TYPE",
-        entity_type="PRODUCT",
+    ) = prepare_all_attributes_in_bulk(
+        e2e_staff_api_client, attribute_type="PRODUCT_TYPE", entity_type="PAGE"
     )
 
-    # Step 1 - Create page type with all attributes
+    # Step 2 - Create product type with all attributes
     add_attributes = [
         attr_dropdown_id,
         attr_multiselect_id,
@@ -85,21 +72,23 @@ def test_create_page_with_each_of_attribute_types_core_0701(
         attr_reference_id,
         attr_file_id,
     ]
-    page_type_data = create_page_type(e2e_staff_api_client, "Page Type", add_attributes)
-    page_type_id = page_type_data["id"]
-    assert page_type_data["name"] == "Page Type"
-    assert len(page_type_data["attributes"]) == 11
+    product_type_data = create_product_type(
+        e2e_staff_api_client,
+        slug="all-attributes-type",
+        product_attributes=add_attributes,
+    )
+    product_type_id = product_type_data["id"]
+    assert len(product_type_data["productAttributes"]) == 11
 
-    # Step 2 - Create page with all attributes
+    # Step 3 - Create product with all attributes
     expected_base_text = "Test rich attribute text"
     expected_rich_text = json.dumps(dummy_editorjs(expected_base_text))
-
     new_value = "new_test_value.txt"
     file_url = f"http://{site_settings.site.domain}{settings.MEDIA_URL}{new_value}"
     file_content_type = "text/plain"
 
     attributes = [
-        {"id": attr_dropdown_id, "values": ["Freddy Torres"]},
+        {"id": attr_dropdown_id, "dropdown": {"value": "Isabella Smith"}},
         {"id": attr_multiselect_id, "values": ["security", "support"]},
         {"id": attr_date_id, "date": "2021-01-01"},
         {
@@ -111,18 +100,14 @@ def test_create_page_with_each_of_attribute_types_core_0701(
         {"id": attr_numeric_id, "numeric": 10},
         {"id": attr_bool_id, "boolean": True},
         {"id": attr_swatch_id, "values": ["blue"]},
-        {"id": attr_reference_id, "references": [product_id]},
+        {"id": attr_reference_id, "references": [page_id]},
         {"id": attr_file_id, "file": file_url, "contentType": file_content_type},
     ]
-
-    page = create_page(
+    product_data = create_product(
         e2e_staff_api_client,
-        page_type_id,
-        title="test Page",
-        is_published=True,
+        product_type_id,
+        category_id,
         attributes=attributes,
     )
-    assert page["title"] == "test Page"
-    assert page["isPublished"] is True
-    attributes = page["attributes"]
-    assert len(attributes) == 11
+    attributes = product_data["attributes"]
+    assert len(product_data["attributes"]) == 11


### PR DESCRIPTION
I want to merge this change because it adds test for [CORE_0704](https://saleor.testmo.net/repositories/5?group_id=116&case_id=4787) Should create a product with all attribute types created in bulk

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
