### PR TITLE
remove redundant if statement in fulfillment_tracking_update function

### DIFF
--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -421,7 +421,7 @@ def fulfillment_tracking_updated(
     events.fulfillment_tracking_updated_event(
         order=fulfillment.order,
         user=user,
-        app=app if app and app.removed_at is not None else None,
+        app=app,
         tracking_number=tracking_number,
         fulfillment=fulfillment,
     )


### PR DESCRIPTION
fix to port https://github.com/saleor/saleor/pull/14536

It removes redundant check for the `fulfillment_tracking_updated` function. It is already checked in `get_app_promise` .

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
