### PR TITLE
Pass allow_replica to subscription request.

### DIFF
--- a/saleor/account/tests/test_notifications.py
+++ b/saleor/account/tests/test_notifications.py
@@ -36,7 +36,7 @@ def test_send_email_request_change(
     redirect_url = "http://localhost:8000/redirect"
     token = "token_example"
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     notifications.send_request_user_change_email_notification(
         redirect_url,
         customer_user,
@@ -71,7 +71,10 @@ def test_send_email_changed_notification(
     old_email = "example@example.com"
 
     notifications.send_user_change_email_notification(
-        old_email, customer_user, get_plugins_manager(), channel_slug=channel_PLN.slug
+        old_email,
+        customer_user,
+        get_plugins_manager(allow_replica=False),
+        channel_slug=channel_PLN.slug,
     )
 
     expected_payload = {
@@ -105,7 +108,7 @@ def test_send_password_reset_notification(
     notifications.send_password_reset_notification(
         redirect_url,
         customer_user,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
         channel_slug=channel_PLN.slug,
         staff=is_staff,
     )

--- a/saleor/account/tests/test_utils.py
+++ b/saleor/account/tests/test_utils.py
@@ -72,7 +72,7 @@ def test_store_user_address_uses_existing_one(address):
 
     expected_user_addresses_count = 1
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     store_user_address(user, address, AddressType.BILLING, manager)
 
     assert user.addresses.count() == expected_user_addresses_count
@@ -86,7 +86,7 @@ def test_store_user_address_uses_existing_one_despite_duplicated(address):
 
     expected_user_addresses_count = 2
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     store_user_address(user, address, AddressType.BILLING, manager)
 
     assert user.addresses.count() == expected_user_addresses_count
@@ -97,7 +97,7 @@ def test_store_user_address_create_new_address_if_not_associated(address):
     user = User.objects.create_user("test@example.com", "password")
     expected_user_addresses_count = 1
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     store_user_address(user, address, AddressType.BILLING, manager)
 
     assert user.addresses.count() == expected_user_addresses_count
@@ -113,7 +113,7 @@ def test_store_user_address_address_not_saved(address):
 
     address_count = user.addresses.count()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     store_user_address(user, address, AddressType.BILLING, manager)
 
     assert user.addresses.count() == address_count

--- a/saleor/app/tests/test_installation_utils.py
+++ b/saleor/app/tests/test_installation_utils.py
@@ -260,6 +260,7 @@ def test_install_app_created_app_trigger_webhook(
         [any_webhook],
         app,
         None,
+        allow_replica=True,
     )
 
 

--- a/saleor/checkout/tests/conftest.py
+++ b/saleor/checkout/tests/conftest.py
@@ -12,7 +12,7 @@ from ..fetch import fetch_checkout_info, fetch_checkout_lines
 @pytest.fixture
 def priced_checkout_factory():
     def factory(checkout):
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         lines, _ = fetch_checkout_lines(checkout)
         checkout_info = fetch_checkout_info(checkout, lines, manager)
 

--- a/saleor/checkout/tests/test_associate_checkout_with_account.py
+++ b/saleor/checkout/tests/test_associate_checkout_with_account.py
@@ -23,7 +23,7 @@ def test_associate_guest_checkout_with_account_if_exists(
     checkout.billing_address = address
     checkout.save()
     user = None
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     checkout_info.channel.order_mark_as_paid_strategy == paid_strategy
@@ -62,7 +62,7 @@ def test_associate_guest_checkout_with_account_if_exists_with_guest_user(
     checkout.billing_address = address
     checkout.save()
     user = None
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     checkout_info.channel.order_mark_as_paid_strategy == paid_strategy
@@ -101,7 +101,7 @@ def test_associate_guest_checkout_with_account_if_exists_with_inactive_user(
     customer_user.is_active = False
     customer_user.save()
     user = None
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     checkout_info.channel.order_mark_as_paid_strategy == paid_strategy

--- a/saleor/checkout/tests/test_base_calculations.py
+++ b/saleor/checkout/tests/test_base_calculations.py
@@ -793,7 +793,7 @@ def test_base_tax_rate_gross_price_zero():
 
 def test_base_checkout_total(checkout_with_item, shipping_method, voucher_percentage):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     channel = checkout_with_item.channel
     currency = checkout_with_item.currency
 
@@ -834,7 +834,7 @@ def test_base_checkout_total_high_discount_on_entire_order_apply_once_per_order(
     voucher_channel_listing.discount_value = 100
     voucher_channel_listing.save(update_fields=["discount_value"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_with_item.shipping_method = shipping_method
     checkout_with_item.voucher_code = voucher_percentage.code
@@ -862,7 +862,7 @@ def test_base_checkout_total_high_discount_on_shipping(
     checkout_with_item, shipping_method, voucher_shipping_type
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     channel = checkout_with_item.channel
     shipping_price = shipping_method.channel_listings.get(channel=channel).price

--- a/saleor/checkout/tests/test_calculations.py
+++ b/saleor/checkout/tests/test_calculations.py
@@ -293,7 +293,7 @@ def test_get_checkout_base_prices_no_charge_taxes_with_voucher(
     variant = line_info.variant
     product_price = variant.get_price(line_info.channel_listing)
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     add_promo_code_to_checkout(
@@ -378,7 +378,7 @@ def test_fetch_checkout_prices_when_tax_exemption_and_include_taxes_in_prices(
     """
     # given
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout = checkout_with_items_and_shipping
     checkout.price_expiration = timezone.now()
@@ -436,7 +436,7 @@ def test_fetch_checkout_prices_when_tax_exemption_and_not_include_taxes_in_price
     """
     # given
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout = checkout_with_items_and_shipping
     checkout.price_expiration = timezone.now()

--- a/saleor/checkout/tests/test_cart.py
+++ b/saleor/checkout/tests/test_cart.py
@@ -28,14 +28,18 @@ def test_get_user_checkout(
 
 def test_adding_zero_quantity(checkout, product):
     variant = product.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 0)
     assert checkout.lines.count() == 0
 
 
 def test_adding_same_variant(checkout, product):
     variant = product.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
     add_variant_to_checkout(checkout_info, variant, 2)
     lines, _ = fetch_checkout_lines(checkout)
@@ -43,9 +47,9 @@ def test_adding_same_variant(checkout, product):
     assert checkout.lines.count() == 1
     assert checkout_quantity == 3
     subtotal = TaxedMoney(Money("30.00", "USD"), Money("30.00", "USD"))
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     assert (
         calculations.checkout_subtotal(
             manager=manager,
@@ -59,7 +63,9 @@ def test_adding_same_variant(checkout, product):
 
 def test_replacing_same_variant(checkout, product):
     variant = product.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1, replace=True)
     add_variant_to_checkout(checkout_info, variant, 2, replace=True)
     lines, _ = fetch_checkout_lines(checkout)
@@ -69,7 +75,9 @@ def test_replacing_same_variant(checkout, product):
 
 def test_adding_invalid_quantity(checkout, product):
     variant = product.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     with pytest.raises(ValueError, match="-1 is not a valid quantity"):
         add_variant_to_checkout(checkout_info, variant, -1)
 
@@ -77,7 +85,9 @@ def test_adding_invalid_quantity(checkout, product):
 def test_getting_line(checkout, product):
     variant = product.variants.get()
     assert checkout.get_line(variant) is None
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant)
     assert checkout.lines.get() == checkout.get_line(variant)
 
@@ -85,7 +95,9 @@ def test_getting_line(checkout, product):
 def test_shipping_detection(checkout, product):
     assert not checkout.is_shipping_required()
     variant = product.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, replace=True)
     assert checkout.is_shipping_required()
 
@@ -131,7 +143,7 @@ def test_get_prices_of_discounted_specific_product_only_product(
     channel = checkout.channel
     variant_channel_listing = line.variant.channel_listings.get(channel=channel)
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
     add_variant_to_checkout(checkout_info, product2.variants.get(), 1)
     voucher.products.add(product)
@@ -164,7 +176,7 @@ def test_get_prices_of_discounted_specific_product_only_collection(
     channel = checkout.channel
     variant_channel_listing = line.variant.channel_listings.get(channel=channel)
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
     add_variant_to_checkout(checkout_info, product2.variants.get(), 1)
     product.collections.add(collection)
@@ -202,7 +214,7 @@ def test_get_prices_of_discounted_specific_product_only_category(
 
     product2.category = category2
     product2.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
     add_variant_to_checkout(checkout_info, product2.variants.get(), 1)
     voucher.categories.add(category)

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -60,7 +60,7 @@ def test_is_valid_delivery_method(checkout_with_item, address, shipping_zone):
     checkout = checkout_with_item
     checkout.shipping_address = address
     checkout.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     delivery_method_info = checkout_info.delivery_method_info
@@ -112,7 +112,7 @@ def test_is_valid_delivery_method_external_method(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     delivery_method_info = checkout_info.delivery_method_info
@@ -152,7 +152,7 @@ def test_is_valid_delivery_method_external_method_shipping_app_id_with_identifie
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     delivery_method_info = checkout_info.delivery_method_info
@@ -192,7 +192,7 @@ def test_is_valid_delivery_method_external_method_old_shipping_app_id(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     delivery_method_info = checkout_info.delivery_method_info
@@ -225,7 +225,7 @@ def test_is_valid_delivery_method_external_method_no_longer_available(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     delivery_method_info = checkout_info.delivery_method_info
@@ -236,7 +236,7 @@ def test_is_valid_delivery_method_external_method_no_longer_available(
 def test_clear_delivery_method(checkout, shipping_method):
     checkout.shipping_method = shipping_method
     checkout.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
     clear_delivery_method(checkout_info)
     checkout.refresh_from_db()
@@ -342,7 +342,7 @@ def test_get_discount_for_checkout_value_entire_order_voucher(
         )
         for line in checkout_with_items.lines.all()
     ]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     discount = get_voucher_discount_for_checkout(
@@ -506,7 +506,7 @@ def test_get_discount_for_checkout_value_specific_product_voucher(
         )
         for line in checkout_with_items.lines.all()
     ]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     discount = get_voucher_discount_for_checkout(
@@ -526,11 +526,11 @@ def test_get_voucher_discount_for_checkout_voucher_validation(
     mock_validate_voucher, voucher, checkout_with_voucher
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_voucher)
     quantity = calculate_checkout_quantity(lines)
     checkout_info = fetch_checkout_info(checkout_with_voucher, lines, manager)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     address = checkout_with_voucher.shipping_address
 
     # when
@@ -607,7 +607,7 @@ def test_get_discount_for_checkout_entire_order_voucher_not_applicable(
         valid_pick_up_points=[],
         all_shipping_methods=[],
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     with pytest.raises(NotApplicable):
         get_voucher_discount_for_checkout(manager, voucher, checkout_info, [], None)
 
@@ -643,7 +643,7 @@ def test_get_discount_for_checkout_specific_products_voucher(
         voucher.products.add(product)
     priced_checkout_with_items.voucher_code = voucher.code
     priced_checkout_with_items.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     lines, _ = fetch_checkout_lines(priced_checkout_with_items)
@@ -698,7 +698,7 @@ def test_get_discount_for_checkout_specific_products_voucher_apply_only_once(
         voucher.products.add(product)
     checkout_with_items.voucher_code = code.code
     checkout_with_items.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     lines, _ = fetch_checkout_lines(checkout_with_items)
@@ -761,7 +761,7 @@ def test_get_discount_for_checkout_specific_products_voucher_not_applicable(
         lambda *args: Money(total, "USD"),
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     voucher = Voucher.objects.create(
         type=VoucherType.SPECIFIC_PRODUCT,
         discount_value_type=discount_type,
@@ -846,7 +846,7 @@ def test_get_discount_for_checkout_shipping_voucher(
     shipping_method,
     shipping_method_data,
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     tax = Decimal("1.23")
     shipping = TaxedMoney(
         Money(shipping_cost, "USD"), Money(shipping_cost * tax, "USD")
@@ -933,7 +933,7 @@ def test_get_discount_for_checkout_shipping_voucher_all_countries(
         discount=Money(50, channel_USD.currency_code),
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = CheckoutInfo(
         checkout=checkout,
         delivery_method_info=get_delivery_method_info(shipping_method_data),
@@ -991,7 +991,7 @@ def test_get_discount_for_checkout_shipping_voucher_limited_countries(
         valid_pick_up_points=[],
         all_shipping_methods=[],
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     with pytest.raises(NotApplicable):
         get_voucher_discount_for_checkout(
             manager,
@@ -1128,7 +1128,7 @@ def test_get_discount_for_checkout_shipping_voucher_not_applicable(
         countries=countries,
     )
     VoucherCode.objects.create(code="unique", voucher=voucher)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     VoucherChannelListing.objects.create(
         voucher=voucher,
         channel=channel_USD,
@@ -1158,7 +1158,7 @@ def test_get_discount_for_checkout_shipping_voucher_not_applicable(
 
 
 def test_get_voucher_for_checkout_info(checkout_with_voucher, voucher):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout_with_voucher, [], manager)
     checkout_voucher, _ = get_voucher_for_checkout_info(checkout_info)
     assert checkout_voucher == voucher
@@ -1168,14 +1168,14 @@ def test_get_voucher_for_checkout_info_expired_voucher(checkout_with_voucher, vo
     date_yesterday = timezone.now() - datetime.timedelta(days=1)
     voucher.end_date = date_yesterday
     voucher.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout_with_voucher, [], manager)
     checkout_voucher, _ = get_voucher_for_checkout_info(checkout_info)
     assert checkout_voucher is None
 
 
 def test_get_voucher_for_checkout_info_no_voucher_code(checkout):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
     checkout_voucher, _ = get_voucher_for_checkout_info(checkout_info)
     assert checkout_voucher is None
@@ -1204,7 +1204,7 @@ def test_recalculate_checkout_discount(
 ):
     voucher.channel_listings.filter(channel=channel_USD).update(discount_value=10)
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_voucher)
     checkout_info = fetch_checkout_info(checkout_with_voucher, lines, manager)
 
@@ -1215,7 +1215,7 @@ def test_recalculate_checkout_discount(
 def test_recalculate_checkout_discount_percentage(
     priced_checkout_with_voucher_percentage,
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(priced_checkout_with_voucher_percentage)
     checkout_info = fetch_checkout_info(
         priced_checkout_with_voucher_percentage, lines, manager
@@ -1240,7 +1240,7 @@ def test_recalculate_checkout_discount_with_sale(
         .discount_value
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1274,7 +1274,7 @@ def test_recalculate_checkout_discount_with_promotion(
 ):
     # given
     checkout = checkout_with_voucher_percentage
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1358,7 +1358,7 @@ def test_recalculate_checkout_discount_voucher_not_applicable(
     checkout = checkout_with_voucher
     voucher.channel_listings.filter(channel=channel_USD).update(min_spent_amount=100)
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     recalculate_checkout_discount(manager, checkout_info, lines)
@@ -1374,7 +1374,7 @@ def test_recalculate_checkout_discount_expired_voucher(checkout_with_voucher, vo
     voucher.end_date = date_yesterday
     voucher.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     recalculate_checkout_discount(manager, checkout_info, lines)
@@ -1390,7 +1390,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_less_than_shipping
     channel_USD,
 ):
     checkout = checkout_with_voucher_free_shipping
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     channel_listing = shipping_method.channel_listings.get(channel_id=channel_USD.id)
@@ -1428,7 +1428,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_bigger_than_shippi
     channel_USD,
 ):
     checkout = checkout_with_voucher_free_shipping
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     channel_listing = shipping_method.channel_listings.get(channel=channel_USD)
@@ -1464,7 +1464,7 @@ def test_recalculate_checkout_discount_free_shipping_for_checkout_without_shippi
     checkout_with_voucher_percentage, voucher_free_shipping
 ):
     checkout = checkout_with_voucher_percentage
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     recalculate_checkout_discount(manager, checkout_info, lines)
@@ -1490,7 +1490,7 @@ def test_recalculate_checkout_discount_translate_discount_in_checkout_language(
 
     voucher.channel_listings.filter(channel=channel_USD).update(discount_value=10)
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1502,7 +1502,7 @@ def test_recalculate_checkout_discount_translate_discount_in_checkout_language(
 
 
 def test_change_address_in_checkout(checkout, address):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1527,7 +1527,7 @@ def test_change_address_in_checkout_to_none(checkout, address):
     checkout.billing_address = address.get_copy()
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     shipping_updated_fields = change_shipping_address_in_checkout(
@@ -1553,7 +1553,7 @@ def test_change_address_in_checkout_to_same(checkout, address):
     shipping_address_id = checkout.shipping_address.id
     billing_address_id = checkout.billing_address.id
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     shipping_updated_fields = change_shipping_address_in_checkout(
@@ -1579,7 +1579,7 @@ def test_change_address_in_checkout_to_other(checkout, address):
     checkout.save(update_fields=["shipping_address", "billing_address"])
     other_address = Address.objects.create(country=Country("DE"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     shipping_updated_fields = change_shipping_address_in_checkout(
@@ -1609,7 +1609,7 @@ def test_change_address_in_checkout_from_user_address_to_other(
     checkout.save(update_fields=["shipping_address", "billing_address"])
     other_address = Address.objects.create(country=Country("DE"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     shipping_updated_fields = change_shipping_address_in_checkout(
@@ -1631,7 +1631,7 @@ def test_change_address_in_checkout_from_user_address_to_other(
 
 def test_add_voucher_to_checkout(checkout_with_item, voucher):
     assert checkout_with_item.voucher_code is None
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     add_voucher_to_checkout(
@@ -1645,7 +1645,7 @@ def test_add_staff_voucher_to_anonymous_checkout(checkout_with_item, voucher):
     voucher.save()
 
     assert checkout_with_item.voucher_code is None
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     with pytest.raises(NotApplicable):
@@ -1663,7 +1663,7 @@ def test_add_staff_voucher_to_customer_checkout(
     voucher.save()
 
     assert checkout_with_item.voucher_code is None
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     with pytest.raises(NotApplicable):
@@ -1679,7 +1679,7 @@ def test_add_staff_voucher_to_staff_checkout(checkout_with_item, voucher, staff_
     voucher.save()
 
     assert checkout_with_item.voucher_code is None
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
 
@@ -1691,7 +1691,7 @@ def test_add_staff_voucher_to_staff_checkout(checkout_with_item, voucher, staff_
 def test_add_voucher_to_checkout_fail(
     checkout_with_item, voucher_with_high_min_spent_amount
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     with pytest.raises(NotApplicable):
@@ -1723,7 +1723,7 @@ def test_get_last_active_payment(checkout_with_payments):
 
 def test_is_fully_paid(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -1745,7 +1745,7 @@ def test_is_fully_paid(checkout_with_item, payment_dummy):
 
 def test_is_fully_paid_mg_payments(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -1775,7 +1775,7 @@ def test_is_fully_paid_mg_payments(checkout_with_item, payment_dummy):
 
 def test_is_fully_paid_partially_paid(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -1797,7 +1797,7 @@ def test_is_fully_paid_partially_paid(checkout_with_item, payment_dummy):
 
 def test_is_fully_paid_no_payment(checkout_with_item):
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     is_paid = is_fully_paid(manager, checkout_info, lines)
@@ -1821,7 +1821,7 @@ def test_checkout_without_delivery_method_creates_empty_delivery_method(
     checkout_with_item,
 ):
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     delivery_method_info = checkout_info.delivery_method_info

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -69,7 +69,7 @@ def test_create_order_captured_payment_creates_expected_events(
     checkout.save()
 
     # Place checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     order = _create_order(
@@ -217,7 +217,7 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
     checkout.save()
 
     # Place checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     order = _create_order(
@@ -360,7 +360,7 @@ def test_create_order_preauth_payment_creates_expected_events(
     checkout.save()
 
     # Place checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     order = _create_order(
@@ -472,7 +472,7 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
     checkout.save()
 
     # Place checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     order = _create_order(
@@ -553,7 +553,7 @@ def test_create_order_insufficient_stock(
     checkout, customer_user, product_without_shipping
 ):
     variant = product_without_shipping.variants.get()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
 
     add_variant_to_checkout(checkout_info, variant, 10, check_quantity=False)
@@ -585,7 +585,7 @@ def test_create_order_doesnt_duplicate_order(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     order_data = _prepare_order_data(
@@ -630,7 +630,7 @@ def test_create_order_with_gift_card(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -686,7 +686,7 @@ def test_create_order_with_gift_card_partial_use(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -745,7 +745,7 @@ def test_create_order_with_many_gift_cards(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -817,7 +817,7 @@ def test_create_order_gift_card_bought(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -912,7 +912,7 @@ def test_create_order_gift_card_bought_order_not_captured_gift_cards_not_sent(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -964,7 +964,9 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
     is_anonymous_user,
 ):
     checkout_user = None if is_anonymous_user else customer_user
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     shippable_variant = shippable_gift_card_product.variants.get()
     add_variant_to_checkout(checkout_info, shippable_variant, 2)
 
@@ -976,7 +978,7 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1036,7 +1038,7 @@ def test_create_order_gift_card_bought_do_not_fulfill_gift_cards_automatically(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1078,7 +1080,7 @@ def test_note_in_created_order(checkout_with_item, address, customer_user):
     checkout_with_item.tracking_code = "tracking_code"
     checkout_with_item.redirect_url = "https://www.example.com"
     checkout_with_item.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     order = _create_order(
@@ -1107,7 +1109,7 @@ def test_create_order_with_variant_tracking_false(
     checkout.tracking_code = ""
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
     add_variant_to_checkout(checkout_info, variant, 10, check_quantity=False)
 
@@ -1147,7 +1149,7 @@ def test_create_order_use_translations(
     checkout.language_code = "fr"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1196,7 +1198,7 @@ def test_complete_checkout_0_total_with_transaction_for_mark_as_paid(
         checkout, zero_money(checkout.currency), checkout_has_lines=True
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1246,7 +1248,7 @@ def test_complete_checkout_0_total_captured_payment_creates_expected_events(
     checkout.save()
 
     # Place checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     order, action_required, action_data = complete_checkout(
@@ -1366,7 +1368,7 @@ def test_complete_checkout_action_required_voucher_once_per_customer(
     voucher.apply_once_per_customer = True
     voucher.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1427,7 +1429,7 @@ def test_complete_checkout_action_required_voucher_single_use(
 
     assert code.is_active
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1485,7 +1487,7 @@ def test_complete_checkout_order_not_created_when_the_refund_is_ongoing(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1536,7 +1538,7 @@ def test_complete_checkout_when_checkout_doesnt_exists(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1589,7 +1591,7 @@ def test_complete_checkout_checkout_was_deleted_before_completing(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1631,7 +1633,7 @@ def test_process_shipping_data_for_order_store_customer_shipping_address(
 
     user_address_count = customer_user.addresses.count()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     shipping_price = zero_taxed_money(checkout.currency)
@@ -1666,7 +1668,7 @@ def test_process_shipping_data_for_order_dont_store_customer_click_and_collect_a
 
     user_address_count = customer_user.addresses.count()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     shipping_price = zero_taxed_money(checkout.currency)
@@ -1694,7 +1696,7 @@ def test_create_order_update_display_gross_prices(checkout_with_item, customer_u
     tax_configuration.save()
     tax_configuration.country_exceptions.all().delete()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
     lines, _ = fetch_checkout_lines(checkout)
     order_data = _prepare_order_data(
@@ -1733,7 +1735,7 @@ def test_create_order_store_shipping_prices(
     )
     expected_shipping_tax_rate = Decimal("0.1")
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.get_checkout_shipping_tax_rate = mock.Mock(
         return_value=expected_shipping_tax_rate
     )
@@ -1778,7 +1780,7 @@ def test_create_order_store_shipping_prices_with_free_shipping_voucher(
 ):
     # given
     checkout = checkout_with_voucher_free_shipping
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     expected_base_shipping_price = zero_money(checkout.currency)
     expected_shipping_price = zero_taxed_money(checkout.currency)
@@ -1855,7 +1857,7 @@ def test_complete_checkout_invalid_shipping_method(
 
     voucher.apply_once_per_customer = True
     voucher.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1898,7 +1900,7 @@ def test_checkout_complete_pick_transaction_flow(
     checkout.tracking_code = ""
     checkout.redirect_url = "https://www.example.com"
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     transaction_item_generator(checkout_id=checkout.pk)
@@ -1940,7 +1942,7 @@ def test_checkout_complete_pick_transaction_flow_when_checkout_total_zero(
     checkout.tracking_code = ""
     checkout.redirect_url = "https://www.example.com"
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1991,7 +1993,7 @@ def test_checkout_complete_pick_payment_flow(
     checkout.tracking_code = ""
     checkout.redirect_url = "https://www.example.com"
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -2055,7 +2057,7 @@ def test_complete_checkout_ensure_prices_are_not_recalculated_in_post_payment_pa
         transaction_id="1234",
         error=None,
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(

--- a/saleor/checkout/tests/test_order_from_checkout.py
+++ b/saleor/checkout/tests/test_order_from_checkout.py
@@ -25,7 +25,7 @@ def test_create_order_insufficient_stock(
     checkout, customer_user, product_without_shipping, app
 ):
     variant = product_without_shipping.variants.get()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
 
     add_variant_to_checkout(checkout_info, variant, 10, check_quantity=False)
@@ -61,7 +61,7 @@ def test_create_order_with_gift_card(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -110,7 +110,7 @@ def test_create_order_with_gift_card_partial_use(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -164,7 +164,7 @@ def test_create_order_with_many_gift_cards_worth_more_than_total(
     checkout.user = customer_user
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -234,7 +234,7 @@ def test_create_order_with_many_gift_cards(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -303,7 +303,7 @@ def test_create_order_gift_card_bought(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -372,7 +372,9 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
     app,
 ):
     checkout_user = None if is_anonymous_user else customer_user
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     shippable_variant = shippable_gift_card_product.variants.get()
     add_variant_to_checkout(checkout_info, shippable_variant, 2)
 
@@ -384,7 +386,7 @@ def test_create_order_gift_card_bought_only_shippable_gift_card(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -438,7 +440,7 @@ def test_create_order_gift_card_bought_do_not_fulfill_gift_cards_automatically(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -477,7 +479,7 @@ def test_note_in_created_order(
     checkout_with_item.tracking_code = "tracking_code"
     checkout_with_item.redirect_url = "https://www.example.com"
     checkout_with_item.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_lines, unavailable_variant_pks = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, checkout_lines, manager)
@@ -508,7 +510,7 @@ def test_create_order_use_translations(
     checkout.language_code = "fr"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     variant = lines[0].variant
@@ -552,7 +554,7 @@ def test_create_order_from_checkout_updates_total_authorized_amount(
         authorized_value=authorized_value,
         currency=checkout_with_item.currency,
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_lines, unavailable_variant_pks = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, checkout_lines, manager)
@@ -588,7 +590,7 @@ def test_create_order_from_checkout_updates_total_charged_amount(
         authorized_value=Decimal(2),
         currency=checkout_with_item.currency,
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_lines, unavailable_variant_pks = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, checkout_lines, manager)
@@ -617,7 +619,7 @@ def test_create_order_from_checkout_update_display_gross_prices(
     tax_configuration.save()
     tax_configuration.country_exceptions.all().delete()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
     checkout_lines, _ = fetch_checkout_lines(checkout)
 
@@ -648,7 +650,7 @@ def test_create_order_from_checkout_store_shipping_prices(
     )
     expected_shipping_tax_rate = Decimal("0.1")
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.get_checkout_shipping_tax_rate = mock.Mock(
         return_value=expected_shipping_tax_rate
     )
@@ -694,7 +696,7 @@ def test_create_order_from_checkout_valid_undiscounted_prices(
     product.tax_class.country_rates.update_or_create(
         country=checkout.shipping_address.country.code, defaults={"rate": 7.75}
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
 
     checkout_info = fetch_checkout_info(checkout, lines, manager, [])
@@ -747,7 +749,7 @@ def test_create_order_from_store_shipping_prices_with_free_shipping_voucher(
     expected_shipping_price = zero_taxed_money(checkout.currency)
     expected_shipping_tax_rate = Decimal("0.0")
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.get_checkout_shipping_tax_rate = mock.Mock(
         return_value=expected_shipping_tax_rate
     )
@@ -789,7 +791,7 @@ def test_note_in_created_order_checkout_line_deleted_in_the_meantime(
     checkout_with_item.tracking_code = "tracking_code"
     checkout_with_item.redirect_url = "https://www.example.com"
     checkout_with_item.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, checkout_lines, manager)
@@ -824,7 +826,7 @@ def test_note_in_created_order_checkout_deleted_in_the_meantime(
     checkout_with_item.tracking_code = "tracking_code"
     checkout_with_item.redirect_url = "https://www.example.com"
     checkout_with_item.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, checkout_lines, manager)
@@ -874,7 +876,7 @@ def test_create_order_from_checkout_update_undiscounted_prices_match(
     mock_unit.return_value = expected_price
     mock_total.return_value = expected_price
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     country_code = checkout.shipping_address.country.code
     line = checkout.lines.first()
     line.quantity = 1
@@ -919,7 +921,7 @@ def test_create_order_product_on_promotion(
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -551,7 +551,7 @@ def create_fake_payment(mock_notify, order):
         total=order.total.gross.amount,
         currency=order.total.gross.currency,
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # Create authorization transaction
     gateway.authorize(payment, payment.token, manager, order.channel.slug)
@@ -587,7 +587,7 @@ def create_order_lines(order, how_many=10):
         lines.append(_get_new_order_line(order, variant, channel))
 
     lines = OrderLine.objects.bulk_create(lines)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     country = order.shipping_method.shipping_zone.countries[0]
     warehouses = Warehouse.objects.filter(
         shipping_zones__countries__contains=country
@@ -644,7 +644,7 @@ def create_order_lines_with_preorder(order, how_many=1):
         lines.append(_get_new_order_line(order, variant, channel))
 
     lines = OrderLine.objects.bulk_create(lines)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     preorder_allocations = []
     for line in lines:
@@ -1502,7 +1502,7 @@ def create_gift_cards(how_many=5):
 def add_address_to_admin(email):
     address = create_address()
     user = User.objects.get(email=email)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     store_user_address(user, address, AddressType.BILLING, manager)
     store_user_address(user, address, AddressType.SHIPPING, manager)
 
@@ -1572,7 +1572,9 @@ def prepare_checkout_info():
     channel = Channel.objects.get(slug=settings.DEFAULT_CHANNEL_SLUG)
     checkout = Checkout.objects.create(currency=channel.currency_code, channel=channel)
     checkout.set_country(channel.default_country, commit=True)
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     return checkout_info
 
 

--- a/saleor/csv/notifications.py
+++ b/saleor/csv/notifications.py
@@ -36,7 +36,7 @@ def send_export_download_link_notification(export_file: "ExportFile", data_type:
         **get_site_context(),
     }
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=True)
     manager.notify(NotifyEventType.CSV_EXPORT_SUCCESS, payload)
     if data_type == "gift cards":
         manager.gift_card_export_completed(export_file)
@@ -54,7 +54,7 @@ def send_export_failed_info(export_file: "ExportFile", data_type: str):
         "data_type": data_type,
         **get_site_context(),
     }
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=True)
     manager.notify(NotifyEventType.CSV_EXPORT_FAILED, payload)
     if data_type == "gift cards":
         manager.gift_card_export_completed(export_file)

--- a/saleor/discount/tasks.py
+++ b/saleor/discount/tasks.py
@@ -42,7 +42,7 @@ def handle_promotion_toggle():
     Send the notifications about starting or ending promotions and call recalculation
     of product discounted prices.
     """
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     staring_promotions = get_starting_promotions()
     ending_promotions = get_ending_promotions()

--- a/saleor/discount/tests/test_rounding_issue.py
+++ b/saleor/discount/tests/test_rounding_issue.py
@@ -99,7 +99,9 @@ def test_rounding_issue_with_percentage_promotion(
 
     update_discounted_prices_for_promotion(Product.objects.all())
 
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
 
     for variant in variants:
         add_variant_to_checkout(checkout_info, variant, 1)

--- a/saleor/discount/tests/test_utils/fixtures.py
+++ b/saleor/discount/tests/test_utils/fixtures.py
@@ -25,7 +25,7 @@ def checkout_lines_info(checkout_with_items, categories, published_collections):
 
 @pytest.fixture
 def checkout_info(checkout_lines_info):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_lines_info[0].line.checkout
     checkout_info = fetch_checkout_info(checkout, checkout_lines_info, manager)
     return checkout_info

--- a/saleor/giftcard/tests/test_notifications.py
+++ b/saleor/giftcard/tests/test_notifications.py
@@ -22,7 +22,7 @@ def test_get_default_gift_card_payload(gift_card):
 def test_send_gift_card_notification(
     mocked_notify, staff_user, customer_user, gift_card, channel_USD, site_settings
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     resending = False
     send_gift_card_notification(
         staff_user,

--- a/saleor/giftcard/tests/test_utils.py
+++ b/saleor/giftcard/tests/test_utils.py
@@ -192,7 +192,7 @@ def test_gift_cards_create(
     staff_user,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     line_1, line_2 = gift_card_shippable_order_line, gift_card_non_shippable_order_line
     user_email = order.user_email
     fulfillment = order.fulfillments.create(tracking_number="123")
@@ -292,7 +292,7 @@ def test_gift_cards_create_expiry_date_set(
     staff_user,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     site_settings.gift_card_expiry_type = GiftCardSettingsExpiryType.EXPIRY_PERIOD
     site_settings.gift_card_expiry_period_type = TimePeriodType.WEEK
     site_settings.gift_card_expiry_period = 20
@@ -368,7 +368,7 @@ def test_gift_cards_create_multiple_quantity(
     staff_user,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     quantity = 3
     gift_card_non_shippable_order_line.quantity = quantity
     gift_card_non_shippable_order_line.save(update_fields=["quantity"])
@@ -425,7 +425,7 @@ def test_gift_cards_create_trigger_webhook(
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     line_1, line_2 = gift_card_shippable_order_line, gift_card_non_shippable_order_line
     fulfillment = order.fulfillments.create(tracking_number="123")
     fulfillment_line_1 = fulfillment.lines.create(
@@ -480,6 +480,7 @@ def test_gift_cards_create_trigger_webhook(
         [any_webhook],
         gift_card,
         None,
+        allow_replica=False,
     )
 
     send_notification_mock.assert_called()
@@ -559,7 +560,7 @@ def test_fulfill_non_shippable_gift_cards(
     warehouse,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order_lines = [gift_card_shippable_order_line, gift_card_non_shippable_order_line]
 
     # when
@@ -599,7 +600,7 @@ def test_fulfill_non_shippable_gift_cards_line_with_allocation(
     warehouse,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order_lines = [gift_card_shippable_order_line, gift_card_non_shippable_order_line]
 
     order = gift_card_non_shippable_order_line.order
@@ -641,7 +642,7 @@ def test_fulfill_gift_card_lines(
     site_settings,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order = gift_card_non_shippable_order_line.order
     non_shippable_variant = gift_card_non_shippable_order_line.variant
     non_shippable_variant.track_inventory = True
@@ -691,7 +692,7 @@ def test_fulfill_gift_card_lines_lack_of_stock(
     site_settings,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order = gift_card_non_shippable_order_line.order
     gift_card_non_shippable_order_line.variant.stocks.all().delete()
 

--- a/saleor/graphql/account/tests/mutations/account/test_account_address_create.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_address_create.py
@@ -94,7 +94,8 @@ def test_customer_create_address_trigger_webhook(
             WebhookEventAsyncType.ADDRESS_CREATED,
             user_api_client.user,
             any_webhook,
-        )
+        ),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/account/tests/mutations/account/test_account_address_delete.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_address_delete.py
@@ -70,7 +70,8 @@ def test_customer_delete_address_trigger_webhook(
             WebhookEventAsyncType.ADDRESS_DELETED,
             user_api_client.user,
             any_webhook,
-        )
+        ),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/account/tests/mutations/account/test_account_address_update.py
+++ b/saleor/graphql/account/tests/mutations/account/test_account_address_update.py
@@ -91,7 +91,8 @@ def test_customer_address_update_trigger_webhook(
             WebhookEventAsyncType.ADDRESS_UPDATED,
             user_api_client.user,
             any_webhook,
-        )
+        ),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/account/tests/mutations/permission_group/test_permission_group_create.py
+++ b/saleor/graphql/account/tests/mutations/permission_group/test_permission_group_create.py
@@ -165,6 +165,7 @@ def test_permission_group_create_mutation_trigger_webhook(
         [any_webhook],
         group,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/account/tests/mutations/permission_group/test_permission_group_delete.py
+++ b/saleor/graphql/account/tests/mutations/permission_group/test_permission_group_delete.py
@@ -139,6 +139,7 @@ def test_group_delete_mutation_trigger_webhook(
         [any_webhook],
         group1,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/account/tests/mutations/permission_group/test_permission_group_update.py
+++ b/saleor/graphql/account/tests/mutations/permission_group/test_permission_group_update.py
@@ -195,6 +195,7 @@ def test_permission_group_update_mutation_trigger_webhook(
         [any_webhook],
         group1,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/account/tests/mutations/staff/test_address_create.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_address_create.py
@@ -103,7 +103,8 @@ def test_create_address_mutation_trigger_webhook(
             WebhookEventAsyncType.ADDRESS_CREATED,
             staff_api_client.user,
             any_webhook,
-        )
+        ),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/account/tests/mutations/staff/test_address_delete.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_address_delete.py
@@ -79,7 +79,8 @@ def test_address_delete_mutation_trigger_webhook(
             WebhookEventAsyncType.ADDRESS_DELETED,
             staff_api_client.user,
             any_webhook,
-        )
+        ),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/account/tests/mutations/staff/test_address_update.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_address_update.py
@@ -91,7 +91,8 @@ def test_address_update_mutation_trigger_webhook(
             WebhookEventAsyncType.ADDRESS_UPDATED,
             staff_api_client.user,
             any_webhook,
-        )
+        ),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/account/tests/mutations/staff/test_customer_delete.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_customer_delete.py
@@ -96,7 +96,9 @@ def test_customer_delete_trigger_webhook(
         customer_user,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
+
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
     )

--- a/saleor/graphql/account/tests/mutations/staff/test_staff_create.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_staff_create.py
@@ -255,6 +255,7 @@ def test_staff_create_trigger_webhook(
         [any_webhook],
         new_staff_user,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
     assert expected_call in mocked_webhook_trigger.call_args_list

--- a/saleor/graphql/account/tests/mutations/staff/test_staff_delete.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_staff_delete.py
@@ -95,6 +95,7 @@ def test_staff_delete_trigger_webhook(
         [any_webhook],
         staff_user,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/account/tests/mutations/staff/test_staff_update.py
+++ b/saleor/graphql/account/tests/mutations/staff/test_staff_update.py
@@ -169,6 +169,7 @@ def test_staff_update_trigger_webhook(
         [any_webhook],
         staff_user,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/app/tests/mutations/test_app_activate.py
+++ b/saleor/graphql/app/tests/mutations/test_app_activate.py
@@ -102,6 +102,7 @@ def test_activate_app_trigger_webhook(
         [any_webhook],
         app,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/app/tests/mutations/test_app_create.py
+++ b/saleor/graphql/app/tests/mutations/test_app_create.py
@@ -123,6 +123,7 @@ def test_app_create_trigger_webhook(
         [any_webhook],
         app,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/app/tests/mutations/test_app_deactivate.py
+++ b/saleor/graphql/app/tests/mutations/test_app_deactivate.py
@@ -102,6 +102,7 @@ def test_deactivate_app_trigger_webhook(
         [any_webhook],
         app,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/app/tests/mutations/test_app_delete.py
+++ b/saleor/graphql/app/tests/mutations/test_app_delete.py
@@ -105,6 +105,7 @@ def test_app_delete_trigger_webhook(
         [any_webhook],
         app,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/app/tests/mutations/test_app_update.py
+++ b/saleor/graphql/app/tests/mutations/test_app_update.py
@@ -136,6 +136,7 @@ def test_app_update_trigger_mutation(
         [any_webhook],
         app_with_token,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
@@ -177,6 +177,7 @@ def test_create_attribute_trigger_webhook(
         [any_webhook],
         attribute,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_delete.py
@@ -101,6 +101,7 @@ def test_delete_attribute_trigger_webhook(
         [any_webhook],
         color_attribute,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_reorder_values.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_reorder_values.py
@@ -219,6 +219,7 @@ def test_sort_values_trigger_webhook(
         [any_webhook],
         color_attribute,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
     def generate_attribute_value_update_call(value):
@@ -237,6 +238,7 @@ def test_sort_values_trigger_webhook(
             [any_webhook],
             value,
             SimpleLazyObject(lambda: staff_api_client.user),
+            allow_replica=False,
         )
 
     attribute_value_1_updated_call = generate_attribute_value_update_call(values[0])

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
@@ -145,6 +145,7 @@ def test_update_attribute_trigger_webhook(
         [any_webhook],
         color_attribute,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
@@ -155,6 +155,7 @@ def test_create_attribute_value_trigger_webhooks(
         [any_webhook],
         color_attribute,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
     attribute_value_created_call = mock.call(
@@ -172,6 +173,7 @@ def test_create_attribute_value_trigger_webhooks(
         [any_webhook],
         attribute_value,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
     # then

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_delete.py
@@ -120,6 +120,7 @@ def test_delete_attribute_value_trigger_webhooks(
         [any_webhook],
         color_attribute,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
     attribute_value_created_call = mock.call(
@@ -137,6 +138,7 @@ def test_delete_attribute_value_trigger_webhooks(
         [any_webhook],
         value,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
     # then

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -166,6 +166,7 @@ def test_update_attribute_value_trigger_webhooks(
         [any_webhook],
         attribute,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
     attribute_value_created_call = mock.call(
@@ -183,6 +184,7 @@ def test_update_attribute_value_trigger_webhooks(
         [any_webhook],
         value,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
     # then

--- a/saleor/graphql/channel/tests/mutations/test_channel_activate.py
+++ b/saleor/graphql/channel/tests/mutations/test_channel_activate.py
@@ -101,6 +101,7 @@ def test_channel_activate_mutation_trigger_webhook(
         [any_webhook],
         channel_USD,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/channel/tests/mutations/test_channel_create.py
+++ b/saleor/graphql/channel/tests/mutations/test_channel_create.py
@@ -535,6 +535,7 @@ def test_channel_create_mutation_trigger_webhook(
         [any_webhook],
         channel,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/channel/tests/mutations/test_channel_deactivate.py
+++ b/saleor/graphql/channel/tests/mutations/test_channel_deactivate.py
@@ -97,6 +97,7 @@ def test_channel_deactivate_mutation_trigger_webhook(
         [any_webhook],
         channel_USD,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/channel/tests/mutations/test_channel_delete.py
+++ b/saleor/graphql/channel/tests/mutations/test_channel_delete.py
@@ -286,6 +286,7 @@ def test_channel_delete_mutation_trigger_webhook(
         [any_webhook],
         channel_USD,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/channel/tests/mutations/test_channel_update.py
+++ b/saleor/graphql/channel/tests/mutations/test_channel_update.py
@@ -540,7 +540,10 @@ def test_channel_update_mutation_trigger_webhook(
     metadata_webhook_args = update_webhook_args.copy()
     metadata_webhook_args[1] = WebhookEventAsyncType.CHANNEL_METADATA_UPDATED
     mocked_webhook_trigger.assert_has_calls(
-        [call(*update_webhook_args), call(*metadata_webhook_args)]
+        [
+            call(*update_webhook_args, allow_replica=False),
+            call(*metadata_webhook_args, allow_replica=False),
+        ]
     )
 
 

--- a/saleor/graphql/checkout/tests/benchmark/conftest.py
+++ b/saleor/graphql/checkout/tests/benchmark/conftest.py
@@ -24,7 +24,9 @@ def checkout_with_variants(
     product_with_single_variant,
     product_with_two_variants,
 ):
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
 
     add_variant_to_checkout(
         checkout_info, product_with_default_variant.variants.get(), 1
@@ -127,7 +129,7 @@ def checkout_with_billing_address_for_cc(checkout_with_delivery_method_for_cc, a
 @pytest.fixture
 def checkout_with_voucher(checkout_with_billing_address, voucher):
     checkout = checkout_with_billing_address
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     add_voucher_to_checkout(
@@ -139,10 +141,10 @@ def checkout_with_voucher(checkout_with_billing_address, voucher):
 @pytest.fixture
 def checkout_with_charged_payment(checkout_with_voucher):
     checkout = checkout_with_voucher
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout_with_voucher, lines, manager)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     taxed_total = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,
@@ -181,9 +183,11 @@ def checkout_with_digital_line_with_charged_payment(
     site_settings.automatic_fulfillment_digital_products = True
     site_settings.save(update_fields=["automatic_fulfillment_digital_products"])
 
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     taxed_total = calculations.checkout_total(
         manager=manager,
@@ -215,10 +219,10 @@ def checkout_with_digital_line_with_charged_payment(
 @pytest.fixture
 def checkout_with_charged_payment_for_cc(checkout_with_billing_address_for_cc):
     checkout = checkout_with_billing_address_for_cc
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     taxed_total = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,
@@ -254,14 +258,14 @@ def checkout_preorder_with_charged_payment(
     preorder_variant_global_threshold,
 ):
     checkout = checkout_with_billing_address
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     add_variant_to_checkout(checkout_info, preorder_variant_channel_threshold, 1)
     add_variant_to_checkout(checkout_info, preorder_variant_global_threshold, 1)
 
     lines, _ = fetch_checkout_lines(checkout)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     taxed_total = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -1077,10 +1077,10 @@ def test_checkout_payment_charge(
         }
     """
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_billing_address)
     checkout_info = fetch_checkout_info(checkout_with_billing_address, lines, manager)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     total = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_complete.py
@@ -91,7 +91,7 @@ def test_checkout_complete(
     checkout_line_quantity = checkout_line.quantity
     checkout_line_variant = checkout_line.variant
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -253,7 +253,7 @@ def test_checkout_complete_for_token_as_input(
     checkout_line_quantity = checkout_line.quantity
     checkout_line_variant = checkout_line.variant
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_line_delete.py
@@ -59,7 +59,7 @@ def test_checkout_line_delete_by_id(
     lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 0
     assert calculate_checkout_quantity(lines) == 0
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
@@ -91,7 +91,7 @@ def test_checkout_line_delete_by_token(
     lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 0
     assert calculate_checkout_quantity(lines) == 0
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
@@ -162,6 +162,6 @@ def test_checkout_line_delete_by_old_line_id(
     lines, _ = fetch_checkout_lines(checkout)
     assert checkout.lines.count() == 0
     assert calculate_checkout_quantity(lines) == 0
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_add.py
@@ -65,7 +65,7 @@ def test_checkout_lines_add_by_checkout_id(
     assert line.quantity == 1
     assert calculate_checkout_quantity(lines) == 4
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -106,7 +106,7 @@ def test_checkout_lines_add_by_checkout_token(
     assert line.quantity == 1
     assert calculate_checkout_quantity(lines) == 4
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_lines_update.py
@@ -70,7 +70,7 @@ def test_checkout_lines_update(
     assert line.quantity == 1
     assert calculate_checkout_quantity(lines) == 1
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -111,7 +111,7 @@ def test_checkout_lines_update_with_token(
     assert line.quantity == 1
     assert calculate_checkout_quantity(lines) == 1
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_address_update.py
@@ -66,7 +66,7 @@ def test_checkout_shipping_address_update_by_id(
     assert checkout.shipping_address.postal_code == shipping_address["postalCode"]
     assert checkout.shipping_address.country == shipping_address["country"]
     assert checkout.shipping_address.city == shipping_address["city"].upper()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -112,7 +112,7 @@ def test_checkout_shipping_address_update_by_token(
     assert checkout.shipping_address.postal_code == shipping_address["postalCode"]
     assert checkout.shipping_address.country == shipping_address["country"]
     assert checkout.shipping_address.city == shipping_address["city"].upper()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)

--- a/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/deprecated/test_checkout_shipping_method_update.py
@@ -59,7 +59,7 @@ def test_checkout_shipping_method_update_by_id(
 
     checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     checkout_info.delivery_method_info = get_delivery_method_info(
@@ -107,7 +107,7 @@ def test_checkout_shipping_method_update_by_token(
 
     checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     checkout_info.delivery_method_info = get_delivery_method_info(
@@ -208,7 +208,7 @@ def test_checkout_shipping_method_update_by_id_no_checkout_metadata(
 
     checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     checkout_info.delivery_method_info = get_delivery_method_info(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_add_promo_code.py
@@ -79,7 +79,7 @@ def test_checkout_add_voucher_for_entire_order(api_client, checkout_with_item, v
         "promoCode": voucher.code,
     }
     assert voucher.type == VoucherType.ENTIRE_ORDER
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     taxed_total = calculations.checkout_total(
@@ -286,7 +286,7 @@ def test_checkout_add_voucher_code_checkout_with_sale(
 ):
     # given
     checkout = checkout_with_item_on_sale
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     address = checkout.shipping_address
 
     lines, _ = fetch_checkout_lines(checkout)
@@ -337,7 +337,7 @@ def test_checkout_add_specific_product_voucher_code_checkout_with_sale(
     voucher = voucher_specific_product_type
     checkout = checkout_with_item_on_sale
     expected_discount = Decimal(1.5)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout.price_expiration = timezone.now()
 
@@ -387,7 +387,7 @@ def test_checkout_add_products_voucher_code_checkout_with_sale(
     voucher.save()
     voucher.products.add(product)
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -456,7 +456,7 @@ def test_checkout_add_collection_voucher_code_checkout_with_sale(
         .discount_value
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout.price_expiration = timezone.now()
     lines, _ = fetch_checkout_lines(checkout)
@@ -517,7 +517,7 @@ def test_checkout_add_category_code_checkout_with_sale(
     )
 
     checkout.price_expiration = timezone.now()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     subtotal_discounted = calculations.checkout_subtotal(
@@ -563,7 +563,7 @@ def test_checkout_add_voucher_code_checkout_on_promotion(
 ):
     # given
     checkout = checkout_with_item_on_promotion
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     address = checkout.shipping_address
@@ -615,7 +615,7 @@ def test_checkout_add_specific_product_voucher_code_checkout_on_promotion(
     # given
     voucher = voucher_specific_product_type
     checkout = checkout_with_item_on_promotion
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -689,7 +689,7 @@ def test_checkout_add_collection_voucher_code_checkout_on_promotion(
         .discount_value
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -752,7 +752,7 @@ def test_checkout_add_category_code_checkout_on_promotion(
         .discount_value
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -841,7 +841,7 @@ def test_checkout_add_variant_voucher_code_apply_once_per_order(
         variant_3_price * (Decimal(discount_value) / 100), checkout.currency
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     checkout.price_expiration = timezone.now()
@@ -1021,7 +1021,7 @@ def test_checkout_add_used_gift_card_code(
 
 
 def test_checkout_get_total_with_gift_card(api_client, checkout_with_item, gift_card):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     taxed_total = calculations.checkout_total(
@@ -1047,7 +1047,7 @@ def test_checkout_get_total_with_gift_card(api_client, checkout_with_item, gift_
 def test_checkout_get_total_with_many_gift_card(
     api_client, checkout_with_gift_card, gift_card_created_by_staff
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_gift_card)
     checkout_info = fetch_checkout_info(checkout_with_gift_card, lines, manager)
     taxed_total = calculations.calculate_checkout_total_with_gift_cards(
@@ -1183,7 +1183,9 @@ def test_checkout_add_promo_code_invalidate_shipping_method(
     checkout.billing_address = address_usa
     checkout.save()
 
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     variant = variant_with_many_stocks_different_shipping_zones
     add_variant_to_checkout(checkout_info, variant, 5)
     checkout.save()
@@ -1387,7 +1389,7 @@ def test_checkout_add_voucher_code_invalidates_price(
     api_client, checkout_with_item, voucher
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     subtotal = base_calculations.base_checkout_subtotal(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete.py
@@ -189,7 +189,7 @@ def test_checkout_complete_0_total_value_no_payment(
 
     checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -253,7 +253,7 @@ def test_checkout_complete_0_total_value_from_voucher(
 
     checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -314,7 +314,7 @@ def test_checkout_complete_0_total_value_from_giftcard(
 
     checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -115,7 +115,7 @@ def test_checkout_complete_with_inactive_channel(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -177,7 +177,7 @@ def test_checkout_complete(
     checkout_line_quantity = checkout_line.quantity
     checkout_line_variant = checkout_line.variant
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -286,7 +286,7 @@ def test_checkout_complete_with_metadata(
     checkout.metadata_storage.save()
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -363,7 +363,7 @@ def test_checkout_complete_with_metadata_updates_existing_keys(
 
     assert checkout.metadata_storage.metadata[meta_key] != new_meta_value
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -425,7 +425,7 @@ def test_checkout_complete_with_metadata_checkout_without_metadata(
     # delete the current metadata
     checkout.metadata_storage.delete()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -498,7 +498,7 @@ def test_checkout_complete_by_app(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -561,7 +561,7 @@ def test_checkout_complete_by_app_with_missing_permission(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -630,7 +630,7 @@ def test_checkout_complete_gift_card_bought(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -704,7 +704,7 @@ def test_checkout_complete_with_variant_without_sku(
     checkout_line_variant.sku = None
     checkout_line_variant.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -841,7 +841,7 @@ def test_checkout_with_voucher_complete(
     checkout_line_quantity = checkout_line.quantity
     checkout_line_variant = checkout_line.variant
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -948,7 +948,7 @@ def test_checkout_complete_with_voucher_apply_once_per_order(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1089,7 +1089,7 @@ def test_checkout_with_voucher_complete_product_on_promotion(
     promotion_without_rules.name = ""
     promotion_without_rules.save(update_fields=["name"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1194,7 +1194,7 @@ def test_checkout_with_voucher_on_specific_product_complete(
     checkout_line_quantity = checkout_line.quantity
     checkout_line_variant = checkout_line.variant
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1298,7 +1298,7 @@ def test_checkout_complete_with_voucher_single_use(
     checkout_line_quantity = checkout_line.quantity
     checkout_line_variant = checkout_line.variant
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1433,7 +1433,7 @@ def test_checkout_complete_product_on_promotion(
         promotion_rule=rule,
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1575,7 +1575,7 @@ def test_checkout_complete_product_on_old_sale(
         promotion_rule=rule,
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1762,7 +1762,7 @@ def test_checkout_complete_multiple_rules_applied(
         ]
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1897,7 +1897,7 @@ def test_checkout_with_voucher_on_specific_product_complete_with_product_on_prom
         name=promotion_without_rules.name,
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -2051,7 +2051,7 @@ def test_checkout_complete_without_inventory_tracking(
     checkout_line_quantity = checkout_line.quantity
     checkout_line_variant = checkout_line.variant
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -2122,7 +2122,7 @@ def test_checkout_complete_checkout_without_lines(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     assert not lines
     checkout_info = fetch_checkout_info(checkout, lines, manager)
@@ -2183,7 +2183,7 @@ def test_checkout_complete_error_in_gateway_response_for_dummy_credit_card(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -2260,7 +2260,7 @@ def test_checkout_complete_does_not_delete_checkout_after_unsuccessful_payment(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     taxed_total = calculations.checkout_total(
@@ -2353,7 +2353,7 @@ def test_checkout_complete_confirmation_needed(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -2410,7 +2410,7 @@ def test_checkout_confirm(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -2457,7 +2457,7 @@ def test_checkout_complete_insufficient_stock(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -2505,7 +2505,7 @@ def test_checkout_complete_insufficient_stock_payment_refunded(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -2564,7 +2564,7 @@ def test_checkout_complete_insufficient_stock_payment_voided(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -2634,7 +2634,7 @@ def test_checkout_complete_insufficient_stock_reserved_by_other_user(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -2688,7 +2688,7 @@ def test_checkout_complete_own_reservation(
         reserved_until=timezone.now() + timedelta(minutes=5),
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -2753,7 +2753,7 @@ def test_checkout_complete_without_redirect_url(
     checkout_line_quantity = checkout_line.quantity
     checkout_line_variant = checkout_line.variant
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -2819,7 +2819,7 @@ def test_checkout_complete_payment_payment_total_different_than_checkout(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -2889,7 +2889,7 @@ def test_create_order_raises_insufficient_stock(
     mocked_create_order, user_api_client, checkout_ready_to_complete, payment_dummy
 ):
     checkout = checkout_ready_to_complete
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     mocked_create_order.side_effect = InsufficientStock(
         [InsufficientStockData(variant=lines[0].variant, available_quantity=0)]
@@ -2938,7 +2938,7 @@ def test_checkout_complete_with_digital(
     checkout.save(update_fields=["billing_address"])
 
     # Create a dummy payment to charge
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -2998,7 +2998,7 @@ def test_checkout_complete_0_total_value(
 
     checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -3069,7 +3069,7 @@ def test_complete_checkout_for_local_click_and_collect(
         "redirectUrl": "https://www.example.com",
     }
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -3137,7 +3137,7 @@ def test_complete_checkout_for_global_click_and_collect(
         "redirectUrl": "https://www.example.com",
     }
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -3248,7 +3248,7 @@ def test_comp_checkout_builds_order_for_all_warehouse_even_if_not_available_loca
     checkout.collection_point = warehouse_for_cc
     checkout.save(update_fields=["collection_point"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -3302,7 +3302,7 @@ def test_checkout_complete_raises_InsufficientStock_when_quantity_above_stock_su
     checkout.billing_address = address
     checkout.save(update_fields=["collection_point", "billing_address"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -3349,7 +3349,7 @@ def test_checkout_complete_raises_InvalidShippingMethod_when_warehouse_disabled(
     warehouse_for_cc.click_and_collect_option = WarehouseClickAndCollectOption.DISABLED
     warehouse_for_cc.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -3399,7 +3399,7 @@ def test_checkout_complete_with_preorder_variant(
 
     variants_and_quantities = {line.variant_id: line.quantity for line in checkout}
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -3501,7 +3501,7 @@ def test_checkout_complete_with_click_collect_preorder_fails_for_disabled_wareho
     warehouse_for_cc.click_and_collect_option = WarehouseClickAndCollectOption.DISABLED
     warehouse_for_cc.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -3555,7 +3555,7 @@ def test_checkout_complete_variant_channel_listing_does_not_exist(
     checkout_line_variant = checkout_line.variant
     checkout_line_variant.channel_listings.get(channel__id=checkout.channel_id).delete()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
 
     checkout_info = fetch_checkout_info(checkout, lines, manager)
@@ -3623,7 +3623,7 @@ def test_checkout_complete_variant_channel_listing_no_price(
         variant_channel_listing.price_amount = None
         variant_channel_listing.save(update_fields=["price_amount"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -3686,7 +3686,7 @@ def test_checkout_complete_product_channel_listing_does_not_exist(
         channel__id=checkout.channel_id
     ).delete()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -3755,7 +3755,7 @@ def test_checkout_complete_product_channel_listing_not_available_for_purchase(
     product_channel_listings.available_for_purchase_at = available_for_purchase
     product_channel_listings.save(update_fields=["available_for_purchase_at"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -3818,7 +3818,7 @@ def test_checkout_complete_error_when_shipping_address_doesnt_have_all_required_
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -3879,7 +3879,7 @@ def test_checkout_complete_error_when_shipping_address_doesnt_have_all_valid_fie
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -3939,7 +3939,7 @@ def test_checkout_complete_error_when_billing_address_doesnt_have_all_required_f
     checkout.shipping_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -3999,7 +3999,7 @@ def test_checkout_complete_error_when_billing_address_doesnt_have_all_valid_fiel
     checkout.shipping_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -4064,7 +4064,7 @@ def test_checkout_complete_with_not_normalized_shipping_address(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -4127,7 +4127,7 @@ def test_checkout_complete_with_not_normalized_billing_address(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -4179,7 +4179,7 @@ def test_checkout_complete_check_reservations_create(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -4238,7 +4238,7 @@ def test_checkout_complete_reservations_drop(
     checkout.tax_exemption = True
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -4290,7 +4290,7 @@ def test_checkout_complete_payment_create_create_run_in_meantime(
     )
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -4369,7 +4369,7 @@ def test_checkout_complete_line_deleted_in_the_meantime(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_transactions.py
@@ -104,7 +104,7 @@ def prepare_checkout_for_test(
     checkout.billing_address = billing_address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -152,7 +152,7 @@ def test_checkout_without_any_transaction(
     channel.automatically_confirm_all_new_orders = True
     channel.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -201,7 +201,7 @@ def test_checkout_without_any_transaction_allow_to_create_order(
     channel.order_mark_as_paid_strategy = MarkAsPaidStrategy.TRANSACTION_FLOW
     channel.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -252,7 +252,7 @@ def test_checkout_with_total_0(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -318,7 +318,7 @@ def test_checkout_with_authorized(
     channel.automatically_confirm_all_new_orders = True
     channel.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -415,7 +415,7 @@ def test_checkout_with_charged(
     channel.automatically_confirm_all_new_orders = True
     channel.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -502,7 +502,7 @@ def test_checkout_paid_with_multiple_transactions(
     channel.automatically_confirm_all_new_orders = True
     channel.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -564,7 +564,7 @@ def test_checkout_partially_paid(
     channel.automatically_confirm_all_new_orders = True
     channel.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -617,7 +617,7 @@ def test_checkout_partially_paid_allow_unpaid_order(
     channel.allow_unpaid_orders = True
     channel.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -673,7 +673,7 @@ def test_checkout_with_pending_charged(
     channel.automatically_confirm_all_new_orders = True
     channel.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -750,7 +750,7 @@ def test_checkout_with_pending_authorized(
     channel.automatically_confirm_all_new_orders = True
     channel.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -1090,7 +1090,7 @@ def test_checkout_complete(
     checkout_line_quantity = checkout_line.quantity
     checkout_line_variant = checkout_line.variant
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -1614,7 +1614,7 @@ def test_checkout_with_voucher_complete(
 
     discount_amount = checkout.discount
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1701,7 +1701,7 @@ def test_checkout_complete_with_voucher_apply_once_per_order(
         transaction_events_generator,
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1779,7 +1779,7 @@ def test_checkout_complete_with_voucher_single_use(
 
     discount_amount = checkout.discount
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1903,7 +1903,7 @@ def test_checkout_with_voucher_complete_product_on_sale(
     promotion_without_rules.name = ""
     promotion_without_rules.save(update_fields=["name"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1979,7 +1979,7 @@ def test_checkout_with_voucher_on_specific_product_complete(
 
     checkout.lines.first()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -2093,7 +2093,7 @@ def test_checkout_complete_product_on_promotion(
         promotion_rule=rule,
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -2249,7 +2249,7 @@ def test_checkout_complete_multiple_rules_applied(
         ]
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -2329,7 +2329,7 @@ def test_checkout_with_voucher_on_specific_product_complete_with_product_on_prom
     rule.catalogue_predicate = predicate
     rule.save(update_fields=["catalogue_predicate"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -2492,7 +2492,7 @@ def test_checkout_complete_checkout_without_lines(
         transaction_events_generator,
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     assert not lines
     checkout_info = fetch_checkout_info(checkout, lines, manager)
@@ -2996,7 +2996,7 @@ def test_checkout_complete_raises_InvalidShippingMethod_when_warehouse_disabled(
     warehouse_for_cc.click_and_collect_option = WarehouseClickAndCollectOption.DISABLED
     warehouse_for_cc.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -3040,7 +3040,7 @@ def test_checkout_complete_with_preorder_variant(
 
     variants_and_quantities = {line.variant_id: line.quantity for line in checkout}
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -3135,7 +3135,7 @@ def test_checkout_complete_with_click_collect_preorder_fails_for_disabled_wareho
     warehouse_for_cc.click_and_collect_option = WarehouseClickAndCollectOption.DISABLED
     warehouse_for_cc.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_delivery_method_update.py
@@ -79,7 +79,7 @@ def test_checkout_delivery_method_update(
     mock_clean_delivery.return_value = is_valid_delivery_method
 
     checkout = checkout_with_item_for_cc
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -151,7 +151,7 @@ def test_checkout_delivery_method_update_no_checkout_metadata(
 
     checkout = checkout_with_item_for_cc
     checkout.metadata_storage.delete()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -475,7 +475,7 @@ def test_checkout_delivery_method_update_with_not_all_required_shipping_address_
     checkout = checkout_with_item_for_cc
     checkout.shipping_address = Address.objects.create(country="US")
     checkout.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -550,7 +550,7 @@ def test_checkout_delivery_method_update_with_not_valid_address_data(
         postal_code="53-601",
     )
     checkout.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_line_delete.py
@@ -75,7 +75,7 @@ def test_checkout_line_delete(
     assert checkout.lines.count() == 0
     assert calculate_checkout_quantity(lines) == 0
     assert Reservation.objects.count() == 0
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change
@@ -85,7 +85,7 @@ def test_checkout_line_delete(
 def test_checkout_lines_delete_with_not_applicable_voucher(
     user_api_client, checkout_with_item, voucher, channel_USD
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     subtotal = base_calculations.base_checkout_subtotal(
@@ -125,7 +125,9 @@ def test_checkout_line_delete_remove_shipping_if_removed_product_with_shipping(
     checkout.shipping_address = address
     checkout.shipping_method = shipping_method
     checkout.save()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, digital_variant, 1)
     line = checkout.lines.first()
 
@@ -153,7 +155,7 @@ def test_with_active_problems_flow(
     variant = product_with_single_variant.variants.first()
 
     checkout_info = fetch_checkout_info(
-        checkout_with_problems, [], get_plugins_manager()
+        checkout_with_problems, [], get_plugins_manager(allow_replica=False)
     )
     add_variant_to_checkout(checkout_info, variant, 1)
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_add.py
@@ -116,7 +116,7 @@ def test_checkout_lines_add(
     assert calculate_checkout_quantity(lines) == 4
     assert not Reservation.objects.exists()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -190,7 +190,7 @@ def test_add_to_existing_line_with_sale_when_checkout_has_voucher(
     )
 
     # create checkout discount objects for checkout lines
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines_infos, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines_infos, manager)
     recalculate_checkout_discount(manager, checkout_info, lines_infos)
@@ -376,7 +376,7 @@ def test_checkout_lines_add_only_stock_in_cc_warehouse(
     assert calculate_checkout_quantity(lines) == 4
     assert not Reservation.objects.exists()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_delete.py
@@ -72,7 +72,7 @@ def test_checkout_lines_delete(
     remaining_lines = data["checkout"]["lines"]
     lines_ids = [line["id"] for line in remaining_lines]
     assert lines_list not in lines_ids
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.last_change != previous_last_change

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_lines_update.py
@@ -102,7 +102,7 @@ def test_checkout_lines_update(
     assert line.quantity == 1
     assert calculate_checkout_quantity(lines) == 1
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -146,7 +146,7 @@ def test_checkout_lines_update_using_line_id(
     assert line.quantity == 1
     assert calculate_checkout_quantity(lines) == 1
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -193,7 +193,7 @@ def test_checkout_lines_update_using_line_id_and_variant_id(
     assert line.quantity == 2
     assert calculate_checkout_quantity(lines) == 2
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -307,7 +307,7 @@ def test_checkout_lines_update_only_stock_in_cc_warehouse(
     assert line.quantity == 1
     assert calculate_checkout_quantity(lines) == 1
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -501,7 +501,9 @@ def test_checkout_lines_update_other_lines_reservations_expirations(
     checkout = checkout_line_with_one_reservation.checkout
     line = checkout_line_with_one_reservation
     reservation = line.reservations.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     lines, _ = fetch_checkout_lines(checkout)
     assert calculate_checkout_quantity(lines) == 2
 
@@ -936,7 +938,7 @@ def test_checkout_line_delete_by_zero_quantity(
     assert not data["errors"]
     checkout.refresh_from_db()
     assert checkout.lines.count() == 0
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -972,7 +974,7 @@ def test_checkout_line_delete_by_zero_quantity_when_variant_unavailable_for_purc
     assert not data["errors"]
     checkout.refresh_from_db()
     assert checkout.lines.count() == 0
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -1008,7 +1010,7 @@ def test_checkout_line_update_by_zero_quantity_dont_create_new_lines(
     assert not data["errors"]
     checkout.refresh_from_db()
     assert checkout.lines.count() == 0
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -1101,7 +1103,9 @@ def test_checkout_lines_update_remove_shipping_if_removed_product_with_shipping(
     checkout.shipping_address = address
     checkout.shipping_method = shipping_method
     checkout.save()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, digital_variant, 1)
     line = checkout.lines.first()
     variant = line.variant
@@ -1133,7 +1137,7 @@ def test_with_active_problems_flow(
     variant = product_with_single_variant.variants.first()
 
     checkout_info = fetch_checkout_info(
-        checkout_with_problems, [], get_plugins_manager()
+        checkout_with_problems, [], get_plugins_manager(allow_replica=False)
     )
     add_variant_to_checkout(checkout_info, variant, 1)
 

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_remove_promo_code.py
@@ -274,7 +274,7 @@ def test_checkout_remove_voucher_code_invalidates_price(
     checkout_with_item.price_expiration = timezone.now() + timedelta(days=2)
     checkout_with_item.voucher_code = voucher.code
     checkout_with_item.save(update_fields=["voucher_code", "price_expiration"])
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     subtotal = base_calculations.base_checkout_subtotal(

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_address_update.py
@@ -132,7 +132,7 @@ def test_checkout_shipping_address_with_metadata_update(
     assert checkout.shipping_address.postal_code == shipping_address["postalCode"]
     assert checkout.shipping_address.country == shipping_address["country"]
     assert checkout.shipping_address.city == shipping_address["city"].upper()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -156,7 +156,9 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     variant = variant_with_many_stocks_different_shipping_zones
     checkout = Checkout.objects.create(channel=channel_USD, currency="USD")
     checkout.set_country("PL", commit=True)
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
     assert checkout.shipping_address is None
     previous_last_change = checkout.last_change
@@ -189,7 +191,7 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     assert checkout.shipping_address.postal_code == shipping_address["postalCode"]
     assert checkout.shipping_address.country == shipping_address["country"]
     assert checkout.shipping_address.city == shipping_address["city"].upper()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
@@ -213,7 +215,9 @@ def test_checkout_shipping_address_update_insufficient_stocks(
     variant = variant_with_many_stocks_different_shipping_zones
     checkout = Checkout.objects.create(channel=channel_USD, currency="USD")
     checkout.set_country("PL", commit=True)
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
     Stock.objects.filter(
         warehouse__shipping_zones__countries__contains="US", product_variant=variant
@@ -261,7 +265,9 @@ def test_checkout_shipping_address_update_doesnt_raise_error(
     Stock.objects.filter(product_variant=variant_b).update(quantity=1)
     checkout = Checkout.objects.create(channel=channel_USD, currency="USD")
     checkout.set_country("PL", commit=True)
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant_b, 1)
     add_variant_to_checkout(checkout_info, variant_a, 4)
     assert checkout.shipping_address is None
@@ -300,7 +306,9 @@ def test_checkout_shipping_address_update_with_reserved_stocks(
     variant = variant_with_many_stocks_different_shipping_zones
     checkout = Checkout.objects.create(channel=channel_USD, currency="USD")
     checkout.set_country("PL", commit=True)
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 2)
     assert checkout.shipping_address is None
 
@@ -351,7 +359,9 @@ def test_checkout_shipping_address_update_against_reserved_stocks(
     variant = variant_with_many_stocks_different_shipping_zones
     checkout = Checkout.objects.create(channel=channel_USD, currency="USD")
     checkout.set_country("PL", commit=True)
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 2)
     Stock.objects.filter(
         warehouse__shipping_zones__countries__contains="US", product_variant=variant
@@ -930,7 +940,7 @@ def test_checkout_shipping_address_update_with_not_applicable_voucher(
     code = voucher.codes.first()
     assert voucher.countries[0].code == address_other_country.country
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     add_voucher_to_checkout(manager, checkout_info, lines, voucher, code)

--- a/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_shipping_method_update.py
@@ -70,7 +70,7 @@ def test_checkout_shipping_method_update(
     data = get_graphql_content(response)["data"]["checkoutShippingMethodUpdate"]
     checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     checkout_info.delivery_method_info = get_delivery_method_info(

--- a/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
+++ b/saleor/graphql/checkout/tests/mutations/test_order_create_from_checkout.py
@@ -140,7 +140,7 @@ def test_order_from_checkout(
     checkout_line_metadata = checkout_line.metadata
     checkout_line_private_metadata = checkout_line.private_metadata
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -323,7 +323,7 @@ def test_order_from_checkout_with_metadata(
     metadata_key = "md key"
     metadata_value = "md value"
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -393,7 +393,7 @@ def test_order_from_checkout_with_metadata_checkout_without_metadata(
     metadata_key = "md key"
     metadata_value = "md value"
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -495,7 +495,7 @@ def test_order_from_checkout_gift_card_bought(
     checkout.save()
     checkout.metadata_storage.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1113,7 +1113,7 @@ def test_order_from_checkout_without_inventory_tracking(
     checkout_line_quantity = checkout_line.quantity
     checkout_line_variant = checkout_line.variant
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -1388,7 +1388,7 @@ def test_order_from_checkout_0_total_value(
 
     checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -1601,7 +1601,7 @@ def test_order_from_checkout_raises_invalid_shipping_method_when_warehouse_disab
     warehouse_for_cc.click_and_collect_option = WarehouseClickAndCollectOption.DISABLED
     warehouse_for_cc.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1643,7 +1643,7 @@ def test_order_from_draft_create_with_preorder_variant(
 
     variants_and_quantities = {line.variant_id: line.quantity for line in checkout}
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -1731,7 +1731,7 @@ def test_order_from_draft_create_click_collect_preorder_fails_for_disabled_wareh
     warehouse_for_cc.click_and_collect_option = WarehouseClickAndCollectOption.DISABLED
     warehouse_for_cc.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -2003,7 +2003,7 @@ def test_order_from_draft_create_0_total_value_from_voucher(
 
     checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -2064,7 +2064,7 @@ def test_order_from_draft_create_0_total_value_from_giftcard(
 
     checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -58,7 +58,7 @@ def test_clean_delivery_method_after_shipping_address_changes_stay_the_same(
     checkout = checkout_with_single_item
     checkout.shipping_address = address
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     delivery_method = convert_to_shipping_method_data(
@@ -74,7 +74,7 @@ def test_clean_delivery_method_with_preorder_is_valid_for_enabled_warehouse(
     checkout = checkout_with_preorders_only
     checkout.shipping_address = address
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     is_valid_method = clean_delivery_method(checkout_info, lines, warehouses_for_cc[1])
@@ -89,7 +89,7 @@ def test_clean_delivery_method_does_nothing_if_no_shipping_method(
 
     checkout = checkout_with_single_item
     checkout.shipping_address = address
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     is_valid_method = clean_delivery_method(checkout_info, lines, None)
@@ -112,7 +112,7 @@ def test_update_checkout_shipping_method_if_invalid(
     shipping_method.shipping_zone = shipping_zone_without_countries
     shipping_method.save(update_fields=["shipping_zone"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     update_checkout_shipping_method_if_invalid(checkout_info, lines)
@@ -143,7 +143,7 @@ def test_update_checkout_shipping_method_if_invalid_no_checkout_metadata(
     shipping_method.shipping_zone = shipping_zone_without_countries
     shipping_method.save(update_fields=["shipping_zone"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -583,7 +583,7 @@ def test_checkout_shipping_methods_with_price_based_shipping_method_and_discount
     shipping_method,
 ):
     checkout_with_item.shipping_address = address
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
 
@@ -625,7 +625,7 @@ def test_checkout_shipping_methods_with_price_based_shipping_and_shipping_discou
 ):
     """Test that shipping discounts properly qualify checkout for price-based shipping."""
     checkout_with_item.shipping_address = address
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
 
@@ -667,7 +667,7 @@ def test_checkout_shipping_methods_with_price_based_method_and_product_voucher(
     """Test that product discounts properly qualify checkout for price-based shipping."""
     # given
     checkout_with_item.shipping_address = address
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
 
     line = checkout_with_item.lines.first()
@@ -1521,7 +1521,7 @@ def test_checkout_prices(user_api_client, checkout_with_item):
     assert data["token"] == str(checkout_with_item.token)
     assert len(data["lines"]) == checkout_with_item.lines.count()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
 
@@ -1592,7 +1592,7 @@ def test_checkout_prices_checkout_with_custom_prices(
     assert data["token"] == str(checkout_with_item.token)
     assert len(data["lines"]) == checkout_with_item.lines.count()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
 
@@ -1627,7 +1627,7 @@ def test_checkout_prices_with_sales(user_api_client, checkout_with_item_on_sale)
     checkout = checkout_with_item_on_sale
     variables = {"id": to_global_id_or_none(checkout)}
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1696,7 +1696,7 @@ def test_checkout_prices_with_promotion(
     checkout = checkout_with_item_on_promotion
     variables = {"id": to_global_id_or_none(checkout)}
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1810,7 +1810,7 @@ def test_checkout_prices_with_specific_voucher(
     assert data["token"] == str(checkout.token)
     assert len(data["lines"]) == checkout.lines.count()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -1873,7 +1873,7 @@ def test_checkout_prices_with_voucher_once_per_order(
     # then
     assert data["token"] == str(checkout.token)
     assert len(data["lines"]) == checkout.lines.count()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -1935,7 +1935,7 @@ def test_checkout_prices_with_voucher(user_api_client, checkout_with_item_and_vo
     # then
     assert data["token"] == str(checkout.token)
     assert len(data["lines"]) == checkout.lines.count()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -2134,10 +2134,10 @@ def test_clean_checkout(checkout_with_item, payment_dummy, address, shipping_met
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -2162,7 +2162,7 @@ def test_clean_checkout_no_shipping_method(checkout_with_item, address):
     checkout.shipping_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     with pytest.raises(ValidationError) as e:
@@ -2177,7 +2177,7 @@ def test_clean_checkout_no_shipping_address(checkout_with_item, shipping_method)
     checkout.shipping_method = shipping_method
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     with pytest.raises(ValidationError) as e:
@@ -2195,7 +2195,7 @@ def test_clean_checkout_invalid_shipping_method(
     checkout.shipping_method = shipping_method
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     with pytest.raises(ValidationError) as e:
@@ -2214,7 +2214,7 @@ def test_clean_checkout_no_billing_address(
     checkout.shipping_method = shipping_method
     checkout.save()
     payment = checkout.get_last_active_payment()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -2233,7 +2233,7 @@ def test_clean_checkout_no_payment(checkout_with_item, shipping_method, address)
     checkout.billing_address = address
     checkout.save()
     payment = checkout.get_last_active_payment()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 

--- a/saleor/graphql/checkout/tests/test_checkout_digital.py
+++ b/saleor/graphql/checkout/tests/test_checkout_digital.py
@@ -48,7 +48,7 @@ def test_remove_shipping_method_if_only_digital_in_checkout(
     checkout.save()
 
     assert checkout.shipping_method
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     update_checkout_shipping_method_if_invalid(checkout_info, lines)

--- a/saleor/graphql/checkout/tests/test_checkout_price_expiration.py
+++ b/saleor/graphql/checkout/tests/test_checkout_price_expiration.py
@@ -33,7 +33,7 @@ def test_checkout_lines_add_invalidate_prices(
     stock,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     query = ADD_CHECKOUT_LINES
     variables = {
         "checkoutId": graphene.Node.to_global_id("Checkout", checkout_with_items.pk),
@@ -78,7 +78,7 @@ def test_checkout_lines_update_invalidate_prices(
     stock,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     query = UPDATE_CHECKOUT_LINES
     variables = {
         "token": checkout_with_items.token,
@@ -122,7 +122,7 @@ def test_checkout_lines_delete_invalidate_prices(
     checkout_with_items,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     query = DELETE_CHECKOUT_LINES
     variables = {
         "token": checkout_with_items.token,
@@ -163,7 +163,7 @@ def test_checkout_line_delete_invalidate_prices(
     checkout_with_items,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     query = DELETE_CHECKOUT_LINE
     variables = {
         "token": checkout_with_items.token,
@@ -207,7 +207,7 @@ def test_checkout_shipping_address_update_invalidate_prices(
     plugins_manager,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     query = UPDATE_CHECKOUT_SHIPPING_ADDRESS
     variables = {
         "token": checkout_with_items.token,
@@ -249,7 +249,7 @@ def test_checkout_billing_address_update_invalidate_prices(
     graphql_address_data,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     query = UPDATE_CHECKOUT_BILLING_ADDRESS
     variables = {
         "token": checkout_with_items.token,

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -41,7 +41,7 @@ def test_checkout_totals_use_discounts(api_client, checkout_with_item, channel_U
     content = get_graphql_content(response)
     data = content["data"]["checkout"]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     taxed_total = calculations.checkout_total(

--- a/saleor/graphql/discount/tests/deprecated/test_voucher_create.py
+++ b/saleor/graphql/discount/tests/deprecated/test_voucher_create.py
@@ -145,6 +145,7 @@ def test_create_voucher_trigger_webhook(
         [any_webhook],
         voucher,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/discount/tests/deprecated/test_voucher_update.py
+++ b/saleor/graphql/discount/tests/deprecated/test_voucher_update.py
@@ -113,6 +113,7 @@ def test_update_voucher_trigger_webhook(
         [any_webhook],
         voucher,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/discount/tests/mutations/test_voucher_catalogues_add.py
+++ b/saleor/graphql/discount/tests/mutations/test_voucher_catalogues_add.py
@@ -135,6 +135,7 @@ def test_voucher_add_catalogues_trigger_webhook(
         [any_webhook],
         voucher,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/discount/tests/mutations/test_voucher_channel_listing_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_voucher_channel_listing_update.py
@@ -179,6 +179,7 @@ def test_voucher_channel_listing_update_trigger_webhook(
         [any_webhook],
         voucher,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/discount/tests/mutations/test_voucher_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_voucher_create.py
@@ -302,6 +302,7 @@ def test_create_voucher_trigger_webhook(
         [any_webhook],
         voucher,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/discount/tests/mutations/test_voucher_delete.py
+++ b/saleor/graphql/discount/tests/mutations/test_voucher_delete.py
@@ -87,4 +87,5 @@ def test_voucher_delete_mutation_trigger_webhook(
         [any_webhook],
         voucher,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )

--- a/saleor/graphql/discount/tests/mutations/test_voucher_update.py
+++ b/saleor/graphql/discount/tests/mutations/test_voucher_update.py
@@ -225,6 +225,7 @@ def test_update_voucher_trigger_webhook(
         [any_webhook],
         voucher,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_activate.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_activate.py
@@ -244,4 +244,5 @@ def test_activate_gift_card_trigger_webhook(
         [any_webhook],
         gift_card,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_add_note.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_add_note.py
@@ -256,4 +256,5 @@ def test_gift_card_add_note_trigger_webhook(
         [any_webhook],
         gift_card,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
@@ -698,6 +698,7 @@ def test_create_gift_card_trigger_webhook(
         [any_webhook],
         gift_card,
         SimpleLazyObject(lambda: app_api_client.app),
+        allow_replica=False,
     )
 
 
@@ -777,6 +778,7 @@ def test_create_gift_card_with_email_triggers_gift_card_sent_webhook(
             "sent_to_email": customer_user.email,
         },
         SimpleLazyObject(lambda: app_api_client.app),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_deactivate.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_deactivate.py
@@ -219,4 +219,5 @@ def test_deactivate_gift_card_trigger_webhook(
         [any_webhook],
         gift_card,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_delete.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_delete.py
@@ -135,4 +135,5 @@ def test_delete_gift_card_trigger_webhook(
         [any_webhook],
         gift_card,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_resend.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_resend.py
@@ -300,6 +300,7 @@ def test_resend_gift_card_triggers_gift_card_sent_event(
             "sent_to_email": email,
         },
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
@@ -800,4 +800,5 @@ def test_update_gift_card_trigger_webhook(
         [any_webhook],
         gift_card,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )

--- a/saleor/graphql/menu/tests/mutations/test_menu_create.py
+++ b/saleor/graphql/menu/tests/mutations/test_menu_create.py
@@ -135,6 +135,7 @@ def test_create_menu_trigger_webhook(
         [any_webhook],
         menu,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/menu/tests/mutations/test_menu_delete.py
+++ b/saleor/graphql/menu/tests/mutations/test_menu_delete.py
@@ -83,4 +83,5 @@ def test_delete_menu_trigger_webhook(
         [any_webhook],
         menu,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )

--- a/saleor/graphql/menu/tests/mutations/test_menu_item_create.py
+++ b/saleor/graphql/menu/tests/mutations/test_menu_item_create.py
@@ -94,4 +94,5 @@ def test_create_menu_item_trigger_webhook(
         [any_webhook],
         menu_item,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )

--- a/saleor/graphql/menu/tests/mutations/test_menu_item_delete.py
+++ b/saleor/graphql/menu/tests/mutations/test_menu_item_delete.py
@@ -85,4 +85,5 @@ def test_delete_menu_item_trigger_webhook(
         [any_webhook],
         menu_item,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )

--- a/saleor/graphql/menu/tests/mutations/test_menu_item_update.py
+++ b/saleor/graphql/menu/tests/mutations/test_menu_item_update.py
@@ -96,6 +96,7 @@ def test_update_menu_item_trigger_webhook(
         [any_webhook],
         menu_item,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/menu/tests/mutations/test_menu_update.py
+++ b/saleor/graphql/menu/tests/mutations/test_menu_update.py
@@ -126,6 +126,7 @@ def test_update_menu_trigger_webhook(
         [any_webhook],
         menu,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/order/tests/mutations/test_fulfillment_approve.py
+++ b/saleor/graphql/order/tests/mutations/test_fulfillment_approve.py
@@ -265,7 +265,7 @@ def test_fulfillment_approve_gift_cards_created(
                 warehouse_pk=stock_2.warehouse.pk,
             ),
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     query = APPROVE_FULFILLMENT_MUTATION

--- a/saleor/graphql/order/tests/test_draft_order_validate.py
+++ b/saleor/graphql/order/tests/test_draft_order_validate.py
@@ -13,14 +13,24 @@ from ..utils import validate_draft_order
 
 def test_validate_draft_order(draft_order):
     # should not raise any errors
-    assert validate_draft_order(draft_order, "US", get_plugins_manager()) is None
+    assert (
+        validate_draft_order(
+            draft_order, "US", get_plugins_manager(allow_replica=False)
+        )
+        is None
+    )
 
 
 def test_validate_draft_order_without_sku(draft_order):
     ProductVariant.objects.update(sku=None)
     draft_order.lines.update(product_sku=None)
     # should not raise any errors
-    assert validate_draft_order(draft_order, "US", get_plugins_manager()) is None
+    assert (
+        validate_draft_order(
+            draft_order, "US", get_plugins_manager(allow_replica=False)
+        )
+        is None
+    )
 
 
 def test_validate_draft_order_wrong_shipping(draft_order):
@@ -30,7 +40,7 @@ def test_validate_draft_order_wrong_shipping(draft_order):
     shipping_zone.save()
     assert order.shipping_address.country.code not in shipping_zone.countries
     with pytest.raises(ValidationError) as e:
-        validate_draft_order(order, "US", get_plugins_manager())
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
     msg = "Shipping method is not valid for chosen shipping address"
     assert e.value.error_dict["shipping"][0].message == msg
 
@@ -38,7 +48,7 @@ def test_validate_draft_order_wrong_shipping(draft_order):
 def test_validate_draft_order_no_order_lines(order, shipping_method):
     order.shipping_method = shipping_method
     with pytest.raises(ValidationError) as e:
-        validate_draft_order(order, "US", get_plugins_manager())
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
     msg = "Could not create order without any products."
     assert e.value.error_dict["lines"][0].message == msg
 
@@ -52,7 +62,7 @@ def test_validate_draft_order_non_existing_variant(draft_order):
     assert line.variant is None
 
     with pytest.raises(ValidationError) as e:
-        validate_draft_order(order, "US", get_plugins_manager())
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
     msg = "Could not create orders with non-existing products."
     assert e.value.error_dict["lines"][0].message == msg
 
@@ -67,7 +77,7 @@ def test_validate_draft_order_with_unpublished_product(draft_order):
     line.refresh_from_db()
 
     with pytest.raises(ValidationError) as e:
-        validate_draft_order(order, "US", get_plugins_manager())
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
     msg = "Can't finalize draft with unpublished product."
     error = e.value.error_dict["lines"][0]
 
@@ -83,7 +93,7 @@ def test_validate_draft_order_with_unavailable_for_purchase_product(draft_order)
     line.refresh_from_db()
 
     with pytest.raises(ValidationError) as e:
-        validate_draft_order(order, "US", get_plugins_manager())
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
     msg = "Can't finalize draft with product unavailable for purchase."
     error = e.value.error_dict["lines"][0]
 
@@ -103,7 +113,7 @@ def test_validate_draft_order_with_product_available_for_purchase_in_future(
     line.refresh_from_db()
 
     with pytest.raises(ValidationError) as e:
-        validate_draft_order(order, "US", get_plugins_manager())
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
     msg = "Can't finalize draft with product unavailable for purchase."
     error = e.value.error_dict["lines"][0]
 
@@ -121,7 +131,7 @@ def test_validate_draft_order_out_of_stock_variant(draft_order):
     stock.save(update_fields=["quantity"])
 
     with pytest.raises(ValidationError) as e:
-        validate_draft_order(order, "US", get_plugins_manager())
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
     msg = "Insufficient product stock."
     assert e.value.error_dict["lines"][0].message == msg
 
@@ -131,7 +141,7 @@ def test_validate_draft_order_no_shipping_address(draft_order):
     order.shipping_address = None
 
     with pytest.raises(ValidationError) as e:
-        validate_draft_order(order, "US", get_plugins_manager())
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
     error = e.value.error_dict["order"][0]
     assert error.message == "Can't finalize draft with no shipping address."
     assert error.code == OrderErrorCode.ORDER_NO_SHIPPING_ADDRESS.value
@@ -142,7 +152,7 @@ def test_validate_draft_order_no_billing_address(draft_order):
     order.billing_address = None
 
     with pytest.raises(ValidationError) as e:
-        validate_draft_order(order, "US", get_plugins_manager())
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
     error = e.value.error_dict["order"][0]
     assert error.message == "Can't finalize draft with no billing address."
     assert error.code == OrderErrorCode.BILLING_ADDRESS_NOT_SET.value
@@ -153,7 +163,7 @@ def test_validate_draft_order_no_shipping_method(draft_order):
     order.shipping_method = None
 
     with pytest.raises(ValidationError) as e:
-        validate_draft_order(order, "US", get_plugins_manager())
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
     error = e.value.error_dict["shipping"][0]
     assert error.message == "Shipping method is required."
     assert error.code == OrderErrorCode.SHIPPING_METHOD_REQUIRED.value
@@ -165,7 +175,10 @@ def test_validate_draft_order_no_shipping_method_shipping_not_required(draft_ord
     required_mock = Mock(return_value=False)
     order.is_shipping_required = required_mock
 
-    assert validate_draft_order(order, "US", get_plugins_manager()) is None
+    assert (
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
+        is None
+    )
 
 
 def test_validate_draft_order_no_shipping_address_no_method_shipping_not_required(
@@ -177,7 +190,10 @@ def test_validate_draft_order_no_shipping_address_no_method_shipping_not_require
     required_mock = Mock(return_value=False)
     order.is_shipping_required = required_mock
 
-    assert validate_draft_order(order, "US", get_plugins_manager()) is None
+    assert (
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
+        is None
+    )
 
 
 def test_validate_draft_order_voucher(draft_order_with_voucher):
@@ -187,7 +203,7 @@ def test_validate_draft_order_voucher(draft_order_with_voucher):
 
     # when & then
     with pytest.raises(ValidationError) as e:
-        validate_draft_order(order, "US", get_plugins_manager())
+        validate_draft_order(order, "US", get_plugins_manager(allow_replica=False))
 
     error = e.value.error_dict["voucher"][0]
     assert error.code == OrderErrorCode.INVALID_VOUCHER.value

--- a/saleor/graphql/page/tests/mutations/test_page_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_create.py
@@ -223,6 +223,7 @@ def test_page_create_trigger_page_webhook(
         page,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial

--- a/saleor/graphql/page/tests/mutations/test_page_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_delete.py
@@ -71,6 +71,7 @@ def test_page_delete_trigger_webhook(
         page,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial

--- a/saleor/graphql/page/tests/mutations/test_page_type_create.py
+++ b/saleor/graphql/page/tests/mutations/test_page_type_create.py
@@ -138,6 +138,7 @@ def test_page_type_create_trigger_webhook(
         [any_webhook],
         page_type,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/page/tests/mutations/test_page_type_delete.py
+++ b/saleor/graphql/page/tests/mutations/test_page_type_delete.py
@@ -115,6 +115,7 @@ def test_page_type_delete_trigger_webhook(
         [any_webhook],
         page_type,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/page/tests/mutations/test_page_type_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_type_update.py
@@ -142,6 +142,7 @@ def test_page_type_update_trigger_webhook(
         [any_webhook],
         page_type,
         SimpleLazyObject(lambda: staff_user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/page/tests/mutations/test_page_update.py
+++ b/saleor/graphql/page/tests/mutations/test_page_update.py
@@ -188,6 +188,7 @@ def test_update_page_trigger_webhook(
         page,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial

--- a/saleor/graphql/payment/tests/deprecated/test_checkout_payment_create.py
+++ b/saleor/graphql/payment/tests/deprecated/test_checkout_payment_create.py
@@ -35,7 +35,7 @@ def test_checkout_add_payment_by_checkout_id(
     checkout.save()
 
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -77,7 +77,7 @@ def test_checkout_add_payment_neither_token_and_id_given(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -111,7 +111,7 @@ def test_checkout_add_payment_both_token_and_id_given(
     checkout.save()
 
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(

--- a/saleor/graphql/payment/tests/mutations/test_checkout_payment_create.py
+++ b/saleor/graphql/payment/tests/mutations/test_checkout_payment_create.py
@@ -49,7 +49,7 @@ def test_checkout_add_payment_without_shipping_method_and_not_shipping_required(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -92,7 +92,7 @@ def test_checkout_add_payment_without_shipping_method_with_shipping_required(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -128,7 +128,7 @@ def test_checkout_add_payment_with_shipping_method_and_shipping_required(
     checkout.shipping_method = other_shipping_method
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -173,7 +173,7 @@ def test_checkout_add_payment(
     checkout.user = customer_user
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -220,7 +220,7 @@ def test_checkout_add_payment_default_amount(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -256,7 +256,7 @@ def test_checkout_add_payment_bad_amount(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -291,7 +291,7 @@ def test_checkout_add_payment_no_checkout_email(
     checkout.email = None
     checkout.save(update_fields=["email"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -399,7 +399,7 @@ def test_use_checkout_billing_address_as_payment_billing(
 ):
     # given
     checkout = checkout_without_shipping_required
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -447,7 +447,7 @@ def test_create_payment_for_checkout_with_active_payments(
     address.street_address_1 = "spanish-inqusition"
     address.save()
     checkout.billing_address = address
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     variant = product_without_shipping.variants.get()
     checkout_info = fetch_checkout_info(checkout, [], manager)
     add_variant_to_checkout(checkout_info, variant, 1)
@@ -505,7 +505,7 @@ def test_create_payment_with_store(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -539,7 +539,7 @@ def test_create_payment_with_store_as_none(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -575,7 +575,7 @@ def test_create_payment_with_metadata(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -613,7 +613,7 @@ def test_checkout_add_payment_no_variant_channel_listings(
     variant = checkout.lines.first().variant
     variant.product.channel_listings.filter(channel=checkout.channel_id).delete()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -659,7 +659,7 @@ def test_checkout_add_payment_no_product_channel_listings(
     variant = checkout.lines.first().variant
     variant.channel_listings.filter(channel=checkout.channel_id).delete()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -704,7 +704,7 @@ def test_checkout_add_payment_checkout_without_lines(
 
     checkout.lines.all().delete()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(
@@ -742,7 +742,7 @@ def test_checkout_add_payment_run_multiple_times(
     checkout.billing_address = address
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.checkout_total(

--- a/saleor/graphql/plugins/tests/queries/test_plugin.py
+++ b/saleor/graphql/plugins/tests/queries/test_plugin.py
@@ -65,7 +65,7 @@ def test_query_plugin_hides_secret_fields(
     settings,
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(PluginSample.PLUGIN_ID)
     configuration = copy.deepcopy(plugin.configuration)
     for conf_field in configuration:
@@ -117,7 +117,7 @@ def test_query_plugin_hides_secret_fields_for_channel_configurations(
     channel_PLN,
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.ChannelPluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     plugin = manager.get_plugin(
         ChannelPluginSample.PLUGIN_ID, channel_slug=channel_PLN.slug
@@ -159,7 +159,7 @@ def test_query_plugin_configuration(
     staff_api_client, permission_manage_plugins, settings
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     sample_plugin = manager.get_plugin(PluginSample.PLUGIN_ID)
 
     variables = {"id": sample_plugin.PLUGIN_ID}
@@ -181,7 +181,7 @@ def test_query_plugin_configuration_for_channel_configurations(
     staff_api_client, permission_manage_plugins, settings, channel_PLN
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.ChannelPluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     sample_plugin = manager.get_plugin(
         ChannelPluginSample.PLUGIN_ID, channel_slug=channel_PLN.slug
     )
@@ -241,7 +241,7 @@ def test_query_plugin_configuration_for_invalid_plugin_name(
 
 def test_query_plugin_configuration_as_customer_user(user_api_client, settings):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     sample_plugin = manager.get_plugin(PluginSample.PLUGIN_ID)
 
     variables = {"id": sample_plugin.PLUGIN_ID}

--- a/saleor/graphql/plugins/tests/queries/test_plugins.py
+++ b/saleor/graphql/plugins/tests/queries/test_plugins.py
@@ -58,7 +58,7 @@ def test_query_plugin_configurations(staff_api_client_can_manage_plugins, settin
 
     assert len(plugins) == 1
     plugin = plugins[0]["node"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     sample_plugin = manager.get_plugin(PluginSample.PLUGIN_ID)
     configuration_structure = PluginSample.CONFIG_STRUCTURE
 
@@ -101,7 +101,7 @@ def test_query_plugin_configurations_for_channel_configurations(
 
     assert len(plugins) == 1
     plugin = plugins[0]["node"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     sample_plugin = manager.get_plugin(
         ChannelPluginSample.PLUGIN_ID, channel_slug=channel_PLN.slug
     )
@@ -165,7 +165,7 @@ def test_query_plugins_hides_secret_fields(
     settings,
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(PluginSample.PLUGIN_ID)
     configuration = copy.deepcopy(plugin.configuration)
     for conf_field in configuration:
@@ -229,7 +229,7 @@ def test_query_plugins_hides_secret_fields_for_channel_configurations(
     channel_PLN,
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.ChannelPluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(
         ChannelPluginSample.PLUGIN_ID, channel_slug=channel_PLN.slug
     )

--- a/saleor/graphql/plugins/tests/test_mutation_plugin_update.py
+++ b/saleor/graphql/plugins/tests/test_mutation_plugin_update.py
@@ -79,7 +79,7 @@ def test_plugin_configuration_update(
     staff_api_client_can_manage_plugins, settings, active, updated_configuration_item
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(PluginSample.PLUGIN_ID)
     old_configuration = copy.deepcopy(plugin.configuration)
 
@@ -120,7 +120,7 @@ def test_plugin_configuration_update_value_not_given(
     staff_api_client_can_manage_plugins, settings
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(PluginSample.PLUGIN_ID)
     old_configuration = copy.deepcopy(plugin.configuration)
 
@@ -171,7 +171,7 @@ def test_plugin_configuration_update_for_channel_configurations(
     staff_api_client_can_manage_plugins, settings, active, channel_PLN
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.ChannelPluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(
         ChannelPluginSample.PLUGIN_ID, channel_slug=channel_PLN.slug
     )
@@ -212,7 +212,7 @@ def test_plugin_configuration_update_channel_slug_required(
     staff_api_client_can_manage_plugins, settings, channel_PLN
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.ChannelPluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(
         ChannelPluginSample.PLUGIN_ID, channel_slug=channel_PLN.slug
     )
@@ -240,7 +240,7 @@ def test_plugin_configuration_update_unneeded_channel_slug(
     staff_api_client_can_manage_plugins, settings, channel_PLN
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(PluginSample.PLUGIN_ID, channel_slug=channel_PLN.slug)
 
     variables = {
@@ -285,7 +285,7 @@ def test_plugin_update_saves_boolean_as_boolean(
     staff_api_client_can_manage_plugins, settings
 ):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(PluginSample.PLUGIN_ID)
     use_sandbox = get_config_value("Use sandbox", plugin.configuration)
     variables = {
@@ -305,7 +305,7 @@ def test_plugin_update_saves_boolean_as_boolean(
 
 def test_plugin_configuration_update_as_customer_user(user_api_client, settings):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(PluginSample.PLUGIN_ID)
 
     variables = {
@@ -326,7 +326,9 @@ def test_cannot_update_configuration_of_hidden_plugin(
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
 
     plugin_id = PluginSample.PLUGIN_ID
-    original_config = get_plugins_manager().get_plugin(plugin_id).configuration
+    original_config = (
+        get_plugins_manager(allow_replica=False).get_plugin(plugin_id).configuration
+    )
 
     variables = {
         "id": plugin_id,
@@ -345,7 +347,7 @@ def test_cannot_update_configuration_of_hidden_plugin(
     ]
 
     # Hidden plugin should be untouched
-    plugin = get_plugins_manager().get_plugin(plugin_id)
+    plugin = get_plugins_manager(allow_replica=False).get_plugin(plugin_id)
     assert plugin.active is True
     assert plugin.configuration == original_config
 
@@ -354,7 +356,7 @@ def test_cannot_update_configuration_of_hidden_plugin(
     assert response.status_code == 200
     content = get_graphql_content(response)
     assert content["data"]["pluginUpdate"]["pluginsErrors"] == []
-    plugin = get_plugins_manager().get_plugin(plugin_id)
+    plugin = get_plugins_manager(allow_replica=False).get_plugin(plugin_id)
     assert plugin.active is False
     assert plugin.configuration != original_config
 
@@ -369,7 +371,7 @@ def test_cannot_update_configuration_of_hidden_multichannel_plugin(
 
     plugin_id = ChannelPluginSample.PLUGIN_ID
     original_config = (
-        get_plugins_manager()
+        get_plugins_manager(allow_replica=False)
         .get_plugin(plugin_id, channel_slug=channel_USD.slug)
         .configuration
     )
@@ -391,7 +393,9 @@ def test_cannot_update_configuration_of_hidden_multichannel_plugin(
     ]
 
     # Hidden plugin should be untouched
-    plugin = get_plugins_manager().get_plugin(plugin_id, channel_slug=channel_USD.slug)
+    plugin = get_plugins_manager(allow_replica=False).get_plugin(
+        plugin_id, channel_slug=channel_USD.slug
+    )
     assert plugin.active is True
     assert plugin.configuration == original_config
 
@@ -400,6 +404,8 @@ def test_cannot_update_configuration_of_hidden_multichannel_plugin(
     assert response.status_code == 200
     content = get_graphql_content(response)
     assert content["data"]["pluginUpdate"]["pluginsErrors"] == []
-    plugin = get_plugins_manager().get_plugin(plugin_id, channel_slug=channel_USD.slug)
+    plugin = get_plugins_manager(allow_replica=False).get_plugin(
+        plugin_id, channel_slug=channel_USD.slug
+    )
     assert plugin.active is False
     assert plugin.configuration != original_config

--- a/saleor/graphql/product/tests/deprecated/test_utils.py
+++ b/saleor/graphql/product/tests/deprecated/test_utils.py
@@ -5,7 +5,7 @@ from ...mutations.utils import clean_tax_code
 
 def test_clean_tax_code_does_nothing_when_empty_data():
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     data = {}
 
     # when
@@ -17,7 +17,7 @@ def test_clean_tax_code_does_nothing_when_empty_data():
 
 def test_clean_tax_code_does_nothing_when_tax_class_provided():
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     data = {"tax_code": "P0000000", "tax_class": "VGF4Q2xhc3M6MQ=="}
 
     # when
@@ -29,7 +29,7 @@ def test_clean_tax_code_does_nothing_when_tax_class_provided():
 
 def test_clean_tax_code_when_tax_class_exists_by_name():
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     tax_code = "P0000000"
     tax_class = TaxClass.objects.create(name=tax_code)
     data = {"tax_code": tax_code}
@@ -43,7 +43,7 @@ def test_clean_tax_code_when_tax_class_exists_by_name():
 
 def test_clean_tax_code_when_tax_class_exists_by_avatax():
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     tax_code = "P0000000"
     tax_class = TaxClass.objects.create(name="Test", metadata={"avatax.code": tax_code})
     data = {"tax_code": tax_code}
@@ -57,7 +57,7 @@ def test_clean_tax_code_when_tax_class_exists_by_avatax():
 
 def test_clean_tax_code_when_tax_class_exists_by_vatlayer():
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     tax_code = "P0000000"
     tax_class = TaxClass.objects.create(
         name="Test", metadata={"vatlayer.code": tax_code}
@@ -73,7 +73,7 @@ def test_clean_tax_code_when_tax_class_exists_by_vatlayer():
 
 def test_clean_tax_code_when_tax_class_does_not_exists():
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     tax_code = "P0000000"
     TaxClass.objects.all().delete()
     data = {"tax_code": tax_code}

--- a/saleor/graphql/product/tests/mutations/test_product_channel_listing_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_channel_listing_update.py
@@ -955,7 +955,9 @@ def test_product_channel_listing_update_remove_channel_removes_checkout_lines(
     # given
     product = product_available_in_many_channels
     variant = product.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
 
     assert checkout.lines.all().exists()
@@ -1301,7 +1303,9 @@ def test_product_channel_listing_remove_variant_removes_checkout_lines(
 ):
     # given
     variant = product.variants.first()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
 
     assert checkout.lines.all().exists()

--- a/saleor/graphql/product/tests/mutations/test_product_delete.py
+++ b/saleor/graphql/product/tests/mutations/test_product_delete.py
@@ -141,6 +141,7 @@ def test_delete_product_trigger_webhook(
         product,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial

--- a/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
+++ b/saleor/graphql/product/tests/mutations/test_product_variant_stocks_update.py
@@ -230,7 +230,7 @@ def test_update_or_create_variant_stocks(variant, warehouses):
     ]
 
     ProductVariantStocksUpdate.update_or_create_variant_stocks(
-        variant, stocks_data, warehouses, get_plugins_manager()
+        variant, stocks_data, warehouses, get_plugins_manager(allow_replica=False)
     )
 
     variant.refresh_from_db()
@@ -269,7 +269,7 @@ def test_update_or_create_variant_stocks_when_stock_out_of_quantity(
     stocks_data = [{"quantity": 10, "warehouse": "321"}]
 
     ProductVariantStocksUpdate.update_or_create_variant_stocks(
-        variant, stocks_data, warehouses, get_plugins_manager()
+        variant, stocks_data, warehouses, get_plugins_manager(allow_replica=False)
     )
 
     variant.refresh_from_db()
@@ -291,7 +291,7 @@ def test_update_or_create_variant_stocks_empty_stocks_data(variant, warehouses):
     )
 
     ProductVariantStocksUpdate.update_or_create_variant_stocks(
-        variant, [], warehouses, get_plugins_manager()
+        variant, [], warehouses, get_plugins_manager(allow_replica=False)
     )
 
     variant.refresh_from_db()
@@ -326,7 +326,7 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_success(
     )
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    plugins = get_plugins_manager()
+    plugins = get_plugins_manager(allow_replica=False)
     stocks_data = [
         {"quantity": 10, "warehouse": "123"},
     ]
@@ -374,7 +374,7 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_only_failed(
 
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    plugins = get_plugins_manager()
+    plugins = get_plugins_manager(allow_replica=False)
     stocks_data = [
         {"quantity": 0, "warehouse": "123"},
     ]
@@ -422,7 +422,7 @@ def test_update_or_create_variant_with_back_in_stock_webhooks_with_allocations(
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    plugins = get_plugins_manager()
+    plugins = get_plugins_manager(allow_replica=False)
     stock.quantity_allocated = stock_quantity
     stock.save(update_fields=["quantity_allocated"])
     stocks_data = [
@@ -469,7 +469,7 @@ def test_update_or_create_variant_with_out_of_stock_webhooks_with_allocations(
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    plugins = get_plugins_manager()
+    plugins = get_plugins_manager(allow_replica=False)
     stock.quantity_allocated = stock_quantity - 1
     stock.save(update_fields=["quantity_allocated"])
     stocks_data = [
@@ -518,7 +518,7 @@ def test_update_or_create_variant_stocks_with_out_of_stock_webhook_only(
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
 
-    plugins = get_plugins_manager()
+    plugins = get_plugins_manager(allow_replica=False)
 
     stocks_data = [
         {"quantity": 0, "warehouse": "123"},

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -1202,7 +1202,9 @@ def test_delete_product_variants_removes_checkout_lines(
 ):
     query = PRODUCT_VARIANT_BULK_DELETE_MUTATION
 
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     variant_list = [product.variants.first() for product in product_list][:2]
     for variant in variant_list:
         add_variant_to_checkout(checkout_info, variant, 1)

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -528,6 +528,7 @@ def test_category_create_trigger_webhook(
         [any_webhook],
         category,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 
@@ -792,6 +793,7 @@ def test_category_update_trigger_webhook(
         [any_webhook],
         category,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 
@@ -1250,6 +1252,7 @@ def test_category_delete_trigger_webhook(
         [any_webhook],
         category,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_method_channel_listing_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_method_channel_listing_update.py
@@ -231,6 +231,7 @@ def test_shipping_method_channel_listing_create_trigger_webhook(
         [any_webhook],
         shipping_method,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_create.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_create.py
@@ -200,6 +200,7 @@ def test_create_shipping_method_trigger_webhook(
         [any_webhook],
         shipping_method,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_delete.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_delete.py
@@ -101,4 +101,5 @@ def test_delete_shipping_method_trigger_webhook(
         [any_webhook],
         shipping_method,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_exclude_products.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_exclude_products.py
@@ -154,4 +154,5 @@ def test_exclude_products_for_shipping_method_trigger_webhook(
         [any_webhook],
         shipping_method,
         issuer,
+        allow_replica=False,
     )

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_remove_product_from_exclude.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_remove_product_from_exclude.py
@@ -177,4 +177,5 @@ def test_remove_products_from_excluded_products_for_shipping_method_trigger_webh
         [any_webhook],
         shipping_method,
         issuer,
+        allow_replica=False,
     )

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_price_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_price_update.py
@@ -169,6 +169,7 @@ def test_update_shipping_method_trigger_webhook(
         [any_webhook],
         shipping_method,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_create.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_create.py
@@ -153,6 +153,7 @@ def test_create_shipping_zone_trigger_webhook(
         [any_webhook],
         shipping_zone,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_delete.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_delete.py
@@ -98,4 +98,5 @@ def test_delete_shipping_zone_trigger_webhook(
         [any_webhook],
         shipping_zone,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )

--- a/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
+++ b/saleor/graphql/shipping/tests/mutations/test_shipping_zone_update.py
@@ -161,6 +161,7 @@ def test_update_shipping_zone_trigger_webhook(
         [any_webhook],
         shipping_zone,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/tests/fixtures.py
+++ b/saleor/graphql/tests/fixtures.py
@@ -159,7 +159,7 @@ def schema_context():
     params = {
         "user": SimpleLazyObject(lambda: None),
         "app": SimpleLazyObject(lambda: None),
-        "plugins": get_plugins_manager(),
+        "plugins": get_plugins_manager(allow_replica=False),
         "auth_token": "",
     }
     return graphene.types.Context(**params)
@@ -172,7 +172,7 @@ def info(schema_context):
 
 @pytest.fixture
 def anonymous_plugins():
-    return get_plugins_manager()
+    return get_plugins_manager(allow_replica=False)
 
 
 class LoggingHandler(logging.Handler):

--- a/saleor/graphql/translations/tests/mutations/test_promotion_rule_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_promotion_rule_translate.py
@@ -90,6 +90,7 @@ def test_promotion_rule_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/translations/tests/mutations/test_promotion_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_promotion_translate.py
@@ -92,6 +92,7 @@ def test_promotion_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/translations/tests/mutations/test_sale_translate.py
+++ b/saleor/graphql/translations/tests/mutations/test_sale_translate.py
@@ -94,6 +94,7 @@ def test_sale_translate(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -880,6 +880,7 @@ def test_product_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1036,6 +1037,7 @@ def test_product_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1101,6 +1103,7 @@ def test_product_variant_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1162,6 +1165,7 @@ def test_product_variant_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
 
 
@@ -1249,6 +1253,7 @@ def test_collection_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1348,6 +1353,7 @@ def test_collection_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1426,6 +1432,7 @@ def test_category_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1523,6 +1530,7 @@ def test_category_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1581,6 +1589,7 @@ def test_voucher_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1640,6 +1649,7 @@ def test_voucher_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1709,6 +1719,7 @@ def test_sale_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1783,6 +1794,7 @@ def test_sale_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1870,6 +1882,7 @@ def test_page_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1963,6 +1976,7 @@ def test_page_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -2023,6 +2037,7 @@ def test_attribute_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -2083,6 +2098,7 @@ def test_attribute_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -2150,6 +2166,7 @@ def test_attribute_value_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -2280,6 +2297,7 @@ def test_attribute_value_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -2740,6 +2758,7 @@ def test_shipping_method_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -2826,6 +2845,7 @@ def test_shipping_method_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -2889,6 +2909,7 @@ def test_menu_item_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -2958,6 +2979,7 @@ def test_shop_create_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -3022,6 +3044,7 @@ def test_shop_update_translation(
         translation,
         SimpleLazyObject(lambda: staff_api_client.user),
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial

--- a/saleor/graphql/warehouse/tests/mutations/test_warehouse_create.py
+++ b/saleor/graphql/warehouse/tests/mutations/test_warehouse_create.py
@@ -184,6 +184,7 @@ def test_mutation_create_warehouse_trigger_webhook(
         [any_webhook],
         warehouse,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/warehouse/tests/mutations/test_warehouse_delete.py
+++ b/saleor/graphql/warehouse/tests/mutations/test_warehouse_delete.py
@@ -83,6 +83,7 @@ def test_delete_warehouse_mutation_trigger_webhook(
         [any_webhook],
         warehouse,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/graphql/warehouse/tests/mutations/test_warehouse_update.py
+++ b/saleor/graphql/warehouse/tests/mutations/test_warehouse_update.py
@@ -155,6 +155,7 @@ def test_mutation_update_warehouse_trigger_webhook(
         [any_webhook],
         warehouse,
         SimpleLazyObject(lambda: staff_api_client.user),
+        allow_replica=False,
     )
 
 

--- a/saleor/order/tasks.py
+++ b/saleor/order/tasks.py
@@ -38,7 +38,7 @@ def recalculate_orders_task(order_ids: list[int]):
 
 @app.task
 def send_order_updated(order_ids):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=True)
     for order in Order.objects.filter(id__in=order_ids):
         manager.order_updated(order)
 
@@ -122,7 +122,7 @@ def _expire_orders(manager, now):
 @app.task
 def expire_orders_task():
     now = timezone.now()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     _expire_orders(manager, now)
 
 

--- a/saleor/order/tests/test_fulfillments_actions.py
+++ b/saleor/order/tests/test_fulfillments_actions.py
@@ -29,7 +29,7 @@ def test_create_fulfillments(
             {"order_line": order_line2, "quantity": 2},
         ]
     }
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     [fulfillment] = create_fulfillments(
         staff_user,
         None,
@@ -101,7 +101,7 @@ def test_create_fulfillments_require_approval(
             {"order_line": order_line2, "quantity": 2},
         ]
     }
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     [fulfillment] = create_fulfillments(
         staff_user,
         None,
@@ -170,7 +170,7 @@ def test_create_fulfillments_require_approval_as_app(
             {"order_line": order_line2, "quantity": 2},
         ]
     }
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     [fulfillment] = create_fulfillments(
         None,
         app,
@@ -241,7 +241,7 @@ def test_create_fulfillments_without_notification(
         None,
         order,
         fulfillment_lines_for_warehouses,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
         site_settings,
         False,
     )
@@ -306,7 +306,7 @@ def test_create_fulfillments_many_warehouses(
         None,
         order,
         fulfillment_lines_for_warehouses,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
         site_settings,
         False,
     )
@@ -356,7 +356,7 @@ def test_create_fulfillments_with_one_line_empty_quantity(
         ]
     }
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     [fulfillment] = create_fulfillments(
         staff_user,
         None,
@@ -410,7 +410,7 @@ def test_create_fulfillments_with_variant_without_inventory_tracking(
         warehouse.pk: [{"order_line": order_line, "quantity": 2}]
     }
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     [fulfillment] = create_fulfillments(
         staff_user,
         None,
@@ -461,7 +461,7 @@ def test_create_fulfillments_without_allocations(
         ]
     }
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     [fulfillment] = create_fulfillments(
         staff_user,
         None,
@@ -524,7 +524,7 @@ def test_create_fulfillments_warehouse_without_stock(
             None,
             order,
             fulfillment_lines_for_warehouses,
-            get_plugins_manager(),
+            get_plugins_manager(allow_replica=False),
             site_settings,
             True,
         )
@@ -579,7 +579,7 @@ def test_create_fulfillments_with_variant_without_inventory_tracking_and_without
             None,
             order,
             fulfillment_lines_for_warehouses,
-            get_plugins_manager(),
+            get_plugins_manager(allow_replica=False),
             site_settings,
             True,
         )
@@ -624,7 +624,7 @@ def test_create_fullfilment_with_out_of_stock_webhook(
             {"order_line": order_line2, "quantity": 2},
         ]
     }
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     create_fulfillments(
         user=staff_user,
         app=None,
@@ -654,7 +654,7 @@ def test_create_fullfilment_with_out_of_stock_webhook_not_triggered(
             {"order_line": order_line2, "quantity": 1},
         ]
     }
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     create_fulfillments(
         user=staff_user,
         app=None,
@@ -707,7 +707,7 @@ def test_create_fulfillments_quantity_allocated_lower_than_line_quantity(
             {"order_line": order_line2, "quantity": line_2_qty},
         ]
     }
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     [fulfillment] = create_fulfillments(

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -316,7 +316,7 @@ def test_get_default_fulfillment_payload(fulfillment, digital_content, site_sett
 
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
 def test_send_email_payment_confirmation(mocked_notify, site_settings, payment_dummy):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order = payment_dummy.order
     order_info = fetch_order_info(order)
     expected_payload = {
@@ -342,7 +342,7 @@ def test_send_email_payment_confirmation(mocked_notify, site_settings, payment_d
 
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
 def test_send_email_order_confirmation(mocked_notify, order, site_settings):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     redirect_url = "https://www.example.com"
     order_info = fetch_order_info(order)
 
@@ -364,7 +364,7 @@ def test_send_email_order_confirmation(mocked_notify, order, site_settings):
 def test_send_email_order_confirmation_for_cc(
     mocked_notify, order_with_lines_for_cc, site_settings, warehouse_for_cc
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     redirect_url = "https://www.example.com"
     order_info = fetch_order_info(order_with_lines_for_cc)
 
@@ -489,7 +489,7 @@ def test_send_fulfillment_confirmation_by_user(
     fulfillment = fulfilled_order.fulfillments.first()
     fulfillment.tracking_number = "https://www.example.com"
     fulfillment.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     notifications.send_fulfillment_confirmation_to_customer(
         order=fulfilled_order,
@@ -516,7 +516,7 @@ def test_send_fulfillment_confirmation_by_app(
     fulfillment = fulfilled_order.fulfillments.first()
     fulfillment.tracking_number = "https://www.example.com"
     fulfillment.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     notifications.send_fulfillment_confirmation_to_customer(
         order=fulfilled_order,
@@ -541,7 +541,7 @@ def test_send_fulfillment_update(mocked_notify, fulfilled_order, site_settings):
     fulfillment = fulfilled_order.fulfillments.first()
     fulfillment.tracking_number = "https://www.example.com"
     fulfillment.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     notifications.send_fulfillment_update(
         order=fulfilled_order, fulfillment=fulfillment, manager=manager
@@ -561,7 +561,7 @@ def test_send_email_order_canceled_by_user(
     mocked_notify, order, site_settings, staff_user
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     notifications.send_order_canceled_confirmation(order, staff_user, None, manager)
@@ -584,7 +584,7 @@ def test_send_email_order_canceled_by_user(
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
 def test_send_email_order_canceled_by_app(mocked_notify, order, site_settings, app):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     notifications.send_order_canceled_confirmation(order, None, app, manager)
@@ -609,7 +609,7 @@ def test_send_email_order_refunded_by_user(
     mocked_notify, order, site_settings, staff_user
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     amount = order.total.gross.amount
 
     # when
@@ -638,7 +638,7 @@ def test_send_email_order_refunded_by_user(
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
 def test_send_email_order_refunded_by_app(mocked_notify, order, site_settings, app):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     amount = order.total.gross.amount
 
     # when

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -78,7 +78,7 @@ def test_order_get_subtotal(order_with_lines):
     )
 
     fetch_order_prices_if_expired(
-        order_with_lines, get_plugins_manager(), force_update=True
+        order_with_lines, get_plugins_manager(allow_replica=False), force_update=True
     )
 
     target_subtotal = order_with_lines.total - order_with_lines.shipping_price
@@ -630,7 +630,7 @@ def test_order_weight_change_line_quantity(staff_user, lines_info):
         new_quantity,
         line_info.quantity,
         order.channel,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
     assert order.weight == _calculate_order_weight_from_lines(order)
 
@@ -638,7 +638,7 @@ def test_order_weight_change_line_quantity(staff_user, lines_info):
 def test_order_weight_delete_line(lines_info):
     order = lines_info[0].line.order
     line_info = lines_info[0]
-    delete_order_line(line_info, get_plugins_manager())
+    delete_order_line(line_info, get_plugins_manager(allow_replica=False))
     assert order.weight == _calculate_order_weight_from_lines(order)
 
 
@@ -942,7 +942,7 @@ def test_ordered_item_change_quantity(staff_user, transactional_db, lines_info):
         lines_info[1].quantity,
         0,
         order.channel,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
     change_order_line_quantity(
         staff_user,
@@ -951,7 +951,7 @@ def test_ordered_item_change_quantity(staff_user, transactional_db, lines_info):
         lines_info[0].quantity,
         0,
         order.channel,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
     assert order.get_total_quantity() == 0
 
@@ -971,7 +971,7 @@ def test_change_order_line_quantity_changes_total_prices(
         line_info.quantity,
         new_quantity,
         order.channel,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
     assert line_info.line.total_price == line_info.line.unit_price * new_quantity
 
@@ -989,7 +989,7 @@ def test_send_fulfillment_order_lines_mails_by_user(
     has_standard,
     has_digital,
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     redirect_url = "http://localhost.pl"
     order = fulfilled_order
     order.redirect_url = redirect_url
@@ -1033,7 +1033,7 @@ def test_send_fulfillment_order_lines_mails_by_app(
     has_standard,
     has_digital,
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     redirect_url = "http://localhost.pl"
     order = fulfilled_order
     order.redirect_url = redirect_url

--- a/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
+++ b/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
@@ -45,7 +45,7 @@ def test_create_return_fulfillment_only_order_lines(
             for line in order_lines_to_return
         ],
         fulfillment_lines=[],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
     returned_fulfillment, replaced_fulfillment, replace_order = response
 
@@ -120,7 +120,7 @@ def test_create_return_fulfillment_only_order_lines_with_refund(
         payment=payment,
         order_lines=order_lines_to_refund,
         fulfillment_lines=[],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         refund=True,
     )
     returned_fulfillment, replaced_fulfillment, replace_order = response
@@ -196,7 +196,7 @@ def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
         payment=payment,
         order_lines=order_lines_to_refund,
         fulfillment_lines=[],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         refund=True,
         refund_shipping_costs=True,
     )
@@ -288,7 +288,7 @@ def test_create_return_fulfillment_only_order_lines_with_replace_request(
         payment=payment,
         order_lines=order_lines_data,
         fulfillment_lines=[],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
     returned_fulfillment, replaced_fulfillment, replace_order = response
 
@@ -401,7 +401,7 @@ def test_create_return_fulfillment_only_fulfillment_lines(
             FulfillmentLineData(line=line, quantity=2, replace=False)
             for line in fulfillment_lines
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     returned_fulfillment, replaced_fulfillment, replace_order = response
@@ -456,7 +456,7 @@ def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
         payment=payment,
         order_lines=[],
         fulfillment_lines=fulfillment_lines_to_return,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     returned_fulfillment, replaced_fulfillment, replace_order = response
@@ -598,7 +598,7 @@ def test_create_return_fulfillment_with_lines_already_refunded(
         payment=payment,
         order_lines=[],
         fulfillment_lines=fulfillment_lines_to_process,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         refund=True,
     )
 
@@ -673,7 +673,7 @@ def test_create_return_fulfillment_only_order_lines_with_old_ids(
             for line in order_lines_to_return
         ],
         fulfillment_lines=[],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
     returned_fulfillment, replaced_fulfillment, replace_order = response
 

--- a/saleor/order/tests/test_order_actions_refund_products.py
+++ b/saleor/order/tests/test_order_actions_refund_products.py
@@ -43,7 +43,7 @@ def test_create_refund_fulfillment_only_order_lines(
         payment=payment,
         order_lines_to_refund=order_refund_lines,
         fulfillment_lines_to_refund=[],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     flush_post_commit_hooks()
@@ -109,7 +109,7 @@ def test_create_refund_fulfillment_included_shipping_costs(
         payment=payment,
         order_lines_to_refund=order_refund_lines,
         fulfillment_lines_to_refund=[],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         refund_shipping_costs=True,
     )
 
@@ -170,7 +170,7 @@ def test_create_refund_fulfillment_only_fulfillment_lines(
         payment=payment,
         order_lines_to_refund=[],
         fulfillment_lines_to_refund=fulfillment_refund_lines,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     flush_post_commit_hooks()
@@ -228,7 +228,7 @@ def test_create_refund_fulfillment_custom_amount(
         payment=payment,
         order_lines_to_refund=[],
         fulfillment_lines_to_refund=fulfillment_refund_lines,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         amount=amount,
     )
 

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -71,7 +71,7 @@ def test_change_quantity_generates_proper_event(
         previous_quantity,
         new_quantity,
         order_with_lines.channel,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
 
     if removed_count:
@@ -123,7 +123,7 @@ def test_change_quantity_update_line_fields(
         line.quantity,
         new_quantity,
         order_with_lines.channel,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
 
     # then
@@ -184,7 +184,9 @@ def test_get_valid_shipping_methods_for_order(order_line_with_one_allocation, ad
 
     # when
     valid_shipping_methods = get_valid_shipping_methods_for_order(
-        order, order.channel.shipping_method_listings.all(), get_plugins_manager()
+        order,
+        order.channel.shipping_method_listings.all(),
+        get_plugins_manager(allow_replica=False),
     )
 
     # then
@@ -206,7 +208,9 @@ def test_get_valid_shipping_methods_for_order_no_channel_shipping_zones(
 
     # when
     valid_shipping_methods = get_valid_shipping_methods_for_order(
-        order, order.channel.shipping_method_listings.all(), get_plugins_manager()
+        order,
+        order.channel.shipping_method_listings.all(),
+        get_plugins_manager(allow_replica=False),
     )
 
     # then
@@ -225,7 +229,9 @@ def test_get_valid_shipping_methods_for_order_no_shipping_address(
 
     # when
     valid_shipping_methods = get_valid_shipping_methods_for_order(
-        order, order.channel.shipping_method_listings.all(), get_plugins_manager()
+        order,
+        order.channel.shipping_method_listings.all(),
+        get_plugins_manager(allow_replica=False),
     )
 
     # then
@@ -246,7 +252,9 @@ def test_get_valid_shipping_methods_for_order_shipping_not_required(
 
     # when
     valid_shipping_methods = get_valid_shipping_methods_for_order(
-        order, order.channel.shipping_method_listings.all(), get_plugins_manager()
+        order,
+        order.channel.shipping_method_listings.all(),
+        get_plugins_manager(allow_replica=False),
     )
 
     # then
@@ -260,7 +268,7 @@ def test_add_variant_to_order(
     promotion_with_single_rule,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     quantity = 4
 
     promotion = promotion_with_single_rule
@@ -309,7 +317,7 @@ def test_add_gift_cards_to_order(
     checkout = checkout_with_item
     checkout.user = staff_user
     checkout.gift_cards.add(gift_card, gift_card_expiry_date)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -363,7 +371,7 @@ def test_add_gift_cards_to_order_with_more_than_total(
     checkout = checkout_with_item
     checkout.user = staff_user
     checkout.gift_cards.add(gift_card_expiry_date, gift_card)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -393,7 +401,7 @@ def test_add_gift_cards_to_order_no_checkout_user(
     checkout.save(update_fields=["user", "email"])
 
     checkout.gift_cards.add(gift_card, gift_card_expiry_date)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 

--- a/saleor/payment/gateways/adyen/tests/conftest.py
+++ b/saleor/payment/gateways/adyen/tests/conftest.py
@@ -41,7 +41,7 @@ def adyen_plugin(settings, channel_USD):
         adyen_auto_capture = adyen_auto_capture or False
         auto_capture = auto_capture or False
         settings.PLUGINS = ["saleor.payment.gateways.adyen.plugin.AdyenGatewayPlugin"]
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
 
         with mock.patch.object(HTTPSession, "request"):
             manager.save_plugin_configuration(
@@ -63,7 +63,7 @@ def adyen_plugin(settings, channel_USD):
                 },
             )
 
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         return manager.plugins_per_channel[channel_USD.slug][0]
 
     return fun
@@ -75,7 +75,7 @@ def payment_adyen_for_checkout(checkout_with_items, address, shipping_method):
     checkout_with_items.shipping_address = address
     checkout_with_items.shipping_method = shipping_method
     checkout_with_items.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_items)
     checkout_info = fetch_checkout_info(checkout_with_items, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(

--- a/saleor/payment/gateways/adyen/tests/utils/test_common.py
+++ b/saleor/payment/gateways/adyen/tests/utils/test_common.py
@@ -717,7 +717,7 @@ def test_request_data_for_gateway_config(
     assert address.country.code != address_other_country.country.code
 
     merchant_account = "test_account"
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines_info, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines_info, manager)
 
@@ -738,7 +738,7 @@ def test_request_data_for_gateway_config(
 def test_request_data_for_gateway_config_no_country(checkout, address, settings):
     # given
     merchant_account = "test_account"
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines_info, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines_info, manager)
 

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
@@ -165,7 +165,7 @@ def test_handle_authorization_sets_psp_reference(
     checkout.save()
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -211,7 +211,7 @@ def test_handle_authorization_for_checkout(
     checkout_token = str(checkout.token)
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -262,7 +262,7 @@ def test_handle_authorization_for_checkout_partial_payment(
     checkout.save()
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -310,7 +310,7 @@ def test_handle_authorization_for_checkout_out_of_stock_after_payment(
     checkout.save()
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -372,7 +372,7 @@ def test_handle_authorization_for_checkout_that_cannot_be_finalized(
     checkout.save()
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -441,7 +441,7 @@ def test_handle_authorization_calls_refund_for_inactive_payment(
     checkout.save()
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -527,7 +527,7 @@ def test_handle_authorization_for_checkout_one_of_variants_deleted(
     checkout.save()
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -574,7 +574,7 @@ def test_handle_authorization_with_adyen_auto_capture(
     checkout.save()
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -856,7 +856,7 @@ def test_handle_capture_for_checkout(
     checkout_token = str(checkout.token)
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -988,7 +988,7 @@ def test_handle_capture_for_checkout_order_not_created_checkout_line_variant_del
     checkout.save()
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -1601,7 +1601,7 @@ def test_handle_not_created_order_order_created(
         payment_adyen_for_checkout,
         payment_adyen_for_checkout.checkout,
         TransactionKind.CAPTURE,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
 
     payment_adyen_for_checkout.refresh_from_db()
@@ -1637,7 +1637,7 @@ def test_handle_not_created_order_order_not_created_checkout_line_variant_delete
         payment_adyen_for_checkout,
         payment_adyen_for_checkout.checkout,
         TransactionKind.CAPTURE,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
 
     # then
@@ -1662,7 +1662,7 @@ def test_handle_not_created_order_refund_when_create_order_raises(
         payment_adyen_for_checkout,
         payment_adyen_for_checkout.checkout,
         TransactionKind.CAPTURE,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
 
     assert payment_adyen_for_checkout.can_refund()
@@ -1685,7 +1685,7 @@ def test_handle_not_created_order_void_when_create_order_raises(
         payment_adyen_for_checkout,
         payment_adyen_for_checkout.checkout,
         TransactionKind.CAPTURE,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
 
     assert payment_adyen_for_checkout.can_void()
@@ -1712,7 +1712,7 @@ def test_handle_not_created_order_return_none(
         payment_adyen_for_checkout,
         payment_adyen_for_checkout.checkout,
         TransactionKind.CAPTURE,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
 
 
@@ -1729,7 +1729,7 @@ def test_handle_not_created_order_create_new_success_transaction(
         payment_adyen_for_checkout,
         payment_adyen_for_checkout.checkout,
         TransactionKind.CAPTURE,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
 
     payment_adyen_for_checkout.refresh_from_db()
@@ -1758,7 +1758,7 @@ def test_handle_not_created_order_success_transaction_create_order_raises_and_re
         payment_adyen_for_checkout,
         payment_adyen_for_checkout.checkout,
         TransactionKind.CAPTURE,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
 
     payment_adyen_for_checkout.refresh_from_db()
@@ -1790,7 +1790,7 @@ def test_handle_not_created_order_success_transaction_create_order_raises_and_vo
         payment_adyen_for_checkout,
         payment_adyen_for_checkout.checkout,
         TransactionKind.CAPTURE,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
 
     payment_adyen_for_checkout.refresh_from_db()
@@ -1816,7 +1816,9 @@ def test_confirm_payment_and_set_back_to_confirm(
     )
 
     confirm_payment_and_set_back_to_confirm(
-        payment_adyen_for_checkout, get_plugins_manager(), plugin.channel.slug
+        payment_adyen_for_checkout,
+        get_plugins_manager(allow_replica=False),
+        plugin.channel.slug,
     )
 
     payment_adyen_for_checkout.refresh_from_db()
@@ -1898,7 +1900,7 @@ def test_handle_order_closed_success_true(
     checkout_token = str(checkout.token)
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -1949,7 +1951,7 @@ def test_handle_order_closed_with_adyen_partial_payments_success_true(
     checkout_token = str(checkout.token)
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -2034,7 +2036,7 @@ def test_handle_order_closed_with_adyen_partial_payments_success_true_without_am
     checkout_token = str(checkout.token)
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -2129,7 +2131,7 @@ def test_order_closed_with_adyen_partial_payments_unable_to_create_order(
     checkout.save()
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -2203,7 +2205,7 @@ def test_order_closed_with_not_active_payment(
     checkout.save()
 
     payment = payment_adyen_for_checkout
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -265,7 +265,7 @@ def append_checkout_details(payment_information: "PaymentData", payment_data: di
     if not checkout:
         raise PaymentError("Unable to calculate products for klarna.")
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     currency = payment_information.currency
@@ -341,7 +341,7 @@ def request_data_for_gateway_config(
     lines: Optional[Iterable[CheckoutLineInfo]],
     merchant_account,
 ) -> dict[str, Any]:
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_info.checkout
     address = checkout_info.shipping_address or checkout_info.billing_address
     lines = lines or []

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -280,7 +280,7 @@ def handle_authorization(notification: dict[str, Any], gateway_config: GatewayCo
         # We don't know anything about that payment
         return
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     adyen_auto_capture = gateway_config.connection_params["adyen_auto_capture"]
     kind = TransactionKind.AUTH
     if adyen_auto_capture:
@@ -380,7 +380,7 @@ def handle_cancellation(
         payment, success_msg, failed_msg, new_transaction.is_success
     )
     if payment.order and new_transaction.is_success:
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         cancel_order(payment.order, None, None, manager)
 
 
@@ -412,7 +412,7 @@ def handle_capture(notification: dict[str, Any], _gateway_config: GatewayConfig)
     if not payment:
         return
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     transaction = get_transaction(payment, transaction_id, TransactionKind.CAPTURE)
 
@@ -534,7 +534,7 @@ def handle_refund(notification: dict[str, Any], _gateway_config: GatewayConfig):
             None,
             transaction.amount,
             payment,
-            get_plugins_manager(),
+            get_plugins_manager(allow_replica=False),
         )
 
 
@@ -849,7 +849,11 @@ def handle_order_closed(notification: dict[str, Any], gateway_config: GatewayCon
     order = None
     try:
         order = handle_not_created_order(
-            notification, payment, checkout, kind, get_plugins_manager()
+            notification,
+            payment,
+            checkout,
+            kind,
+            get_plugins_manager(allow_replica=False),
         )
     except Exception as e:
         logger.exception("Exception during order creation", extra={"error": e})
@@ -1170,7 +1174,7 @@ def handle_api_response(
         gateway_response=gateway_response,
     )
     if is_success and not action_required and not payment.order and checkout:
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
 
         confirm_payment_and_set_back_to_confirm(payment, manager, channel_slug)
         payment.refresh_from_db()  # refresh charge_status

--- a/saleor/payment/gateways/authorize_net/tests/conftest.py
+++ b/saleor/payment/gateways/authorize_net/tests/conftest.py
@@ -37,7 +37,7 @@ def authorize_net_plugin(_, settings, channel_USD, authorize_net_gateway_config)
     settings.PLUGINS = [
         "saleor.payment.gateways.authorize_net.plugin.AuthorizeNetGatewayPlugin"
     ]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     connection_params = authorize_net_gateway_config.connection_params
 
@@ -70,5 +70,5 @@ def authorize_net_plugin(_, settings, channel_USD, authorize_net_gateway_config)
         },
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     return manager.plugins_per_channel[channel_USD.slug][0]

--- a/saleor/payment/gateways/dummy/tests/test_dummy.py
+++ b/saleor/payment/gateways/dummy/tests/test_dummy.py
@@ -16,7 +16,7 @@ def test_authorize_success(payment_dummy):
     txn = gateway.authorize(
         payment=payment_dummy,
         token="Fake",
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         channel_slug=payment_dummy.order.channel.slug,
     )
     assert txn.is_success
@@ -49,7 +49,7 @@ def test_authorize_failed(is_active, charge_status, payment_dummy):
         gateway.authorize(
             payment=payment,
             token="Fake",
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             channel_slug=payment.order.channel.slug,
         )
 
@@ -60,7 +60,7 @@ def test_authorize_gateway_error(payment_dummy, monkeypatch):
         gateway.authorize(
             payment=payment_dummy,
             token="Fake",
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             channel_slug=payment_dummy.order.channel.slug,
         )
 
@@ -70,7 +70,7 @@ def test_void_success(payment_txn_preauth):
     assert payment_txn_preauth.charge_status == ChargeStatus.NOT_CHARGED
     txn = gateway.void(
         payment=payment_txn_preauth,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         channel_slug=payment_txn_preauth.order.channel.slug,
     )
     assert txn.is_success
@@ -103,7 +103,7 @@ def test_void_failed(is_active, charge_status, payment_dummy):
     with pytest.raises(PaymentError):
         gateway.void(
             payment=payment,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             channel_slug=payment.order.channel.slug,
         )
 
@@ -113,7 +113,7 @@ def test_void_gateway_error(payment_txn_preauth, monkeypatch):
     with pytest.raises(PaymentError):
         gateway.void(
             payment=payment_txn_preauth,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             channel_slug=payment_txn_preauth.order.channel.slug,
         )
 
@@ -125,7 +125,7 @@ def test_void_gateway_error(payment_txn_preauth, monkeypatch):
 def test_capture_success(amount, charge_status, payment_txn_preauth):
     txn = gateway.capture(
         payment=payment_txn_preauth,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         amount=Decimal(amount),
         channel_slug=payment_txn_preauth.order.channel.slug,
     )
@@ -157,7 +157,7 @@ def test_capture_failed(
     with pytest.raises(PaymentError):
         gateway.capture(
             payment=payment,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             amount=amount,
             channel_slug=payment.order.channel.slug,
         )
@@ -168,7 +168,7 @@ def test_capture_gateway_error(payment_txn_preauth, monkeypatch):
     with pytest.raises(PaymentError):
         gateway.capture(
             payment=payment_txn_preauth,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             amount=80,
             channel_slug=payment_txn_preauth.order.channel.slug,
         )
@@ -201,7 +201,7 @@ def test_refund_success(
     payment.save()
     txn = gateway.refund(
         payment=payment,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         amount=Decimal(refund_amount),
         channel_slug=payment.order.channel.slug,
     )
@@ -235,7 +235,7 @@ def test_refund_failed(
     with pytest.raises(PaymentError):
         gateway.refund(
             payment=payment,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             amount=Decimal(refund_amount),
             channel_slug=payment.order.channel.slug,
         )
@@ -250,7 +250,7 @@ def test_refund_gateway_error(payment_txn_captured, monkeypatch):
     with pytest.raises(PaymentError):
         gateway.refund(
             payment=payment,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             amount=Decimal("80.00"),
             channel_slug=payment.order.channel.slug,
         )

--- a/saleor/payment/gateways/dummy_credit_card/tests/test_dummy_credit_card.py
+++ b/saleor/payment/gateways/dummy_credit_card/tests/test_dummy_credit_card.py
@@ -38,7 +38,7 @@ def test_authorize_success(payment_dummy_credit_card):
     txn = gateway.authorize(
         payment=payment_dummy_credit_card,
         token="Fake",
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         channel_slug=payment_dummy_credit_card.order.channel.slug,
     )
     assert txn.is_success
@@ -71,7 +71,7 @@ def test_authorize_failed(is_active, charge_status, error, payment_dummy_credit_
         gateway.authorize(
             payment=payment,
             token="Fake",
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             channel_slug=payment_dummy_credit_card.order.channel.slug,
         )
 
@@ -86,7 +86,7 @@ def test_authorize_gateway_error(payment_dummy_credit_card, monkeypatch):
         gateway.authorize(
             payment=payment_dummy_credit_card,
             token="Fake",
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             channel_slug=payment_dummy_credit_card.order.channel.slug,
         )
 
@@ -119,7 +119,7 @@ def test_void_success(payment_txn_preauth):
     assert payment_txn_preauth.charge_status == ChargeStatus.NOT_CHARGED
     txn = gateway.void(
         payment=payment_txn_preauth,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         channel_slug=payment_txn_preauth.order.channel.slug,
     )
     assert txn.is_success
@@ -147,7 +147,7 @@ def test_void_failed(is_active, charge_status, error, payment_dummy_credit_card)
     with pytest.raises(PaymentError) as e:
         gateway.void(
             payment=payment,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             channel_slug=payment.order.channel.slug,
         )
 
@@ -164,7 +164,7 @@ def test_void_gateway_error(payment_txn_preauth, monkeypatch):
     with pytest.raises(PaymentError) as e:
         gateway.void(
             payment=payment_txn_preauth,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             channel_slug=payment_txn_preauth.order.channel.slug,
         )
 
@@ -203,7 +203,7 @@ def test_capture_success(amount, charge_status, token, payment_txn_preauth):
 
     txn = gateway.capture(
         payment=payment_txn_preauth,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         amount=Decimal(amount),
         channel_slug=payment_txn_preauth.order.channel.slug,
     )
@@ -236,7 +236,7 @@ def test_capture_failed(
     with pytest.raises(PaymentError) as e:
         gateway.capture(
             payment=payment,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             amount=amount,
             channel_slug=payment.order.channel.slug,
         )
@@ -258,7 +258,7 @@ def test_capture_error_in_response(token, error, payment_txn_preauth):
     with pytest.raises(PaymentError) as e:
         gateway.capture(
             payment=payment_txn_preauth,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             channel_slug=payment_txn_preauth.order.channel.slug,
         )
 
@@ -309,7 +309,7 @@ def test_refund_success(
     payment.save()
     txn = gateway.refund(
         payment=payment,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         amount=Decimal(refund_amount),
         channel_slug=payment.order.channel.slug,
     )
@@ -347,7 +347,7 @@ def test_refund_failed(
     with pytest.raises(PaymentError) as e:
         gateway.refund(
             payment=payment,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             amount=Decimal(refund_amount),
             channel_slug=payment.order.channel.slug,
         )
@@ -367,7 +367,7 @@ def test_refund_gateway_error(payment_txn_captured, monkeypatch):
     with pytest.raises(PaymentError):
         gateway.refund(
             payment=payment,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             amount=Decimal("80.00"),
             channel_slug=payment.order.channel.slug,
         )
@@ -387,7 +387,7 @@ def test_process_payment_success(token, payment_dummy_credit_card):
     txn = gateway.process_payment(
         payment=payment_dummy_credit_card,
         token=token,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         channel_slug=payment_dummy_credit_card.order.channel.slug,
     )
 
@@ -407,7 +407,7 @@ def test_process_payment_failed(token, error, payment_dummy_credit_card):
         gateway.process_payment(
             payment=payment_dummy_credit_card,
             token=token,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             channel_slug=payment_dummy_credit_card.order.channel.slug,
         )
 
@@ -445,7 +445,7 @@ def test_process_payment_pre_authorized(
     txn = gateway.process_payment(
         payment=payment_dummy_credit_card,
         token=token,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         channel_slug=payment_dummy_credit_card.order.channel.slug,
     )
 
@@ -474,7 +474,7 @@ def test_process_payment_pre_authorized_and_capture(
     txn = gateway.process_payment(
         payment=payment_dummy_credit_card,
         token=token,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         channel_slug=payment_dummy_credit_card.order.channel.slug,
     )
 
@@ -504,7 +504,7 @@ def test_process_payment_pre_authorized_and_capture_error(
         gateway.process_payment(
             payment=payment_dummy_credit_card,
             token=token,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             channel_slug=payment_dummy_credit_card.order.channel.slug,
         )
 

--- a/saleor/payment/gateways/np_atobarai/tests/conftest.py
+++ b/saleor/payment/gateways/np_atobarai/tests/conftest.py
@@ -56,7 +56,7 @@ def np_atobarai_plugin(settings, monkeypatch, channel_USD):
             configuration=configuration,
         )
 
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         return manager.plugins_per_channel[channel_USD.slug][0]
 
     return fun
@@ -164,7 +164,7 @@ def create_refund(payment_dummy):
                 payment=payment_dummy,
                 order_lines_to_refund=order_lines or [],
                 fulfillment_lines_to_refund=fulfillment_lines or [],
-                manager=get_plugins_manager(),
+                manager=get_plugins_manager(allow_replica=False),
                 amount=manual_refund_amount,
                 refund_shipping_costs=refund_shipping_costs,
             )

--- a/saleor/payment/gateways/stripe/tests/conftest.py
+++ b/saleor/payment/gateways/stripe/tests/conftest.py
@@ -19,7 +19,7 @@ def payment_stripe_for_checkout(checkout_with_items, address, shipping_method):
     checkout_with_items.shipping_method = shipping_method
     checkout_with_items.email = "test@example.com"
     checkout_with_items.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_items)
     checkout_info = fetch_checkout_info(checkout_with_items, lines, manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
@@ -109,7 +109,7 @@ def stripe_plugin(settings, monkeypatch, channel_USD):
             configuration=configuration,
         )
 
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         return manager.plugins_per_channel[channel_USD.slug][0]
 
     return fun

--- a/saleor/payment/gateways/stripe/tests/test_webhooks.py
+++ b/saleor/payment/gateways/stripe/tests/test_webhooks.py
@@ -1529,7 +1529,7 @@ def test_handle_successful_payment_intent_for_checkout_when_already_processing_c
 ):
     # given
     plugin = stripe_plugin()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     payment = payment_stripe_for_checkout
     payment.to_confirm = True
     payment.save()

--- a/saleor/payment/gateways/stripe/webhooks.py
+++ b/saleor/payment/gateways/stripe/webhooks.py
@@ -183,7 +183,7 @@ def _finalize_checkout(
         payment.refresh_from_db()
         checkout.refresh_from_db()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, unavailable_variant_pks = fetch_checkout_lines(checkout)
     if unavailable_variant_pks:
         payment_refund_or_void(payment, manager, checkout.channel.slug)
@@ -329,7 +329,7 @@ def handle_authorized_payment_intent(
             payment_intent.amount,
             payment_intent.currency,
         )
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         try_void_or_refund_inactive_payment(payment, transaction, manager)
         return
 
@@ -380,7 +380,9 @@ def handle_failed_payment_intent(
     )
 
     if payment.order:
-        order_voided(payment.order, None, None, payment, get_plugins_manager())
+        order_voided(
+            payment.order, None, None, payment, get_plugins_manager(allow_replica=False)
+        )
 
 
 def handle_processing_payment_intent(
@@ -457,7 +459,9 @@ def handle_successful_payment_intent(
             payment_intent.amount_received,
             payment_intent.currency,
         )
-        try_void_or_refund_inactive_payment(payment, transaction, get_plugins_manager())
+        try_void_or_refund_inactive_payment(
+            payment, transaction, get_plugins_manager(allow_replica=False)
+        )
         return
 
     if payment.order:
@@ -476,7 +480,7 @@ def handle_successful_payment_intent(
                 None,
                 capture_transaction.amount,
                 payment,
-                get_plugins_manager(),
+                get_plugins_manager(allow_replica=False),
             )
         return
 
@@ -538,5 +542,5 @@ def handle_refund(
             None,
             refund_transaction.amount,
             payment,
-            get_plugins_manager(),
+            get_plugins_manager(allow_replica=False),
         )

--- a/saleor/payment/tasks.py
+++ b/saleor/payment/tasks.py
@@ -108,7 +108,7 @@ def transaction_release_funds_for_checkout_task():
                 [event for _tr, event in transactions_with_cancel_request_events]
                 + [event for _tr, event in transactions_with_charge_request_events]
             )
-            manager = get_plugins_manager()
+            manager = get_plugins_manager(allow_replica=False)
             for transaction, event in transactions_with_cancel_request_events:
                 channel_slug = channel_map[transaction.channel_id].slug
                 try:

--- a/saleor/payment/tests/test_gateway.py
+++ b/saleor/payment/tests/test_gateway.py
@@ -206,7 +206,7 @@ def test_refund_for_manual_payment(payment_txn_captured):
     payment_txn_captured.gateway = CustomPaymentChoices.MANUAL
     transaction = gateway.refund(
         payment=payment_txn_captured,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         amount=PARTIAL_REFUND_AMOUNT,
         channel_slug=payment_txn_captured.order.channel.slug,
     )
@@ -359,7 +359,7 @@ def test_request_charge_action_missing_active_event(
     with pytest.raises(PaymentError):
         request_charge_action(
             transaction=transaction,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             charge_value=action_value,
             channel_slug=order.channel.slug,
             user=staff_user,
@@ -405,7 +405,7 @@ def test_request_charge_action_on_order(
     # when
     request_charge_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         charge_value=action_value,
         channel_slug=order.channel.slug,
         user=staff_user,
@@ -469,7 +469,7 @@ def test_request_charge_action_by_app(
     # when
     request_charge_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         charge_value=action_value,
         channel_slug=order.channel.slug,
         user=None,
@@ -523,7 +523,7 @@ def test_request_action_by_removed_app(mocked_transaction_request, order, remove
     with pytest.raises(PaymentError):
         request_charge_action(
             transaction=transaction,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             charge_value=action_value,
             channel_slug=order.channel.slug,
             user=None,
@@ -560,7 +560,7 @@ def test_request_action_by_disabled_app(mocked_transaction_request, order, app):
     with pytest.raises(PaymentError):
         request_charge_action(
             transaction=transaction,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             charge_value=action_value,
             channel_slug=order.channel.slug,
             user=None,
@@ -614,7 +614,7 @@ def test_request_action_by_removed_app_and_second_active(
     # when
     request_charge_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         charge_value=action_value,
         channel_slug=order.channel.slug,
         user=None,
@@ -676,7 +676,7 @@ def test_request_action_by_disabled_app_and_second_active(
     # when
     request_charge_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         charge_value=action_value,
         channel_slug=order.channel.slug,
         user=None,
@@ -734,7 +734,7 @@ def test_request_charge_action_on_checkout(
     # when
     request_charge_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         charge_value=action_value,
         channel_slug=checkout.channel.slug,
         user=staff_user,
@@ -781,7 +781,7 @@ def test_request_refund_action_missing_active_event(
     with pytest.raises(PaymentError):
         request_refund_action(
             transaction=transaction,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             refund_value=action_value,
             channel_slug=order.channel.slug,
             user=staff_user,
@@ -812,7 +812,7 @@ def test_request_refund_action_updates_refundable_for_checkout(
     with pytest.raises(PaymentError):
         request_refund_action(
             transaction=transaction,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             refund_value=action_value,
             channel_slug=checkout.channel.slug,
             user=staff_user,
@@ -864,7 +864,7 @@ def test_request_refund_action_on_order(
     # when
     request_refund_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         refund_value=action_value,
         channel_slug=order.channel.slug,
         user=staff_user,
@@ -938,7 +938,7 @@ def test_request_refund_action_with_granted_refund(
     # when
     request_refund_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         refund_value=action_value,
         channel_slug=order_with_lines.channel.slug,
         user=staff_user,
@@ -1005,7 +1005,7 @@ def test_request_refund_action_by_app(
     # when
     request_refund_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         refund_value=action_value,
         channel_slug=order.channel.slug,
         user=None,
@@ -1071,7 +1071,7 @@ def test_request_refund_action_on_checkout(
     # when
     request_refund_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         refund_value=action_value,
         channel_slug=checkout.channel.slug,
         user=staff_user,
@@ -1117,7 +1117,7 @@ def test_request_cancelation_action_missing_active_event(
     with pytest.raises(PaymentError):
         request_cancelation_action(
             transaction=transaction,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             cancel_value=None,
             channel_slug=order.channel.slug,
             user=staff_user,
@@ -1149,7 +1149,7 @@ def test_request_cancel_action_updates_refundable_for_checkout(
     with pytest.raises(PaymentError):
         request_cancelation_action(
             transaction=transaction,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             cancel_value=None,
             channel_slug=checkout.channel.slug,
             user=staff_user,
@@ -1202,7 +1202,7 @@ def test_request_cancelation_action_on_order(
     # when
     request_cancelation_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         cancel_value=None,
         channel_slug=order.channel.slug,
         user=staff_user,
@@ -1266,7 +1266,7 @@ def test_request_cancelation_action_by_app(
     # when
     request_cancelation_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         cancel_value=None,
         channel_slug=order.channel.slug,
         user=None,
@@ -1332,7 +1332,7 @@ def test_request_cancelation_action_on_checkout(
     # when
     request_cancelation_action(
         transaction=transaction,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         cancel_value=None,
         channel_slug=checkout.channel.slug,
         user=staff_user,
@@ -1360,7 +1360,7 @@ def test_request_cancelation_action_on_checkout(
 def test_payment_refund_or_void_no_payment(refund_mock, void_mock):
     """Test that neither refund nor void is called when there is no payment object."""
     # when
-    gateway.payment_refund_or_void(None, get_plugins_manager(), None)
+    gateway.payment_refund_or_void(None, get_plugins_manager(allow_replica=False), None)
 
     # then
     refund_mock.assert_not_called()
@@ -1376,7 +1376,9 @@ def test_payment_refund_or_void_refund_called(refund_mock, payment):
     payment.save(update_fields=["charge_status"])
 
     # when
-    gateway.payment_refund_or_void(payment, get_plugins_manager(), None)
+    gateway.payment_refund_or_void(
+        payment, get_plugins_manager(allow_replica=False), None
+    )
 
     # then
     assert refund_mock.called_once()
@@ -1404,7 +1406,9 @@ def test_payment_refund_or_void_refund_not_called_refund_already_started(
     )
 
     # when
-    gateway.payment_refund_or_void(payment, get_plugins_manager(), None)
+    gateway.payment_refund_or_void(
+        payment, get_plugins_manager(allow_replica=False), None
+    )
 
     # then
     refund_mock.assert_not_called()
@@ -1431,7 +1435,10 @@ def test_payment_refund_or_void_refund_called_txn_exist(refund_mock, payment):
 
     # when
     gateway.payment_refund_or_void(
-        payment, get_plugins_manager(), None, transaction_id=txn.token
+        payment,
+        get_plugins_manager(allow_replica=False),
+        None,
+        transaction_id=txn.token,
     )
 
     # then
@@ -1461,7 +1468,10 @@ def test_payment_refund_or_void_refund_called_no_txn_with_given_transaction_id(
 
     # when
     gateway.payment_refund_or_void(
-        payment, get_plugins_manager(), None, transaction_id="another value"
+        payment,
+        get_plugins_manager(allow_replica=False),
+        None,
+        transaction_id="another value",
     )
 
     # then
@@ -1477,7 +1487,9 @@ def test_payment_refund_or_void_void_called(void_mock, payment):
     payment.transactions.count() == 0
 
     # when
-    gateway.payment_refund_or_void(payment, get_plugins_manager(), None)
+    gateway.payment_refund_or_void(
+        payment, get_plugins_manager(allow_replica=False), None
+    )
 
     # then
     assert void_mock.called_once()
@@ -1503,7 +1515,10 @@ def test_payment_refund_or_void_void_not_called_txn_exist(void_mock, payment):
 
     # when
     gateway.payment_refund_or_void(
-        payment, get_plugins_manager(), None, transaction_id=txn.token
+        payment,
+        get_plugins_manager(allow_replica=False),
+        None,
+        transaction_id=txn.token,
     )
 
     # then

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -116,7 +116,7 @@ def test_create_payment(checkout_with_item, address):
     checkout_with_item.billing_address = address
     checkout_with_item.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     total = checkout_total(
@@ -157,7 +157,7 @@ def test_create_payment_from_checkout_requires_billing_address(checkout_with_ite
     checkout_with_item.billing_address = None
     checkout_with_item.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     total = checkout_total(
@@ -199,7 +199,7 @@ def test_create_payment_information_for_checkout_payment(address, checkout_with_
     checkout_with_item.shipping_address = address
     checkout_with_item.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     total = checkout_total(
@@ -335,7 +335,7 @@ def test_create_payment_information_store(checkout_with_item, address, store):
     checkout_with_item.shipping_address = address
     checkout_with_item.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     total = checkout_total(
@@ -370,7 +370,7 @@ def test_create_payment_information_metadata(checkout_with_item, address, metada
     checkout_with_item.shipping_address = address
     checkout_with_item.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     total = checkout_total(
@@ -441,7 +441,7 @@ def test_gateway_charge_failed(
     dummy_response.kind = TransactionKind.CAPTURE
     mock_capture_payment.return_value = dummy_response
     with pytest.raises(PaymentError):
-        gateway.capture(payment, get_plugins_manager(), amount)
+        gateway.capture(payment, get_plugins_manager(allow_replica=False), amount)
     mock_capture_payment.assert_called_once()
     payment.refresh_from_db()
     assert payment.charge_status == ChargeStatus.NOT_CHARGED
@@ -454,13 +454,13 @@ def test_gateway_charge_errors(payment_dummy, transaction_token, settings):
     gateway.authorize(
         payment,
         transaction_token,
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
         channel_slug=payment_dummy.order.channel.slug,
     )
     with pytest.raises(PaymentError) as exc:
         gateway.capture(
             payment,
-            get_plugins_manager(),
+            get_plugins_manager(allow_replica=False),
             amount=Decimal("0"),
             channel_slug=payment_dummy.order.channel.slug,
         )
@@ -471,7 +471,7 @@ def test_gateway_charge_errors(payment_dummy, transaction_token, settings):
     with pytest.raises(PaymentError) as exc:
         gateway.capture(
             payment,
-            get_plugins_manager(),
+            get_plugins_manager(allow_replica=False),
             amount=Decimal("10"),
             channel_slug=payment_dummy.order.channel.slug,
         )
@@ -482,7 +482,7 @@ def test_gateway_charge_errors(payment_dummy, transaction_token, settings):
     with pytest.raises(PaymentError) as exc:
         gateway.capture(
             payment,
-            get_plugins_manager(),
+            get_plugins_manager(allow_replica=False),
             amount=Decimal("1000000"),
             channel_slug=payment_dummy.order.channel.slug,
         )
@@ -494,7 +494,7 @@ def test_gateway_refund_errors(payment_txn_captured):
     with pytest.raises(PaymentError) as exc:
         gateway.refund(
             payment,
-            get_plugins_manager(),
+            get_plugins_manager(allow_replica=False),
             amount=Decimal("1000000"),
             channel_slug=payment_txn_captured.order.channel.slug,
         )
@@ -503,7 +503,7 @@ def test_gateway_refund_errors(payment_txn_captured):
     with pytest.raises(PaymentError) as exc:
         gateway.refund(
             payment,
-            get_plugins_manager(),
+            get_plugins_manager(allow_replica=False),
             amount=Decimal("0"),
             channel_slug=payment_txn_captured.order.channel.slug,
         )
@@ -514,7 +514,7 @@ def test_gateway_refund_errors(payment_txn_captured):
     with pytest.raises(PaymentError) as exc:
         gateway.refund(
             payment,
-            get_plugins_manager(),
+            get_plugins_manager(allow_replica=False),
             amount=Decimal("1"),
             channel_slug=payment_txn_captured.order.channel.slug,
         )
@@ -687,7 +687,7 @@ def test_is_currency_supported(
     currency, exp_response, dummy_gateway_config, monkeypatch, channel_USD
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     dummy_gateway_config.supported_currencies = "USD, EUR"
     monkeypatch.setattr(
         "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin._get_gateway_config",

--- a/saleor/payment/tests/test_utils.py
+++ b/saleor/payment/tests/test_utils.py
@@ -35,7 +35,7 @@ from ..utils import (
 
 def test_create_payment_lines_information_order(payment_dummy):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     payment_lines_data = create_payment_lines_information(payment_dummy, manager)
@@ -61,7 +61,7 @@ def test_create_payment_lines_information_order_with_voucher(payment_dummy):
     voucher_amount = Decimal("12.30")
     order = payment_dummy.order
     order.undiscounted_total_gross_amount += voucher_amount
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     payment_lines_data = create_payment_lines_information(payment_dummy, manager)
@@ -120,7 +120,7 @@ def get_expected_checkout_payment_lines(manager, checkout_info, lines, address):
 
 def test_create_payment_lines_information_checkout(payment_dummy, checkout_with_items):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     payment_dummy.order = None
     payment_dummy.checkout = checkout_with_items
 
@@ -142,7 +142,7 @@ def test_create_payment_lines_information_checkout_with_voucher(
     payment_dummy, checkout_with_items
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     voucher_amount = Decimal("12.30")
     payment_dummy.order = None
     checkout_with_items.discount_amount = voucher_amount
@@ -166,7 +166,7 @@ def test_create_payment_lines_information_checkout_with_voucher(
 
 def test_create_payment_lines_information_invalid_payment(payment_dummy):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     payment_dummy.order = None
 
     # when

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -312,7 +312,7 @@ def create_payment_information(
         refund_data=refund_data,
         transactions=generate_transactions_data(payment),
         _resolve_lines_data=lambda: create_payment_lines_information(
-            payment, manager or get_plugins_manager()
+            payment, manager or get_plugins_manager(allow_replica=False)
         ),
     )
 
@@ -1340,7 +1340,7 @@ def create_transaction_event_from_request_and_webhook_response(
         # circular import
         from ..order.actions import order_transaction_updated
 
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         order = cast(Order, transaction_item.order)
         order_info = fetch_order_info(order)
         update_order_with_transaction_details(transaction_item)
@@ -1355,7 +1355,7 @@ def create_transaction_event_from_request_and_webhook_response(
             previous_refunded_value=previous_refunded_value,
         )
     elif transaction_item.checkout_id:
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=True)
         recalculate_refundable_for_checkout(transaction_item, request_event, event)
         transaction_amounts_for_checkout_updated(transaction_item, manager)
     return event

--- a/saleor/plugins/admin_email/tests/conftest.py
+++ b/saleor/plugins/admin_email/tests/conftest.py
@@ -61,7 +61,7 @@ def admin_email_plugin(settings):
         staff_password_reset_subject=STAFF_PASSWORD_RESET_DEFAULT_SUBJECT,
     ):
         settings.PLUGINS = ["saleor.plugins.admin_email.plugin.AdminEmailPlugin"]
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         with patch(
             "saleor.plugins.admin_email.plugin.validate_default_email_configuration"
         ):
@@ -122,7 +122,7 @@ def admin_email_plugin(settings):
                     ],
                 },
             )
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         return manager.global_plugins[0]
 
     return fun

--- a/saleor/plugins/admin_email/tests/test_plugin.py
+++ b/saleor/plugins/admin_email/tests/test_plugin.py
@@ -280,7 +280,7 @@ def test_plugin_manager_doesnt_load_email_templates_from_db(
     admin_email_plugin, admin_email_template, settings
 ):
     settings.PLUGINS = ["saleor.plugins.admin_email.plugin.AdminEmailPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.all_plugins[0]
 
     email_config_item = None

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -92,7 +92,7 @@ def test_calculate_checkout_line_total(
     plugin_configuration,
 ):
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_with_item.shipping_address = ship_to_pl_address
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
@@ -147,7 +147,7 @@ def test_calculate_checkout_line_total_with_promotion(
 ):
     # given
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout = checkout_with_item_on_promotion
     checkout.shipping_address = ship_to_pl_address
@@ -204,7 +204,7 @@ def test_calculate_checkout_line_total_with_variant_on_promotion(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     checkout.shipping_address = address
@@ -267,7 +267,7 @@ def test_calculate_checkout_line_total_with_voucher(
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     checkout.shipping_address = address
@@ -327,7 +327,7 @@ def test_calculate_checkout_line_total_with_voucher_once_per_order(
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     checkout.shipping_address = address
@@ -386,7 +386,7 @@ def test_calculate_checkout_line_total_with_variant_on_promotion_and_voucher(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     checkout.shipping_address = address
@@ -446,7 +446,7 @@ def test_calculate_checkout_line_total_with_variant_on_promotion_and_voucher_onl
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     checkout.shipping_address = address
@@ -500,7 +500,7 @@ def test_calculate_checkout_line_without_sku_total(
     )
 
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_with_item.shipping_address = ship_to_pl_address
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
@@ -561,7 +561,7 @@ def test_calculate_checkout_line_without_sku_total_with_promotion(
     )
 
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout = checkout_with_item_on_promotion
     checkout.shipping_address = ship_to_pl_address
@@ -613,7 +613,7 @@ def test_calculate_order_line_total(
     plugin_configuration,
 ):
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     order = order_line.order
 
@@ -682,7 +682,7 @@ def test_calculate_order_line_without_sku_total(
     )
 
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     site_settings.company_address = address
     site_settings.save(update_fields=["company_address"])
@@ -740,7 +740,7 @@ def test_calculate_order_line_total_with_discount(
 ):
     # given
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     site_settings.company_address = address
     site_settings.save(update_fields=["company_address"])
@@ -820,7 +820,7 @@ def test_calculate_order_line_total_entire_order_voucher(
 ):
     # given
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     order = order_line.order
     channel = order.channel
@@ -912,7 +912,7 @@ def test_calculate_order_line_total_shipping_voucher(
 ):
     # given
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     order = order_line.order
     channel = order_line.order.channel
@@ -991,7 +991,7 @@ def test_calculate_order_line_total_order_not_valid(
     plugin_configuration,
 ):
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     site_settings.company_address = address
     site_settings.save(update_fields=["company_address"])
@@ -1041,7 +1041,7 @@ def test_calculate_order_shipping_order_not_valid(
 ):
     # given
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     site_settings.company_address = address
     site_settings.save(update_fields=["company_address"])
@@ -1111,7 +1111,7 @@ def test_calculate_checkout_total_uses_default_calculation(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_with_item.shipping_address = ship_to_pl_address
     checkout_with_item.save()
 
@@ -1178,7 +1178,7 @@ def test_calculate_checkout_total_uses_default_calculation_with_promotion(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item_on_promotion
     checkout.shipping_address = ship_to_pl_address
     checkout.save()
@@ -1251,7 +1251,7 @@ def test_calculate_checkout_total(
     monkeypatch.setattr(
         "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_with_item.shipping_address = ship_to_pl_address
     checkout_with_item.save()
 
@@ -1326,7 +1326,7 @@ def test_calculate_checkout_total_with_promotion(
     monkeypatch.setattr(
         "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item_on_promotion
     checkout.shipping_address = ship_to_pl_address
     checkout.save()
@@ -1404,7 +1404,7 @@ def test_calculate_checkout_total_for_JPY(
     monkeypatch.setattr(
         "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout.shipping_address = ship_to_pl_address
     checkout.save()
 
@@ -1477,7 +1477,7 @@ def test_calculate_checkout_total_for_JPY_with_promotion(
     monkeypatch.setattr(
         "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout.shipping_address = ship_to_pl_address
     checkout.save()
 
@@ -1586,7 +1586,7 @@ def test_calculate_checkout_total_voucher_on_entire_order(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     channel = checkout_with_item.channel
 
     tax_configuration = channel.tax_configuration
@@ -1640,7 +1640,7 @@ def test_calculate_checkout_total_voucher_on_entire_order_applied_once_per_order
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     site_settings.company_address = address
     site_settings.save()
 
@@ -1707,7 +1707,7 @@ def test_calculate_checkout_total_voucher_on_entire_order_product_without_taxes(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     channel = checkout_with_item.channel
 
     tax_configuration = channel.tax_configuration
@@ -1775,7 +1775,7 @@ def test_calculate_checkout_total_voucher_on_shipping(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     channel = checkout_with_item.channel
 
     tax_configuration = channel.tax_configuration
@@ -1822,7 +1822,7 @@ def test_calculate_checkout_total_not_charged_product_and_shipping_with_0_price(
     monkeypatch.setattr(
         "saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin", lambda *_: False
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_with_item.shipping_address = ship_to_pl_address
     checkout_with_item.save()
     channel = checkout_with_item.channel
@@ -1878,7 +1878,7 @@ def test_calculate_checkout_shipping(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     site_settings.company_address = address
     site_settings.save()
 
@@ -1926,7 +1926,7 @@ def test_calculate_checkout_subtotal(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     tax_configuration = checkout_with_item.channel.tax_configuration
     tax_configuration.prices_entered_with_tax = prices_entered_with_tax
@@ -1976,7 +1976,7 @@ def test_calculate_checkout_subtotal_with_promotion(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout = checkout_with_item_on_promotion
     tax_configuration = checkout.channel.tax_configuration
@@ -2034,7 +2034,7 @@ def test_calculate_checkout_subtotal_for_product_without_tax(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     tax_configuration = checkout.channel.tax_configuration
     tax_configuration.prices_entered_with_tax = True
@@ -2092,7 +2092,7 @@ def test_calculate_checkout_subtotal_voucher_on_entire_order(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     channel = checkout_with_item.channel
 
     tax_configuration = channel.tax_configuration
@@ -2149,7 +2149,7 @@ def test_calculate_checkout_subtotal_voucher_on_shipping(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     channel = checkout_with_item.channel
 
     tax_configuration = channel.tax_configuration
@@ -2185,7 +2185,7 @@ def test_calculate_order_shipping(
     order_line, shipping_zone, site_settings, address, plugin_configuration
 ):
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order = order_line.order
     method = shipping_zone.shipping_methods.get()
     order.shipping_address = order.billing_address.get_copy()
@@ -2206,7 +2206,7 @@ def test_calculate_order_total(
     order_line, shipping_zone, site_settings, address, plugin_configuration
 ):
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order = order_line.order
     method = shipping_zone.shipping_methods.get()
     order.shipping_address = order.billing_address.get_copy()
@@ -2233,7 +2233,7 @@ def test_calculate_order_total_for_JPY(
 ):
     # given
     plugin_configuration(channel=channel_JPY)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order = order_line_JPY.order
     method = shipping_zone_JPY.shipping_methods.get()
     order.shipping_address = order.billing_address.get_copy()
@@ -2258,7 +2258,7 @@ def test_calculate_order_shipping_entire_order_voucher(
 ):
     # given
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     variant = order_line.variant
     channel = order_line.order.channel
@@ -2310,7 +2310,7 @@ def test_calculate_order_shipping_free_shipping_voucher(
 ):
     # given
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     variant = order_line.variant
     channel = order_line.order.channel
@@ -2369,7 +2369,7 @@ def test_calculate_order_shipping_voucher_on_shipping(
 ):
     # given
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     variant = order_line.variant
     channel = order_line.order.channel
@@ -2421,7 +2421,7 @@ def test_calculate_order_shipping_zero_shipping_amount(
     order_line, shipping_zone, site_settings, address, plugin_configuration
 ):
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order = order_line.order
     method = shipping_zone.shipping_methods.get()
     order.shipping_address = order.billing_address.get_copy()
@@ -2446,7 +2446,7 @@ def test_calculate_order_shipping_base_shipping_price_0(
     order_line, shipping_zone, site_settings, address, plugin_configuration
 ):
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order = order_line.order
     method = shipping_zone.shipping_methods.get()
     order.shipping_address = order.billing_address.get_copy()
@@ -2471,7 +2471,7 @@ def test_calculate_order_shipping_not_shippable_order(
 ):
     # given
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     order_line.is_shipping_required = False
     order_line.save(update_fields=["is_shipping_required"])
@@ -2501,7 +2501,7 @@ def test_calculate_order_line_unit(
     plugin_configuration,
 ):
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order_line.unit_price = TaxedMoney(
         net=Money("10.00", "USD"), gross=Money("10.00", "USD")
     )
@@ -2543,7 +2543,7 @@ def test_calculate_order_line_unit_in_JPY(
     plugin_configuration,
 ):
     plugin_configuration(channel=channel_JPY)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # Net price from `test_calculate_checkout_line_unit_price_in_JPY`
     order_line_JPY.unit_price = TaxedMoney(
@@ -2586,7 +2586,7 @@ def test_calculate_order_line_unit_with_discount(
 ):
     # given
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     unit_price = TaxedMoney(net=Money("10.00", "USD"), gross=Money("10.00", "USD"))
     order_line.unit_price = unit_price
     order_line.base_unit_price = unit_price.gross
@@ -2636,7 +2636,7 @@ def test_calculate_checkout_line_unit_price(
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     checkout.shipping_address = address
@@ -2684,7 +2684,7 @@ def test_calculate_checkout_line_unit_price_in_JPY(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone_JPY.shipping_methods.get()
     checkout.shipping_address = ship_to_pl_address
@@ -2722,7 +2722,7 @@ def test_calculate_checkout_line_unit_price_with_variant_on_promotion(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     checkout.shipping_address = address
@@ -2781,7 +2781,7 @@ def test_calculate_checkout_line_unit_price_with_voucher(
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     checkout.shipping_address = address
@@ -2841,7 +2841,7 @@ def test_calculate_checkout_line_unit_price_with_voucher_once_per_order(
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_line_info = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     checkout.shipping_address = address
@@ -2901,7 +2901,7 @@ def test_calculate_checkout_line_unit_price_with_variant_on_promotion_and_vouche
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     checkout.shipping_address = address
@@ -2961,7 +2961,7 @@ def test_calculate_checkout_line_unit_price_variant_on_promotion_and_voucher_onl
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     checkout.shipping_address = address
@@ -3008,7 +3008,7 @@ def test_preprocess_order_creation(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     site_settings.company_address = address
     site_settings.save()
 
@@ -3040,7 +3040,7 @@ def test_preprocess_order_creation_no_lines_data(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     site_settings.company_address = address
     site_settings.save()
 
@@ -3069,7 +3069,7 @@ def test_preprocess_order_creation_wrong_data(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_with_item.shipping_address = address
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
@@ -3100,7 +3100,7 @@ def test_preprocess_order_creation_shipping_voucher_no_tax_class_on_delivery_met
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"PC040156": "desc"},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     site_settings.company_address = address
     site_settings.save()
 
@@ -3159,7 +3159,7 @@ def test_checkout_needs_new_fetch(checkout_with_item, address, shipping_method):
         from_postal_code="53-601",
         from_country="PL",
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     checkout_data = generate_request_data_from_checkout(checkout_info, lines, config)
@@ -3190,7 +3190,7 @@ def test_generate_request_data_from_checkout_for_cc(
         from_postal_code="53-601",
         from_country="PL",
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
 
@@ -3235,7 +3235,7 @@ def test_generate_request_data_from_checkout_for_cc_and_single_location(
     avatax_config.from_postal_code = address_data.get("postal_code")
     avatax_config.from_country = address_data.get("country")
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
 
@@ -3290,7 +3290,7 @@ def test_get_checkout_tax_data_with_single_point(
     checkout_with_item.collection_point = warehouse
     checkout_with_item.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
 
@@ -3317,7 +3317,7 @@ def test_taxes_need_new_fetch_uses_cached_data(checkout_with_item, address):
         from_postal_code="53-601",
         from_country="PL",
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     checkout_data = generate_request_data_from_checkout(checkout_info, lines, config)
@@ -3344,7 +3344,7 @@ def test_get_checkout_line_tax_rate(
     )
     unit_price = TaxedMoney(Money(12, "USD"), Money(14, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_with_item.shipping_address = address
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
@@ -3404,7 +3404,7 @@ def test_get_checkout_line_tax_rate_for_product_with_charge_taxes_set_to_false(
     )
     unit_price = TaxedMoney(Money(12, "USD"), Money(12, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     tax_configuration = checkout_with_item.channel.tax_configuration
     tax_configuration.prices_entered_with_tax = False
@@ -3473,7 +3473,7 @@ def test_get_checkout_line_tax_rate_for_product_type_with_non_taxable_product(
     )
     unit_price = TaxedMoney(Money(12, "USD"), Money(12, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     product_type = ProductType.objects.create(
         name="non-taxable", kind=ProductTypeKind.NORMAL, tax_class=tax_class_zero_rates
@@ -3540,7 +3540,7 @@ def test_get_checkout_line_tax_rate_checkout_no_shipping_method_default_value_re
     plugin_configuration()
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_with_item.shipping_address = address
     checkout_with_item.save(update_fields=["shipping_address"])
@@ -3574,7 +3574,7 @@ def test_get_checkout_line_tax_rate_error_in_response(
     )
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_with_item.shipping_address = address
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
@@ -3614,7 +3614,7 @@ def test_get_order_line_tax_rate(
 
     unit_price = TaxedMoney(Money(12, "USD"), Money(14, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     product = Product.objects.get(name=order_line.product_name)
 
@@ -3645,7 +3645,7 @@ def test_get_order_line_tax_rate_order_not_valid_default_value_returned(
     plugin_configuration()
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     product = Product.objects.get(name=order_line.product_name)
 
@@ -3675,7 +3675,7 @@ def test_get_order_line_tax_rate_error_in_response(
     )
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     product = Product.objects.get(name=order_line.product_name)
 
@@ -3708,7 +3708,7 @@ def test_get_checkout_shipping_tax_rate(
     plugin_configuration()
     shipping_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_with_item.shipping_address = address
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
@@ -3733,7 +3733,7 @@ def test_get_checkout_shipping_tax_rate(
 def test__get_shipping_tax_rate_handles_multiple_tax_districts(
     avalara_response_for_checkout_with_items_and_shipping, channel_USD
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
 
     # 0.46 == sum of two tax districts
@@ -3746,7 +3746,7 @@ def test__get_shipping_tax_rate_handles_multiple_tax_districts(
 def test__get_unit_tax_rate_handles_multiple_tax_districts(
     avalara_response_for_checkout_with_items_and_shipping, channel_USD
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
 
     # 0.36 == sum of two tax districts
@@ -3763,7 +3763,7 @@ def test_get_checkout_shipping_tax_rate_checkout_not_valid_default_value_returne
     plugin_configuration()
     shipping_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_with_item.shipping_address = address
     checkout_with_item.save(update_fields=["shipping_address"])
@@ -3795,7 +3795,7 @@ def test_get_checkout_shipping_tax_rate_error_in_response(
     )
     shipping_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_with_item.shipping_address = address
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
@@ -3828,7 +3828,7 @@ def test_get_checkout_shipping_tax_rate_skip_plugin(
     )
     shipping_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     checkout_with_item.shipping_address = address
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
@@ -3861,7 +3861,7 @@ def test_get_order_shipping_tax_rate(
     plugin_configuration()
     shipping_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     order.shipping_address = order.billing_address.get_copy()
@@ -3887,7 +3887,7 @@ def test_get_order_shipping_tax_rate_shipping_with_tax_class(
     plugin_configuration()
     shipping_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     order.shipping_address = order.billing_address.get_copy()
@@ -3914,7 +3914,7 @@ def test_get_order_shipping_tax_rate_order_not_valid_default_value_returned(
     plugin_configuration()
     shipping_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     tax_rate = manager.get_order_shipping_tax_rate(order, shipping_price)
@@ -3936,7 +3936,7 @@ def test_get_order_shipping_tax_rate_error_in_response(
     )
     shipping_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     order.shipping_address = order.billing_address.get_copy()
@@ -3963,7 +3963,7 @@ def test_get_order_shipping_tax_rate_skip_plugin(
     )
     shipping_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     method = shipping_zone.shipping_methods.get()
     order.shipping_address = order.billing_address.get_copy()
@@ -3979,7 +3979,7 @@ def test_get_order_shipping_tax_rate_skip_plugin(
 
 def test_get_plugin_configuration(settings, channel_USD):
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
 
     configuration_fields = [
@@ -3999,7 +3999,7 @@ def test_save_plugin_configuration(
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
     plugin_configuration()
     api_get_request_mock.return_value = {"authenticated": True}
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.save_plugin_configuration(
         AvataxPlugin.PLUGIN_ID,
         channel_USD.slug,
@@ -4028,7 +4028,7 @@ def test_save_plugin_configuration_authentication_failed(
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
     plugin_configuration(active=False)
     api_get_request_mock.return_value = {"authenticated": False}
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     with pytest.raises(ValidationError) as e:
@@ -4057,7 +4057,7 @@ def test_save_plugin_configuration_cannot_be_enabled_without_config(
 ):
     plugin_configuration(None, None)
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     with pytest.raises(ValidationError):
         manager.save_plugin_configuration(
             AvataxPlugin.PLUGIN_ID, channel_USD.slug, {"active": True}
@@ -4066,7 +4066,7 @@ def test_save_plugin_configuration_cannot_be_enabled_without_config(
 
 def test_show_taxes_on_storefront(plugin_configuration):
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     assert manager.show_taxes_on_storefront() is False
 
 
@@ -4085,7 +4085,7 @@ def test_order_confirmed(
     )
     conf = {data["name"]: data["value"] for data in plugin_conf.configuration}
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     manager.order_confirmed(order)
@@ -4164,7 +4164,7 @@ def test_order_created_no_lines(
 ):
     """Ensure that when order has no lines, the request to avatax api is not sent."""
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     manager.order_created(order)
@@ -4186,7 +4186,7 @@ def test_plugin_uses_configuration_from_db(
 ):
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
     configuration = plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     monkeypatch.setattr(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
@@ -4209,7 +4209,7 @@ def test_plugin_uses_configuration_from_db(
     AvataxPlugin._update_config_items(field_to_update, configuration.configuration)
     configuration.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     with pytest.raises(TaxError):
         manager.preprocess_order_creation(checkout_info, lines)
 
@@ -4217,7 +4217,7 @@ def test_plugin_uses_configuration_from_db(
 def test_skip_disabled_plugin(settings, plugin_configuration):
     plugin_configuration(username=None, password=None)
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin: AvataxPlugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
 
     assert (
@@ -4234,7 +4234,7 @@ def test_get_tax_code_from_object_meta(product, settings, plugin_configuration):
     )
     plugin_configuration(username=None, password=None)
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     tax_type = manager.get_tax_code_from_object_meta(product.tax_class)
 
     assert isinstance(tax_type, TaxType)
@@ -4970,7 +4970,9 @@ def test_validate_checkout_click_and_collect(
     )
     lines_info, _ = fetch_checkout_lines(user_checkout_with_items_for_cc)
     checkout_info = fetch_checkout_info(
-        user_checkout_with_items_for_cc, lines_info, get_plugins_manager()
+        user_checkout_with_items_for_cc,
+        lines_info,
+        get_plugins_manager(allow_replica=False),
     )
 
     # when
@@ -4997,7 +4999,7 @@ def test_generate_request_data_from_checkout_lines_uses_tax_code_from_product_ta
 
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
-        checkout_with_item, lines, get_plugins_manager()
+        checkout_with_item, lines, get_plugins_manager(allow_replica=False)
     )
 
     config = avatax_config
@@ -5030,7 +5032,7 @@ def test_generate_request_data_from_checkout_lines_uses_tax_code_from_product_ty
 
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
-        checkout_with_item, lines, get_plugins_manager()
+        checkout_with_item, lines, get_plugins_manager(allow_replica=False)
     )
 
     config = avatax_config
@@ -5059,7 +5061,7 @@ def test_generate_request_data_from_checkout_lines_sets_different_tax_code_for_z
 
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
-        checkout_with_item, lines, get_plugins_manager()
+        checkout_with_item, lines, get_plugins_manager(allow_replica=False)
     )
 
     config = avatax_config
@@ -5092,7 +5094,7 @@ def test_generate_request_data_from_checkout_lines_sets_different_tax_code_only_
 
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
-        checkout_with_item, lines, get_plugins_manager()
+        checkout_with_item, lines, get_plugins_manager(allow_replica=False)
     )
 
     config = avatax_config
@@ -5134,7 +5136,7 @@ def test_generate_request_data_from_checkout_lines_with_collection_point(
 
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
-        checkout_with_item, lines, get_plugins_manager()
+        checkout_with_item, lines, get_plugins_manager(allow_replica=False)
     )
     config = avatax_config
 
@@ -5174,7 +5176,7 @@ def test_generate_request_data_from_checkout_lines_with_shipping_method(
 
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
-        checkout_with_item, lines, get_plugins_manager()
+        checkout_with_item, lines, get_plugins_manager(allow_replica=False)
     )
     config = avatax_config
 
@@ -5207,7 +5209,7 @@ def test_generate_request_data_from_checkout_lines_adds_lines_with_taxes_disable
 
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(
-        checkout_with_item, lines, get_plugins_manager()
+        checkout_with_item, lines, get_plugins_manager(allow_replica=False)
     )
 
     # when
@@ -5405,7 +5407,7 @@ def test_assign_tax_code_to_object_meta(
         lambda _: {tax_code: description},
     )
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     manager.assign_tax_code_to_object_meta(product.tax_class, tax_code)
@@ -5431,7 +5433,7 @@ def test_assign_tax_code_to_object_meta_none_as_tax_code(
         "saleor.plugins.avatax.plugin.get_cached_tax_codes_or_fetch",
         lambda _: {"standard": description},
     )
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     manager.assign_tax_code_to_object_meta(product.tax_class, tax_code)
@@ -5456,7 +5458,7 @@ def test_assign_tax_code_to_object_meta_no_obj_id_and_none_as_tax_code(
     )
 
     tax_class = TaxClass(name="A new tax class.")
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     manager.assign_tax_code_to_object_meta(tax_class, tax_code)
@@ -5480,7 +5482,7 @@ def test_assign_tax_code_to_object_meta_no_obj_id(
         lambda _: {tax_code: description},
     )
     tax_class = TaxClass(name="A new product.")
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     manager.assign_tax_code_to_object_meta(tax_class, tax_code)
@@ -5499,7 +5501,7 @@ def test_calculate_checkout_shipping_validates_checkout(
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
     plugin_configuration(channel=channel_USD)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item
     lines, _ = fetch_checkout_lines(checkout)
 
@@ -5530,7 +5532,7 @@ def test_calculate_checkout_line_total_validates_checkout(
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
     plugin_configuration(channel=channel_USD)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item
     lines, _ = fetch_checkout_lines(checkout)
 
@@ -5562,7 +5564,7 @@ def test_calculate_checkout_line_unit_price_validates_checkout(
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
     plugin_configuration(channel=channel_USD)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item
     lines, _ = fetch_checkout_lines(checkout)
 

--- a/saleor/plugins/avatax/tests/test_avatax_caching.py
+++ b/saleor/plugins/avatax/tests/test_avatax_caching.py
@@ -27,7 +27,7 @@ def test_calculate_checkout_total_use_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -71,7 +71,7 @@ def test_calculate_checkout_total_save_avatax_response_in_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -116,7 +116,7 @@ def test_calculate_checkout_subtotal_use_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -160,7 +160,7 @@ def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -205,7 +205,7 @@ def test_calculate_checkout_shipping_use_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -249,7 +249,7 @@ def test_calculate_checkout_shipping_save_avatax_response_in_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -294,7 +294,7 @@ def test_calculate_checkout_line_total_use_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -342,7 +342,7 @@ def test_calculate_checkout_line_save_avatax_response_in_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -388,7 +388,7 @@ def test_calculate_checkout_line_unit_price_use_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -436,7 +436,7 @@ def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -488,7 +488,7 @@ def test_get_checkout_line_tax_rate_use_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -538,7 +538,7 @@ def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -593,7 +593,7 @@ def test_get_checkout_shipping_tax_rate_use_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
@@ -638,7 +638,7 @@ def test_get_checkout_shipping_tax_rate_save_avatax_response_in_cache(
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -2120,7 +2120,9 @@ class PluginsManager(PaymentInterface):
 
 def get_plugins_manager(
     requestor_getter: Optional[Callable[[], "Requestor"]] = None,
-    allow_replica=True,
+    allow_replica: Optional[bool] = None,
 ) -> PluginsManager:
+    if allow_replica is None:
+        raise ValueError("Please pass an allow_replica argument explicitly.")
     with opentracing.global_tracer().start_active_span("get_plugins_manager"):
         return PluginsManager(settings.PLUGINS, requestor_getter, allow_replica)

--- a/saleor/plugins/openid_connect/tests/conftest.py
+++ b/saleor/plugins/openid_connect/tests/conftest.py
@@ -63,7 +63,7 @@ def openid_plugin(settings, plugin_configuration):
         default_group_name_for_new_staff_users="OpenID test group",
     ):
         settings.PLUGINS = ["saleor.plugins.openid_connect.plugin.OpenIDConnectPlugin"]
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         manager.save_plugin_configuration(
             OpenIDConnectPlugin.PLUGIN_ID,
             None,
@@ -85,7 +85,7 @@ def openid_plugin(settings, plugin_configuration):
                 ),
             },
         )
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         return manager.all_plugins[0]
 
     return fun

--- a/saleor/plugins/sendgrid/tests/conftest.py
+++ b/saleor/plugins/sendgrid/tests/conftest.py
@@ -28,7 +28,7 @@ def sendgrid_email_plugin(settings, channel_USD):
         api_key=None,
     ):
         settings.PLUGINS = ["saleor.plugins.sendgrid.plugin.SendgridEmailPlugin"]
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         manager.save_plugin_configuration(
             SendgridEmailPlugin.PLUGIN_ID,
             channel_USD.slug,
@@ -101,7 +101,7 @@ def sendgrid_email_plugin(settings, channel_USD):
                 ],
             },
         )
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         return manager.plugins_per_channel[channel_USD.slug][0]
 
     return fun

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -53,7 +53,7 @@ from ..tests.sample_plugins import (
 def test_get_plugins_manager(settings):
     plugin_path = "saleor.plugins.tests.sample_plugins.PluginSample"
     settings.PLUGINS = [plugin_path]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     assert isinstance(manager, PluginsManager)
     assert len(manager.all_plugins) == 1
 
@@ -65,7 +65,7 @@ def test_manager_with_default_configuration_for_channel_plugins(
         "saleor.plugins.tests.sample_plugins.ChannelPluginSample",
         "saleor.plugins.tests.sample_plugins.PluginSample",
     ]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     assert len(manager.global_plugins) == 1
     assert isinstance(manager.global_plugins[0], PluginSample)
     assert {channel_PLN.slug, channel_USD.slug} == set(
@@ -91,7 +91,7 @@ def test_manager_with_channel_plugins(
     settings.PLUGINS = [
         "saleor.plugins.tests.sample_plugins.ChannelPluginSample",
     ]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     assert {channel_PLN.slug, channel_USD.slug} == set(
         manager.plugins_per_channel.keys()
@@ -113,7 +113,7 @@ def test_manager_get_plugins_with_channel_slug(
         "saleor.plugins.tests.sample_plugins.PluginInactive",
         "saleor.plugins.tests.sample_plugins.PluginSample",
     ]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     plugins = manager.get_plugins(channel_slug=channel_USD.slug)
 
@@ -127,7 +127,7 @@ def test_manager_get_active_plugins_with_channel_slug(
         "saleor.plugins.tests.sample_plugins.PluginInactive",
         "saleor.plugins.tests.sample_plugins.PluginSample",
     ]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     plugins = manager.get_plugins(channel_slug=channel_USD.slug, active_only=True)
 
@@ -142,7 +142,7 @@ def test_manager_get_plugins_without_channel_slug(
         "saleor.plugins.tests.sample_plugins.PluginInactive",
         "saleor.plugins.tests.sample_plugins.PluginSample",
     ]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     plugins = manager.get_plugins(channel_slug=None)
 
@@ -156,7 +156,7 @@ def test_manager_get_active_plugins_without_channel_slug(
         "saleor.plugins.tests.sample_plugins.PluginInactive",
         "saleor.plugins.tests.sample_plugins.PluginSample",
     ]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     plugins = manager.get_plugins(channel_slug=None, active_only=True)
 
@@ -259,7 +259,7 @@ def test_manager_calculates_checkout_line_total(
     checkout = checkout_with_item_on_promotion
     currency = checkout.currency
     expected_total = Money(amount, currency)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
@@ -306,7 +306,7 @@ def test_manager_get_checkout_line_tax_rate_sample_plugin(checkout_with_item):
     plugins = ["saleor.plugins.tests.sample_plugins.PluginSample"]
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     checkout_line_info = lines[0]
@@ -331,7 +331,7 @@ def test_manager_get_checkout_line_tax_rate_sample_plugin(checkout_with_item):
 def test_manager_get_checkout_line_tax_rate_no_plugins(
     checkout_with_item, unit_price, expected_tax_rate
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     checkout_line_info = lines[0]
@@ -388,7 +388,7 @@ def test_manager_get_checkout_shipping_tax_rate_sample_plugin(checkout_with_item
     plugins = ["saleor.plugins.tests.sample_plugins.PluginSample"]
     shipping_price = TaxedMoney(Money(12, "USD"), Money(14, "USD"))
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
 
@@ -411,7 +411,7 @@ def test_manager_get_checkout_shipping_tax_rate_sample_plugin(checkout_with_item
 def test_manager_get_checkout_shipping_tax_rate_no_plugins(
     checkout_with_item, shipping_price, expected_tax_rate
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
 
@@ -555,7 +555,7 @@ def test_manager_get_taxes_for_checkout(
     expected_tax_data,
 ):
     lines, _ = fetch_checkout_lines(checkout)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     assert PluginsManager(plugins=plugins).get_taxes_for_checkout(
         checkout_info, lines

--- a/saleor/plugins/tests/test_plugins.py
+++ b/saleor/plugins/tests/test_plugins.py
@@ -11,7 +11,7 @@ def test_update_config_items_keeps_bool_value(plugin_configuration, settings):
         {"name": "Username", "value": "new_admin@example.com"},
         {"name": "Use sandbox", "value": False},
     ]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin_sample = manager.get_plugin(PluginSample.PLUGIN_ID)
     plugin_sample._update_config_items(data_to_update, plugin_sample.configuration)
 
@@ -207,7 +207,7 @@ def test_base_plugin__update_configuration_structure_configuration_has_change(
 
 def test_base_plugin__append_config_structure_to_config(settings):
     settings.PLUGINS = ["saleor.plugins.tests.sample_plugins.PluginSample"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.get_plugin(PluginSample.PLUGIN_ID)
     config = [
         {"name": "Username", "value": "my_test_user"},
@@ -235,7 +235,7 @@ def test_base_plugin__append_config_structure_to_config(settings):
 
 def test_change_user_address_in_anonymize_plugin_reset_phone(address, settings):
     settings.PLUGINS = ["saleor.plugins.anonymize.plugin.AnonymizePlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     anonymize_plugin = manager.get_plugin(AnonymizePlugin.PLUGIN_ID)
 
     # ensure that phone is set

--- a/saleor/plugins/user_email/tests/conftest.py
+++ b/saleor/plugins/user_email/tests/conftest.py
@@ -106,7 +106,7 @@ def user_email_plugin(settings, channel_USD):
         order_refund_subject=ORDER_REFUND_CONFIRMATION_DEFAULT_SUBJECT,
     ):
         settings.PLUGINS = ["saleor.plugins.user_email.plugin.UserEmailPlugin"]
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         with patch(
             "saleor.plugins.user_email.plugin.validate_default_email_configuration"
         ):
@@ -239,7 +239,7 @@ def user_email_plugin(settings, channel_USD):
                     ],
                 },
             )
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         return manager.plugins_per_channel[channel_USD.slug][0]
 
     return fun

--- a/saleor/plugins/user_email/tests/test_plugin.py
+++ b/saleor/plugins/user_email/tests/test_plugin.py
@@ -301,7 +301,7 @@ def test_plugin_manager_doesnt_load_email_templates_from_db(
     user_email_plugin, user_email_template, settings
 ):
     settings.PLUGINS = ["saleor.plugins.user_email.plugin.UserEmailPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     plugin = manager.all_plugins[0]
 
     email_config_item = None

--- a/saleor/plugins/views.py
+++ b/saleor/plugins/views.py
@@ -5,19 +5,19 @@ from .manager import get_plugins_manager
 
 
 def handle_plugin_webhook(request: SaleorContext, plugin_id: str) -> HttpResponse:
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     return manager.webhook_endpoint_without_channel(request, plugin_id)
 
 
 def handle_global_plugin_webhook(
     request: SaleorContext, plugin_id: str
 ) -> HttpResponse:
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     return manager.webhook(request, plugin_id, channel_slug=None)
 
 
 def handle_plugin_per_channel_webhook(
     request: SaleorContext, plugin_id: str, channel_slug: str
 ) -> HttpResponse:
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     return manager.webhook(request, plugin_id, channel_slug=channel_slug)

--- a/saleor/plugins/webhook/conftest.py
+++ b/saleor/plugins/webhook/conftest.py
@@ -70,7 +70,7 @@ def tax_app_with_webhooks(tax_app, tax_checkout_webhook, tax_order_webhook):
 def webhook_plugin(settings):
     def factory():
         settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         return manager.global_plugins[0]
 
     return factory

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -193,7 +193,7 @@ class WebhookPlugin(BasePlugin):
             metadata_payload_generator = partial(
                 generate_metadata_updated_payload, instance, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -222,7 +222,7 @@ class WebhookPlugin(BasePlugin):
                 raw_payload["new_email"] = new_email
                 data["new_email"] = new_email
 
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 self._serialize_payload(raw_payload),
                 event_type,
                 webhooks,
@@ -236,13 +236,16 @@ class WebhookPlugin(BasePlugin):
                 "id": graphene.Node.to_global_id("User", user.id),
             }
             data = {"user": user}
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 self._serialize_payload(raw_payload),
                 event_type,
                 webhooks,
                 data,
                 self.requestor,
             )
+
+    def trigger_webhooks_async(self, *args, **kwargs):
+        return trigger_webhooks_async(*args, **kwargs, allow_replica=self.allow_replica)  # type: ignore
 
     def account_confirmed(self, user: "User", previous_value: None) -> None:
         if not self.active:
@@ -360,8 +363,12 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, address, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                address,
+                self.requestor,
             )
 
     def address_created(self, address: "Address", previous_value: None) -> None:
@@ -389,7 +396,9 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(payload, event_type, webhooks, app, self.requestor)
+            self.trigger_webhooks_async(
+                payload, event_type, webhooks, app, self.requestor
+            )
 
     def app_installed(self, app: "App", previous_value: None) -> None:
         if not self.active:
@@ -421,8 +430,12 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, attribute, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                attribute,
+                self.requestor,
             )
 
     def attribute_created(self, attribute: "Attribute", previous_value: None) -> None:
@@ -465,8 +478,12 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, attribute_value, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                attribute_value,
+                self.requestor,
             )
 
     def attribute_value_created(
@@ -508,8 +525,12 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, category, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                category,
+                self.requestor,
             )
 
     def category_created(self, category: "Category", previous_value: None) -> None:
@@ -540,8 +561,12 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, channel, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                channel,
+                self.requestor,
             )
 
     def channel_created(self, channel: "Channel", previous_value: None) -> None:
@@ -590,8 +615,12 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, gift_card, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                gift_card,
+                self.requestor,
             )
 
     def gift_card_created(
@@ -640,7 +669,7 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 payload,
                 event_type,
                 webhooks,
@@ -680,7 +709,7 @@ class WebhookPlugin(BasePlugin):
                     "recipient_email": export.user.email if export.user else None,
                 }
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 payload,
                 event_type,
                 webhooks,
@@ -706,7 +735,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -724,7 +753,9 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(payload, event_type, webhooks, menu, self.requestor)
+            self.trigger_webhooks_async(
+                payload, event_type, webhooks, menu, self.requestor
+            )
 
     def menu_created(self, menu: "Menu", previous_value: None) -> None:
         if not self.active:
@@ -755,8 +786,12 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, menu_item, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                menu_item,
+                self.requestor,
             )
 
     def menu_item_created(self, menu_item: "MenuItem", previous_value: None) -> None:
@@ -790,7 +825,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -807,7 +842,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -824,7 +859,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -841,7 +876,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -858,7 +893,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -875,7 +910,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -892,7 +927,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -918,7 +953,7 @@ class WebhookPlugin(BasePlugin):
                 current_catalogue=current_catalogue,
                 requestor=self.requestor,
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -945,7 +980,7 @@ class WebhookPlugin(BasePlugin):
                 current_catalogue,
                 self.requestor,
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -971,7 +1006,7 @@ class WebhookPlugin(BasePlugin):
                 previous_catalogue=previous_catalogue,
                 requestor=self.requestor,
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -996,7 +1031,7 @@ class WebhookPlugin(BasePlugin):
                 catalogue=catalogue,
                 requestor=self.requestor,
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1014,7 +1049,7 @@ class WebhookPlugin(BasePlugin):
                     "id": graphene.Node.to_global_id("Promotion", promotion.id),
                 }
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 payload, event_type, webhooks, promotion, self.requestor
             )
 
@@ -1080,8 +1115,12 @@ class WebhookPlugin(BasePlugin):
                     ),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, promotion_rule, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                promotion_rule,
+                self.requestor,
             )
 
     def promotion_rule_created(
@@ -1131,7 +1170,7 @@ class WebhookPlugin(BasePlugin):
             invoice_data_generator = partial(
                 generate_invoice_payload, invoice, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1148,7 +1187,7 @@ class WebhookPlugin(BasePlugin):
             invoice_data_generator = partial(
                 generate_invoice_payload, invoice, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1165,7 +1204,7 @@ class WebhookPlugin(BasePlugin):
             invoice_data_generator = partial(
                 generate_invoice_payload, invoice, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1184,7 +1223,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1201,7 +1240,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1228,7 +1267,7 @@ class WebhookPlugin(BasePlugin):
                     generate_order_payload(order, self.requestor) for order in orders
                 ]
 
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1245,7 +1284,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1262,7 +1301,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1279,7 +1318,7 @@ class WebhookPlugin(BasePlugin):
             order_data_generator = partial(
                 generate_order_payload, order, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1301,7 +1340,7 @@ class WebhookPlugin(BasePlugin):
             fulfillment_data_generator = partial(
                 generate_fulfillment_payload, fulfillment, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1321,7 +1360,7 @@ class WebhookPlugin(BasePlugin):
             fulfillment_data_generator = partial(
                 generate_fulfillment_payload, fulfillment, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1343,7 +1382,7 @@ class WebhookPlugin(BasePlugin):
             fulfillment_data_generator = partial(
                 generate_fulfillment_payload, fulfillment, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1368,8 +1407,12 @@ class WebhookPlugin(BasePlugin):
         event_type = WebhookEventAsyncType.FULFILLMENT_TRACKING_NUMBER_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
             fulfillment_data = generate_fulfillment_payload(fulfillment, self.requestor)
-            trigger_webhooks_async(
-                fulfillment_data, event_type, webhooks, fulfillment, self.requestor
+            self.trigger_webhooks_async(
+                fulfillment_data,
+                event_type,
+                webhooks,
+                fulfillment,
+                self.requestor,
             )
 
     def customer_created(self, customer: "User", previous_value: Any) -> Any:
@@ -1380,7 +1423,7 @@ class WebhookPlugin(BasePlugin):
             customer_data_generator = partial(
                 generate_customer_payload, customer, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1399,7 +1442,7 @@ class WebhookPlugin(BasePlugin):
             customer_data_generator = partial(
                 generate_customer_payload, customer, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1418,7 +1461,7 @@ class WebhookPlugin(BasePlugin):
             customer_data_generator = partial(
                 generate_customer_payload, customer, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1444,7 +1487,7 @@ class WebhookPlugin(BasePlugin):
             collection_data_generator = partial(
                 generate_collection_payload, collection, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1461,7 +1504,7 @@ class WebhookPlugin(BasePlugin):
             collection_data_generator = partial(
                 generate_collection_payload, collection, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1480,7 +1523,7 @@ class WebhookPlugin(BasePlugin):
             collection_data_generator = partial(
                 generate_collection_payload, collection, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1508,7 +1551,7 @@ class WebhookPlugin(BasePlugin):
             product_data_generator = partial(
                 generate_product_payload, product, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1527,7 +1570,7 @@ class WebhookPlugin(BasePlugin):
             product_data_generator = partial(
                 generate_product_payload, product, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1568,7 +1611,7 @@ class WebhookPlugin(BasePlugin):
             product_data_generator = partial(
                 generate_product_deleted_payload, product, variants, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1583,7 +1626,7 @@ class WebhookPlugin(BasePlugin):
         event_type = WebhookEventAsyncType.PRODUCT_MEDIA_CREATED
         if webhooks := get_webhooks_for_event(event_type):
             media_data_generator = partial(generate_product_media_payload, media)
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1598,7 +1641,7 @@ class WebhookPlugin(BasePlugin):
         event_type = WebhookEventAsyncType.PRODUCT_MEDIA_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
             media_data_generator = partial(generate_product_media_payload, media)
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1613,7 +1656,7 @@ class WebhookPlugin(BasePlugin):
         event_type = WebhookEventAsyncType.PRODUCT_MEDIA_DELETED
         if webhooks := get_webhooks_for_event(event_type):
             media_data_generator = partial(generate_product_media_payload, media)
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1632,7 +1675,7 @@ class WebhookPlugin(BasePlugin):
             product_variant_data_generator = partial(
                 generate_product_variant_payload, [product_variant], self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1651,7 +1694,7 @@ class WebhookPlugin(BasePlugin):
             product_variant_data_generator = partial(
                 generate_product_variant_payload, [product_variant], self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1670,7 +1713,7 @@ class WebhookPlugin(BasePlugin):
             product_variant_data_generator = partial(
                 generate_product_variant_payload, [product_variant], self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1698,7 +1741,7 @@ class WebhookPlugin(BasePlugin):
             product_variant_data_generator = partial(
                 generate_product_variant_with_stock_payload, [stock]
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1717,7 +1760,7 @@ class WebhookPlugin(BasePlugin):
             product_variant_data_generator = partial(
                 generate_product_variant_with_stock_payload, [stock], self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1736,7 +1779,7 @@ class WebhookPlugin(BasePlugin):
             product_variant_data_generator = (
                 generate_product_variant_with_stock_payload([stock], self.requestor)
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1753,7 +1796,7 @@ class WebhookPlugin(BasePlugin):
             checkout_data_generator = partial(
                 generate_checkout_payload, checkout, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1770,7 +1813,7 @@ class WebhookPlugin(BasePlugin):
             checkout_data_generator = partial(
                 generate_checkout_payload, checkout, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1787,7 +1830,7 @@ class WebhookPlugin(BasePlugin):
             checkout_data_generator = partial(
                 generate_checkout_payload, checkout, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1823,7 +1866,7 @@ class WebhookPlugin(BasePlugin):
             )
             if event not in NotifyEventType.CHOICES:
                 logger.info(f"Webhook {event_type} triggered for {event} notify event.")
-            trigger_webhooks_async(data, event_type, webhooks)
+            self.trigger_webhooks_async(data, event_type, webhooks)
 
     def page_created(self, page: "Page", previous_value: Any) -> Any:
         if not self.active:
@@ -1831,7 +1874,7 @@ class WebhookPlugin(BasePlugin):
         event_type = WebhookEventAsyncType.PAGE_CREATED
         if webhooks := get_webhooks_for_event(event_type):
             page_data_generator = partial(generate_page_payload, page, self.requestor)
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1846,7 +1889,7 @@ class WebhookPlugin(BasePlugin):
         event_type = WebhookEventAsyncType.PAGE_UPDATED
         if webhooks := get_webhooks_for_event(event_type):
             page_data_generator = partial(generate_page_payload, page, self.requestor)
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1861,7 +1904,7 @@ class WebhookPlugin(BasePlugin):
         event_type = WebhookEventAsyncType.PAGE_DELETED
         if webhooks := get_webhooks_for_event(event_type):
             page_data_generator = partial(generate_page_payload, page, self.requestor)
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -1880,7 +1923,7 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 payload, event_type, webhooks, page_type, self.requestor
             )
 
@@ -1913,7 +1956,9 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(payload, event_type, webhooks, group, self.requestor)
+            self.trigger_webhooks_async(
+                payload, event_type, webhooks, group, self.requestor
+            )
 
     def permission_group_created(self, group: "Group", previous_value: Any) -> Any:
         if not self.active:
@@ -1946,8 +1991,12 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, shipping_method, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                shipping_method,
+                self.requestor,
             )
 
     def shipping_price_created(
@@ -1988,8 +2037,12 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, shipping_zone, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                shipping_zone,
+                self.requestor,
             )
 
     def shipping_zone_created(
@@ -2039,8 +2092,12 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, staff_user, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                staff_user,
+                self.requestor,
             )
 
     def staff_created(self, staff_user: "User", previous_value: None) -> None:
@@ -2090,10 +2147,10 @@ class WebhookPlugin(BasePlugin):
         event_type = WebhookEventAsyncType.THUMBNAIL_CREATED
         if webhooks := get_webhooks_for_event(event_type):
             thumbnail_data_generator = partial(generate_thumbnail_payload, thumbnail)
-            trigger_webhooks_async(
-                data=None,
-                event_type=event_type,
-                webhooks=webhooks,
+            self.trigger_webhooks_async(
+                None,
+                event_type,
+                webhooks,
                 subscribable_object=thumbnail,
                 legacy_data_generator=thumbnail_data_generator,
             )
@@ -2106,7 +2163,7 @@ class WebhookPlugin(BasePlugin):
             translation_data_generator = partial(
                 generate_translation_payload, translation, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -2123,7 +2180,7 @@ class WebhookPlugin(BasePlugin):
             translation_data_generator = partial(
                 generate_translation_payload, translation, self.requestor
             )
-            trigger_webhooks_async(
+            self.trigger_webhooks_async(
                 None,
                 event_type,
                 webhooks,
@@ -2140,8 +2197,12 @@ class WebhookPlugin(BasePlugin):
                     "name": warehouse.name,
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, warehouse, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                warehouse,
+                self.requestor,
             )
 
     def warehouse_created(self, warehouse: "Warehouse", previous_value: None) -> None:
@@ -2184,8 +2245,12 @@ class WebhookPlugin(BasePlugin):
                     "meta": self._generate_meta(),
                 }
             )
-            trigger_webhooks_async(
-                payload, event_type, webhooks, voucher, self.requestor
+            self.trigger_webhooks_async(
+                payload,
+                event_type,
+                webhooks,
+                voucher,
+                self.requestor,
             )
 
     def voucher_created(
@@ -2281,6 +2346,7 @@ class WebhookPlugin(BasePlugin):
             event_type,
             payload,
             webhook,
+            False,
             subscribable_object=StoredPaymentMethodRequestDeleteData(
                 payment_method_id=app_data.name,
                 user=request_delete_data.user,
@@ -2319,7 +2385,8 @@ class WebhookPlugin(BasePlugin):
                     event_type,
                     payload,
                     webhook,
-                    cache_data=payload_dict,
+                    payload_dict,
+                    self.allow_replica,
                     subscribable_object=list_payment_method_data,
                     request_timeout=WEBHOOK_SYNC_TIMEOUT,
                     cache_timeout=WEBHOOK_CACHE_DEFAULT_TIMEOUT,
@@ -2354,6 +2421,7 @@ class WebhookPlugin(BasePlugin):
             event_type,
             payload,
             webhook,
+            False,
             subscribable_object=request_data,
             timeout=WEBHOOK_SYNC_TIMEOUT,
         )
@@ -2583,7 +2651,11 @@ class WebhookPlugin(BasePlugin):
             if not webhook:
                 raise PaymentError(f"No payment webhook found for event: {event_type}.")
             response_data = trigger_webhook_sync(
-                event_type, webhook_payload, webhook, subscribable_object=payment
+                event_type,
+                webhook_payload,
+                webhook,
+                False,
+                subscribable_object=payment,
             )
             if response_data is None:
                 continue
@@ -2633,6 +2705,7 @@ class WebhookPlugin(BasePlugin):
             event_type=WebhookEventSyncType.PAYMENT_GATEWAY_INITIALIZE_SESSION,
             payload=json.dumps(payload, cls=CustomJsonEncoder),
             webhook=webhook,
+            allow_replica=False,
             subscribable_object=subscribable_object,
             request=request,
         )
@@ -2720,6 +2793,7 @@ class WebhookPlugin(BasePlugin):
             event_type=webhook_event,
             payload=payload,
             webhook=webhook,
+            allow_replica=False,
             subscribable_object=transaction_session_data,
         )
         error_msg = None
@@ -2775,6 +2849,7 @@ class WebhookPlugin(BasePlugin):
                 event_type=event_type,
                 payload=generate_list_gateways_payload(currency, checkout),
                 webhook=webhook,
+                allow_replica=False,
                 subscribable_object=checkout,
             )
             if response_data:
@@ -2895,7 +2970,6 @@ class WebhookPlugin(BasePlugin):
             parse_tax_data,
             checkout_info.checkout,
             self.requestor,
-            self.allow_replica,
         )
 
     def get_taxes_for_order(
@@ -2907,7 +2981,6 @@ class WebhookPlugin(BasePlugin):
             parse_tax_data,
             order,
             self.requestor,
-            self.allow_replica,
         )
 
     def get_shipping_methods_for_checkout(
@@ -2925,6 +2998,7 @@ class WebhookPlugin(BasePlugin):
                     payload=payload,
                     webhook=webhook,
                     cache_data=cache_data,
+                    allow_replica=self.allow_replica,
                     subscribable_object=checkout,
                     request_timeout=WEBHOOK_SYNC_TIMEOUT,
                     cache_timeout=CACHE_TIME_SHIPPING_LIST_METHODS_FOR_CHECKOUT,
@@ -2983,6 +3057,7 @@ class WebhookPlugin(BasePlugin):
             payload_fun=payload_fun,
             cache_key=cache_key,
             subscribable_object=order,
+            allow_replica=self.allow_replica,
         )
 
     def excluded_shipping_methods_for_checkout(
@@ -3003,6 +3078,7 @@ class WebhookPlugin(BasePlugin):
             payload_fun=payload_function,
             cache_key=cache_key,
             subscribable_object=checkout,
+            allow_replica=self.allow_replica,
         )
 
     def is_event_active(self, event: str, channel=Optional[str]):

--- a/saleor/plugins/webhook/tests/conftest.py
+++ b/saleor/plugins/webhook/tests/conftest.py
@@ -17,7 +17,7 @@ from ....webhook.models import Webhook, WebhookEvent
 def webhook_plugin(settings):
     def factory() -> WebhookPlugin:
         settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-        manager = get_plugins_manager()
+        manager = get_plugins_manager(allow_replica=False)
         return manager.global_plugins[0]
 
     return factory

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
@@ -37,7 +37,7 @@ def test_trigger_webhooks_async(
     webhook_type = WebhookEventAsyncType.ORDER_CREATED
     webhooks, payload = Webhook.objects.all(), {"example": "payload"}
 
-    trigger_webhooks_async(payload, webhook_type, webhooks, order)
+    trigger_webhooks_async(payload, webhook_type, webhooks, order, allow_replica=False)
 
     deliveries = EventDelivery.objects.all()
     assert deliveries.count() == 2
@@ -62,7 +62,7 @@ def test_trigger_webhooks_async_no_subscription_webhooks(
     webhook_type = WebhookEventAsyncType.ORDER_UPDATED
     webhooks = Webhook.objects.all()
     data = {"regular_webhook": "data"}
-    trigger_webhooks_async(data, webhook_type, webhooks, order)
+    trigger_webhooks_async(data, webhook_type, webhooks, order, allow_replica=False)
     mocked_create_deliveries_for_subscriptions.assert_not_called()
 
 
@@ -79,6 +79,7 @@ def test_trigger_webhook_sync_with_subscription(
         WebhookEventSyncType.PAYMENT_AUTHORIZE,
         data,
         payment_app.webhooks.first(),
+        False,
         payment,
     )
     event_delivery = EventDelivery.objects.first()

--- a/saleor/plugins/webhook/tests/test_payment_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook.py
@@ -70,7 +70,7 @@ def webhook_data():
 def test_trigger_webhook_sync(mock_request, payment_app):
     data = '{"key": "value"}'
     trigger_webhook_sync(
-        WebhookEventSyncType.PAYMENT_CAPTURE, data, payment_app.webhooks.first()
+        WebhookEventSyncType.PAYMENT_CAPTURE, data, payment_app.webhooks.first(), False
     )
     event_delivery = EventDelivery.objects.first()
     mock_request.assert_called_once_with(event_delivery)
@@ -94,6 +94,7 @@ def test_trigger_webhook_sync_with_subscription(
         WebhookEventSyncType.PAYMENT_CAPTURE,
         data,
         payment_app.webhooks.first(),
+        False,
         payment,
     )
     mock_request.assert_called_once_with(fake_delivery)

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -118,6 +118,7 @@ def test_excluded_shipping_methods_for_order(
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
         payload,
         shipping_app.webhooks.get(events__event_type=event_type),
+        False,
         subscribable_object=order_with_lines,
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
     )
@@ -200,6 +201,7 @@ def test_multiple_app_with_excluded_shipping_methods_for_order(
         event_type,
         payload,
         shipping_app.webhooks.get(events__event_type=event_type),
+        False,
         subscribable_object=order_with_lines,
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
     )
@@ -207,6 +209,7 @@ def test_multiple_app_with_excluded_shipping_methods_for_order(
         event_type,
         payload,
         second_shipping_app.webhooks.get(events__event_type=event_type),
+        False,
         subscribable_object=order_with_lines,
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
     )
@@ -307,6 +310,7 @@ def test_multiple_webhooks_on_the_same_app_with_excluded_shipping_methods_for_or
             event_type,
             payload,
             webhook,
+            False,
             subscribable_object=order_with_lines,
             timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         )
@@ -516,7 +520,7 @@ def test_trigger_webhook_sync(mock_request, shipping_app):
     data = '{"key": "value"}'
     webhook = shipping_app.webhooks.first()
     trigger_webhook_sync(
-        WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT, data, webhook
+        WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT, data, webhook, False
     )
     event_delivery = EventDelivery.objects.first()
     mock_request.assert_called_once_with(event_delivery)
@@ -576,6 +580,7 @@ def test_excluded_shipping_methods_for_checkout_webhook(
         event_type,
         payload,
         shipping_app.webhooks.get(events__event_type=event_type),
+        False,
         subscribable_object=checkout_with_items,
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
     )
@@ -704,6 +709,7 @@ def test_multiple_app_with_excluded_shipping_methods_for_checkout(
         event_type,
         payload,
         shipping_app.webhooks.get(events__event_type=event_type),
+        False,
         subscribable_object=checkout_with_items,
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
     )
@@ -711,6 +717,7 @@ def test_multiple_app_with_excluded_shipping_methods_for_checkout(
         event_type,
         payload,
         second_shipping_app.webhooks.get(events__event_type=event_type),
+        False,
         subscribable_object=checkout_with_items,
         timeout=settings.WEBHOOK_SYNC_TIMEOUT,
     )
@@ -812,6 +819,7 @@ def test_multiple_webhooks_on_the_same_app_with_excluded_shipping_methods_for_ch
             event_type,
             payload,
             webhook,
+            False,
             subscribable_object=checkout_with_items,
             timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         )

--- a/saleor/plugins/webhook/tests/test_tax_webhook.py
+++ b/saleor/plugins/webhook/tests/test_tax_webhook.py
@@ -202,7 +202,9 @@ def test_get_taxes_for_checkout_with_sync_subscription(
     tax_app,
 ):
     # given
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     mock_request.return_value = tax_data_response
     plugin = webhook_plugin()
     webhook = Webhook.objects.create(

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -113,7 +113,10 @@ def test_trigger_webhooks_for_event_calls_expected_events(
     third_webhook.events.create(event_type=WebhookEventAsyncType.ANY)
     event_payload = EventPayload.objects.create()
     trigger_webhooks_async(
-        event_payload, event_name, get_webhooks_for_event(event_name)
+        event_payload,
+        event_name,
+        get_webhooks_for_event(event_name),
+        allow_replica=False,
     )
     deliveries_called = {
         EventDelivery.objects.get(id=delivery_id[0][0])
@@ -136,9 +139,8 @@ def test_order_created(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.order_created(order_with_lines)
-
     mocked_webhook_trigger.assert_called_once_with(
         None,
         WebhookEventAsyncType.ORDER_CREATED,
@@ -146,6 +148,7 @@ def test_order_created(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -164,7 +167,7 @@ def test_order_confirmed(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.order_confirmed(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -174,6 +177,7 @@ def test_order_confirmed(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -192,7 +196,7 @@ def test_draft_order_created(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.draft_order_created(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -202,6 +206,7 @@ def test_draft_order_created(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -220,7 +225,7 @@ def test_draft_order_deleted(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.draft_order_deleted(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -230,6 +235,7 @@ def test_draft_order_deleted(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -248,7 +254,7 @@ def test_draft_order_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.draft_order_updated(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -258,6 +264,7 @@ def test_draft_order_updated(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -276,7 +283,7 @@ def test_customer_created(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.customer_created(customer_user)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -286,6 +293,7 @@ def test_customer_created(
         customer_user,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -304,7 +312,7 @@ def test_customer_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.customer_updated(customer_user)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -314,6 +322,7 @@ def test_customer_updated(
         customer_user,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -332,7 +341,7 @@ def test_customer_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.customer_metadata_updated(customer_user)
     mocked_webhook_trigger.assert_called_once_with(
         None,
@@ -341,6 +350,7 @@ def test_customer_metadata_updated(
         customer_user,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -359,7 +369,7 @@ def test_order_fully_paid(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.order_fully_paid(order_with_lines)
     mocked_webhook_trigger.assert_called_once_with(
         None,
@@ -368,6 +378,7 @@ def test_order_fully_paid(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -387,7 +398,7 @@ def test_order_paid(
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     manager.order_paid(order_with_lines)
@@ -400,6 +411,7 @@ def test_order_paid(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -419,7 +431,7 @@ def test_order_refunded(
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     manager.order_refunded(order_with_lines)
@@ -432,6 +444,7 @@ def test_order_refunded(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -451,7 +464,7 @@ def test_order_fully_refunded(
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     manager.order_fully_refunded(order_with_lines)
@@ -464,6 +477,7 @@ def test_order_fully_refunded(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -482,7 +496,7 @@ def test_collection_created(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.collection_created(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -492,6 +506,7 @@ def test_collection_created(
         collection,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -510,7 +525,7 @@ def test_collection_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.collection_updated(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -520,6 +535,7 @@ def test_collection_updated(
         collection,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -538,7 +554,7 @@ def test_collection_deleted(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.collection_deleted(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -548,6 +564,7 @@ def test_collection_deleted(
         collection,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -566,7 +583,7 @@ def test_collection_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.collection_metadata_updated(collection)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -576,6 +593,7 @@ def test_collection_metadata_updated(
         collection,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -594,7 +612,7 @@ def test_product_created(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.product_created(product)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -604,6 +622,7 @@ def test_product_created(
         product,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -622,7 +641,7 @@ def test_product_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.product_updated(product)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -632,6 +651,7 @@ def test_product_updated(
         product,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -650,7 +670,7 @@ def test_product_deleted(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     product = product
     variants_id = list(product.variants.all().values_list("id", flat=True))
@@ -676,6 +696,7 @@ def test_product_deleted(
         product,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -694,7 +715,7 @@ def test_product_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.product_metadata_updated(product)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -704,6 +725,7 @@ def test_product_metadata_updated(
         product,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -722,7 +744,7 @@ def test_product_variant_created(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.product_variant_created(variant)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -732,6 +754,7 @@ def test_product_variant_created(
         variant,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -750,7 +773,7 @@ def test_product_variant_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.product_variant_updated(variant)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -760,6 +783,7 @@ def test_product_variant_updated(
         variant,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -778,7 +802,7 @@ def test_product_variant_deleted(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.product_variant_deleted(variant)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -788,6 +812,7 @@ def test_product_variant_deleted(
         variant,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -806,7 +831,7 @@ def test_product_variant_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.product_variant_metadata_updated(variant)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -816,6 +841,7 @@ def test_product_variant_metadata_updated(
         variant,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -835,7 +861,7 @@ def test_product_variant_out_of_stock(
     variant = variant_with_many_stocks.stocks.first()
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.product_variant_out_of_stock(variant)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -845,6 +871,7 @@ def test_product_variant_out_of_stock(
         variant,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -864,7 +891,7 @@ def test_product_variant_back_in_stock(
     variant = variant_with_many_stocks.stocks.first()
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.product_variant_back_in_stock(variant)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -874,6 +901,7 @@ def test_product_variant_back_in_stock(
         variant,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -892,7 +920,7 @@ def test_order_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.order_updated(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -902,6 +930,7 @@ def test_order_updated(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -920,7 +949,7 @@ def test_order_cancelled(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.order_cancelled(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -930,6 +959,7 @@ def test_order_cancelled(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -948,7 +978,7 @@ def test_order_expired(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.order_expired(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -958,6 +988,7 @@ def test_order_expired(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -976,7 +1007,7 @@ def test_order_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.order_metadata_updated(order_with_lines)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -986,6 +1017,7 @@ def test_order_metadata_updated(
         order_with_lines,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1004,7 +1036,7 @@ def test_checkout_created(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.checkout_created(checkout_with_items)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1014,6 +1046,7 @@ def test_checkout_created(
         checkout_with_items,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1093,7 +1126,7 @@ def test_checkout_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.checkout_updated(checkout_with_items)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1103,6 +1136,7 @@ def test_checkout_updated(
         checkout_with_items,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1122,7 +1156,7 @@ def test_checkout_fully_paid(
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     manager.checkout_fully_paid(checkout_with_items)
@@ -1135,6 +1169,7 @@ def test_checkout_fully_paid(
         checkout_with_items,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1153,7 +1188,7 @@ def test_checkout_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.checkout_metadata_updated(checkout_with_items)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1163,6 +1198,7 @@ def test_checkout_metadata_updated(
         checkout_with_items,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1177,7 +1213,7 @@ def test_page_created(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.page_created(page)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1187,6 +1223,7 @@ def test_page_created(
         page,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1201,7 +1238,7 @@ def test_page_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.page_updated(page)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1211,6 +1248,7 @@ def test_page_updated(
         page,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1225,7 +1263,7 @@ def test_page_deleted(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     page_id = page.id
     page.delete()
     page.id = page_id
@@ -1238,6 +1276,7 @@ def test_page_deleted(
         page,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1256,7 +1295,7 @@ def test_invoice_request(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     invoice = fulfilled_order.invoices.first()
     manager.invoice_request(fulfilled_order, invoice, invoice.number)
 
@@ -1267,6 +1306,7 @@ def test_invoice_request(
         invoice,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1285,7 +1325,7 @@ def test_invoice_delete(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     invoice = fulfilled_order.invoices.first()
     manager.invoice_delete(invoice)
 
@@ -1296,6 +1336,7 @@ def test_invoice_delete(
         invoice,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1314,7 +1355,7 @@ def test_invoice_sent(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     invoice = fulfilled_order.invoices.first()
     manager.invoice_sent(invoice, fulfilled_order.user.email)
 
@@ -1325,6 +1366,7 @@ def test_invoice_sent(
         invoice,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1343,7 +1385,7 @@ def test_fulfillment_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.fulfillment_metadata_updated(fulfillment)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1353,6 +1395,7 @@ def test_fulfillment_metadata_updated(
         fulfillment,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1371,7 +1414,7 @@ def test_gift_card_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.gift_card_metadata_updated(gift_card)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1381,6 +1424,7 @@ def test_gift_card_metadata_updated(
         gift_card,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1399,7 +1443,7 @@ def test_voucher_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.voucher_metadata_updated(voucher)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1409,6 +1453,7 @@ def test_voucher_metadata_updated(
         voucher,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1428,7 +1473,7 @@ def test_shop_metadata_updated(
     assert site_settings
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.shop_metadata_updated(site_settings)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1438,6 +1483,7 @@ def test_shop_metadata_updated(
         site_settings,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1456,7 +1502,7 @@ def test_shipping_zone_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.shipping_zone_metadata_updated(shipping_zone)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1466,6 +1512,7 @@ def test_shipping_zone_metadata_updated(
         shipping_zone,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1484,7 +1531,7 @@ def test_warehouse_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.warehouse_metadata_updated(warehouse)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1494,6 +1541,7 @@ def test_warehouse_metadata_updated(
         warehouse,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1512,7 +1560,7 @@ def test_transaction_item_metadata_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     manager.transaction_item_metadata_updated(transaction_item_created_by_app)
 
     mocked_webhook_trigger.assert_called_once_with(
@@ -1522,6 +1570,7 @@ def test_transaction_item_metadata_updated(
         transaction_item_created_by_app,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1541,7 +1590,7 @@ def test_notify_user(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager(lambda: customer_user)
+    manager = get_plugins_manager(lambda: customer_user, True)
     timestamp = timezone.make_aware(
         datetime.strptime("2020-03-18 12:00", "%Y-%m-%d %H:%M"), timezone.utc
     ).isoformat()
@@ -1574,7 +1623,10 @@ def test_notify_user(
         },
     }
     mocked_webhook_trigger.assert_called_once_with(
-        json.dumps(data), WebhookEventAsyncType.NOTIFY_USER, [any_webhook]
+        json.dumps(data),
+        WebhookEventAsyncType.NOTIFY_USER,
+        [any_webhook],
+        allow_replica=True,
     )
 
 
@@ -1601,7 +1653,10 @@ def test_create_event_payload_reference_with_error(
     expected_data = serialize("json", [order_with_lines])
     event_payload = EventPayload.objects.create(payload=expected_data)
     trigger_webhooks_async(
-        event_payload, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+        event_payload,
+        WebhookEventAsyncType.ORDER_CREATED,
+        [webhook],
+        allow_replica=False,
     )
     delivery = EventDelivery.objects.first()
     send_webhook_request_async(delivery.id)
@@ -1629,7 +1684,7 @@ def test_sale_created(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     promotion = promotion_converted_from_sale
     predicate = promotion.rules.first().catalogue_predicate
@@ -1645,6 +1700,7 @@ def test_sale_created(
         promotion,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1664,7 +1720,7 @@ def test_sale_updated(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     promotion = promotion_converted_from_sale
     rule = promotion.rules.first()
@@ -1691,6 +1747,7 @@ def test_sale_updated(
         promotion,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1709,7 +1766,7 @@ def test_sale_deleted(
 ):
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     promotion = promotion_converted_from_sale
     predicate = promotion.rules.first().catalogue_predicate
@@ -1723,6 +1780,7 @@ def test_sale_deleted(
         promotion,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1742,7 +1800,7 @@ def test_sale_toggle(
     # given
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     promotion = promotion_converted_from_sale
     predicate = promotion.rules.first().catalogue_predicate
@@ -1759,6 +1817,7 @@ def test_sale_toggle(
         promotion,
         None,
         legacy_data_generator=ANY,
+        allow_replica=False,
     )
     assert isinstance(
         mocked_webhook_trigger.call_args.kwargs["legacy_data_generator"], partial
@@ -1769,7 +1828,7 @@ def test_sale_toggle(
 def test_event_delivery_retry(mocked_webhook_send, event_delivery, settings):
     # given
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     manager.event_delivery_retry(event_delivery)
@@ -1878,7 +1937,7 @@ def test_transaction_charge_requested(
 
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     transaction = TransactionItem.objects.create(
         name="Credit card",
         psp_reference="PSP ref",
@@ -1930,7 +1989,7 @@ def test_transaction_refund_requested(
 
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     transaction = TransactionItem.objects.create(
         name="Credit card",
         psp_reference="PSP ref",
@@ -1986,7 +2045,7 @@ def test_transaction_refund_requested_missing_app_owner_updated_refundable_for_c
 
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     transaction = TransactionItem.objects.create(
         name="Credit card",
         psp_reference="PSP ref",
@@ -2039,7 +2098,7 @@ def test_transaction_cancel_requested_missing_app_owner_updated_refundable_for_c
 
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     transaction = TransactionItem.objects.create(
         name="Credit card",
         psp_reference="PSP ref",
@@ -2090,7 +2149,7 @@ def test_transaction_cancelation_requested(
 
     mocked_get_webhooks_for_event.return_value = [any_webhook]
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     transaction = TransactionItem.objects.create(
         name="Credit card",
         psp_reference="PSP ref",
@@ -2117,7 +2176,6 @@ def test_transaction_cancelation_requested(
     manager.transaction_cancelation_requested(
         transaction_action_data, channel_slug=channel_USD.slug
     )
-
     # then
     mocked_webhook_trigger.assert_called_once_with(
         transaction_action_data,
@@ -2218,7 +2276,7 @@ def test_is_event_active(settings, webhook, permission_manage_orders):
     webhook.app.permissions.add(permission_manage_orders)
     webhook.events.create(event_type=WebhookEventAsyncType.INVOICE_REQUESTED)
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     # when
     is_active = manager.is_event_active_for_any_plugin(event)

--- a/saleor/plugins/webhook/tests/test_webhook_ip_filtering.py
+++ b/saleor/plugins/webhook/tests/test_webhook_ip_filtering.py
@@ -18,7 +18,9 @@ def test_rejects_private_ips(webhook, monkeypatch):
     ), "should not have any pre-existing attempts"
 
     # Trigger the webhook
-    trigger_webhooks_async(data="", event_type="test", webhooks=[webhook])
+    trigger_webhooks_async(
+        data="", event_type="test", webhooks=[webhook], allow_replica=False
+    )
 
     # Should have rejected the ip address used in all attempts.
     statuses = list(EventDeliveryAttempt.objects.values_list("status", "response"))

--- a/saleor/plugins/webhook/tests/test_webhook_protocols.py
+++ b/saleor/plugins/webhook/tests/test_webhook_protocols.py
@@ -50,7 +50,10 @@ def test_trigger_webhooks_with_aws_sqs(
     expected_data = serialize("json", [order_with_lines])
     expected_signature = signature_for_payload(expected_data.encode("utf-8"), None)
     trigger_webhooks_async(
-        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+        expected_data,
+        WebhookEventAsyncType.ORDER_CREATED,
+        [webhook],
+        allow_replica=False,
     )
 
     mocked_client_constructor.assert_called_once_with(
@@ -119,7 +122,10 @@ def test_trigger_webhooks_with_aws_sqs_and_secret_key(
         message.encode("utf-8"), webhook.secret_key
     )
     trigger_webhooks_async(
-        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+        expected_data,
+        WebhookEventAsyncType.ORDER_CREATED,
+        [webhook],
+        allow_replica=False,
     )
 
     mocked_client_constructor.assert_called_once_with(
@@ -164,7 +170,10 @@ def test_trigger_webhooks_with_google_pub_sub(
     expected_signature = signature_for_payload(expected_data.encode("utf-8"), None)
 
     trigger_webhooks_async(
-        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+        expected_data,
+        WebhookEventAsyncType.ORDER_CREATED,
+        [webhook],
+        allow_replica=False,
     )
     mocked_publisher.publish.assert_called_once_with(
         "projects/saleor/topics/test",
@@ -201,7 +210,10 @@ def test_trigger_webhooks_with_google_pub_sub_and_secret_key(
         message.encode("utf-8"), webhook.secret_key
     )
     trigger_webhooks_async(
-        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+        expected_data,
+        WebhookEventAsyncType.ORDER_CREATED,
+        [webhook],
+        allow_replica=False,
     )
     mocked_publisher.publish.assert_called_once_with(
         "projects/saleor/topics/test",
@@ -239,7 +251,10 @@ def test_trigger_webhooks_with_http(
     )
 
     trigger_webhooks_async(
-        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+        expected_data,
+        WebhookEventAsyncType.ORDER_CREATED,
+        [webhook],
+        allow_replica=False,
     )
 
     expected_headers = {
@@ -282,7 +297,10 @@ def test_trigger_webhooks_with_http_and_secret_key(
 
     expected_data = serialize("json", [order_with_lines])
     trigger_webhooks_async(
-        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+        expected_data,
+        WebhookEventAsyncType.ORDER_CREATED,
+        [webhook],
+        allow_replica=False,
     )
 
     expected_signature = signature_for_payload(
@@ -328,7 +346,10 @@ def test_trigger_webhooks_with_http_and_secret_key_as_empty_string(
 
     expected_data = serialize("json", [order_with_lines])
     trigger_webhooks_async(
-        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+        expected_data,
+        WebhookEventAsyncType.ORDER_CREATED,
+        [webhook],
+        allow_replica=False,
     )
 
     expected_signature = signature_for_payload(expected_data.encode("utf-8"), "")
@@ -387,7 +408,10 @@ def test_trigger_webhooks_with_http_and_custom_headers(
 
     # when
     trigger_webhooks_async(
-        expected_data, WebhookEventAsyncType.ORDER_CREATED, [webhook]
+        expected_data,
+        WebhookEventAsyncType.ORDER_CREATED,
+        [webhook],
+        allow_replica=False,
     )
 
     # then

--- a/saleor/product/tests/test_category.py
+++ b/saleor/product/tests/test_category.py
@@ -28,7 +28,7 @@ def test_delete_categories(
     child = parent.children.first()
     product_list = [child.products.first(), parent.products.first()]
 
-    delete_categories([parent.pk], manager=get_plugins_manager())
+    delete_categories([parent.pk], manager=get_plugins_manager(allow_replica=False))
 
     assert not Category.objects.filter(
         id__in=[category.id for category in [parent, child]]
@@ -65,7 +65,7 @@ def test_delete_categories_trigger_product_updated_webhook(
     product_list = [child.products.first(), parent.products.first()]
 
     # when
-    delete_categories([parent.pk], manager=get_plugins_manager())
+    delete_categories([parent.pk], manager=get_plugins_manager(allow_replica=False))
     flush_post_commit_hooks()
 
     # then

--- a/saleor/tax/tests/test_checkout_calculations.py
+++ b/saleor/tax/tests/test_checkout_calculations.py
@@ -58,7 +58,7 @@ def test_calculate_checkout_total(
     product.tax_class.country_rates.update_or_create(country=address.country, rate=23)
 
     lines, _ = fetch_checkout_lines(checkout)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     # when
@@ -106,7 +106,7 @@ def test_calculate_checkout_total_with_sale(
     product.tax_class.country_rates.update_or_create(country=address.country, rate=23)
 
     lines, _ = fetch_checkout_lines(checkout)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     # when
@@ -142,7 +142,7 @@ def test_calculate_checkout_total_no_tax_rates(
     TaxClassCountryRate.objects.all().delete()
 
     lines, _ = fetch_checkout_lines(checkout)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     # when
@@ -175,7 +175,7 @@ def test_calculate_checkout_total_default_tax_rate_for_country(
     TaxClassCountryRate.objects.create(country=address.country, rate=23)
 
     lines, _ = fetch_checkout_lines(checkout)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     # when
@@ -210,7 +210,7 @@ def test_calculate_checkout_total_with_shipping_voucher(
     checkout = checkout_with_item
     _enable_flat_rates(checkout, prices_entered_with_tax)
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout.shipping_address = address
     checkout.save()
     voucher_amount = Money(voucher_amount, "USD")
@@ -259,7 +259,7 @@ def test_calculate_checkout_total_with_shipping_voucher_and_sale(
     checkout = checkout_with_item_on_promotion
     _enable_flat_rates(checkout, prices_entered_with_tax)
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout.shipping_address = address
     checkout.save()
     voucher_amount = Money(voucher_amount, "USD")
@@ -319,7 +319,7 @@ def test_calculate_checkout_subtotal(
     checkout.shipping_method = shipping_zone.shipping_methods.get()
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
     add_variant_to_checkout(checkout_info, variant, 2)
     lines, _ = fetch_checkout_lines(checkout)
@@ -358,7 +358,7 @@ def test_calculate_checkout_subtotal_with_promotion_prices_entered_with_tax(
     checkout.shipping_method = shipping_zone.shipping_methods.get()
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
     add_variant_to_checkout(checkout_info, variant, 2)
     lines, _ = fetch_checkout_lines(checkout)
@@ -403,7 +403,7 @@ def test_calculate_checkout_subtotal_with_promotion_prices_not_entered_with_tax(
     checkout.shipping_method = shipping_zone.shipping_methods.get()
     checkout.save()
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, [], manager)
     add_variant_to_checkout(checkout_info, variant, 2)
     lines, _ = fetch_checkout_lines(checkout)
@@ -430,7 +430,7 @@ def test_calculate_checkout_subtotal_with_promotion_prices_not_entered_with_tax(
 
 
 def test_calculate_checkout_line_total(checkout_with_item, shipping_zone, address):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item
 
     rate = Decimal(23)
@@ -469,7 +469,7 @@ def test_calculate_checkout_line_total_voucher_on_entire_order(
 ):
     # given
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
 
     rate = Decimal(23)
     prices_entered_with_tax = True
@@ -519,7 +519,7 @@ def test_calculate_checkout_line_total_with_voucher_one_line(
 ):
     # given
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     line = checkout_with_item.lines.first()
 
     rate = Decimal(23)
@@ -571,7 +571,7 @@ def test_calculate_checkout_line_total_with_voucher_multiple_lines(
     checkout_with_item, shipping_zone, address, voucher, product_list
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item
 
     rate = Decimal(23)
@@ -641,7 +641,7 @@ def test_calculate_checkout_line_total_with_voucher_multiple_lines_last_line(
     checkout_with_item, shipping_zone, address, voucher, product_list
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item
 
     rate = Decimal(23)
@@ -721,7 +721,7 @@ def test_calculate_checkout_line_total_with_shipping_voucher(
     voucher_shipping_type,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout = checkout_with_item
 
     rate = Decimal(23)
@@ -775,7 +775,7 @@ def test_calculate_checkout_shipping(
 ):
     # given
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     rate = Decimal(23)
     prices_entered_with_tax = True
     _enable_flat_rates(checkout, prices_entered_with_tax)
@@ -808,7 +808,7 @@ def test_calculate_checkout_shipping_no_shipping_price(
 ):
     # given
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     rate = Decimal(23)
     prices_entered_with_tax = True
     _enable_flat_rates(checkout, prices_entered_with_tax)
@@ -840,7 +840,7 @@ def test_calculate_checkout_shipping_voucher_on_shipping(
 ):
     # given
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     rate = Decimal(23)
     prices_entered_with_tax = True
     _enable_flat_rates(checkout, prices_entered_with_tax)
@@ -884,7 +884,7 @@ def test_calculate_checkout_shipping_free_shipping_voucher(
 ):
     # given
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     rate = Decimal(23)
     prices_entered_with_tax = True
     _enable_flat_rates(checkout, prices_entered_with_tax)
@@ -922,7 +922,7 @@ def test_calculate_checkout_shipping_free_entire_order_voucher(
 ):
     # given
     checkout = checkout_with_item
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     rate = Decimal(23)
     prices_entered_with_tax = True
     _enable_flat_rates(checkout, prices_entered_with_tax)

--- a/saleor/tax/tests/test_order_calculations.py
+++ b/saleor/tax/tests/test_order_calculations.py
@@ -686,7 +686,7 @@ def test_use_default_country_rate_when_no_tax_class_was_set_before(
     order_with_lines,
 ):
     # given
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     order = order_with_lines
     country = get_order_country(order)
     TaxClassCountryRate.objects.create(country=country, rate=20)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -315,7 +315,9 @@ def checkout_JPY(channel_JPY):
 @pytest.fixture
 def checkout_with_item(checkout, product):
     variant = product.variants.first()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 3)
     checkout.save()
     return checkout
@@ -423,7 +425,9 @@ def checkout_with_item_and_tax_exemption(checkout_with_item):
 @pytest.fixture
 def checkout_with_same_items_in_multiple_lines(checkout, product):
     variant = product.variants.first()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
     add_variant_to_checkout(checkout_info, variant, 1, force_new_line=True)
     checkout.save()
@@ -434,7 +438,7 @@ def checkout_with_same_items_in_multiple_lines(checkout, product):
 def checkout_with_item_and_voucher_specific_products(
     checkout_with_item, voucher_specific_product_type
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     add_voucher_to_checkout(
@@ -452,7 +456,7 @@ def checkout_with_item_and_voucher_specific_products(
 def checkout_with_item_and_voucher_once_per_order(checkout_with_item, voucher):
     voucher.apply_once_per_order = True
     voucher.save()
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     add_voucher_to_checkout(
@@ -464,7 +468,7 @@ def checkout_with_item_and_voucher_once_per_order(checkout_with_item, voucher):
 
 @pytest.fixture
 def checkout_with_item_and_voucher(checkout_with_item, voucher):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, manager)
     add_voucher_to_checkout(
@@ -482,7 +486,9 @@ def checkout_line(checkout_with_item):
 @pytest.fixture
 def checkout_with_item_total_0(checkout, product_price_0):
     variant = product_price_0.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
     checkout.save()
     return checkout
@@ -491,7 +497,9 @@ def checkout_with_item_total_0(checkout, product_price_0):
 @pytest.fixture
 def checkout_JPY_with_item(checkout_JPY, product_in_channel_JPY):
     variant = product_in_channel_JPY.variants.get()
-    checkout_info = fetch_checkout_info(checkout_JPY, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout_JPY, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 3)
     checkout_JPY.save()
     return checkout_JPY
@@ -553,7 +561,9 @@ def checkout_ready_to_complete(checkout_with_item, address, shipping_method, gif
 def checkout_with_digital_item(checkout, digital_content, address):
     """Create a checkout with a digital line."""
     variant = digital_content.product_variant
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
     checkout.discount_amount = Decimal(0)
     checkout.billing_address = address
@@ -566,7 +576,9 @@ def checkout_with_digital_item(checkout, digital_content, address):
 def checkout_with_shipping_required(checkout_with_item, product):
     checkout = checkout_with_item
     variant = product.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 3)
     checkout.save()
     return checkout
@@ -609,7 +621,9 @@ def other_shipping_method(shipping_zone, channel_USD):
 @pytest.fixture
 def checkout_without_shipping_required(checkout, product_without_shipping):
     variant = product_without_shipping.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
     checkout.save()
     return checkout
@@ -618,7 +632,9 @@ def checkout_without_shipping_required(checkout, product_without_shipping):
 @pytest.fixture
 def checkout_with_single_item(checkout, product):
     variant = product.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
     checkout.save()
     return checkout
@@ -629,7 +645,9 @@ def checkout_with_variant_without_inventory_tracking(
     checkout, variant_without_inventory_tracking, address, shipping_method
 ):
     variant = variant_without_inventory_tracking
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
     checkout.shipping_address = address
     checkout.shipping_method = shipping_method
@@ -651,7 +669,9 @@ def checkout_with_variants(
     product_with_single_variant,
     product_with_two_variants,
 ):
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
 
     add_variant_to_checkout(
         checkout_info, product_with_default_variant.variants.get(), 1
@@ -720,7 +740,9 @@ def checkout_with_shipping_address_for_cc(checkout_with_variants_for_cc, address
 @pytest.fixture
 def checkout_with_items(checkout, product_list, product):
     variant = product.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 1)
     for prod in product_list:
         variant = prod.variants.get()
@@ -742,7 +764,9 @@ def checkout_with_items_and_shipping(checkout_with_items, address, shipping_meth
 @pytest.fixture
 def checkout_with_voucher(checkout, product, voucher):
     variant = product.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 3)
     checkout.voucher_code = voucher.code
     checkout.discount = Money("20.00", "USD")
@@ -753,7 +777,9 @@ def checkout_with_voucher(checkout, product, voucher):
 @pytest.fixture
 def checkout_with_voucher_percentage(checkout, product, voucher_percentage):
     variant = product.variants.get()
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, variant, 3)
     checkout.voucher_code = voucher_percentage.code
     checkout.discount = Money("3.00", "USD")
@@ -765,7 +791,7 @@ def checkout_with_voucher_percentage(checkout, product, voucher_percentage):
 def checkout_with_voucher_free_shipping(
     checkout_with_items_and_shipping, voucher_free_shipping
 ):
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     lines, _ = fetch_checkout_lines(checkout_with_items_and_shipping)
     checkout_info = fetch_checkout_info(
         checkout_with_items_and_shipping, lines, manager
@@ -795,7 +821,9 @@ def checkout_with_preorders_only(
     preorder_variant_channel_threshold,
 ):
     lines, _ = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, lines, get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, preorder_variant_with_end_date, 2)
     add_variant_to_checkout(checkout_info, preorder_variant_channel_threshold, 2)
 
@@ -808,7 +836,9 @@ def checkout_with_preorders_and_regular_variant(
     checkout, stocks_for_cc, preorder_variant_with_end_date, product_variant_list
 ):
     lines, _ = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, lines, get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, preorder_variant_with_end_date, 2)
     add_variant_to_checkout(checkout_info, product_variant_list[0], 2)
 
@@ -820,7 +850,9 @@ def checkout_with_preorders_and_regular_variant(
 def checkout_with_gift_card_items(
     checkout, non_shippable_gift_card_product, shippable_gift_card_product
 ):
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     non_shippable_variant = non_shippable_gift_card_product.variants.get()
     shippable_variant = shippable_gift_card_product.variants.get()
     add_variant_to_checkout(checkout_info, non_shippable_variant, 1)
@@ -859,7 +891,9 @@ def checkout_with_payments(checkout):
 def checkout_with_item_and_preorder_item(
     checkout_with_item, product, preorder_variant_channel_threshold
 ):
-    checkout_info = fetch_checkout_info(checkout_with_item, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, preorder_variant_channel_threshold, 1)
     return checkout_with_item
 
@@ -1074,7 +1108,9 @@ def user_checkout_PLN(customer_user, channel_PLN):
 
 @pytest.fixture
 def user_checkout_with_items(user_checkout, product_list):
-    checkout_info = fetch_checkout_info(user_checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        user_checkout, [], get_plugins_manager(allow_replica=False)
+    )
     for product in product_list:
         variant = product.variants.get()
         add_variant_to_checkout(checkout_info, variant, 1)
@@ -1084,7 +1120,9 @@ def user_checkout_with_items(user_checkout, product_list):
 
 @pytest.fixture
 def user_checkout_with_items_for_cc(user_checkout_for_cc, product_list):
-    checkout_info = fetch_checkout_info(user_checkout_for_cc, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        user_checkout_for_cc, [], get_plugins_manager(allow_replica=False)
+    )
     for product in product_list:
         variant = product.variants.get()
         add_variant_to_checkout(checkout_info, variant, 1)
@@ -4416,7 +4454,9 @@ def checkout_line_with_one_reservation(
 def checkout_line_with_preorder_item(
     checkout, product, preorder_variant_channel_threshold
 ):
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, preorder_variant_channel_threshold, 1)
     return checkout.lines.last()
 
@@ -4425,7 +4465,9 @@ def checkout_line_with_preorder_item(
 def checkout_line_with_reserved_preorder_item(
     checkout, product, preorder_variant_channel_threshold
 ):
-    checkout_info = fetch_checkout_info(checkout, [], get_plugins_manager())
+    checkout_info = fetch_checkout_info(
+        checkout, [], get_plugins_manager(allow_replica=False)
+    )
     add_variant_to_checkout(checkout_info, preorder_variant_channel_threshold, 2)
     checkout_line = checkout.lines.last()
 
@@ -5174,7 +5216,7 @@ def fulfilled_order(order_with_lines):
                 line=line_2, quantity=line_2.quantity, warehouse_pk=warehouse_2_pk
             ),
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
     order.status = OrderStatus.FULFILLED
     order.save(update_fields=["status"])
@@ -5201,7 +5243,7 @@ def fulfilled_order_without_inventory_tracking(
     fulfillment.lines.create(order_line=line, quantity=line.quantity, stock=stock)
     fulfill_order_lines(
         [OrderLineInfo(line=line, quantity=line.quantity, warehouse_pk=warehouse_pk)],
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
     order.status = OrderStatus.FULFILLED
     order.save(update_fields=["status"])
@@ -5225,7 +5267,13 @@ def fulfilled_order_with_all_cancelled_fulfillments(
     fulfilled_order, staff_user, warehouse
 ):
     fulfillment = fulfilled_order.fulfillments.get()
-    cancel_fulfillment(fulfillment, staff_user, None, warehouse, get_plugins_manager())
+    cancel_fulfillment(
+        fulfillment,
+        staff_user,
+        None,
+        warehouse,
+        get_plugins_manager(allow_replica=False),
+    )
     return fulfilled_order
 
 
@@ -7492,7 +7540,7 @@ def checkout_with_prices(
     checkout_with_items.shipping_method = shipping_method
     checkout_with_items.save(update_fields=["shipping_method"])
 
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     channel = checkout_with_items.channel
     lines = checkout_with_items.lines.all()
     lines_info, _ = fetch_checkout_lines(checkout_with_items)

--- a/saleor/thumbnail/views.py
+++ b/saleor/thumbnail/views.py
@@ -113,7 +113,7 @@ def handle_thumbnail(
     # set additional `instance` attribute, to easily get instance data
     # for ThumbnailCreated subscription type
     setattr(thumbnail, "instance", instance)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     call_event(manager.thumbnail_created, thumbnail)
 
     return HttpResponseRedirect(thumbnail.image.url)

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -32,7 +32,10 @@ def test_allocate_stocks(order_line, stock, channel_USD):
     line_data = OrderLineInfo(line=order_line, variant=order_line.variant, quantity=50)
 
     allocate_stocks(
-        [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
+        [line_data],
+        COUNTRY_CODE,
+        channel_USD,
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     stock.refresh_from_db()
@@ -72,7 +75,7 @@ def test_allocate_stocks_multiple_lines_the_highest_stock_strategy(
         [line_data_1, line_data_2],
         COUNTRY_CODE,
         channel_USD,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     stock.refresh_from_db()
@@ -93,7 +96,10 @@ def test_allocate_stock_many_stocks_the_highest_stock_strategy(
 
     line_data = OrderLineInfo(line=order_line, variant=order_line.variant, quantity=5)
     allocate_stocks(
-        [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
+        [line_data],
+        COUNTRY_CODE,
+        channel_USD,
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     allocations = Allocation.objects.filter(order_line=order_line, stock__in=stocks)
@@ -125,7 +131,7 @@ def test_allocate_stocks_the_highest_stock_strategy_with_collection_point(
         [line_data],
         COUNTRY_CODE,
         channel_USD,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         collection_point_pk=warehouse_for_cc.pk,
     )
 
@@ -162,7 +168,10 @@ def test_allocate_stock_many_stocks_prioritize_sorting_order_strategy(
 
     # when
     allocate_stocks(
-        [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
+        [line_data],
+        COUNTRY_CODE,
+        channel_USD,
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     # then
@@ -223,7 +232,7 @@ def test_allocate_stock_prioritize_sorting_order_strategy_with_collection_point(
         [line_data],
         COUNTRY_CODE,
         channel_USD,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         collection_point_pk=warehouse_for_cc.pk,
     )
 
@@ -248,7 +257,7 @@ def test_allocate_stock_with_reservations_the_highest_stock_strategy(
         [line_data],
         COUNTRY_CODE,
         channel_USD,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         check_reservations=True,
     )
 
@@ -294,7 +303,7 @@ def test_allocate_stock_with_reservations_prioritize_sorting_order_strategy(
         [line_data],
         COUNTRY_CODE,
         channel_USD,
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         check_reservations=True,
     )
 
@@ -324,7 +333,7 @@ def test_allocate_stock_insufficient_stock_due_to_reservations(
             [line_data],
             COUNTRY_CODE,
             channel_USD,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
             check_reservations=True,
         )
 
@@ -350,7 +359,10 @@ def test_allocate_stock_many_stocks_partially_allocated(
 
     # when
     allocate_stocks(
-        [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
+        [line_data],
+        COUNTRY_CODE,
+        channel_USD,
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     # then
@@ -376,7 +388,10 @@ def test_allocate_stock_partially_allocated_insufficient_stocks(
     line_data = OrderLineInfo(line=order_line, variant=order_line.variant, quantity=6)
     with pytest.raises(InsufficientStock):
         allocate_stocks(
-            [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
+            [line_data],
+            COUNTRY_CODE,
+            channel_USD,
+            manager=get_plugins_manager(allow_replica=False),
         )
 
     assert not Allocation.objects.filter(
@@ -393,7 +408,10 @@ def test_allocate_stocks_no_channel_shipping_zones(order_line, stock, channel_US
     line_data = OrderLineInfo(line=order_line, variant=order_line.variant, quantity=50)
     with pytest.raises(InsufficientStock):
         allocate_stocks(
-            [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
+            [line_data],
+            COUNTRY_CODE,
+            channel_USD,
+            manager=get_plugins_manager(allow_replica=False),
         )
 
 
@@ -406,7 +424,10 @@ def test_allocate_stock_insufficient_stocks(
     line_data = OrderLineInfo(line=order_line, variant=order_line.variant, quantity=10)
     with pytest.raises(InsufficientStock):
         allocate_stocks(
-            [line_data], COUNTRY_CODE, channel_USD, manager=get_plugins_manager()
+            [line_data],
+            COUNTRY_CODE,
+            channel_USD,
+            manager=get_plugins_manager(allow_replica=False),
         )
 
     assert not Allocation.objects.filter(
@@ -444,7 +465,7 @@ def test_allocate_stock_insufficient_stocks_for_multiple_lines(
             [line_data_1, line_data_2],
             COUNTRY_CODE,
             channel_USD,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
         )
 
     assert set(item.variant for item in exc._excinfo[1].items) == {variant, variant_2}
@@ -468,7 +489,7 @@ def test_deallocate_stock(allocation):
                 line=allocation.order_line, quantity=80, variant=stock.product_variant
             )
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     stock.refresh_from_db()
@@ -491,7 +512,7 @@ def test_deallocate_stock_when_quantity_less_than_zero(allocation):
                 line=allocation.order_line, quantity=80, variant=stock.product_variant
             )
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     stock.refresh_from_db()
@@ -514,7 +535,7 @@ def test_deallocate_stock_partially(allocation):
                 line=allocation.order_line, quantity=50, variant=stock.product_variant
             )
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     stock.refresh_from_db()
@@ -531,7 +552,7 @@ def test_deallocate_stock_many_allocations(
 
     deallocate_stock(
         [OrderLineInfo(line=order_line, quantity=3, variant=order_line.variant)],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     allocations = order_line.allocations.all()
@@ -546,7 +567,7 @@ def test_deallocate_stock_many_allocations_partially(
 
     deallocate_stock(
         [OrderLineInfo(line=order_line, quantity=1, variant=order_line.variant)],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     allocations = order_line.allocations.all()
@@ -620,7 +641,9 @@ def test_increase_allocations(quantity, allocation):
     allocation.save(update_fields=["quantity_allocated"])
 
     increase_allocations(
-        [order_line_info], order_line.order.channel, manager=get_plugins_manager()
+        [order_line_info],
+        order_line.order.channel,
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     stock.refresh_from_db()
@@ -654,7 +677,7 @@ def test_increase_allocation_insufficient_stock(allocation):
         increase_allocations(
             [order_line_info],
             order_line.order.channel,
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
         )
 
     stock.refresh_from_db()
@@ -702,7 +725,7 @@ def test_decrease_stock(allocation):
                 warehouse_pk=warehouse_pk,
             )
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     stock.refresh_from_db()
@@ -731,7 +754,7 @@ def test_decrease_stock_without_stock_update(quantity, expected_allocated, alloc
                 warehouse_pk=warehouse_pk,
             )
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
         update_stocks=False,
     )
 
@@ -772,7 +795,7 @@ def test_decrease_stock_multiple_lines(allocations):
                 warehouse_pk=warehouse_pk_2,
             ),
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     stock.refresh_from_db()
@@ -836,7 +859,7 @@ def test_decrease_stock_multiple_lines_deallocate_stock_raises_error(order_with_
                 warehouse_pk=warehouse_pk_2,
             ),
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     # then
@@ -870,7 +893,7 @@ def test_decrease_stock_partially(allocation):
                 warehouse_pk=warehouse_pk,
             )
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     stock.refresh_from_db()
@@ -895,7 +918,7 @@ def test_decrease_stock_many_allocations(
                 warehouse_pk=warehouse_pk,
             )
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     assert allocations[0].quantity_allocated == 0
@@ -920,7 +943,7 @@ def test_decrease_stock_many_allocations_partially(
                 warehouse_pk=warehouse_pk,
             )
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     assert allocations[0].quantity_allocated == 0
@@ -949,7 +972,7 @@ def test_decrease_stock_more_then_allocated(
                 warehouse_pk=warehouse_pk,
             )
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     allocations = order_line.allocations.all()
@@ -980,7 +1003,7 @@ def test_decrease_stock_insufficient_stock(allocation):
                     warehouse_pk=warehouse_pk,
                 )
             ],
-            manager=get_plugins_manager(),
+            manager=get_plugins_manager(allow_replica=False),
         )
 
     stock.refresh_from_db()
@@ -994,7 +1017,7 @@ def test_deallocate_stock_for_order(order_line_with_allocation_in_many_stocks):
     order_line = order_line_with_allocation_in_many_stocks
     order = order_line.order
 
-    deallocate_stock_for_order(order, manager=get_plugins_manager())
+    deallocate_stock_for_order(order, manager=get_plugins_manager(allow_replica=False))
 
     allocations = order_line.allocations.all()
     assert (
@@ -1063,7 +1086,7 @@ def test_decrease_stock_with_out_of_stock_webhook_triggered(
                 warehouse_pk=warehouse_pk,
             )
         ],
-        manager=get_plugins_manager(),
+        manager=get_plugins_manager(allow_replica=False),
     )
 
     flush_post_commit_hooks()

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -422,7 +422,7 @@ def test_generate_fulfillment_lines_payload(order_with_lines):
     )
     fulfill_order_lines(
         [OrderLineInfo(line=line, quantity=line.quantity, warehouse_pk=warehouse_pk)],
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
     payload = json.loads(generate_fulfillment_lines_payload(fulfillment))[0]
 
@@ -470,7 +470,7 @@ def test_generate_fulfillment_lines_payload_deleted_variant(order_with_lines):
     fulfillment.lines.create(order_line=line, quantity=line.quantity, stock=stock)
     fulfill_order_lines(
         [OrderLineInfo(line=line, quantity=line.quantity, warehouse_pk=warehouse_pk)],
-        get_plugins_manager(),
+        get_plugins_manager(allow_replica=False),
     )
 
     # when
@@ -1679,7 +1679,7 @@ def test_generate_checkout_payload_for_tax_calculation_entire_order_voucher(
 
     # when
     lines, _ = fetch_checkout_lines(checkout_with_prices)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout_with_prices, lines, manager)
     payload = json.loads(
         generate_checkout_payload_for_tax_calculation(checkout_info, lines)
@@ -1776,7 +1776,7 @@ def test_generate_checkout_payload_for_tax_calculation_specific_product_voucher(
 
     # when
     lines, _ = fetch_checkout_lines(checkout_with_prices)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout_with_prices, lines, manager)
     payload = json.loads(
         generate_checkout_payload_for_tax_calculation(checkout_info, lines)
@@ -1859,7 +1859,7 @@ def test_generate_checkout_payload_for_tax_calculation_digital_checkout(
         mocked_serialized_checkout_lines
     )
     lines, _ = fetch_checkout_lines(checkout)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     # when

--- a/saleor/webhook/tests/test_webhook_serializers.py
+++ b/saleor/webhook/tests/test_webhook_serializers.py
@@ -283,7 +283,7 @@ def test_serialize_checkout_lines_for_tax_calculation(
     # given
     checkout = checkout_with_prices
     lines, _ = fetch_checkout_lines(checkout)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
 
     tax_configuration = checkout_info.tax_configuration
@@ -346,7 +346,7 @@ def test_serialize_checkout_lines_for_tax_calculation_with_promotion(
     update_discounted_prices_for_promotion(Product.objects.all())
 
     lines, _ = fetch_checkout_lines(checkout)
-    manager = get_plugins_manager()
+    manager = get_plugins_manager(allow_replica=False)
     checkout_info = fetch_checkout_info(checkout, lines, manager)
     create_or_update_discount_objects_from_promotion_for_checkout(lines)
 

--- a/saleor/webhook/transport/asynchronous/transport.py
+++ b/saleor/webhook/transport/asynchronous/transport.py
@@ -42,7 +42,7 @@ task_logger = get_task_logger(__name__)
 
 
 def create_deliveries_for_subscriptions(
-    event_type, subscribable_object, webhooks, requestor=None
+    event_type, subscribable_object, webhooks, requestor=None, allow_replica=False
 ) -> list[EventDelivery]:
     """Create a list of event deliveries with payloads based on subscription query.
 
@@ -54,6 +54,7 @@ def create_deliveries_for_subscriptions(
     :param webhooks: sequence of async webhooks.
     :param requestor: used in subscription webhooks to generate meta data for payload.
     :return: List of event deliveries to send via webhook tasks.
+    :param allow_replica: use replica database.
     """
     if event_type not in WEBHOOK_TYPES_MAP:
         logger.info(
@@ -72,6 +73,7 @@ def create_deliveries_for_subscriptions(
                 requestor,
                 event_type in WebhookEventSyncType.ALL,
                 event_type=event_type,
+                allow_replica=allow_replica,
             ),
             app=webhook.app,
         )
@@ -128,6 +130,7 @@ def trigger_webhooks_async(
     subscribable_object=None,
     requestor=None,
     legacy_data_generator=None,
+    allow_replica=False,
 ):
     """Trigger async webhooks - both regular and subscription.
 
@@ -136,8 +139,9 @@ def trigger_webhooks_async(
         `legacy_data_generator` function is used to generate the payload when needed.
     :param event_type: used in both webhook types as event type.
     :param webhooks: used in both webhook types, queryset of async webhooks.
+    :param allow_replica: use a replica database.
     :param subscribable_object: subscribable object used in subscription webhooks.
-    :param requestor: used in subscription webhooks to generate meta data for payload.
+    :param requestor: used in subscription webhooks to generate mžeta data for payload.
     :param legacy_data_generator: used to generate payload for regular webhooks.
     """
     regular_webhooks, subscription_webhooks = group_webhooks_by_subscription(webhooks)
@@ -163,6 +167,7 @@ def trigger_webhooks_async(
                 subscribable_object=subscribable_object,
                 webhooks=subscription_webhooks,
                 requestor=requestor,
+                allow_replica=allow_replica,
             )
         )
 

--- a/saleor/webhook/transport/shipping.py
+++ b/saleor/webhook/transport/shipping.py
@@ -93,6 +93,7 @@ def get_excluded_shipping_methods_or_fetch(
     payload: str,
     cache_key: str,
     subscribable_object: Optional[Union["Order", "Checkout"]],
+    allow_replica: bool,
 ) -> dict[str, list[ExcludedShippingMethod]]:
     """Return data of all excluded shipping methods.
 
@@ -116,6 +117,7 @@ def get_excluded_shipping_methods_or_fetch(
             event_type,
             payload,
             webhook,
+            allow_replica,
             subscribable_object=subscribable_object,
             timeout=settings.WEBHOOK_SYNC_TIMEOUT,
         )
@@ -133,6 +135,7 @@ def get_excluded_shipping_data(
     payload_fun: Callable[[], str],
     cache_key: str,
     subscribable_object: Optional[Union["Order", "Checkout"]],
+    allow_replica: bool,
 ) -> list[ExcludedShippingMethod]:
     """Exclude not allowed shipping methods by sync webhook.
 
@@ -152,7 +155,7 @@ def get_excluded_shipping_data(
         payload = payload_fun()
 
         excluded_methods_map = get_excluded_shipping_methods_or_fetch(
-            webhooks, event_type, payload, cache_key, subscribable_object
+            webhooks, event_type, payload, cache_key, subscribable_object, allow_replica
         )
 
     # Gather responses for previous plugins

--- a/saleor/webhook/transport/synchronous/transport.py
+++ b/saleor/webhook/transport/synchronous/transport.py
@@ -170,6 +170,7 @@ def trigger_webhook_sync_if_not_cached(
     payload: str,
     webhook: "Webhook",
     cache_data: dict,
+    allow_replica: bool,
     subscribable_object=None,
     request_timeout=None,
     cache_timeout=None,
@@ -190,6 +191,7 @@ def trigger_webhook_sync_if_not_cached(
             event_type,
             payload,
             webhook,
+            allow_replica,
             subscribable_object=subscribable_object,
             timeout=request_timeout,
             request=request,
@@ -204,7 +206,12 @@ def trigger_webhook_sync_if_not_cached(
 
 
 def create_delivery_for_subscription_sync_event(
-    event_type, subscribable_object, webhook, requestor=None, request=None
+    event_type,
+    subscribable_object,
+    webhook,
+    requestor=None,
+    request=None,
+    allow_replica=False,
 ) -> Optional[EventDelivery]:
     """Generate webhook payload based on subscription query and create delivery object.
 
@@ -217,6 +224,7 @@ def create_delivery_for_subscription_sync_event(
     :param requestor: used in subscription webhooks to generate meta data for payload.
     :param request: used to share context between sync event calls
     :return: List of event deliveries to send via webhook tasks.
+    :param allow_replica: use replica database.
     """
     if event_type not in WEBHOOK_TYPES_MAP:
         logger.info(
@@ -226,7 +234,10 @@ def create_delivery_for_subscription_sync_event(
 
     if not request:
         request = initialize_request(
-            requestor, event_type in WebhookEventSyncType.ALL, event_type=event_type
+            requestor,
+            event_type in WebhookEventSyncType.ALL,
+            event_type=event_type,
+            allow_replica=allow_replica,
         )
     data = generate_payload_from_subscription(
         event_type=event_type,
@@ -256,6 +267,7 @@ def trigger_webhook_sync(
     event_type: str,
     payload: str,
     webhook: "Webhook",
+    allow_replica,
     subscribable_object=None,
     timeout=None,
     request=None,
@@ -267,6 +279,7 @@ def trigger_webhook_sync(
             subscribable_object=subscribable_object,
             webhook=webhook,
             request=request,
+            allow_replica=allow_replica,
         )
         if not delivery:
             return None


### PR DESCRIPTION
I want to merge this change because it allows us to pass an `allow_replica` parameter to subscription webhooks and decide to use replica or main db in a subscription API call. 

resolves: https://github.com/saleor/saleor/issues/14472

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
