### PR TITLE
Update filter_payment_status to fix filtering orders by Unpaid

### DIFF
--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -8,6 +8,7 @@ from graphql.error import GraphQLError
 
 from ...giftcard import GiftCardEvents
 from ...giftcard.models import GiftCardEvent
+from ...order import OrderChargeStatus
 from ...order.models import Order, OrderLine
 from ...order.search import search_orders
 from ...payment import ChargeStatus
@@ -31,6 +32,8 @@ def filter_payment_status(qs, _, value):
         lookup = Q(payments__is_active=True, payments__charge_status__in=value)
         if ChargeStatus.FULLY_REFUNDED in value:
             lookup |= Q(payments__charge_status=ChargeStatus.FULLY_REFUNDED)
+        elif ChargeStatus.NOT_CHARGED in value:
+            lookup |= Q(charge_status=OrderChargeStatus.NONE)
         qs = qs.filter(lookup)
     return qs
 


### PR DESCRIPTION
Some Unpaid orders don't have payment records such as those manually created from a draft order or those created via bulk import. These types of Unpaid orders aren't included when filtering orders by Unpaid payment status which I consider a bug.

This update fixes this issue and ensures all Unpaid orders are included when filtering orders by Unpaid payment status.

<!-- Please mention all relevant issue numbers. -->

# Impact

No impacts.

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

No changes to docs required.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [x] Privileged queries and mutations are either absent or guarded by proper permission checks
- [x] Database queries are optimized and the number of queries is constant
- [x] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [x] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [x] All migrations have proper dependencies
- [x] All indexes are added concurrently in migrations
- [x] All RunSql and RunPython migrations have revert option defined
