### PR TITLE
Fix Field Validation of `orderBulkCreate` Mutation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Highlights
 
 ### Breaking changes
+- `status` of `orders` in `OrderBulkCreate`  now become required field.
 
 ### GraphQL API
+- Fix field validation of `orderBulkCreate` that requires status field. - #14506 by @maarcingebala
 
 ### Saleor Apps
 

--- a/saleor/graphql/order/bulk_mutations/order_bulk_create.py
+++ b/saleor/graphql/order/bulk_mutations/order_bulk_create.py
@@ -481,7 +481,7 @@ class OrderBulkCreateInput(BaseInputObjectType):
         required=True,
         description="The date, when the order was inserted to Saleor database.",
     )
-    status = OrderStatusEnum(description="Status of the order.")
+    status = OrderStatusEnum(description="Status of the order.", required=True)
     user = graphene.Field(
         OrderBulkCreateUserInput,
         required=True,


### PR DESCRIPTION
Modify OrderBulkCreateInput.status making required=True to ensure the caller passing the status to orderBulkCreate mutation.

Write unittests to ensure the request without status is reject by validator instead of KeyError raised.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [x] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
