### PR TITLE
Fix few resolvers which were missed in replicas during 3.14 replica PR

### DIFF
--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -107,7 +107,9 @@ def resolve_homepage_events(info):
         # get order events from orders that user has access to
         accessible_channels = get_user_accessible_channels(info, info.context.user)
         channel_ids = [channel.id for channel in accessible_channels]
-        accessible_orders = models.Order.objects.filter(channel_id__in=channel_ids)
+        accessible_orders = models.Order.objects.using(database_connection_name).filter(
+            channel_id__in=channel_ids
+        )
         lookup &= Q(order_id__in=accessible_orders.values("id"))
     return models.OrderEvent.objects.using(database_connection_name).filter(lookup)
 

--- a/saleor/graphql/payment/resolvers.py
+++ b/saleor/graphql/payment/resolvers.py
@@ -15,15 +15,16 @@ def resolve_payment_by_id(info, id):
 
 
 def resolve_payments(info):
+    connection_name = get_database_connection_name(info.context)
     requestor = get_user_or_app_from_context(info.context)
-    payments = models.Payment.objects.using(
-        get_database_connection_name(info.context)
-    ).all()
+    payments = models.Payment.objects.using(connection_name).all()
     if isinstance(requestor, app_models.App):
         return payments
     accessible_channels = get_user_accessible_channels(info, requestor)
     channel_ids = [channel.id for channel in accessible_channels]
-    orders = order_models.Order.objects.filter(channel_id__in=channel_ids)
+    orders = order_models.Order.objects.using(connection_name).filter(
+        channel_id__in=channel_ids
+    )
     return payments.filter(order_id__in=orders.values("id"))
 
 

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -85,15 +85,17 @@ def resolve_product(
 def resolve_products(
     info: ResolveInfo, requestor, channel_slug=None
 ) -> ChannelQsContext:
-    database_connection_name = get_database_connection_name(info.context)
+    connection_name = get_database_connection_name(info.context)
     qs = (
         models.Product.objects.all()
-        .using(database_connection_name)
+        .using(connection_name)
         .visible_to_user(requestor, channel_slug)
     )
     if not has_one_of_permissions(requestor, ALL_PRODUCTS_PERMISSIONS):
-        channels = Channel.objects.filter(slug=str(channel_slug))
-        product_channel_listings = models.ProductChannelListing.objects.filter(
+        channels = Channel.objects.using(connection_name).filter(slug=str(channel_slug))
+        product_channel_listings = models.ProductChannelListing.objects.using(
+            connection_name
+        ).filter(
             Exists(channels.filter(pk=OuterRef("channel_id"))),
             visible_in_listings=True,
         )


### PR DESCRIPTION
I want to merge this change because it fixes few resolvers:
- resolve_homepage_events
- resolve_payments
- resolve_products

Which are missing replica usages and were missed in https://github.com/saleor/saleor/pull/14548

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
