### PR TITLE
Add error handling when stock to create already exists

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23367,6 +23367,7 @@ enum ProductVariantBulkErrorCode @doc(category: "Products") {
   REQUIRED
   UNIQUE
   PRODUCT_NOT_ASSIGNED_TO_CHANNEL
+  STOCK_ALREADY_EXISTS
 }
 
 type BulkProductError @doc(category: "Products") {

--- a/saleor/product/error_codes.py
+++ b/saleor/product/error_codes.py
@@ -47,6 +47,7 @@ class ProductVariantBulkErrorCode(Enum):
     REQUIRED = "required"
     UNIQUE = "unique"
     PRODUCT_NOT_ASSIGNED_TO_CHANNEL = "product_not_assigned_to_channel"
+    STOCK_ALREADY_EXISTS = "stock_already_exists"
 
 
 class ProductBulkCreateErrorCode(Enum):


### PR DESCRIPTION
I want to merge this change because it fixes #14593

Port of #14692

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
