### PR TITLE
Use replicas in webhook payloads

### DIFF
--- a/saleor/webhook/serializers.py
+++ b/saleor/webhook/serializers.py
@@ -18,11 +18,15 @@ if TYPE_CHECKING:
     from ..product.models import ProductVariant
 
 
-def serialize_checkout_lines(checkout: "Checkout") -> List[dict]:
+def serialize_checkout_lines(
+    checkout: "Checkout", allow_replica: bool = False
+) -> List[dict]:
     data = []
     channel = checkout.channel
     currency = channel.currency_code
-    lines, _ = fetch_checkout_lines(checkout, prefetch_variant_attributes=True)
+    lines, _ = fetch_checkout_lines(
+        checkout, prefetch_variant_attributes=True, allow_replica=allow_replica
+    )
     for line_info in lines:
         variant = line_info.variant
         channel_listing = line_info.channel_listing


### PR DESCRIPTION
I want to merge this change because it adds usage of replicas to webhook payloads.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
