### PR TITLE
Fix handling thumbnails 

### DIFF
--- a/saleor/graphql/core/validators/file.py
+++ b/saleor/graphql/core/validators/file.py
@@ -1,4 +1,3 @@
-import mimetypes
 import os
 
 import requests
@@ -26,23 +25,13 @@ def is_supported_image_mimetype(mimetype: str) -> bool:
     return mimetype in MIME_TYPE_TO_PIL_IDENTIFIER.keys()
 
 
-def is_image_url(url: str) -> bool:
-    """Check if file URL seems to be an image."""
-    if url.endswith(".webp"):
-        # webp is not recognized by mimetypes as image
-        # https://bugs.python.org/issue38902
-        return True
-    filetype = mimetypes.guess_type(url)[0]
-    return filetype is not None and is_image_mimetype(filetype)
-
-
 def validate_image_url(url: str, field_name: str, error_code: str) -> None:
     """Check if remote file has content type of image.
 
     Instead of the whole file, only the headers are fetched.
     """
     head = requests.head(
-        url, timeout=settings.COMMON_REQUESTS_TIMEOUT, allow_redirects=False
+        url, timeout=settings.COMMON_REQUESTS_TIMEOUT, allow_redirects=True
     )
     header = head.headers
     content_type = header.get("content-type")

--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -43,7 +43,7 @@ from ...core.types import (
 )
 from ...core.utils import get_duplicated_values
 from ...core.validators import clean_seo_fields
-from ...core.validators.file import clean_image_file, is_image_url, validate_image_url
+from ...core.validators.file import clean_image_file, validate_image_url
 from ...meta.mutations import MetadataInput
 from ...plugins.dataloaders import get_plugin_manager_promise
 from ..mutations.product.product_create import ProductCreateInput
@@ -802,7 +802,7 @@ class ProductBulkCreate(BaseMutation):
                     )
                 )
             if media_url:
-                if is_image_url(media_url):
+                try:
                     validate_image_url(
                         media_url, "media_url", ProductBulkCreateErrorCode.INVALID.value
                     )
@@ -822,7 +822,7 @@ class ProductBulkCreate(BaseMutation):
                             type=ProductMediaTypes.IMAGE,
                         )
                     )
