### PR TITLE
Refactor: unify how undiscounted price for checkout and order are handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Other changes
 
+- Unify how undiscounted prices are handled in orders and checkouts - #14780 by @jakubkuc
+
 # 3.18.0
 
 ### Highlights

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -56,6 +56,7 @@ from ..payment import PaymentError, TransactionKind, gateway
 from ..payment.models import Payment, Transaction
 from ..payment.utils import fetch_customer_id, store_customer_id
 from ..product.models import ProductTranslation, ProductVariantTranslation
+from ..tax.calculations import get_taxed_undiscounted_price
 from ..tax.utils import (
     get_shipping_tax_class_kwargs_for_order,
     get_tax_class_kwargs_for_order_line,
@@ -88,7 +89,6 @@ from .models import Checkout
 from .utils import (
     get_checkout_metadata,
     get_or_create_checkout_metadata,
-    get_taxed_undiscounted_price,
     get_voucher_for_checkout_info,
 )
 

--- a/saleor/checkout/tests/test_utils.py
+++ b/saleor/checkout/tests/test_utils.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 import pytest
 from prices import Money, TaxedMoney
 
-from ..utils import get_taxed_undiscounted_price
+from ...tax.calculations import get_taxed_undiscounted_price
 
 BASE = Money("35.00", "USD")
 

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -7,11 +7,10 @@ import graphene
 from django.core.exceptions import ValidationError
 from django.db.models import prefetch_related_objects
 from django.utils import timezone
-from prices import Money, TaxedMoney
+from prices import Money
 
 from ..account.models import User
 from ..core.exceptions import ProductNotPublished
-from ..core.prices import quantize_price
 from ..core.taxes import zero_taxed_money
 from ..core.utils.promo_code import (
     InvalidPromoCode,
@@ -37,7 +36,6 @@ from ..product import models as product_models
 from ..shipping.interface import ShippingMethodData
 from ..shipping.models import ShippingMethod, ShippingMethodChannelListing
 from ..shipping.utils import convert_to_shipping_method_data
-from ..tax.calculations import calculate_flat_rate_tax
 from ..warehouse.availability import check_stock_and_preorder_quantity
 from ..warehouse.models import Warehouse
 from ..warehouse.reservations import reserve_stocks_and_preorders
@@ -962,27 +960,3 @@ def get_checkout_metadata(checkout: "Checkout"):
         return checkout.metadata_storage
     else:
         return CheckoutMetadata(checkout=checkout)
-
-
-def get_taxed_undiscounted_price(
-    undiscounted_base_price: "Money",
-    price: "TaxedMoney",
-    tax_rate: "Decimal",
-    prices_entered_with_tax: bool,
-):
-    """Apply taxes to undiscounted base price.
-
-    This function also prevents rounding difference between prices from tax-app and
-    local calculations based on tax_rate that might occur in orders without discounts.
-    """
-    price_to_compare = price.gross if prices_entered_with_tax else price.net
-    if undiscounted_base_price == price_to_compare:
-        return price
-    return quantize_price(
-        calculate_flat_rate_tax(
-            money=undiscounted_base_price,
-            tax_rate=tax_rate * 100,
-            prices_entered_with_tax=prices_entered_with_tax,
-        ),
-        undiscounted_base_price.currency,
-    )

--- a/saleor/tax/calculations/__init__.py
+++ b/saleor/tax/calculations/__init__.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 from prices import Money, TaxedMoney
 
-from saleor.core.prices import quantize_price
+from ..core.prices import quantize_price
 
 
 def calculate_flat_rate_tax(

--- a/saleor/tax/calculations/__init__.py
+++ b/saleor/tax/calculations/__init__.py
@@ -2,6 +2,8 @@ from decimal import Decimal
 
 from prices import Money, TaxedMoney
 
+from saleor.core.prices import quantize_price
+
 
 def calculate_flat_rate_tax(
     money: "Money", tax_rate: "Decimal", prices_entered_with_tax: bool
@@ -17,4 +19,28 @@ def calculate_flat_rate_tax(
         gross_amount = money.amount * tax_rate
     return TaxedMoney(
         net=Money(net_amount, currency), gross=Money(gross_amount, currency)
+    )
+
+
+def get_taxed_undiscounted_price(
+    undiscounted_base_price: "Money",
+    price: "TaxedMoney",
+    tax_rate: "Decimal",
+    prices_entered_with_tax: bool,
+):
+    """Apply taxes to undiscounted base price.
+
+    This function also prevents rounding difference between prices from tax-app and
+    local calculations based on tax_rate that might occur in orders without discounts.
+    """
+    price_to_compare = price.gross if prices_entered_with_tax else price.net
+    if undiscounted_base_price == price_to_compare:
+        return price
+    return quantize_price(
+        calculate_flat_rate_tax(
+            money=undiscounted_base_price,
+            tax_rate=tax_rate * 100,
+            prices_entered_with_tax=prices_entered_with_tax,
+        ),
+        undiscounted_base_price.currency,
     )

--- a/saleor/tax/calculations/__init__.py
+++ b/saleor/tax/calculations/__init__.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 from prices import Money, TaxedMoney
 
-from ..core.prices import quantize_price
+from ...core.prices import quantize_price
 
 
 def calculate_flat_rate_tax(


### PR DESCRIPTION
I want to merge this change because it unifies how order and checkout undiscounted prices are handled.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
