### PR TITLE
Add error handling when stock to create already exists

### DIFF
--- a/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_bulk_update.py
@@ -147,7 +147,6 @@ def test_product_variant_bulk_update_stocks(
     staff_api_client,
     variant_with_many_stocks,
     warehouse,
-    size_attribute,
     permission_manage_products,
     any_webhook,
     settings,
@@ -211,6 +210,53 @@ def test_product_variant_bulk_update_stocks(
     update_product_discounted_price_task_mock.assert_called_once_with(
         variant.product_id
     )
+
+
+def test_product_variant_bulk_update_create_already_existing_stock(
+    staff_api_client,
+    variant_with_many_stocks,
+    permission_manage_products,
+):
+    # given
+    variant = variant_with_many_stocks
+    product_id = graphene.Node.to_global_id("Product", variant.product_id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    stocks = variant.stocks.all()
+    assert len(stocks) == 2
+    stock_to_update = stocks[0]
+
+    warehouse_global_id = graphene.Node.to_global_id(
+        "Warehouse", stock_to_update.warehouse_id
+    )
+    variants = [
+        {
+            "id": variant_id,
+            "stocks": {
+                "create": [
+                    {"quantity": 999, "warehouse": warehouse_global_id},
+                ]
+            },
+        }
+    ]
+
+    variables = {"productId": product_id, "variants": variants}
+
+    # when
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_UPDATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["productVariantBulkUpdate"]
+
+    # then
+    errors = data["results"][0]["errors"]
+    assert errors
+    assert errors[0]["field"] == "warehouse"
+    assert errors[0]["path"] == "stocks.create.0.warehouse"
+    assert errors[0]["code"] == ProductVariantBulkErrorCode.STOCK_ALREADY_EXISTS.name
+    assert errors[0]["warehouses"] == [warehouse_global_id]
 
 
 def test_product_variant_bulk_update_and_remove_stock(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -22306,6 +22306,7 @@ enum ProductVariantBulkErrorCode @doc(category: "Products") {
   REQUIRED
   UNIQUE
   PRODUCT_NOT_ASSIGNED_TO_CHANNEL
+  STOCK_ALREADY_EXISTS
 }
 
 type BulkProductError @doc(category: "Products") {

--- a/saleor/product/error_codes.py
+++ b/saleor/product/error_codes.py
@@ -47,6 +47,7 @@ class ProductVariantBulkErrorCode(Enum):
     REQUIRED = "required"
     UNIQUE = "unique"
     PRODUCT_NOT_ASSIGNED_TO_CHANNEL = "product_not_assigned_to_channel"
+    STOCK_ALREADY_EXISTS = "stock_already_exists"
 
 
 class ProductBulkCreateErrorCode(Enum):


### PR DESCRIPTION
I want to merge this change because it fixes #14593

Port of #14692
<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
