### PR TITLE
[TEST] Anonymous order should be assigned to the user CORE_1517 & CORE_1518

### DIFF
--- a/saleor/tests/e2e/checkout/test_guest_checkout_should_be_associated_with_user_account.py
+++ b/saleor/tests/e2e/checkout/test_guest_checkout_should_be_associated_with_user_account.py
@@ -1,7 +1,9 @@
 import pytest
 
 from ..product.utils.preparing_product import prepare_product
+from ..shop.utils import update_shop_settings
 from ..shop.utils.preparing_shop import prepare_shop
+from ..users.utils import create_customer, get_user
 from ..utils import assign_permissions
 from .utils import (
     checkout_complete,
@@ -11,16 +13,56 @@ from .utils import (
 )
 
 
-@pytest.mark.e2e
-def test_process_checkout_with_physical_product_CORE_0103(
+def create_shop(
     e2e_staff_api_client,
-    e2e_logged_api_client,
+):
+    (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    ) = prepare_shop(e2e_staff_api_client)
+
+    input_data = {
+        "enableAccountConfirmationByEmail": True,
+        "allowLoginWithoutConfirmation": True,
+    }
+    update_shop_settings(e2e_staff_api_client, input_data)
+    return (
+        warehouse_id,
+        channel_id,
+        channel_slug,
+        shipping_method_id,
+    )
+
+
+def create_active_customer(
+    e2e_staff_api_client,
+):
+    email = "user@saleor.io"
+
+    user_data = create_customer(
+        e2e_staff_api_client,
+        email,
+        is_active=True,
+    )
+    user_id = user_data["id"]
+
+    return user_id, email
+
+
+@pytest.mark.e2e
+def test_guest_checkout_should_be_associated_with_user_account_CORE_1517(
+    e2e_staff_api_client,
+    e2e_not_logged_api_client,
     permission_manage_products,
     permission_manage_channels,
-    permission_manage_product_types_and_attributes,
     permission_manage_shipping,
+    permission_manage_product_types_and_attributes,
     permission_manage_orders,
     permission_manage_checkouts,
+    permission_manage_users,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -30,6 +72,8 @@ def test_process_checkout_with_physical_product_CORE_0103(
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
+        permission_manage_users,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
@@ -38,7 +82,7 @@ def test_process_checkout_with_physical_product_CORE_0103(
         channel_id,
         channel_slug,
         shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    ) = create_shop(e2e_staff_api_client)
 
     variant_price = 10
 
@@ -53,49 +97,57 @@ def test_process_checkout_with_physical_product_CORE_0103(
         variant_price,
     )
 
-    # Step 1 - Create checkout.
+    user_id, email = create_active_customer(e2e_staff_api_client)
+
+    # Step 1 - Create checkout as a guest user
     lines = [
-        {"variantId": product_variant_id, "quantity": 1},
+        {
+            "variantId": product_variant_id,
+            "quantity": 1,
+        },
     ]
     checkout_data = checkout_create(
-        e2e_logged_api_client,
+        e2e_not_logged_api_client,
         lines,
         channel_slug,
-        email=None,
+        email,
         set_default_billing_address=True,
         set_default_shipping_address=True,
     )
     checkout_id = checkout_data["id"]
 
-    expected_email = e2e_logged_api_client.user.email
-    assert checkout_data["email"] == expected_email
-    assert checkout_data["user"]["email"] == expected_email
     assert checkout_data["isShippingRequired"] is True
-    assert checkout_data["shippingMethods"] != []
     shipping_method_id = checkout_data["shippingMethods"][0]["id"]
+    assert checkout_data["deliveryMethod"] is None
 
-    # Step 3 - Set DeliveryMethod for checkout.
+    # Step 2 - Set DeliveryMethod for checkout
     checkout_data = checkout_delivery_method_update(
-        e2e_logged_api_client,
+        e2e_not_logged_api_client,
         checkout_id,
         shipping_method_id,
     )
     assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
     total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]
 
-    # Step 4 - Create payment for checkout.
+    # Step 3 - Create payment for checkout
     checkout_dummy_payment_create(
-        e2e_logged_api_client,
+        e2e_not_logged_api_client,
         checkout_id,
         total_gross_amount,
     )
 
-    # Step 5 - Complete checkout.
+    # Step 4 - Complete checkout.
     order_data = checkout_complete(
-        e2e_logged_api_client,
+        e2e_not_logged_api_client,
         checkout_id,
     )
+    order_id = order_data["id"]
     assert order_data["isShippingRequired"] is True
     assert order_data["status"] == "UNFULFILLED"
     assert order_data["total"]["gross"]["amount"] == total_gross_amount
     assert order_data["deliveryMethod"]["id"] == shipping_method_id
+
+    # Step 5 - Check the order is assigned to the customer's account
+    data = get_user(e2e_staff_api_client, user_id)
+    assert data["id"] == user_id
+    assert data["orders"]["edges"][0]["node"]["id"] == order_id

--- a/saleor/tests/e2e/checkout/utils/checkout_complete.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_complete.py
@@ -13,9 +13,6 @@ mutation CheckoutComplete($checkoutId: ID!) {
       status
       paymentStatus
       isPaid
-      user {
-        email
-      }
       isShippingRequired
       total {
         gross {

--- a/saleor/tests/e2e/users/utils/__init__.py
+++ b/saleor/tests/e2e/users/utils/__init__.py
@@ -10,4 +10,5 @@ __all__ = [
     "customer_update",
     "create_staff",
     "update_staff",
+    "get_user",
 ]

--- a/saleor/tests/e2e/users/utils/__init__.py
+++ b/saleor/tests/e2e/users/utils/__init__.py
@@ -1,6 +1,7 @@
 from .create_customer import create_customer
 from .customer_bulk_update import customer_bulk_update
 from .customer_update import customer_update
+from .get_user import get_user
 from .staff_create import create_staff
 from .staff_update import update_staff
 

--- a/saleor/tests/e2e/users/utils/create_customer.py
+++ b/saleor/tests/e2e/users/utils/create_customer.py
@@ -31,12 +31,14 @@ def create_customer(
     email,
     metadata=None,
     private_metadata=None,
+    is_active=False,
 ):
     variables = {
         "input": {
             "email": email,
             "metadata": metadata,
             "privateMetadata": private_metadata,
+            "isActive": is_active,
         }
     }
 

--- a/saleor/tests/e2e/users/utils/get_user.py
+++ b/saleor/tests/e2e/users/utils/get_user.py
@@ -4,6 +4,9 @@ USER_QUERY = """
 query CustomerDetails($id:ID!){
   user(id: $id) {
     id
+    email
+    isConfirmed
+    isActive
     orders(first: 10){
       edges {
         node {

--- a/saleor/tests/e2e/users/utils/get_user.py
+++ b/saleor/tests/e2e/users/utils/get_user.py
@@ -1,0 +1,36 @@
+from ...utils import get_graphql_content
+
+USER_QUERY = """
+query CustomerDetails($id:ID!){
+  user(id: $id) {
+    id
+    orders(first: 10){
+      edges {
+        node {
+          id
+          number
+          paymentStatus
+          created
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def get_user(
+    staff_api_client,
+    user_id,
+):
+    variables = {"id": user_id}
+
+    response = staff_api_client.post_graphql(
+        USER_QUERY,
+        variables,
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["user"]
+
+    return data


### PR DESCRIPTION
I want to merge this change because it covers:
- [CORE_1517](https://saleor.testmo.net/repositories/5?group_id=118&sort_column=repository_cases:custom_automated&sort_direction=desc&case_id=794)
- [CORE_1518](https://saleor.testmo.net/repositories/5?group_id=118&sort_column=repository_cases:custom_automated&sort_direction=desc&case_id=793)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
