### PR TITLE
[TEST] Should be able to login before email confirmation CORE_1510

### DIFF
--- a/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
@@ -28,6 +28,7 @@ def test_should_create_account_without_email_confirmation_core_1502(
 
     test_email = "new-user@saleor.io"
     test_password = "password!"
+    redirect_url = ""
 
     # Step 1 - Create account for the new customer
     user_account = account_register(
@@ -35,13 +36,14 @@ def test_should_create_account_without_email_confirmation_core_1502(
         test_email,
         test_password,
         channel_slug,
+        redirect_url,
     )
-    user_id = user_account["id"]
-    assert user_account["isActive"] is True
+    user_id = user_account["user"]["id"]
+    assert user_account["user"]["isActive"] is True
 
     # Step 2 - Authenticate as new created user
 
     login_data = token_create(e2e_not_logged_api_client, test_email, test_password)
 
-    assert login_data["id"] == user_id
-    assert login_data["email"] == test_email
+    assert login_data["user"]["id"] == user_id
+    assert login_data["user"]["email"] == test_email

--- a/saleor/tests/e2e/account/test_should_login_before_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_login_before_email_confirmation.py
@@ -17,8 +17,8 @@ def test_should_login_before_email_confirmation_core_1510(
     permissions = [permission_manage_channels, permission_manage_settings]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    chanel_data = create_channel(e2e_staff_api_client)
-    channel_slug = chanel_data["slug"]
+    channel_data = create_channel(e2e_staff_api_client)
+    channel_slug = channel_data["slug"]
 
     input_data = {
         "enableAccountConfirmationByEmail": True,

--- a/saleor/tests/e2e/account/test_should_not_be_able_to_login_with_invalid_credentials.py
+++ b/saleor/tests/e2e/account/test_should_not_be_able_to_login_with_invalid_credentials.py
@@ -36,9 +36,9 @@ def test_should_not_be_able_to_login_with_invalid_credentials_core_1506(
         user_password,
         channel_slug,
     )
-    user_id = user_account["id"]
+    user_id = user_account["user"]["id"]
     assert user_id is not None
-    assert user_account["isActive"] is True
+    assert user_account["user"]["isActive"] is True
 
     # Step 2 - Login with invalid password
     invalid_password = "password"

--- a/saleor/tests/e2e/account/utils/account_register.py
+++ b/saleor/tests/e2e/account/utils/account_register.py
@@ -24,12 +24,14 @@ def raw_account_register(
     email,
     password,
     channel_slug,
+    redirect_url=None,
 ):
     variables = {
         "input": {
             "email": email,
             "password": password,
             "channel": channel_slug,
+            "redirectUrl": redirect_url,
         }
     }
 
@@ -47,17 +49,19 @@ def account_register(
     email,
     password,
     channel_slug,
+    redirect_url=None,
 ):
     response = raw_account_register(
         e2e_not_logged_api_client,
         email,
         password,
         channel_slug,
+        redirect_url,
     )
     assert response["data"]["accountRegister"]["errors"] == []
 
-    data = response["data"]["accountRegister"]["user"]
-    assert data["id"] is not None
-    assert data["email"] == email
+    data = response["data"]["accountRegister"]
+    assert data["user"]["id"] is not None
+    assert data["user"]["email"] == email
 
     return data

--- a/saleor/tests/e2e/account/utils/token_create.py
+++ b/saleor/tests/e2e/account/utils/token_create.py
@@ -13,6 +13,8 @@ mutation TokenCreate($email: String!, $password: String!) {
     user {
       id
       email
+      isActive
+      isConfirmed
     }
   }
 }
@@ -44,14 +46,14 @@ def token_create(
         email,
         password,
     )
+    data = response["data"]["tokenCreate"]
+    assert data["errors"] == []
 
-    assert response["data"]["tokenCreate"]["errors"] == []
+    assert data["token"] is not None
+    assert data["refreshToken"] is not None
 
-    assert response["data"]["tokenCreate"]["token"] is not None
-    assert response["data"]["tokenCreate"]["refreshToken"] is not None
-
-    data = response["data"]["tokenCreate"]["user"]
-    assert data["id"] is not None
-    assert data["email"] == email
+    user = data["user"]
+    assert user["id"] is not None
+    assert user["email"] == email
 
     return data


### PR DESCRIPTION
I want to merge this change because it covers TC [CORE_1510](https://saleor.testmo.net/repositories/5?group_id=118&case_id=1705)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
