### PR TITLE
[TEST] Should be able to add add a gift card to a checkout before email

### DIFF
--- a/saleor/tests/e2e/checkout/test_checkout_add_gift_card_before_email.py
+++ b/saleor/tests/e2e/checkout/test_checkout_add_gift_card_before_email.py
@@ -1,0 +1,129 @@
+import pytest
+
+from ..gift_cards.utils import create_gift_card
+from ..product.utils.preparing_product import prepare_product
+from ..shop.utils.preparing_shop import prepare_shop
+from ..utils import assign_permissions
+from .utils import (
+    checkout_add_promo_code,
+    checkout_complete,
+    checkout_create,
+    checkout_delivery_method_update,
+    checkout_update_email,
+    raw_checkout_dummy_payment_create,
+)
+
+
+@pytest.mark.e2e
+def test_add_gift_card_before_email_in_checkout_core_1104(
+    e2e_not_logged_api_client,
+    e2e_staff_api_client,
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_shipping,
+    permission_manage_product_types_and_attributes,
+    permission_manage_gift_card,
+):
+    # Before
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_product_types_and_attributes,
+        permission_manage_gift_card,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    (
+        _product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client,
+        warehouse_id,
+        channel_id,
+        variant_price=24.99,
+    )
+    product_variant_price = float(product_variant_price)
+    gift_card = create_gift_card(e2e_staff_api_client, 10, "USD", active=True)
+    gift_card_code = gift_card["code"]
+    gift_card_id = gift_card["id"]
+    gift_card_balance = gift_card["initialBalance"]["amount"]
+
+    # Step 1 - Create checkout for product
+    lines = [
+        {
+            "variantId": product_variant_id,
+            "quantity": 3,
+        },
+    ]
+    checkout_data = checkout_create(
+        e2e_not_logged_api_client,
+        lines,
+        channel_slug,
+        set_default_billing_address=True,
+        set_default_shipping_address=True,
+    )
+    checkout_id = checkout_data["id"]
+    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
+    calculated_subtotal = product_variant_price * 3
+    assert checkout_data["isShippingRequired"] is True
+    assert checkout_data["totalPrice"]["gross"]["amount"] == calculated_subtotal
+    assert checkout_data["email"] is None
+
+    # Step 2 Add gift card to checkout
+    checkout_data = checkout_add_promo_code(
+        e2e_not_logged_api_client,
+        checkout_id,
+        gift_card_code,
+    )
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    assert total_gross_amount == calculated_subtotal - gift_card_balance
+    assert checkout_data["giftCards"][0]["id"] == gift_card_id
+    assert checkout_data["giftCards"][0]["last4CodeChars"] == gift_card_code[-4:]
+
+    # Step 3 - Set email for checkout
+    checkout_data = checkout_update_email(
+        e2e_not_logged_api_client, checkout_id, "testEmail@saleor.io"
+    )
+    assert checkout_data["email"] == "testEmail@saleor.io"
+
+    # Step 4 - Set DeliveryMethod for checkout.
+    checkout_data = checkout_delivery_method_update(
+        e2e_not_logged_api_client,
+        checkout_id,
+        shipping_method_id,
+    )
+    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
+    shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
+    assert shipping_price == 10
+    calculated_total = calculated_subtotal + shipping_price - gift_card_balance
+    assert total_gross_amount == calculated_total
+
+    # Step 5 - Create payment for checkout.
+    create_payment = raw_checkout_dummy_payment_create(
+        e2e_not_logged_api_client,
+        checkout_id,
+        total_gross_amount,
+        token="fully_charged",
+    )
+    assert create_payment["errors"] == []
+    assert create_payment["checkout"]["id"] == checkout_id
+
+    # Step 6 - Complete checkout.
+    order_data = checkout_complete(
+        e2e_not_logged_api_client,
+        checkout_id,
+    )
+    assert order_data["status"] == "UNFULFILLED"
+    assert order_data["total"]["gross"]["amount"] == calculated_total
+    assert order_data["giftCards"][0]["id"] == gift_card_id
+    assert order_data["giftCards"][0]["last4CodeChars"] == gift_card_code[-4:]

--- a/saleor/tests/e2e/checkout/utils/__init__.py
+++ b/saleor/tests/e2e/checkout/utils/__init__.py
@@ -10,6 +10,7 @@ from .checkout_complete import checkout_complete, raw_checkout_complete
 from .checkout_create import checkout_create, raw_checkout_create
 from .checkout_create_from_order import checkout_create_from_order
 from .checkout_delivery_method_update import checkout_delivery_method_update
+from .checkout_email_update import checkout_update_email
 from .checkout_lines_add import checkout_lines_add
 from .checkout_lines_update import checkout_lines_update
 from .checkout_payment_create import (
@@ -40,4 +41,5 @@ __all__ = [
     "raw_checkout_add_promo_code",
     "get_checkout",
     "checkout_remove_promo_code",
+    "checkout_update_email",
 ]

--- a/saleor/tests/e2e/checkout/utils/checkout_email_update.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_email_update.py
@@ -1,0 +1,36 @@
+from ...utils import get_graphql_content
+
+CHECKOUT_EMAIL_UPDATE_MUTATION = """
+mutation checkoutEmailUpdate($checkoutId: ID!, $email: String!){
+  checkoutEmailUpdate(
+    id: $checkoutId
+    email: $email
+  ) {
+    checkout {
+      email
+    }
+    errors {
+      field
+      message
+    }
+  }
+}
+"""
+
+
+def checkout_update_email(
+    staff_api_client,
+    checkout_id,
+    email,
+):
+    variables = {
+        "checkoutId": checkout_id,
+        "email": email,
+    }
+
+    response = staff_api_client.post_graphql(CHECKOUT_EMAIL_UPDATE_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    assert content["data"]["checkoutEmailUpdate"]["errors"] == []
+    data = content["data"]["checkoutEmailUpdate"]["checkout"]
+    return data

--- a/saleor/tests/e2e/gift_cards/utils/gift_card_create.py
+++ b/saleor/tests/e2e/gift_cards/utils/gift_card_create.py
@@ -6,6 +6,9 @@ mutation GiftCardCreate($input: GiftCardCreateInput!) {
     giftCard {
       id
       code
+      initialBalance {
+        amount
+      }
     }
     errors {
       code


### PR DESCRIPTION
I want to merge this change because it adds a test for [CORE_1104](https://saleor.testmo.net/repositories/5?group_id=239&case_id=1724) Should be able to add add a gift card to a checkout before email


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