-                else:
+                except ValidationError:
                     oembed_data, media_type = get_oembed_data(media_url, "media_url")
                     media_to_create.append(
                         models.ProductMedia(

--- a/saleor/thumbnail/tests/test_views.py
+++ b/saleor/thumbnail/tests/test_views.py
@@ -16,7 +16,7 @@ def test_handle_thumbnail_view_with_format(client, category_with_image, settings
     response = client.get(f"/thumbnail/{category_id}/{size}/{format}/")
 
     # then
-    assert response.status_code == 302
+    assert response.status_code == 301
     file_path, _ = category_with_image.background_image.name.rsplit(".")
     assert (
         response.url
@@ -35,7 +35,7 @@ def test_handle_thumbnail_view_for_category(client, category_with_image, setting
     response = client.get(f"/thumbnail/{category_id}/{size}/")
 
     # then
-    assert response.status_code == 302
+    assert response.status_code == 301
     file_path, ext = category_with_image.background_image.name.rsplit(".")
     assert (
         response.url
@@ -54,7 +54,7 @@ def test_handle_thumbnail_view_for_collection(client, collection_with_image, set
     response = client.get(f"/thumbnail/{collection_id}/{size}/")
 
     # then
-    assert response.status_code == 302
+    assert response.status_code == 301
     file_path, ext = collection_with_image.background_image.name.rsplit(".")
     assert (
         response.url
@@ -78,7 +78,7 @@ def test_handle_thumbnail_view_for_user(
     response = client.get(f"/thumbnail/{user_uuid}/{size}/")
 
     # then
-    assert response.status_code == 302
+    assert response.status_code == 301
     file_path, ext = staff_user.avatar.name.rsplit(".")
     assert (
         response.url
@@ -101,7 +101,7 @@ def test_handle_thumbnail_view_for_product_media(
     response = client.get(f"/thumbnail/{product_media_id}/{size}/")
 
     # then
-    assert response.status_code == 302
+    assert response.status_code == 301
     file_path, ext = product_media.image.name.rsplit(".")
     assert (
         response.url
@@ -272,7 +272,7 @@ def test_handle_icon_thumbnail_view_with_format(
     response = client.get(f"/thumbnail/{app_uuid}/{size}/{format}/")
 
     # then
-    assert response.status_code == 302
+    assert response.status_code == 301
     file_path, _ = app.brand_logo_default.name.rsplit(".")
     assert (
         response.url
@@ -300,7 +300,7 @@ def test_handle_thumbnail_view_for_app_logo_default(
     response = client.get(f"/thumbnail/{uuid}/{size}/")
 
     # then
-    assert response.status_code == 302
+    assert response.status_code == 301
     file_path, ext = app.brand_logo_default.name.rsplit(".")
     assert (
         response.url
@@ -342,7 +342,7 @@ def test_handle_thumbnail_view_for_app_installation_logo_default(
     response = client.get(f"/thumbnail/{uuid}/{size}/")
 
     # then
-    assert response.status_code == 302
+    assert response.status_code == 301
     file_path, ext = app_installation.brand_logo_default.name.rsplit(".")
     assert (
         response.url

--- a/saleor/thumbnail/utils.py
+++ b/saleor/thumbnail/utils.py
@@ -87,6 +87,10 @@ def prepare_thumbnail_file_name(
     return file_path + f"_thumbnail_{size}." + file_ext
 
 
+def get_image_mimetype(image):
+    return magic.from_buffer(image.read(1024), mime=True)
+
+
 class ProcessedImage:
     EXIF_ORIENTATION_KEY = 274
     # Whether to create progressive JPEGs. Read more about progressive JPEGs
@@ -141,7 +145,7 @@ class ProcessedImage:
             [1]: InMemoryUploadedFile-friendly save format (i.e. 'image/jpeg')
         image_format, in_memory_file_type
         """
-        mime_type = magic.from_buffer(file_like.read(1024), mime=True)
+        mime_type = get_image_mimetype(file_like)
         file_like.seek(0)
         image_format = MIME_TYPE_TO_PIL_IDENTIFIER[mime_type]
         return image_format

--- a/saleor/thumbnail/views.py
+++ b/saleor/thumbnail/views.py
@@ -2,7 +2,8 @@ from collections import namedtuple
 from typing import Optional
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.http import HttpResponseNotFound, HttpResponseRedirect
+from django.http import HttpResponseNotFound, HttpResponseRedirect, \
+    HttpResponsePermanentRedirect
 from graphql.error import GraphQLError
 
 from ..account.models import User
@@ -17,7 +18,7 @@ from .utils import (
     ProcessedIconImage,
     ProcessedImage,
     get_thumbnail_size,
-    prepare_thumbnail_file_name,
+    prepare_thumbnail_file_name, get_image_mimetype,
 )
 
 ModelData = namedtuple("ModelData", ["model", "image_field", "thumbnail_field"])
@@ -115,5 +116,5 @@ def handle_thumbnail(
     setattr(thumbnail, "instance", instance)
     manager = get_plugins_manager()
     call_event(manager.thumbnail_created, thumbnail)
-
-    return HttpResponseRedirect(thumbnail.image.url)
+    content_type = get_image_mimetype(thumbnail.image)
+    return HttpResponsePermanentRedirect(thumbnail.image.url, content_type=content_type)


### PR DESCRIPTION
I want to merge this change because it fixes #14508 
Here is a list of changes we decided to do in scope of this bug:

- drop the is_image_url function - we shouldn't assume that URL represents an image just by the looks of the URL; instead, we should download the file and check its mime type.

- downloading the file and checking the mime type is already done in the validate_image_url, which should be used instead of is_image_url.

- fix the handle_thumbnail view to always set the Content-Type header in the redirect responses (we should be able to get mime-type from the image file)

- in both mutations productMediaCreate and productBulkCreate, we should allow redirects when fetching the actual image data image_data = HTTPClient.send_request(...)

- Extra fix: the handle_thumbnail uses 302 redirect code, but it should be a permanent redirect code, this can be fixed by using HttpResponsePermanentRedirect redirect class.


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
