### PR TITLE
Refactor fetching variants for predicates

### DIFF
--- a/saleor/discount/tasks.py
+++ b/saleor/discount/tasks.py
@@ -8,7 +8,7 @@ from celery.utils.log import get_task_logger
 from django.db.models import Exists, F, OuterRef, Q, QuerySet
 
 from ..celeryconf import app
-from ..graphql.discount.utils import get_variants_for_predicate
+from ..graphql.discount.utils import get_variants_for_catalogue_predicate
 from ..order import OrderStatus
 from ..order.models import Order, OrderLine
 from ..plugins.manager import get_plugins_manager
@@ -148,7 +148,7 @@ def fetch_promotion_variants_and_product_ids(promotions: "QuerySet[Promotion]"):
         Exists(promotions.filter(id=OuterRef("promotion_id")))
     )
     for rule in rules:
-        rule_variants = get_variants_for_predicate(rule.catalogue_predicate)
+        rule_variants = get_variants_for_catalogue_predicate(rule.catalogue_predicate)
         variants |= rule_variants
         promotion_id_to_variants[rule.promotion_id] |= rule_variants
     products = Product.objects.filter(

--- a/saleor/graphql/discount/mutations/bulk_mutations.py
+++ b/saleor/graphql/discount/mutations/bulk_mutations.py
@@ -24,7 +24,7 @@ from ...plugins.dataloaders import get_plugin_manager_promise
 from ..types import Sale, Voucher
 from ..utils import (
     convert_migrated_sale_predicate_to_catalogue_info,
-    get_variants_for_predicate,
+    get_variants_for_catalogue_predicate,
 )
 
 
@@ -121,7 +121,7 @@ class SaleBulkDelete(ModelBulkDeleteMutation):
     def get_product_ids(cls, get_sale_and_rules: dict):
         variants = product_models.ProductVariant.objects.none()
         for rule in get_sale_and_rules.values():
-            variants |= get_variants_for_predicate(rule.catalogue_predicate)
+            variants |= get_variants_for_catalogue_predicate(rule.catalogue_predicate)
 
         products = product_models.Product.objects.filter(
             Exists(variants.filter(product_id=OuterRef("id")))

--- a/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_bulk_delete.py
@@ -15,7 +15,7 @@ from ....core.types import DiscountError, NonNullList
 from ....core.utils import WebhookEventInfo
 from ....plugins.dataloaders import get_plugin_manager_promise
 from ...types import Promotion
-from ...utils import get_variants_for_predicate
+from ...utils import get_variants_for_catalogue_predicate
 
 
 class PromotionBulkDelete(ModelBulkDeleteMutation):
@@ -57,7 +57,7 @@ class PromotionBulkDelete(ModelBulkDeleteMutation):
         )
         variants = product_models.ProductVariant.objects.none()
         for rule in rules:
-            variants |= get_variants_for_predicate(rule.catalogue_predicate)
+            variants |= get_variants_for_catalogue_predicate(rule.catalogue_predicate)
         products = product_models.Product.objects.filter(
             Exists(variants.filter(product_id=OuterRef("id")))
         )

--- a/saleor/graphql/discount/tests/test_utils.py
+++ b/saleor/graphql/discount/tests/test_utils.py
@@ -6,12 +6,14 @@ from ....discount import RewardValueType
 from ....discount.models import Promotion, PromotionRule
 from ..utils import (
     convert_migrated_sale_predicate_to_catalogue_info,
-    get_variants_for_predicate,
+    get_variants_for_catalogue_predicate,
     get_variants_for_promotion,
 )
 
 
-def test_get_variants_for_predicate_with_or(product_with_two_variants, variant):
+def test_get_variants_for_catalogue_predicate_with_or(
+    product_with_two_variants, variant
+):
     # given
     catalogue_predicate = {
         "OR": [
@@ -33,7 +35,7 @@ def test_get_variants_for_predicate_with_or(product_with_two_variants, variant):
     }
 
     # when
-    variants = get_variants_for_predicate(catalogue_predicate)
+    variants = get_variants_for_catalogue_predicate(catalogue_predicate)
 
     # then
     assert variant in variants
@@ -41,7 +43,7 @@ def test_get_variants_for_predicate_with_or(product_with_two_variants, variant):
         assert variant in variants
 
 
-def test_get_variants_for_predicate_with_and(collection, product_list):
+def test_get_variants_for_catalogue_predicate_with_and(collection, product_list):
     # given
     product_in_collection = product_list[1]
     collection.products.add(product_in_collection)
@@ -64,7 +66,7 @@ def test_get_variants_for_predicate_with_and(collection, product_list):
     }
 
     # when
-    variants = get_variants_for_predicate(catalogue_predicate)
+    variants = get_variants_for_catalogue_predicate(catalogue_predicate)
 
     # then
     assert len(variants) == product_in_collection.variants.count()
@@ -81,7 +83,7 @@ def test_get_variants_for_product_predicate(product_with_two_variants, variant):
     }
 
     # when
