### PR TITLE
Fix unserializable decimal values in catalogue predicate.

### DIFF
--- a/saleor/discount/migrations/0064_alter_promotionrule_catalogue_predicate.py
+++ b/saleor/discount/migrations/0064_alter_promotionrule_catalogue_predicate.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+import saleor.core.utils.json_serializer
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("discount", "0063_basediscount_voucher_code"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="promotionrule",
+            name="catalogue_predicate",
+            field=models.JSONField(
+                blank=True,
+                default=dict,
+                encoder=saleor.core.utils.json_serializer.CustomJsonEncoder,
+            ),
+        ),
+    ]

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -338,7 +338,9 @@ class PromotionRule(models.Model):
         Promotion, on_delete=models.CASCADE, related_name="rules"
     )
     channels = models.ManyToManyField(Channel)
-    catalogue_predicate = models.JSONField(blank=True, default=dict)
+    catalogue_predicate = models.JSONField(
+        blank=True, default=dict, encoder=CustomJsonEncoder
+    )
     reward_value_type = models.CharField(
         max_length=255, choices=RewardValueType.CHOICES, blank=True, null=True
     )


### PR DESCRIPTION
I want to merge this change because there is no encoder for `PromotionRule.catalogue_predicate` json field, what resulting in error, when trying to save Decimal values.

Issue: https://github.com/saleor/saleor/issues/14353

<!-- Please mention all relevant issue numbers. -->

# Impact

- [x] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
