### PR TITLE
Fix error handling for required value attributes in productBulkCreate

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -295,14 +295,15 @@ class ProductBulkCreate(BaseMutation):
                         product_index, exc, index_error_map, "attributes"
                     )
                 else:
-                    index_error_map[product_index].append(
-                        ProductBulkCreateError(
-                            path="attributes",
-                            message=exc.message,
-                            code=exc.code,
+                    for error in exc.error_list:
+                        index_error_map[product_index].append(
+                            ProductBulkCreateError(
+                                path="attributes",
+                                message=error.message,
+                                code=error.code,
+                            )
                         )
-                    )
-                attributes_errors_count += 1
+                    attributes_errors_count += 1
         return attributes_errors_count
 
     @classmethod

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2207,6 +2207,26 @@ def product_type(color_attribute, size_attribute, default_tax_class):
 
 
 @pytest.fixture
+def product_type_with_value_required_attributes(
+    color_attribute, size_attribute, default_tax_class
+):
+    product_type = ProductType.objects.create(
+        name="Default Type",
+        slug="default-type",
+        kind=ProductTypeKind.NORMAL,
+        has_variants=True,
+        is_shipping_required=True,
+        tax_class=default_tax_class,
+    )
+    color_attribute.value_required = True
+    size_attribute.value_required = True
+    Attribute.objects.bulk_update([color_attribute, size_attribute], ["value_required"])
+    product_type.product_attributes.add(color_attribute)
+    product_type.product_attributes.add(size_attribute)
+    return product_type
+
+
+@pytest.fixture
 def product_type_list():
     product_type_1 = ProductType.objects.create(
         name="Type 1", slug="type-1", kind=ProductTypeKind.NORMAL


### PR DESCRIPTION
I want to merge this change because it fixes error handling for required value attributes in `productBulkCreate`

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
