### PR TITLE
Fix max_sort_order calculations when value was None

### DIFF
--- a/saleor/attribute/models/base.py
+++ b/saleor/attribute/models/base.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, TypeVar, Union
 
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models, transaction
-from django.db.models import Exists, F, OrderBy, OuterRef, Q
+from django.db.models import Case, Exists, F, OrderBy, OuterRef, Q, Value, When
 
 from ...core.db.fields import SanitizedJSONField
 from ...core.models import ModelWithExternalReference, ModelWithMetadata, SortableModel
@@ -291,11 +291,17 @@ class AttributeValue(ModelWithExternalReference):
             ):
                 if self.attribute.max_sort_order is None:
                     value = self._calculate_sort_order_value()
-                    self.attribute.max_sort_order = value - 1
+                    self.attribute.max_sort_order = max(value - 1, 0)
                     self.attribute.save(update_fields=["max_sort_order"])
                 else:
                     Attribute.objects.filter(pk=self.attribute.pk).update(
-                        max_sort_order=F("max_sort_order") - 1
+                        max_sort_order=Case(
+                            When(
+                                Q(max_sort_order__gt=0),
+                                then=F("max_sort_order") - 1,
+                            ),
+                            default=Value(0),
+                        )
                     )
 
         super().delete(*args, **kwargs)
@@ -303,7 +309,7 @@ class AttributeValue(ModelWithExternalReference):
     def _calculate_sort_order_value(self):
         qs = self.get_ordering_queryset()
         existing_max = SortableModel.get_max_sort_order(qs)
-        return 0 if existing_max is None else existing_max
+        return -1 if existing_max is None else existing_max
 
     def _save_new_max_sort_order(self, value):
         self.sort_order = value

--- a/saleor/attribute/tests/models/test_base.py
+++ b/saleor/attribute/tests/models/test_base.py
@@ -2,7 +2,7 @@ from saleor.attribute import AttributeType
 from saleor.attribute.models import Attribute, AttributeValue
 
 
-def test_attribute_value_setting_up_max_sort_oder():
+def test_attribute_value_setting_up_max_sort_order():
     # given
     attribute = Attribute.objects.create(
         slug="test-slug",
@@ -17,8 +17,8 @@ def test_attribute_value_setting_up_max_sort_oder():
     )
 
     # then
-    assert attribute_value.sort_order == 1
-    assert attribute.max_sort_order == 1
+    assert attribute_value.sort_order == 0
+    assert attribute.max_sort_order == 0
 
 
 def test_attribute_value_using_max_sort_order_from_parent():
@@ -51,7 +51,7 @@ def test_attribute_value_sort_order_when_attribute_has_other_values():
     AttributeValue.objects.create(
         attribute=attribute, name="value", slug="value", sort_order=1
     )
-    assert attribute.max_sort_order == 1
+    assert attribute.max_sort_order == 0
 
     # when
     attribute_value = AttributeValue.objects.create(
@@ -59,8 +59,8 @@ def test_attribute_value_sort_order_when_attribute_has_other_values():
     )
 
     # then
-    assert attribute_value.sort_order == 2
-    assert attribute.max_sort_order == 2
+    assert attribute_value.sort_order == 1
+    assert attribute.max_sort_order == 1
 
 
 def test_max_sort_order_when_deleting_attribute_value():
@@ -76,13 +76,73 @@ def test_max_sort_order_when_deleting_attribute_value():
     value2 = AttributeValue.objects.create(
         attribute=attribute, name="value2", slug="value2", sort_order=2
     )
-    assert attribute.max_sort_order == 2
+    assert attribute.max_sort_order == 1
 
     # when
     value.delete()
 
     # then
     attribute.refresh_from_db()
-    assert attribute.max_sort_order == 1
+    assert attribute.max_sort_order == 0
     value2.refresh_from_db()
+    assert value2.sort_order == 0
+
+
+def test_max_sort_order_none_when_deleting_attribute_value_with_sort_order_0():
+    # given
+    attribute = Attribute.objects.create(
+        slug="test-slug",
+        name="test name",
+        type=AttributeType.PRODUCT_TYPE,
+    )
+    value = AttributeValue.objects.create(
+        attribute=attribute, name="value", slug="value", sort_order=1
+    )
+    value2 = AttributeValue.objects.create(
+        attribute=attribute, name="value2", slug="value2"
+    )
+
+    attribute.max_sort_order = None
+    attribute.save()
+    assert attribute.max_sort_order is None
+    assert value.sort_order == 0
     assert value2.sort_order == 1
+
+    # when
+    value.delete()
+
+    # then
+    attribute.refresh_from_db()
+    assert attribute.max_sort_order == 0
+    value2.refresh_from_db()
+    assert value2.sort_order == 0
+
+
+def test_max_sort_order_0_when_deleting_attribute_value_with_sort_order_0():
+    # given
+    attribute = Attribute.objects.create(
+        slug="test-slug",
+        name="test name",
+        type=AttributeType.PRODUCT_TYPE,
+    )
+    value = AttributeValue.objects.create(
+        attribute=attribute, name="value", slug="value"
+    )
+    value2 = AttributeValue.objects.create(
+        attribute=attribute, name="value2", slug="value2"
+    )
+
+    attribute.max_sort_order = 0
+    attribute.save()
+    assert attribute.max_sort_order == 0
+    assert value.sort_order == 0
+    assert value2.sort_order == 1
+
+    # when
+    value.delete()
+
+    # then
+    attribute.refresh_from_db()
+    assert attribute.max_sort_order == 0
+    value2.refresh_from_db()
+    assert value2.sort_order == 0


### PR DESCRIPTION
I want to merge this change because it is a port of https://github.com/saleor/saleor/pull/14762

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
