### PR TITLE
[TEST] [E2E] Prepare_shop refactor

### DIFF
--- a/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
@@ -1,7 +1,6 @@
 import pytest
 
-from ..channel.utils import create_channel
-from ..shop.utils import update_shop_settings
+from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
 from .utils import account_register, token_create
 
@@ -10,22 +9,29 @@ from .utils import account_register, token_create
 def test_should_create_account_without_email_confirmation_core_1502(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
+    permission_manage_products,
     permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_taxes,
     permission_manage_settings,
 ):
     # Before
-    permissions = [permission_manage_channels, permission_manage_settings]
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_product_types_and_attributes,
+        permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
+    ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    chanel_data = create_channel(e2e_staff_api_client)
-    channel_slug = chanel_data["slug"]
-
-    input = {
-        "enableAccountConfirmationByEmail": False,
-    }
-
-    update_shop_settings(e2e_staff_api_client, input)
-
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+        enable_account_confirmation_by_email=False,
+    )
+    channel_slug = shop_data["channel_slug"]
     test_email = "new-user@saleor.io"
     test_password = "password!"
     redirect_url = ""

--- a/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
@@ -9,32 +9,27 @@ from .utils import account_register, token_create
 def test_should_create_account_without_email_confirmation_core_1502(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
         permission_manage_product_types_and_attributes,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
+    shop_settings = {
+        "enableAccountConfirmationByEmail": False,
+    }
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        enable_account_confirmation_by_email=False,
+        shop_settings_update=shop_settings,
     )
-    channel_slug = shop_data["channel_slug"]
+    channel_slug = shop_data["channels"][0]["slug"]
     test_email = "new-user@saleor.io"
     test_password = "password!"
-    redirect_url = ""
+    redirect_url = "https://www.example.com"
 
     # Step 1 - Create account for the new customer
     user_account = account_register(
@@ -48,7 +43,6 @@ def test_should_create_account_without_email_confirmation_core_1502(
     assert user_account["user"]["isActive"] is True
 
     # Step 2 - Authenticate as new created user
-
     login_data = token_create(e2e_not_logged_api_client, test_email, test_password)
 
     assert login_data["user"]["id"] == user_id

--- a/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_create_account_without_email_confirmation.py
@@ -19,14 +19,26 @@ def test_should_create_account_without_email_confirmation_core_1502(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_settings = {
-        "enableAccountConfirmationByEmail": False,
-    }
-    shop_data = prepare_shop(
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        shop_settings_update=shop_settings,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [
+                            {},
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            }
+        ],
+        shop_settings={
+            "enableAccountConfirmationByEmail": False,
+        },
     )
-    channel_slug = shop_data["channels"][0]["slug"]
+
+    channel_slug = shop_data[0]["slug"]
     test_email = "new-user@saleor.io"
     test_password = "password!"
     redirect_url = "https://www.example.com"

--- a/saleor/tests/e2e/account/test_should_login_before_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_login_before_email_confirmation.py
@@ -1,7 +1,6 @@
 import pytest
 
-from ..channel.utils import create_channel
-from ..shop.utils import update_shop_settings
+from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
 from .utils import account_register, token_create
 
@@ -10,22 +9,30 @@ from .utils import account_register, token_create
 def test_should_login_before_email_confirmation_core_1510(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
+    permission_manage_products,
     permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_taxes,
     permission_manage_settings,
 ):
     # Before
-    permissions = [permission_manage_channels, permission_manage_settings]
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_product_types_and_attributes,
+        permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
+    ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    channel_data = create_channel(e2e_staff_api_client)
-    channel_slug = channel_data["slug"]
-
-    input_data = {
-        "enableAccountConfirmationByEmail": True,
-        "allowLoginWithoutConfirmation": True,
-    }
-
-    update_shop_settings(e2e_staff_api_client, input_data)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+        enable_account_confirmation_by_email=True,
+        allow_login_without_confirmation=True,
+    )
+    channel_slug = shop_data["channel_slug"]
 
     test_email = "user@saleor.io"
     test_password = "Password!"

--- a/saleor/tests/e2e/account/test_should_login_before_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_login_before_email_confirmation.py
@@ -9,30 +9,24 @@ from .utils import account_register, token_create
 def test_should_login_before_email_confirmation_core_1510(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
         permission_manage_product_types_and_attributes,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-
+    shop_settings = {
+        "enableAccountConfirmationByEmail": True,
+        "allowLoginWithoutConfirmation": True,
+    }
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        enable_account_confirmation_by_email=True,
-        allow_login_without_confirmation=True,
+        shop_settings_update=shop_settings,
     )
-    channel_slug = shop_data["channel_slug"]
+    channel_slug = shop_data["channels"][0]["slug"]
 
     test_email = "user@saleor.io"
     test_password = "Password!"

--- a/saleor/tests/e2e/account/test_should_login_before_email_confirmation.py
+++ b/saleor/tests/e2e/account/test_should_login_before_email_confirmation.py
@@ -18,15 +18,27 @@ def test_should_login_before_email_confirmation_core_1510(
         *shop_permissions,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_settings = {
-        "enableAccountConfirmationByEmail": True,
-        "allowLoginWithoutConfirmation": True,
-    }
-    shop_data = prepare_shop(
+
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        shop_settings_update=shop_settings,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [
+                            {},
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            },
+        ],
+        shop_settings={
+            "enableAccountConfirmationByEmail": True,
+            "allowLoginWithoutConfirmation": True,
+        },
     )
-    channel_slug = shop_data["channels"][0]["slug"]
+    channel_slug = shop_data[0]["slug"]
 
     test_email = "user@saleor.io"
     test_password = "Password!"

--- a/saleor/tests/e2e/account/test_should_not_be_able_to_create_account_with_existing_email.py
+++ b/saleor/tests/e2e/account/test_should_not_be_able_to_create_account_with_existing_email.py
@@ -1,7 +1,6 @@
 import pytest
 
-from ..channel.utils import create_channel
-from ..shop.utils import update_shop_settings
+from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
 from .utils import account_register, raw_account_register
 
@@ -10,22 +9,29 @@ from .utils import account_register, raw_account_register
 def test_should_not_be_able_to_create_account_with_existing_email_core_1503(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
+    permission_manage_products,
     permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_taxes,
     permission_manage_settings,
 ):
     # Before
-    permissions = [permission_manage_channels, permission_manage_settings]
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_product_types_and_attributes,
+        permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
+    ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    chanel_data = create_channel(e2e_staff_api_client)
-    channel_slug = chanel_data["slug"]
-
-    input_data = {
-        "enableAccountConfirmationByEmail": False,
-    }
-
-    update_shop_settings(e2e_staff_api_client, input_data)
-
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+        enable_account_confirmation_by_email=False,
+    )
+    channel_slug = shop_data["channel_slug"]
     user_email = "user@saleor.io"
     user_password = "Test1234!"
 

--- a/saleor/tests/e2e/account/test_should_not_be_able_to_create_account_with_existing_email.py
+++ b/saleor/tests/e2e/account/test_should_not_be_able_to_create_account_with_existing_email.py
@@ -9,29 +9,24 @@ from .utils import account_register, raw_account_register
 def test_should_not_be_able_to_create_account_with_existing_email_core_1503(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
         permission_manage_product_types_and_attributes,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
+    shop_settings = {
+        "enableAccountConfirmationByEmail": False,
+    }
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        enable_account_confirmation_by_email=False,
+        shop_settings_update=shop_settings,
     )
-    channel_slug = shop_data["channel_slug"]
+    channel_slug = shop_data["channels"][0]["slug"]
     user_email = "user@saleor.io"
     user_password = "Test1234!"
 

--- a/saleor/tests/e2e/account/test_should_not_be_able_to_create_account_with_existing_email.py
+++ b/saleor/tests/e2e/account/test_should_not_be_able_to_create_account_with_existing_email.py
@@ -19,14 +19,25 @@ def test_should_not_be_able_to_create_account_with_existing_email_core_1503(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_settings = {
-        "enableAccountConfirmationByEmail": False,
-    }
-    shop_data = prepare_shop(
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        shop_settings_update=shop_settings,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [
+                            {},
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            }
+        ],
+        shop_settings={
+            "enableAccountConfirmationByEmail": False,
+        },
     )
-    channel_slug = shop_data["channels"][0]["slug"]
+    channel_slug = shop_data[0]["slug"]
     user_email = "user@saleor.io"
     user_password = "Test1234!"
 

--- a/saleor/tests/e2e/account/test_should_not_be_able_to_login_with_invalid_credentials.py
+++ b/saleor/tests/e2e/account/test_should_not_be_able_to_login_with_invalid_credentials.py
@@ -1,7 +1,6 @@
 import pytest
 
-from ..channel.utils import create_channel
-from ..shop.utils import update_shop_settings
+from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
 from .utils import account_register, raw_token_create
 
@@ -10,22 +9,29 @@ from .utils import account_register, raw_token_create
 def test_should_not_be_able_to_login_with_invalid_credentials_core_1506(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
+    permission_manage_products,
     permission_manage_channels,
+    permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_taxes,
     permission_manage_settings,
 ):
     # Before
-    permissions = [permission_manage_channels, permission_manage_settings]
+    permissions = [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_product_types_and_attributes,
+        permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
+    ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    chanel_data = create_channel(e2e_staff_api_client)
-    channel_slug = chanel_data["slug"]
-
-    input_data = {
-        "enableAccountConfirmationByEmail": False,
-    }
-
-    update_shop_settings(e2e_staff_api_client, input_data)
-
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+        enable_account_confirmation_by_email=False,
+    )
+    channel_slug = shop_data["channel_slug"]
     user_email = "user1@saleor.io"
     user_password = "Test1234!"
 

--- a/saleor/tests/e2e/account/test_should_not_be_able_to_login_with_invalid_credentials.py
+++ b/saleor/tests/e2e/account/test_should_not_be_able_to_login_with_invalid_credentials.py
@@ -19,14 +19,25 @@ def test_should_not_be_able_to_login_with_invalid_credentials_core_1506(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_settings = {
-        "enableAccountConfirmationByEmail": False,
-    }
-    shop_data = prepare_shop(
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        shop_settings_update=shop_settings,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [
+                            {},
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            }
+        ],
+        shop_settings={
+            "enableAccountConfirmationByEmail": False,
+        },
     )
-    channel_slug = shop_data["channels"][0]["slug"]
+    channel_slug = shop_data[0]["slug"]
     user_email = "user1@saleor.io"
     user_password = "Test1234!"
 

--- a/saleor/tests/e2e/account/test_should_not_be_able_to_login_with_invalid_credentials.py
+++ b/saleor/tests/e2e/account/test_should_not_be_able_to_login_with_invalid_credentials.py
@@ -9,29 +9,24 @@ from .utils import account_register, raw_token_create
 def test_should_not_be_able_to_login_with_invalid_credentials_core_1506(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
         permission_manage_product_types_and_attributes,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
+    shop_settings = {
+        "enableAccountConfirmationByEmail": False,
+    }
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        enable_account_confirmation_by_email=False,
+        shop_settings_update=shop_settings,
     )
-    channel_slug = shop_data["channel_slug"]
+    channel_slug = shop_data["channels"][0]["slug"]
     user_email = "user1@saleor.io"
     user_password = "Test1234!"
 

--- a/saleor/tests/e2e/channel/utils/channel_create.py
+++ b/saleor/tests/e2e/channel/utils/channel_create.py
@@ -38,7 +38,6 @@ def create_channel(
     allow_unpaid_orders=False,
     automatically_confirm_all_new_orders=True,
     mark_as_paid_strategy="PAYMENT_FLOW",
-    expire_orders_after=0,
 ):
     if not warehouse_ids:
         warehouse_ids = []
@@ -60,7 +59,6 @@ def create_channel(
                 "automaticallyConfirmAllNewOrders": (
                     automatically_confirm_all_new_orders
                 ),
-                "expireOrdersAfter": expire_orders_after,
             },
         }
     }

--- a/saleor/tests/e2e/channel/utils/channel_create.py
+++ b/saleor/tests/e2e/channel/utils/channel_create.py
@@ -51,21 +51,18 @@ def create_channel(
     staff_api_client,
     warehouse_ids=None,
     channel_name="Test channel",
-    slug=f"channel_slug_{uuid.uuid4()}",
+    slug=None,
     currency="USD",
     country="US",
+    shipping_zones=None,
     is_active=True,
-    order_settings={
-        "markAsPaidStrategy": "PAYMENT_FLOW",
-        "automaticallyFulfillNonShippableGiftCard": False,
-        "allowUnpaidOrders": False,
-        "automaticallyConfirmAllNewOrders": True,
-        "expireOrdersAfter": 60,
-        "deleteExpiredOrdersAfter": 1,
-    },
+    order_settings={},
 ):
     if not warehouse_ids:
         warehouse_ids = []
