### PR TITLE
Remove unneeded self-call from update search vector task for giftcards

### DIFF
--- a/saleor/giftcard/tasks.py
+++ b/saleor/giftcard/tasks.py
@@ -33,4 +33,3 @@ def update_gift_cards_search_vector_task():
         return
     gift_cards_batch = list(gift_cards[:GIFT_CARD_BATCH_SIZE])
     update_gift_cards_search_vector(gift_cards_batch)
-    update_gift_cards_search_vector_task.delay()


### PR DESCRIPTION
I want to merge this change because `update_gift_cards_search_vector_task` should not re-run itself since it is in celery beat schedule.

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
