### PR TITLE
Fixes for granted refund logic 

### DIFF
--- a/saleor/graphql/order/mutations/order_grant_refund_create.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_create.py
@@ -183,7 +183,7 @@ class OrderGrantRefundCreate(BaseMutation):
         input: dict[str, Any],
     ):
         amount = input.get("amount")
-        reason = input.get("reason", "")
+        reason = input.get("reason") or ""
         input_lines = input.get("lines", [])
         grant_refund_for_shipping = input.get("grant_refund_for_shipping", None)
 

--- a/saleor/graphql/order/mutations/order_grant_refund_update.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_update.py
@@ -126,13 +126,13 @@ class OrderGrantRefundUpdate(BaseMutation):
     @classmethod
     def validate_input(cls, input: dict[str, Any]):
         amount = input.get("amount")
-        reason = input.get("reason", "")
+        reason = input.get("reason")
         input_lines = input.get("add_lines", [])
         remove_lines = input.get("remove_lines", [])
         grant_refund_for_shipping = input.get("grant_refund_for_shipping", False)
         if (
-            not amount
-            and not reason
+            amount is None
+            and reason is None
             and not input_lines
             and not grant_refund_for_shipping
             and not remove_lines

--- a/saleor/graphql/order/mutations/order_grant_refund_utils.py
+++ b/saleor/graphql/order/mutations/order_grant_refund_utils.py
@@ -26,11 +26,14 @@ def handle_lines_with_quantity_already_refunded(
     all_granted_refund_lines = models.OrderGrantedRefundLine.objects.filter(
         granted_refund_id__in=all_granted_refund_ids
     )
+    lines_to_process = all_granted_refund_lines
     if granted_refund_lines_to_exclude:
-        all_granted_refund_lines.exclude(pk__in=granted_refund_lines_to_exclude)
+        lines_to_process = all_granted_refund_lines.exclude(
+            pk__in=granted_refund_lines_to_exclude
+        )
 
     lines_with_quantity_already_refunded: dict[uuid.UUID, int] = defaultdict(int)
-    for line in all_granted_refund_lines:
+    for line in lines_to_process:
         lines_with_quantity_already_refunded[line.order_line_id] += line.quantity
 
     for granted_refund_line in input_lines_data.values():


### PR DESCRIPTION
I want to merge this change because it covers three small fixes for granted refund logic:
1. https://github.com/saleor/saleor/issues/14405 - unable to create granted refund when `reason` is not provided
2. https://github.com/saleor/saleor/issues/14597 - incorrect flow in update when same line is provided in `removeLines` and `addLines` input
3. https://github.com/saleor/saleor/issues/14596 - failed to update granted refund when provided amount is 0

Port of changes from #14598

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
