### PR TITLE
Lazy legacy payload generation

### DIFF
--- a/saleor/graphql/account/tests/mutations/staff/test_customer_delete.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_customer_delete.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock, patch
+from functools import partial
+from unittest.mock import ANY, Mock, patch
 
 import graphene
 import pytest
@@ -7,7 +8,6 @@ from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
 
 from ......webhook.event_types import WebhookEventAsyncType
-from ......webhook.payloads import generate_customer_payload
 from .....tests.utils import get_graphql_content
 from ....mutations.staff import CustomerDelete
 
@@ -93,11 +93,15 @@ def test_customer_delete_trigger_webhook(
     assert data["errors"] == []
     assert data["user"]["id"] == customer_id
     mocked_webhook_trigger.assert_called_once_with(
-        generate_customer_payload(customer_user, staff_api_client.user),
+        None,
         WebhookEventAsyncType.CUSTOMER_DELETED,
         [any_webhook],
         customer_user,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 

--- a/saleor/graphql/discount/tests/mutations/test_sale_bulk_delete.py
+++ b/saleor/graphql/discount/tests/mutations/test_sale_bulk_delete.py
@@ -157,6 +157,7 @@ def test_delete_sales_with_variants_triggers_webhook(
     variables = {
         "ids": [graphene.Node.to_global_id("Sale", sale.id) for sale in sale_list]
     }
+
     # when
     response = staff_api_client.post_graphql(
         SALE_BULK_DELETE_MUTATION, variables, permissions=[permission_manage_discounts]
@@ -164,8 +165,10 @@ def test_delete_sales_with_variants_triggers_webhook(
     content = get_graphql_content(response)
     # create a list of payloads with which the webhook was called
     called_payloads_list = []
+
     for arg_list in mocked_webhook_trigger.call_args_list:
-        called_arg = json.loads(arg_list[0][0])
+        data_generator = arg_list[1]["legacy_data_generator"]
+        called_arg = json.loads(data_generator())
         # we don't want to compare meta fields, only rest of payloads
         called_arg[0].pop("meta")
         called_payloads_list.append(called_arg)

--- a/saleor/graphql/page/tests/mutations/test_page_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_delete.py
@@ -1,14 +1,15 @@
+from functools import partial
 from unittest import mock
 
 import graphene
 import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
+from mock import ANY
 
 from .....attribute.models import AttributeValue
 from .....attribute.utils import associate_attribute_values_to_instance
 from .....webhook.event_types import WebhookEventAsyncType
-from .....webhook.payloads import generate_page_payload
 from ....tests.utils import get_graphql_content
 
 PAGE_DELETE_MUTATION = """
@@ -63,13 +64,16 @@ def test_page_delete_trigger_webhook(
     assert data["page"]["title"] == page.title
     with pytest.raises(page._meta.model.DoesNotExist):
         page.refresh_from_db()
-    expected_data = generate_page_payload(page, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PAGE_DELETED,
         [any_webhook],
         page,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 

--- a/saleor/graphql/page/tests/mutations/test_page_types_bulk_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_types_bulk_delete.py
@@ -91,7 +91,7 @@ def test_page_type_bulk_delete_trigger_webhooks(
 
     assert not data["errors"]
     assert data["count"] == page_type_count
-    mocked_webhook_trigger.call_count == page_type_count
+    assert mocked_webhook_trigger.call_count == page_type_count
 
 
 def test_page_type_bulk_delete_by_staff_no_perm(

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -1,16 +1,17 @@
 import json
+from functools import partial
 from unittest.mock import patch
 
 import graphene
 import pytest
 from django.utils.functional import SimpleLazyObject
 from freezegun import freeze_time
+from mock import ANY
 
 from ....attribute.utils import associate_attribute_values_to_instance
 from ....permission.models import Permission
 from ....tests.utils import dummy_editorjs
 from ....webhook.event_types import WebhookEventAsyncType
-from ....webhook.payloads import generate_translation_payload
 from ...core.enums import LanguageCodeEnum
 from ...tests.utils import assert_no_permission, get_graphql_content
 from ..schema import TranslatableKinds
@@ -865,13 +866,16 @@ def test_product_create_translation(
     assert data["product"]["translation"]["language"]["code"] == "PL"
 
     translation = product.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1018,13 +1022,16 @@ def test_product_update_translation(
     assert data["product"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1080,13 +1087,16 @@ def test_product_variant_create_translation(
     assert data["productVariant"]["translation"]["language"]["code"] == "PL"
 
     translation = variant.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1138,13 +1148,13 @@ def test_product_variant_update_translation(
     assert data["productVariant"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
     )
 
 
@@ -1225,13 +1235,16 @@ def test_collection_create_translation(
     assert data["collection"]["translation"]["language"]["code"] == "PL"
 
     translation = published_collection.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1321,13 +1334,16 @@ def test_collection_update_translation(
     assert data["collection"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1396,13 +1412,16 @@ def test_category_create_translation(
     assert data["category"]["translation"]["language"]["code"] == "PL"
 
     translation = category.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1490,13 +1509,16 @@ def test_category_update_translation(
     assert data["category"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1545,13 +1567,16 @@ def test_voucher_create_translation(
     assert data["voucher"]["translation"]["language"]["code"] == "PL"
 
     translation = voucher.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1601,13 +1626,16 @@ def test_voucher_update_translation(
     assert data["voucher"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1656,13 +1684,16 @@ def test_sale_create_translation(
     assert data["sale"]["translation"]["language"]["code"] == "PL"
 
     translation = sale.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1713,13 +1744,16 @@ def test_sale_update_translation(
     assert data["sale"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1769,13 +1803,16 @@ def test_page_create_translation(
     assert data["page"]["translation"]["language"]["code"] == "PL"
 
     translation = page.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1859,13 +1896,16 @@ def test_page_update_translation(
     assert data["page"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1916,13 +1956,16 @@ def test_attribute_create_translation(
     assert data["attribute"]["translation"]["language"]["code"] == "PL"
 
     translation = color_attribute.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1973,13 +2016,16 @@ def test_attribute_update_translation(
     assert data["attribute"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -2037,13 +2083,16 @@ def test_attribute_value_create_translation(
     assert data["attributeValue"]["translation"]["language"]["code"] == "PL"
 
     translation = pink_attribute_value.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -2163,13 +2212,16 @@ def test_attribute_value_update_translation(
     assert data["attributeValue"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -2615,13 +2667,16 @@ def test_shipping_method_create_translation(
     assert data["shippingMethod"]["translation"]["language"]["code"] == "PL"
 
     translation = shipping_method.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -2698,13 +2753,16 @@ def test_shipping_method_update_translation(
     assert data["shippingMethod"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -2758,13 +2816,16 @@ def test_menu_item_update_translation(
     assert data["menuItem"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -2824,13 +2885,16 @@ def test_shop_create_translation(
     assert data["shop"]["translation"]["language"]["code"] == "PL"
 
     translation = site_settings.translations.first()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_CREATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -2885,13 +2949,16 @@ def test_shop_update_translation(
     assert data["shop"]["translation"]["language"]["code"] == "PL"
 
     translation.refresh_from_db()
-    expected_payload = generate_translation_payload(translation, staff_api_client.user)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_payload,
+        None,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
         [any_webhook],
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from decimal import Decimal
+from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -166,11 +167,17 @@ class WebhookPlugin(BasePlugin):
 
     def _trigger_metadata_updated_event(self, event_type, instance, webhooks=None):
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            metadata_updated_data = generate_metadata_updated_payload(
-                instance, self.requestor
+            metadata_payload_generator = partial(
+                generate_metadata_updated_payload, instance, self.requestor
             )
+
             trigger_webhooks_async(
-                metadata_updated_data, event_type, webhooks, instance, self.requestor
+                None,
+                event_type,
+                webhooks,
+                instance,
+                self.requestor,
+                legacy_data_generator=metadata_payload_generator,
             )
 
     def _trigger_account_request_event(
@@ -646,9 +653,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def _trigger_menu_event(self, event_type, menu, webhooks=None):
@@ -723,9 +737,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_CONFIRMED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_fully_paid(self, order: "Order", previous_value: Any) -> Any:
@@ -733,9 +754,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_FULLY_PAID
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_paid(self, order: "Order", previous_value: Any) -> Any:
@@ -743,9 +771,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_PAID
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_refunded(self, order: "Order", previous_value: Any) -> Any:
@@ -753,9 +788,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_REFUNDED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_fully_refunded(self, order: "Order", previous_value: Any) -> Any:
@@ -763,19 +805,33 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_FULLY_REFUNDED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_updated(self, order: "Order", previous_value: Any, webhooks=None) -> Any:
         if not self.active:
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_UPDATED
-        if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            order_data = generate_order_payload(order, self.requestor)
+        if webhooks := get_webhooks_for_event(event_type):
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_expired(self, order: "Order", previous_value: Any) -> Any:
@@ -783,9 +839,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_EXPIRED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def sale_created(
@@ -798,14 +861,20 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.SALE_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            sale_data = generate_sale_payload(
+            sale_data_generator = partial(
+                generate_sale_payload,
                 sale,
                 previous_catalogue=None,
                 current_catalogue=current_catalogue,
                 requestor=self.requestor,
             )
             trigger_webhooks_async(
-                sale_data, event_type, webhooks, sale, self.requestor
+                None,
+                event_type,
+                webhooks,
+                sale,
+                self.requestor,
+                legacy_data_generator=sale_data_generator,
             )
 
     def sale_updated(
@@ -819,11 +888,20 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.SALE_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            sale_data = generate_sale_payload(
-                sale, previous_catalogue, current_catalogue, self.requestor
+            sale_data_generator = partial(
+                generate_sale_payload,
+                sale,
+                previous_catalogue,
+                current_catalogue,
+                self.requestor,
             )
             trigger_webhooks_async(
-                sale_data, event_type, webhooks, sale, self.requestor
+                None,
+                event_type,
+                webhooks,
+                sale,
+                self.requestor,
+                legacy_data_generator=sale_data_generator,
             )
 
     def sale_deleted(
@@ -837,11 +915,19 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.SALE_DELETED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            sale_data = generate_sale_payload(
-                sale, previous_catalogue=previous_catalogue, requestor=self.requestor
+            sale_data_generator = partial(
+                generate_sale_payload,
+                sale,
+                previous_catalogue=previous_catalogue,
+                requestor=self.requestor,
             )
             trigger_webhooks_async(
-                sale_data, event_type, webhooks, sale, self.requestor
+                None,
+                event_type,
+                webhooks,
+                sale,
+                self.requestor,
+                legacy_data_generator=sale_data_generator,
             )
 
     def sale_toggle(
@@ -854,11 +940,19 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.SALE_TOGGLE
         if webhooks := get_webhooks_for_event(event_type):
-            sale_data = generate_sale_toggle_payload(
-                sale, catalogue=catalogue, requestor=self.requestor
+            sale_data_generator = partial(
+                generate_sale_toggle_payload,
+                sale,
+                catalogue=catalogue,
+                requestor=self.requestor,
             )
             trigger_webhooks_async(
-                sale_data, event_type, webhooks, sale, self.requestor
+                None,
+                event_type,
+                webhooks,
+                sale,
+                self.requestor,
+                legacy_data_generator=sale_data_generator,
             )
 
     def invoice_request(
@@ -872,9 +966,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.INVOICE_REQUESTED
         if webhooks := get_webhooks_for_event(event_type):
-            invoice_data = generate_invoice_payload(invoice, self.requestor)
+            invoice_data_generator = partial(
+                generate_invoice_payload, invoice, self.requestor
+            )
             trigger_webhooks_async(
-                invoice_data, event_type, webhooks, invoice, self.requestor
+                None,
+                event_type,
+                webhooks,
+                invoice,
+                self.requestor,
+                legacy_data_generator=invoice_data_generator,
             )
 
     def invoice_delete(self, invoice: "Invoice", previous_value: Any):
@@ -882,9 +983,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.INVOICE_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            invoice_data = generate_invoice_payload(invoice, self.requestor)
+            invoice_data_generator = partial(
+                generate_invoice_payload, invoice, self.requestor
+            )
             trigger_webhooks_async(
-                invoice_data, event_type, webhooks, invoice, self.requestor
+                None,
+                event_type,
+                webhooks,
+                invoice,
+                self.requestor,
+                legacy_data_generator=invoice_data_generator,
             )
 
     def invoice_sent(self, invoice: "Invoice", email: str, previous_value: Any) -> Any:
@@ -892,9 +1000,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.INVOICE_SENT
         if webhooks := get_webhooks_for_event(event_type):
-            invoice_data = generate_invoice_payload(invoice, self.requestor)
+            invoice_data_generator = partial(
+                generate_invoice_payload, invoice, self.requestor
+            )
             trigger_webhooks_async(
-                invoice_data, event_type, webhooks, invoice, self.requestor
+                None,
+                event_type,
+                webhooks,
+                invoice,
+                self.requestor,
+                legacy_data_generator=invoice_data_generator,
             )
 
     def order_cancelled(
@@ -904,9 +1019,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_CANCELLED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_fulfilled(self, order: "Order", previous_value: Any) -> Any:
@@ -914,9 +1036,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_FULFILLED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def order_metadata_updated(self, order: "Order", previous_value: Any) -> Any:
@@ -931,11 +1060,19 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.ORDER_BULK_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = [
-                generate_order_payload(order, self.requestor) for order in orders
-            ]
+
+            def generate_bulk_order_payload():
+                return [
+                    generate_order_payload(order, self.requestor) for order in orders
+                ]
+
             trigger_webhooks_async(
-                order_data, event_type, webhooks, orders, self.requestor
+                None,
+                event_type,
+                webhooks,
+                orders,
+                self.requestor,
+                legacy_data_generator=generate_bulk_order_payload,
             )
 
     def draft_order_created(self, order: "Order", previous_value: Any) -> Any:
@@ -943,9 +1080,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def draft_order_updated(self, order: "Order", previous_value: Any) -> Any:
@@ -953,9 +1097,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def draft_order_deleted(self, order: "Order", previous_value: Any) -> Any:
@@ -963,9 +1114,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.DRAFT_ORDER_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            order_data = generate_order_payload(order, self.requestor)
+            order_data_generator = partial(
+                generate_order_payload, order, self.requestor
+            )
             trigger_webhooks_async(
-                order_data, event_type, webhooks, order, self.requestor
+                None,
+                event_type,
+                webhooks,
+                order,
+                self.requestor,
+                legacy_data_generator=order_data_generator,
             )
 
     def fulfillment_created(self, fulfillment: "Fulfillment", previous_value):
@@ -973,9 +1131,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.FULFILLMENT_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
+            fulfillment_data_generator = partial(
+                generate_fulfillment_payload, fulfillment, self.requestor
+            )
             trigger_webhooks_async(
-                fulfillment_data, event_type, webhooks, fulfillment, self.requestor
+                None,
+                event_type,
+                webhooks,
+                fulfillment,
+                self.requestor,
+                legacy_data_generator=fulfillment_data_generator,
             )
 
     def fulfillment_canceled(self, fulfillment: "Fulfillment", previous_value):
@@ -983,9 +1148,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.FULFILLMENT_CANCELED
         if webhooks := get_webhooks_for_event(event_type):
-            fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
+            fulfillment_data_generator = partial(
+                generate_fulfillment_payload, fulfillment, self.requestor
+            )
             trigger_webhooks_async(
-                fulfillment_data, event_type, webhooks, fulfillment, self.requestor
+                None,
+                event_type,
+                webhooks,
+                fulfillment,
+                self.requestor,
+                legacy_data_generator=fulfillment_data_generator,
             )
 
     def fulfillment_approved(self, fulfillment: "Fulfillment", previous_value):
@@ -993,9 +1165,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.FULFILLMENT_APPROVED
         if webhooks := get_webhooks_for_event(event_type):
-            fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
+            fulfillment_data_generator = partial(
+                generate_fulfillment_payload, fulfillment, self.requestor
+            )
             trigger_webhooks_async(
-                fulfillment_data, event_type, webhooks, fulfillment, self.requestor
+                None,
+                event_type,
+                webhooks,
+                fulfillment,
+                self.requestor,
+                legacy_data_generator=fulfillment_data_generator,
             )
 
     def fulfillment_metadata_updated(self, fulfillment: "Fulfillment", previous_value):
@@ -1010,9 +1189,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CUSTOMER_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            customer_data = generate_customer_payload(customer, self.requestor)
+            customer_data_generator = partial(
+                generate_customer_payload, customer, self.requestor
+            )
             trigger_webhooks_async(
-                customer_data, event_type, webhooks, customer, self.requestor
+                None,
+                event_type,
+                webhooks,
+                customer,
+                self.requestor,
+                legacy_data_generator=customer_data_generator,
             )
 
     def customer_updated(
@@ -1022,9 +1208,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CUSTOMER_UPDATED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            customer_data = generate_customer_payload(customer, self.requestor)
+            customer_data_generator = partial(
+                generate_customer_payload, customer, self.requestor
+            )
             trigger_webhooks_async(
-                customer_data, event_type, webhooks, customer, self.requestor
+                None,
+                event_type,
+                webhooks,
+                customer,
+                self.requestor,
+                legacy_data_generator=customer_data_generator,
             )
 
     def customer_deleted(
@@ -1034,9 +1227,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CUSTOMER_DELETED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            customer_data = generate_customer_payload(customer, self.requestor)
+            customer_data_generator = partial(
+                generate_customer_payload, customer, self.requestor
+            )
             trigger_webhooks_async(
-                customer_data, event_type, webhooks, customer, self.requestor
+                None,
+                event_type,
+                webhooks,
+                customer,
+                self.requestor,
+                legacy_data_generator=customer_data_generator,
             )
 
     def customer_metadata_updated(
@@ -1053,9 +1253,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.COLLECTION_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            collection_data = generate_collection_payload(collection, self.requestor)
+            collection_data_generator = partial(
+                generate_collection_payload, collection, self.requestor
+            )
             trigger_webhooks_async(
-                collection_data, event_type, webhooks, collection, self.requestor
+                None,
+                event_type,
+                webhooks,
+                collection,
+                self.requestor,
+                legacy_data_generator=collection_data_generator,
             )
 
     def collection_updated(self, collection: "Collection", previous_value: Any) -> Any:
@@ -1063,9 +1270,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.COLLECTION_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            collection_data = generate_collection_payload(collection, self.requestor)
+            collection_data_generator = partial(
+                generate_collection_payload, collection, self.requestor
+            )
             trigger_webhooks_async(
-                collection_data, event_type, webhooks, collection, self.requestor
+                None,
+                event_type,
+                webhooks,
+                collection,
+                self.requestor,
+                legacy_data_generator=collection_data_generator,
             )
 
     def collection_deleted(
@@ -1075,9 +1289,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.COLLECTION_DELETED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            collection_data = generate_collection_payload(collection, self.requestor)
+            collection_data_generator = partial(
+                generate_collection_payload, collection, self.requestor
+            )
             trigger_webhooks_async(
-                collection_data, event_type, webhooks, collection, self.requestor
+                None,
+                event_type,
+                webhooks,
+                collection,
+                self.requestor,
+                legacy_data_generator=collection_data_generator,
             )
 
     def collection_metadata_updated(
@@ -1096,9 +1317,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_CREATED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_data = generate_product_payload(product, self.requestor)
+            product_data_generator = partial(
+                generate_product_payload, product, self.requestor
+            )
             trigger_webhooks_async(
-                product_data, event_type, webhooks, product, self.requestor
+                None,
+                event_type,
+                webhooks,
+                product,
+                self.requestor,
+                legacy_data_generator=product_data_generator,
             )
 
     def product_updated(
@@ -1108,9 +1336,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_UPDATED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_data = generate_product_payload(product, self.requestor)
+            product_data_generator = partial(
+                generate_product_payload, product, self.requestor
+            )
             trigger_webhooks_async(
-                product_data, event_type, webhooks, product, self.requestor
+                None,
+                event_type,
+                webhooks,
+                product,
+                self.requestor,
+                legacy_data_generator=product_data_generator,
             )
 
     def product_metadata_updated(self, product: "Product", previous_value: Any) -> Any:
@@ -1131,15 +1366,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_DELETED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_data = generate_product_deleted_payload(
-                product, variants, self.requestor
+            product_data_generator = partial(
+                generate_product_deleted_payload, product, variants, self.requestor
             )
             trigger_webhooks_async(
-                product_data,
+                None,
                 event_type,
                 webhooks,
                 product,
                 self.requestor,
+                legacy_data_generator=product_data_generator,
             )
 
     def product_media_created(self, media: "ProductMedia", previous_value: Any) -> Any:
@@ -1147,13 +1383,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_MEDIA_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            media_data = generate_product_media_payload(media)
+            media_data_generator = partial(generate_product_media_payload, media)
             trigger_webhooks_async(
-                media_data,
+                None,
                 event_type,
                 webhooks,
                 media,
                 self.requestor,
+                legacy_data_generator=media_data_generator,
             )
 
     def product_media_updated(self, media: "ProductMedia", previous_value: Any) -> Any:
@@ -1161,13 +1398,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_MEDIA_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            media_data = generate_product_media_payload(media)
+            media_data_generator = partial(generate_product_media_payload, media)
             trigger_webhooks_async(
-                media_data,
+                None,
                 event_type,
                 webhooks,
                 media,
                 self.requestor,
+                legacy_data_generator=media_data_generator,
             )
 
     def product_media_deleted(self, media: "ProductMedia", previous_value: Any) -> Any:
@@ -1175,13 +1413,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_MEDIA_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            media_data = generate_product_media_payload(media)
+            media_data_generator = partial(generate_product_media_payload, media)
             trigger_webhooks_async(
-                media_data,
+                None,
                 event_type,
                 webhooks,
                 media,
                 self.requestor,
+                legacy_data_generator=media_data_generator,
             )
 
     def product_variant_created(
@@ -1191,15 +1430,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_CREATED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_variant_data = generate_product_variant_payload(
-                [product_variant], self.requestor
+            product_variant_data_generator = partial(
+                generate_product_variant_payload, [product_variant], self.requestor
             )
             trigger_webhooks_async(
-                product_variant_data,
+                None,
                 event_type,
                 webhooks,
                 product_variant,
                 self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def product_variant_updated(
@@ -1209,15 +1449,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_variant_data = generate_product_variant_payload(
-                [product_variant], self.requestor
+            product_variant_data_generator = partial(
+                generate_product_variant_payload, [product_variant], self.requestor
             )
             trigger_webhooks_async(
-                product_variant_data,
+                None,
                 event_type,
                 webhooks,
                 product_variant,
                 self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def product_variant_deleted(
@@ -1227,15 +1468,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_DELETED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_variant_data = generate_product_variant_payload(
-                [product_variant], self.requestor
+            product_variant_data_generator = partial(
+                generate_product_variant_payload, [product_variant], self.requestor
             )
             trigger_webhooks_async(
-                product_variant_data,
+                None,
                 event_type,
                 webhooks,
                 product_variant,
                 self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def product_variant_metadata_updated(
@@ -1254,9 +1496,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_variant_data = generate_product_variant_with_stock_payload([stock])
+            product_variant_data_generator = partial(
+                generate_product_variant_with_stock_payload, [stock]
+            )
             trigger_webhooks_async(
-                product_variant_data, event_type, webhooks, stock, self.requestor
+                None,
+                event_type,
+                webhooks,
+                stock,
+                self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def product_variant_back_in_stock(
@@ -1266,11 +1515,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_variant_data = generate_product_variant_with_stock_payload(
-                [stock], self.requestor
+            product_variant_data_generator = partial(
+                generate_product_variant_with_stock_payload, [stock], self.requestor
             )
             trigger_webhooks_async(
-                product_variant_data, event_type, webhooks, stock, self.requestor
+                None,
+                event_type,
+                webhooks,
+                stock,
+                self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def product_variant_stock_updated(
@@ -1280,11 +1534,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PRODUCT_VARIANT_STOCK_UPDATED
         if webhooks := self._get_webhooks_for_event(event_type, webhooks):
-            product_variant_data = generate_product_variant_with_stock_payload(
-                [stock], self.requestor
+            product_variant_data_generator = (
+                generate_product_variant_with_stock_payload([stock], self.requestor)
             )
             trigger_webhooks_async(
-                product_variant_data, event_type, webhooks, stock, self.requestor
+                None,
+                event_type,
+                webhooks,
+                stock,
+                self.requestor,
+                legacy_data_generator=product_variant_data_generator,
             )
 
     def checkout_created(self, checkout: "Checkout", previous_value: Any) -> Any:
@@ -1292,9 +1551,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CHECKOUT_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            checkout_data = generate_checkout_payload(checkout, self.requestor)
+            checkout_data_generator = partial(
+                generate_checkout_payload, checkout, self.requestor
+            )
             trigger_webhooks_async(
-                checkout_data, event_type, webhooks, checkout, self.requestor
+                None,
+                event_type,
+                webhooks,
+                checkout,
+                self.requestor,
+                legacy_data_generator=checkout_data_generator,
             )
 
     def checkout_updated(self, checkout: "Checkout", previous_value: Any) -> Any:
@@ -1302,9 +1568,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CHECKOUT_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            checkout_data = generate_checkout_payload(checkout, self.requestor)
+            checkout_data_generator = partial(
+                generate_checkout_payload, checkout, self.requestor
+            )
             trigger_webhooks_async(
-                checkout_data, event_type, webhooks, checkout, self.requestor
+                None,
+                event_type,
+                webhooks,
+                checkout,
+                self.requestor,
+                legacy_data_generator=checkout_data_generator,
             )
 
     def checkout_fully_paid(self, checkout: "Checkout", previous_value: Any) -> Any:
@@ -1312,9 +1585,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.CHECKOUT_FULLY_PAID
         if webhooks := get_webhooks_for_event(event_type):
-            checkout_data = generate_checkout_payload(checkout, self.requestor)
+            checkout_data_generator = partial(
+                generate_checkout_payload, checkout, self.requestor
+            )
             trigger_webhooks_async(
-                checkout_data, event_type, webhooks, checkout, self.requestor
+                None,
+                event_type,
+                webhooks,
+                checkout,
+                self.requestor,
+                legacy_data_generator=checkout_data_generator,
             )
 
     def checkout_metadata_updated(
@@ -1351,9 +1631,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PAGE_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            page_data = generate_page_payload(page, self.requestor)
+            page_data_generator = partial(generate_page_payload, page, self.requestor)
             trigger_webhooks_async(
-                page_data, event_type, webhooks, page, self.requestor
+                None,
+                event_type,
+                webhooks,
+                page,
+                self.requestor,
+                legacy_data_generator=page_data_generator,
             )
 
     def page_updated(self, page: "Page", previous_value: Any) -> Any:
@@ -1361,9 +1646,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PAGE_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            page_data = generate_page_payload(page, self.requestor)
+            page_data_generator = partial(generate_page_payload, page, self.requestor)
             trigger_webhooks_async(
-                page_data, event_type, webhooks, page, self.requestor
+                None,
+                event_type,
+                webhooks,
+                page,
+                self.requestor,
+                legacy_data_generator=page_data_generator,
             )
 
     def page_deleted(self, page: "Page", previous_value: Any) -> Any:
@@ -1371,9 +1661,14 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.PAGE_DELETED
         if webhooks := get_webhooks_for_event(event_type):
-            page_data = generate_page_payload(page, self.requestor)
+            page_data_generator = partial(generate_page_payload, page, self.requestor)
             trigger_webhooks_async(
-                page_data, event_type, webhooks, page, self.requestor
+                None,
+                event_type,
+                webhooks,
+                page,
+                self.requestor,
+                legacy_data_generator=page_data_generator,
             )
 
     def _trigger_page_type_event(self, event_type, page_type):
@@ -1595,12 +1890,13 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.THUMBNAIL_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            thumbnail_data = generate_thumbnail_payload(thumbnail)
+            thumbnail_data_generator = partial(generate_thumbnail_payload, thumbnail)
             trigger_webhooks_async(
-                data=thumbnail_data,
+                data=None,
                 event_type=event_type,
                 webhooks=webhooks,
                 subscribable_object=thumbnail,
+                legacy_data_generator=thumbnail_data_generator,
             )
 
     def translation_created(self, translation: "Translation", previous_value: Any):
@@ -1608,9 +1904,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.TRANSLATION_CREATED
         if webhooks := get_webhooks_for_event(event_type):
-            translation_data = generate_translation_payload(translation, self.requestor)
+            translation_data_generator = partial(
+                generate_translation_payload, translation, self.requestor
+            )
             trigger_webhooks_async(
-                translation_data, event_type, webhooks, translation, self.requestor
+                None,
+                event_type,
+                webhooks,
+                translation,
+                self.requestor,
+                legacy_data_generator=translation_data_generator,
             )
 
     def translation_updated(self, translation: "Translation", previous_value: Any):
@@ -1618,9 +1921,16 @@ class WebhookPlugin(BasePlugin):
             return previous_value
         event_type = WebhookEventAsyncType.TRANSLATION_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
-            translation_data = generate_translation_payload(translation, self.requestor)
+            translation_data_generator = partial(
+                generate_translation_payload, translation, self.requestor
+            )
             trigger_webhooks_async(
-                translation_data, event_type, webhooks, translation, self.requestor
+                None,
+                event_type,
+                webhooks,
+                translation,
+                self.requestor,
+                legacy_data_generator=translation_data_generator,
             )
 
     def _trigger_warehouse_event(self, event_type, warehouse):

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -184,20 +184,33 @@ def create_delivery_for_subscription_sync_event(
 
 
 def trigger_webhooks_async(
-    data, event_type, webhooks, subscribable_object=None, requestor=None
+    data,  # deprecated, legacy_data_generator should be used instead
+    event_type,
+    webhooks,
+    subscribable_object=None,
+    requestor=None,
+    legacy_data_generator=None,
 ):
     """Trigger async webhooks - both regular and subscription.
 
     :param data: used as payload in regular webhooks.
+        Note: this is a legacy parameter, thus it is optional; if it's not provided,
+        `legacy_data_generator` function is used to generate the payload when needed.
     :param event_type: used in both webhook types as event type.
     :param webhooks: used in both webhook types, queryset of async webhooks.
     :param subscribable_object: subscribable object used in subscription webhooks.
     :param requestor: used in subscription webhooks to generate meta data for payload.
+    :param legacy_data_generator: used to generate payload for regular webhooks.
     """
     regular_webhooks, subscription_webhooks = group_webhooks_by_subscription(webhooks)
     deliveries = []
 
     if regular_webhooks:
+        if legacy_data_generator:
+            data = legacy_data_generator()
+        elif data is None:
+            raise NotImplementedError("No payload was provided for regular webhooks.")
+
         payload = EventPayload.objects.create(payload=data)
         deliveries.extend(
             create_event_delivery_list_for_webhooks(

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from decimal import Decimal
+from functools import partial
 from unittest import mock
 from unittest.mock import ANY, MagicMock
 from urllib.parse import urlencode
@@ -42,18 +43,7 @@ from ....site.models import SiteSettings
 from ....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ....webhook.payloads import (
     generate_checkout_payload,
-    generate_collection_payload,
-    generate_customer_payload,
-    generate_invoice_payload,
-    generate_metadata_updated_payload,
-    generate_order_payload,
-    generate_page_payload,
     generate_product_deleted_payload,
-    generate_product_payload,
-    generate_product_variant_payload,
-    generate_product_variant_with_stock_payload,
-    generate_sale_payload,
-    generate_sale_toggle_payload,
 )
 from ....webhook.utils import get_webhooks_for_event
 from ...manager import get_plugins_manager
@@ -141,14 +131,17 @@ def test_order_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_created(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_CREATED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -166,14 +159,17 @@ def test_order_confirmed(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_confirmed(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_CONFIRMED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -191,14 +187,17 @@ def test_draft_order_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.draft_order_created(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.DRAFT_ORDER_CREATED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -216,14 +215,17 @@ def test_draft_order_deleted(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.draft_order_deleted(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.DRAFT_ORDER_DELETED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -241,14 +243,17 @@ def test_draft_order_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.draft_order_updated(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -266,14 +271,17 @@ def test_customer_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.customer_created(customer_user)
-    expected_data = generate_customer_payload(customer_user)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CUSTOMER_CREATED,
         [any_webhook],
         customer_user,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -291,14 +299,17 @@ def test_customer_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.customer_updated(customer_user)
-    expected_data = generate_customer_payload(customer_user)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CUSTOMER_UPDATED,
         [any_webhook],
         customer_user,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -316,14 +327,16 @@ def test_customer_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.customer_metadata_updated(customer_user)
-    expected_data = generate_metadata_updated_payload(customer_user)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CUSTOMER_METADATA_UPDATED,
         [any_webhook],
         customer_user,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -341,14 +354,16 @@ def test_order_fully_paid(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_fully_paid(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_FULLY_PAID,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -371,14 +386,16 @@ def test_order_paid(
     manager.order_paid(order_with_lines)
 
     # then
-    expected_data = generate_order_payload(order_with_lines)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_PAID,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -401,14 +418,16 @@ def test_order_refunded(
     manager.order_refunded(order_with_lines)
 
     # then
-    expected_data = generate_order_payload(order_with_lines)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_REFUNDED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -431,14 +450,16 @@ def test_order_fully_refunded(
     manager.order_fully_refunded(order_with_lines)
 
     # then
-    expected_data = generate_order_payload(order_with_lines)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_FULLY_REFUNDED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -456,14 +477,17 @@ def test_collection_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.collection_created(collection)
-    expected_data = generate_collection_payload(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.COLLECTION_CREATED,
         [any_webhook],
         collection,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -481,14 +505,17 @@ def test_collection_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.collection_updated(collection)
-    expected_data = generate_collection_payload(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.COLLECTION_UPDATED,
         [any_webhook],
         collection,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -506,14 +533,17 @@ def test_collection_deleted(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.collection_deleted(collection)
-    expected_data = generate_collection_payload(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.COLLECTION_DELETED,
         [any_webhook],
         collection,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -531,14 +561,17 @@ def test_collection_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.collection_metadata_updated(collection)
-    expected_data = generate_metadata_updated_payload(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.COLLECTION_METADATA_UPDATED,
         [any_webhook],
         collection,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -556,14 +589,17 @@ def test_product_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_created(product)
-    expected_data = generate_product_payload(product)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_CREATED,
         [any_webhook],
         product,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -581,14 +617,17 @@ def test_product_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_updated(product)
-    expected_data = generate_product_payload(product)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_UPDATED,
         [any_webhook],
         product,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -624,11 +663,15 @@ def test_product_deleted(
     assert variant_global_ids == expected_data_dict["variants"]
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_DELETED,
         [any_webhook],
         product,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -646,14 +689,17 @@ def test_product_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_metadata_updated(product)
-    expected_data = generate_metadata_updated_payload(product)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_METADATA_UPDATED,
         [any_webhook],
         product,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -671,14 +717,17 @@ def test_product_variant_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_variant_created(variant)
-    expected_data = generate_product_variant_payload([variant])
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_CREATED,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -696,14 +745,17 @@ def test_product_variant_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_variant_updated(variant)
-    expected_data = generate_product_variant_payload([variant])
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -721,14 +773,17 @@ def test_product_variant_deleted(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_variant_deleted(variant)
-    expected_data = generate_product_variant_payload([variant])
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_DELETED,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -746,14 +801,17 @@ def test_product_variant_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.product_variant_metadata_updated(variant)
-    expected_data = generate_metadata_updated_payload(variant)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_METADATA_UPDATED,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -773,13 +831,16 @@ def test_product_variant_out_of_stock(
     manager = get_plugins_manager()
     manager.product_variant_out_of_stock(variant)
 
-    expected_data = generate_product_variant_with_stock_payload([variant])
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -799,13 +860,16 @@ def test_product_variant_back_in_stock(
     manager = get_plugins_manager()
     manager.product_variant_back_in_stock(variant)
 
-    expected_data = generate_product_variant_with_stock_payload([variant])
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK,
         [any_webhook],
         variant,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -823,14 +887,17 @@ def test_order_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_updated(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_UPDATED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -848,14 +915,17 @@ def test_order_cancelled(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_cancelled(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_CANCELLED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -873,14 +943,17 @@ def test_order_expired(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_expired(order_with_lines)
-    expected_data = generate_order_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_EXPIRED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -898,14 +971,17 @@ def test_order_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.order_metadata_updated(order_with_lines)
-    expected_data = generate_metadata_updated_payload(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.ORDER_METADATA_UPDATED,
         [any_webhook],
         order_with_lines,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -923,14 +999,17 @@ def test_checkout_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.checkout_created(checkout_with_items)
-    expected_data = generate_checkout_payload(checkout_with_items)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CHECKOUT_CREATED,
         [any_webhook],
         checkout_with_items,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -982,14 +1061,17 @@ def test_checkout_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.checkout_updated(checkout_with_items)
-    expected_data = generate_checkout_payload(checkout_with_items)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CHECKOUT_UPDATED,
         [any_webhook],
         checkout_with_items,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1012,14 +1094,16 @@ def test_checkout_fully_paid(
     manager.checkout_fully_paid(checkout_with_items)
 
     # then
-    expected_data = generate_checkout_payload(checkout_with_items)
-
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CHECKOUT_FULLY_PAID,
         [any_webhook],
         checkout_with_items,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1037,14 +1121,17 @@ def test_checkout_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.checkout_metadata_updated(checkout_with_items)
-    expected_data = generate_metadata_updated_payload(checkout_with_items)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.CHECKOUT_METADATA_UPDATED,
         [any_webhook],
         checkout_with_items,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1058,10 +1145,17 @@ def test_page_created(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.page_created(page)
-    expected_data = generate_page_payload(page)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.PAGE_CREATED, [any_webhook], page, None
+        None,
+        WebhookEventAsyncType.PAGE_CREATED,
+        [any_webhook],
+        page,
+        None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1075,10 +1169,17 @@ def test_page_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.page_updated(page)
-    expected_data = generate_page_payload(page)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.PAGE_UPDATED, [any_webhook], page, None
+        None,
+        WebhookEventAsyncType.PAGE_UPDATED,
+        [any_webhook],
+        page,
+        None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1095,10 +1196,17 @@ def test_page_deleted(
     page.delete()
     page.id = page_id
     manager.page_deleted(page)
-    expected_data = generate_page_payload(page)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.PAGE_DELETED, [any_webhook], page, None
+        None,
+        WebhookEventAsyncType.PAGE_DELETED,
+        [any_webhook],
+        page,
+        None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1117,14 +1225,17 @@ def test_invoice_request(
     manager = get_plugins_manager()
     invoice = fulfilled_order.invoices.first()
     manager.invoice_request(fulfilled_order, invoice, invoice.number)
-    expected_data = generate_invoice_payload(invoice)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.INVOICE_REQUESTED,
         [any_webhook],
         invoice,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1143,14 +1254,17 @@ def test_invoice_delete(
     manager = get_plugins_manager()
     invoice = fulfilled_order.invoices.first()
     manager.invoice_delete(invoice)
-    expected_data = generate_invoice_payload(invoice)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.INVOICE_DELETED,
         [any_webhook],
         invoice,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1169,10 +1283,17 @@ def test_invoice_sent(
     manager = get_plugins_manager()
     invoice = fulfilled_order.invoices.first()
     manager.invoice_sent(invoice, fulfilled_order.user.email)
-    expected_data = generate_invoice_payload(invoice)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.INVOICE_SENT, [any_webhook], invoice, None
+        None,
+        WebhookEventAsyncType.INVOICE_SENT,
+        [any_webhook],
+        invoice,
+        None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1190,14 +1311,17 @@ def test_fulfillment_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.fulfillment_metadata_updated(fulfillment)
-    expected_data = generate_metadata_updated_payload(fulfillment)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.FULFILLMENT_METADATA_UPDATED,
         [any_webhook],
         fulfillment,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1215,14 +1339,17 @@ def test_gift_card_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.gift_card_metadata_updated(gift_card)
-    expected_data = generate_metadata_updated_payload(gift_card)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.GIFT_CARD_METADATA_UPDATED,
         [any_webhook],
         gift_card,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1240,14 +1367,17 @@ def test_voucher_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.voucher_metadata_updated(voucher)
-    expected_data = generate_metadata_updated_payload(voucher)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.VOUCHER_METADATA_UPDATED,
         [any_webhook],
         voucher,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1266,14 +1396,17 @@ def test_shop_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.shop_metadata_updated(site_settings)
-    expected_data = generate_metadata_updated_payload(site_settings)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.SHOP_METADATA_UPDATED,
         [any_webhook],
         site_settings,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1291,14 +1424,17 @@ def test_shipping_zone_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.shipping_zone_metadata_updated(shipping_zone)
-    expected_data = generate_metadata_updated_payload(shipping_zone)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.SHIPPING_ZONE_METADATA_UPDATED,
         [any_webhook],
         shipping_zone,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1316,14 +1452,17 @@ def test_warehouse_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.warehouse_metadata_updated(warehouse)
-    expected_data = generate_metadata_updated_payload(warehouse)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.WAREHOUSE_METADATA_UPDATED,
         [any_webhook],
         warehouse,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1341,14 +1480,17 @@ def test_transaction_item_metadata_updated(
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
     manager.transaction_item_metadata_updated(transaction_item_created_by_app)
-    expected_data = generate_metadata_updated_payload(transaction_item_created_by_app)
 
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data,
+        None,
         WebhookEventAsyncType.TRANSACTION_ITEM_METADATA_UPDATED,
         [any_webhook],
         transaction_item_created_by_app,
         None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1454,9 +1596,16 @@ def test_sale_created(
         fetch_catalogue_info(sale)
     )
     manager.sale_created(sale, current_catalogue=sale_catalogue_info)
-    expected_data = generate_sale_payload(sale, current_catalogue=sale_catalogue_info)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.SALE_CREATED, [any_webhook], sale, None
+        None,
+        WebhookEventAsyncType.SALE_CREATED,
+        [any_webhook],
+        sale,
+        None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1487,13 +1636,16 @@ def test_sale_updated(
         previous_catalogue=previous_sale_catalogue_info,
         current_catalogue=current_sale_catalogue_info,
     )
-    expected_data = generate_sale_payload(
-        sale,
-        current_catalogue=current_sale_catalogue_info,
-        previous_catalogue=previous_sale_catalogue_info,
-    )
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.SALE_UPDATED, [any_webhook], sale, None
+        None,
+        WebhookEventAsyncType.SALE_UPDATED,
+        [any_webhook],
+        sale,
+        None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1510,9 +1662,16 @@ def test_sale_deleted(
         fetch_catalogue_info(sale)
     )
     manager.sale_deleted(sale, previous_catalogue=sale_catalogue_info)
-    expected_data = generate_sale_payload(sale, previous_catalogue=sale_catalogue_info)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.SALE_DELETED, [any_webhook], sale, None
+        None,
+        WebhookEventAsyncType.SALE_DELETED,
+        [any_webhook],
+        sale,
+        None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 
@@ -1534,9 +1693,16 @@ def test_sale_toggle(
     manager.sale_toggle(sale, catalogue=sale_catalogue_info)
 
     # then
-    expected_data = generate_sale_toggle_payload(sale, catalogue=sale_catalogue_info)
     mocked_webhook_trigger.assert_called_once_with(
-        expected_data, WebhookEventAsyncType.SALE_TOGGLE, [any_webhook], sale, None
+        None,
+        WebhookEventAsyncType.SALE_TOGGLE,
+        [any_webhook],
+        sale,
+        None,
+        legacy_data_generator=ANY,
+    )
+    assert isinstance(
+        mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )
 
 


### PR DESCRIPTION
I want to merge this change because it is a backport of https://github.com/saleor/saleor/pull/13758

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
