### PR TITLE
Fix failing checkout.0060 migration

### DIFF
--- a/saleor/checkout/migrations/tasks/saleor3_13.py
+++ b/saleor/checkout/migrations/tasks/saleor3_13.py
@@ -67,7 +67,7 @@ def _update_authorize_status(
         checkout.authorize_status = "none"
     elif total_covered >= checkout_total_gross:
         checkout.authorize_status = "full"
-    elif total_covered < checkout_total_gross and total_covered > zero_money_amount:
+    elif checkout_total_gross > total_covered > zero_money_amount:
         checkout.authorize_status = "partial"
     else:
         checkout.authorize_status = "none"
@@ -125,7 +125,7 @@ def fix_statuses_for_empty_checkouts_task():
         for checkout in checkouts:
             update_checkout_payment_statuses(
                 checkout,
-                checkout.total_gross_amount,
+                Money(checkout.total_gross_amount, checkout.currency),
                 False,
                 checkout.payment_transactions.all(),
             )


### PR DESCRIPTION
I want to merge this change because it fixes failing celery task triggered by checkout.0060.

Tested locally with different stages of the checkouts

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
