### PR TITLE
Add identifier field to app object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 - Add taxes to undiscounted prices - #14095 by @jakubkuc
 - Mark as deprecated: `ordersTotal`, `reportProductSales` and `homepageEvents` - #14806 by @8r2y5
+- Add `identifier` field to App graphql object. Identifier field is the same as Manifest.id field (explicit ID set by the app).
 
 ### Saleor Apps
 

--- a/saleor/graphql/app/tests/queries/test_app.py
+++ b/saleor/graphql/app/tests/queries/test_app.py
@@ -14,6 +14,7 @@ QUERY_APP = """
     query ($id: ID){
         app(id: $id){
             id
+            identifier
             created
             isActive
             permissions{
@@ -82,6 +83,7 @@ def test_app_query(
     app.permissions.add(permission_manage_staff)
     app.store_value_in_metadata({"test": "123"})
     app.author = "Acme Ltd"
+    app.identifier = "saleor.app.mock"
     app.save()
 
     webhook = webhook
@@ -128,6 +130,7 @@ def test_app_query(
     assert app_data["metadata"][0]["value"] == "123"
     assert app_data["metafield"] == "123"
     assert app_data["metafields"] == {"test": "123"}
+    assert app_data["identifier"] == "saleor.app.mock"
 
 
 def test_app_query_no_permission(

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -492,6 +492,9 @@ class AppToken(BaseObjectType):
 @federated_entity("id")
 class App(ModelObjectType[models.App]):
     id = graphene.GlobalID(required=True, description="The ID of the app.")
+    identifier = graphene.String(
+        required=False, description="Canonical app ID from the manifest"
+    )
     permissions = NonNullList(Permission, description="List of the app's permissions.")
     created = graphene.DateTime(
         description="The date and time when the app was created."

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3069,6 +3069,9 @@ type App implements Node & ObjectWithMetadata @doc(category: "Apps") {
   """
   metafields(keys: [String!]): Metadata
 
+  """Canonical app ID from the manifest"""
+  identifier: String
+
   """List of the app's permissions."""
   permissions: [Permission!]
 


### PR DESCRIPTION
I want to merge this change because

it adds missing field in App object in schema

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [x] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
