### PR TITLE
Fix missing permissions in Promotion state

### DIFF
--- a/saleor/discount/migrations/0051_detach_sale_from_permission.py
+++ b/saleor/discount/migrations/0051_detach_sale_from_permission.py
@@ -92,4 +92,17 @@ class Migration(migrations.Migration):
             """,
             reverse_sql=migrations.RunSQL.noop,
         ),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterModelOptions(
+                    name="promotion",
+                    options={
+                        "ordering": ("name", "pk"),
+                        "permissions": (
+                            ("manage_discounts", "Manage sales and vouchers."),
+                        ),
+                    },
+                ),
+            ],
+        ),
     ]

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -22,6 +22,7 @@ from ..core.models import ModelWithMetadata
 from ..core.utils.editorjs import clean_editor_js
 from ..core.utils.json_serializer import CustomJsonEncoder
 from ..core.utils.translations import Translation
+from ..permission.enums import DiscountPermissions
 from . import (
     DiscountType,
     DiscountValueType,
@@ -320,6 +321,12 @@ class Promotion(ModelWithMetadata):
 
     class Meta:
         ordering = ("name", "pk")
+        permissions = (
+            (
+                DiscountPermissions.MANAGE_DISCOUNTS.codename,
+                "Manage sales and vouchers.",
+            ),
+        )
 
     def is_active(self, date=None):
         if date is None:


### PR DESCRIPTION
I want to merge this change because I fixed missing permissions in the Promotion state.

Port of https://github.com/saleor/saleor/pull/14853

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