+
+    if slug is None:
+        slug = f"channel_slug_{uuid.uuid4()}"
 
     variables = {
         "input": {
@@ -75,7 +72,16 @@ def create_channel(
             "defaultCountry": country,
             "isActive": is_active,
             "addWarehouses": warehouse_ids,
-            "orderSettings": order_settings,
+            "addShippingZones": shipping_zones,
+            "orderSettings": {
+                "markAsPaidStrategy": "PAYMENT_FLOW",
+                "automaticallyFulfillNonShippableGiftCard": False,
+                "allowUnpaidOrders": False,
+                "automaticallyConfirmAllNewOrders": True,
+                "expireOrdersAfter": 60,
+                "deleteExpiredOrdersAfter": 1,
+                **order_settings,
+            },
         }
     }
 

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_fixed_promotion.py
@@ -21,6 +21,8 @@ def test_checkout_products_on_fixed_promotion_core_2102(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
 
@@ -30,15 +32,17 @@ def test_checkout_products_on_fixed_promotion_core_2102(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_fixed_promotion.py
@@ -2,7 +2,7 @@ import pytest
 
 from ....product.utils.preparing_product import prepare_product
 from ....promotions.utils import create_promotion, create_promotion_rule
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ...utils import (
     checkout_complete,
@@ -29,11 +29,11 @@ def test_checkout_products_on_fixed_promotion_core_2102(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_fixed_promotion.py
@@ -16,33 +16,24 @@ from ...utils import (
 def test_checkout_products_on_fixed_promotion_core_2102(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
 
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,
@@ -89,7 +80,6 @@ def test_checkout_products_on_fixed_promotion_core_2102(
     )
     checkout_id = checkout_data["id"]
     checkout_lines = checkout_data["lines"][0]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     unit_price = float(product_variant_price) - discount_value
 
     assert checkout_data["isShippingRequired"] is True

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_percentage_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_percentage_promotion.py
@@ -21,6 +21,8 @@ def test_checkout_products_on_percentage_promotion_core_2104(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
 
@@ -30,15 +32,17 @@ def test_checkout_products_on_percentage_promotion_core_2104(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_percentage_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_percentage_promotion.py
@@ -16,33 +16,24 @@ from ...utils import (
 def test_checkout_products_on_percentage_promotion_core_2104(
     e2e_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
 
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,
@@ -89,7 +80,6 @@ def test_checkout_products_on_percentage_promotion_core_2104(
     )
     checkout_id = checkout_data["id"]
     checkout_lines = checkout_data["lines"][0]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     line_discount = round(float(product_variant_price) * discount_value / 100, 2)
     unit_price = float(product_variant_price) - line_discount
 

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_percentage_promotion.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_products_on_percentage_promotion.py
@@ -2,7 +2,7 @@ import pytest
 
 from ....product.utils.preparing_product import prepare_product
 from ....promotions.utils import create_promotion, create_promotion_rule
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ...utils import (
     checkout_complete,
@@ -29,11 +29,11 @@ def test_checkout_products_on_percentage_promotion_core_2104(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_with_fixed_promotion_should_not_result_in_negative_price_not.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_with_fixed_promotion_should_not_result_in_negative_price_not.py
@@ -18,6 +18,8 @@ def test_checkout_with_fixed_promotion_should_not_result_in_negative_price_CORE_
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -27,23 +29,23 @@ def test_checkout_with_fixed_promotion_should_not_result_in_negative_price_CORE_
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        result_warehouse_id,
-        result_channel_id,
-        result_channel_slug,
-        _,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,
         product_variant_id,
         product_variant_price,
-    ) = prepare_product(
-        e2e_staff_api_client, result_warehouse_id, result_channel_id, variant_price=5
-    )
+    ) = prepare_product(e2e_staff_api_client, warehouse_id, channel_id, variant_price=5)
 
     promotion_name = "Promotion Fixed"
 
@@ -69,14 +71,14 @@ def test_checkout_with_fixed_promotion_should_not_result_in_negative_price_CORE_
         discount_type,
         discount_value,
         promotion_rule_name,
-        result_channel_id,
+        channel_id,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
-    assert promotion_rule["channels"][0]["id"] == result_channel_id
+    assert promotion_rule["channels"][0]["id"] == channel_id
     assert product_predicate[0] == product_id
 
     # Step 2 - Get product and check if it is on promotion
-    product_data = get_product(e2e_staff_api_client, product_id, result_channel_slug)
+    product_data = get_product(e2e_staff_api_client, product_id, channel_slug)
     assert product_data["id"] == product_id
     assert product_data["pricing"]["onSale"] is True
     variant_data = product_data["variants"][0]
@@ -91,7 +93,7 @@ def test_checkout_with_fixed_promotion_should_not_result_in_negative_price_CORE_
     checkout_data = checkout_create(
         e2e_not_logged_api_client,
         lines,
-        result_channel_slug,
+        channel_slug,
         email="testEmail@example.com",
         set_default_billing_address=True,
         set_default_shipping_address=True,

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_with_fixed_promotion_should_not_result_in_negative_price_not.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_with_fixed_promotion_should_not_result_in_negative_price_not.py
@@ -12,34 +12,24 @@ from ...utils import checkout_create
 def test_checkout_with_fixed_promotion_should_not_result_in_negative_price_CORE_2111(
     e2e_staff_api_client,
     e2e_not_logged_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_with_fixed_promotion_should_not_result_in_negative_price_not.py
+++ b/saleor/tests/e2e/checkout/discounts/promotions/test_checkout_with_fixed_promotion_should_not_result_in_negative_price_not.py
@@ -3,7 +3,7 @@ import pytest
 from ....product.utils import get_product
 from ....product.utils.preparing_product import prepare_product
 from ....promotions.utils import create_promotion, create_promotion_rule
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ...utils import checkout_create
 
@@ -26,10 +26,10 @@ def test_checkout_with_fixed_promotion_should_not_result_in_negative_price_CORE_
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_fixed_sale.py
+++ b/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_fixed_sale.py
@@ -60,6 +60,8 @@ def test_checkout_products_on_fixed_sale_core_1002(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -68,15 +70,18 @@ def test_checkout_products_on_fixed_sale_core_1002(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_fixed_sale.py
+++ b/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_fixed_sale.py
@@ -55,33 +55,23 @@ def prepare_sale_for_product(
 def test_checkout_products_on_fixed_sale_core_1002(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,
@@ -116,7 +106,6 @@ def test_checkout_products_on_fixed_sale_core_1002(
     )
     checkout_id = checkout_data["id"]
     checkout_lines = checkout_data["lines"][0]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     unit_price = float(product_variant_price) - sale_discount_value
 
     assert checkout_data["isShippingRequired"] is True

--- a/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_fixed_sale.py
+++ b/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_fixed_sale.py
@@ -6,7 +6,7 @@ from ....sales.utils import (
     create_sale_channel_listing,
     sale_catalogues_add,
 )
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ...utils import (
     checkout_complete,
@@ -67,11 +67,11 @@ def test_checkout_products_on_fixed_sale_core_1002(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
+++ b/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
@@ -60,6 +60,8 @@ def test_checkout_products_on_percentage_sale_core_1004(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -68,15 +70,18 @@ def test_checkout_products_on_percentage_sale_core_1004(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
+++ b/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
@@ -55,33 +55,23 @@ def prepare_sale_for_product(
 def test_checkout_products_on_percentage_sale_core_1004(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,
@@ -119,7 +109,6 @@ def test_checkout_products_on_percentage_sale_core_1004(
     )
     checkout_id = checkout_data["id"]
     checkout_lines = checkout_data["lines"][0]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     line_discount = round(float(product_variant_price) * sale_discount_value / 100, 2)
     unit_price = float(product_variant_price) - line_discount
 

--- a/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
+++ b/saleor/tests/e2e/checkout/discounts/sales/test_checkout_product_on_percentage_sale.py
@@ -6,7 +6,7 @@ from ....sales.utils import (
     create_sale_channel_listing,
     sale_catalogues_add,
 )
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ...utils import (
     checkout_complete,
@@ -67,11 +67,11 @@ def test_checkout_products_on_percentage_sale_core_1004(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
@@ -106,6 +106,8 @@ def test_checkout_calculate_discount_for_sale_and_voucher_1014(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
     variant_price,
     sale_discount_value,
     sale_discount_type,
@@ -122,15 +124,17 @@ def test_checkout_calculate_discount_for_sale_and_voucher_1014(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
@@ -2,7 +2,7 @@ import pytest
 
 from ...product.utils.preparing_product import prepare_product
 from ...sales.utils import create_sale, create_sale_channel_listing, sale_catalogues_add
-from ...shop.utils.preparing_shop import prepare_shop
+from ...shop.utils.preparing_shop import prepare_default_shop
 from ...utils import assign_permissions
 from ...vouchers.utils import create_voucher, create_voucher_channel_listing
 from ..utils import (
@@ -121,11 +121,11 @@ def test_checkout_calculate_discount_for_sale_and_voucher_1014(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/test_checkout_calculate_correct_discount_for_sale_and_voucher.py
@@ -101,13 +101,9 @@ def prepare_voucher(
 def test_checkout_calculate_discount_for_sale_and_voucher_1014(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
     variant_price,
     sale_discount_value,
     sale_discount_type,
@@ -119,22 +115,17 @@ def test_checkout_calculate_discount_for_sale_and_voucher_1014(
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -177,7 +168,6 @@ def test_checkout_calculate_discount_for_sale_and_voucher_1014(
     )
     checkout_id = checkout_data["id"]
     checkout_lines = checkout_data["lines"][0]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     assert checkout_data["isShippingRequired"] is True
     unit_price_on_sale = round(float(product_variant_price - expected_sale_discount), 2)

--- a/saleor/tests/e2e/checkout/discounts/test_checkout_with_promotion_and_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/test_checkout_with_promotion_and_voucher.py
@@ -126,6 +126,8 @@ def test_checkout_with_promotion_and_voucher_CORE_2107(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
     variant_price,
     promotion_type,
     promotion_value,
@@ -142,15 +144,16 @@ def test_checkout_with_promotion_and_voucher_CORE_2107(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/test_checkout_with_promotion_and_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/test_checkout_with_promotion_and_voucher.py
@@ -2,7 +2,7 @@ import pytest
 
 from ...product.utils.preparing_product import prepare_product
 from ...promotions.utils import create_promotion, create_promotion_rule
-from ...shop.utils.preparing_shop import prepare_shop
+from ...shop.utils.preparing_shop import prepare_default_shop
 from ...utils import assign_permissions
 from ...vouchers.utils import (
     add_catalogue_to_voucher,
@@ -141,11 +141,11 @@ def test_checkout_with_promotion_and_voucher_CORE_2107(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/test_checkout_with_promotion_and_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/test_checkout_with_promotion_and_voucher.py
@@ -121,13 +121,9 @@ def prepare_voucher(
 def test_checkout_with_promotion_and_voucher_CORE_2107(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
     variant_price,
     promotion_type,
     promotion_value,
@@ -139,21 +135,17 @@ def test_checkout_with_promotion_and_voucher_CORE_2107(
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,
@@ -196,7 +188,6 @@ def test_checkout_with_promotion_and_voucher_CORE_2107(
     )
     checkout_id = checkout_data["id"]
     checkout_lines = checkout_data["lines"][0]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     assert checkout_data["isShippingRequired"] is True
     unit_price_with_promotion = round(

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_apply_voucher_to_the_specific_product_per_order.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_apply_voucher_to_the_specific_product_per_order.py
@@ -168,6 +168,8 @@ def test_checkout_apply_voucher_to_the_specific_product_per_order_CORE_0915(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -177,15 +179,17 @@ def test_checkout_apply_voucher_to_the_specific_product_per_order_CORE_0915(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         first_product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_apply_voucher_to_the_specific_product_per_order.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_apply_voucher_to_the_specific_product_per_order.py
@@ -8,7 +8,7 @@ from ....product.utils import (
     create_product_variant,
     create_product_variant_channel_listing,
 )
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -176,11 +176,11 @@ def test_checkout_apply_voucher_to_the_specific_product_per_order_CORE_0915(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         first_product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_apply_voucher_to_the_specific_product_per_order.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_apply_voucher_to_the_specific_product_per_order.py
@@ -162,34 +162,25 @@ def prepare_voucher(
 def test_checkout_apply_voucher_to_the_specific_product_per_order_CORE_0915(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         first_product_id,
@@ -236,7 +227,6 @@ def test_checkout_apply_voucher_to_the_specific_product_per_order_CORE_0915(
     )
     checkout_id = checkout["id"]
     checkout_line = checkout["lines"]
-    shipping_method_id = checkout["shippingMethods"][0]["id"]
     first_product_unit_price = float(first_product_variant_price)
     second_product_unit_price = float(second_product_variant_price)
     total_gross_amount = checkout["totalPrice"]["gross"]["amount"]

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_exceed_voucher_usage_limit.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_exceed_voucher_usage_limit.py
@@ -63,6 +63,8 @@ def test_checkout_unable_to_exceed_voucher_usage_limit_CORE_0909(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -72,15 +74,17 @@ def test_checkout_unable_to_exceed_voucher_usage_limit_CORE_0909(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_exceed_voucher_usage_limit.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_exceed_voucher_usage_limit.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -71,11 +71,11 @@ def test_checkout_unable_to_exceed_voucher_usage_limit_CORE_0909(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_exceed_voucher_usage_limit.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_exceed_voucher_usage_limit.py
@@ -57,34 +57,25 @@ def test_checkout_unable_to_exceed_voucher_usage_limit_CORE_0909(
     e2e_not_logged_api_client,
     e2e_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,
@@ -124,7 +115,6 @@ def test_checkout_unable_to_exceed_voucher_usage_limit_CORE_0909(
     )
     checkout_id = checkout["id"]
     checkout_lines = checkout["lines"][0]
-    shipping_method_id = checkout["shippingMethods"][0]["id"]
     unit_price = float(product_variant_price)
     total_gross_amount = checkout["totalPrice"]["gross"]["amount"]
     assert checkout["isShippingRequired"] is True

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_update_single_use_settings_after_usage.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_update_single_use_settings_after_usage.py
@@ -59,6 +59,8 @@ def test_checkout_unable_to_update_single_use_settings_after_usage_CORE_0926(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -68,15 +70,17 @@ def test_checkout_unable_to_update_single_use_settings_after_usage_CORE_0926(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_update_single_use_settings_after_usage.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_update_single_use_settings_after_usage.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -67,11 +67,11 @@ def test_checkout_unable_to_update_single_use_settings_after_usage_CORE_0926(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_update_single_use_settings_after_usage.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_update_single_use_settings_after_usage.py
@@ -53,34 +53,25 @@ def prepare_voucher(
 def test_checkout_unable_to_update_single_use_settings_after_usage_CORE_0926(
     e2e_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -117,7 +108,6 @@ def test_checkout_unable_to_update_single_use_settings_after_usage_CORE_0926(
     )
     checkout_id = checkout["id"]
     checkout_lines = checkout["lines"][0]
-    shipping_method_id = checkout["shippingMethods"][0]["id"]
     unit_price = float(product_variant_price)
     assert checkout["isShippingRequired"] is True
     assert checkout_lines["unitPrice"]["gross"]["amount"] == unit_price

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher.py
@@ -53,6 +53,8 @@ def test_checkout_unable_to_use_deleted_voucher_CORE_0923(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -62,15 +64,17 @@ def test_checkout_unable_to_use_deleted_voucher_CORE_0923(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -61,10 +61,10 @@ def test_checkout_unable_to_use_deleted_voucher_CORE_0923(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher.py
@@ -47,34 +47,24 @@ def prepare_voucher(
 def test_checkout_unable_to_use_deleted_voucher_CORE_0923(
     e2e_staff_api_client,
     e2e_not_logged_api_client,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_products,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_products,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher_code.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher_code.py
@@ -53,6 +53,8 @@ def test_checkout_unable_to_use_deleted_voucher_code_CORE_0914(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -62,15 +64,17 @@ def test_checkout_unable_to_use_deleted_voucher_code_CORE_0914(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
     (
         _product_id,
         product_variant_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher_code.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher_code.py
@@ -47,34 +47,25 @@ def create_voucher_with_multiple_codes(e2e_staff_api_client, channel_id):
 def test_checkout_unable_to_use_deleted_voucher_code_CORE_0914(
     e2e_staff_api_client,
     e2e_logged_api_client,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_products,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_products,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+
     (
         _product_id,
         product_variant_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher_code.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_deleted_voucher_code.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -61,10 +61,10 @@ def test_checkout_unable_to_use_deleted_voucher_code_CORE_0914(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_expired_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_expired_voucher.py
@@ -66,6 +66,8 @@ def test_checkout_unable_to_use_expired_voucher_CORE_0921(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -75,18 +77,20 @@ def test_checkout_unable_to_use_expired_voucher_CORE_0921(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
-        product_id,
+        _product_id,
         product_variant_id,
         product_variant_price,
     ) = prepare_product(

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_expired_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_expired_voucher.py
@@ -4,7 +4,7 @@ import pytest
 from django.utils import timezone
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -74,11 +74,11 @@ def test_checkout_unable_to_use_expired_voucher_CORE_0921(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_expired_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_expired_voucher.py
@@ -60,34 +60,25 @@ def prepare_voucher(
 def test_checkout_unable_to_use_expired_voucher_CORE_0921(
     e2e_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -130,7 +121,6 @@ def test_checkout_unable_to_use_expired_voucher_CORE_0921(
     )
     checkout_id = checkout["id"]
     checkout_lines = checkout["lines"][0]
-    shipping_method_id = checkout["shippingMethods"][0]["id"]
     unit_price = float(product_variant_price)
     total_gross_amount = checkout["totalPrice"]["gross"]["amount"]
     assert checkout["isShippingRequired"] is True

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_not_started_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_not_started_voucher.py
@@ -65,6 +65,8 @@ def test_checkout_unable_to_use_not_started_voucher_CORE_0920(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -74,15 +76,17 @@ def test_checkout_unable_to_use_not_started_voucher_CORE_0920(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_not_started_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_not_started_voucher.py
@@ -4,7 +4,7 @@ import pytest
 from django.utils import timezone
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -73,11 +73,11 @@ def test_checkout_unable_to_use_not_started_voucher_CORE_0920(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_not_started_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_unable_to_use_not_started_voucher.py
@@ -59,34 +59,25 @@ def prepare_voucher(
 def test_checkout_unable_to_use_not_started_voucher_CORE_0920(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -129,7 +120,6 @@ def test_checkout_unable_to_use_not_started_voucher_CORE_0920(
     )
     checkout_id = checkout["id"]
     checkout_lines = checkout["lines"][0]
-    shipping_method_id = checkout["shippingMethods"][0]["id"]
     unit_price = float(product_variant_price)
     total_gross_amount = checkout["totalPrice"]["gross"]["amount"]
     assert checkout["isShippingRequired"] is True

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_use_voucher_for_cheapest_product.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_use_voucher_for_cheapest_product.py
@@ -68,6 +68,8 @@ def test_checkout_use_voucher_for_cheapest_product_0907(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
     first_variant_price,
     second_variant_price,
     voucher_discount_type,
@@ -81,15 +83,17 @@ def test_checkout_use_voucher_for_cheapest_product_0907(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_use_voucher_for_cheapest_product.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_use_voucher_for_cheapest_product.py
@@ -63,13 +63,9 @@ def prepare_voucher_for_cheapest_product(
 def test_checkout_use_voucher_for_cheapest_product_0907(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
     first_variant_price,
     second_variant_price,
     voucher_discount_type,
@@ -78,22 +74,17 @@ def test_checkout_use_voucher_for_cheapest_product_0907(
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,
@@ -151,7 +142,6 @@ def test_checkout_use_voucher_for_cheapest_product_0907(
     )
     checkout_id = checkout_data["id"]
     checkout_lines = checkout_data["lines"]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     assert checkout_data["isShippingRequired"] is True
     first_line = checkout_lines[0]

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_use_voucher_for_cheapest_product.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_use_voucher_for_cheapest_product.py
@@ -5,7 +5,7 @@ from ....product.utils import (
     create_product_variant_channel_listing,
 )
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import create_voucher, create_voucher_channel_listing
 from ...utils import (
@@ -80,11 +80,11 @@ def test_checkout_use_voucher_for_cheapest_product_0907(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_user_cannot_use_voucher_for_staff_only.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_user_cannot_use_voucher_for_staff_only.py
@@ -47,6 +47,8 @@ def test_user_cannot_use_voucher_for_staff_only_in_checkout_core_0905(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
 
@@ -56,15 +58,17 @@ def test_user_cannot_use_voucher_for_staff_only_in_checkout_core_0905(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_user_cannot_use_voucher_for_staff_only.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_user_cannot_use_voucher_for_staff_only.py
@@ -42,33 +42,23 @@ def prepare_voucher_for_staff_only(
 def test_user_cannot_use_voucher_for_staff_only_in_checkout_core_0905(
     e2e_staff_api_client,
     e2e_not_logged_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
 
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_user_cannot_use_voucher_for_staff_only.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_user_cannot_use_voucher_for_staff_only.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import create_voucher, create_voucher_channel_listing
 from ...utils import checkout_create, raw_checkout_add_promo_code
@@ -55,10 +55,10 @@ def test_user_cannot_use_voucher_for_staff_only_in_checkout_core_0905(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_checkout_fails.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_checkout_fails.py
@@ -59,6 +59,8 @@ def test_checkout_voucher_is_still_active_when_checkout_fails_core_0918(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -68,15 +70,17 @@ def test_checkout_voucher_is_still_active_when_checkout_fails_core_0918(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_checkout_fails.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_checkout_fails.py
@@ -53,34 +53,25 @@ def prepare_voucher(
 def test_checkout_voucher_is_still_active_when_checkout_fails_core_0918(
     e2e_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_checkout_fails.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_checkout_fails.py
@@ -2,7 +2,7 @@ import pytest
 
 from ....product.utils import product_variant_stock_update
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -67,11 +67,11 @@ def test_checkout_voucher_is_still_active_when_checkout_fails_core_0918(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_payment_fails.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_payment_fails.py
@@ -57,6 +57,8 @@ def test_checkout_voucher_is_still_active_when_payment_fails_core_0919(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -66,15 +68,17 @@ def test_checkout_voucher_is_still_active_when_payment_fails_core_0919(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_payment_fails.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_payment_fails.py
@@ -51,34 +51,25 @@ def prepare_voucher(
 def test_checkout_voucher_is_still_active_when_payment_fails_core_0919(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -117,7 +108,6 @@ def test_checkout_voucher_is_still_active_when_payment_fails_core_0919(
     )
     checkout_id = checkout["id"]
     checkout_lines = checkout["lines"][0]
-    shipping_method_id = checkout["shippingMethods"][0]["id"]
     unit_price = float(product_variant_price)
     total_gross_amount = checkout["totalPrice"]["gross"]["amount"]
 

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_payment_fails.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_voucher_is_still_active_when_payment_fails.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -65,11 +65,11 @@ def test_checkout_voucher_is_still_active_when_payment_fails_core_0919(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher.py
@@ -54,6 +54,8 @@ def test_checkout_use_fixed_voucher_core_0901(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -62,15 +64,17 @@ def test_checkout_use_fixed_voucher_core_0901(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher.py
@@ -49,32 +49,23 @@ def prepare_fixed_voucher(
 def test_checkout_use_fixed_voucher_core_0901(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -125,7 +116,6 @@ def test_checkout_use_fixed_voucher_core_0901(
         e2e_not_logged_api_client, checkout_id
     )
     assert len(checkout_data["shippingMethods"]) == 1
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     checkout_data = checkout_delivery_method_update(
         e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import create_voucher, create_voucher_channel_listing
 from ...utils import (
@@ -61,11 +61,11 @@ def test_checkout_use_fixed_voucher_core_0901(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher_should_not_result_in_negative_variant_price.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher_should_not_result_in_negative_variant_price.py
@@ -56,6 +56,8 @@ def test_checkout_voucher_should_not_cause_negative_variant_price_CORE_0911(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -64,15 +66,17 @@ def test_checkout_voucher_should_not_cause_negative_variant_price_CORE_0911(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher_should_not_result_in_negative_variant_price.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher_should_not_result_in_negative_variant_price.py
@@ -51,32 +51,23 @@ def prepare_fixed_voucher(
 def test_checkout_voucher_should_not_cause_negative_variant_price_CORE_0911(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,
@@ -127,7 +118,6 @@ def test_checkout_voucher_should_not_cause_negative_variant_price_CORE_0911(
         e2e_not_logged_api_client, checkout_id
     )
     assert len(checkout_data["shippingMethods"]) == 1
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     checkout_data = checkout_delivery_method_update(
         e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher_should_not_result_in_negative_variant_price.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_fixed_voucher_should_not_result_in_negative_variant_price.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import create_voucher, create_voucher_channel_listing
 from ...utils import (
@@ -63,11 +63,11 @@ def test_checkout_voucher_should_not_cause_negative_variant_price_CORE_0911(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_quantity_of_items.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_quantity_of_items.py
@@ -56,6 +56,8 @@ def test_checkout_use_free_shipping_voucher_with_min_quantity_of_items_0906(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -64,15 +66,17 @@ def test_checkout_use_free_shipping_voucher_with_min_quantity_of_items_0906(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_quantity_of_items.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_quantity_of_items.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import create_voucher, create_voucher_channel_listing
 from ...utils import (
@@ -63,11 +63,11 @@ def test_checkout_use_free_shipping_voucher_with_min_quantity_of_items_0906(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_quantity_of_items.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_quantity_of_items.py
@@ -51,32 +51,23 @@ def prepare_free_shipping_voucher(
 def test_checkout_use_free_shipping_voucher_with_min_quantity_of_items_0906(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -116,7 +107,6 @@ def test_checkout_use_free_shipping_voucher_with_min_quantity_of_items_0906(
     )
     checkout_id = checkout_data["id"]
     checkout_lines = checkout_data["lines"][0]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     assert checkout_data["isShippingRequired"] is True
     assert checkout_lines["unitPrice"]["gross"]["amount"] == float(

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_spent_amount.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_spent_amount.py
@@ -56,6 +56,8 @@ def test_checkout_use_free_shipping_voucher_with_min_spent_amount_0903(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -64,15 +66,17 @@ def test_checkout_use_free_shipping_voucher_with_min_spent_amount_0903(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_spent_amount.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_spent_amount.py
@@ -51,32 +51,23 @@ def prepare_free_shipping_voucher(
 def test_checkout_use_free_shipping_voucher_with_min_spent_amount_0903(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -116,7 +107,6 @@ def test_checkout_use_free_shipping_voucher_with_min_spent_amount_0903(
     )
     checkout_id = checkout_data["id"]
     checkout_lines = checkout_data["lines"][0]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     assert checkout_data["isShippingRequired"] is True
     assert checkout_lines["unitPrice"]["gross"]["amount"] == float(

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_spent_amount.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_free_shipping_voucher_with_min_spent_amount.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import create_voucher, create_voucher_channel_listing
 from ...utils import (
@@ -63,11 +63,11 @@ def test_checkout_use_free_shipping_voucher_with_min_spent_amount_0903(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_percentage_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_percentage_voucher.py
@@ -53,6 +53,8 @@ def test_checkout_use_percentage_voucher_core_0902(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -61,15 +63,17 @@ def test_checkout_use_percentage_voucher_core_0902(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_percentage_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_percentage_voucher.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import create_voucher, create_voucher_channel_listing
 from ...utils import (
@@ -60,11 +60,11 @@ def test_checkout_use_percentage_voucher_core_0902(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_percentage_voucher.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_percentage_voucher.py
@@ -48,32 +48,23 @@ def prepare_percentage_voucher(
 def test_checkout_use_percentage_voucher_core_0902(
     e2e_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -112,7 +103,6 @@ def test_checkout_use_percentage_voucher_core_0902(
     )
     checkout_id = checkout["id"]
     checkout_lines = checkout["lines"][0]
-    shipping_method_id = checkout["shippingMethods"][0]["id"]
     unit_price = float(product_variant_price)
     assert checkout["isShippingRequired"] is True
     assert checkout_lines["unitPrice"]["gross"]["amount"] == unit_price

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_limit_per_customer.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_limit_per_customer.py
@@ -64,6 +64,8 @@ def test_checkout_with_voucher_limit_per_customer_CORE_0910(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -73,15 +75,17 @@ def test_checkout_with_voucher_limit_per_customer_CORE_0910(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_limit_per_customer.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_limit_per_customer.py
@@ -58,34 +58,25 @@ def prepare_voucher(
 def test_checkout_with_voucher_limit_per_customer_CORE_0910(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,
@@ -125,7 +116,6 @@ def test_checkout_with_voucher_limit_per_customer_CORE_0910(
     )
     checkout_id = checkout["id"]
     checkout_lines = checkout["lines"][0]
-    shipping_method_id = checkout["shippingMethods"][0]["id"]
     unit_price = float(product_variant_price)
     total_gross_amount = checkout["totalPrice"]["gross"]["amount"]
     assert checkout["isShippingRequired"] is True

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_limit_per_customer.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_limit_per_customer.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -72,11 +72,11 @@ def test_checkout_with_voucher_limit_per_customer_CORE_0910(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_with_min_item_quantity.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_with_min_item_quantity.py
@@ -65,6 +65,8 @@ def test_checkout_with_voucher_with_min_item_quantity_core_0908(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -74,15 +76,17 @@ def test_checkout_with_voucher_with_min_item_quantity_core_0908(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_with_min_item_quantity.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_with_min_item_quantity.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -73,11 +73,11 @@ def test_checkout_with_voucher_with_min_item_quantity_core_0908(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_with_min_item_quantity.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_checkout_with_voucher_with_min_item_quantity.py
@@ -59,34 +59,25 @@ def prepare_voucher(
 def test_checkout_with_voucher_with_min_item_quantity_core_0908(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,
@@ -126,7 +117,6 @@ def test_checkout_with_voucher_with_min_item_quantity_core_0908(
     )
     checkout_id = checkout["id"]
     checkout_lines = checkout["lines"][0]
-    shipping_method_id = checkout["shippingMethods"][0]["id"]
     unit_price = float(product_variant_price)
     assert checkout["isShippingRequired"] is True
     assert checkout_lines["unitPrice"]["gross"]["amount"] == unit_price

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_only_one_voucher_per_checkout.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_only_one_voucher_per_checkout.py
@@ -89,6 +89,8 @@ def test_checkout_use_fixed_voucher_core_0901(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -98,15 +100,17 @@ def test_checkout_use_fixed_voucher_core_0901(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_only_one_voucher_per_checkout.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_only_one_voucher_per_checkout.py
@@ -83,34 +83,25 @@ def prepare_fixed_voucher(
 def test_checkout_use_fixed_voucher_core_0901(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -170,7 +161,6 @@ def test_checkout_use_fixed_voucher_core_0901(
         e2e_not_logged_api_client, checkout_id
     )
     assert len(checkout_data["shippingMethods"]) == 1
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     checkout_data = checkout_delivery_method_update(
         e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_only_one_voucher_per_checkout.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_only_one_voucher_per_checkout.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -97,11 +97,11 @@ def test_checkout_use_fixed_voucher_core_0901(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_should_be_able_to_remove_voucher_code_from_checkout.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_should_be_able_to_remove_voucher_code_from_checkout.py
@@ -60,6 +60,8 @@ def test_should_be_able_to_remove_voucher_code_from_checkout_CORE_0917(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -69,15 +71,17 @@ def test_should_be_able_to_remove_voucher_code_from_checkout_CORE_0917(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_should_be_able_to_remove_voucher_code_from_checkout.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_should_be_able_to_remove_voucher_code_from_checkout.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import (
     create_voucher,
@@ -68,11 +68,11 @@ def test_should_be_able_to_remove_voucher_code_from_checkout_CORE_0917(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_should_be_able_to_remove_voucher_code_from_checkout.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_should_be_able_to_remove_voucher_code_from_checkout.py
@@ -54,34 +54,25 @@ def prepare_fixed_voucher(
 def test_should_be_able_to_remove_voucher_code_from_checkout_CORE_0917(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -132,7 +123,6 @@ def test_should_be_able_to_remove_voucher_code_from_checkout_CORE_0917(
         e2e_not_logged_api_client, checkout_id
     )
     assert len(checkout_data["shippingMethods"]) == 1
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     checkout_data = checkout_delivery_method_update(
         e2e_not_logged_api_client,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_staff_user_can_use_voucher_for_staff_only.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_staff_user_can_use_voucher_for_staff_only.py
@@ -53,6 +53,8 @@ def test_staff_can_use_voucher_for_staff_only_in_checkout_core_0904(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
 
@@ -62,15 +64,16 @@ def test_staff_can_use_voucher_for_staff_only_in_checkout_core_0904(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_staff_user_can_use_voucher_for_staff_only.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_staff_user_can_use_voucher_for_staff_only.py
@@ -48,32 +48,23 @@ def prepare_voucher_for_staff_only(
 def test_staff_can_use_voucher_for_staff_only_in_checkout_core_0904(
     e2e_staff_api_client,
     e2e_no_permission_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
-
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -110,7 +101,6 @@ def test_staff_can_use_voucher_for_staff_only_in_checkout_core_0904(
         set_default_shipping_address=True,
     )
     checkout_id = checkout_data["id"]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     checkout_lines = checkout_data["lines"][0]
     assert checkout_lines["unitPrice"]["gross"]["amount"] == float(
         product_variant_price

--- a/saleor/tests/e2e/checkout/discounts/vouchers/test_staff_user_can_use_voucher_for_staff_only.py
+++ b/saleor/tests/e2e/checkout/discounts/vouchers/test_staff_user_can_use_voucher_for_staff_only.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ....product.utils.preparing_product import prepare_product
-from ....shop.utils.preparing_shop import prepare_shop
+from ....shop.utils import prepare_default_shop
 from ....utils import assign_permissions
 from ....vouchers.utils import create_voucher, create_voucher_channel_listing
 from ...utils import (
@@ -60,11 +60,11 @@ def test_staff_can_use_voucher_for_staff_only_in_checkout_core_0904(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
+++ b/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_based_on_shipping_country.py
@@ -28,58 +28,73 @@ def test_checkout_calculate_simple_tax_based_on_shipping_country_CORE_2001(
         permission_manage_product_types_and_attributes,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
+
     tax_settings = {
         "charge_taxes": True,
         "tax_calculation_strategy": "FLAT_RATES",
         "display_gross_prices": False,
         "prices_entered_with_tax": True,
-        "tax_rates": [
-            {
-                "type": "shipping_country",
-                "name": "Shipping Country Tax Class",
-                "country_code": "CZ",
-                "rate": 21,
-            },
-            {
-                "type": "billing_country",
-                "name": "Billing Country Tax Class",
-                "country_code": "DE",
-                "rate": 19,
-            },
-        ],
     }
-    shipping_method_channel_listing_settings = {
-        "price": "6.66",
-    }
-    shop_data = prepare_shop(
+    shipping_price = "6.66"
+
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        shipping_zones=[{"countries": ["CZ", "US", "DE"]}],
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "us shipping zone",
+                                "add_channels": {"price": "6.66"},
+                            }
+                        ],
+                    },
+                    {
+                        "countries": ["CZ"],
+                        "shipping_methods": [
+                            {
+                                "name": "cz shipping zone",
+                                "add_channels": {"price": "6.66"},
+                            }
+                        ],
+                    },
+                    {
+                        "countries": ["DE"],
+                        "shipping_methods": [
+                            {
+                                "name": "de shipping zone",
+                                "add_channels": {"price": shipping_price},
+                            }
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            }
+        ],
         tax_settings=tax_settings,
-        shipping_method_channel_listing_settings=shipping_method_channel_listing_settings,
     )
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
-    shipping_price = shop_data["shipping_methods"][0]["price"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_class_tax_rate = shop_data["tax_rates"].get("shipping_country").get("rate")
-    shipping_country_code = (
-        shop_data["tax_rates"].get("shipping_country").get("country_code")
-    )
-    billing_class_tax_rate = shop_data["tax_rates"].get("billing_country").get("rate")
-    billing_country_code = (
-        shop_data["tax_rates"].get("billing_country").get("country_code")
-    )
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    cz_shipping_method_id = shop_data[0]["shipping_zones"][1]["shipping_methods"][0][
+        "id"
+    ]
+    shipping_country_tax_rate = 21
+    shipping_country_code = "CZ"
+    billing_country_tax_rate = 19
+    billing_country_code = "DE"
 
     update_country_tax_rates(
         e2e_staff_api_client,
         shipping_country_code,
-        [{"rate": shipping_class_tax_rate}],
+        [{"rate": shipping_country_tax_rate}],
     )
     update_country_tax_rates(
         e2e_staff_api_client,
         billing_country_code,
-        [{"rate": billing_class_tax_rate}],
+        [{"rate": billing_country_tax_rate}],
     )
 
     variant_price = "17.77"
@@ -125,11 +140,13 @@ def test_checkout_calculate_simple_tax_based_on_shipping_country_CORE_2001(
         "phone": "+420722274643",
         "countryArea": "",
     }
+
     checkout_data = checkout_shipping_address_update(
         e2e_not_logged_api_client,
         checkout_id,
         shipping_address,
     )
+
     assert len(checkout_data["shippingMethods"]) == 1
 
     # Step 3 - Set billing address for checkout
@@ -151,8 +168,8 @@ def test_checkout_calculate_simple_tax_based_on_shipping_country_CORE_2001(
     checkout_data = get_checkout(e2e_not_logged_api_client, checkout_id)
     assert checkout_data["totalPrice"]["gross"]["amount"] == float(variant_price)
     calculated_tax = round(
-        (float(variant_price) * shipping_class_tax_rate)
-        / (100 + shipping_class_tax_rate),
+        (float(variant_price) * shipping_country_tax_rate)
+        / (100 + shipping_country_tax_rate),
         2,
     )
     assert checkout_data["totalPrice"]["tax"]["amount"] == calculated_tax
@@ -165,14 +182,14 @@ def test_checkout_calculate_simple_tax_based_on_shipping_country_CORE_2001(
     checkout_data = checkout_delivery_method_update(
         e2e_not_logged_api_client,
         checkout_id,
-        shipping_method_id,
+        cz_shipping_method_id,
     )
-    assert checkout_data["deliveryMethod"]["id"] == shipping_method_id
+    assert checkout_data["deliveryMethod"]["id"] == cz_shipping_method_id
 
     assert checkout_data["shippingPrice"]["gross"]["amount"] == float(shipping_price)
     shipping_tax = round(
-        (float(shipping_price) * shipping_class_tax_rate)
-        / (100 + shipping_class_tax_rate),
+        (float(shipping_price) * shipping_country_tax_rate)
+        / (100 + shipping_country_tax_rate),
         2,
     )
     assert checkout_data["shippingPrice"]["tax"]["amount"] == shipping_tax

--- a/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_for_digital_product.py
+++ b/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_for_digital_product.py
@@ -1,19 +1,9 @@
 import pytest
 
-from ...channel.utils import create_channel
 from ...product.utils.preparing_product import prepare_digital_product
-from ...shipping_zone.utils import (
-    create_shipping_method,
-    create_shipping_method_channel_listing,
-    create_shipping_zone,
-)
-from ...taxes.utils import (
-    get_tax_configurations,
-    update_country_tax_rates,
-    update_tax_configuration,
-)
+from ...shop.utils.preparing_shop import prepare_shop
+from ...taxes.utils import update_country_tax_rates
 from ...utils import assign_permissions
-from ...warehouse.utils import create_warehouse
 from ..utils import (
     checkout_billing_address_update,
     checkout_complete,
@@ -21,85 +11,6 @@ from ..utils import (
     checkout_dummy_payment_create,
     get_checkout,
 )
-
-
-def prepare_shop(
-    e2e_staff_api_client,
-    shipping_price,
-):
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-    channel_slug = "channel-cz"
-    warehouse_ids = [warehouse_id]
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        slug=channel_slug,
-        warehouse_ids=warehouse_ids,
-        currency="CZK",
-        country="CZ",
-    )
-    channel_id = channel_data["id"]
-    channel_ids = [channel_id]
-    shipping_zone_data = create_shipping_zone(
-        e2e_staff_api_client,
-        countries=["CZ", "US"],
-        warehouse_ids=warehouse_ids,
-        channel_ids=channel_ids,
-    )
-    shipping_zone_id = shipping_zone_data["id"]
-
-    shipping_method_data = create_shipping_method(
-        e2e_staff_api_client, shipping_zone_id
-    )
-    shipping_method_id = shipping_method_data["id"]
-    create_shipping_method_channel_listing(
-        e2e_staff_api_client,
-        shipping_method_id,
-        channel_id,
-        price=shipping_price,
-    )
-
-    return (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-        shipping_price,
-    )
-
-
-def prepare_tax_configuration(
-    e2e_staff_api_client,
-    channel_slug,
-    shipping_country_code,
-    shipping_country_tax_rate,
-    billing_country_code,
-    billing_country_tax_rate,
-    prices_entered_with_tax,
-):
-    tax_config_data = get_tax_configurations(e2e_staff_api_client)
-    channel_tax_config = tax_config_data[0]["node"]
-    assert channel_tax_config["channel"]["slug"] == channel_slug
-    tax_config_id = channel_tax_config["id"]
-
-    tax_config_data = update_tax_configuration(
-        e2e_staff_api_client,
-        tax_config_id,
-        charge_taxes=True,
-        tax_calculation_strategy="FLAT_RATES",
-        display_gross_prices=True,
-        prices_entered_with_tax=prices_entered_with_tax,
-    )
-    update_country_tax_rates(
-        e2e_staff_api_client,
-        shipping_country_code,
-        [{"rate": shipping_country_tax_rate}],
-    )
-    update_country_tax_rates(
-        e2e_staff_api_client, billing_country_code, [{"rate": billing_country_tax_rate}]
-    )
-
-    return billing_country_tax_rate
 
 
 @pytest.mark.e2e
@@ -111,6 +22,7 @@ def test_digital_checkout_calculate_simple_tax_based_on_billing_country_CORE_200
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -119,26 +31,34 @@ def test_digital_checkout_calculate_simple_tax_based_on_billing_country_CORE_200
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shipping_price = 15
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-        shipping_price,
-    ) = prepare_shop(e2e_staff_api_client, shipping_price)
-
-    billing_country_tax_rate = prepare_tax_configuration(
+    shop_data = prepare_shop(
         e2e_staff_api_client,
-        channel_slug,
+        currency="CZK",
+        country="CZ",
+        countries=["CZ", "US"],
         shipping_country_code="US",
         shipping_country_tax_rate=9,
         billing_country_code="CZ",
         billing_country_tax_rate=21,
         prices_entered_with_tax=False,
+        shipping_price=15.0,
+        shipping_zones_structure=[
+            {"countries": ["CZ", "US"], "num_shipping_methods": 1}
+        ],
+    )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    billing_country_tax_rate = shop_data["billing_country_tax_rate"]
+    billing_country_code = shop_data["billing_country_code"]
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        billing_country_code,
+        [{"rate": billing_country_tax_rate}],
     )
     variant_price = 88.89
     _product_id, product_variant_id, product_variant_price = prepare_digital_product(

--- a/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_product_tax_class.py
+++ b/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_product_tax_class.py
@@ -3,12 +3,7 @@ import pytest
 from ...product.utils import update_product
 from ...product.utils.preparing_product import prepare_product
 from ...shop.utils.preparing_shop import prepare_shop
-from ...taxes.utils import (
-    create_tax_class,
-    get_tax_configurations,
-    update_country_tax_rates,
-    update_tax_configuration,
-)
+from ...taxes.utils import update_country_tax_rates
 from ...utils import assign_permissions
 from ..utils import (
     checkout_complete,
@@ -16,44 +11,6 @@ from ..utils import (
     checkout_delivery_method_update,
     checkout_dummy_payment_create,
 )
-
-
-def prepare_tax_configuration(
-    e2e_staff_api_client,
-    channel_slug,
-    country_code,
-    country_tax_rate,
-    product_tax_rate,
-    prices_entered_with_tax,
-):
-    tax_config_data = get_tax_configurations(e2e_staff_api_client)
-    channel_tax_config = tax_config_data[0]["node"]
-    assert channel_tax_config["channel"]["slug"] == channel_slug
-    tax_config_id = channel_tax_config["id"]
-
-    tax_config_data = update_tax_configuration(
-        e2e_staff_api_client,
-        tax_config_id,
-        charge_taxes=True,
-        tax_calculation_strategy="FLAT_RATES",
-        display_gross_prices=True,
-        prices_entered_with_tax=prices_entered_with_tax,
-    )
-    update_country_tax_rates(
-        e2e_staff_api_client,
-        country_code,
-        [{"rate": country_tax_rate}],
-    )
-
-    country_rates = [{"countryCode": country_code, "rate": product_tax_rate}]
-    tax_class_data = create_tax_class(
-        e2e_staff_api_client,
-        "Product tax class",
-        country_rates,
-    )
-    tax_class_id = tax_class_data["id"]
-
-    return country_tax_rate, product_tax_rate, tax_class_id
 
 
 @pytest.mark.e2e
@@ -65,6 +22,7 @@ def test_checkout_calculate_simple_tax_based_on_product_tax_class_CORE_2005(
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -73,33 +31,39 @@ def test_checkout_calculate_simple_tax_based_on_product_tax_class_CORE_2005(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
-
-    country_tax_rate, product_tax_rate, tax_class_id = prepare_tax_configuration(
+    shop_data = prepare_shop(
         e2e_staff_api_client,
-        channel_slug,
-        country_code="US",
+        country="US",
         country_tax_rate=23,
         product_tax_rate=5,
         prices_entered_with_tax=True,
     )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
+    product_tax_class_id = shop_data["product_tax_class_id"]
+    product_tax_rate = shop_data["product_tax_rate"]
+    country_tax_rate = shop_data["country_tax_rate"]
+    shipping_method_id = shop_data["shipping_method_id"]
+    country = shop_data["country"]
 
-    variant_price = "25.55"
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country,
+        [{"rate": country_tax_rate}],
+    )
+    variant_price = float("25.55")
     (product_id, product_variant_id, product_variant_price) = prepare_product(
         e2e_staff_api_client,
         warehouse_id,
         channel_id,
         variant_price,
     )
-    product_tax_class = {"taxClass": tax_class_id}
+    product_tax_class = {"taxClass": product_tax_class_id}
     update_product(e2e_staff_api_client, product_id, input=product_tax_class)
 
     # Step 1 - Create checkout and check prices
@@ -119,7 +83,6 @@ def test_checkout_calculate_simple_tax_based_on_product_tax_class_CORE_2005(
         set_default_shipping_address=True,
     )
     checkout_id = checkout_data["id"]
-
     assert checkout_data["isShippingRequired"] is True
     product_variant_price = float(product_variant_price)
     assert checkout_data["totalPrice"]["gross"]["amount"] == product_variant_price
@@ -127,7 +90,7 @@ def test_checkout_calculate_simple_tax_based_on_product_tax_class_CORE_2005(
         (product_variant_price * product_tax_rate) / (100 + product_tax_rate),
         2,
     )
-    assert checkout_data["totalPrice"]["tax"]["amount"] == calculated_tax
+
     assert checkout_data["totalPrice"]["net"]["amount"] == round(
         product_variant_price - calculated_tax, 2
     )
@@ -139,6 +102,7 @@ def test_checkout_calculate_simple_tax_based_on_product_tax_class_CORE_2005(
         checkout_id,
         shipping_method_id,
     )
+
     shipping_price = checkout_data["deliveryMethod"]["price"]["amount"]
     shipping_price = float(shipping_price)
     assert checkout_data["deliveryMethod"]["id"] == shipping_method_id

--- a/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_product_tax_class.py
+++ b/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_product_tax_class.py
@@ -26,18 +26,13 @@ def test_checkout_calculate_simple_tax_based_on_product_tax_class_CORE_2005(
         permission_manage_product_types_and_attributes,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
+
     tax_settings = {
         "charge_taxes": True,
         "tax_calculation_strategy": "FLAT_RATES",
         "display_gross_prices": False,
         "prices_entered_with_tax": True,
         "tax_rates": [
-            {
-                "type": "country",
-                "name": "Country Tax Rate",
-                "country_code": "US",
-                "rate": 23,
-            },
             {
                 "type": "product",
                 "name": "Product Tax Rate",
@@ -46,18 +41,34 @@ def test_checkout_calculate_simple_tax_based_on_product_tax_class_CORE_2005(
             },
         ],
     }
-    shop_data = prepare_shop(
+    shop_data, tax_config = prepare_shop(
         e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [
+                            {
+                                "add_channels": {},
+                            }
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            },
+        ],
         tax_settings=tax_settings,
     )
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
-    product_tax_class_id = shop_data["tax_classes"].get("product_tax_class_id")
-    product_tax_rate = shop_data["tax_rates"].get("product").get("rate")
-    country_tax_rate = shop_data["tax_rates"].get("country").get("rate")
-    country = shop_data["tax_rates"].get("country").get("country_code")
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    shipping_price = 10.0
+    warehouse_id = shop_data[0]["warehouse_id"]
+    product_tax_class_id = tax_config[0]["product_tax_class_id"]
+    product_tax_rate = tax_config[1]["product"]["rate"]
+    country_tax_rate = 23
+    country = "US"
+
     update_country_tax_rates(
         e2e_staff_api_client,
         country,

--- a/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_product_type_tax_class.py
+++ b/saleor/tests/e2e/checkout/taxes/test_checkout_calculate_simple_taxes_product_type_tax_class.py
@@ -86,18 +86,13 @@ def test_checkout_calculate_simple_tax_based_on_product_type_tax_class_CORE_2003
         permission_manage_product_types_and_attributes,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
+
     tax_settings = {
         "charge_taxes": True,
         "tax_calculation_strategy": "FLAT_RATES",
         "display_gross_prices": False,
         "prices_entered_with_tax": False,
         "tax_rates": [
-            {
-                "type": "country",
-                "name": "Country Tax Rate",
-                "country_code": "US",
-                "rate": 10,
-            },
             {
                 "type": "product_type",
                 "name": "Product Type Tax Rate",
@@ -106,20 +101,34 @@ def test_checkout_calculate_simple_tax_based_on_product_type_tax_class_CORE_2003
             },
         ],
     }
-    shop_data = prepare_shop(
+    shop_data, tax_config = prepare_shop(
         e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [
+                            {
+                                "add_channels": {},
+                            }
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            },
+        ],
         tax_settings=tax_settings,
     )
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
-    product_type_tax_class_id = shop_data["tax_classes"].get(
-        "product_type_tax_class_id"
-    )
-    product_type_tax_rate = shop_data["tax_rates"].get("product_type").get("rate")
-    country_tax_rate = shop_data["tax_rates"].get("country").get("rate")
-    country = shop_data["tax_rates"].get("country").get("country_code")
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    shipping_price = 10.0
+    warehouse_id = shop_data[0]["warehouse_id"]
+    product_type_tax_class_id = tax_config[0]["product_type_tax_class_id"]
+    product_type_tax_rate = tax_config[1]["product_type"]["rate"]
+    country = "US"
+    country_tax_rate = 10
+
     update_country_tax_rates(
         e2e_staff_api_client,
         country,

--- a/saleor/tests/e2e/checkout/test_buy_gift_card_in_the_checkout.py
+++ b/saleor/tests/e2e/checkout/test_buy_gift_card_in_the_checkout.py
@@ -92,25 +92,27 @@ def test_buy_gift_card_in_the_checkout_CORE_1102(
         permission_manage_plugins,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_settings = {
-        "fulfillmentAutoApprove": True,
-        "fulfillmentAllowUnpaid": True,
-    }
-    channel_config = [
-        {
-            "order_settings": {
-                "automaticallyFulfillNonShippableGiftCard": True,
-            }
-        }
-    ]
-    shop_data = prepare_shop(
+
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        channels_settings=channel_config,
-        shop_settings_update=shop_settings,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [{}],
+                    },
+                ],
+                "order_settings": {"automaticallyFulfillNonShippableGiftCard": True},
+            }
+        ],
+        shop_settings={
+            "fulfillmentAutoApprove": True,
+            "fulfillmentAllowUnpaid": True,
+        },
     )
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    warehouse_id = shop_data[0]["warehouse_id"]
 
     product_variant_id, _product_variant_price, _product_id = prepare_product_gift_card(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/checkout/test_buy_gift_card_in_the_checkout.py
+++ b/saleor/tests/e2e/checkout/test_buy_gift_card_in_the_checkout.py
@@ -78,37 +78,39 @@ def test_buy_gift_card_in_the_checkout_CORE_1102(
     e2e_logged_api_client,
     e2e_staff_api_client,
     permission_manage_product_types_and_attributes,
-    permission_manage_channels,
-    permission_manage_products,
-    permission_manage_shipping,
     permission_manage_gift_card,
     permission_manage_orders,
-    permission_manage_settings,
     permission_manage_plugins,
-    permission_manage_taxes,
+    shop_permissions,
 ):
     # Before
     permissions = [
         permission_manage_product_types_and_attributes,
-        permission_manage_channels,
-        permission_manage_products,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_gift_card,
         permission_manage_orders,
-        permission_manage_settings,
         permission_manage_plugins,
-        permission_manage_taxes,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
+    shop_settings = {
+        "fulfillmentAutoApprove": True,
+        "fulfillmentAllowUnpaid": True,
+    }
+    channel_config = [
+        {
+            "order_settings": {
+                "automaticallyFulfillNonShippableGiftCard": True,
+            }
+        }
+    ]
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        automatically_fulfill_non_shippable_giftcard=True,
-        fulfillment_auto_approve=True,
-        fulfillment_allow_unpaid=True,
+        channels_settings=channel_config,
+        shop_settings_update=shop_settings,
     )
-    warehouse_id = shop_data["warehouse_id"]
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     product_variant_id, _product_variant_price, _product_id = prepare_product_gift_card(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/checkout/test_checkout_add_gift_card_before_email.py
+++ b/saleor/tests/e2e/checkout/test_checkout_add_gift_card_before_email.py
@@ -23,6 +23,8 @@ def test_add_gift_card_before_email_in_checkout_core_1104(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_gift_card,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -31,16 +33,17 @@ def test_add_gift_card_before_email_in_checkout_core_1104(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_gift_card,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
-
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
     (
         _product_id,
         product_variant_id,

--- a/saleor/tests/e2e/checkout/test_checkout_add_gift_card_before_email.py
+++ b/saleor/tests/e2e/checkout/test_checkout_add_gift_card_before_email.py
@@ -2,7 +2,7 @@ import pytest
 
 from ..gift_cards.utils import create_gift_card
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     checkout_add_promo_code,
@@ -30,11 +30,11 @@ def test_add_gift_card_before_email_in_checkout_core_1104(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
     (
         _product_id,
         product_variant_id,

--- a/saleor/tests/e2e/checkout/test_checkout_add_gift_card_before_email.py
+++ b/saleor/tests/e2e/checkout/test_checkout_add_gift_card_before_email.py
@@ -18,32 +18,23 @@ from .utils import (
 def test_add_gift_card_before_email_in_checkout_core_1104(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_gift_card,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_gift_card,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    warehouse_id = shop_data["warehouse_id"]
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
     (
         _product_id,
         product_variant_id,
@@ -75,7 +66,6 @@ def test_add_gift_card_before_email_in_checkout_core_1104(
         set_default_shipping_address=True,
     )
     checkout_id = checkout_data["id"]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     calculated_subtotal = product_variant_price * 3
     assert checkout_data["isShippingRequired"] is True
     assert checkout_data["totalPrice"]["gross"]["amount"] == calculated_subtotal

--- a/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
@@ -16,6 +16,8 @@ def test_checkout_create_from_order_core_0104(
     permission_manage_shipping,
     permission_manage_orders,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -25,17 +27,18 @@ def test_checkout_create_from_order_core_0104(
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
 
     (
         _product_id,
@@ -48,7 +51,7 @@ def test_checkout_create_from_order_core_0104(
         price,
     )
 
-    # Step 1 - Create checkout from order
+    # Step 1 - Create order
     channel_id = {"channelId": channel_id}
     data = draft_order_create(
         e2e_staff_api_client,
@@ -72,6 +75,7 @@ def test_checkout_create_from_order_core_0104(
     order_product_variant_id = order_data["order"]["lines"][0]["variant"]
     order_product_quantity = order_data["order"]["lines"][0]["quantity"]
 
+    # Step 2 - Create checkout from order
     checkout_data = checkout_create_from_order(
         e2e_staff_api_client,
         order_id,

--- a/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
@@ -2,7 +2,7 @@ import pytest
 
 from ..orders.utils import draft_order_create, order_lines_create
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import checkout_create_from_order
 
@@ -26,9 +26,9 @@ def test_checkout_create_from_order_core_0104(
 
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_from_order.py
@@ -10,35 +10,25 @@ from .utils import checkout_create_from_order
 @pytest.mark.e2e
 def test_checkout_create_from_order_core_0104(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    warehouse_id = shop_data["warehouse_id"]
-    channel_id = shop_data["channel_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/test_checkout_create_order_with_no_payment.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_order_with_no_payment.py
@@ -1,64 +1,13 @@
 import pytest
 
-from ..channel.utils import create_channel
 from ..product.utils.preparing_product import prepare_product
-from ..shipping_zone.utils import (
-    create_shipping_method,
-    create_shipping_method_channel_listing,
-    create_shipping_zone,
-)
+from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
-from ..warehouse.utils import create_warehouse
 from .utils import (
     checkout_create,
     checkout_delivery_method_update,
     raw_checkout_complete,
 )
-
-
-def create_shop_for_orders_without_payments(
-    e2e_staff_api_client,
-):
-    channel_slug = "test-test"
-
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-
-    warehouse_ids = [warehouse_id]
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        slug=channel_slug,
-        warehouse_ids=warehouse_ids,
-        allow_unpaid_orders=True,
-        automatically_confirm_all_new_orders=True,
-    )
-    channel_id = channel_data["id"]
-
-    channel_ids = [channel_id]
-    shipping_zone_data = create_shipping_zone(
-        e2e_staff_api_client,
-        warehouse_ids=warehouse_ids,
-        channel_ids=channel_ids,
-    )
-    shipping_zone_id = shipping_zone_data["id"]
-
-    shipping_method_data = create_shipping_method(
-        e2e_staff_api_client,
-        shipping_zone_id,
-    )
-    shipping_method_id = shipping_method_data["id"]
-
-    create_shipping_method_channel_listing(
-        e2e_staff_api_client,
-        shipping_method_id,
-        channel_id,
-    )
-    return (
-        channel_slug,
-        warehouse_id,
-        channel_id,
-        shipping_method_id,
-    )
 
 
 @pytest.mark.e2e
@@ -70,6 +19,8 @@ def test_should_be_able_to_create_order_with_no_payment_CORE_0111(
     permission_manage_shipping,
     permission_manage_orders,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -79,14 +30,18 @@ def test_should_be_able_to_create_order_with_no_payment_CORE_0111(
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    (
-        channel_slug,
-        warehouse_id,
-        channel_id,
-        shipping_method_id,
-    ) = create_shop_for_orders_without_payments(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+        allow_unpaid_orders=True,
+    )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_checkout_create_order_with_no_payment.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_order_with_no_payment.py
@@ -13,35 +13,35 @@ from .utils import (
 @pytest.mark.e2e
 def test_should_be_able_to_create_order_with_no_payment_CORE_0111(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
+
+    channel_config = [
+        {
+            "order_settings": {
+                "allowUnpaidOrders": True,
+            }
+        }
+    ]
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        allow_unpaid_orders=True,
+        channels_settings=channel_config,
     )
-    warehouse_id = shop_data["warehouse_id"]
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     variant_price = 10
 
@@ -75,7 +75,6 @@ def test_should_be_able_to_create_order_with_no_payment_CORE_0111(
     assert checkout_data["isShippingRequired"] is True
     assert checkout_data["deliveryMethod"] is None
     assert checkout_data["shippingMethod"] is None
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     # Step 2 - Set shipping address and DeliveryMethod for checkout
     checkout_data = checkout_delivery_method_update(

--- a/saleor/tests/e2e/checkout/test_checkout_create_order_with_no_payment.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_order_with_no_payment.py
@@ -27,21 +27,29 @@ def test_should_be_able_to_create_order_with_no_payment_CORE_0111(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    channel_config = [
-        {
-            "order_settings": {
-                "allowUnpaidOrders": True,
-            }
-        }
-    ]
-    shop_data = prepare_shop(
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        channels_settings=channel_config,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [{}],
+                    },
+                ],
+                "order_settings": {
+                    "allowUnpaidOrders": True,
+                },
+            }
+        ],
+        shop_settings={
+            "fulfillmentAutoApprove": True,
+            "fulfillmentAllowUnpaid": True,
+        },
     )
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_checkout_create_partially_paid_order.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_partially_paid_order.py
@@ -1,65 +1,14 @@
 import pytest
 
-from ..channel.utils import create_channel
 from ..product.utils.preparing_product import prepare_product
-from ..shipping_zone.utils import (
-    create_shipping_method,
-    create_shipping_method_channel_listing,
-    create_shipping_zone,
-)
+from ..shop.utils import prepare_shop
 from ..transactions.utils import create_transaction
 from ..utils import assign_permissions
-from ..warehouse.utils import create_warehouse
 from .utils import (
     checkout_create,
     checkout_delivery_method_update,
     raw_checkout_complete,
 )
-
-
-def create_shop_for_orders_without_payments(
-    e2e_staff_api_client,
-):
-    channel_slug = "test-test"
-
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-
-    warehouse_ids = [warehouse_id]
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        slug=channel_slug,
-        warehouse_ids=warehouse_ids,
-        allow_unpaid_orders=True,
-        automatically_confirm_all_new_orders=True,
-    )
-    channel_id = channel_data["id"]
-
-    channel_ids = [channel_id]
-    shipping_zone_data = create_shipping_zone(
-        e2e_staff_api_client,
-        warehouse_ids=warehouse_ids,
-        channel_ids=channel_ids,
-    )
-    shipping_zone_id = shipping_zone_data["id"]
-
-    shipping_method_data = create_shipping_method(
-        e2e_staff_api_client,
-        shipping_zone_id,
-    )
-    shipping_method_id = shipping_method_data["id"]
-
-    create_shipping_method_channel_listing(
-        e2e_staff_api_client,
-        shipping_method_id,
-        channel_id,
-    )
-    return (
-        channel_slug,
-        warehouse_id,
-        channel_id,
-        shipping_method_id,
-    )
 
 
 @pytest.mark.e2e
@@ -74,6 +23,8 @@ def test_should_be_able_to_create_partially_paid_order_core_0112(
     permission_manage_orders,
     permission_manage_checkouts,
     permission_manage_payments,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -84,14 +35,19 @@ def test_should_be_able_to_create_partially_paid_order_core_0112(
         permission_manage_orders,
         permission_manage_checkouts,
         permission_manage_payments,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    (
-        channel_slug,
-        warehouse_id,
-        channel_id,
-        shipping_method_id,
-    ) = create_shop_for_orders_without_payments(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+        allow_unpaid_orders=True,
+    )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    shipping_method_id = shop_data["shipping_method_id"]
+
     app_permissions = [permission_manage_payments]
     assign_permissions(e2e_app_api_client, app_permissions)
 

--- a/saleor/tests/e2e/checkout/test_checkout_create_partially_paid_order.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_partially_paid_order.py
@@ -16,37 +16,36 @@ def test_should_be_able_to_create_partially_paid_order_core_0112(
     e2e_staff_api_client,
     e2e_not_logged_api_client,
     e2e_app_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_orders,
     permission_manage_checkouts,
     permission_manage_payments,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
         permission_manage_payments,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
+    channel_config = [
+        {
+            "order_settings": {
+                "allowUnpaidOrders": True,
+            }
+        }
+    ]
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        allow_unpaid_orders=True,
+        channels_settings=channel_config,
     )
-    warehouse_id = shop_data["warehouse_id"]
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     app_permissions = [permission_manage_payments]
     assign_permissions(e2e_app_api_client, app_permissions)
@@ -85,7 +84,6 @@ def test_should_be_able_to_create_partially_paid_order_core_0112(
     assert checkout_data["isShippingRequired"] is True
     assert checkout_data["deliveryMethod"] is None
     assert checkout_data["shippingMethod"] is None
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     # Step 2 - Set shipping address and DeliveryMethod for checkout
     checkout_data = checkout_delivery_method_update(

--- a/saleor/tests/e2e/checkout/test_checkout_create_partially_paid_order.py
+++ b/saleor/tests/e2e/checkout/test_checkout_create_partially_paid_order.py
@@ -31,21 +31,30 @@ def test_should_be_able_to_create_partially_paid_order_core_0112(
         permission_manage_payments,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    channel_config = [
-        {
-            "order_settings": {
-                "allowUnpaidOrders": True,
-            }
-        }
-    ]
-    shop_data = prepare_shop(
+
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        channels_settings=channel_config,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [{}],
+                    },
+                ],
+                "order_settings": {
+                    "allowUnpaidOrders": True,
+                },
+            }
+        ],
+        shop_settings={
+            "fulfillmentAutoApprove": True,
+            "fulfillmentAllowUnpaid": True,
+        },
     )
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
 
     app_permissions = [permission_manage_payments]
     assign_permissions(e2e_app_api_client, app_permissions)

--- a/saleor/tests/e2e/checkout/test_checkout_should_be_able_to_remove_shipping_method.py
+++ b/saleor/tests/e2e/checkout/test_checkout_should_be_able_to_remove_shipping_method.py
@@ -16,6 +16,8 @@ def test_checkout_should_be_able_to_remove_shipping_method_CORE_0115(
     permission_manage_shipping,
     permission_manage_orders,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -25,15 +27,17 @@ def test_checkout_should_be_able_to_remove_shipping_method_CORE_0115(
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_checkout_should_be_able_to_remove_shipping_method.py
+++ b/saleor/tests/e2e/checkout/test_checkout_should_be_able_to_remove_shipping_method.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import checkout_create, checkout_delivery_method_update
 
@@ -24,11 +24,11 @@ def test_checkout_should_be_able_to_remove_shipping_method_CORE_0115(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_checkout_should_be_able_to_remove_shipping_method.py
+++ b/saleor/tests/e2e/checkout/test_checkout_should_be_able_to_remove_shipping_method.py
@@ -10,34 +10,25 @@ from .utils import checkout_create, checkout_delivery_method_update
 def test_checkout_should_be_able_to_remove_shipping_method_CORE_0115(
     e2e_staff_api_client,
     e2e_not_logged_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_orders,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    warehouse_id = shop_data["warehouse_id"]
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     variant_price = 10
 
@@ -69,7 +60,6 @@ def test_checkout_should_be_able_to_remove_shipping_method_CORE_0115(
     )
     checkout_id = checkout_data["id"]
     assert checkout_data["shippingMethods"] != []
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     assert checkout_data["isShippingRequired"] is True
     assert checkout_data["deliveryMethod"] is None
     total_gross_amount = checkout_data["totalPrice"]["gross"]["amount"]

--- a/saleor/tests/e2e/checkout/test_checkout_unable_to_make_purchase_with_no_payment.py
+++ b/saleor/tests/e2e/checkout/test_checkout_unable_to_make_purchase_with_no_payment.py
@@ -18,6 +18,8 @@ def test_should_not_be_able_to_make_purchase_with_no_payment_CORE_0113(
     permission_manage_channels,
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -25,15 +27,18 @@ def test_should_not_be_able_to_make_purchase_with_no_payment_CORE_0113(
         permission_manage_channels,
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+
     variant_price = 10
 
     (

--- a/saleor/tests/e2e/checkout/test_checkout_unable_to_make_purchase_with_no_payment.py
+++ b/saleor/tests/e2e/checkout/test_checkout_unable_to_make_purchase_with_no_payment.py
@@ -14,30 +14,21 @@ from .utils import (
 def test_should_not_be_able_to_make_purchase_with_no_payment_CORE_0113(
     e2e_staff_api_client,
     e2e_not_logged_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    warehouse_id = shop_data["warehouse_id"]
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     variant_price = 10
 
@@ -72,7 +63,6 @@ def test_should_not_be_able_to_make_purchase_with_no_payment_CORE_0113(
     assert checkout_data["isShippingRequired"] is True
     assert checkout_data["deliveryMethod"] is None
     assert checkout_data["shippingMethod"] is None
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     # Step 2 - Set shipping address and DeliveryMethod for checkout
 

--- a/saleor/tests/e2e/checkout/test_checkout_unable_to_make_purchase_with_no_payment.py
+++ b/saleor/tests/e2e/checkout/test_checkout_unable_to_make_purchase_with_no_payment.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     checkout_create,
@@ -24,11 +24,11 @@ def test_should_not_be_able_to_make_purchase_with_no_payment_CORE_0113(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_checkout_use_multiple_gift_cards.py
+++ b/saleor/tests/e2e/checkout/test_checkout_use_multiple_gift_cards.py
@@ -45,6 +45,8 @@ def test_use_multiple_gift_cards_in_checkout_core_1105(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_gift_card,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -53,15 +55,17 @@ def test_use_multiple_gift_cards_in_checkout_core_1105(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_gift_card,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/test_checkout_use_multiple_gift_cards.py
+++ b/saleor/tests/e2e/checkout/test_checkout_use_multiple_gift_cards.py
@@ -40,32 +40,23 @@ def prepare_gift_cards(
 def test_use_multiple_gift_cards_in_checkout_core_1105(
     e2e_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_gift_card,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_gift_card,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    warehouse_id = shop_data["warehouse_id"]
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -102,7 +93,6 @@ def test_use_multiple_gift_cards_in_checkout_core_1105(
         set_default_shipping_address=True,
     )
     checkout_id = checkout_data["id"]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     assert checkout_data["isShippingRequired"] is True
     calculated_subtotal = product_variant_price * 4
     assert checkout_data["totalPrice"]["gross"]["amount"] == calculated_subtotal

--- a/saleor/tests/e2e/checkout/test_checkout_use_multiple_gift_cards.py
+++ b/saleor/tests/e2e/checkout/test_checkout_use_multiple_gift_cards.py
@@ -2,7 +2,7 @@ import pytest
 
 from ..gift_cards.utils import bulk_create_gift_card
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     checkout_add_promo_code,
@@ -52,11 +52,11 @@ def test_use_multiple_gift_cards_in_checkout_core_1105(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/test_checkout_with_shipping_method_with_min_order_value.py
+++ b/saleor/tests/e2e/checkout/test_checkout_with_shipping_method_with_min_order_value.py
@@ -2,19 +2,13 @@ import base64
 
 import pytest
 
-from ..channel.utils import create_channel
 from ..product.utils import (
     create_product_variant,
     create_product_variant_channel_listing,
 )
 from ..product.utils.preparing_product import prepare_product
-from ..shipping_zone.utils import (
-    create_shipping_method,
-    create_shipping_method_channel_listing,
-    create_shipping_zone,
-)
+from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
-from ..warehouse.utils import create_warehouse
 from .utils import checkout_create, checkout_delivery_method_update
 
 
@@ -27,35 +21,6 @@ def decode_base64_and_get_last_3_chars(encoded_string):
     return decoded_string[-2:]
 
 
-def prepare_shop_with_shipping_method_with_min_order_value(
-    e2e_staff_api_client,
-):
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-    channel_slug = "test"
-    warehouse_ids = [warehouse_id]
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        slug=channel_slug,
-        warehouse_ids=warehouse_ids,
-    )
-    channel_id = channel_data["id"]
-    channel_ids = [channel_id]
-    shipping_zone_data = create_shipping_zone(
-        e2e_staff_api_client,
-        warehouse_ids=warehouse_ids,
-        channel_ids=channel_ids,
-    )
-    shipping_zone_id = shipping_zone_data["id"]
-
-    return (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_zone_id,
-    )
-
-
 @pytest.mark.e2e
 def test_checkout_with_shipping_method_with_min_order_value_CORE_0501(
     e2e_not_logged_api_client,
@@ -65,6 +30,8 @@ def test_checkout_with_shipping_method_with_min_order_value_CORE_0501(
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -73,17 +40,19 @@ def test_checkout_with_shipping_method_with_min_order_value_CORE_0501(
         permission_manage_product_types_and_attributes,
         permission_manage_shipping,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
 
     assign_permissions(e2e_staff_api_client, permissions)
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_zone_id,
-    ) = prepare_shop_with_shipping_method_with_min_order_value(
+    shop_data = prepare_shop(
         e2e_staff_api_client,
+        minimum_order_price=20.0,
     )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     first_variant_price = 25
 
@@ -118,25 +87,7 @@ def test_checkout_with_shipping_method_with_min_order_value_CORE_0501(
         second_variant_price,
     )
 
-    # Step 1 - Create shipping method with minimal order value
-    minimum_order_price = 20.0
-    shipping_method_data = create_shipping_method(
-        e2e_staff_api_client, shipping_zone_id
-    )
-    shipping_method_id = shipping_method_data["id"]
-    data = create_shipping_method_channel_listing(
-        e2e_staff_api_client,
-        shipping_method_id,
-        channel_id,
-        price="5.00",
-        minimumOrderPrice=minimum_order_price,
-    )
-    shipping_method_min_order_value = data["channelListings"][0]["minimumOrderPrice"][
-        "amount"
-    ]
-    assert shipping_method_min_order_value == minimum_order_price
-
-    # Step 2 - Create checkout with the first product variant
+    # Step 1 - Create checkout with the first product variant
     lines = [
         {
             "variantId": first_product_variant_id,

--- a/saleor/tests/e2e/checkout/test_checkout_with_shipping_method_with_min_order_value.py
+++ b/saleor/tests/e2e/checkout/test_checkout_with_shipping_method_with_min_order_value.py
@@ -26,18 +26,26 @@ def test_checkout_with_shipping_method_with_min_order_value_CORE_0501(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shipping_method_channel_listing_settings = {
-        "minimumOrderPrice": 20.0,
-    }
-
-    shop_data = prepare_shop(
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        shipping_method_channel_listing_settings=shipping_method_channel_listing_settings,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [
+                            {"add_channels": {"minimum_order_price": 20.0}}
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            }
+        ],
+        shop_settings={},
     )
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
 
     first_variant_price = 25
 

--- a/saleor/tests/e2e/checkout/test_checkout_with_shipping_method_with_min_order_value.py
+++ b/saleor/tests/e2e/checkout/test_checkout_with_shipping_method_with_min_order_value.py
@@ -1,5 +1,3 @@
-import base64
-
 import pytest
 
 from ..product.utils import (
@@ -12,47 +10,34 @@ from ..utils import assign_permissions
 from .utils import checkout_create, checkout_delivery_method_update
 
 
-#  Please note: decoding won't be necessary once
-# https://github.com/saleor/saleor/issues/13675 is fixed
-def decode_base64_and_get_last_3_chars(encoded_string):
-    base64_bytes = encoded_string.encode("ascii")
-    decoded_bytes = base64.b64decode(base64_bytes)
-    decoded_string = decoded_bytes.decode("ascii")
-    return decoded_string[-2:]
-
-
 @pytest.mark.e2e
 def test_checkout_with_shipping_method_with_min_order_value_CORE_0501(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
-        permission_manage_shipping,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
-
     assign_permissions(e2e_staff_api_client, permissions)
+
+    shipping_method_channel_listing_settings = {
+        "minimumOrderPrice": 20.0,
+    }
+
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        minimum_order_price=20.0,
+        shipping_method_channel_listing_settings=shipping_method_channel_listing_settings,
     )
-    warehouse_id = shop_data["warehouse_id"]
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     first_variant_price = 25
 
@@ -106,11 +91,7 @@ def test_checkout_with_shipping_method_with_min_order_value_CORE_0501(
 
     assert checkout_data["isShippingRequired"] is True
     checkout_shipping_method = checkout_data["shippingMethods"][0]["id"]
-    decoded_checkout_shipping_method = decode_base64_and_get_last_3_chars(
-        checkout_shipping_method
-    )
-    decoded_shipping_method = decode_base64_and_get_last_3_chars(shipping_method_id)
-    assert decoded_checkout_shipping_method == decoded_shipping_method
+    assert checkout_shipping_method == shipping_method_id
 
     # Step 2 - Set DeliveryMethod for the checkout with the first product variant
     checkout_data = checkout_delivery_method_update(

--- a/saleor/tests/e2e/checkout/test_guest_checkout_should_be_assigned_to_user_after_creating_the_account.py
+++ b/saleor/tests/e2e/checkout/test_guest_checkout_should_be_assigned_to_user_after_creating_the_account.py
@@ -2,7 +2,6 @@ import pytest
 
 from ..account.utils import account_register
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils import update_shop_settings
 from ..shop.utils.preparing_shop import prepare_shop
 from ..users.utils import customer_update, get_user
 from ..utils import assign_permissions
@@ -28,6 +27,7 @@ def test_guest_checkout_should_be_assigned_to_user_after_creating_the_account_CO
     permission_manage_users,
     permission_manage_settings,
     permission_manage_payments,
+    permission_manage_taxes,
 ):
     # Before
     permissions = [
@@ -40,6 +40,7 @@ def test_guest_checkout_should_be_assigned_to_user_after_creating_the_account_CO
         permission_manage_users,
         permission_manage_settings,
         permission_manage_payments,
+        permission_manage_taxes,
     ]
     assign_permissions(
         app_api_client,
@@ -51,17 +52,14 @@ def test_guest_checkout_should_be_assigned_to_user_after_creating_the_account_CO
     )
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
-
-    input_data = {
-        "enableAccountConfirmationByEmail": False,
-    }
-    update_shop_settings(e2e_staff_api_client, input_data)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+        enable_account_confirmation_by_email=False,
+    )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_guest_checkout_should_be_assigned_to_user_after_creating_the_account.py
+++ b/saleor/tests/e2e/checkout/test_guest_checkout_should_be_assigned_to_user_after_creating_the_account.py
@@ -44,17 +44,26 @@ def test_guest_checkout_should_be_assigned_to_user_after_creating_the_account_CO
     )
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_settings = {
-        "enableAccountConfirmationByEmail": False,
-    }
-    shop_data = prepare_shop(
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        shop_settings_update=shop_settings,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [{}],
+                    },
+                ],
+                "order_settings": {},
+            }
+        ],
+        shop_settings={
+            "enableAccountConfirmationByEmail": False,
+        },
     )
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_guest_checkout_should_be_assigned_to_user_after_creating_the_account.py
+++ b/saleor/tests/e2e/checkout/test_guest_checkout_should_be_assigned_to_user_after_creating_the_account.py
@@ -18,29 +18,21 @@ def test_guest_checkout_should_be_assigned_to_user_after_creating_the_account_CO
     e2e_staff_api_client,
     app_api_client,
     e2e_not_logged_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_orders,
     permission_manage_checkouts,
     permission_manage_users,
-    permission_manage_settings,
     permission_manage_payments,
-    permission_manage_taxes,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
         permission_manage_users,
-        permission_manage_settings,
         permission_manage_payments,
-        permission_manage_taxes,
     ]
     assign_permissions(
         app_api_client,
@@ -52,14 +44,17 @@ def test_guest_checkout_should_be_assigned_to_user_after_creating_the_account_CO
     )
     assign_permissions(e2e_staff_api_client, permissions)
 
+    shop_settings = {
+        "enableAccountConfirmationByEmail": False,
+    }
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        enable_account_confirmation_by_email=False,
+        shop_settings_update=shop_settings,
     )
-    warehouse_id = shop_data["warehouse_id"]
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     variant_price = 10
 
@@ -93,7 +88,6 @@ def test_guest_checkout_should_be_assigned_to_user_after_creating_the_account_CO
     checkout_id = checkout_data["id"]
 
     assert checkout_data["isShippingRequired"] is True
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     assert checkout_data["deliveryMethod"] is None
 
     # Step 2 - Set DeliveryMethod for checkout

--- a/saleor/tests/e2e/checkout/test_guest_checkout_should_be_associated_with_user_account.py
+++ b/saleor/tests/e2e/checkout/test_guest_checkout_should_be_associated_with_user_account.py
@@ -39,6 +39,7 @@ def test_guest_checkout_should_be_associated_with_user_account_CORE_1517(
     permission_manage_checkouts,
     permission_manage_users,
     permission_manage_settings,
+    permission_manage_taxes,
 ):
     # Before
     permissions = [
@@ -50,15 +51,17 @@ def test_guest_checkout_should_be_associated_with_user_account_CORE_1517(
         permission_manage_checkouts,
         permission_manage_users,
         permission_manage_settings,
+        permission_manage_taxes,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_guest_checkout_should_be_associated_with_user_account.py
+++ b/saleor/tests/e2e/checkout/test_guest_checkout_should_be_associated_with_user_account.py
@@ -31,37 +31,27 @@ def create_active_customer(
 def test_guest_checkout_should_be_associated_with_user_account_CORE_1517(
     e2e_staff_api_client,
     e2e_not_logged_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_orders,
     permission_manage_checkouts,
     permission_manage_users,
-    permission_manage_settings,
-    permission_manage_taxes,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
         permission_manage_users,
-        permission_manage_settings,
-        permission_manage_taxes,
+        *shop_permissions,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    warehouse_id = shop_data["warehouse_id"]
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     variant_price = 10
 
@@ -96,7 +86,6 @@ def test_guest_checkout_should_be_associated_with_user_account_CORE_1517(
     checkout_id = checkout_data["id"]
 
     assert checkout_data["isShippingRequired"] is True
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     assert checkout_data["deliveryMethod"] is None
 
     # Step 2 - Set DeliveryMethod for checkout

--- a/saleor/tests/e2e/checkout/test_guest_checkout_should_be_associated_with_user_account.py
+++ b/saleor/tests/e2e/checkout/test_guest_checkout_should_be_associated_with_user_account.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..users.utils import create_customer, get_user
 from ..utils import assign_permissions
 from .utils import (
@@ -47,11 +47,11 @@ def test_guest_checkout_should_be_associated_with_user_account_CORE_1517(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_logged_customer_is_unable_to_buy_more_products_than_the_limit_per_customer.py
+++ b/saleor/tests/e2e/checkout/test_logged_customer_is_unable_to_buy_more_products_than_the_limit_per_customer.py
@@ -14,12 +14,12 @@ from .utils import checkout_create, checkout_lines_update
 
 
 def prepare_product_with_limit(e2e_staff_api_client):
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -83,6 +83,8 @@ def test_checkout_with_product_quantity_exceeding_the_limit_per_customer_core_01
     permission_manage_channels,
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -90,6 +92,8 @@ def test_checkout_with_product_quantity_exceeding_the_limit_per_customer_core_01
         permission_manage_channels,
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     (

--- a/saleor/tests/e2e/checkout/test_logged_customer_is_unable_to_buy_more_products_than_the_limit_per_customer.py
+++ b/saleor/tests/e2e/checkout/test_logged_customer_is_unable_to_buy_more_products_than_the_limit_per_customer.py
@@ -8,16 +8,16 @@ from ..product.utils import (
     create_product_variant,
     create_product_variant_channel_listing,
 )
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import checkout_create, checkout_lines_update
 
 
 def prepare_product_with_limit(e2e_staff_api_client):
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/checkout/test_logged_customer_is_unable_to_buy_more_products_than_the_limit_per_customer.py
+++ b/saleor/tests/e2e/checkout/test_logged_customer_is_unable_to_buy_more_products_than_the_limit_per_customer.py
@@ -14,12 +14,10 @@ from .utils import checkout_create, checkout_lines_update
 
 
 def prepare_product_with_limit(e2e_staff_api_client):
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -79,21 +77,13 @@ def prepare_product_with_limit(e2e_staff_api_client):
 def test_checkout_with_product_quantity_exceeding_the_limit_per_customer_core_0110(
     e2e_staff_api_client,
     e2e_logged_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     (

--- a/saleor/tests/e2e/checkout/test_logged_in_customer_should_be_able_to_order_physical_product.py
+++ b/saleor/tests/e2e/checkout/test_logged_in_customer_should_be_able_to_order_physical_product.py
@@ -21,6 +21,8 @@ def test_process_checkout_with_physical_product_CORE_0103(
     permission_manage_shipping,
     permission_manage_orders,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -30,15 +32,17 @@ def test_process_checkout_with_physical_product_CORE_0103(
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_logged_in_customer_should_be_able_to_order_physical_product.py
+++ b/saleor/tests/e2e/checkout/test_logged_in_customer_should_be_able_to_order_physical_product.py
@@ -15,34 +15,25 @@ from .utils import (
 def test_process_checkout_with_physical_product_CORE_0103(
     e2e_staff_api_client,
     e2e_logged_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     variant_price = 10
 
@@ -76,7 +67,6 @@ def test_process_checkout_with_physical_product_CORE_0103(
     assert checkout_data["user"]["email"] == expected_email
     assert checkout_data["isShippingRequired"] is True
     assert checkout_data["shippingMethods"] != []
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     # Step 3 - Set DeliveryMethod for checkout.
     checkout_data = checkout_delivery_method_update(

--- a/saleor/tests/e2e/checkout/test_logged_in_customer_should_be_able_to_order_physical_product.py
+++ b/saleor/tests/e2e/checkout/test_logged_in_customer_should_be_able_to_order_physical_product.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     checkout_complete,
@@ -29,11 +29,12 @@ def test_process_checkout_with_physical_product_CORE_0103(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_logged_in_customer_should_not_be_able_to_buy_unavailable_product.py
+++ b/saleor/tests/e2e/checkout/test_logged_in_customer_should_not_be_able_to_buy_unavailable_product.py
@@ -16,12 +16,12 @@ from .utils import raw_checkout_create
 def prepare_unavailable_product(
     e2e_staff_api_client,
 ):
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -83,6 +83,8 @@ def test_should_not_be_able_to_buy_unavailable_product_core_0108(
     permission_manage_channels,
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -90,6 +92,8 @@ def test_should_not_be_able_to_buy_unavailable_product_core_0108(
         permission_manage_channels,
         permission_manage_product_types_and_attributes,
         permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
 
     assign_permissions(e2e_staff_api_client, permissions)

--- a/saleor/tests/e2e/checkout/test_logged_in_customer_should_not_be_able_to_buy_unavailable_product.py
+++ b/saleor/tests/e2e/checkout/test_logged_in_customer_should_not_be_able_to_buy_unavailable_product.py
@@ -8,7 +8,7 @@ from ..product.utils import (
     create_product_variant_channel_listing,
     raw_create_product_channel_listing,
 )
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import raw_checkout_create
 
@@ -16,10 +16,10 @@ from .utils import raw_checkout_create
 def prepare_unavailable_product(
     e2e_staff_api_client,
 ):
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/checkout/test_logged_in_customer_should_not_be_able_to_buy_unavailable_product.py
+++ b/saleor/tests/e2e/checkout/test_logged_in_customer_should_not_be_able_to_buy_unavailable_product.py
@@ -16,12 +16,10 @@ from .utils import raw_checkout_create
 def prepare_unavailable_product(
     e2e_staff_api_client,
 ):
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -79,21 +77,13 @@ def prepare_unavailable_product(
 def test_should_not_be_able_to_buy_unavailable_product_core_0108(
     e2e_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
 
     assign_permissions(e2e_staff_api_client, permissions)

--- a/saleor/tests/e2e/checkout/test_pay_for_part_of_checkout_with_gift_card.py
+++ b/saleor/tests/e2e/checkout/test_pay_for_part_of_checkout_with_gift_card.py
@@ -22,6 +22,8 @@ def test_gift_card_partial_payment_for_checkout_core_1103(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_gift_card,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -30,15 +32,17 @@ def test_gift_card_partial_payment_for_checkout_core_1103(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_gift_card,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/test_pay_for_part_of_checkout_with_gift_card.py
+++ b/saleor/tests/e2e/checkout/test_pay_for_part_of_checkout_with_gift_card.py
@@ -17,32 +17,23 @@ from .utils import (
 def test_gift_card_partial_payment_for_checkout_core_1103(
     e2e_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_gift_card,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_gift_card,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -77,7 +68,6 @@ def test_gift_card_partial_payment_for_checkout_core_1103(
         set_default_shipping_address=True,
     )
     checkout_id = checkout_data["id"]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     assert checkout_data["isShippingRequired"] is True
     calculated_subtotal = float(product_variant_price * 4)
     assert checkout_data["totalPrice"]["gross"]["amount"] == calculated_subtotal

--- a/saleor/tests/e2e/checkout/test_pay_for_part_of_checkout_with_gift_card.py
+++ b/saleor/tests/e2e/checkout/test_pay_for_part_of_checkout_with_gift_card.py
@@ -2,7 +2,7 @@ import pytest
 
 from ..gift_cards.utils import create_gift_card
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     checkout_add_promo_code,
@@ -29,11 +29,11 @@ def test_gift_card_partial_payment_for_checkout_core_1103(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/test_pay_for_total_checkout_with_gift_card.py
+++ b/saleor/tests/e2e/checkout/test_pay_for_total_checkout_with_gift_card.py
@@ -22,6 +22,8 @@ def test_gift_card_total_payment_for_checkout_core_1101(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_gift_card,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -30,15 +32,17 @@ def test_gift_card_total_payment_for_checkout_core_1101(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_gift_card,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/test_pay_for_total_checkout_with_gift_card.py
+++ b/saleor/tests/e2e/checkout/test_pay_for_total_checkout_with_gift_card.py
@@ -17,32 +17,23 @@ from .utils import (
 def test_gift_card_total_payment_for_checkout_core_1101(
     e2e_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_gift_card,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_gift_card,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -74,7 +65,6 @@ def test_gift_card_total_payment_for_checkout_core_1101(
         set_default_shipping_address=True,
     )
     checkout_id = checkout_data["id"]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
     assert checkout_data["isShippingRequired"] is True
     assert checkout_data["totalPrice"]["gross"]["amount"] == float(
         product_variant_price * 3

--- a/saleor/tests/e2e/checkout/test_pay_for_total_checkout_with_gift_card.py
+++ b/saleor/tests/e2e/checkout/test_pay_for_total_checkout_with_gift_card.py
@@ -2,7 +2,7 @@ import pytest
 
 from ..gift_cards.utils import create_gift_card
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     checkout_add_promo_code,
@@ -29,11 +29,11 @@ def test_gift_card_total_payment_for_checkout_core_1101(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_is_unable_to_buy_unpublished_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_is_unable_to_buy_unpublished_product.py
@@ -16,12 +16,12 @@ from .utils import raw_checkout_create
 def prepare_unpublished_product(
     e2e_staff_api_client,
 ):
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -77,6 +77,8 @@ def test_unlogged_customer_is_unable_to_buy_unpublished_product_core_0109(
     permission_manage_channels,
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -84,6 +86,8 @@ def test_unlogged_customer_is_unable_to_buy_unpublished_product_core_0109(
         permission_manage_channels,
         permission_manage_product_types_and_attributes,
         permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     (

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_is_unable_to_buy_unpublished_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_is_unable_to_buy_unpublished_product.py
@@ -16,12 +16,10 @@ from .utils import raw_checkout_create
 def prepare_unpublished_product(
     e2e_staff_api_client,
 ):
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -73,21 +71,13 @@ def prepare_unpublished_product(
 def test_unlogged_customer_is_unable_to_buy_unpublished_product_core_0109(
     e2e_staff_api_client,
     e2e_not_logged_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     (

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_is_unable_to_buy_unpublished_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_is_unable_to_buy_unpublished_product.py
@@ -8,7 +8,7 @@ from ..product.utils import (
     create_product_variant_channel_listing,
     raw_create_product_channel_listing,
 )
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import raw_checkout_create
 
@@ -16,10 +16,10 @@ from .utils import raw_checkout_create
 def prepare_unpublished_product(
     e2e_staff_api_client,
 ):
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_buy_by_click_and_collect.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_buy_by_click_and_collect.py
@@ -1,36 +1,14 @@
 import pytest
 
-from ..channel.utils import create_channel
 from ..product.utils.preparing_product import prepare_product
+from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
-from ..warehouse.utils import create_warehouse, update_warehouse
 from .utils import (
     checkout_complete,
     checkout_create,
     checkout_delivery_method_update,
     checkout_dummy_payment_create,
 )
-
-
-def prepare_shop_click_and_collect(
-    e2e_staff_api_client,
-):
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-    update_warehouse(
-        e2e_staff_api_client,
-        warehouse_data["id"],
-        is_private=False,
-        click_and_collect_option="LOCAL",
-    )
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        warehouse_data["id"],
-    )
-    channel_id = channel_data["id"]
-    channel_slug = channel_data["slug"]
-
-    return channel_id, channel_slug, warehouse_id
 
 
 @pytest.mark.e2e
@@ -40,22 +18,28 @@ def test_unlogged_customer_buy_by_click_and_collect_CORE_0105(
     permission_manage_products,
     permission_manage_channels,
     permission_manage_product_types_and_attributes,
+    permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
         permission_manage_products,
         permission_manage_channels,
         permission_manage_product_types_and_attributes,
+        permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
 
     assign_permissions(e2e_staff_api_client, permissions)
-    (
-        channel_id,
-        channel_slug,
-        warehouse_id,
-    ) = prepare_shop_click_and_collect(
+    shop_data = prepare_shop(
         e2e_staff_api_client,
+        click_and_collect_option="LOCAL",
     )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_buy_by_click_and_collect.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_buy_by_click_and_collect.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from ..warehouse.utils import update_warehouse
 from .utils import (
@@ -26,12 +26,11 @@ def test_unlogged_customer_buy_by_click_and_collect_CORE_0105(
     ]
 
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
     update_warehouse(
         e2e_staff_api_client,
         warehouse_id,

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_buy_by_click_and_collect.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_buy_by_click_and_collect.py
@@ -3,6 +3,7 @@ import pytest
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
+from ..warehouse.utils import update_warehouse
 from .utils import (
     checkout_complete,
     checkout_create,
@@ -15,32 +16,28 @@ from .utils import (
 def test_unlogged_customer_buy_by_click_and_collect_CORE_0105(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
         permission_manage_product_types_and_attributes,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
 
     assign_permissions(e2e_staff_api_client, permissions)
     shop_data = prepare_shop(
         e2e_staff_api_client,
+    )
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    update_warehouse(
+        e2e_staff_api_client,
+        warehouse_id,
+        is_private=False,
         click_and_collect_option="LOCAL",
     )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
-
     variant_price = 10
 
     (

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
@@ -22,12 +22,12 @@ from .utils import (
 def prepare_product(
     e2e_staff_api_client,
 ):
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -81,6 +81,8 @@ def test_process_checkout_with_digital_product_CORE_0101(
     permission_manage_channels,
     permission_manage_products,
     permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -88,6 +90,8 @@ def test_process_checkout_with_digital_product_CORE_0101(
         permission_manage_channels,
         permission_manage_products,
         permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     product_variant_id, channel_slug = prepare_product(

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
@@ -9,7 +9,7 @@ from ..product.utils import (
     create_product_variant,
     create_product_variant_channel_listing,
 )
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     checkout_billing_address_update,
@@ -22,10 +22,10 @@ from .utils import (
 def prepare_product(
     e2e_staff_api_client,
 ):
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_digital_product.py
@@ -22,12 +22,10 @@ from .utils import (
 def prepare_product(
     e2e_staff_api_client,
 ):
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -78,20 +76,12 @@ def test_process_checkout_with_digital_product_CORE_0101(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
     permission_manage_product_types_and_attributes,
-    permission_manage_channels,
-    permission_manage_products,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
         permission_manage_product_types_and_attributes,
-        permission_manage_channels,
-        permission_manage_products,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     product_variant_id, channel_slug = prepare_product(

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
@@ -22,6 +22,8 @@ def test_process_checkout_with_physical_product_CORE_0102(
     permission_manage_shipping,
     permission_manage_orders,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -31,15 +33,17 @@ def test_process_checkout_with_physical_product_CORE_0102(
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
@@ -16,34 +16,25 @@ from .utils import (
 def test_process_checkout_with_physical_product_CORE_0102(
     e2e_staff_api_client,
     e2e_not_logged_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     variant_price = 10
 
@@ -85,7 +76,6 @@ def test_process_checkout_with_physical_product_CORE_0102(
         checkout_id,
     )
     assert len(checkout_data["shippingMethods"]) == 1
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     # Step 3 - Set DeliveryMethod for checkout.
     checkout_data = checkout_delivery_method_update(

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_be_able_to_order_physical_product.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     checkout_complete,
@@ -30,11 +30,12 @@ def test_process_checkout_with_physical_product_CORE_0102(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_buy_product_without_shipping_option.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_buy_product_without_shipping_option.py
@@ -20,10 +20,23 @@ def test_unlogged_customer_unable_to_buy_product_without_shipping_option_CORE_01
     ]
 
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_data = prepare_shop(e2e_staff_api_client, shipping_methods=[])
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [],
+                    },
+                ],
+                "order_settings": {},
+            }
+        ],
+        shop_settings={},
+    )
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    warehouse_id = shop_data[0]["warehouse_id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_buy_product_without_shipping_option.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_buy_product_without_shipping_option.py
@@ -10,32 +10,20 @@ from .utils import checkout_create, raw_checkout_dummy_payment_create
 def test_unlogged_customer_unable_to_buy_product_without_shipping_option_CORE_0106(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
         permission_manage_product_types_and_attributes,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
 
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-        shipping_zones_structure=[{"countries": ["US"], "num_shipping_methods": 0}],
-    )
-
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client, shipping_methods=[])
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     variant_price = 10
 

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_order_product_quantity_greater_than_stock.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_order_product_quantity_greater_than_stock.py
@@ -16,12 +16,12 @@ from .utils import raw_checkout_create
 def prepare_product(
     e2e_staff_api_client,
 ):
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -86,6 +86,8 @@ def test_unlogged_customer_cannot_buy_product_in_quantity_grater_than_stock_core
     permission_manage_channels,
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -93,6 +95,8 @@ def test_unlogged_customer_cannot_buy_product_in_quantity_grater_than_stock_core
         permission_manage_channels,
         permission_manage_product_types_and_attributes,
         permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     (

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_order_product_quantity_greater_than_stock.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_order_product_quantity_greater_than_stock.py
@@ -16,12 +16,10 @@ from .utils import raw_checkout_create
 def prepare_product(
     e2e_staff_api_client,
 ):
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -82,21 +80,13 @@ def prepare_product(
 def test_unlogged_customer_cannot_buy_product_in_quantity_grater_than_stock_core_0107(
     e2e_not_logged_api_client,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
         permission_manage_product_types_and_attributes,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     (

--- a/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_order_product_quantity_greater_than_stock.py
+++ b/saleor/tests/e2e/checkout/test_unlogged_customer_should_not_be_able_to_order_product_quantity_greater_than_stock.py
@@ -8,7 +8,7 @@ from ..product.utils import (
     create_product_variant_channel_listing,
     raw_create_product_variant,
 )
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import raw_checkout_create
 
@@ -16,10 +16,11 @@ from .utils import raw_checkout_create
 def prepare_product(
     e2e_staff_api_client,
 ):
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/checkout/utils/checkout_create.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_create.py
@@ -72,6 +72,9 @@ mutation CreateCheckout($input: CheckoutCreateInput!) {
           gross {
             amount
           }
+          tax {
+            amount
+          }
         }
         undiscountedUnitPrice {
           amount

--- a/saleor/tests/e2e/checkout/utils/checkout_create.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_create.py
@@ -19,7 +19,6 @@ mutation CreateCheckout($input: CheckoutCreateInput!) {
       channel {
         slug
       }
-      isShippingRequired
       totalPrice {
         gross {
           amount
@@ -33,6 +32,16 @@ mutation CreateCheckout($input: CheckoutCreateInput!) {
       }
       created
       isShippingRequired
+      billingAddress {
+        country {
+          code
+        }
+      }
+      shippingAddress {
+        country {
+          code
+        }
+      }
       shippingMethods {
         id
       }

--- a/saleor/tests/e2e/checkout/utils/checkout_delivery_method_update.py
+++ b/saleor/tests/e2e/checkout/utils/checkout_delivery_method_update.py
@@ -28,10 +28,8 @@ mutation checkoutDeliveryMethodUpdate($checkoutId: ID!, $deliveryMethodId: ID) {
         gross {
           amount
         }
-      }
-      shippingPrice{
-        gross {
-        amount
+        tax {
+          amount
         }
       }
       shippingMethods {

--- a/saleor/tests/e2e/checkout/utils/query_checkout.py
+++ b/saleor/tests/e2e/checkout/utils/query_checkout.py
@@ -30,6 +30,17 @@ query Checkout($checkoutId: ID!){
         amount
       }
     }
+    shippingPrice {
+      tax {
+        amount
+      }
+      net {
+        amount
+      }
+      gross {
+        amount
+      }
+    }
   }
 }
 """

--- a/saleor/tests/e2e/orders/discounts/test_apply_better_promotion_to_product.py
+++ b/saleor/tests/e2e/orders/discounts/test_apply_better_promotion_to_product.py
@@ -67,6 +67,8 @@ def test_apply_best_promotion_to_product_core_2105(
     permission_manage_discounts,
     permission_manage_orders,
     permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -76,19 +78,21 @@ def test_apply_best_promotion_to_product_core_2105(
         permission_manage_discounts,
         permission_manage_orders,
         permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    (
-        result_warehouse_id,
-        result_channel_id,
-        result_channel_slug,
-        _,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     product_id, product_variant_id, product_variant_price = prepare_product(
         e2e_staff_api_client,
-        result_warehouse_id,
-        result_channel_id,
+        warehouse_id,
+        channel_id,
         variant_price,
     )
 
@@ -102,7 +106,7 @@ def test_apply_best_promotion_to_product_core_2105(
         first_discount_type,
         first_discount_value,
         first_rule_name,
-        result_channel_id,
+        channel_id,
         product_id,
     )
 
@@ -116,12 +120,12 @@ def test_apply_best_promotion_to_product_core_2105(
         second_discount_type,
         second_discount_value,
         second_rule_name,
-        result_channel_id,
+        channel_id,
         product_id,
     )
 
     # Step 1 - Get product and check if it is on promotion
-    product_data = get_product(e2e_staff_api_client, product_id, result_channel_slug)
+    product_data = get_product(e2e_staff_api_client, product_id, channel_slug)
 
     assert product_data["pricing"]["onSale"] is True
 
@@ -136,7 +140,7 @@ def test_apply_best_promotion_to_product_core_2105(
 
     # Step 2 - Create draft order
     input = {
-        "channelId": result_channel_id,
+        "channelId": channel_id,
         "billingAddress": DEFAULT_ADDRESS,
         "shippingAddress": DEFAULT_ADDRESS,
     }

--- a/saleor/tests/e2e/orders/discounts/test_apply_better_promotion_to_product.py
+++ b/saleor/tests/e2e/orders/discounts/test_apply_better_promotion_to_product.py
@@ -61,33 +61,23 @@ def test_apply_best_promotion_to_product_core_2105(
     second_discount_value,
     expected_discount,
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     product_id, product_variant_id, product_variant_price = prepare_product(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/orders/discounts/test_apply_better_promotion_to_product.py
+++ b/saleor/tests/e2e/orders/discounts/test_apply_better_promotion_to_product.py
@@ -4,7 +4,7 @@ from ... import DEFAULT_ADDRESS
 from ...product.utils import get_product
 from ...product.utils.preparing_product import prepare_product
 from ...promotions.utils import create_promotion, create_promotion_rule
-from ...shop.utils.preparing_shop import prepare_shop
+from ...shop.utils.preparing_shop import prepare_default_shop
 from ...utils import assign_permissions
 from ..utils import draft_order_create, order_lines_create
 
@@ -74,10 +74,11 @@ def test_apply_best_promotion_to_product_core_2105(
         permission_manage_orders,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     product_id, product_variant_id, product_variant_price = prepare_product(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/orders/discounts/test_order_product_with_percentage_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_product_with_percentage_promotion.py
@@ -22,6 +22,8 @@ def test_order_products_on_percentage_promotion_CORE_2103(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     permissions = [
         permission_manage_products,
@@ -30,22 +32,24 @@ def test_order_products_on_percentage_promotion_CORE_2103(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        result_warehouse_id,
-        result_channel_id,
-        _,
-        result_shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         product_id,
         product_variant_id,
         product_variant_price,
     ) = prepare_product(
-        e2e_staff_api_client, result_warehouse_id, result_channel_id, variant_price=20
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=20
     )
 
     promotion_name = "Promotion Fixed"
@@ -65,18 +69,18 @@ def test_order_products_on_percentage_promotion_CORE_2103(
         discount_type,
         discount_value,
         promotion_rule_name,
-        result_channel_id,
+        channel_id,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
-    assert promotion_rule["channels"][0]["id"] == result_channel_id
+    assert promotion_rule["channels"][0]["id"] == channel_id
     assert product_predicate[0] == product_id
 
     # Step 1 - Create a draft order for a product with fixed promotion
     input = {
-        "channelId": result_channel_id,
+        "channelId": channel_id,
         "billingAddress": DEFAULT_ADDRESS,
         "shippingAddress": DEFAULT_ADDRESS,
-        "shippingMethod": result_shipping_method_id,
+        "shippingMethod": shipping_method_id,
     }
     data = draft_order_create(e2e_staff_api_client, input)
     order_id = data["order"]["id"]
@@ -103,7 +107,7 @@ def test_order_products_on_percentage_promotion_CORE_2103(
     assert promotion_reason == f"Promotion: {promotion_id}"
 
     # Step 3 - Add a shipping method to the order
-    input = {"shippingMethod": result_shipping_method_id}
+    input = {"shippingMethod": shipping_method_id}
     draft_update = draft_order_update(e2e_staff_api_client, order_id, input)
     order_shipping_id = draft_update["order"]["deliveryMethod"]["id"]
     shipping_price = draft_update["order"]["shippingPrice"]["gross"]["amount"]

--- a/saleor/tests/e2e/orders/discounts/test_order_product_with_percentage_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_product_with_percentage_promotion.py
@@ -16,33 +16,23 @@ from ..utils import (
 @pytest.mark.e2e
 def test_order_products_on_percentage_promotion_CORE_2103(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_product_with_percentage_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_product_with_percentage_promotion.py
@@ -3,7 +3,7 @@ import pytest
 from ... import DEFAULT_ADDRESS
 from ...product.utils.preparing_product import prepare_product
 from ...promotions.utils import create_promotion, create_promotion_rule
-from ...shop.utils.preparing_shop import prepare_shop
+from ...shop.utils.preparing_shop import prepare_default_shop
 from ...utils import assign_permissions
 from ..utils import (
     draft_order_complete,
@@ -29,10 +29,10 @@ def test_order_products_on_percentage_promotion_CORE_2103(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_from_the_same_category_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_from_the_same_category_on_fixed_promotion.py
@@ -1,7 +1,6 @@
 import pytest
 
 from ... import DEFAULT_ADDRESS
-from ...channel.utils import create_channel
 from ...product.utils import (
     create_category,
     create_product,
@@ -11,13 +10,8 @@ from ...product.utils import (
     create_product_variant_channel_listing,
 )
 from ...promotions.utils import create_promotion, create_promotion_rule
-from ...shipping_zone.utils import (
-    create_shipping_method,
-    create_shipping_method_channel_listing,
-    create_shipping_zone,
-)
+from ...shop.utils import prepare_shop
 from ...utils import assign_permissions
-from ...warehouse.utils import create_warehouse, update_warehouse
 from ..utils import (
     draft_order_complete,
     draft_order_create,
@@ -28,13 +22,10 @@ from ..utils import (
 
 def prepare_product(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_product_types_and_attributes,
-    permission_manage_discounts,
-    permission_manage_orders,
+    warehouse_id,
+    channel_id,
     channel_slug,
+    shipping_method_id,
     variant_price_1,
     variant_price_2,
     promotion_name,
@@ -42,39 +33,6 @@ def prepare_product(
     discount_type,
     promotion_rule_name,
 ):
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-    update_warehouse(
-        e2e_staff_api_client,
-        warehouse_data["id"],
-        is_private=False,
-    )
-    warehouse_ids = [warehouse_id]
-
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        warehouse_ids,
-        slug=channel_slug,
-    )
-    channel_id = channel_data["id"]
-    channel_ids = [channel_id]
-
-    shipping_zone_data = create_shipping_zone(
-        e2e_staff_api_client,
-        warehouse_ids=warehouse_ids,
-        channel_ids=channel_ids,
-    )
-    shipping_zone_id = shipping_zone_data["id"]
-
-    shipping_method_data = create_shipping_method(
-        e2e_staff_api_client, shipping_zone_id
-    )
-    shipping_method_id = shipping_method_data["id"]
-
-    create_shipping_method_channel_listing(
-        e2e_staff_api_client, shipping_method_id, channel_id
-    )
-
     product_type_data = create_product_type(
         e2e_staff_api_client,
     )
@@ -96,7 +54,7 @@ def prepare_product(
 
     stocks = [
         {
-            "warehouse": warehouse_data["id"],
+            "warehouse": warehouse_id,
             "quantity": 5,
         }
     ]
@@ -121,7 +79,7 @@ def prepare_product(
 
     stocks = [
         {
-            "warehouse": warehouse_data["id"],
+            "warehouse": warehouse_id,
             "quantity": 5,
         }
     ]
@@ -177,6 +135,8 @@ def test_order_products_from_category_on_fixed_promotion_CORE_2106(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -186,10 +146,18 @@ def test_order_products_from_category_on_fixed_promotion_CORE_2106(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-
-    channel_slug = "test-channel"
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
     variant_price_1 = "20"
     variant_price_2 = "10"
     promotion_name = "Promotion Fixed"
@@ -204,13 +172,10 @@ def test_order_products_from_category_on_fixed_promotion_CORE_2106(
         promotion_id,
     ) = prepare_product(
         e2e_staff_api_client,
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_product_types_and_attributes,
-        permission_manage_discounts,
-        permission_manage_orders,
+        warehouse_id,
+        channel_id,
         channel_slug,
+        shipping_method_id,
         variant_price_1,
         variant_price_2,
         promotion_name,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_from_the_same_category_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_from_the_same_category_on_fixed_promotion.py
@@ -129,35 +129,24 @@ def prepare_product(
 @pytest.mark.e2e
 def test_order_products_from_category_on_fixed_promotion_CORE_2106(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
     variant_price_1 = "20"
     variant_price_2 = "10"
     promotion_name = "Promotion Fixed"

--- a/saleor/tests/e2e/orders/discounts/test_order_products_from_the_same_category_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_from_the_same_category_on_fixed_promotion.py
@@ -10,7 +10,7 @@ from ...product.utils import (
     create_product_variant_channel_listing,
 )
 from ...promotions.utils import create_promotion, create_promotion_rule
-from ...shop.utils import prepare_shop
+from ...shop.utils.preparing_shop import prepare_default_shop
 from ...utils import assign_permissions
 from ..utils import (
     draft_order_complete,
@@ -24,7 +24,6 @@ def prepare_product(
     e2e_staff_api_client,
     warehouse_id,
     channel_id,
-    channel_slug,
     shipping_method_id,
     variant_price_1,
     variant_price_2,
@@ -142,11 +141,12 @@ def test_order_products_from_category_on_fixed_promotion_CORE_2106(
         permission_manage_orders,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+
     variant_price_1 = "20"
     variant_price_2 = "10"
     promotion_name = "Promotion Fixed"
@@ -163,7 +163,6 @@ def test_order_products_from_category_on_fixed_promotion_CORE_2106(
         e2e_staff_api_client,
         warehouse_id,
         channel_id,
-        channel_slug,
         shipping_method_id,
         variant_price_1,
         variant_price_2,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_promotion.py
@@ -16,14 +16,10 @@ from ..utils import (
 @pytest.mark.e2e
 def test_order_products_on_fixed_promotion_CORE_2101(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     promotion_name = "Promotion Fixed"
@@ -32,23 +28,17 @@ def test_order_products_on_fixed_promotion_CORE_2101(
     promotion_rule_name = "rule for product"
 
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_promotion.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_promotion.py
@@ -3,7 +3,7 @@ import pytest
 from ... import DEFAULT_ADDRESS
 from ...product.utils.preparing_product import prepare_product
 from ...promotions.utils import create_promotion, create_promotion_rule
-from ...shop.utils.preparing_shop import prepare_shop
+from ...shop.utils.preparing_shop import prepare_default_shop
 from ...utils import assign_permissions
 from ..utils import (
     draft_order_complete,
@@ -35,10 +35,10 @@ def test_order_products_on_fixed_promotion_CORE_2101(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_sale.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_sale.py
@@ -57,6 +57,8 @@ def test_order_products_on_fixed_sale_CORE_1001(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -66,15 +68,17 @@ def test_order_products_on_fixed_sale_CORE_1001(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_sale.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_sale.py
@@ -3,7 +3,7 @@ import pytest
 from ... import DEFAULT_ADDRESS
 from ...product.utils.preparing_product import prepare_product
 from ...sales.utils import create_sale, create_sale_channel_listing, sale_catalogues_add
-from ...shop.utils.preparing_shop import prepare_shop
+from ...shop.utils.preparing_shop import prepare_default_shop
 from ...utils import assign_permissions
 from ..utils import (
     draft_order_complete,
@@ -65,10 +65,10 @@ def test_order_products_on_fixed_sale_CORE_1001(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_sale.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_fixed_sale.py
@@ -51,34 +51,24 @@ def prepare_sale_for_product(
 @pytest.mark.e2e
 def test_order_products_on_fixed_sale_CORE_1001(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_percentage_sale.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_percentage_sale.py
@@ -57,6 +57,8 @@ def test_order_products_on_percentage_sale_CORE_1003(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -66,15 +68,17 @@ def test_order_products_on_percentage_sale_CORE_1003(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_percentage_sale.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_percentage_sale.py
@@ -51,34 +51,24 @@ def prepare_sale_for_product(
 @pytest.mark.e2e
 def test_order_products_on_percentage_sale_CORE_1003(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_percentage_sale.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_percentage_sale.py
@@ -3,7 +3,7 @@ import pytest
 from ... import DEFAULT_ADDRESS
 from ...product.utils.preparing_product import prepare_product
 from ...sales.utils import create_sale, create_sale_channel_listing, sale_catalogues_add
-from ...shop.utils.preparing_shop import prepare_shop
+from ...shop.utils.preparing_shop import prepare_default_shop
 from ...utils import assign_permissions
 from ..utils import (
     draft_order_complete,
@@ -65,10 +65,10 @@ def test_order_products_on_percentage_sale_CORE_1003(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
@@ -20,33 +20,23 @@ from ..utils import (
 @pytest.mark.e2e
 def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
@@ -6,7 +6,7 @@ from .....core.prices import quantize_price
 from ... import DEFAULT_ADDRESS
 from ...product.utils.preparing_product import prepare_product
 from ...promotions.utils import create_promotion, create_promotion_rule
-from ...shop.utils.preparing_shop import prepare_shop
+from ...shop.utils.preparing_shop import prepare_default_shop
 from ...utils import assign_permissions
 from ..utils import (
     draft_order_complete,
@@ -33,11 +33,11 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
-
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
+    base_shipping_price = 10
     (
         product_id,
         product_variant_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_products_on_promotion_and_manual_order_discount.py
@@ -26,6 +26,8 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     permissions = [
         permission_manage_products,
@@ -34,15 +36,17 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        result_warehouse_id,
-        result_channel_id,
-        _,
-        result_shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         product_id,
@@ -50,8 +54,8 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
         product_variant_price,
     ) = prepare_product(
         e2e_staff_api_client,
-        result_warehouse_id,
-        result_channel_id,
+        warehouse_id,
+        channel_id,
         variant_price=20,
     )
 
@@ -72,19 +76,19 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
         discount_type,
         promotion_discount_value,
         promotion_rule_name,
-        result_channel_id,
+        channel_id,
     )
     product_predicate = promotion_rule["cataloguePredicate"]["productPredicate"]["ids"]
-    assert promotion_rule["channels"][0]["id"] == result_channel_id
+    assert promotion_rule["channels"][0]["id"] == channel_id
     assert product_predicate[0] == product_id
     currency = "USD"
 
     # Step 1 - Create a draft order for a product with fixed promotion
     input = {
-        "channelId": result_channel_id,
+        "channelId": channel_id,
         "billingAddress": DEFAULT_ADDRESS,
         "shippingAddress": DEFAULT_ADDRESS,
-        "shippingMethod": result_shipping_method_id,
+        "shippingMethod": shipping_method_id,
     }
     data = draft_order_create(e2e_staff_api_client, input)
     order_id = data["order"]["id"]
@@ -132,8 +136,7 @@ def test_order_products_on_promotion_and_manual_order_discount_CORE_2108(
     assert discount["value"] == manual_discount_value
 
     # Step 4 - Add a shipping method to the order
-    base_shipping_price = 10
-    input = {"shippingMethod": result_shipping_method_id}
+    input = {"shippingMethod": shipping_method_id}
     draft_update = draft_order_update(e2e_staff_api_client, order_id, input)
     order_shipping_id = draft_update["order"]["deliveryMethod"]["id"]
     shipping_price = draft_update["order"]["shippingPrice"]["gross"]["amount"]

--- a/saleor/tests/e2e/orders/discounts/test_order_promotion_not_applied_when_not_within_time_range.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_promotion_not_applied_when_not_within_time_range.py
@@ -23,6 +23,8 @@ def test_order_promotion_not_applied_when_not_within_time_range_CORE_2110(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -32,6 +34,8 @@ def test_order_promotion_not_applied_when_not_within_time_range_CORE_2110(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
@@ -43,12 +47,13 @@ def test_order_promotion_not_applied_when_not_within_time_range_CORE_2110(
     tomorrow = today + timedelta(days=1)
     month_after = today + timedelta(days=30)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_promotion_not_applied_when_not_within_time_range.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_promotion_not_applied_when_not_within_time_range.py
@@ -8,7 +8,7 @@ from ... import DEFAULT_ADDRESS
 from ...product.utils import get_product
 from ...product.utils.preparing_product import prepare_product
 from ...promotions.utils import create_promotion, create_promotion_rule
-from ...shop.utils.preparing_shop import prepare_shop
+from ...shop.utils.preparing_shop import prepare_default_shop
 from ...utils import assign_permissions
 from ..utils import draft_order_create
 
@@ -39,11 +39,11 @@ def test_order_promotion_not_applied_when_not_within_time_range_CORE_2110(
     tomorrow = today + timedelta(days=1)
     month_after = today + timedelta(days=30)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_promotion_not_applied_when_not_within_time_range.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_promotion_not_applied_when_not_within_time_range.py
@@ -17,25 +17,17 @@ from ..utils import draft_order_create
 @pytest.mark.e2e
 def test_order_promotion_not_applied_when_not_within_time_range_CORE_2110(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
@@ -47,13 +39,11 @@ def test_order_promotion_not_applied_when_not_within_time_range_CORE_2110(
     tomorrow = today + timedelta(days=1)
     month_after = today + timedelta(days=30)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_promotion_still_applied_to_the_order_when_promotion_is_removed.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_promotion_still_applied_to_the_order_when_promotion_is_removed.py
@@ -28,6 +28,8 @@ def test_order_promotion_still_applied_to_the_order_when_promotion_is_removed_CO
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     promotion_name = "Promotion Fixed"
@@ -42,15 +44,18 @@ def test_order_promotion_still_applied_to_the_order_when_promotion_is_removed_CO
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_promotion_still_applied_to_the_order_when_promotion_is_removed.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_promotion_still_applied_to_the_order_when_promotion_is_removed.py
@@ -9,7 +9,7 @@ from ...promotions.utils import (
     delete_promotion,
     promotion_query,
 )
-from ...shop.utils.preparing_shop import prepare_shop
+from ...shop.utils.preparing_shop import prepare_default_shop
 from ...utils import assign_permissions
 from ..utils import (
     draft_order_complete,
@@ -41,11 +41,11 @@ def test_order_promotion_still_applied_to_the_order_when_promotion_is_removed_CO
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/discounts/test_order_promotion_still_applied_to_the_order_when_promotion_is_removed.py
+++ b/saleor/tests/e2e/orders/discounts/test_order_promotion_still_applied_to_the_order_when_promotion_is_removed.py
@@ -22,14 +22,10 @@ from ..utils import (
 @pytest.mark.e2e
 def test_order_promotion_still_applied_to_the_order_when_promotion_is_removed_CORE_2115(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     promotion_name = "Promotion Fixed"
@@ -38,24 +34,18 @@ def test_order_promotion_still_applied_to_the_order_when_promotion_is_removed_CO
     promotion_rule_name = "rule for product"
 
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_based_on_shipping_address.py
+++ b/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_based_on_shipping_address.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ...product.utils.preparing_product import prepare_product
-from ...shop.utils import prepare_shop
+from ...shop.utils.preparing_shop import prepare_shop
 from ...taxes.utils import update_country_tax_rates
 from ...utils import assign_permissions
 from ..utils import (
@@ -13,7 +13,7 @@ from ..utils import (
 
 
 @pytest.mark.e2e
-def test_order_calculate_simple_tax_based_on_shipping_address_tax_class_CORE_2002(
+def test_order_calculate_simple_tax_based_on_shipping_address_CORE_2002(
     e2e_staff_api_client,
     shop_permissions,
     permission_manage_product_types_and_attributes,
@@ -26,54 +26,58 @@ def test_order_calculate_simple_tax_based_on_shipping_address_tax_class_CORE_200
         permission_manage_orders,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
+
     tax_settings = {
         "charge_taxes": True,
         "tax_calculation_strategy": "FLAT_RATES",
         "display_gross_prices": False,
         "prices_entered_with_tax": False,
-        "tax_rates": [
-            {
-                "type": "shipping_country",
-                "name": "Shipping Country Tax Class",
-                "country_code": "DE",
-                "rate": 19,
-            },
-            {
-                "type": "billing_country",
-                "name": "Billing Country Tax Class",
-                "country_code": "CZ",
-                "rate": 21,
-            },
-        ],
     }
-    shipping_method_channel_listing_settings = {
-        "price": "6.66",
-    }
-    shop_data = prepare_shop(
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        shipping_zones=[{"countries": ["CZ", "US", "DE"]}],
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "us shipping zone",
+                                "add_channels": {},
+                            }
+                        ],
+                    },
+                    {
+                        "countries": ["CZ"],
+                        "shipping_methods": [
+                            {
+                                "name": "cz shipping zone",
+                                "add_channels": {},
+                            }
+                        ],
+                    },
+                    {
+                        "countries": ["DE"],
+                        "shipping_methods": [
+                            {
+                                "name": "de shipping zone",
+                                "add_channels": {},
+                            }
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            }
+        ],
         tax_settings=tax_settings,
-        shipping_method_channel_listing_settings=shipping_method_channel_listing_settings,
     )
-    channel_id = shop_data["channels"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
-    shipping_price = shop_data["shipping_methods"][0]["price"]
-
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_tax_class_id = shop_data["tax_classes"].get(
-        "shipping_country_tax_class_id"
-    )
-    shipping_country_tax_rate = (
-        shop_data["tax_rates"].get("shipping_country").get("rate")
-    )
-    shipping_country_code = (
-        shop_data["tax_rates"].get("shipping_country").get("country_code")
-    )
-    billing_country_tax_rate = shop_data["tax_rates"].get("billing_country").get("rate")
-    billing_country_code = (
-        shop_data["tax_rates"].get("billing_country").get("country_code")
-    )
-    input_data = {"taxClass": shipping_tax_class_id}
+    channel_id = shop_data[0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][2]["shipping_methods"][0]["id"]
+    billing_country_tax_rate = 21
+    billing_country_code = "CZ"
+    shipping_country_code = "DE"
+    shipping_country_tax_rate = 19
 
     update_country_tax_rates(
         e2e_staff_api_client,
@@ -85,7 +89,6 @@ def test_order_calculate_simple_tax_based_on_shipping_address_tax_class_CORE_200
         billing_country_code,
         [{"rate": billing_country_tax_rate}],
     )
-
     variant_price = "155.88"
     (_product_id, product_variant_id, product_variant_price) = prepare_product(
         e2e_staff_api_client,
@@ -95,12 +98,12 @@ def test_order_calculate_simple_tax_based_on_shipping_address_tax_class_CORE_200
     )
 
     # Step 1 - Create a draft order
-    input_data = {
+    input = {
         "channelId": channel_id,
     }
     data = draft_order_create(
         e2e_staff_api_client,
-        input_data,
+        input,
     )
     order_id = data["order"]["id"]
     product_variant_price = float(product_variant_price)
@@ -140,7 +143,7 @@ def test_order_calculate_simple_tax_based_on_shipping_address_tax_class_CORE_200
         "phone": "+420722274643",
         "countryArea": "",
     }
-    input_data = {
+    input = {
         "userEmail": "test_user@test.com",
         "shippingAddress": shipping_address,
         "billingAddress": billing_address,
@@ -148,13 +151,13 @@ def test_order_calculate_simple_tax_based_on_shipping_address_tax_class_CORE_200
     draft_order = draft_order_update(
         e2e_staff_api_client,
         order_id,
-        input_data,
+        input,
     )
     assert draft_order["order"]["userEmail"] == "test_user@test.com"
     assert draft_order["order"]["shippingAddress"] is not None
     assert draft_order["order"]["billingAddress"] is not None
 
-    # Step 3 - Add a shipping method
+    # Step 4 - Add a shipping method
     input = {"shippingMethod": shipping_method_id}
     order_data = draft_order_update(
         e2e_staff_api_client,
@@ -162,6 +165,7 @@ def test_order_calculate_simple_tax_based_on_shipping_address_tax_class_CORE_200
         input,
     )
     order_data = order_data["order"]
+    shipping_price = order_data["shippingPrice"]["net"]["amount"]
     shipping_tax = round(shipping_price * (shipping_country_tax_rate / 100), 2)
     calculated_tax = round(product_variant_price * (shipping_country_tax_rate / 100), 2)
     assert (
@@ -171,11 +175,12 @@ def test_order_calculate_simple_tax_based_on_shipping_address_tax_class_CORE_200
     assert order_data["shippingPrice"]["net"]["amount"] == shipping_price
     total_tax = calculated_tax + shipping_tax
     calculated_total = float(variant_price) + float(shipping_price)
+
     assert order_data["total"]["tax"]["amount"] == total_tax
     assert order_data["total"]["net"]["amount"] == calculated_total
     assert order_data["total"]["gross"]["amount"] == total_tax + calculated_total
 
-    # Step 4 - Complete the draft order
+    # Step 5 - Complete the draft order
     order = draft_order_complete(
         e2e_staff_api_client,
         order_id,

--- a/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_based_on_shipping_tax_class.py
+++ b/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_based_on_shipping_tax_class.py
@@ -1,15 +1,10 @@
 import pytest
 
 from ... import DEFAULT_ADDRESS
+from ...product.utils import update_product
 from ...product.utils.preparing_product import prepare_product
-from ...shipping_zone.utils import update_shipping_price
 from ...shop.utils import prepare_shop
-from ...taxes.utils import (
-    create_tax_class,
-    get_tax_configurations,
-    update_country_tax_rates,
-    update_tax_configuration,
-)
+from ...taxes.utils import update_country_tax_rates
 from ...utils import assign_permissions
 from ..utils import (
     draft_order_complete,
@@ -17,44 +12,6 @@ from ..utils import (
     draft_order_update,
     order_lines_create,
 )
-
-
-def prepare_tax_configuration(
-    e2e_staff_api_client,
-    channel_slug,
-    country_code,
-    country_tax_rate,
-    shipping_tax_rate,
-    prices_entered_with_tax,
-):
-    tax_config_data = get_tax_configurations(e2e_staff_api_client)
-    channel_tax_config = tax_config_data[0]["node"]
-    assert channel_tax_config["channel"]["slug"] == channel_slug
-    tax_config_id = channel_tax_config["id"]
-
-    tax_config_data = update_tax_configuration(
-        e2e_staff_api_client,
-        tax_config_id,
-        charge_taxes=True,
-        tax_calculation_strategy="FLAT_RATES",
-        display_gross_prices=True,
-        prices_entered_with_tax=prices_entered_with_tax,
-    )
-    update_country_tax_rates(
-        e2e_staff_api_client,
-        country_code,
-        [{"rate": country_tax_rate}],
-    )
-
-    country_rates = [{"countryCode": country_code, "rate": shipping_tax_rate}]
-    tax_class_data = create_tax_class(
-        e2e_staff_api_client,
-        "Shipping tax class",
-        country_rates,
-    )
-    tax_class_id = tax_class_data["id"]
-
-    return country_tax_rate, shipping_tax_rate, tax_class_id
 
 
 @pytest.mark.e2e
@@ -66,6 +23,7 @@ def test_order_calculate_simple_tax_based_on_shipping_tax_class_CORE_2010(
     permission_manage_shipping,
     permission_manage_taxes,
     permission_manage_orders,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -74,39 +32,40 @@ def test_order_calculate_simple_tax_based_on_shipping_tax_class_CORE_2010(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_taxes,
+        permission_manage_settings,
         permission_manage_orders,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
-
-    country_tax_rate, shipping_tax_rate, tax_class_id = prepare_tax_configuration(
+    shop_data = prepare_shop(
         e2e_staff_api_client,
-        channel_slug,
-        country_code="US",
         country_tax_rate=10,
-        shipping_tax_rate=8,
+        shipping_country_tax_rate=8,
         prices_entered_with_tax=True,
     )
-
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_price = shop_data["shipping_price"]
+    shipping_method_id = shop_data["shipping_method_id"]
+    shipping_country_tax_rate = shop_data["shipping_country_tax_rate"]
+    country_tax_rate = shop_data["country_tax_rate"]
+    country_tax_class_id = shop_data["country_tax_class_id"]
+    country = shop_data["country"]
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country,
+        [{"rate": shipping_country_tax_rate}],
+    )
     variant_price = "33.33"
-    (
-        _product_id,
-        product_variant_id,
-        product_variant_price,
-    ) = prepare_product(
+    (product_id, product_variant_id, product_variant_price) = prepare_product(
         e2e_staff_api_client,
         warehouse_id,
         channel_id,
         variant_price,
     )
-    shipping_tax_class = {"taxClass": tax_class_id}
-    update_shipping_price(e2e_staff_api_client, shipping_method_id, shipping_tax_class)
+
+    tax_class = {"taxClass": country_tax_class_id}
+    update_product(e2e_staff_api_client, product_id, tax_class)
 
     # Step 1 - Create a draft order
     input = {
@@ -134,6 +93,7 @@ def test_order_calculate_simple_tax_based_on_shipping_tax_class_CORE_2010(
     shipping_price = float(shipping_price)
 
     subtotal_gross = round((product_variant_price * 2), 2)
+
     subtotal_tax = round(
         (subtotal_gross * country_tax_rate) / (100 + country_tax_rate),
         2,
@@ -156,7 +116,9 @@ def test_order_calculate_simple_tax_based_on_shipping_tax_class_CORE_2010(
 
     shipping_gross = shipping_price
     shipping_tax = round(
-        (shipping_price * shipping_tax_rate) / (shipping_tax_rate + 100), 2
+        (shipping_price * shipping_country_tax_rate)
+        / (shipping_country_tax_rate + 100),
+        2,
     )
     shipping_net = round(shipping_price - shipping_tax, 2)
 

--- a/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_based_on_shipping_tax_class.py
+++ b/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_based_on_shipping_tax_class.py
@@ -1,8 +1,8 @@
 import pytest
 
 from ... import DEFAULT_ADDRESS
-from ...product.utils import update_product
 from ...product.utils.preparing_product import prepare_product
+from ...shipping_zone.utils import update_shipping_price
 from ...shop.utils import prepare_shop
 from ...taxes.utils import update_country_tax_rates
 from ...utils import assign_permissions
@@ -17,55 +17,71 @@ from ..utils import (
 @pytest.mark.e2e
 def test_order_calculate_simple_tax_based_on_shipping_tax_class_CORE_2010(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
-    permission_manage_taxes,
     permission_manage_orders,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
-        permission_manage_taxes,
-        permission_manage_settings,
         permission_manage_orders,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "display_gross_prices": False,
+        "prices_entered_with_tax": True,
+        "tax_rates": [
+            {
+                "type": "country",
+                "name": "Country Tax Rate",
+                "country_code": "US",
+                "rate": 10,
+            },
+            {
+                "type": "shipping_country",
+                "name": "Shipping Country Tax Rate",
+                "country_code": "US",
+                "rate": 8,
+            },
+        ],
+    }
 
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        country_tax_rate=10,
-        shipping_country_tax_rate=8,
-        prices_entered_with_tax=True,
+        tax_settings=tax_settings,
     )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_price = shop_data["shipping_price"]
-    shipping_method_id = shop_data["shipping_method_id"]
-    shipping_country_tax_rate = shop_data["shipping_country_tax_rate"]
-    country_tax_rate = shop_data["country_tax_rate"]
-    country_tax_class_id = shop_data["country_tax_class_id"]
-    country = shop_data["country"]
+    channel_id = shop_data["channels"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shipping_price = shop_data["shipping_methods"][0]["price"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_tax_class_id = shop_data["tax_classes"].get(
+        "shipping_country_tax_class_id"
+    )
+    shipping_class_tax_rate = shop_data["tax_rates"].get("shipping_country").get("rate")
+    country_tax_rate = shop_data["tax_rates"].get("country").get("rate")
+    country = shop_data["tax_rates"].get("country").get("country_code")
+
     update_country_tax_rates(
         e2e_staff_api_client,
         country,
-        [{"rate": shipping_country_tax_rate}],
+        [{"rate": country_tax_rate}],
+    )
+    input_data = {"taxClass": shipping_tax_class_id}
+    update_shipping_price(
+        e2e_staff_api_client,
+        shipping_method_id,
+        input_data,
     )
     variant_price = "33.33"
-    (product_id, product_variant_id, product_variant_price) = prepare_product(
+    (_product_id, product_variant_id, product_variant_price) = prepare_product(
         e2e_staff_api_client,
         warehouse_id,
         channel_id,
         variant_price,
     )
-
-    tax_class = {"taxClass": country_tax_class_id}
-    update_product(e2e_staff_api_client, product_id, tax_class)
 
     # Step 1 - Create a draft order
     input = {
@@ -88,9 +104,6 @@ def test_order_calculate_simple_tax_based_on_shipping_tax_class_CORE_2010(
         lines,
     )
     order_data = order_data["order"]
-    shipping_method_id = order_data["shippingMethods"][0]["id"]
-    shipping_price = order_data["shippingMethods"][0]["price"]["amount"]
-    shipping_price = float(shipping_price)
 
     subtotal_gross = round((product_variant_price * 2), 2)
 
@@ -116,12 +129,10 @@ def test_order_calculate_simple_tax_based_on_shipping_tax_class_CORE_2010(
 
     shipping_gross = shipping_price
     shipping_tax = round(
-        (shipping_price * shipping_country_tax_rate)
-        / (shipping_country_tax_rate + 100),
+        (shipping_price * shipping_class_tax_rate) / (shipping_class_tax_rate + 100),
         2,
     )
     shipping_net = round(shipping_price - shipping_tax, 2)
-
     assert order_data["deliveryMethod"]["id"] == shipping_method_id
     assert order_data["shippingPrice"]["net"]["amount"] == shipping_net
     assert order_data["shippingPrice"]["tax"]["amount"] == shipping_tax

--- a/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_for_digital_product.py
+++ b/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_for_digital_product.py
@@ -1,99 +1,10 @@
 import pytest
 
-from ...channel.utils import create_channel
 from ...product.utils.preparing_product import prepare_digital_product
-from ...shipping_zone.utils import (
-    create_shipping_method,
-    create_shipping_method_channel_listing,
-    create_shipping_zone,
-)
-from ...taxes.utils import (
-    get_tax_configurations,
-    update_country_tax_rates,
-    update_tax_configuration,
-)
+from ...shop.utils.preparing_shop import prepare_shop
+from ...taxes.utils import update_country_tax_rates
 from ...utils import assign_permissions
-from ...warehouse.utils import create_warehouse
 from ..utils import draft_order_complete, draft_order_create, order_lines_create
-
-
-def prepare_shop(
-    e2e_staff_api_client,
-    shipping_price,
-):
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-    channel_slug = "channel-de"
-    warehouse_ids = [warehouse_id]
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        slug=channel_slug,
-        warehouse_ids=warehouse_ids,
-        currency="EUR",
-        country="DE",
-    )
-    channel_id = channel_data["id"]
-    channel_ids = [channel_id]
-    shipping_zone_data = create_shipping_zone(
-        e2e_staff_api_client,
-        countries=["DE", "US"],
-        warehouse_ids=warehouse_ids,
-        channel_ids=channel_ids,
-    )
-    shipping_zone_id = shipping_zone_data["id"]
-
-    shipping_method_data = create_shipping_method(
-        e2e_staff_api_client, shipping_zone_id
-    )
-    shipping_method_id = shipping_method_data["id"]
-    create_shipping_method_channel_listing(
-        e2e_staff_api_client,
-        shipping_method_id,
-        channel_id,
-        price=shipping_price,
-    )
-
-    return (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-        shipping_price,
-    )
-
-
-def prepare_tax_configuration(
-    e2e_staff_api_client,
-    channel_slug,
-    shipping_country_code,
-    shipping_country_tax_rate,
-    billing_country_code,
-    billing_country_tax_rate,
-    prices_entered_with_tax,
-):
-    tax_config_data = get_tax_configurations(e2e_staff_api_client)
-    channel_tax_config = tax_config_data[0]["node"]
-    assert channel_tax_config["channel"]["slug"] == channel_slug
-    tax_config_id = channel_tax_config["id"]
-
-    tax_config_data = update_tax_configuration(
-        e2e_staff_api_client,
-        tax_config_id,
-        charge_taxes=True,
-        tax_calculation_strategy="FLAT_RATES",
-        display_gross_prices=True,
-        prices_entered_with_tax=prices_entered_with_tax,
-    )
-    update_country_tax_rates(
-        e2e_staff_api_client,
-        shipping_country_code,
-        [{"rate": shipping_country_tax_rate}],
-    )
-    update_country_tax_rates(
-        e2e_staff_api_client, billing_country_code, [{"rate": billing_country_tax_rate}]
-    )
-
-    return billing_country_tax_rate
 
 
 @pytest.mark.e2e
@@ -105,6 +16,7 @@ def test_digital_order_calculate_simple_tax_based_on_billing_country_CORE_2008(
     permission_manage_shipping,
     permission_manage_taxes,
     permission_manage_orders,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -114,29 +26,33 @@ def test_digital_order_calculate_simple_tax_based_on_billing_country_CORE_2008(
         permission_manage_product_types_and_attributes,
         permission_manage_taxes,
         permission_manage_orders,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shipping_price = 10
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-        shipping_price,
-    ) = prepare_shop(e2e_staff_api_client, shipping_price)
-
-    billing_country_tax_rate = prepare_tax_configuration(
+    shop_data = prepare_shop(
         e2e_staff_api_client,
-        channel_slug,
         shipping_country_code="US",
         shipping_country_tax_rate=5,
         billing_country_code="DE",
         billing_country_tax_rate=19,
         prices_entered_with_tax=True,
+        shipping_zones_structure=[
+            {"countries": ["US", "DE"], "num_shipping_methods": 1}
+        ],
     )
+    warehouse_id = shop_data["warehouse_id"]
+    channel_id = shop_data["channel_id"]
+    billing_country_tax_rate = shop_data["billing_country_tax_rate"]
+    billing_country_code = shop_data["billing_country_code"]
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        billing_country_code,
+        [{"rate": billing_country_tax_rate}],
+    )
+
     variant_price = 100
-    product_id, product_variant_id, product_variant_price = prepare_digital_product(
+    _product_id, product_variant_id, product_variant_price = prepare_digital_product(
         e2e_staff_api_client, channel_id, warehouse_id, variant_price
     )
 

--- a/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_product_tax_class.py
+++ b/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_product_tax_class.py
@@ -4,12 +4,7 @@ from ... import DEFAULT_ADDRESS
 from ...product.utils import update_product
 from ...product.utils.preparing_product import prepare_product
 from ...shop.utils.preparing_shop import prepare_shop
-from ...taxes.utils import (
-    create_tax_class,
-    get_tax_configurations,
-    update_country_tax_rates,
-    update_tax_configuration,
-)
+from ...taxes.utils import update_country_tax_rates
 from ...utils import assign_permissions
 from ..utils import (
     draft_order_complete,
@@ -17,44 +12,6 @@ from ..utils import (
     draft_order_update,
     order_lines_create,
 )
-
-
-def prepare_tax_configuration(
-    e2e_staff_api_client,
-    channel_slug,
-    country_code,
-    country_tax_rate,
-    product_tax_rate,
-    prices_entered_with_tax,
-):
-    tax_config_data = get_tax_configurations(e2e_staff_api_client)
-    channel_tax_config = tax_config_data[0]["node"]
-    assert channel_tax_config["channel"]["slug"] == channel_slug
-    tax_config_id = channel_tax_config["id"]
-
-    tax_config_data = update_tax_configuration(
-        e2e_staff_api_client,
-        tax_config_id,
-        charge_taxes=True,
-        tax_calculation_strategy="FLAT_RATES",
-        display_gross_prices=True,
-        prices_entered_with_tax=prices_entered_with_tax,
-    )
-    update_country_tax_rates(
-        e2e_staff_api_client,
-        country_code,
-        [{"rate": country_tax_rate}],
-    )
-
-    country_rates = [{"countryCode": country_code, "rate": product_tax_rate}]
-    tax_class_data = create_tax_class(
-        e2e_staff_api_client,
-        "Product tax class",
-        country_rates,
-    )
-    tax_class_id = tax_class_data["id"]
-
-    return country_tax_rate, product_tax_rate, tax_class_id
 
 
 @pytest.mark.e2e
@@ -65,6 +22,7 @@ def test_order_calculate_simple_tax_based_on_product_tax_class_CORE_2006(
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_taxes,
+    permission_manage_settings,
     permission_manage_orders,
 ):
     # Before
@@ -74,26 +32,30 @@ def test_order_calculate_simple_tax_based_on_product_tax_class_CORE_2006(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_taxes,
+        permission_manage_settings,
         permission_manage_orders,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
-
-    country_tax_rate, product_tax_rate, tax_class_id = prepare_tax_configuration(
+    shop_data = prepare_shop(
         e2e_staff_api_client,
-        channel_slug,
         country_code="US",
         country_tax_rate=20,
         product_tax_rate=13,
         prices_entered_with_tax=False,
     )
-
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
+    product_tax_rate = shop_data["product_tax_rate"]
+    country_tax_rate = shop_data["country_tax_rate"]
+    product_tax_class_id = shop_data["product_tax_class_id"]
+    country = shop_data["country"]
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        country,
+        [{"rate": country_tax_rate}],
+    )
     variant_price = "1234"
     (product_id, product_variant_id, product_variant_price) = prepare_product(
         e2e_staff_api_client,
@@ -101,7 +63,7 @@ def test_order_calculate_simple_tax_based_on_product_tax_class_CORE_2006(
         channel_id,
         variant_price,
     )
-    product_tax_class = {"taxClass": tax_class_id}
+    product_tax_class = {"taxClass": product_tax_class_id}
     update_product(e2e_staff_api_client, product_id, input=product_tax_class)
 
     # Step 1 - Create a draft order

--- a/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_product_tax_class.py
+++ b/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_product_tax_class.py
@@ -28,18 +28,13 @@ def test_order_calculate_simple_tax_based_on_product_tax_class_CORE_2006(
         permission_manage_orders,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
+
     tax_settings = {
         "charge_taxes": True,
         "tax_calculation_strategy": "FLAT_RATES",
         "display_gross_prices": False,
         "prices_entered_with_tax": False,
         "tax_rates": [
-            {
-                "type": "country",
-                "name": "Country Tax Rate",
-                "country_code": "US",
-                "rate": 20,
-            },
             {
                 "type": "product",
                 "name": "Product Tax Rate",
@@ -49,18 +44,33 @@ def test_order_calculate_simple_tax_based_on_product_tax_class_CORE_2006(
         ],
     }
 
-    shop_data = prepare_shop(
+    shop_data, tax_config = prepare_shop(
         e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [
+                            {
+                                "add_channels": {},
+                            }
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            },
+        ],
         tax_settings=tax_settings,
     )
+    channel_id = shop_data[0]["id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    shipping_price = 10.0
+    warehouse_id = shop_data[0]["warehouse_id"]
+    product_tax_class_id = tax_config[0]["product_tax_class_id"]
+    product_tax_rate = tax_config[1]["product"]["rate"]
+    country_tax_rate = 20
+    country = "US"
 
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
-    product_tax_class_id = shop_data["tax_classes"].get("product_tax_class_id")
-    product_tax_rate = shop_data["tax_rates"].get("product").get("rate")
-    country_tax_rate = shop_data["tax_rates"].get("country").get("rate")
-    country = shop_data["tax_rates"].get("country").get("country_code")
     update_country_tax_rates(
         e2e_staff_api_client,
         country,

--- a/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_product_type_tax_class.py
+++ b/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_product_type_tax_class.py
@@ -88,18 +88,13 @@ def test_order_calculate_simple_tax_based_on_product_type_tax_class_CORE_2004(
         permission_manage_orders,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
+
     tax_settings = {
         "charge_taxes": True,
         "tax_calculation_strategy": "FLAT_RATES",
         "display_gross_prices": False,
         "prices_entered_with_tax": True,
         "tax_rates": [
-            {
-                "type": "country",
-                "name": "Country Tax Rate",
-                "country_code": "US",
-                "rate": 21,
-            },
             {
                 "type": "product_type",
                 "name": "Product Type Tax Rate",
@@ -108,19 +103,33 @@ def test_order_calculate_simple_tax_based_on_product_type_tax_class_CORE_2004(
             },
         ],
     }
-    shop_data = prepare_shop(
+    shop_data, tax_config = prepare_shop(
         e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [
+                            {
+                                "add_channels": {},
+                            }
+                        ],
+                    },
+                ],
+                "order_settings": {},
+            },
+        ],
         tax_settings=tax_settings,
     )
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
-    product_type_tax_class_id = shop_data["tax_classes"].get(
-        "product_type_tax_class_id"
-    )
-    product_type_tax_rate = shop_data["tax_rates"].get("product_type").get("rate")
-    shipping_country_tax_rate = shop_data["tax_rates"].get("country").get("rate")
-    country = shop_data["tax_rates"].get("country").get("country_code")
+    channel_id = shop_data[0]["id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    shipping_price = 10.0
+    warehouse_id = shop_data[0]["warehouse_id"]
+    product_type_tax_class_id = tax_config[0]["product_type_tax_class_id"]
+    product_type_tax_rate = tax_config[1]["product_type"]["rate"]
+    shipping_country_tax_rate = 21
+    country = "US"
+
     update_country_tax_rates(
         e2e_staff_api_client,
         country,

--- a/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_product_type_tax_class.py
+++ b/saleor/tests/e2e/orders/taxes/test_order_calculate_simple_taxes_product_type_tax_class.py
@@ -77,40 +77,50 @@ def prepare_product(
 @pytest.mark.e2e
 def test_order_calculate_simple_tax_based_on_product_type_tax_class_CORE_2004(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
     permission_manage_orders,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
-        permission_manage_taxes,
-        permission_manage_settings,
         permission_manage_orders,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "display_gross_prices": False,
+        "prices_entered_with_tax": True,
+        "tax_rates": [
+            {
+                "type": "country",
+                "name": "Country Tax Rate",
+                "country_code": "US",
+                "rate": 21,
+            },
+            {
+                "type": "product_type",
+                "name": "Product Type Tax Rate",
+                "country_code": "US",
+                "rate": 11,
+            },
+        ],
+    }
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        country_code="US",
-        shipping_country_tax_rate=21,
-        product_type_tax_rate=11,
-        prices_entered_with_tax=True,
+        tax_settings=tax_settings,
     )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
-    product_type_tax_rate = shop_data["product_type_tax_rate"]
-    product_type_tax_class_id = shop_data["product_type_tax_class_id"]
-    shipping_country_tax_rate = shop_data["shipping_country_tax_rate"]
-    country = shop_data["country"]
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    product_type_tax_class_id = shop_data["tax_classes"].get(
+        "product_type_tax_class_id"
+    )
+    product_type_tax_rate = shop_data["tax_rates"].get("product_type").get("rate")
+    shipping_country_tax_rate = shop_data["tax_rates"].get("country").get("rate")
+    country = shop_data["tax_rates"].get("country").get("country_code")
     update_country_tax_rates(
         e2e_staff_api_client,
         country,
@@ -158,7 +168,6 @@ def test_order_calculate_simple_tax_based_on_product_type_tax_class_CORE_2004(
     assert order_data["total"]["net"]["amount"] == round(
         product_variant_price - calculated_tax, 2
     )
-    shipping_method_id = order_data["shippingMethods"][0]["id"]
 
     # Step 3 - Add a shipping method to the order and check prices
     input = {"shippingMethod": shipping_method_id}

--- a/saleor/tests/e2e/orders/test_app_can_create_order_from_checkout.py
+++ b/saleor/tests/e2e/orders/test_app_can_create_order_from_checkout.py
@@ -18,6 +18,8 @@ def test_app_can_create_order_from_checkout_CORE_0215(
     permission_manage_orders,
     permission_manage_payments,
     permission_handle_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -26,6 +28,8 @@ def test_app_can_create_order_from_checkout_CORE_0215(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [
@@ -33,17 +37,20 @@ def test_app_can_create_order_from_checkout_CORE_0215(
         permission_handle_checkouts,
         permission_manage_orders,
         permission_manage_channels,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_app_api_client, app_permissions)
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_app_can_create_order_from_checkout.py
+++ b/saleor/tests/e2e/orders/test_app_can_create_order_from_checkout.py
@@ -2,7 +2,7 @@ import pytest
 
 from ..checkout.utils import checkout_create, checkout_delivery_method_update
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import order_create_from_checkout
 
@@ -34,11 +34,11 @@ def test_app_can_create_order_from_checkout_CORE_0215(
 
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_app_can_create_order_from_checkout.py
+++ b/saleor/tests/e2e/orders/test_app_can_create_order_from_checkout.py
@@ -11,46 +11,34 @@ from .utils import order_create_from_checkout
 def test_app_can_create_order_from_checkout_CORE_0215(
     e2e_staff_api_client,
     e2e_app_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
     permission_manage_payments,
     permission_handle_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [
         permission_manage_payments,
         permission_handle_checkouts,
         permission_manage_orders,
-        permission_manage_channels,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_app_api_client, app_permissions)
 
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -82,7 +70,6 @@ def test_app_can_create_order_from_checkout_CORE_0215(
     assert checkout_id is not None
     assert checkout_data["isShippingRequired"] is True
     assert len(checkout_data["shippingMethods"]) == 1
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     # Step 2 - Assign shipping method
     checkout_data = checkout_delivery_method_update(

--- a/saleor/tests/e2e/orders/test_cancel_fully_paid_order.py
+++ b/saleor/tests/e2e/orders/test_cancel_fully_paid_order.py
@@ -25,6 +25,8 @@ def test_cancel_fully_paid_order_CORE_0206(
     permission_manage_shipping,
     permission_manage_orders,
     permission_manage_payments,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -34,6 +36,8 @@ def test_cancel_fully_paid_order_CORE_0206(
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_payments,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [permission_manage_payments, permission_manage_orders]
@@ -41,12 +45,12 @@ def test_cancel_fully_paid_order_CORE_0206(
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_cancel_fully_paid_order.py
+++ b/saleor/tests/e2e/orders/test_cancel_fully_paid_order.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..transactions.utils import create_transaction
 from ..utils import assign_permissions
 from .utils import (
@@ -37,10 +37,10 @@ def test_cancel_fully_paid_order_CORE_0206(
 
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_cancel_fully_paid_order.py
+++ b/saleor/tests/e2e/orders/test_cancel_fully_paid_order.py
@@ -19,25 +19,17 @@ from .utils import (
 def test_cancel_fully_paid_order_CORE_0206(
     e2e_staff_api_client,
     e2e_app_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
     permission_manage_payments,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_payments,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [permission_manage_payments, permission_manage_orders]
@@ -45,12 +37,10 @@ def test_cancel_fully_paid_order_CORE_0206(
 
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_cancel_partially_paid_order.py
+++ b/saleor/tests/e2e/orders/test_cancel_partially_paid_order.py
@@ -25,6 +25,8 @@ def test_cancel_partially_paid_order_CORE_0207(
     permission_manage_shipping,
     permission_manage_orders,
     permission_manage_payments,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -34,6 +36,8 @@ def test_cancel_partially_paid_order_CORE_0207(
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_payments,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [permission_manage_payments, permission_manage_orders]
@@ -41,12 +45,12 @@ def test_cancel_partially_paid_order_CORE_0207(
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_cancel_partially_paid_order.py
+++ b/saleor/tests/e2e/orders/test_cancel_partially_paid_order.py
@@ -19,25 +19,17 @@ from .utils import (
 def test_cancel_partially_paid_order_CORE_0207(
     e2e_staff_api_client,
     e2e_app_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
     permission_manage_payments,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_payments,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [permission_manage_payments, permission_manage_orders]
@@ -45,12 +37,10 @@ def test_cancel_partially_paid_order_CORE_0207(
 
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_cancel_partially_paid_order.py
+++ b/saleor/tests/e2e/orders/test_cancel_partially_paid_order.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..transactions.utils import create_transaction
 from ..utils import assign_permissions
 from .utils import (
@@ -37,10 +37,10 @@ def test_cancel_partially_paid_order_CORE_0207(
 
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_cancel_unpaid_order.py
+++ b/saleor/tests/e2e/orders/test_cancel_unpaid_order.py
@@ -21,6 +21,8 @@ def test_cancel_unpaid_order_CORE_0204(
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -29,17 +31,19 @@ def test_cancel_unpaid_order_CORE_0204(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_cancel_unpaid_order.py
+++ b/saleor/tests/e2e/orders/test_cancel_unpaid_order.py
@@ -16,34 +16,24 @@ from .utils import (
 @pytest.mark.e2e
 def test_cancel_unpaid_order_CORE_0204(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_cancel_unpaid_order.py
+++ b/saleor/tests/e2e/orders/test_cancel_unpaid_order.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     draft_order_complete,
@@ -30,10 +30,10 @@ def test_cancel_unpaid_order_CORE_0204(
 
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_delete_draft_order.py
+++ b/saleor/tests/e2e/orders/test_delete_draft_order.py
@@ -21,6 +21,8 @@ def test_delete_draft_order_CORE_0205(
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -29,17 +31,19 @@ def test_delete_draft_order_CORE_0205(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_delete_draft_order.py
+++ b/saleor/tests/e2e/orders/test_delete_draft_order.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     draft_order_create,
@@ -30,10 +30,10 @@ def test_delete_draft_order_CORE_0205(
 
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_delete_draft_order.py
+++ b/saleor/tests/e2e/orders/test_delete_draft_order.py
@@ -16,34 +16,24 @@ from .utils import (
 @pytest.mark.e2e
 def test_delete_draft_order_CORE_0205(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_expired_order_is_deleted_after_specified_time.py
+++ b/saleor/tests/e2e/orders/test_expired_order_is_deleted_after_specified_time.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from ....order.tasks import delete_expired_orders_task, expire_orders_task
-from ..channel.utils import update_channel
 from ..checkout.utils import checkout_create, checkout_delivery_method_update
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_shop
@@ -24,6 +23,8 @@ def test_expired_order_is_deleted_after_specified_time_CORE_0216(
     permission_manage_orders,
     permission_manage_payments,
     permission_handle_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -32,6 +33,8 @@ def test_expired_order_is_deleted_after_specified_time_CORE_0216(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [
@@ -39,35 +42,25 @@ def test_expired_order_is_deleted_after_specified_time_CORE_0216(
         permission_handle_checkouts,
         permission_manage_orders,
         permission_manage_channels,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_app_api_client, app_permissions)
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
-
-    expire_order_after_in_minutes = 1
-    delete_expired_order_after_in_days = "1"
-    channel_update_input = {
-        "orderSettings": {
-            "allowUnpaidOrders": True,
-            "automaticallyFulfillNonShippableGiftCard": True,
-            "automaticallyConfirmAllNewOrders": True,
-            "expireOrdersAfter": expire_order_after_in_minutes,
-            "deleteExpiredOrdersAfter": delete_expired_order_after_in_days,
-        }
-    }
-
-    update_channel(
+    shop_data = prepare_shop(
         e2e_staff_api_client,
-        channel_id,
-        channel_update_input,
+        expire_order_after_in_minutes=1,
+        delete_expired_order_after_in_days="1",
+        allow_unpaid_orders=True,
     )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
+    delete_expired_order_after_in_days = shop_data["delete_expired_order_after_in_days"]
+    expire_order_after_in_minutes = shop_data["expire_order_after_in_minutes"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_expired_order_is_deleted_after_specified_time.py
+++ b/saleor/tests/e2e/orders/test_expired_order_is_deleted_after_specified_time.py
@@ -16,52 +16,49 @@ from .utils import order_create_from_checkout, order_query
 def test_expired_order_is_deleted_after_specified_time_CORE_0216(
     e2e_staff_api_client,
     e2e_app_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
     permission_manage_payments,
     permission_handle_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_product_types_and_attributes,
+        *shop_permissions,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
+        permission_manage_product_types_and_attributes,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [
         permission_manage_payments,
         permission_handle_checkouts,
         permission_manage_orders,
-        permission_manage_channels,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_app_api_client, app_permissions)
 
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-        expire_order_after_in_minutes=1,
-        delete_expired_order_after_in_days="1",
-        allow_unpaid_orders=True,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
-    delete_expired_order_after_in_days = shop_data["delete_expired_order_after_in_days"]
-    expire_order_after_in_minutes = shop_data["expire_order_after_in_minutes"]
+    channel_config = [
+        {
+            "order_settings": {
+                "expireOrdersAfter": 1,
+                "deleteExpiredOrdersAfter": "1",
+            }
+        }
+    ]
 
+    shop_data = prepare_shop(e2e_staff_api_client, channels_settings=channel_config)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    expire_order_after_in_minutes = shop_data["channels"][0]["orderSettings"][
+        "expireOrdersAfter"
+    ]
+    delete_expired_order_after_in_days = shop_data["channels"][0]["orderSettings"][
+        "deleteExpiredOrdersAfter"
+    ]
     (
         _product_id,
         product_variant_id,
@@ -92,7 +89,6 @@ def test_expired_order_is_deleted_after_specified_time_CORE_0216(
     assert checkout_id is not None
     assert checkout_data["isShippingRequired"] is True
     assert len(checkout_data["shippingMethods"]) == 1
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     # Step 2 - Assign shipping method
     checkout_data = checkout_delivery_method_update(

--- a/saleor/tests/e2e/orders/test_expired_order_is_deleted_after_specified_time.py
+++ b/saleor/tests/e2e/orders/test_expired_order_is_deleted_after_specified_time.py
@@ -39,24 +39,29 @@ def test_expired_order_is_deleted_after_specified_time_CORE_0216(
 
     price = 10
 
-    channel_config = [
-        {
-            "order_settings": {
-                "expireOrdersAfter": 1,
-                "deleteExpiredOrdersAfter": "1",
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [{}],
+                    },
+                ],
+                "order_settings": {
+                    "expireOrdersAfter": 1,
+                    "deleteExpiredOrdersAfter": "1",
+                },
             }
-        }
-    ]
-
-    shop_data = prepare_shop(e2e_staff_api_client, channels_settings=channel_config)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
-    expire_order_after_in_minutes = shop_data["channels"][0]["orderSettings"][
-        "expireOrdersAfter"
-    ]
-    delete_expired_order_after_in_days = shop_data["channels"][0]["orderSettings"][
+        ],
+        shop_settings={},
+    )
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    expire_order_after_in_minutes = shop_data[0]["order_settings"]["expireOrdersAfter"]
+    delete_expired_order_after_in_days = shop_data[0]["order_settings"][
         "deleteExpiredOrdersAfter"
     ]
     (

--- a/saleor/tests/e2e/orders/test_order_cancel_fulfillment.py
+++ b/saleor/tests/e2e/orders/test_order_cancel_fulfillment.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils import prepare_shop, update_shop_settings
+from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
 from .utils import (
     draft_order_complete,
@@ -18,15 +18,13 @@ from .utils import (
 
 def prepare_order(e2e_staff_api_client):
     price = 10
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
-
-    data = {"fulfillmentAutoApprove": True, "fulfillmentAllowUnpaid": False}
-    update_shop_settings(e2e_staff_api_client, data)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+        fulfillment_auto_approve=True,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,
@@ -84,6 +82,7 @@ def test_order_cancel_fulfillment_CORE_0220(
     permission_manage_shipping,
     permission_manage_orders,
     permission_manage_settings,
+    permission_manage_taxes,
 ):
     # Before
     permissions = [
@@ -93,6 +92,7 @@ def test_order_cancel_fulfillment_CORE_0220(
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_settings,
+        permission_manage_taxes,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 

--- a/saleor/tests/e2e/orders/test_order_cancel_fulfillment.py
+++ b/saleor/tests/e2e/orders/test_order_cancel_fulfillment.py
@@ -18,13 +18,18 @@ from .utils import (
 
 def prepare_order(e2e_staff_api_client):
     price = 10
+    shop_settings = {
+        "fulfillmentAutoApprove": True,
+        "fulfillmentAllowUnpaid": False,
+    }
+
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        fulfillment_auto_approve=True,
+        shop_settings_update=shop_settings,
     )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,
@@ -76,32 +81,25 @@ def prepare_order(e2e_staff_api_client):
 @pytest.mark.e2e
 def test_order_cancel_fulfillment_CORE_0220(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
-    permission_manage_settings,
-    permission_manage_taxes,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_settings,
-        permission_manage_taxes,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-
     (
         order_id,
         product_variant_id,
         warehouse_id,
         order_line_id,
-    ) = prepare_order(e2e_staff_api_client)
+    ) = prepare_order(
+        e2e_staff_api_client,
+    )
 
     # Step 1 - Complete the order
     order = draft_order_complete(

--- a/saleor/tests/e2e/orders/test_order_cancel_fulfillment.py
+++ b/saleor/tests/e2e/orders/test_order_cancel_fulfillment.py
@@ -18,18 +18,27 @@ from .utils import (
 
 def prepare_order(e2e_staff_api_client):
     price = 10
-    shop_settings = {
-        "fulfillmentAutoApprove": True,
-        "fulfillmentAllowUnpaid": False,
-    }
 
-    shop_data = prepare_shop(
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        shop_settings_update=shop_settings,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [{}],
+                    },
+                ],
+                "order_settings": {},
+            }
+        ],
+        shop_settings={
+            "fulfillmentAutoApprove": True,
+            "fulfillmentAllowUnpaid": False,
+        },
     )
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    channel_id = shop_data[0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/orders/test_order_create_invoice_with_metadata.py
+++ b/saleor/tests/e2e/orders/test_order_create_invoice_with_metadata.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils import prepare_shop, update_shop_settings
+from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
 from .utils import (
     draft_order_complete,
@@ -18,15 +18,13 @@ from .utils import (
 
 def prepare_fulfilled_order(e2e_staff_api_client):
     price = 10
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
-
-    data = {"fulfillmentAutoApprove": True, "fulfillmentAllowUnpaid": False}
-    update_shop_settings(e2e_staff_api_client, data)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+        fulfillment_auto_approve=True,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,
@@ -105,6 +103,7 @@ def test_order_create_invoice_with_metadata_CORE_0212(
     permission_manage_shipping,
     permission_manage_orders,
     permission_manage_settings,
+    permission_manage_taxes,
 ):
     # Before
     permissions = [
@@ -114,6 +113,7 @@ def test_order_create_invoice_with_metadata_CORE_0212(
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_settings,
+        permission_manage_taxes,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 

--- a/saleor/tests/e2e/orders/test_order_create_invoice_with_metadata.py
+++ b/saleor/tests/e2e/orders/test_order_create_invoice_with_metadata.py
@@ -18,13 +18,16 @@ from .utils import (
 
 def prepare_fulfilled_order(e2e_staff_api_client):
     price = 10
+    shop_settings = {
+        "fulfillmentAutoApprove": True,
+    }
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        fulfillment_auto_approve=True,
+        shop_settings_update=shop_settings,
     )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,
@@ -97,23 +100,15 @@ def prepare_fulfilled_order(e2e_staff_api_client):
 @pytest.mark.e2e
 def test_order_create_invoice_with_metadata_CORE_0212(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
-    permission_manage_settings,
-    permission_manage_taxes,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_settings,
-        permission_manage_taxes,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 

--- a/saleor/tests/e2e/orders/test_order_create_invoice_with_metadata.py
+++ b/saleor/tests/e2e/orders/test_order_create_invoice_with_metadata.py
@@ -18,16 +18,26 @@ from .utils import (
 
 def prepare_fulfilled_order(e2e_staff_api_client):
     price = 10
-    shop_settings = {
-        "fulfillmentAutoApprove": True,
-    }
-    shop_data = prepare_shop(
+
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        shop_settings_update=shop_settings,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [{}],
+                    },
+                ],
+                "order_settings": {},
+            }
+        ],
+        shop_settings={
+            "fulfillmentAutoApprove": True,
+        },
     )
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    channel_id = shop_data[0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/orders/test_order_created_by_staff_member.py
+++ b/saleor/tests/e2e/orders/test_order_created_by_staff_member.py
@@ -18,6 +18,8 @@ def test_order_created_by_staff_member_CORE_0201(
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -26,17 +28,19 @@ def test_order_created_by_staff_member_CORE_0201(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_created_by_staff_member.py
+++ b/saleor/tests/e2e/orders/test_order_created_by_staff_member.py
@@ -6,7 +6,7 @@ from ..orders.utils.draft_order_create import draft_order_create
 from ..orders.utils.draft_order_update import draft_order_update
 from ..orders.utils.order_lines_create import order_lines_create
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 
 
@@ -27,10 +27,10 @@ def test_order_created_by_staff_member_CORE_0201(
 
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_created_by_staff_member.py
+++ b/saleor/tests/e2e/orders/test_order_created_by_staff_member.py
@@ -13,34 +13,24 @@ from ..utils import assign_permissions
 @pytest.mark.e2e
 def test_order_created_by_staff_member_CORE_0201(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_fulfill_and_add_tracking.py
+++ b/saleor/tests/e2e/orders/test_order_fulfill_and_add_tracking.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils import prepare_shop, update_shop_settings
+from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
 from .utils import (
     draft_order_complete,
@@ -18,15 +18,13 @@ from .utils import (
 
 def prepare_order(e2e_staff_api_client):
     price = 10
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
-
-    data = {"fulfillmentAutoApprove": True, "fulfillmentAllowUnpaid": False}
-    update_shop_settings(e2e_staff_api_client, data)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+        fulfillment_auto_approve=True,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,
@@ -84,6 +82,7 @@ def test_order_fulfill_and_add_tracking_CORE_0219(
     permission_manage_shipping,
     permission_manage_orders,
     permission_manage_settings,
+    permission_manage_taxes,
 ):
     # Before
     permissions = [
@@ -92,6 +91,7 @@ def test_order_fulfill_and_add_tracking_CORE_0219(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
         permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)

--- a/saleor/tests/e2e/orders/test_order_fulfill_and_add_tracking.py
+++ b/saleor/tests/e2e/orders/test_order_fulfill_and_add_tracking.py
@@ -18,13 +18,17 @@ from .utils import (
 
 def prepare_order(e2e_staff_api_client):
     price = 10
+    shop_settings = {
+        "fulfillmentAutoApprove": True,
+        "fulfillmentAllowUnpaid": False,
+    }
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        fulfillment_auto_approve=True,
+        shop_settings_update=shop_settings,
     )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,
@@ -76,23 +80,15 @@ def prepare_order(e2e_staff_api_client):
 @pytest.mark.e2e
 def test_order_fulfill_and_add_tracking_CORE_0219(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
-    permission_manage_settings,
-    permission_manage_taxes,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 

--- a/saleor/tests/e2e/orders/test_order_fulfill_and_add_tracking.py
+++ b/saleor/tests/e2e/orders/test_order_fulfill_and_add_tracking.py
@@ -18,17 +18,27 @@ from .utils import (
 
 def prepare_order(e2e_staff_api_client):
     price = 10
-    shop_settings = {
-        "fulfillmentAutoApprove": True,
-        "fulfillmentAllowUnpaid": False,
-    }
-    shop_data = prepare_shop(
+
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        shop_settings_update=shop_settings,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [{}],
+                    },
+                ],
+                "order_settings": {},
+            }
+        ],
+        shop_settings={
+            "fulfillmentAutoApprove": True,
+            "fulfillmentAllowUnpaid": False,
+        },
     )
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    channel_id = shop_data[0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/orders/test_order_in_channel_with_transaction_flow_as_mark_as_paid_strategy.py
+++ b/saleor/tests/e2e/orders/test_order_in_channel_with_transaction_flow_as_mark_as_paid_strategy.py
@@ -34,19 +34,25 @@ def test_order_in_channel_with_transaction_flow_as_mark_as_paid_strategy_CORE_02
     app_permissions = [permission_manage_payments]
     assign_permissions(e2e_app_api_client, app_permissions)
 
-    shop_settings = {
-        "fulfillmentAutoApprove": True,
-    }
-    channel_config = [{"order_settings": {"markAsPaidStrategy": "TRANSACTION_FLOW"}}]
-
-    shop_data = prepare_shop(
+    shop_data, _tax_config = prepare_shop(
         e2e_staff_api_client,
-        channels_settings=channel_config,
-        shop_settings_update=shop_settings,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [{}],
+                    },
+                ],
+                "order_settings": {"markAsPaidStrategy": "TRANSACTION_FLOW"},
+            }
+        ],
+        shop_settings={
+            "fulfillmentAutoApprove": True,
+        },
     )
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    channel_id = shop_data[0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
 
     price = 2
     (

--- a/saleor/tests/e2e/orders/test_order_in_channel_with_transaction_flow_as_mark_as_paid_strategy.py
+++ b/saleor/tests/e2e/orders/test_order_in_channel_with_transaction_flow_as_mark_as_paid_strategy.py
@@ -18,38 +18,35 @@ from .utils import (
 def test_order_in_channel_with_transaction_flow_as_mark_as_paid_strategy_CORE_0209(
     e2e_staff_api_client,
     e2e_app_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
     permission_manage_payments,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
         permission_manage_payments,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [permission_manage_payments]
     assign_permissions(e2e_app_api_client, app_permissions)
 
+    shop_settings = {
+        "fulfillmentAutoApprove": True,
+    }
+    channel_config = [{"order_settings": {"markAsPaidStrategy": "TRANSACTION_FLOW"}}]
+
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        fulfillment_auto_approve=True,
-        mark_as_paid_strategy="TRANSACTION_FLOW",
+        channels_settings=channel_config,
+        shop_settings_update=shop_settings,
     )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     price = 2
     (

--- a/saleor/tests/e2e/orders/test_order_is_expired_after_specific_time.py
+++ b/saleor/tests/e2e/orders/test_order_is_expired_after_specific_time.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from ....order.tasks import expire_orders_task
-from ..channel.utils import update_channel
 from ..checkout.utils import checkout_create, checkout_delivery_method_update
 from ..product.utils.preparing_product import prepare_product
 from ..shop.utils.preparing_shop import prepare_shop
@@ -24,6 +23,8 @@ def test_order_is_expired_after_specific_time_CORE_0214(
     permission_manage_orders,
     permission_manage_payments,
     permission_handle_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -32,6 +33,8 @@ def test_order_is_expired_after_specific_time_CORE_0214(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [
@@ -44,28 +47,15 @@ def test_order_is_expired_after_specific_time_CORE_0214(
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
-
-    expire_order_after_in_minutes = 1
-    channel_update_input = {
-        "orderSettings": {
-            "allowUnpaidOrders": True,
-            "automaticallyFulfillNonShippableGiftCard": True,
-            "automaticallyConfirmAllNewOrders": True,
-            "expireOrdersAfter": expire_order_after_in_minutes,
-        }
-    }
-
-    update_channel(
+    shop_data = prepare_shop(
         e2e_staff_api_client,
-        channel_id,
-        channel_update_input,
+        expire_order_after_in_minutes=1,
     )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
+    expire_order_after_in_minutes = shop_data["expire_order_after_in_minutes"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_is_expired_after_specific_time.py
+++ b/saleor/tests/e2e/orders/test_order_is_expired_after_specific_time.py
@@ -40,16 +40,27 @@ def test_order_is_expired_after_specific_time_CORE_0214(
 
     price = 10
 
-    channel_config = [{"order_settings": {"expireOrdersAfter": 1}}]
-
-    shop_data = prepare_shop(e2e_staff_api_client, channels_settings=channel_config)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
-    expire_order_after_in_minutes = shop_data["channels"][0]["orderSettings"][
-        "expireOrdersAfter"
-    ]
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "shipping_methods": [{}],
+                    },
+                ],
+                "order_settings": {
+                    "expireOrdersAfter": 1,
+                },
+            }
+        ],
+        shop_settings={},
+    )
+    channel_id = shop_data[0]["id"]
+    channel_slug = shop_data[0]["slug"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+    expire_order_after_in_minutes = shop_data[0]["order_settings"]["expireOrdersAfter"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_mark_as_paid.py
+++ b/saleor/tests/e2e/orders/test_order_mark_as_paid.py
@@ -21,6 +21,8 @@ def test_order_mark_as_paid_CORE_0208(
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -29,17 +31,19 @@ def test_order_mark_as_paid_CORE_0208(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/orders/test_order_mark_as_paid.py
+++ b/saleor/tests/e2e/orders/test_order_mark_as_paid.py
@@ -16,34 +16,24 @@ from .utils import (
 @pytest.mark.e2e
 def test_order_mark_as_paid_CORE_0208(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/orders/test_order_mark_as_paid.py
+++ b/saleor/tests/e2e/orders/test_order_mark_as_paid.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     draft_order_complete,
@@ -30,10 +30,10 @@ def test_order_mark_as_paid_CORE_0208(
 
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/orders/test_order_staff_can_create_order_with_the_same_variant_in_multiple_lines_and_overwrite_prices.py
+++ b/saleor/tests/e2e/orders/test_order_staff_can_create_order_with_the_same_variant_in_multiple_lines_and_overwrite_prices.py
@@ -20,6 +20,8 @@ def test_order_with_the_same_variant_in_multiple_lines_and_overwrite_prices_core
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -28,15 +30,17 @@ def test_order_with_the_same_variant_in_multiple_lines_and_overwrite_prices_core
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_staff_can_create_order_with_the_same_variant_in_multiple_lines_and_overwrite_prices.py
+++ b/saleor/tests/e2e/orders/test_order_staff_can_create_order_with_the_same_variant_in_multiple_lines_and_overwrite_prices.py
@@ -15,32 +15,22 @@ from .utils import (
 @pytest.mark.e2e
 def test_order_with_the_same_variant_in_multiple_lines_and_overwrite_prices_core_0213(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_staff_can_create_order_with_the_same_variant_in_multiple_lines_and_overwrite_prices.py
+++ b/saleor/tests/e2e/orders/test_order_staff_can_create_order_with_the_same_variant_in_multiple_lines_and_overwrite_prices.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     draft_order_complete,
@@ -27,10 +27,10 @@ def test_order_with_the_same_variant_in_multiple_lines_and_overwrite_prices_core
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_staff_can_overwrite_prices.py
+++ b/saleor/tests/e2e/orders/test_order_staff_can_overwrite_prices.py
@@ -18,6 +18,8 @@ def test_order_staff_can_overwrite_prices_CORE_0202(
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -26,17 +28,19 @@ def test_order_staff_can_overwrite_prices_CORE_0202(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     regular_variant_price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_staff_can_overwrite_prices.py
+++ b/saleor/tests/e2e/orders/test_order_staff_can_overwrite_prices.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils.draft_order_complete import draft_order_complete
 from .utils.draft_order_create import draft_order_create
@@ -27,10 +27,10 @@ def test_order_staff_can_overwrite_prices_CORE_0202(
 
     regular_variant_price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_staff_can_overwrite_prices.py
+++ b/saleor/tests/e2e/orders/test_order_staff_can_overwrite_prices.py
@@ -13,34 +13,24 @@ from .utils.order_lines_create import order_lines_create
 @pytest.mark.e2e
 def test_order_staff_can_overwrite_prices_CORE_0202(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     regular_variant_price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_void_once_voided_payment.py
+++ b/saleor/tests/e2e/orders/test_order_void_once_voided_payment.py
@@ -18,12 +18,13 @@ def prepare_checkout_with_voided_payment(
 ):
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         _product_id,
@@ -92,6 +93,8 @@ def test_checkout_void_once_voided_payment_CORE_0218(
     permission_manage_orders,
     permission_manage_payments,
     permission_handle_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -100,6 +103,8 @@ def test_checkout_void_once_voided_payment_CORE_0218(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [

--- a/saleor/tests/e2e/orders/test_order_void_once_voided_payment.py
+++ b/saleor/tests/e2e/orders/test_order_void_once_voided_payment.py
@@ -7,7 +7,7 @@ from ..checkout.utils import (
     raw_checkout_dummy_payment_create,
 )
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import order_query, order_void, raw_order_void
 
@@ -15,11 +15,11 @@ from .utils import order_query, order_void, raw_order_void
 def prepare_checkout_with_voided_payment(e2e_staff_api_client):
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_void_once_voided_payment.py
+++ b/saleor/tests/e2e/orders/test_order_void_once_voided_payment.py
@@ -12,19 +12,14 @@ from ..utils import assign_permissions
 from .utils import order_query, order_void, raw_order_void
 
 
-def prepare_checkout_with_voided_payment(
-    e2e_staff_api_client,
-    e2e_app_api_client,
-):
+def prepare_checkout_with_voided_payment(e2e_staff_api_client):
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -52,7 +47,6 @@ def prepare_checkout_with_voided_payment(
         set_default_shipping_address=True,
     )
     checkout_id = checkout_data["id"]
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     checkout_data = checkout_delivery_method_update(
         e2e_staff_api_client,
@@ -86,25 +80,18 @@ def prepare_checkout_with_voided_payment(
 def test_checkout_void_once_voided_payment_CORE_0218(
     e2e_staff_api_client,
     e2e_app_api_client,
-    permission_manage_products,
+    shop_permissions,
     permission_manage_channels,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
     permission_manage_payments,
     permission_handle_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [
@@ -117,7 +104,6 @@ def test_checkout_void_once_voided_payment_CORE_0218(
 
     order_id = prepare_checkout_with_voided_payment(
         e2e_staff_api_client,
-        e2e_app_api_client,
     )
 
     # Step 1 - Check the order's payment is voided

--- a/saleor/tests/e2e/orders/test_order_void_payment.py
+++ b/saleor/tests/e2e/orders/test_order_void_payment.py
@@ -23,6 +23,8 @@ def test_checkout_void_payment_CORE_0217(
     permission_manage_orders,
     permission_manage_payments,
     permission_handle_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -31,6 +33,8 @@ def test_checkout_void_payment_CORE_0217(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [
@@ -38,17 +42,20 @@ def test_checkout_void_payment_CORE_0217(
         permission_handle_checkouts,
         permission_manage_orders,
         permission_manage_channels,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_app_api_client, app_permissions)
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_order_void_payment.py
+++ b/saleor/tests/e2e/orders/test_order_void_payment.py
@@ -16,46 +16,34 @@ from .utils import order_void
 def test_checkout_void_payment_CORE_0217(
     e2e_staff_api_client,
     e2e_app_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
     permission_manage_payments,
     permission_handle_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     app_permissions = [
         permission_manage_payments,
         permission_handle_checkouts,
         permission_manage_orders,
-        permission_manage_channels,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_app_api_client, app_permissions)
 
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,
@@ -88,7 +76,6 @@ def test_checkout_void_payment_CORE_0217(
     assert checkout_id is not None
     assert checkout_data["isShippingRequired"] is True
     assert len(checkout_data["shippingMethods"]) == 1
-    shipping_method_id = checkout_data["shippingMethods"][0]["id"]
 
     # Step 2 - Assign shipping method
     checkout_data = checkout_delivery_method_update(

--- a/saleor/tests/e2e/orders/test_order_void_payment.py
+++ b/saleor/tests/e2e/orders/test_order_void_payment.py
@@ -7,7 +7,7 @@ from ..checkout.utils import (
     raw_checkout_dummy_payment_create,
 )
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import order_void
 
@@ -39,11 +39,11 @@ def test_checkout_void_payment_CORE_0217(
 
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_unable_to_void_order_marked_as_paid.py
+++ b/saleor/tests/e2e/orders/test_unable_to_void_order_marked_as_paid.py
@@ -18,12 +18,12 @@ from .utils import (
 def prepare_order_marked_as_paid(e2e_staff_api_client):
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,
@@ -85,6 +85,8 @@ def test_unable_to_void_order_marked_as_paid_CORE_0211(
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -93,6 +95,8 @@ def test_unable_to_void_order_marked_as_paid_CORE_0211(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 

--- a/saleor/tests/e2e/orders/test_unable_to_void_order_marked_as_paid.py
+++ b/saleor/tests/e2e/orders/test_unable_to_void_order_marked_as_paid.py
@@ -18,12 +18,10 @@ from .utils import (
 def prepare_order_marked_as_paid(e2e_staff_api_client):
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,
@@ -80,23 +78,15 @@ def prepare_order_marked_as_paid(e2e_staff_api_client):
 @pytest.mark.e2e
 def test_unable_to_void_order_marked_as_paid_CORE_0211(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 

--- a/saleor/tests/e2e/orders/test_unable_to_void_order_marked_as_paid.py
+++ b/saleor/tests/e2e/orders/test_unable_to_void_order_marked_as_paid.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     draft_order_complete,
@@ -18,10 +18,10 @@ from .utils import (
 def prepare_order_marked_as_paid(e2e_staff_api_client):
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     _product_id, product_variant_id, _product_variant_price = prepare_product(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/orders/test_unable_to_void_order_without_payment.py
+++ b/saleor/tests/e2e/orders/test_unable_to_void_order_without_payment.py
@@ -21,6 +21,8 @@ def test_unable_to_void_order_without_payment_CORE_0210(
     permission_manage_product_types_and_attributes,
     permission_manage_shipping,
     permission_manage_orders,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -29,17 +31,19 @@ def test_unable_to_void_order_without_payment_CORE_0210(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
+    shipping_method_id = shop_data["shipping_method_id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_unable_to_void_order_without_payment.py
+++ b/saleor/tests/e2e/orders/test_unable_to_void_order_without_payment.py
@@ -2,7 +2,7 @@ import pytest
 
 from .. import DEFAULT_ADDRESS
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     draft_order_complete,
@@ -30,10 +30,10 @@ def test_unable_to_void_order_without_payment_CORE_0210(
 
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    shipping_method_id = shop_data["shipping_methods"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
+    shipping_method_id = shop_data["shipping_method"]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/test_unable_to_void_order_without_payment.py
+++ b/saleor/tests/e2e/orders/test_unable_to_void_order_without_payment.py
@@ -16,34 +16,24 @@ from .utils import (
 @pytest.mark.e2e
 def test_unable_to_void_order_without_payment_CORE_0210(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
-    shipping_method_id = shop_data["shipping_method_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    shipping_method_id = shop_data["shipping_methods"][0]["id"]
 
     (
         _product_id,

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -15,6 +15,9 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
           gross {
             amount
           }
+          tax {
+            amount
+          }
         }
         unitPrice {
           gross {

--- a/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
+++ b/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
@@ -22,6 +22,8 @@ def test_create_page_with_each_of_attribute_types_core_0701(
     permission_manage_channels,
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
+    permission_manage_taxes,
+    permission_manage_settings,
     site_settings,
 ):
     # Before
@@ -32,15 +34,16 @@ def test_create_page_with_each_of_attribute_types_core_0701(
         permission_manage_channels,
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
+++ b/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
@@ -18,32 +18,22 @@ def test_create_page_with_each_of_attribute_types_core_0701(
     e2e_staff_api_client,
     permission_manage_page_types_and_attributes,
     permission_manage_pages,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_taxes,
-    permission_manage_settings,
     site_settings,
 ):
     # Before
     permissions = [
         permission_manage_page_types_and_attributes,
         permission_manage_pages,
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
+++ b/saleor/tests/e2e/pages/test_create_page_with_all_attributes_types.py
@@ -9,7 +9,7 @@ from ....tests.utils import dummy_editorjs
 from ..attributes.utils import prepare_all_attributes
 from ..pages.utils import create_page, create_page_type
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 
 
@@ -31,9 +31,9 @@ def test_create_page_with_each_of_attribute_types_core_0701(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/product/test_create_simple_product.py
+++ b/saleor/tests/e2e/product/test_create_simple_product.py
@@ -42,6 +42,8 @@ def test_should_create_simple_product_core_0302(
     permission_manage_products,
     permission_manage_channels,
     permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -49,15 +51,17 @@ def test_should_create_simple_product_core_0302(
         permission_manage_products,
         permission_manage_channels,
         permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         attribute_product_id,

--- a/saleor/tests/e2e/product/test_create_simple_product.py
+++ b/saleor/tests/e2e/product/test_create_simple_product.py
@@ -39,29 +39,19 @@ def prepare_attributes_and_product_type(e2e_staff_api_client):
 def test_should_create_simple_product_core_0302(
     e2e_staff_api_client,
     permission_manage_product_types_and_attributes,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
         permission_manage_product_types_and_attributes,
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     (
         attribute_product_id,

--- a/saleor/tests/e2e/product/test_create_simple_product.py
+++ b/saleor/tests/e2e/product/test_create_simple_product.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..attributes.utils import attribute_create
-from ..shop.utils import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     create_category,
@@ -48,10 +48,10 @@ def test_should_create_simple_product_core_0302(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     (
         attribute_product_id,

--- a/saleor/tests/e2e/product/test_product_no_longer_on_promotion_when_promotion_is_removed.py
+++ b/saleor/tests/e2e/product/test_product_no_longer_on_promotion_when_promotion_is_removed.py
@@ -15,34 +15,24 @@ from .utils.product_query import get_product
 @pytest.mark.e2e
 def test_product_no_longer_on_promotion_when_promotion_is_removed_CORE_2114(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_orders,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_orders,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/product/test_product_no_longer_on_promotion_when_promotion_is_removed.py
+++ b/saleor/tests/e2e/product/test_product_no_longer_on_promotion_when_promotion_is_removed.py
@@ -6,7 +6,7 @@ from ..promotions.utils import (
     delete_promotion,
     promotion_query,
 )
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils.preparing_product import prepare_product
 from .utils.product_query import get_product
@@ -29,10 +29,10 @@ def test_product_no_longer_on_promotion_when_promotion_is_removed_CORE_2114(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/product/test_should_create_variants_in_bulk.py
+++ b/saleor/tests/e2e/product/test_should_create_variants_in_bulk.py
@@ -66,6 +66,8 @@ def test_should_create_product_with_few_variants_core_0301(
     permission_manage_products,
     permission_manage_channels,
     permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -73,15 +75,17 @@ def test_should_create_product_with_few_variants_core_0301(
         permission_manage_products,
         permission_manage_channels,
         permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         attribute_product_id,

--- a/saleor/tests/e2e/product/test_should_create_variants_in_bulk.py
+++ b/saleor/tests/e2e/product/test_should_create_variants_in_bulk.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ..attributes.utils import attribute_create
-from ..shop.utils import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     create_category,
@@ -72,10 +72,10 @@ def test_should_create_product_with_few_variants_core_0301(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     (
         attribute_product_id,

--- a/saleor/tests/e2e/product/test_should_create_variants_in_bulk.py
+++ b/saleor/tests/e2e/product/test_should_create_variants_in_bulk.py
@@ -63,29 +63,19 @@ def prepare_attributes_and_product_type(e2e_staff_api_client):
 def test_should_create_product_with_few_variants_core_0301(
     e2e_staff_api_client,
     permission_manage_product_types_and_attributes,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
+    shop_permissions,
 ):
     # Before
     permissions = [
         permission_manage_product_types_and_attributes,
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
+        *shop_permissions,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     (
         attribute_product_id,

--- a/saleor/tests/e2e/promotions/test_sale_updated_by_promotion_can_not_be_handled_by_sales.py
+++ b/saleor/tests/e2e/promotions/test_sale_updated_by_promotion_can_not_be_handled_by_sales.py
@@ -55,6 +55,8 @@ def test_sale_updated_by_promotion_can_not_be_handled_by_sales_core_2116(
     permission_manage_shipping,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -63,15 +65,16 @@ def test_sale_updated_by_promotion_can_not_be_handled_by_sales_core_2116(
         permission_manage_shipping,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/promotions/test_sale_updated_by_promotion_can_not_be_handled_by_sales.py
+++ b/saleor/tests/e2e/promotions/test_sale_updated_by_promotion_can_not_be_handled_by_sales.py
@@ -50,31 +50,21 @@ def prepare_sale_for_product(
 @pytest.mark.e2e
 def test_sale_updated_by_promotion_can_not_be_handled_by_sales_core_2116(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_shipping,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/promotions/test_sale_updated_by_promotion_can_not_be_handled_by_sales.py
+++ b/saleor/tests/e2e/promotions/test_sale_updated_by_promotion_can_not_be_handled_by_sales.py
@@ -8,7 +8,7 @@ from ..sales.utils import (
     raw_create_sale_channel_listing,
     sale_catalogues_add,
 )
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 
 
@@ -62,9 +62,9 @@ def test_sale_updated_by_promotion_can_not_be_handled_by_sales_core_2116(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
@@ -54,6 +54,8 @@ def test_staff_can_change_catalogue_predicate_core_2112(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -62,11 +64,17 @@ def test_staff_can_change_catalogue_predicate_core_2112(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    warehouse_id, channel_id, channel_slug, _ = prepare_shop(e2e_staff_api_client)
-
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
     product_id, product_variant_id, _ = prepare_product(
         e2e_staff_api_client, warehouse_id, channel_id, "7.99"
     )

--- a/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
@@ -49,32 +49,23 @@ def prepare_promotion(
 @pytest.mark.e2e
 def test_staff_can_change_catalogue_predicate_core_2112(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+
     product_id, product_variant_id, _ = prepare_product(
         e2e_staff_api_client, warehouse_id, channel_id, "7.99"
     )

--- a/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_catalog_predicate.py
@@ -14,7 +14,7 @@ from ..promotions.utils import (
     create_promotion_rule,
     update_promotion_rule,
 )
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 
 
@@ -61,10 +61,10 @@ def test_staff_can_change_catalogue_predicate_core_2112(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     product_id, product_variant_id, _ = prepare_product(
         e2e_staff_api_client, warehouse_id, channel_id, "7.99"

--- a/saleor/tests/e2e/promotions/test_staff_can_change_channel_in_promotion_rule.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_channel_in_promotion_rule.py
@@ -43,15 +43,29 @@ def prepare_promotion(
 
 
 def prepare_channels_with_product(e2e_staff_api_client):
+    channels = [
+        {
+            "channel_name": "First Channel",
+            "slug": "first-channel",
+            "currency": "USD",
+            "country": "US",
+        },
+        {
+            "channel_name": "Second Channel",
+            "slug": "second-channel",
+            "currency": "PLN",
+            "country": "PL",
+        },
+    ]
     shop_data = prepare_shop(
         e2e_staff_api_client,
-        num_channels=2,
+        channels_settings=channels,
     )
-    warehouse_id = shop_data["warehouse_id"]
-    first_channel_id = shop_data["created_channels"][0]["id"]
-    first_channel_slug = shop_data["created_channels"][0]["slug"]
-    second_channel_id = shop_data["created_channels"][1]["id"]
-    second_channel_slug = shop_data["created_channels"][1]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+    first_channel_id = shop_data["channels"][0]["id"]
+    first_channel_slug = shop_data["channels"][0]["slug"]
+    second_channel_id = shop_data["channels"][1]["id"]
+    second_channel_slug = shop_data["channels"][1]["slug"]
 
     product_id, product_variant_id, _ = prepare_product(
         e2e_staff_api_client, warehouse_id, first_channel_id, "7.99"
@@ -89,23 +103,15 @@ def prepare_channels_with_product(e2e_staff_api_client):
 @pytest.mark.e2e
 def test_staff_can_change_promotion_rule_channel_core_2113(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 

--- a/saleor/tests/e2e/promotions/test_staff_can_change_reward_value_type_in_promotion_rule.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_reward_value_type_in_promotion_rule.py
@@ -43,6 +43,8 @@ def test_staff_can_change_reward_value_type_in_promotion_rule_core_2117(
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
     permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -51,12 +53,17 @@ def test_staff_can_change_reward_value_type_in_promotion_rule_core_2117(
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    warehouse_id, channel_id, channel_slug, _shipping_method_id = prepare_shop(
-        e2e_staff_api_client
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
     )
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
+    warehouse_id = shop_data["warehouse_id"]
 
     product_id, product_variant_id, product_variant_price = prepare_product(
         e2e_staff_api_client, warehouse_id, channel_id, "14.99"

--- a/saleor/tests/e2e/promotions/test_staff_can_change_reward_value_type_in_promotion_rule.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_reward_value_type_in_promotion_rule.py
@@ -38,32 +38,22 @@ def prepare_promotion(
 @pytest.mark.e2e
 def test_staff_can_change_reward_value_type_in_promotion_rule_core_2117(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     product_id, product_variant_id, product_variant_price = prepare_product(
         e2e_staff_api_client, warehouse_id, channel_id, "14.99"

--- a/saleor/tests/e2e/promotions/test_staff_can_change_reward_value_type_in_promotion_rule.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_change_reward_value_type_in_promotion_rule.py
@@ -2,7 +2,7 @@ import pytest
 
 from ..product.utils import get_product
 from ..product.utils.preparing_product import prepare_product
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import create_promotion, create_promotion_rule, update_promotion_rule
 
@@ -50,10 +50,10 @@ def test_staff_can_change_reward_value_type_in_promotion_rule_core_2117(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     product_id, product_variant_id, product_variant_price = prepare_product(
         e2e_staff_api_client, warehouse_id, channel_id, "14.99"

--- a/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
@@ -1,6 +1,5 @@
 import pytest
 
-from ..channel.utils import create_channel
 from ..product.utils import (
     create_category,
     create_collection,
@@ -13,31 +12,19 @@ from ..product.utils import (
     get_product,
 )
 from ..promotions.utils import create_promotion, create_promotion_rule
+from ..shop.utils import prepare_shop
 from ..utils import assign_permissions
 
 
 def prepare_product(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
-    permission_manage_product_types_and_attributes,
-    permission_manage_discounts,
-    channel_slug,
     variant_price,
 ):
-    permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_product_types_and_attributes,
-        permission_manage_discounts,
-    ]
-    assign_permissions(e2e_staff_api_client, permissions)
-
-    channel_data = create_channel(
+    shop_data = prepare_shop(
         e2e_staff_api_client,
-        slug=channel_slug,
     )
-    channel_id = channel_data["id"]
+    channel_id = shop_data["channel_id"]
+    channel_slug = shop_data["channel_slug"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -76,7 +63,7 @@ def prepare_product(
         variant_price,
     )
 
-    return product_id, channel_id, collection_id
+    return product_id, channel_id, channel_slug, collection_id
 
 
 @pytest.mark.e2e
@@ -86,17 +73,29 @@ def test_create_promotion_for_collection_core_2109(
     permission_manage_channels,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
+    permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
-    channel_slug = "promotion_collections_channel"
-    variant_price = "9.99"
-    product_id, channel_id, collection_id = prepare_product(
-        e2e_staff_api_client,
+    permissions = [
         permission_manage_products,
         permission_manage_channels,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
+        permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+    variant_price = "9.99"
+    (
+        product_id,
+        channel_id,
         channel_slug,
+        collection_id,
+    ) = prepare_product(
+        e2e_staff_api_client,
         variant_price,
     )
 

--- a/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
@@ -20,11 +20,9 @@ def prepare_product(
     e2e_staff_api_client,
     variant_price,
 ):
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    channel_slug = shop_data["channel_slug"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,
@@ -69,23 +67,15 @@ def prepare_product(
 @pytest.mark.e2e
 def test_create_promotion_for_collection_core_2109(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_shipping,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_shipping,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
     variant_price = "9.99"

--- a/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_create_promotion_for_collections.py
@@ -12,7 +12,7 @@ from ..product.utils import (
     get_product,
 )
 from ..promotions.utils import create_promotion, create_promotion_rule
-from ..shop.utils import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 
 
@@ -20,9 +20,9 @@ def prepare_product(
     e2e_staff_api_client,
     variant_price,
 ):
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
 
     product_type_data = create_product_type(
         e2e_staff_api_client,

--- a/saleor/tests/e2e/promotions/test_staff_can_translate_promotions.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_translate_promotions.py
@@ -62,6 +62,8 @@ def test_staff_translate_promotions_core_2119(
     permission_manage_discounts,
     permission_manage_shipping,
     permission_manage_translations,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -71,10 +73,15 @@ def test_staff_translate_promotions_core_2119(
         permission_manage_discounts,
         permission_manage_shipping,
         permission_manage_translations,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    warehouse_id, channel_id, _channel_slug, _ = prepare_shop(e2e_staff_api_client)
-
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
     product_id, _product_variant_id, _ = prepare_product(
         e2e_staff_api_client, warehouse_id, channel_id, "37.99"
     )

--- a/saleor/tests/e2e/promotions/test_staff_can_translate_promotions.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_translate_promotions.py
@@ -56,32 +56,23 @@ def prepare_promotion(
 @pytest.mark.e2e
 def test_staff_translate_promotions_core_2119(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
     permission_manage_discounts,
-    permission_manage_shipping,
     permission_manage_translations,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
-        permission_manage_shipping,
         permission_manage_translations,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
+
     product_id, _product_variant_id, _ = prepare_product(
         e2e_staff_api_client, warehouse_id, channel_id, "37.99"
     )

--- a/saleor/tests/e2e/promotions/test_staff_can_translate_promotions.py
+++ b/saleor/tests/e2e/promotions/test_staff_can_translate_promotions.py
@@ -9,7 +9,7 @@ from ..promotions.utils import (
     translate_promotion,
     translate_promotion_rule,
 )
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..translations.utils import get_translations
 from ..utils import assign_permissions
 
@@ -69,9 +69,10 @@ def test_staff_translate_promotions_core_2119(
         permission_manage_translations,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     product_id, _product_variant_id, _ = prepare_product(
         e2e_staff_api_client, warehouse_id, channel_id, "37.99"

--- a/saleor/tests/e2e/promotions/test_unable_to_query_nor_mutate_sale_updated_by_promotion_translations.py
+++ b/saleor/tests/e2e/promotions/test_unable_to_query_nor_mutate_sale_updated_by_promotion_translations.py
@@ -16,16 +16,15 @@ from .utils import promotions_query, translate_promotion
 def prepare_sale(e2e_staff_api_client):
     price = 10
 
-    (
-        warehouse_id,
-        channel_id,
-        _channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
+    warehouse_id = shop_data["warehouse_id"]
 
     (
         product_id,
-        product_variant_id,
+        _product_variant_id,
         _product_variant_price,
     ) = prepare_product(
         e2e_staff_api_client,
@@ -76,6 +75,8 @@ def test_unable_to_query_nor_mutate_sale_updated_by_promotion_translations_CORE_
     permission_manage_shipping,
     permission_manage_discounts,
     permission_manage_translations,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -85,6 +86,8 @@ def test_unable_to_query_nor_mutate_sale_updated_by_promotion_translations_CORE_
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_translations,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 

--- a/saleor/tests/e2e/promotions/test_unable_to_query_nor_mutate_sale_updated_by_promotion_translations.py
+++ b/saleor/tests/e2e/promotions/test_unable_to_query_nor_mutate_sale_updated_by_promotion_translations.py
@@ -16,11 +16,10 @@ from .utils import promotions_query, translate_promotion
 def prepare_sale(e2e_staff_api_client):
     price = 10
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
-    warehouse_id = shop_data["warehouse_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
+    channel_slug = shop_data["channels"][0]["slug"]
+    warehouse_id = shop_data["warehouses"][0]["id"]
 
     (
         product_id,
@@ -61,6 +60,7 @@ def prepare_sale(e2e_staff_api_client):
 
     return (
         channel_id,
+        channel_slug,
         sale_name,
         sale_id,
     )
@@ -69,30 +69,23 @@ def prepare_sale(e2e_staff_api_client):
 @pytest.mark.e2e
 def test_unable_to_query_nor_mutate_sale_updated_by_promotion_translations_CORE_2120(
     e2e_staff_api_client,
-    permission_manage_products,
-    permission_manage_channels,
+    shop_permissions,
     permission_manage_product_types_and_attributes,
-    permission_manage_shipping,
     permission_manage_discounts,
     permission_manage_translations,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_products,
-        permission_manage_channels,
-        permission_manage_shipping,
+        *shop_permissions,
         permission_manage_product_types_and_attributes,
         permission_manage_discounts,
         permission_manage_translations,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     (
         channel_id,
+        channel_slug,
         sale_name,
         sale_id,
     ) = prepare_sale(e2e_staff_api_client)

--- a/saleor/tests/e2e/promotions/test_unable_to_query_nor_mutate_sale_updated_by_promotion_translations.py
+++ b/saleor/tests/e2e/promotions/test_unable_to_query_nor_mutate_sale_updated_by_promotion_translations.py
@@ -8,7 +8,7 @@ from ..sales.utils import (
     raw_create_sale_channel_listing,
     sale_catalogues_add,
 )
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import promotions_query, translate_promotion
 
@@ -16,10 +16,10 @@ from .utils import promotions_query, translate_promotion
 def prepare_sale(e2e_staff_api_client):
     price = 10
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
-    channel_slug = shop_data["channels"][0]["slug"]
-    warehouse_id = shop_data["warehouses"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
+    channel_slug = shop_data["channel"]["slug"]
+    warehouse_id = shop_data["warehouse"]["id"]
 
     (
         product_id,

--- a/saleor/tests/e2e/shipping_zone/utils/shipping_method.py
+++ b/saleor/tests/e2e/shipping_zone/utils/shipping_method.py
@@ -1,3 +1,5 @@
+import base64
+
 from ...utils import get_graphql_content
 
 SHIPPING_PRICE_CREATE_MUTATION = """
@@ -33,12 +35,34 @@ mutation CreateShippingRate($input: ShippingPriceInput!) {
 """
 
 
+def decode_and_modify_base64_descriptor(encoded_string, new_descriptor=None):
+    base64_bytes = encoded_string.encode("ascii")
+    decoded_bytes = base64.b64decode(base64_bytes)
+    decoded_string = decoded_bytes.decode("ascii")
+
+    modified_string = decoded_string
+    if new_descriptor:
+        parts = decoded_string.split(":")
+        if len(parts) >= 2:
+            modified_string = f"{new_descriptor}:{parts[1]}"
+
+    modified_base64 = base64.b64encode(modified_string.encode("ascii")).decode("ascii")
+
+    padding = "=" * ((4 - len(modified_base64) % 4) % 4)
+    modified_base64_padded = modified_base64 + padding
+
+    return modified_base64_padded
+
+
 def create_shipping_method(
     staff_api_client,
     shipping_zone_id,
-    name="Test shipping method",
+    name=None,
     type="PRICE",
 ):
+    if name is None:
+        name = "Test shipping method"
+
     variables = {
         "input": {
             "shippingZone": shipping_zone_id,
@@ -54,5 +78,7 @@ def create_shipping_method(
 
     data = content["data"]["shippingPriceCreate"]["shippingMethod"]
     assert data["id"] is not None
+
+    data["id"] = decode_and_modify_base64_descriptor(data["id"], "ShippingMethod")
 
     return data

--- a/saleor/tests/e2e/shipping_zone/utils/shipping_method.py
+++ b/saleor/tests/e2e/shipping_zone/utils/shipping_method.py
@@ -13,6 +13,20 @@ mutation CreateShippingRate($input: ShippingPriceInput!) {
     }
     shippingMethod {
       id
+      channelListings {
+        maximumOrderPrice {
+          amount
+        }
+        minimumOrderPrice {
+          amount
+        }
+        price {
+          amount
+        }
+        channel {
+          id
+        }
+      }
     }
   }
 }

--- a/saleor/tests/e2e/shipping_zone/utils/shipping_method_channel_listing.py
+++ b/saleor/tests/e2e/shipping_zone/utils/shipping_method_channel_listing.py
@@ -28,8 +28,8 @@ def create_shipping_method_channel_listing(
     shipping_method_id,
     channel_id,
     price="10.00",
-    minimumOrderPrice=None,
-    maximumOrderPrice=None,
+    minimum_order_price=None,
+    maximum_order_price=None,
 ):
     variables = {
         "id": shipping_method_id,
@@ -38,8 +38,8 @@ def create_shipping_method_channel_listing(
                 {
                     "channelId": channel_id,
                     "price": price,
-                    "maximumOrderPrice": maximumOrderPrice,
-                    "minimumOrderPrice": minimumOrderPrice,
+                    "maximumOrderPrice": maximum_order_price,
+                    "minimumOrderPrice": minimum_order_price,
                 }
             ]
         },

--- a/saleor/tests/e2e/shipping_zone/utils/shipping_method_channel_listing.py
+++ b/saleor/tests/e2e/shipping_zone/utils/shipping_method_channel_listing.py
@@ -15,7 +15,16 @@ mutation ShippingMethodChannelListingUpdate(
         channelListings {
             minimumOrderPrice {
                 amount
-             }
+            }
+            maximumOrderPrice {
+                amount
+            }
+            price {
+                amount
+            }
+            channel {
+                id
+            }
         }
     }
   }
@@ -27,9 +36,9 @@ def create_shipping_method_channel_listing(
     staff_api_client,
     shipping_method_id,
     channel_id,
-    price="10.00",
-    minimum_order_price=None,
-    maximum_order_price=None,
+    price,
+    minimum_order_price,
+    maximum_order_price,
 ):
     variables = {
         "id": shipping_method_id,

--- a/saleor/tests/e2e/shipping_zone/utils/shipping_method_channel_listing.py
+++ b/saleor/tests/e2e/shipping_zone/utils/shipping_method_channel_listing.py
@@ -33,22 +33,19 @@ mutation ShippingMethodChannelListingUpdate(
 
 
 def create_shipping_method_channel_listing(
-    staff_api_client,
-    shipping_method_id,
-    channel_id,
-    price,
-    minimum_order_price,
-    maximum_order_price,
+    staff_api_client, shipping_method_id, channel_id, add_channels
 ):
+    if add_channels is None:
+        add_channels = {}
     variables = {
         "id": shipping_method_id,
         "input": {
             "addChannels": [
                 {
                     "channelId": channel_id,
-                    "price": price,
-                    "maximumOrderPrice": maximum_order_price,
-                    "minimumOrderPrice": minimum_order_price,
+                    "price": add_channels.get("price", "10.00"),
+                    "maximumOrderPrice": add_channels.get("maximum_order_price", None),
+                    "minimumOrderPrice": add_channels.get("minimum_order_price", None),
                 }
             ]
         },

--- a/saleor/tests/e2e/shipping_zone/utils/shipping_zone.py
+++ b/saleor/tests/e2e/shipping_zone/utils/shipping_zone.py
@@ -18,6 +18,13 @@ mutation createShipping($input: ShippingZoneCreateInput!) {
       channels {
         id
       }
+      countries {
+        code
+        country
+      }
+      shippingMethods {
+        id
+      }
     }
   }
 }

--- a/saleor/tests/e2e/shipping_zone/utils/shipping_zone.py
+++ b/saleor/tests/e2e/shipping_zone/utils/shipping_zone.py
@@ -14,9 +14,24 @@ mutation createShipping($input: ShippingZoneCreateInput!) {
       description
       warehouses {
         name
+        id
+        shippingZones(first: 10) {
+          edges {
+            node {
+              id
+              countries {
+                code
+              }
+            }
+          }
+        }
+        slug
       }
       channels {
         id
+        countries {
+          code
+        }
       }
       countries {
         code
@@ -34,10 +49,13 @@ mutation createShipping($input: ShippingZoneCreateInput!) {
 def create_shipping_zone(
     staff_api_client,
     name="Test shipping zone",
-    countries=["US"],
+    countries=None,
     warehouse_ids=None,
     channel_ids=None,
 ):
+    if countries is None:
+        countries = ["US"]
+
     if not warehouse_ids:
         warehouse_ids = []
     if not channel_ids:

--- a/saleor/tests/e2e/shop/utils/__init__.py
+++ b/saleor/tests/e2e/shop/utils/__init__.py
@@ -1,7 +1,8 @@
-from .preparing_shop import prepare_shop
+from .preparing_shop import prepare_default_shop, prepare_shop
 from .shop_update_settings import update_shop_settings
 
 __all__ = [
     "prepare_shop",
+    "prepare_default_shop",
     "update_shop_settings",
 ]

--- a/saleor/tests/e2e/shop/utils/preparing_shop.py
+++ b/saleor/tests/e2e/shop/utils/preparing_shop.py
@@ -1,44 +1,308 @@
-from ...channel.utils import create_channel
-from ...shipping_zone.utils.shipping_method import create_shipping_method
-from ...shipping_zone.utils.shipping_method_channel_listing import (
+import uuid
+
+from ...channel.utils import create_channel, update_channel
+from ...shipping_zone.utils import (
+    create_shipping_method,
     create_shipping_method_channel_listing,
+    create_shipping_zone,
 )
-from ...shipping_zone.utils.shipping_zone import create_shipping_zone
-from ...warehouse.utils import create_warehouse
+from ...taxes.utils import (
+    create_tax_class,
+    get_tax_configurations,
+    update_tax_class,
+    update_tax_configuration,
+)
+from ...warehouse.utils import create_warehouse, update_warehouse
+from ..utils.shop_update_settings import update_shop_settings
 
 
-def prepare_shop(e2e_staff_api_client):
-    warehouse_data = create_warehouse(e2e_staff_api_client)
-    warehouse_id = warehouse_data["id"]
-    channel_slug = "test"
-    warehouse_ids = [warehouse_id]
-    channel_data = create_channel(
-        e2e_staff_api_client,
-        slug=channel_slug,
-        warehouse_ids=warehouse_ids,
-    )
-    channel_id = channel_data["id"]
-    channel_ids = [channel_id]
-    shipping_zone_data = create_shipping_zone(
-        e2e_staff_api_client,
-        warehouse_ids=warehouse_ids,
-        channel_ids=channel_ids,
-    )
-    shipping_zone_id = shipping_zone_data["id"]
+def create_and_update_tax_rates(e2e_staff_api_client, tax_rates):
+    created_tax_classes = {}
+    for tax_rate_info in tax_rates:
+        tax_class_data = create_tax_class(
+            e2e_staff_api_client,
+            tax_rate_info["name"],
+            [
+                {
+                    "countryCode": tax_rate_info["country_code"],
+                    "rate": tax_rate_info["rate"],
+                }
+            ],
+        )
+        created_tax_classes[tax_rate_info["type"]] = {
+            "id": tax_class_data["id"],
+            "rate": tax_rate_info["rate"],
+        }
 
-    shipping_method_data = create_shipping_method(
-        e2e_staff_api_client,
-        shipping_zone_id,
+        tax_class_update_input = {
+            "updateCountryRates": [
+                {
+                    "countryCode": tax_rate_info["country_code"],
+                    "rate": tax_rate_info["rate"],
+                }
+            ]
+        }
+        update_tax_class(
+            e2e_staff_api_client, tax_class_data["id"], tax_class_update_input
+        )
+
+    return created_tax_classes
+
+
+def prepare_shop(e2e_staff_api_client, **kwargs):
+    num_channels = kwargs.get("num_channels", 1)
+    num_warehouses = kwargs.get("num_warehouses", 1)
+    is_private = kwargs.get("is_private", False)
+    click_and_collect_option = kwargs.get("click_and_collect_option", "DISABLED")
+    currency = kwargs.get("currency", "USD")
+    country = kwargs.get("country", "US")
+    automatically_fulfill_non_shippable_giftcard = kwargs.get(
+        "automatically_fulfill_non_shippable_giftcard", False
     )
-    shipping_method_id = shipping_method_data["id"]
-    create_shipping_method_channel_listing(
-        e2e_staff_api_client,
-        shipping_method_id,
-        channel_id,
+    allow_unpaid_orders = kwargs.get("allow_unpaid_orders", False)
+    automatically_confirm_all_new_orders = kwargs.get(
+        "automaticallyConfirmAllNewOrders", True
     )
-    return (
-        warehouse_id,
-        channel_id,
-        channel_slug,
-        shipping_method_id,
+    mark_as_paid_strategy = kwargs.get("mark_as_paid_strategy", "PAYMENT_FLOW")
+    expire_order_after_in_minutes = kwargs.get("expire_order_after_in_minutes", None)
+    delete_expired_order_after_in_days = kwargs.get(
+        "delete_expired_order_after_in_days", "1"
     )
+    fulfillment_auto_approve = kwargs.get("fulfillment_auto_approve", False)
+    fulfillment_allow_unpaid = kwargs.get("fulfillment_allow_unpaid", False)
+    minimum_order_price = kwargs.get("minimum_order_price", None)
+    maximum_order_price = kwargs.get("maximum_order_price", None)
+    enable_account_confirmation_by_email = kwargs.get(
+        "enable_account_confirmation_by_email", True
+    )
+    allow_login_without_confirmation = kwargs.get(
+        "allow_login_without_confirmation", False
+    )
+    allow_unpaid_orders = kwargs.get("allow_unpaid_orders", False)
+    shipping_zone_countries = kwargs.get("shipping_zone_countries", ["US"])
+    shipping_zones_structure = kwargs.get(
+        "shipping_zones_structure", [{"countries": ["US"], "num_shipping_methods": 1}]
+    )
+    billing_country_code = kwargs.get("billing_country_code", "US")
+    shipping_country_code = kwargs.get("shipping_country_code", "US")
+    shipping_price = kwargs.get("shipping_price", "10.00")
+    billing_country_tax_rate = kwargs.get("billing_country_tax_rate")
+    shipping_country_tax_rate = kwargs.get("shipping_country_tax_rate")
+    country_tax_rate = kwargs.get("country_tax_rate")
+    product_tax_rate = kwargs.get("product_tax_rate")
+    product_type_tax_rate = kwargs.get("product_type_tax_rate")
+    tax_calculation_strategy = kwargs.get("tax_calculation_strategy", "FLAT_RATES")
+    display_gross_prices = kwargs.get("display_gross_prices", True)
+    prices_entered_with_tax = kwargs.get("prices_entered_with_tax", True)
+    created_warehouses = []
+    created_channels = []
+    created_shipping_zones = []
+    created_shipping_methods = []
+    created_shipping_methods_ids = []
+    warehouse_id = None
+    channel_id = None
+    channel_slug = None
+    shipping_zone_id = None
+    shipping_method_id = None
+    country_tax_class_id = kwargs.get("country_tax_class_id", None)
+    shipping_tax_class_id = kwargs.get("shipping_tax_class_id", None)
+    product_tax_class_id = kwargs.get("product_tax_class_id", None)
+    product_type_tax_class_id = kwargs.get("product_type_tax_class_id", None)
+    billing_tax_class_id = kwargs.get("billing_tax_class_id", None)
+
+    for _ in range(num_warehouses):
+        warehouse_data = create_warehouse(e2e_staff_api_client)
+        warehouse_id = warehouse_data["id"]
+        warehouse_ids = [warehouse_id]
+        created_warehouses.append(warehouse_data)
+
+        update_warehouse(
+            e2e_staff_api_client,
+            warehouse_data["id"],
+            is_private=is_private,
+            click_and_collect_option=click_and_collect_option,
+        )
+        if num_channels is not None:
+            for i in range(num_channels):
+                channel_slug = kwargs.get(
+                    f"channel_slug_{i}", f"test_channel_{uuid.uuid4()}"
+                )
+
+                channel_data = create_channel(
+                    e2e_staff_api_client,
+                    slug=channel_slug,
+                    warehouse_ids=warehouse_ids,
+                    currency=currency,
+                    country=country,
+                    is_active=True,
+                    automatically_fulfill_non_shippable_giftcard=automatically_fulfill_non_shippable_giftcard,
+                    allow_unpaid_orders=allow_unpaid_orders,
+                    automatically_confirm_all_new_orders=automatically_confirm_all_new_orders,
+                    mark_as_paid_strategy=mark_as_paid_strategy,
+                )
+                channel_id = channel_data["id"]
+                channel_ids = [channel_id]
+                created_channels.append(
+                    {"id": channel_data["id"], "slug": channel_slug}
+                )
+
+                channel_update_input = {
+                    "orderSettings": {
+                        "markAsPaidStrategy": mark_as_paid_strategy,
+                        "automaticallyFulfillNonShippableGiftCard": automatically_fulfill_non_shippable_giftcard,
+                        "allowUnpaidOrders": allow_unpaid_orders,
+                        "automaticallyConfirmAllNewOrders": automatically_confirm_all_new_orders,
+                        "expireOrdersAfter": expire_order_after_in_minutes,
+                        "deleteExpiredOrdersAfter": delete_expired_order_after_in_days,
+                    },
+                }
+                update_channel(
+                    e2e_staff_api_client,
+                    channel_id,
+                    channel_update_input,
+                )
+
+                for zone_info in shipping_zones_structure:
+                    zone_countries = zone_info["countries"]
+                    shipping_zone_data = create_shipping_zone(
+                        e2e_staff_api_client,
+                        name=f"{zone_countries} shipping zone",
+                        countries=zone_countries,
+                        warehouse_ids=warehouse_ids,
+                        channel_ids=channel_ids,
+                    )
+                    shipping_zone_id = shipping_zone_data["id"]
+                    shipping_methods_for_zone = []
+
+                    for _ in range(zone_info.get("num_shipping_methods", 1)):
+                        shipping_method_data = create_shipping_method(
+                            e2e_staff_api_client, shipping_zone_id
+                        )
+                        shipping_method_id = shipping_method_data["id"]
+
+                        created_shipping_methods.append(shipping_method_data)
+                        shipping_methods_for_zone.append(shipping_method_id)
+                        created_shipping_methods_ids.append(shipping_method_id)
+
+                        create_shipping_method_channel_listing(
+                            e2e_staff_api_client,
+                            shipping_method_id,
+                            channel_id,
+                            price=shipping_price,
+                            minimum_order_price=minimum_order_price,
+                            maximum_order_price=maximum_order_price,
+                        )
+
+                        shipping_zone_data[
+                            "shippingMethods"
+                        ] = shipping_methods_for_zone
+                        created_shipping_zones.append(shipping_zone_data)
+
+            tax_config_data = get_tax_configurations(e2e_staff_api_client)
+            channel_tax_config = tax_config_data[0]["node"]
+            tax_config_id = channel_tax_config["id"]
+
+            update_tax_configuration(
+                e2e_staff_api_client,
+                tax_config_id,
+                tax_calculation_strategy=tax_calculation_strategy,
+                display_gross_prices=display_gross_prices,
+                prices_entered_with_tax=prices_entered_with_tax,
+            )
+
+            tax_rates = [
+                {
+                    "type": "country",
+                    "name": "Country Tax Class",
+                    "country_code": country,
+                    "rate": country_tax_rate,
+                }
+                if country_tax_rate is not None
+                else None,
+                {
+                    "type": "shipping",
+                    "name": "Shipping Tax Class",
+                    "country_code": shipping_country_code,
+                    "rate": shipping_country_tax_rate,
+                }
+                if shipping_country_tax_rate is not None
+                else None,
+                {
+                    "type": "billing",
+                    "name": "Billing Tax Class",
+                    "country_code": billing_country_code,
+                    "rate": billing_country_tax_rate,
+                }
+                if billing_country_tax_rate is not None
+                else None,
+                {
+                    "type": "product",
+                    "name": "Product Tax Class",
+                    "country_code": country,
+                    "rate": product_tax_rate,
+                }
+                if product_tax_rate is not None
+                else None,
+                {
+                    "type": "product_type",
+                    "name": "Product Type Tax Class",
+                    "country_code": country,
+                    "rate": product_type_tax_rate,
+                }
+                if product_type_tax_rate is not None
+                else None,
+            ]
+            tax_rates = [rate for rate in tax_rates if rate is not None]
+
+            created_tax_classes = create_and_update_tax_rates(
+                e2e_staff_api_client, tax_rates
+            )
+            if "country" in created_tax_classes:
+                country_tax_class_id = created_tax_classes["country"]["id"]
+
+            if "shipping" in created_tax_classes:
+                shipping_tax_class_id = created_tax_classes["shipping"]["id"]
+
+            if "billing" in created_tax_classes:
+                billing_tax_class_id = created_tax_classes["billing"]["id"]
+
+            if "product" in created_tax_classes:
+                product_tax_class_id = created_tax_classes["product"]["id"]
+            if "product_type" in created_tax_classes:
+                product_type_tax_class_id = created_tax_classes["product_type"]["id"]
+
+            input_data = {
+                "enableAccountConfirmationByEmail": enable_account_confirmation_by_email,
+                "allowLoginWithoutConfirmation": allow_login_without_confirmation,
+                "fulfillmentAutoApprove": fulfillment_auto_approve,
+                "fulfillmentAllowUnpaid": fulfillment_allow_unpaid,
+            }
+            update_shop_settings(e2e_staff_api_client, input_data)
+
+    return {
+        "warehouse_id": warehouse_id,
+        "channel_id": channel_id,
+        "country": country,
+        "channel_slug": channel_slug,
+        "created_channels": created_channels,
+        "shipping_zone_id": shipping_zone_id,
+        "shipping_method_id": shipping_method_id,
+        "shipping_method_ids": created_shipping_methods_ids,
+        "shipping_price": shipping_price,
+        "shipping_country_tax_rate": shipping_country_tax_rate,
+        "billing_country_tax_rate": billing_country_tax_rate,
+        "product_tax_rate": product_tax_rate,
+        "product_type_tax_rate": product_type_tax_rate,
+        "country_tax_rate": country_tax_rate,
+        "shipping_tax_class_id": shipping_tax_class_id,
+        "product_tax_class_id": product_tax_class_id,
+        "product_type_tax_class_id": product_type_tax_class_id,
+        "shipping_zone_countries": shipping_zone_countries,
+        "shipping_country_code": shipping_country_code,
+        "billing_country_code": billing_country_code,
+        "created_shipping_zones": created_shipping_zones,
+        "billing_tax_class_id": billing_tax_class_id,
+        "country_tax_class_id": country_tax_class_id,
+        "expire_order_after_in_minutes": expire_order_after_in_minutes,
+        "delete_expired_order_after_in_days": delete_expired_order_after_in_days,
+    }

--- a/saleor/tests/e2e/shop/utils/preparing_shop.py
+++ b/saleor/tests/e2e/shop/utils/preparing_shop.py
@@ -1,6 +1,6 @@
-import uuid
+import base64
 
-from ...channel.utils import create_channel, update_channel
+from ...channel.utils import create_channel
 from ...shipping_zone.utils import (
     create_shipping_method,
     create_shipping_method_channel_listing,
@@ -12,12 +12,32 @@ from ...taxes.utils import (
     update_tax_class,
     update_tax_configuration,
 )
-from ...warehouse.utils import create_warehouse, update_warehouse
+from ...warehouse.utils import create_warehouse
 from ..utils.shop_update_settings import update_shop_settings
 
 
-def create_and_update_tax_rates(e2e_staff_api_client, tax_rates):
-    created_tax_classes = {}
+def decode_and_modify_base64_descriptor(encoded_string, new_descriptor=None):
+    base64_bytes = encoded_string.encode("ascii")
+    decoded_bytes = base64.b64decode(base64_bytes)
+    decoded_string = decoded_bytes.decode("ascii")
+
+    modified_string = decoded_string
+    if new_descriptor:
+        parts = decoded_string.split(":")
+        if len(parts) >= 2:
+            modified_string = f"{new_descriptor}:{parts[1]}"
+
+    modified_base64 = base64.b64encode(modified_string.encode("ascii")).decode("ascii")
+
+    padding = "=" * ((4 - len(modified_base64) % 4) % 4)
+    modified_base64_padded = modified_base64 + padding
+
+    return decoded_string, modified_base64_padded
+
+
+def create_and_update_tax_classes(e2e_staff_api_client, tax_rates):
+    created_tax_classes = {rate["type"]: {} for rate in tax_rates}
+
     for tax_rate_info in tax_rates:
         tax_class_data = create_tax_class(
             e2e_staff_api_client,
@@ -49,260 +69,117 @@ def create_and_update_tax_rates(e2e_staff_api_client, tax_rates):
     return created_tax_classes
 
 
-def prepare_shop(e2e_staff_api_client, **kwargs):
-    num_channels = kwargs.get("num_channels", 1)
-    num_warehouses = kwargs.get("num_warehouses", 1)
-    is_private = kwargs.get("is_private", False)
-    click_and_collect_option = kwargs.get("click_and_collect_option", "DISABLED")
-    currency = kwargs.get("currency", "USD")
-    country = kwargs.get("country", "US")
-    automatically_fulfill_non_shippable_giftcard = kwargs.get(
-        "automatically_fulfill_non_shippable_giftcard", False
-    )
-    allow_unpaid_orders = kwargs.get("allow_unpaid_orders", False)
-    automatically_confirm_all_new_orders = kwargs.get(
-        "automaticallyConfirmAllNewOrders", True
-    )
-    mark_as_paid_strategy = kwargs.get("mark_as_paid_strategy", "PAYMENT_FLOW")
-    expire_order_after_in_minutes = kwargs.get("expire_order_after_in_minutes", None)
-    delete_expired_order_after_in_days = kwargs.get(
-        "delete_expired_order_after_in_days", "1"
-    )
-    fulfillment_auto_approve = kwargs.get("fulfillment_auto_approve", False)
-    fulfillment_allow_unpaid = kwargs.get("fulfillment_allow_unpaid", False)
-    minimum_order_price = kwargs.get("minimum_order_price", None)
-    maximum_order_price = kwargs.get("maximum_order_price", None)
-    enable_account_confirmation_by_email = kwargs.get(
-        "enable_account_confirmation_by_email", True
-    )
-    allow_login_without_confirmation = kwargs.get(
-        "allow_login_without_confirmation", False
-    )
-    allow_unpaid_orders = kwargs.get("allow_unpaid_orders", False)
-    shipping_zone_countries = kwargs.get("shipping_zone_countries", ["US"])
-    shipping_zones_structure = kwargs.get(
-        "shipping_zones_structure", [{"countries": ["US"], "num_shipping_methods": 1}]
-    )
-    billing_country_code = kwargs.get("billing_country_code", "US")
-    shipping_country_code = kwargs.get("shipping_country_code", "US")
-    shipping_price = kwargs.get("shipping_price", "10.00")
-    billing_country_tax_rate = kwargs.get("billing_country_tax_rate")
-    shipping_country_tax_rate = kwargs.get("shipping_country_tax_rate")
-    country_tax_rate = kwargs.get("country_tax_rate")
-    product_tax_rate = kwargs.get("product_tax_rate")
-    product_type_tax_rate = kwargs.get("product_type_tax_rate")
-    tax_calculation_strategy = kwargs.get("tax_calculation_strategy", "FLAT_RATES")
-    display_gross_prices = kwargs.get("display_gross_prices", True)
-    prices_entered_with_tax = kwargs.get("prices_entered_with_tax", True)
-    created_warehouses = []
+def prepare_shop(
+    e2e_staff_api_client,
+    warehouses=None,
+    channels_settings=None,
+    shipping_zones=None,
+    shipping_methods=None,
+    shop_settings_update=None,
+    tax_settings=None,
+    shipping_method_channel_listing_settings={},
+    **kwargs,
+):
+    if warehouses is None:
+        warehouses = [create_warehouse(e2e_staff_api_client, **kwargs)]
     created_channels = []
-    created_shipping_zones = []
-    created_shipping_methods = []
-    created_shipping_methods_ids = []
-    warehouse_id = None
-    channel_id = None
-    channel_slug = None
-    shipping_zone_id = None
-    shipping_method_id = None
-    country_tax_class_id = kwargs.get("country_tax_class_id", None)
-    shipping_tax_class_id = kwargs.get("shipping_tax_class_id", None)
-    product_tax_class_id = kwargs.get("product_tax_class_id", None)
-    product_type_tax_class_id = kwargs.get("product_type_tax_class_id", None)
-    billing_tax_class_id = kwargs.get("billing_tax_class_id", None)
-
-    for _ in range(num_warehouses):
-        warehouse_data = create_warehouse(e2e_staff_api_client)
-        warehouse_id = warehouse_data["id"]
-        warehouse_ids = [warehouse_id]
-        created_warehouses.append(warehouse_data)
-
-        update_warehouse(
-            e2e_staff_api_client,
-            warehouse_data["id"],
-            is_private=is_private,
-            click_and_collect_option=click_and_collect_option,
-        )
-        if num_channels is not None:
-            for i in range(num_channels):
-                channel_slug = kwargs.get(
-                    f"channel_slug_{i}", f"test_channel_{uuid.uuid4()}"
-                )
-
-                channel_data = create_channel(
-                    e2e_staff_api_client,
-                    slug=channel_slug,
-                    warehouse_ids=warehouse_ids,
-                    currency=currency,
-                    country=country,
-                    is_active=True,
-                    automatically_fulfill_non_shippable_giftcard=automatically_fulfill_non_shippable_giftcard,
-                    allow_unpaid_orders=allow_unpaid_orders,
-                    automatically_confirm_all_new_orders=automatically_confirm_all_new_orders,
-                    mark_as_paid_strategy=mark_as_paid_strategy,
-                )
-                channel_id = channel_data["id"]
-                channel_ids = [channel_id]
-                created_channels.append(
-                    {"id": channel_data["id"], "slug": channel_slug}
-                )
-
-                channel_update_input = {
-                    "orderSettings": {
-                        "markAsPaidStrategy": mark_as_paid_strategy,
-                        "automaticallyFulfillNonShippableGiftCard": automatically_fulfill_non_shippable_giftcard,
-                        "allowUnpaidOrders": allow_unpaid_orders,
-                        "automaticallyConfirmAllNewOrders": automatically_confirm_all_new_orders,
-                        "expireOrdersAfter": expire_order_after_in_minutes,
-                        "deleteExpiredOrdersAfter": delete_expired_order_after_in_days,
-                    },
-                }
-                update_channel(
-                    e2e_staff_api_client,
-                    channel_id,
-                    channel_update_input,
-                )
-
-                for zone_info in shipping_zones_structure:
-                    zone_countries = zone_info["countries"]
-                    shipping_zone_data = create_shipping_zone(
-                        e2e_staff_api_client,
-                        name=f"{zone_countries} shipping zone",
-                        countries=zone_countries,
-                        warehouse_ids=warehouse_ids,
-                        channel_ids=channel_ids,
-                    )
-                    shipping_zone_id = shipping_zone_data["id"]
-                    shipping_methods_for_zone = []
-
-                    for _ in range(zone_info.get("num_shipping_methods", 1)):
-                        shipping_method_data = create_shipping_method(
-                            e2e_staff_api_client, shipping_zone_id
-                        )
-                        shipping_method_id = shipping_method_data["id"]
-
-                        created_shipping_methods.append(shipping_method_data)
-                        shipping_methods_for_zone.append(shipping_method_id)
-                        created_shipping_methods_ids.append(shipping_method_id)
-
-                        create_shipping_method_channel_listing(
-                            e2e_staff_api_client,
-                            shipping_method_id,
-                            channel_id,
-                            price=shipping_price,
-                            minimum_order_price=minimum_order_price,
-                            maximum_order_price=maximum_order_price,
-                        )
-
-                        shipping_zone_data[
-                            "shippingMethods"
-                        ] = shipping_methods_for_zone
-                        created_shipping_zones.append(shipping_zone_data)
-
-            tax_config_data = get_tax_configurations(e2e_staff_api_client)
-            channel_tax_config = tax_config_data[0]["node"]
-            tax_config_id = channel_tax_config["id"]
-
-            update_tax_configuration(
+    if channels_settings:
+        for channel_config in channels_settings:
+            channel = create_channel(
                 e2e_staff_api_client,
-                tax_config_id,
-                tax_calculation_strategy=tax_calculation_strategy,
-                display_gross_prices=display_gross_prices,
-                prices_entered_with_tax=prices_entered_with_tax,
+                warehouse_ids=[warehouses[0]["id"]],
+                **channel_config,
             )
-
-            tax_rates = [
-                {
-                    "type": "country",
-                    "name": "Country Tax Class",
-                    "country_code": country,
-                    "rate": country_tax_rate,
-                }
-                if country_tax_rate is not None
-                else None,
-                {
-                    "type": "shipping",
-                    "name": "Shipping Tax Class",
-                    "country_code": shipping_country_code,
-                    "rate": shipping_country_tax_rate,
-                }
-                if shipping_country_tax_rate is not None
-                else None,
-                {
-                    "type": "billing",
-                    "name": "Billing Tax Class",
-                    "country_code": billing_country_code,
-                    "rate": billing_country_tax_rate,
-                }
-                if billing_country_tax_rate is not None
-                else None,
-                {
-                    "type": "product",
-                    "name": "Product Tax Class",
-                    "country_code": country,
-                    "rate": product_tax_rate,
-                }
-                if product_tax_rate is not None
-                else None,
-                {
-                    "type": "product_type",
-                    "name": "Product Type Tax Class",
-                    "country_code": country,
-                    "rate": product_type_tax_rate,
-                }
-                if product_type_tax_rate is not None
-                else None,
-            ]
-            tax_rates = [rate for rate in tax_rates if rate is not None]
-
-            created_tax_classes = create_and_update_tax_rates(
-                e2e_staff_api_client, tax_rates
+            created_channels.append(channel)
+    else:
+        default_channel = create_channel(
+            e2e_staff_api_client, warehouse_ids=[warehouses[0]["id"]], **kwargs
+        )
+        created_channels.append(default_channel)
+    shipping_zones = []
+    if shipping_zones is not None:
+        for shipping_zone in shipping_zones:
+            created = create_shipping_zone(
+                e2e_staff_api_client,
+                warehouse_ids=[w["id"] for w in warehouses],
+                channel_ids=[c["id"] for c in created_channels],
+                countries=shipping_zone.get("countries"),
             )
-            if "country" in created_tax_classes:
-                country_tax_class_id = created_tax_classes["country"]["id"]
+            shipping_zones.append(created)
+    else:
+        shipping_zones.append(
+            create_shipping_zone(
+                e2e_staff_api_client,
+                warehouse_ids=[w["id"] for w in warehouses],
+                channel_ids=[c["id"] for c in created_channels],
+            )
+        )
 
-            if "shipping" in created_tax_classes:
-                shipping_tax_class_id = created_tax_classes["shipping"]["id"]
+    if shipping_methods is None:
+        shipping_methods = []
+        for shipping_zone in shipping_zones:
+            shipping_method_data = create_shipping_method(
+                e2e_staff_api_client, shipping_zone_id=shipping_zone["id"], **kwargs
+            )
+            _, modified_encoded_id = decode_and_modify_base64_descriptor(
+                shipping_method_data["id"], "ShippingMethod"
+            )
+            shipping_method_data["id"] = modified_encoded_id
 
-            if "billing" in created_tax_classes:
-                billing_tax_class_id = created_tax_classes["billing"]["id"]
+            for channel in created_channels:
+                channel_listing_data = create_shipping_method_channel_listing(
+                    e2e_staff_api_client,
+                    shipping_method_id=modified_encoded_id,
+                    channel_id=channel["id"],
+                    price=shipping_method_channel_listing_settings.get(
+                        "price", "10.00"
+                    ),
+                    minimum_order_price=shipping_method_channel_listing_settings.get(
+                        "minimumOrderPrice", None
+                    ),
+                    maximum_order_price=shipping_method_channel_listing_settings.get(
+                        "maximumOrderPrice", None
+                    ),
+                    **kwargs,
+                )
+                if channel_listing_data.get("channelListings"):
+                    price_info = channel_listing_data["channelListings"][0].get(
+                        "price", {}
+                    )
+                    shipping_price = price_info.get("amount")
+                    shipping_method_data["price"] = shipping_price
 
-            if "product" in created_tax_classes:
-                product_tax_class_id = created_tax_classes["product"]["id"]
-            if "product_type" in created_tax_classes:
-                product_type_tax_class_id = created_tax_classes["product_type"]["id"]
+            shipping_methods.append(shipping_method_data)
 
-            input_data = {
-                "enableAccountConfirmationByEmail": enable_account_confirmation_by_email,
-                "allowLoginWithoutConfirmation": allow_login_without_confirmation,
-                "fulfillmentAutoApprove": fulfillment_auto_approve,
-                "fulfillmentAllowUnpaid": fulfillment_allow_unpaid,
-            }
-            update_shop_settings(e2e_staff_api_client, input_data)
+    if shop_settings_update is not None:
+        update_shop_settings(e2e_staff_api_client, input_data=shop_settings_update)
+
+    created_tax_classes = {}
+    tax_rates = {}
+    if tax_settings:
+        tax_rates_list = tax_settings.pop("tax_rates", [])
+        tax_rates = {rate["type"]: rate for rate in tax_rates_list}
+
+        tax_config_data = get_tax_configurations(e2e_staff_api_client)
+        channel_tax_config = tax_config_data[0]["node"]
+        tax_config_id = channel_tax_config["id"]
+        update_tax_configuration(e2e_staff_api_client, tax_config_id, **tax_settings)
+
+        if tax_rates:
+            tax_classes_result = create_and_update_tax_classes(
+                e2e_staff_api_client, tax_rates.values()
+            )
+            for tax_type, tax_rate in tax_rates.items():
+                tax_class_id = tax_classes_result.get(tax_type, {}).get("id")
+                if tax_class_id:
+                    created_tax_classes[f"{tax_type}_tax_class_id"] = tax_class_id
 
     return {
-        "warehouse_id": warehouse_id,
-        "channel_id": channel_id,
-        "country": country,
-        "channel_slug": channel_slug,
-        "created_channels": created_channels,
-        "shipping_zone_id": shipping_zone_id,
-        "shipping_method_id": shipping_method_id,
-        "shipping_method_ids": created_shipping_methods_ids,
-        "shipping_price": shipping_price,
-        "shipping_country_tax_rate": shipping_country_tax_rate,
-        "billing_country_tax_rate": billing_country_tax_rate,
-        "product_tax_rate": product_tax_rate,
-        "product_type_tax_rate": product_type_tax_rate,
-        "country_tax_rate": country_tax_rate,
-        "shipping_tax_class_id": shipping_tax_class_id,
-        "product_tax_class_id": product_tax_class_id,
-        "product_type_tax_class_id": product_type_tax_class_id,
-        "shipping_zone_countries": shipping_zone_countries,
-        "shipping_country_code": shipping_country_code,
-        "billing_country_code": billing_country_code,
-        "created_shipping_zones": created_shipping_zones,
-        "billing_tax_class_id": billing_tax_class_id,
-        "country_tax_class_id": country_tax_class_id,
-        "expire_order_after_in_minutes": expire_order_after_in_minutes,
-        "delete_expired_order_after_in_days": delete_expired_order_after_in_days,
+        "warehouses": warehouses,
+        "channels": created_channels,
+        "shipping_zones": shipping_zones,
+        "shipping_methods": shipping_methods,
+        "tax_classes": created_tax_classes,
+        "tax_rates": tax_rates,
+        "shop_settings": shop_settings_update,
     }

--- a/saleor/tests/e2e/shop/utils/shop_update_settings.py
+++ b/saleor/tests/e2e/shop/utils/shop_update_settings.py
@@ -18,8 +18,16 @@ mutation ShopSettingsUpdate($input: ShopSettingsInput!) {
 """
 
 
-def update_shop_settings(staff_api_client, input):
-    variables = {"input": input}
+def update_shop_settings(
+    staff_api_client,
+    input_data={
+        "enableAccountConfirmationByEmail": True,
+        "allowLoginWithoutConfirmation": False,
+        "fulfillmentAutoApprove": False,
+        "fulfillmentAllowUnpaid": False,
+    },
+):
+    variables = {"input": input_data}
 
     response = staff_api_client.post_graphql(SHOP_SETTING_UPDATE_MUTATION, variables)
     content = get_graphql_content(response)

--- a/saleor/tests/e2e/taxes/utils/__init__.py
+++ b/saleor/tests/e2e/taxes/utils/__init__.py
@@ -1,5 +1,6 @@
 from .query_tax_configurations import get_tax_configurations
 from .tax_class_create import create_tax_class
+from .tax_class_update import update_tax_class
 from .tax_configuration_update import update_tax_configuration
 from .tax_country_configuration_update import update_country_tax_rates
 
@@ -8,4 +9,5 @@ __all__ = [
     "update_tax_configuration",
     "update_country_tax_rates",
     "create_tax_class",
+    "update_tax_class",
 ]

--- a/saleor/tests/e2e/taxes/utils/tax_class_update.py
+++ b/saleor/tests/e2e/taxes/utils/tax_class_update.py
@@ -1,0 +1,40 @@
+from ...utils import get_graphql_content
+
+TAX_CLASS_UPDATE_MUTATION = """
+mutation taxClassUpdate($id:ID!, $input:TaxClassUpdateInput!){
+  taxClassUpdate(id:$id, input:$input) {
+    errors {
+        field
+        message
+    }
+    taxClass {
+        id
+        countries {
+            country {
+                code
+                }
+                rate
+                taxClass { id }
+            }
+        }
+  }
+}
+"""
+
+
+def update_tax_class(
+    staff_api_client,
+    tax_class_id,
+    tax_class_update_input,
+):
+    variables = {"id": tax_class_id, "input": tax_class_update_input}
+
+    response = staff_api_client.post_graphql(TAX_CLASS_UPDATE_MUTATION, variables)
+    content = get_graphql_content(response)
+
+    assert content["data"]["taxClassUpdate"]["errors"] == []
+
+    data = content["data"]["taxClassUpdate"]["taxClass"]
+    assert data["id"] is not None
+
+    return data

--- a/saleor/tests/e2e/vouchers/test_export_voucher_codes.py
+++ b/saleor/tests/e2e/vouchers/test_export_voucher_codes.py
@@ -63,6 +63,8 @@ def test_export_valid_voucher_ids_CORE_0925(
     permission_manage_products,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
     file_type,
     voucher_id_array_index,
     media_root,
@@ -74,15 +76,15 @@ def test_export_valid_voucher_ids_CORE_0925(
         permission_manage_products,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        _warehouse_id,
-        channel_id,
-        _channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
 
     voucher_ids, _voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id
@@ -127,6 +129,8 @@ def test_export_voucher_ids_and_codes_CORE_0925(
     permission_manage_products,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
     file_type,
     voucher_code_id_indexes,
     voucher_id_array_index,
@@ -138,15 +142,15 @@ def test_export_voucher_ids_and_codes_CORE_0925(
         permission_manage_products,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        _warehouse_id,
-        channel_id,
-        _channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
 
     voucher_ids, voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id
@@ -185,6 +189,8 @@ def test_export_valid_voucher_code_ids_CORE_0925(
     permission_manage_products,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
     file_type,
     voucher_code_id_indexes,
     media_root,
@@ -196,15 +202,15 @@ def test_export_valid_voucher_code_ids_CORE_0925(
         permission_manage_products,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        _warehouse_id,
-        channel_id,
-        _channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
 
     _voucher_ids, voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id
@@ -239,6 +245,8 @@ def test_export_voucher_codes_with_invalid_voucher_id_CORE_0925(
     permission_manage_products,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
     file_type,
 ):
     # Before
@@ -248,6 +256,8 @@ def test_export_voucher_codes_with_invalid_voucher_id_CORE_0925(
         permission_manage_products,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
@@ -279,6 +289,8 @@ def test_export_voucher_codes_with_invalid_voucher_codes_CORE_0925(
     permission_manage_products,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
     file_type,
 ):
     # Before
@@ -288,6 +300,8 @@ def test_export_voucher_codes_with_invalid_voucher_codes_CORE_0925(
         permission_manage_products,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
@@ -318,6 +332,8 @@ def test_export_voucher_codes_without_voucher_id_nor_codes_CORE_0925(
     permission_manage_products,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
     file_type,
 ):
     # Before
@@ -327,6 +343,8 @@ def test_export_voucher_codes_without_voucher_id_nor_codes_CORE_0925(
         permission_manage_products,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
@@ -364,6 +382,8 @@ def test_export_voucher_codes_with_invalid_file_type_CORE_0925(
     permission_manage_products,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
     file_type,
     voucher_id,
 ):
@@ -374,15 +394,15 @@ def test_export_voucher_codes_with_invalid_file_type_CORE_0925(
         permission_manage_products,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        _warehouse_id,
-        channel_id,
-        _channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
 
     voucher_ids, _voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id

--- a/saleor/tests/e2e/vouchers/test_export_voucher_codes.py
+++ b/saleor/tests/e2e/vouchers/test_export_voucher_codes.py
@@ -2,7 +2,7 @@ import uuid
 
 import pytest
 
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     create_voucher,
@@ -73,10 +73,8 @@ def test_export_valid_voucher_ids_CORE_0925(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channels"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
 
     voucher_ids, _voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id
@@ -131,8 +129,8 @@ def test_export_voucher_ids_and_codes_CORE_0925(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
 
     voucher_ids, voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id
@@ -182,8 +180,8 @@ def test_export_valid_voucher_code_ids_CORE_0925(
 
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
 
     _voucher_ids, voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id
@@ -340,8 +338,8 @@ def test_export_voucher_codes_with_invalid_file_type_CORE_0925(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(e2e_staff_api_client)
-    channel_id = shop_data["channels"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
 
     voucher_ids, _voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id

--- a/saleor/tests/e2e/vouchers/test_export_voucher_codes.py
+++ b/saleor/tests/e2e/vouchers/test_export_voucher_codes.py
@@ -58,33 +58,25 @@ def create_vouchers_with_multiple_codes(e2e_staff_api_client, channel_id):
 )
 def test_export_valid_voucher_ids_CORE_0925(
     e2e_staff_api_client,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_products,
+    shop_permissions,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
     file_type,
     voucher_id_array_index,
     media_root,
 ):
     # Before
     permissions = [
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_products,
+        *shop_permissions,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     shop_data = prepare_shop(
         e2e_staff_api_client,
     )
-    channel_id = shop_data["channel_id"]
+    channel_id = shop_data["channels"][0]["id"]
 
     voucher_ids, _voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id
@@ -124,33 +116,23 @@ def test_export_valid_voucher_ids_CORE_0925(
 )
 def test_export_voucher_ids_and_codes_CORE_0925(
     e2e_staff_api_client,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_products,
+    shop_permissions,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
     file_type,
     voucher_code_id_indexes,
     voucher_id_array_index,
 ):
     # Before
     permissions = [
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_products,
+        *shop_permissions,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
 
     voucher_ids, voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id
@@ -184,33 +166,24 @@ def test_export_voucher_ids_and_codes_CORE_0925(
 )
 def test_export_valid_voucher_code_ids_CORE_0925(
     e2e_staff_api_client,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_products,
+    shop_permissions,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
     file_type,
     voucher_code_id_indexes,
     media_root,
 ):
     # Before
     permissions = [
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_products,
+        *shop_permissions,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
+
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
 
     _voucher_ids, voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id
@@ -240,24 +213,16 @@ def test_export_valid_voucher_code_ids_CORE_0925(
 )
 def test_export_voucher_codes_with_invalid_voucher_id_CORE_0925(
     e2e_staff_api_client,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_products,
+    shop_permissions,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
     file_type,
 ):
     # Before
     permissions = [
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_products,
+        *shop_permissions,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
@@ -284,24 +249,16 @@ def test_export_voucher_codes_with_invalid_voucher_id_CORE_0925(
 )
 def test_export_voucher_codes_with_invalid_voucher_codes_CORE_0925(
     e2e_staff_api_client,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_products,
+    shop_permissions,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
     file_type,
 ):
     # Before
     permissions = [
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_products,
+        *shop_permissions,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
@@ -327,24 +284,16 @@ def test_export_voucher_codes_with_invalid_voucher_codes_CORE_0925(
 )
 def test_export_voucher_codes_without_voucher_id_nor_codes_CORE_0925(
     e2e_staff_api_client,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_products,
+    shop_permissions,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
     file_type,
 ):
     # Before
     permissions = [
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_products,
+        *shop_permissions,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
@@ -377,32 +326,22 @@ def test_export_voucher_codes_without_voucher_id_nor_codes_CORE_0925(
 )
 def test_export_voucher_codes_with_invalid_file_type_CORE_0925(
     e2e_staff_api_client,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_products,
+    shop_permissions,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
     file_type,
     voucher_id,
 ):
     # Before
     permissions = [
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_products,
+        *shop_permissions,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channel_id"]
+    shop_data = prepare_shop(e2e_staff_api_client)
+    channel_id = shop_data["channels"][0]["id"]
 
     voucher_ids, _voucher_code_ids = create_vouchers_with_multiple_codes(
         e2e_staff_api_client, channel_id

--- a/saleor/tests/e2e/vouchers/test_staff_can_delete_vouchers_in_bulk.py
+++ b/saleor/tests/e2e/vouchers/test_staff_can_delete_vouchers_in_bulk.py
@@ -47,6 +47,8 @@ def test_staff_can_delete_vouchers_in_bulk_CORE_0924(
     permission_manage_products,
     permission_manage_discounts,
     permission_manage_checkouts,
+    permission_manage_taxes,
+    permission_manage_settings,
 ):
     # Before
     permissions = [
@@ -55,15 +57,15 @@ def test_staff_can_delete_vouchers_in_bulk_CORE_0924(
         permission_manage_products,
         permission_manage_discounts,
         permission_manage_checkouts,
+        permission_manage_taxes,
+        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    (
-        _warehouse_id,
-        channel_id,
-        _channel_slug,
-        _shipping_method_id,
-    ) = prepare_shop(e2e_staff_api_client)
+    shop_data = prepare_shop(
+        e2e_staff_api_client,
+    )
+    channel_id = shop_data["channel_id"]
 
     voucher_ids = create_multiple_vouchers(e2e_staff_api_client, channel_id)
 

--- a/saleor/tests/e2e/vouchers/test_staff_can_delete_vouchers_in_bulk.py
+++ b/saleor/tests/e2e/vouchers/test_staff_can_delete_vouchers_in_bulk.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..shop.utils.preparing_shop import prepare_shop
+from ..shop.utils.preparing_shop import prepare_default_shop
 from ..utils import assign_permissions
 from .utils import (
     create_voucher,
@@ -54,10 +54,8 @@ def test_staff_can_delete_vouchers_in_bulk_CORE_0924(
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
-    shop_data = prepare_shop(
-        e2e_staff_api_client,
-    )
-    channel_id = shop_data["channels"][0]["id"]
+    shop_data = prepare_default_shop(e2e_staff_api_client)
+    channel_id = shop_data["channel"]["id"]
 
     voucher_ids = create_multiple_vouchers(e2e_staff_api_client, channel_id)
 

--- a/saleor/tests/e2e/vouchers/test_staff_can_delete_vouchers_in_bulk.py
+++ b/saleor/tests/e2e/vouchers/test_staff_can_delete_vouchers_in_bulk.py
@@ -42,30 +42,22 @@ def create_multiple_vouchers(e2e_staff_api_client, channel_id):
 @pytest.mark.e2e
 def test_staff_can_delete_vouchers_in_bulk_CORE_0924(
     e2e_staff_api_client,
-    permission_manage_channels,
-    permission_manage_shipping,
-    permission_manage_products,
+    shop_permissions,
     permission_manage_discounts,
     permission_manage_checkouts,
-    permission_manage_taxes,
-    permission_manage_settings,
 ):
     # Before
     permissions = [
-        permission_manage_channels,
-        permission_manage_shipping,
-        permission_manage_products,
+        *shop_permissions,
         permission_manage_discounts,
         permission_manage_checkouts,
-        permission_manage_taxes,
-        permission_manage_settings,
     ]
     assign_permissions(e2e_staff_api_client, permissions)
 
     shop_data = prepare_shop(
         e2e_staff_api_client,
     )
-    channel_id = shop_data["channel_id"]
+    channel_id = shop_data["channels"][0]["id"]
 
     voucher_ids = create_multiple_vouchers(e2e_staff_api_client, channel_id)
 

--- a/saleor/tests/e2e/warehouse/utils/create_warehouse.py
+++ b/saleor/tests/e2e/warehouse/utils/create_warehouse.py
@@ -1,3 +1,5 @@
+import uuid
+
 from ... import DEFAULT_ADDRESS
 from ...utils import get_graphql_content
 
@@ -13,6 +15,18 @@ mutation createWarehouse($input: WarehouseCreateInput!) {
       id
       name
       slug
+      isPrivate
+      shippingZones(first: 10) {
+        edges {
+          node {
+            id
+            countries {
+              code
+            }
+          }
+        }
+      }
+      clickAndCollectOption
     }
   }
 }
@@ -22,7 +36,7 @@ mutation createWarehouse($input: WarehouseCreateInput!) {
 def create_warehouse(
     staff_api_client,
     name="Test warehouse",
-    slug="test-slug",
+    slug=f"warehouse_slug_{uuid.uuid4()}",
     address=DEFAULT_ADDRESS,
 ):
     variables = {

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -6050,6 +6050,23 @@ def permission_group_all_perms_without_any_channel(
 
 
 @pytest.fixture
+def shop_permissions(
+    permission_manage_products,
+    permission_manage_channels,
+    permission_manage_shipping,
+    permission_manage_taxes,
+    permission_manage_settings,
+):
+    return [
+        permission_manage_products,
+        permission_manage_channels,
+        permission_manage_shipping,
+        permission_manage_taxes,
+        permission_manage_settings,
+    ]
+
+
+@pytest.fixture
 def collection(db):
     collection = Collection.objects.create(
         name="Collection",


### PR DESCRIPTION
I want to merge this change because it creates more generic helper for preparing shop in e2e tests.


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
