### PR TITLE
Add lock to avoid deadlocks between checkout process and payment plugins

### DIFF
--- a/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
+++ b/saleor/graphql/checkout/tests/mutations/test_checkout_complete_with_payment.py
@@ -3856,8 +3856,8 @@ def test_checkout_complete_payment_create_create_run_in_meantime(
         user_api_client.post_graphql(CREATE_PAYMENT_MUTATION, variables)
 
     # when
-    with before_after.before(
-        "saleor.checkout.complete_checkout._get_order_data",
+    with before_after.after(
+        "saleor.checkout.complete_checkout._process_payment",
         call_payment_create_mutation,
     ):
         response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)


### PR DESCRIPTION
I want to merge this change because it adds a missing lock to process payment block. Without it, we were seeing a lot of deadlocks, between checkoutComplete mutation and processing the webhook from payment provider

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
