### PR TITLE
Drop defaultTransactionFlowStrategy from orderSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable, unreleased changes to this project will be documented in this file.
   - `promotion_deleted`
   - `staff_deleted`
 - Saleor will no longer reattempt delivery for webhooks that return non-transient HTTP errors (400, 404 etc.) or redirects - #14566 by @patrys
+- **Feature preview breaking change**:
+  - Drop `defaultTransactionFlowStrategy` from `OrderSettings` type. Use `PaymentSettings.defaultTransactionFlowStrategy` instead. Drop `defaultTransactionFlowStrategy` from `OrderSettingsInput` type. Use `PaymentSettingsInput.defaultTransactionFlowStrategy` instead. - #14671 by @korycins
 
 ### GraphQL API
 - Fix draft order voucher assignment - #14336 by @IKarbowiak

--- a/saleor/graphql/channel/mutations/channel_create.py
+++ b/saleor/graphql/channel/mutations/channel_create.py
@@ -19,7 +19,6 @@ from ...core.descriptions import (
     ADDED_IN_316,
     ADDED_IN_318,
     DEPRECATED_IN_3X_INPUT,
-    DEPRECATED_PREVIEW_IN_316_INPUT,
     PREVIEW_FEATURE,
 )
 from ...core.doc_category import (
@@ -119,18 +118,6 @@ class OrderSettingsInput(BaseInputObjectType):
             "\n`TRANSACTION_FLOW` - creates the `TransactionItem` object."
             + ADDED_IN_313
             + PREVIEW_FEATURE
-        ),
-    )
-    default_transaction_flow_strategy = TransactionFlowStrategyEnum(
-        required=False,
-        description=(
-            "Determine the transaction flow strategy to be used. "
-            "Include the selected option in the payload sent to the payment app, as a "
-            "requested action for the transaction."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
-            + DEPRECATED_PREVIEW_IN_316_INPUT
-            + " Use `PaymentSettingsInput.defaultTransactionFlowStrategy` instead."
         ),
     )
     allow_unpaid_orders = graphene.Boolean(

--- a/saleor/graphql/channel/mutations/utils.py
+++ b/saleor/graphql/channel/mutations/utils.py
@@ -47,7 +47,6 @@ def clean_input_order_settings(
     channel_settings = [
         "automatically_confirm_all_new_orders",
         "automatically_fulfill_non_shippable_gift_card",
-        "default_transaction_flow_strategy",
         "allow_unpaid_orders",
         "include_draft_order_in_voucher_usage",
     ]

--- a/saleor/graphql/channel/tests/mutations/test_channel_create.py
+++ b/saleor/graphql/channel/tests/mutations/test_channel_create.py
@@ -44,7 +44,6 @@ CHANNEL_CREATE_MUTATION = """
                     automaticallyFulfillNonShippableGiftCard
                     expireOrdersAfter
                     markAsPaidStrategy
-                    defaultTransactionFlowStrategy
                     deleteExpiredOrdersAfter
                     allowUnpaidOrders
                     includeDraftOrderInVoucherUsage
@@ -606,52 +605,6 @@ def test_channel_create_set_order_mark_as_paid(
     assert (
         channel.order_mark_as_paid_strategy
         == MarkAsPaidStrategyEnum.TRANSACTION_FLOW.value
-    )
-
-
-def test_channel_create_set_default_transaction_flow_strategy_via_order_settings(
-    permission_manage_channels,
-    staff_api_client,
-):
-    # given
-    name = "testName"
-    slug = "test_slug"
-    currency_code = "USD"
-    default_country = "US"
-    variables = {
-        "input": {
-            "name": name,
-            "slug": slug,
-            "currencyCode": currency_code,
-            "defaultCountry": default_country,
-            "orderSettings": {
-                "defaultTransactionFlowStrategy": (
-                    TransactionFlowStrategyEnum.AUTHORIZATION.name
-                )
-            },
-        }
-    }
-
-    # when
-    response = staff_api_client.post_graphql(
-        CHANNEL_CREATE_MUTATION,
-        variables=variables,
-        permissions=(permission_manage_channels,),
-    )
-    content = get_graphql_content(response)
-
-    # then
-    data = content["data"]["channelCreate"]
-    assert not data["errors"]
-    channel_data = data["channel"]
-    channel = Channel.objects.get()
-    assert (
-        channel_data["orderSettings"]["defaultTransactionFlowStrategy"]
-        == TransactionFlowStrategyEnum.AUTHORIZATION.name
-    )
-    assert (
-        channel.default_transaction_flow_strategy
-        == TransactionFlowStrategyEnum.AUTHORIZATION.value
     )
 
 

--- a/saleor/graphql/channel/tests/mutations/test_channel_update.py
+++ b/saleor/graphql/channel/tests/mutations/test_channel_update.py
@@ -42,7 +42,6 @@ CHANNEL_UPDATE_MUTATION = """
                     automaticallyFulfillNonShippableGiftCard
                     expireOrdersAfter
                     markAsPaidStrategy
-                    defaultTransactionFlowStrategy
                     deleteExpiredOrdersAfter
                     allowUnpaidOrders
                     includeDraftOrderInVoucherUsage
@@ -1023,47 +1022,6 @@ def test_channel_update_order_mark_as_paid_strategy(
     assert (
         channel_USD.order_mark_as_paid_strategy
         == MarkAsPaidStrategyEnum.TRANSACTION_FLOW.value
-    )
-
-
-def test_channel_update_default_transaction_flow_strategy_via_order_settings(
-    permission_manage_orders,
-    staff_api_client,
-    channel_USD,
-):
-    # given
-    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
-    variables = {
-        "id": channel_id,
-        "input": {
-            "orderSettings": {
-                "defaultTransactionFlowStrategy": (
-                    TransactionFlowStrategyEnum.AUTHORIZATION.name
-                ),
-            },
-        },
-    }
-
-    # when
-    response = staff_api_client.post_graphql(
-        CHANNEL_UPDATE_MUTATION,
-        variables=variables,
-        permissions=(permission_manage_orders,),
-    )
-    content = get_graphql_content(response)
-
-    # then
-    data = content["data"]["channelUpdate"]
-    assert not data["errors"]
-    channel_data = data["channel"]
-    assert (
-        channel_data["orderSettings"]["defaultTransactionFlowStrategy"]
-        == TransactionFlowStrategyEnum.AUTHORIZATION.name
-    )
-    channel_USD.refresh_from_db()
-    assert (
-        channel_USD.default_transaction_flow_strategy
-        == TransactionFlowStrategyEnum.AUTHORIZATION.value
     )
 
 

--- a/saleor/graphql/channel/tests/queries/test_channel.py
+++ b/saleor/graphql/channel/tests/queries/test_channel.py
@@ -291,7 +291,6 @@ QUERY_CHANNEL_ORDER_SETTINGS = """
                 automaticallyFulfillNonShippableGiftCard
                 expireOrdersAfter
                 markAsPaidStrategy
-                defaultTransactionFlowStrategy
                 deleteExpiredOrdersAfter
                 allowUnpaidOrders
                 includeDraftOrderInVoucherUsage
@@ -338,10 +337,6 @@ def test_query_channel_order_settings_as_staff_user(
     assert (
         channel_data["orderSettings"]["expireOrdersAfter"]
         == channel_USD.expire_orders_after
-    )
-    assert (
-        channel_data["orderSettings"]["defaultTransactionFlowStrategy"]
-        == channel_USD.default_transaction_flow_strategy.upper()
     )
     assert (
         channel_data["orderSettings"]["deleteExpiredOrdersAfter"]
@@ -396,10 +391,6 @@ def test_query_channel_order_settings_as_app(
     assert (
         channel_data["orderSettings"]["expireOrdersAfter"]
         == channel_USD.expire_orders_after
-    )
-    assert (
-        channel_data["orderSettings"]["defaultTransactionFlowStrategy"]
-        == channel_USD.default_transaction_flow_strategy.upper()
     )
     assert (
         channel_data["orderSettings"]["includeDraftOrderInVoucherUsage"]

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -32,7 +32,6 @@ from ..core.descriptions import (
     ADDED_IN_316,
     ADDED_IN_318,
     DEPRECATED_IN_3X_FIELD,
-    DEPRECATED_PREVIEW_IN_316_FIELD,
     PREVIEW_FEATURE,
 )
 from ..core.doc_category import (
@@ -244,18 +243,6 @@ class OrderSettings(ObjectType):
             "\n`TRANSACTION_FLOW` - creates the `TransactionItem` object."
             + ADDED_IN_313
             + PREVIEW_FEATURE
-        ),
-    )
-    default_transaction_flow_strategy = TransactionFlowStrategyEnum(
-        required=True,
-        description=(
-            "Determine the transaction flow strategy to be used. "
-            "Include the selected option in the payload sent to the payment app, as a "
-            "requested action for the transaction."
-            + ADDED_IN_313
-            + PREVIEW_FEATURE
-            + DEPRECATED_PREVIEW_IN_316_FIELD
-            + " Use `PaymentSettings.defaultTransactionFlowStrategy` instead."
         ),
     )
     delete_expired_orders_after = Day(
@@ -563,7 +550,6 @@ class Channel(ModelObjectType):
             ),
             expire_orders_after=root.expire_orders_after,
             mark_as_paid_strategy=root.order_mark_as_paid_strategy,
-            default_transaction_flow_strategy=root.default_transaction_flow_strategy,
             delete_expired_orders_after=root.delete_expired_orders_after.days,
             include_draft_order_in_voucher_usage=(
                 root.include_draft_order_in_voucher_usage

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -2,16 +2,9 @@
 # `deprecation_reason` argument is supported.
 DEPRECATED_IN_3X_FIELD = "This field will be removed in Saleor 4.0."
 
-DEPRECATED_PREVIEW_IN_316_FIELD = (
-    "This preview feature field will be removed in Saleor 3.17."
-)
 # Deprecation message for input fields and query arguments. Use it, when
 # deprecation message needs to be included in the field description.
 DEPRECATED_IN_3X_INPUT = "\n\nDEPRECATED: this field will be removed in Saleor 4.0."
-
-DEPRECATED_PREVIEW_IN_316_INPUT = (
-    "\n\nDEPRECATED: this preview feature field will be removed in Saleor 3.17."
-)
 
 # Deprecation message for enum values.
 DEPRECATED_IN_3X_ENUM_VALUE = (

--- a/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
+++ b/saleor/graphql/payment/mutations/transaction/transaction_initialize.py
@@ -52,8 +52,9 @@ class TransactionInitialize(TransactionSessionBase):
             TransactionFlowStrategyEnum,
             description=(
                 "The expected action called for the transaction. By default, the "
-                "`channel.defaultTransactionFlowStrategy` will be used. The field "
-                "can be used only by app that has `HANDLE_PAYMENTS` permission."
+                "`channel.paymentSettings.defaultTransactionFlowStrategy` will be used."
+                "The field can be used only by app that has `HANDLE_PAYMENTS` "
+                "permission."
             ),
         )
         customer_ip_address = graphene.String(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5573,15 +5573,6 @@ type OrderSettings {
   markAsPaidStrategy: MarkAsPaidStrategyEnum!
 
   """
-  Determine the transaction flow strategy to be used. Include the selected option in the payload sent to the payment app, as a requested action for the transaction.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.This preview feature field will be removed in Saleor 3.17. Use `PaymentSettings.defaultTransactionFlowStrategy` instead.
-  """
-  defaultTransactionFlowStrategy: TransactionFlowStrategyEnum!
-
-  """
   The time in days after expired orders will be deleted.
   
   Added in Saleor 3.14.
@@ -5628,17 +5619,6 @@ enum MarkAsPaidStrategyEnum @doc(category: "Channels") {
   PAYMENT_FLOW
 }
 
-"""
-Determine the transaction flow strategy.
-
-    AUTHORIZATION - the processed transaction should be only authorized
-    CHARGE - the processed transaction should be charged.
-"""
-enum TransactionFlowStrategyEnum @doc(category: "Payments") {
-  AUTHORIZATION
-  CHARGE
-}
-
 """The `Day` scalar type represents number of days by integer value."""
 scalar Day
 
@@ -5668,6 +5648,17 @@ type PaymentSettings {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   defaultTransactionFlowStrategy: TransactionFlowStrategyEnum!
+}
+
+"""
+Determine the transaction flow strategy.
+
+    AUTHORIZATION - the processed transaction should be only authorized
+    CHARGE - the processed transaction should be charged.
+"""
+enum TransactionFlowStrategyEnum @doc(category: "Payments") {
+  AUTHORIZATION
+  CHARGE
 }
 
 """Represents shipping method postal code rule."""
@@ -16508,7 +16499,7 @@ type Mutation {
   """
   transactionInitialize(
     """
-    The expected action called for the transaction. By default, the `channel.defaultTransactionFlowStrategy` will be used. The field can be used only by app that has `HANDLE_PAYMENTS` permission.
+    The expected action called for the transaction. By default, the `channel.paymentSettings.defaultTransactionFlowStrategy` will be used.The field can be used only by app that has `HANDLE_PAYMENTS` permission.
     """
     action: TransactionFlowStrategyEnum
 
@@ -21142,7 +21133,7 @@ input OrderSettingsUpdateInput @doc(category: "Orders") {
   automaticallyConfirmAllNewOrders: Boolean
 
   """
-  When enabled, all non-shippable gift card orders will be fulfilled automatically. By defualt set to True.
+  When enabled, all non-shippable gift card orders will be fulfilled automatically. By default set to True.
   """
   automaticallyFulfillNonShippableGiftCard: Boolean
 }
@@ -29136,17 +29127,6 @@ input OrderSettingsInput @doc(category: "Orders") {
   Note: this API is currently in Feature Preview and can be subject to changes at later point.
   """
   markAsPaidStrategy: MarkAsPaidStrategyEnum
-
-  """
-  Determine the transaction flow strategy to be used. Include the selected option in the payload sent to the payment app, as a requested action for the transaction.
-  
-  Added in Saleor 3.13.
-  
-  Note: this API is currently in Feature Preview and can be subject to changes at later point.
-  
-  DEPRECATED: this preview feature field will be removed in Saleor 3.17. Use `PaymentSettingsInput.defaultTransactionFlowStrategy` instead.
-  """
-  defaultTransactionFlowStrategy: TransactionFlowStrategyEnum
 
   """
   Determine if it is possible to place unpaid order by calling `checkoutComplete` mutation.

--- a/saleor/graphql/shop/mutations/order_settings_update.py
+++ b/saleor/graphql/shop/mutations/order_settings_update.py
@@ -21,7 +21,7 @@ class OrderSettingsUpdateInput(BaseInputObjectType):
     automatically_fulfill_non_shippable_gift_card = graphene.Boolean(
         required=False,
         description="When enabled, all non-shippable gift card orders "
-        "will be fulfilled automatically. By defualt set to True.",
+        "will be fulfilled automatically. By default set to True.",
     )
 
     class Meta:
@@ -85,8 +85,5 @@ class OrderSettingsUpdate(BaseMutation):
                 channel.automatically_fulfill_non_shippable_gift_card
             ),
             mark_as_paid_strategy=channel.order_mark_as_paid_strategy,
-            default_transaction_flow_strategy=(
-                channel.default_transaction_flow_strategy
-            ),
         )
         return OrderSettingsUpdate(order_settings=order_settings)

--- a/saleor/graphql/shop/tests/mutations/test_order_settings_update.py
+++ b/saleor/graphql/shop/tests/mutations/test_order_settings_update.py
@@ -1,4 +1,3 @@
-from ....channel.enums import TransactionFlowStrategyEnum
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 ORDER_SETTINGS_UPDATE_MUTATION = """
@@ -13,7 +12,6 @@ ORDER_SETTINGS_UPDATE_MUTATION = """
                 automaticallyConfirmAllNewOrders
                 automaticallyFulfillNonShippableGiftCard
                 markAsPaidStrategy
-                defaultTransactionFlowStrategy
             }
         }
     }
@@ -37,11 +35,6 @@ def test_order_settings_update_by_staff(
     response_settings = content["data"]["orderSettingsUpdate"]["orderSettings"]
     assert response_settings["automaticallyConfirmAllNewOrders"] is False
     assert response_settings["automaticallyFulfillNonShippableGiftCard"] is False
-    assert (
-        response_settings["defaultTransactionFlowStrategy"]
-        == TransactionFlowStrategyEnum.CHARGE.name
-        == channel_USD.default_transaction_flow_strategy.upper()
-    )
     channel_PLN.refresh_from_db()
     channel_USD.refresh_from_db()
     assert channel_PLN.automatically_confirm_all_new_orders is False
@@ -125,11 +118,6 @@ def test_order_settings_update_by_app(
     response_settings = content["data"]["orderSettingsUpdate"]["orderSettings"]
     assert response_settings["automaticallyConfirmAllNewOrders"] is False
     assert response_settings["automaticallyFulfillNonShippableGiftCard"] is False
-    assert (
-        response_settings["defaultTransactionFlowStrategy"]
-        == TransactionFlowStrategyEnum.CHARGE.name
-        == channel_USD.default_transaction_flow_strategy.upper()
-    )
     channel_PLN.refresh_from_db()
     channel_USD.refresh_from_db()
     assert channel_PLN.automatically_confirm_all_new_orders is False


### PR DESCRIPTION
I want to merge this change because it covers https://github.com/saleor/saleor/issues/13762

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [x] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
