### PR TITLE
Fix order_by in get_product_attributes

### DIFF
--- a/saleor/attribute/tests/model_helpers.py
+++ b/saleor/attribute/tests/model_helpers.py
@@ -41,7 +41,7 @@ def get_product_attributes(product: Product):
     )
     return Attribute.objects.filter(
         Exists(product_attributes.filter(attribute_id=OuterRef("id")))
-    ).order_by("attributeproduct__sort_order")
+    ).order_by("storefront_search_position", "slug")
 
 
 def get_product_attribute_values(product: Product, attribute: Attribute):


### PR DESCRIPTION
I want to merge this change because it was randomly producing errors during tests.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