-    variants = get_variants_for_predicate(catalogue_predicate)
+    variants = get_variants_for_catalogue_predicate(catalogue_predicate)
 
     # then
     assert len(variants) == product_with_two_variants.variants.count()
@@ -102,7 +104,7 @@ def test_get_variants_for_variant_predicate(product_with_two_variants, variant):
     }
 
     # when
-    variants = get_variants_for_predicate(catalogue_predicate)
+    variants = get_variants_for_catalogue_predicate(catalogue_predicate)
 
     # then
     assert len(variants) == product_with_two_variants.variants.count()
@@ -125,7 +127,7 @@ def test_get_variants_for_category_predicate(
     product.save(update_fields=["category"])
 
     # when
-    variants = get_variants_for_predicate(catalogue_predicate)
+    variants = get_variants_for_catalogue_predicate(catalogue_predicate)
 
     # then
     assert len(variants) == product.variants.count()
@@ -147,7 +149,7 @@ def test_get_variants_for_collection_predicate(
     collection.products.add(product)
 
     # when
-    variants = get_variants_for_predicate(catalogue_predicate)
+    variants = get_variants_for_catalogue_predicate(catalogue_predicate)
 
     # then
     assert len(variants) == product.variants.count()
@@ -174,7 +176,7 @@ def test_get_variants_for_variant_and_empty_list_of_other_predicates(
     }
 
     # when
-    variants = get_variants_for_predicate(catalogue_predicate)
+    variants = get_variants_for_catalogue_predicate(catalogue_predicate)
 
     # then
     assert len(variants) == 0
@@ -207,14 +209,14 @@ def test_get_variants_for_variant_or_operator_and_empty_list_of_other_predicates
     }
 
     # when
-    variants = get_variants_for_predicate(catalogue_predicate)
+    variants = get_variants_for_catalogue_predicate(catalogue_predicate)
 
     # then
     assert len(variants) == product_with_two_variants.variants.count()
     assert variant not in variants
 
 
-def test_get_variants_for_predicate_with_nested_conditions(
+def test_get_variants_for_catalogue_predicate_with_nested_conditions(
     product_list, collection, variant
 ):
     # given
@@ -250,7 +252,7 @@ def test_get_variants_for_predicate_with_nested_conditions(
     }
 
     # when
-    variants = get_variants_for_predicate(catalogue_predicate)
+    variants = get_variants_for_catalogue_predicate(catalogue_predicate)
 
     # then
     assert len(variants) == product_in_collection.variants.count() + 1
@@ -266,7 +268,7 @@ def test_get_variants_for_variant_predicate_empty_predicate_data(
     catalogue_predicate = {}
 
     # when
-    variants = get_variants_for_predicate(catalogue_predicate)
+    variants = get_variants_for_catalogue_predicate(catalogue_predicate)
 
     # then
     assert len(variants) == 0


### PR DESCRIPTION
Refactor `saleor/graphql/discount/utils.py`.
- Introduce `filter_qs_by_predicate` that will be generic function for different predicates
- Reduce the `qs` that are used for `where` filters in promotions

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
