### PR TITLE
Fix failing tests for channel listing and local time

### DIFF
--- a/saleor/graphql/product/tests/deprecated/test_product_channel_listing_update.py
+++ b/saleor/graphql/product/tests/deprecated/test_product_channel_listing_update.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import graphene
 import pytz
+from freezegun import freeze_time
 
 from .....product.error_codes import ProductErrorCode
 from .....product.utils.costs import get_product_costs_data
@@ -58,6 +59,7 @@ mutation UpdateProductChannelListing(
 """
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 @patch(
     "saleor.product.tasks.update_products_discounted_prices_for_promotion_task.delay"
 )
@@ -142,6 +144,7 @@ def test_product_channel_listing_update_as_staff_user(
     )
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 @patch("saleor.plugins.manager.PluginsManager.product_updated")
 def test_product_channel_listing_update_trigger_webhook_product_updated(
     mock_product_updated,
@@ -184,6 +187,7 @@ def test_product_channel_listing_update_trigger_webhook_product_updated(
     mock_product_updated.assert_called_once_with(product)
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 def test_product_channel_listing_update_add_channel(
     staff_api_client, product, permission_manage_products, channel_USD, channel_PLN
 ):
@@ -238,6 +242,7 @@ def test_product_channel_listing_update_add_channel(
     )
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 def test_product_channel_listing_update_update_publication_data(
     staff_api_client, product, permission_manage_products, channel_USD
 ):
@@ -285,6 +290,7 @@ def test_product_channel_listing_update_update_publication_data(
     )
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 def test_product_channel_listing_update_update_publication_date_and_published_at(
     staff_api_client, product, permission_manage_products, channel_USD
 ):
@@ -369,6 +375,7 @@ def test_product_channel_listing_update_update_is_available_for_purchase_past_da
     )
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 def test_product_channel_listing_update_update_is_available_for_purchase_future_date(
     staff_api_client, product, permission_manage_products, channel_USD
 ):
@@ -413,6 +420,7 @@ def test_product_channel_listing_update_update_is_available_for_purchase_future_
     )
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 def test_product_channel_listing_update_update_is_available_for_purchase_false_and_date(
     staff_api_client, product, permission_manage_products, channel_USD
 ):
@@ -450,6 +458,7 @@ def test_product_channel_listing_update_update_is_available_for_purchase_false_a
     assert len(errors) == 1
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 def test_product_channel_listing_update_available_for_purchase_both_date_value_given(
     staff_api_client, product, permission_manage_products, channel_USD
 ):

--- a/saleor/graphql/product/tests/mutations/test_product_channel_listing_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_channel_listing_update.py
@@ -499,12 +499,13 @@ def test_product_channel_listing_update_add_channel_without_publication_date(
     assert product_data["channelListings"][0]["channel"]["slug"] == channel_USD.slug
     assert product_data["channelListings"][1]["isPublished"] is True
     assert (
-        datetime.date(2020, 3, 18).isoformat()
-        in product_data["channelListings"][1]["publishedAt"]
+        datetime.datetime.now(pytz.UTC).isoformat()
+        == product_data["channelListings"][1]["publishedAt"]
     )
     assert product_data["channelListings"][1]["channel"]["slug"] == channel_PLN.slug
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 def test_product_channel_listing_update_unpublished(
     staff_api_client, product, permission_manage_products, channel_USD
 ):
@@ -532,8 +533,8 @@ def test_product_channel_listing_update_unpublished(
     assert product_data["slug"] == product.slug
     assert product_data["channelListings"][0]["isPublished"] is False
     assert (
-        datetime.date.today().isoformat()
-        in product_data["channelListings"][0]["publishedAt"]
+        datetime.datetime.now(pytz.UTC).isoformat()
+        == product_data["channelListings"][0]["publishedAt"]
     )
     assert product_data["channelListings"][0]["channel"]["slug"] == channel_USD.slug
     assert product_data["channelListings"][0]["visibleInListings"] is True
@@ -572,8 +573,8 @@ def test_product_channel_listing_update_publish_without_publication_date(
     assert product_data["slug"] == product.slug
     assert product_data["channelListings"][0]["isPublished"] is True
     assert (
-        datetime.date(2020, 3, 18).isoformat()
-        in product_data["channelListings"][0]["publishedAt"]
+        datetime.datetime.now(pytz.UTC).isoformat()
+        == product_data["channelListings"][0]["publishedAt"]
     )
     assert product_data["channelListings"][0]["channel"]["slug"] == channel_USD.slug
 
@@ -734,6 +735,7 @@ def test_product_channel_listing_update_update_is_available_for_purchase_false(
     assert not product_data["channelListings"][0]["availableForPurchaseAt"]
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 def test_product_channel_listing_update_update_is_available_for_purchase_without_date(
     staff_api_client, product, permission_manage_products, channel_USD
 ):
@@ -768,11 +770,12 @@ def test_product_channel_listing_update_update_is_available_for_purchase_without
     assert product_data["channelListings"][0]["visibleInListings"] is True
     assert product_data["channelListings"][0]["isAvailableForPurchase"] is True
     assert (
-        datetime.date.today().isoformat()
-        in product_data["channelListings"][0]["availableForPurchaseAt"]
+        datetime.datetime.now(pytz.UTC).isoformat()
+        == product_data["channelListings"][0]["availableForPurchaseAt"]
     )
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 def test_product_channel_listing_update_update_is_available_for_purchase_past_date(
     staff_api_client, product, permission_manage_products, channel_USD
 ):
@@ -817,6 +820,7 @@ def test_product_channel_listing_update_update_is_available_for_purchase_past_da
     )
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 def test_product_channel_listing_update_update_is_available_for_purchase_future_date(
     staff_api_client, product, permission_manage_products, channel_USD
 ):
@@ -863,6 +867,7 @@ def test_product_channel_listing_update_update_is_available_for_purchase_future_
     )
 
 
+@freeze_time("2023-11-13T14:53:59.655366")
 def test_product_channel_listing_update_update_is_available_for_purchase_false_and_date(
     staff_api_client, product, permission_manage_products, channel_USD
 ):


### PR DESCRIPTION
I want to merge this change because it fixes a failing tests called in specific moment (like at the end of the day, when local time could provide different `day` than `utc` time)

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
