### PR TITLE
Test for Voucher without any codes

### DIFF
--- a/saleor/graphql/discount/tests/mutations/test_voucher_create.py
+++ b/saleor/graphql/discount/tests/mutations/test_voucher_create.py
@@ -118,6 +118,55 @@ def test_create_voucher(
     assert len(codes) == 2
 
 
+def test_create_voucher_no_codes(
+    staff_api_client,
+    permission_manage_discounts,
+    product,
+    variant,
+    collection,
+    category,
+):
+    # given
+    start_date = timezone.now() - timedelta(days=365)
+    end_date = timezone.now() + timedelta(days=365)
+
+    name = "test voucher"
+    variables = {
+        "input": {
+            "name": name,
+            "type": VoucherTypeEnum.ENTIRE_ORDER.name,
+            "addCodes": [""],
+            "discountValueType": DiscountValueTypeEnum.FIXED.name,
+            "minCheckoutItemsQuantity": 10,
+            "startDate": start_date.isoformat(),
+            "endDate": end_date.isoformat(),
+            "applyOncePerOrder": True,
+            "applyOncePerCustomer": True,
+            "singleUse": True,
+            "usageLimit": 3,
+            "products": [graphene.Node.to_global_id("Product", product.pk)],
+            "variants": [graphene.Node.to_global_id("ProductVariant", variant.pk)],
+            "collections": [graphene.Node.to_global_id("Collection", collection.pk)],
+            "categories": [graphene.Node.to_global_id("Category", category.pk)],
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_VOUCHER_MUTATION, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["voucherCreate"]
+    assert not data["errors"]
+    voucher = Voucher.objects.get()
+
+    assert voucher.name == name
+    assert voucher.type == VoucherType.ENTIRE_ORDER
+    # check if used function is calculated properly
+    assert data["voucher"]["used"] == 0
+    assert data["voucher"]["usageLimit"] == 3
+
+
 def test_create_voucher_return_error_when_code_and_codes_args_combined(
     staff_api_client, permission_manage_discounts
 ):


### PR DESCRIPTION
Add test for voucher without any codes, potential edge case to check if Voucher.used resolver works properly.


<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
