### PR TITLE
Fix `PromotionRuleUpdateInput.add_channels` description.

### DIFF
--- a/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
+++ b/saleor/graphql/discount/mutations/promotion/promotion_rule_update.py
@@ -39,7 +39,7 @@ class PromotionRuleUpdateError(Error):
 class PromotionRuleUpdateInput(PromotionRuleBaseInput):
     add_channels = NonNullList(
         graphene.ID,
-        description="List of channel ids to remove.",
+        description="List of channel ids to add.",
     )
     remove_channels = NonNullList(
         graphene.ID,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -27599,7 +27599,7 @@ input PromotionRuleUpdateInput {
   """
   rewardValue: PositiveDecimal
 
-  """List of channel ids to remove."""
+  """List of channel ids to add."""
   addChannels: [ID!]
 
   """List of channel ids to remove."""


### PR DESCRIPTION
I want to merge this change because it correct `PromotionRuleUpdateInput.add_channels` description.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
